### PR TITLE
fix(db): unblock pgvector embedding migration on PostgreSQL

### DIFF
--- a/alembic/versions/202602280003_convert_embedding_to_vector768.py
+++ b/alembic/versions/202602280003_convert_embedding_to_vector768.py
@@ -8,9 +8,9 @@ Converts user_knowledge.embedding from TEXT (JSON array) to pgvector VECTOR(768)
 on PostgreSQL for native cosine similarity search.  No-op on SQLite (tests
 keep TEXT column and use application-level cosine).
 
-The existing embeddings are stored as JSON arrays (e.g., "[0.1, 0.2, ...]").
-PostgreSQL's json_array_elements_text extracts array elements, and array_agg
-reconstructs them into pgvector's text format before casting to vector.
+The existing embeddings are stored as JSON arrays rendered as text
+(e.g., "[0.1, 0.2, ...]").  PostgreSQL normalizes whitespace and casts the
+string directly to pgvector format during the type conversion.
 
 IVFFlat index is deferred until sufficient data (>1000 rows).
 
@@ -31,19 +31,20 @@ depends_on = None
 def upgrade() -> None:
     dialect = op.get_bind().dialect.name
     if dialect == "postgresql":
-        # Convert JSON array text to pgvector format.
-        # The embedding column stores JSON arrays like "[0.1, 0.2, ...]".
-        # We parse the JSON and reconstruct as pgvector text format.
+        # RU: PostgreSQL запрещает подзапросы внутри ALTER COLUMN ... USING.
+        # EN: PostgreSQL rejects subqueries inside ALTER COLUMN ... USING.
+        #
+        # RU: Данные уже хранятся как JSON-массив в текстовом виде, например
+        # "[0.1, 0.2, ...]". После удаления пробелов строка совместима с pgvector.
+        # EN: Existing values are already JSON-array text like "[0.1, 0.2, ...]".
+        # After whitespace normalization the string is pgvector-compatible.
         op.execute("""
             ALTER TABLE user_knowledge
             ALTER COLUMN embedding TYPE vector(768)
             USING (
                 CASE
                     WHEN embedding IS NULL OR embedding = '' THEN NULL
-                    ELSE (
-                        SELECT ('[' || string_agg(elem::text, ',') || ']')::vector(768)
-                        FROM json_array_elements_text(embedding::json) AS elem
-                    )
+                    ELSE regexp_replace(embedding, '\\s+', '', 'g')::vector(768)
                 END
             )
             """)

--- a/alembic/versions/202602280003_convert_embedding_to_vector768.py
+++ b/alembic/versions/202602280003_convert_embedding_to_vector768.py
@@ -43,7 +43,8 @@ def upgrade() -> None:
             ALTER COLUMN embedding TYPE vector(768)
             USING (
                 CASE
-                    WHEN embedding IS NULL OR embedding = '' THEN NULL
+                    WHEN embedding IS NULL THEN NULL
+                    WHEN NULLIF(regexp_replace(embedding, '\\s+', '', 'g'), '') IS NULL THEN NULL
                     ELSE regexp_replace(embedding, '\\s+', '', 'g')::vector(768)
                 END
             )

--- a/docs/orchestration/PGVECTOR_EMBEDDING_MIGRATION_BLOCKER_PACKET_2026-04-12.md
+++ b/docs/orchestration/PGVECTOR_EMBEDDING_MIGRATION_BLOCKER_PACKET_2026-04-12.md
@@ -1,0 +1,62 @@
+# PGVector Embedding Migration Blocker Packet
+
+Date: `2026-04-12`
+Lane: `coordinator-owned PostgreSQL migration blocker fix`
+Branch: `fix/pgvector-embedding-migration-blocker`
+
+## Summary
+
+Fix pre-existing PostgreSQL migration blocker in `202602280003_convert_embedding_to_vector768.py`.
+
+Current clean-room PostgreSQL `alembic upgrade head` fails before downstream revisions because
+the migration uses a subquery inside `ALTER TABLE ... ALTER COLUMN ... USING (...)`, which
+PostgreSQL rejects with `cannot use subquery in transform expression`.
+
+## Source Of Truth
+
+- Repo migration chain in `alembic/versions/`
+- Runtime / schema contracts already checked into repo
+- Local PostgreSQL execution proof
+
+## In Scope
+
+- Minimal fix inside `202602280003_convert_embedding_to_vector768.py`
+- Regression test for the migration DDL contract
+- Local validation proving PostgreSQL clean-room upgrade succeeds through current main head
+
+## Out Of Scope
+
+- No changes to downstream revisions unrelated to the blocker
+- No runtime RAG/schema redesign
+- No PR-A foods catalog edits in this lane
+- No deploy / OpenAPI / importer changes
+
+## Touched Files
+
+- `alembic/versions/202602280003_convert_embedding_to_vector768.py`
+- `tests/test_pgvector_embedding_migration.py`
+- `docs/orchestration/PGVECTOR_EMBEDDING_MIGRATION_BLOCKER_PACKET_2026-04-12.md`
+
+## Execution Order
+
+1. `agent-coordinator`
+2. `backend-engineer`
+3. `security-auditor`
+4. `qa-engineer-agent`
+5. `bug-hunter`
+6. `dev-operator`
+
+## Validation Plan
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `pytest -q tests/test_pgvector_embedding_migration.py`
+- local PostgreSQL clean-room `alembic upgrade head` on `pgvector/pgvector:pg16`
+- `pre-commit run --all-files`
+- `make verify`
+
+## Success Criteria
+
+- PostgreSQL no longer errors at revision `202602280003`
+- Clean-room PostgreSQL migration chain reaches current branch head
+- Regression test locks the migration away from subquery-based transform logic

--- a/docs/review/PR_1410_FIXED_MAPPING.md
+++ b/docs/review/PR_1410_FIXED_MAPPING.md
@@ -11,14 +11,13 @@ Bot and human review threads must be dispositioned here before they are resolved
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
-Commit: 25464f6047629e822e794c2df6b328d40f831d08
+Commit: 25464f6046de35b161fd9d88fd76c0486c857bdb
 Evidence: `alembic/versions/202602280003_convert_embedding_to_vector768.py:40`; `tests/test_pgvector_embedding_migration.py:16`
 Reason: The PostgreSQL migration now treats whitespace-only embeddings as `NULL` before the `vector(768)` cast, and the SQL-contract regression test now checks the full migration text with regex-based guards instead of depending on a brittle `op.execute(\"\"\")` split. This resolves the actionable whitespace-cast risk raised by CodeRabbit and the robustness concern raised by Sourcery.
-
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1410#pullrequestreview-4095824877 -> 25464f6047629e822e794c2df6b328d40f831d08
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1410#pullrequestreview-4095827966 -> 25464f6047629e822e794c2df6b328d40f831d08
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1410#discussion_r3070302806 -> 25464f6047629e822e794c2df6b328d40f831d08
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1410#discussion_r3070306140 -> 25464f6047629e822e794c2df6b328d40f831d08
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1410#pullrequestreview-4095824877 -> 25464f6046de35b161fd9d88fd76c0486c857bdb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1410#pullrequestreview-4095827966 -> 25464f6046de35b161fd9d88fd76c0486c857bdb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1410#discussion_r3070302806 -> 25464f6046de35b161fd9d88fd76c0486c857bdb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1410#discussion_r3070306140 -> 25464f6046de35b161fd9d88fd76c0486c857bdb
 
 ## Merge Readiness
 

--- a/docs/review/PR_1410_FIXED_MAPPING.md
+++ b/docs/review/PR_1410_FIXED_MAPPING.md
@@ -10,7 +10,15 @@ Bot and human review threads must be dispositioned here before they are resolved
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 25464f6047629e822e794c2df6b328d40f831d08
+Evidence: `alembic/versions/202602280003_convert_embedding_to_vector768.py:40`; `tests/test_pgvector_embedding_migration.py:16`
+Reason: The PostgreSQL migration now treats whitespace-only embeddings as `NULL` before the `vector(768)` cast, and the SQL-contract regression test now checks the full migration text with regex-based guards instead of depending on a brittle `op.execute(\"\"\")` split. This resolves the actionable whitespace-cast risk raised by CodeRabbit and the robustness concern raised by Sourcery.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1410#pullrequestreview-4095824877 -> 25464f6047629e822e794c2df6b328d40f831d08
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1410#pullrequestreview-4095827966 -> 25464f6047629e822e794c2df6b328d40f831d08
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1410#discussion_r3070302806 -> 25464f6047629e822e794c2df6b328d40f831d08
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1410#discussion_r3070306140 -> 25464f6047629e822e794c2df6b328d40f831d08
 
 ## Merge Readiness
 

--- a/docs/review/PR_1410_FIXED_MAPPING.md
+++ b/docs/review/PR_1410_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1410 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Bot and human review threads must be dispositioned here before they are resolved on GitHub.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+<!-- markdownlint-enable MD034 -->

--- a/tests/test_pgvector_embedding_migration.py
+++ b/tests/test_pgvector_embedding_migration.py
@@ -1,0 +1,23 @@
+"""Regression checks for the pgvector embedding conversion migration.
+
+RU: Фиксирует PostgreSQL-safe контракт для ревизии 202602280003.
+EN: Locks the PostgreSQL-safe contract for revision 202602280003.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_pgvector_embedding_migration_avoids_subquery_transform_expression() -> None:
+    """The migration must avoid subqueries inside ALTER COLUMN ... USING."""
+    repo_root = Path(__file__).resolve().parents[1]
+    migration_path = repo_root / "alembic/versions/202602280003_convert_embedding_to_vector768.py"
+    migration_text = migration_path.read_text(encoding="utf-8")
+    executable_sql = migration_text.split('op.execute("""', maxsplit=1)[1]
+
+    assert "ALTER TABLE user_knowledge" in migration_text
+    assert "ALTER COLUMN embedding TYPE vector(768)" in migration_text
+    assert "regexp_replace(embedding, '\\\\s+', '', 'g')::vector(768)" in executable_sql
+    assert "json_array_elements_text" not in executable_sql
+    assert "SELECT ('[' || string_agg" not in executable_sql

--- a/tests/test_pgvector_embedding_migration.py
+++ b/tests/test_pgvector_embedding_migration.py
@@ -7,6 +7,7 @@ EN: Locks the PostgreSQL-safe contract for revision 202602280003.
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 
 def test_pgvector_embedding_migration_avoids_subquery_transform_expression() -> None:
@@ -14,10 +15,19 @@ def test_pgvector_embedding_migration_avoids_subquery_transform_expression() -> 
     repo_root = Path(__file__).resolve().parents[1]
     migration_path = repo_root / "alembic/versions/202602280003_convert_embedding_to_vector768.py"
     migration_text = migration_path.read_text(encoding="utf-8")
-    executable_sql = migration_text.split('op.execute("""', maxsplit=1)[1]
+    normalized_cast_pattern = re.compile(
+        r"regexp_replace\(\s*embedding\s*,\s*'\\\\s\+'\s*,\s*''\s*,\s*'g'\s*\)\s*::\s*vector\(768\)",
+        re.MULTILINE,
+    )
+    normalized_null_guard_pattern = re.compile(
+        r"NULLIF\(\s*regexp_replace\(\s*embedding\s*,\s*'\\\\s\+'\s*,\s*''\s*,\s*'g'\s*\)\s*,\s*''\s*\)\s+IS\s+NULL",
+        re.MULTILINE,
+    )
 
     assert "ALTER TABLE user_knowledge" in migration_text
     assert "ALTER COLUMN embedding TYPE vector(768)" in migration_text
-    assert "regexp_replace(embedding, '\\\\s+', '', 'g')::vector(768)" in executable_sql
-    assert "json_array_elements_text" not in executable_sql
-    assert "SELECT ('[' || string_agg" not in executable_sql
+    assert migration_text.count('op.execute("""') >= 1
+    assert normalized_cast_pattern.search(migration_text)
+    assert normalized_null_guard_pattern.search(migration_text)
+    assert "json_array_elements_text" not in migration_text
+    assert "SELECT ('[' || string_agg" not in migration_text


### PR DESCRIPTION
## Summary
Fix PostgreSQL blocker in `202602280003_convert_embedding_to_vector768.py` so clean-room `alembic upgrade head` no longer fails before downstream revisions.

## Why
The existing migration used a subquery inside `ALTER TABLE ... ALTER COLUMN ... USING (...)`.
PostgreSQL rejects that shape with:
- `cannot use subquery in transform expression`

That failure blocks clean-room PostgreSQL migration validation for downstream work, including the foods catalog foundation lane.

## Scope
- patch revision `202602280003`
- replace unsupported subquery transform with PostgreSQL-safe direct cast path
- add regression test for the migration DDL contract
- add coordinator-owned blocker packet

## Non-goals
- no downstream migration rewrites
- no PR-A foods schema changes in this branch
- no runtime RAG redesign
- no deploy / OpenAPI / importer changes

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pytest -q tests/test_pgvector_embedding_migration.py`
- local PostgreSQL clean-room proof on `pgvector/pgvector:pg16`
- `pre-commit run --all-files`
- `make verify`

## PostgreSQL Proof
- Clean-room PostgreSQL `alembic upgrade head` now succeeds through current main head.
- Verified local result:
  - `alembic_version = 202604060001`
  - `user_knowledge.embedding_type = vector`
- Raw local evidence:
  - `artifacts/agent_runs/pgvector_embedding_migration_blocker_postgres_proof_2026-04-12.txt`

## Unblocks
- repo-wide PostgreSQL migration chain
- follow-on undraft path for PR-A foods catalog foundation once this blocker is merged or otherwise incorporated

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- No actionable review comments

## Merge Readiness

- [ ] Current-head CI green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`

## Summary by Sourcery

Устранить блокирующую проблему миграции PostgreSQL в ревизии конвертации в pgvector embeddings и задокументировать и протестировать новый, безопасный для PostgreSQL подход.

Исправления ошибок:
- Заменить неподдерживаемое преобразование на основе подзапроса в миграции pgvector embeddings на безопасное для PostgreSQL прямое приведение типов для текста embeddings с нормализованными пробелами.

Документация:
- Добавить принадлежащий координатору пакет-блокер, документирующий проблему миграции pgvector embeddings, её охват, план валидации и критерии успешности.
- Добавить привязанный к PR документ соответствия «исправлено-в-коммите» для отслеживания веток обсуждения и готовности к слиянию.

Тесты:
- Добавить регрессионный тест, который фиксирует миграцию pgvector embeddings на безопасное для PostgreSQL выражение `ALTER COLUMN USING` и защищает от повторного внедрения преобразований на основе подзапросов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve a PostgreSQL migration blocker in the pgvector embedding conversion revision and document and test the new, PostgreSQL-safe approach.

Bug Fixes:
- Replace the unsupported subquery-based transform in the pgvector embedding migration with a PostgreSQL-safe direct cast on whitespace-normalized embedding text.

Documentation:
- Add a coordinator-owned blocker packet documenting the pgvector embedding migration issue, its scope, validation plan, and success criteria.
- Add a PR-specific fixed-in-commit mapping document to track discussion threads and merge readiness.

Tests:
- Introduce a regression test that locks the pgvector embedding migration to a PostgreSQL-safe ALTER COLUMN USING expression and guards against reintroducing subquery-based transforms.

</details>

Исправления ошибок:
- Заменить неподдерживаемое выражение преобразования на основе подзапроса PostgreSQL в миграции встраиваний на прямое приведение с нормализацией пробелов к типу `vector(768)`.

Документация:
- Добавить блокирующий пакет, управляемый координатором, документирующий проблему миграции встраиваний pgvector, её область действия, валидацию и критерии успеха.

Тесты:
- Добавить регрессионный тест, который закрепляет миграцию встраиваний pgvector на PostgreSQL‑безопасном выражении `ALTER COLUMN USING` и защищает от повторного внесения преобразований на основе подзапросов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Устранить блокирующую проблему миграции PostgreSQL в ревизии конвертации в pgvector embeddings и задокументировать и протестировать новый, безопасный для PostgreSQL подход.

Исправления ошибок:
- Заменить неподдерживаемое преобразование на основе подзапроса в миграции pgvector embeddings на безопасное для PostgreSQL прямое приведение типов для текста embeddings с нормализованными пробелами.

Документация:
- Добавить принадлежащий координатору пакет-блокер, документирующий проблему миграции pgvector embeddings, её охват, план валидации и критерии успешности.
- Добавить привязанный к PR документ соответствия «исправлено-в-коммите» для отслеживания веток обсуждения и готовности к слиянию.

Тесты:
- Добавить регрессионный тест, который фиксирует миграцию pgvector embeddings на безопасное для PostgreSQL выражение `ALTER COLUMN USING` и защищает от повторного внедрения преобразований на основе подзапросов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve a PostgreSQL migration blocker in the pgvector embedding conversion revision and document and test the new, PostgreSQL-safe approach.

Bug Fixes:
- Replace the unsupported subquery-based transform in the pgvector embedding migration with a PostgreSQL-safe direct cast on whitespace-normalized embedding text.

Documentation:
- Add a coordinator-owned blocker packet documenting the pgvector embedding migration issue, its scope, validation plan, and success criteria.
- Add a PR-specific fixed-in-commit mapping document to track discussion threads and merge readiness.

Tests:
- Introduce a regression test that locks the pgvector embedding migration to a PostgreSQL-safe ALTER COLUMN USING expression and guards against reintroducing subquery-based transforms.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a PostgreSQL migration blocker by replacing the unsupported subquery in ALTER COLUMN ... USING with a whitespace-normalized, NULL-safe cast. Clean-room `alembic upgrade head` now completes and unblocks downstream migrations.

- **Bug Fixes**
  - Replaced the subquery transform with `regexp_replace(embedding, '\s+', '', 'g')::vector(768)`.
  - Treated NULL and whitespace-only embeddings as NULL before the cast.
  - Added a regression test to lock the SQL contract and forbid subqueries; updated the blocker packet and normalized the PR 1410 fixed-in-commit mapping.

<sup>Written for commit 053348cd70f8519ac92eccacf77b25e1ab7e1fda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database migration updated to reliably convert stored embeddings and safely handle empty/null values, preventing prior migration failures.

* **Tests**
  * Added a regression test that verifies the migration uses the safe transformation and avoids previously problematic constructs.

* **Documentation**
  * Added an orchestration blocker packet and a PR review checklist documenting validation, rollout steps, and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->