### PR TITLE
fix(ci): stabilize nightly tests and security scan

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,12 +30,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.13'
-          cache: 'pip'
-
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -44,10 +38,15 @@ jobs:
             build-essential \
             python3-dev
 
-      - name: Install Python dependencies
-        run: |
-          python scripts/ci/install_locked_python_requirements.py --python-executable python --constraints-file constraints.txt --install-dev
-          pip list
+      - name: Setup Python environment
+        uses: ./.github/actions/python-setup
+        with:
+          python-version: '3.13'
+          requirements-profile: runtime-dev
+          install-mode: direct-proxy
+
+      - name: Show installed Python packages
+        run: pip list
 
       - name: Run linting
         if: matrix.shard_id == 1  # Run once (shard 1 only) - codebase-wide check
@@ -258,15 +257,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - name: Setup Python environment
+        uses: ./.github/actions/python-setup
         with:
           python-version: '3.13'
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: |
-          python scripts/ci/install_locked_python_requirements.py --python-executable python --constraints-file constraints.txt --install-dev
+          requirements-profile: runtime-dev
+          install-mode: direct-proxy
 
       - name: Run performance tests
         env:
@@ -311,22 +307,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - name: Setup Python environment
+        uses: ./.github/actions/python-setup
         with:
           python-version: '3.13'
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: |
-          set -euo pipefail
-          : "${PULSEPLATE_PYTHON_INDEX_URL:?Set PULSEPLATE_PYTHON_INDEX_URL to the approved private package proxy URL.}"
-          pip_index_args=(--index-url "$PULSEPLATE_PYTHON_INDEX_URL")
-          if [[ -n "${PULSEPLATE_PYTHON_TRUSTED_HOST:-}" ]]; then
-            pip_index_args+=(--trusted-host "$PULSEPLATE_PYTHON_TRUSTED_HOST")
-          fi
-          python scripts/ci/install_locked_python_requirements.py --python-executable python --constraints-file constraints.txt --install-dev
-          python -m pip install "${pip_index_args[@]}" psycopg2-binary -c constraints.txt
+          requirements-profile: runtime-dev
+          install-mode: direct-proxy
 
       - name: Run integration tests
         env:
@@ -385,11 +371,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - name: Setup Python environment
+        uses: ./.github/actions/python-setup
         with:
           python-version: '3.13'
-          cache: 'pip'
+          requirements-profile: runtime-dev
+          install-mode: direct-proxy
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.6.2
@@ -421,17 +408,6 @@ jobs:
             echo "ERROR: Expected ${expected_count} binary .coverage data files, found ${file_count}."
             exit 1
           fi
-
-      - name: Install coverage
-        run: |
-          set -euo pipefail
-          : "${PULSEPLATE_PYTHON_INDEX_URL:?Set PULSEPLATE_PYTHON_INDEX_URL to the approved private package proxy URL.}"
-          pip_index_args=(--index-url "$PULSEPLATE_PYTHON_INDEX_URL")
-          if [[ -n "${PULSEPLATE_PYTHON_TRUSTED_HOST:-}" ]]; then
-            pip_index_args+=(--trusted-host "$PULSEPLATE_PYTHON_TRUSTED_HOST")
-          fi
-          python -m pip install "${pip_index_args[@]}" --upgrade pip
-          python -m pip install "${pip_index_args[@]}" coverage -c constraints.txt
 
       - name: Combine coverage and generate report
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,6 +46,7 @@ jobs:
           install-mode: direct-proxy
 
       - name: Show installed Python packages
+        if: matrix.shard_id == 1
         run: pip list
 
       - name: Run linting

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,7 +40,7 @@ jobs:
           if [[ -n "${PULSEPLATE_PYTHON_TRUSTED_HOST:-}" ]]; then
             pip_index_args+=(--trusted-host "$PULSEPLATE_PYTHON_TRUSTED_HOST")
           fi
-          python -m pip install "${pip_index_args[@]}" "safety>=3.7.0" -c constraints.txt
+          python -m pip install "${pip_index_args[@]}" "bandit==1.8.6" "safety>=3.7.0" -c constraints.txt
           if ! command -v jq >/dev/null 2>&1; then
             sudo apt-get update
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends jq

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,14 +25,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
-      - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+      - name: Setup Python environment
+        uses: ./.github/actions/python-setup
         with:
-          python-version-file: .python-version
-          cache: pip
-          cache-dependency-path: |
-            requirements.txt
-            requirements-dev.txt
+          python-version: '3.13.6'
+          requirements-profile: ci-lite
+          install-mode: direct-proxy
 
       - name: Install security tooling
         run: |
@@ -42,8 +40,7 @@ jobs:
           if [[ -n "${PULSEPLATE_PYTHON_TRUSTED_HOST:-}" ]]; then
             pip_index_args+=(--trusted-host "$PULSEPLATE_PYTHON_TRUSTED_HOST")
           fi
-          python -m pip install "${pip_index_args[@]}" --upgrade pip
-          python -m pip install "${pip_index_args[@]}" bandit==1.8.6 "safety>=3.7.0" -c constraints.txt
+          python -m pip install "${pip_index_args[@]}" "safety>=3.7.0" -c constraints.txt
           if ! command -v jq >/dev/null 2>&1; then
             sudo apt-get update
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends jq
@@ -97,13 +94,6 @@ jobs:
       - name: Run Safety (dependency audit with policy)
         run: |
           set -eo pipefail
-          : "${PULSEPLATE_PYTHON_INDEX_URL:?Set PULSEPLATE_PYTHON_INDEX_URL to the approved private package proxy URL.}"
-          pip_index_args=(--index-url "$PULSEPLATE_PYTHON_INDEX_URL")
-          if [[ -n "${PULSEPLATE_PYTHON_TRUSTED_HOST:-}" ]]; then
-            pip_index_args+=(--trusted-host "$PULSEPLATE_PYTHON_TRUSTED_HOST")
-          fi
-
-          python -m pip install "${pip_index_args[@]}" --upgrade pip setuptools wheel
 
           if [ ! -f requirements.txt ]; then
             echo "❌ ERROR: requirements.txt not found. Safety scan requires requirements.txt to be present."

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -182,14 +182,14 @@
         "filename": ".github/workflows/nightly.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 300
+        "line_number": 296
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/nightly.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 334
+        "line_number": 320
       }
     ],
     "conftest.py": [
@@ -1576,5 +1576,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-12T18:33:37Z"
+  "generated_at": "2026-04-13T08:33:35Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -182,14 +182,14 @@
         "filename": ".github/workflows/nightly.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 296
+        "line_number": 297
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/nightly.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 320
+        "line_number": 321
       }
     ],
     "conftest.py": [
@@ -1576,5 +1576,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-13T08:33:35Z"
+  "generated_at": "2026-04-13T11:30:39Z"
 }

--- a/docs/review/PR_1412_FIXED_MAPPING.md
+++ b/docs/review/PR_1412_FIXED_MAPPING.md
@@ -25,6 +25,10 @@ Disposition: NOT-A-BUG
 Reason: The review contains advisory suggestions, not a correctness or policy violation. The security workflow intentionally pins `python-version: '3.13.6'` to match the scheduled audit baseline in `.github/workflows/security.yml`, while nightly jobs keep `python-version: '3.13'` in `.github/workflows/nightly.yml` because that lane is normalized onto the existing runtime-dev CI surface rather than a separate patch-pinned audit baseline.
 Evidence: `tests/test_python_supply_chain_controls.py:221` checks the scheduled security lane stays on `ci-lite` with `python-version == "3.13.6"`, and `tests/test_python_supply_chain_controls.py:244` separately locks nightly jobs to the canonical `runtime-dev` path with `python-version == "3.13"`. The install-step assertion is already scoped to the key command contract (`"safety>=3.7.0"` through constrained proxy bootstrap) rather than the full workflow body.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1412#pullrequestreview-4098315589 -> 94a1cc3c7
+Disposition: FIXED
+Evidence: `94a1cc3c7` restores explicit `Bandit 1.8.6` installation in `.github/workflows/security.yml`, gates nightly `pip list` to `matrix.shard_id == 1` in `.github/workflows/nightly.yml`, and removes the duplicate `_python_setup_step` helper from `tests/test_python_supply_chain_controls.py`.
+
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head

--- a/docs/review/PR_1412_FIXED_MAPPING.md
+++ b/docs/review/PR_1412_FIXED_MAPPING.md
@@ -10,7 +10,15 @@ Bot and human review threads must be dispositioned here before they are resolved
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1412#issuecomment-4235534880
+Disposition: NOT-A-BUG
+Reason: QA lane summary comment records a clean review of the changed workflow/test surfaces and does not request a code or docs change.
+Evidence: The comment confirms `pytest -q tests/test_python_supply_chain_controls.py`, `pre-commit run --all-files`, and `make verify` all passed in the stabilization worktree.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1412#issuecomment-4235534998
+Disposition: NOT-A-BUG
+Reason: Bug-hunter lane summary comment records no new failure-mode regressions and does not request a code or docs change.
+Evidence: The comment confirms bootstrap parity, approved proxy preservation, pinned tool availability, and `.secrets.baseline` metadata-only churn.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1412_FIXED_MAPPING.md
+++ b/docs/review/PR_1412_FIXED_MAPPING.md
@@ -20,6 +20,11 @@ Disposition: NOT-A-BUG
 Reason: Bug-hunter lane summary comment records no new failure-mode regressions and does not request a code or docs change.
 Evidence: The comment confirms bootstrap parity, approved proxy preservation, pinned tool availability, and `.secrets.baseline` metadata-only churn.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1412#pullrequestreview-4098291639
+Disposition: NOT-A-BUG
+Reason: The review contains advisory suggestions, not a correctness or policy violation. The security workflow intentionally pins `python-version: '3.13.6'` to match the scheduled audit baseline in `.github/workflows/security.yml`, while nightly jobs keep `python-version: '3.13'` in `.github/workflows/nightly.yml` because that lane is normalized onto the existing runtime-dev CI surface rather than a separate patch-pinned audit baseline.
+Evidence: `tests/test_python_supply_chain_controls.py:221` checks the scheduled security lane stays on `ci-lite` with `python-version == "3.13.6"`, and `tests/test_python_supply_chain_controls.py:244` separately locks nightly jobs to the canonical `runtime-dev` path with `python-version == "3.13"`. The install-step assertion is already scoped to the key command contract (`"safety>=3.7.0"` through constrained proxy bootstrap) rather than the full workflow body.
+
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head

--- a/docs/review/PR_1412_FIXED_MAPPING.md
+++ b/docs/review/PR_1412_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1412 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+Bot and human review threads must be dispositioned here before they are resolved on GitHub.
+
+## Fixed in Commit Mapping
+
+- Pending post-open review lane (`qa-engineer-agent -> bug-hunter`) and GitHub review feedback.
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1412_FIXED_MAPPING.md
+++ b/docs/review/PR_1412_FIXED_MAPPING.md
@@ -27,6 +27,7 @@ Evidence: `tests/test_python_supply_chain_controls.py:221` checks the scheduled 
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1412#pullrequestreview-4098315589 -> 94a1cc3c7
 Disposition: FIXED
+Commit: 94a1cc3c7
 Evidence: `94a1cc3c7` restores explicit `Bandit 1.8.6` installation in `.github/workflows/security.yml`, gates nightly `pip list` to `matrix.shard_id == 1` in `.github/workflows/nightly.yml`, and removes the duplicate `_python_setup_step` helper from `tests/test_python_supply_chain_controls.py`.
 
 ## Merge Readiness

--- a/docs/review/PR_1412_FIXED_MAPPING.md
+++ b/docs/review/PR_1412_FIXED_MAPPING.md
@@ -3,14 +3,14 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 Bot and human review threads must be dispositioned here before they are resolved on GitHub.
 
 ## Fixed in Commit Mapping
 
-- Pending post-open review lane (`qa-engineer-agent -> bug-hunter`) and GitHub review feedback.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -231,11 +231,10 @@ def test_security_scan_workflow_uses_ci_lite_direct_proxy_setup() -> None:
         if step.get("name") == "Install security tooling"
     )
     install_script = install_step["run"]
-    assert "bandit==" not in install_script
-    assert (
-        'python -m pip install "${pip_index_args[@]}" "safety>=3.7.0" -c constraints.txt'
-        in install_script
-    )
+    assert '"bandit==1.8.6"' in install_script
+    assert '"safety>=3.7.0"' in install_script
+    assert 'python -m pip install "${pip_index_args[@]}"' in install_script
+    assert "-c constraints.txt" in install_script
 
 
 @pytest.mark.parametrize(
@@ -262,13 +261,6 @@ def test_ci_workflow_uses_single_direct_proxy_python_install_path_per_job() -> N
     )
     jobs = ci_workflow["jobs"]
 
-    def _python_setup_step(job_name: str) -> dict[str, object]:
-        steps = jobs[job_name]["steps"]
-        for step in steps:
-            if step.get("uses") == "./.github/actions/python-setup":
-                return step
-        raise AssertionError(f"Missing python-setup step for job: {job_name}")
-
     direct_proxy_jobs = (
         "lint",
         "security",
@@ -279,16 +271,16 @@ def test_ci_workflow_uses_single_direct_proxy_python_install_path_per_job() -> N
         "test-main",
     )
     for job_name in direct_proxy_jobs:
-        setup_step = _python_setup_step(job_name)
+        setup_step = _python_setup_step(".github/workflows/ci.yml", job_name)
         assert setup_step["with"]["install-mode"] == "direct-proxy"
 
     for job_name in ("lint", "security", "openapi-sync", "diff-coverage"):
-        setup_step = _python_setup_step(job_name)
+        setup_step = _python_setup_step(".github/workflows/ci.yml", job_name)
         assert setup_step["with"]["requirements-profile"] == "ci-lite"
         assert "install-dev-deps" not in setup_step["with"]
 
     for job_name in ("test-pr", "test-feature", "test-main"):
-        setup_step = _python_setup_step(job_name)
+        setup_step = _python_setup_step(".github/workflows/ci.yml", job_name)
         assert setup_step["with"]["requirements-profile"] == "runtime-test"
         assert "install-test-deps" not in setup_step["with"]
         assert all(step.get("name") != "Install dependencies" for step in jobs[job_name]["steps"])

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -35,6 +35,25 @@ APPROVED_TRUSTED_HOST_EXPRESSION = (
 PIP_INSTALL_PATTERN = re.compile(r"\b\S*python\S*\s+-m\s+pip\s+install\b")
 
 
+def _load_workflow(path: str) -> dict[str, object]:
+    """Load a GitHub Actions workflow as structured YAML."""
+    return yaml.safe_load((REPO_ROOT / path).read_text(encoding="utf-8"))
+
+
+def _workflow_steps(path: str, job_name: str) -> list[dict[str, object]]:
+    """Return workflow steps for a specific job."""
+    workflow = _load_workflow(path)
+    return workflow["jobs"][job_name]["steps"]
+
+
+def _python_setup_step(path: str, job_name: str) -> dict[str, object]:
+    """Return the canonical python-setup step for a workflow job."""
+    for step in _workflow_steps(path, job_name):
+        if step.get("uses") == "./.github/actions/python-setup":
+            return step
+    raise AssertionError(f"Missing python-setup step for {path}:{job_name}")
+
+
 def test_dependency_security_schema_blocks_known_bad_litellm_versions() -> None:
     schema = json.loads(
         (REPO_ROOT / "tests" / "fixtures" / "dependency_security_schema.json").read_text(
@@ -197,6 +216,42 @@ def test_no_canonical_workflow_uses_unscoped_public_pip_install() -> None:
                 continue
             context = "\n".join(lines[max(0, index - 6) : index + 1])
             assert "PULSEPLATE_PYTHON_INDEX_URL" in context
+
+
+def test_security_scan_workflow_uses_ci_lite_direct_proxy_setup() -> None:
+    setup_step = _python_setup_step(".github/workflows/security.yml", "bandit")
+
+    assert setup_step["with"]["python-version"] == "3.13.6"
+    assert setup_step["with"]["requirements-profile"] == "ci-lite"
+    assert setup_step["with"]["install-mode"] == "direct-proxy"
+
+    install_step = next(
+        step
+        for step in _workflow_steps(".github/workflows/security.yml", "bandit")
+        if step.get("name") == "Install security tooling"
+    )
+    install_script = install_step["run"]
+    assert "bandit==" not in install_script
+    assert (
+        'python -m pip install "${pip_index_args[@]}" "safety>=3.7.0" -c constraints.txt'
+        in install_script
+    )
+
+
+@pytest.mark.parametrize(
+    "job_name", ("test", "performance-test", "integration-test", "coverage-merge")
+)
+def test_nightly_workflow_jobs_use_runtime_dev_direct_proxy_setup(job_name: str) -> None:
+    setup_step = _python_setup_step(".github/workflows/nightly.yml", job_name)
+
+    assert setup_step["with"]["python-version"] == "3.13"
+    assert setup_step["with"]["requirements-profile"] == "runtime-dev"
+    assert setup_step["with"]["install-mode"] == "direct-proxy"
+
+    assert all(
+        "install_locked_python_requirements.py" not in step.get("run", "")
+        for step in _workflow_steps(".github/workflows/nightly.yml", job_name)
+    )
 
 
 def test_ci_workflow_uses_single_direct_proxy_python_install_path_per_job() -> None:


### PR DESCRIPTION
## Summary
- stabilize scheduled `Nightly Tests` and `Security Scan` on `main` commit `4702ed252f2d8f893e80d1be3baaf57cf8f18faf`
- normalize `.github/workflows/nightly.yml` and `.github/workflows/security.yml` onto the canonical `./.github/actions/python-setup` bootstrap path
- preserve the approved private proxy contract and keep Bandit/Safety report semantics unchanged

## Scope
- `.github/workflows/security.yml`
- `.github/workflows/nightly.yml`
- `tests/test_python_supply_chain_controls.py`
- `docs/review/PR_1412_FIXED_MAPPING.md`
- `.secrets.baseline`

## Lane
- Tier 1 CI/CD coordinator-owned stabilization lane
- post-open review lane: `qa-engineer-agent -> bug-hunter`
- canonical review artifact: `docs/review/PR_1412_FIXED_MAPPING.md`

## Validation
- `python3 scripts/orchestration/check_preflight.py` — passed
- `python3 scripts/orchestration/check_agent_consistency.py` — passed
- `pytest -q tests/test_python_supply_chain_controls.py` — passed (`29 passed`)
- `pre-commit run --all-files` — passed
- `make verify` — passed

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1412#issuecomment-4235534880
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1412#issuecomment-4235534998
- Canonical SoT: `docs/review/PR_1412_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Current-head CI green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`

## Summary by Sourcery

Нормализовать nightly и security GitHub Actions workflow, переведя их на общий action `python-setup`, при этом сохранить одобренное использование прокси и поведение security-сканов.

CI:
- Обновить задания nightly workflow так, чтобы они использовали общий action `python-setup` с конфигурацией `runtime-dev` с прямым прокси вместо разрозненной настройки и установки Python.
- Обновить workflow security-сканов для использования общего action `python-setup` с конфигурацией `ci-lite` с прямым прокси и упростить шаги установки Bandit/Safety.

Документация:
- Добавить документ сопоставления `fixed-in-commit`, фиксирующий результаты обсуждений в review-тредах и чек-лист готовности к слиянию для этого PR.

Тесты:
- Расширить тесты контроля цепочки поставок (supply-chain control tests), чтобы проверять, что nightly и security workflow используют каноническую конфигурацию `python-setup` и избегают устаревших путей установки.

Служебные задачи:
- Обновить файл с baseline для секретов без функционального влияния.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize nightly and security GitHub Actions workflows onto the shared python-setup action while preserving approved proxy usage and security scan behavior.

CI:
- Update nightly workflow jobs to use the shared python-setup action with runtime-dev direct-proxy configuration instead of ad-hoc Python setup and installs.
- Update security scan workflow to use the shared python-setup action with a ci-lite direct-proxy configuration and simplify Bandit/Safety installation steps.

Documentation:
- Add a fixed-in-commit mapping document capturing review thread dispositions and merge readiness checklist for this PR.

Tests:
- Extend supply-chain control tests to assert the nightly and security workflows use the canonical python-setup configuration and avoid legacy install paths.

Chores:
- Refresh the secrets baseline file without functional impact.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now uses a repo-local centralized Python setup; nightly jobs use Python 3.13 and security uses Python 3.13.6 with a standardized direct-proxy install mode.
  * Removed per-job pip index/trusted-host plumbing and local dependency-install scripts; security job installs Bandit and Safety with pinned/constrainted versions without bootstrapping build tooling.
  * Updated secrets baseline timestamps/line mappings.
* **Tests**
  * Added shared test helpers and assertions to validate CI Python setup, install-mode, and security-tooling configuration; pip listing is limited to a single shard.
* **Documentation**
  * Added PR review summary documenting dispositions, fixed mappings, and merge readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->