### PR TITLE
feat(data): promote offline foods snapshot into PostgreSQL foods

### DIFF
--- a/docs/orchestration/FOODS_POSTGRES_PROMOTION_PR_B1_TASK_PACKET_2026-04-13.md
+++ b/docs/orchestration/FOODS_POSTGRES_PROMOTION_PR_B1_TASK_PACKET_2026-04-13.md
@@ -1,0 +1,126 @@
+# Foods PostgreSQL Promotion PR-B1 Task Packet
+
+**Effective date:** 2026-04-13 (`America/New_York`)
+**Status:** Active execution packet
+**Mode:** coordinator-owned backend/data promotion lane
+
+## Goal
+
+Land one narrow offline promotion lane that copies the existing SQLite foods
+snapshot into PostgreSQL `foods` without widening scope into schema redesign,
+runtime cutover, or restaurant importer rewiring.
+
+## Relationship to the Follow-Through Train
+
+- This packet owns only **PR-B1**.
+- The execution train is fixed as:
+  - `PR-B1`: foods snapshot promotion into PostgreSQL `foods`
+  - `ledger-p0-self-hosted-postgres-droplet-foundation`
+  - `PR-B2`: restaurant relational bridge
+  - `B3` deferred: runtime read-switch / cutover
+- `PR-B2` must not start execution until the infra blocker closes on `main`.
+
+## Source of Truth
+
+- Repo code remains the final source of truth for vocabulary and compatibility
+  boundaries.
+- The source/target contract for this lane must stay grounded in:
+  - `alembic/versions/202604120001_add_foods_catalog_foundation.py`
+  - `app/services/food_store.py`
+  - `scripts/build_food_db.py`
+  - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-postgres-foundation-followthrough`
+  - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p0-self-hosted-postgres-droplet-foundation`
+
+## PR Metadata
+
+- Branch: `feat/pr-b1-foods-offline-etl-postgres`
+- PR title: `feat(data): promote offline foods snapshot into PostgreSQL foods`
+- Merge method: **merge commit** via `gh pr merge --merge --delete-branch`
+
+## In Scope
+
+- Add one offline promotion script:
+  - `scripts/promote_foods_snapshot_to_postgres.py`
+- Add deterministic tests for promotion behavior:
+  - `tests/test_promote_foods_snapshot_to_postgres.py`
+  - optional integration coverage when a PostgreSQL path is available
+- Promote only `data/food.sqlite::foods` into PostgreSQL `foods`
+- Use deterministic `id`-based upsert and a fixed column allowlist aligned to
+  Alembic revision `202604120001`
+- Validate and transfer JSON-shaped fields deterministically:
+  - `flags`
+  - `nutrition_inputs_json`
+  - `nutrition_provenance_json`
+  - `nutrition_nutrient_confidence_json`
+- Emit a promotion summary/report under gitignored `artifacts/`
+
+## Out of Scope
+
+- No new Alembic revision and no schema redesign
+- No changes to `core/models.py`
+- No runtime cutover or read-switch from SQLite/local-first behavior
+- No rewiring of `scripts/import_restaurant_menu.py`
+- No changes to `app/services/restaurant_store.py`
+- No API/OpenAPI, deploy, Meilisearch, vector, or feature-flag changes
+- No direct execution of `PR-B2`
+
+## Touched Files
+
+- `docs/roadmap/BACKLOG_LEDGER.md`
+- `docs/orchestration/FOODS_POSTGRES_PROMOTION_PR_B1_TASK_PACKET_2026-04-13.md`
+- `scripts/promote_foods_snapshot_to_postgres.py`
+- `tests/test_promote_foods_snapshot_to_postgres.py`
+- optional: `docs/runbooks/FOODS_POSTGRES_PROMOTION.md`
+
+## Role Order
+
+1. `agent-coordinator`
+2. `backend-engineer`
+3. `security-auditor`
+4. `qa-engineer-agent`
+5. `bug-hunter`
+6. `dev-operator`
+
+Mandatory post-open review lane remains: `qa-engineer-agent -> bug-hunter`.
+
+## Lifecycle Notes
+
+- Before edits:
+  - `python3 scripts/orchestration/check_preflight.py`
+  - `python3 scripts/orchestration/check_agent_consistency.py`
+- Pre-open bootstrap:
+  - `python3 scripts/orchestration/task_bootstrap.py --goal "<B1 goal>" --task-class backend --path scripts/promote_foods_snapshot_to_postgres.py --path scripts/build_food_db.py --path app/services/food_store.py --path tests/test_promote_foods_snapshot_to_postgres.py --pr-phase pre_open`
+- Open as **draft PR** after local stabilization and packet scope lock.
+- Immediately after opening the PR:
+  - create canonical artifact `docs/review/PR_<N>_FIXED_MAPPING.md`
+  - run post-open synthesis with `--pr-phase post_open_review`
+- Current-head merge verdict is canonical only through:
+  - `python3 scripts/orchestration/check_merge_ready.py --pr-number <N> --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`
+- Post-merge cleanup for this lane:
+  - `git checkout main`
+  - `git fetch --prune origin`
+  - `git merge --ff-only origin/main`
+  - remove only lane-specific worktree, local branch, and gitignored local artifacts
+
+## Validation Plan
+
+- Targeted tests:
+  - `pytest -q tests/test_promote_foods_snapshot_to_postgres.py`
+- Full local gates before undraft:
+  - `pre-commit run --all-files`
+  - `make verify`
+- Conditional PostgreSQL proof when target DB is available:
+  - run the promotion script against a PostgreSQL path with existing `foods`
+  - confirm idempotent rerun behavior
+  - confirm deterministic report output in `artifacts/`
+
+## Acceptance Criteria
+
+- The source contract is fixed to `data/food.sqlite::foods`
+- The target contract is fixed to PostgreSQL `foods`
+- Missing source table fails closed
+- Missing target table fails closed
+- Promotion uses deterministic `ON CONFLICT(id)` upsert semantics
+- JSON-shaped fields are validated and preserved deterministically
+- The lane introduces no runtime/importer/schema/OpenAPI drift
+- `PR-B2` remains blocked on the self-hosted Droplet foundation closeout

--- a/docs/review/PR_1413_FIXED_MAPPING.md
+++ b/docs/review/PR_1413_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1413 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+Bot and human review threads must be dispositioned here before they are resolved on GitHub.
+
+## Fixed in Commit Mapping
+
+No review threads are dispositioned yet.
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1413_FIXED_MAPPING.md
+++ b/docs/review/PR_1413_FIXED_MAPPING.md
@@ -3,14 +3,14 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 Bot and human review threads must be dispositioned here before they are resolved on GitHub.
 
 ## Fixed in Commit Mapping
 
-No review threads are dispositioned yet.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1413_FIXED_MAPPING.md
+++ b/docs/review/PR_1413_FIXED_MAPPING.md
@@ -10,7 +10,38 @@ Bot and human review threads must be dispositioned here before they are resolved
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: ddd15df92
+Evidence: `scripts/promote_foods_snapshot_to_postgres.py:68`; `scripts/promote_foods_snapshot_to_postgres.py:71`; `scripts/promote_foods_snapshot_to_postgres.py:85`; `scripts/promote_foods_snapshot_to_postgres.py:194`; `tests/test_promote_foods_snapshot_to_postgres.py:215`; `tests/test_promote_foods_snapshot_to_postgres.py:246`; `tests/test_promote_foods_snapshot_to_postgres.py:493`; `tests/test_promote_foods_snapshot_to_postgres.py:545`
+Reason: The follow-up commit removes the deprecated SQLAlchemy `future=True` engine argument, drops the dead first definition of `REQUIRED_SOURCE_COLUMNS`, aligns the integration fixtures with the actual `nutrition_inputs_json -> list` contract, and tightens the CLI success assertion to the real `main() -> int` behavior. The false-negative fixture issue was also identified by cubic.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1413#pullrequestreview-4099306933 -> ddd15df92
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1413#pullrequestreview-4099333522 -> ddd15df92
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1413#discussion_r3073551798 -> ddd15df92
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1413#discussion_r3073556736 -> ddd15df92
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1413#discussion_r3073581105 -> ddd15df92
+
+Disposition: NOT-A-BUG
+Evidence: `scripts/promote_foods_snapshot_to_postgres.py:116`; `scripts/promote_foods_snapshot_to_postgres.py:125`; `scripts/promote_foods_snapshot_to_postgres.py:126`; `tests/test_promote_foods_snapshot_to_postgres.py:477`; `tests/test_promote_foods_snapshot_to_postgres.py:628`
+Reason: The aggregate Sourcery summary is fully triaged by the thread-level entries below. The only real regression it surfaced was the fixture-type mismatch already fixed in `ddd15df92`; the remaining items in that summary are compatibility or enhancement suggestions, so the summary URL itself does not represent an additional unresolved defect.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1413#pullrequestreview-4099299619
+
+Disposition: NOT-A-BUG
+Evidence: `scripts/promote_foods_snapshot_to_postgres.py:116`; `scripts/promote_foods_snapshot_to_postgres.py:125`; `scripts/promote_foods_snapshot_to_postgres.py:126`; `tests/test_promote_foods_snapshot_to_postgres.py:477`
+Reason: The report intentionally keeps both `checksum` and `source_checksum` during the B1 promotion lane to preserve additive compatibility for local artifact consumers while still exposing `checksum` as the canonical field checked by the tests. Removing the alias here would widen the output contract for a non-runtime helper beyond the packet's narrow scope.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1413#discussion_r3073549993
+
+Disposition: NOT-A-BUG
+Evidence: `scripts/promote_foods_snapshot_to_postgres.py:85`; `scripts/promote_foods_snapshot_to_postgres.py:205`; `scripts/promote_foods_snapshot_to_postgres.py:214`; `scripts/promote_foods_snapshot_to_postgres.py:242`; `tests/test_promote_foods_snapshot_to_postgres.py:635`; `tests/test_promote_foods_snapshot_to_postgres.py:670`; `tests/test_promote_foods_snapshot_to_postgres.py:721`
+Reason: These comments request extra coverage, not a correctness fix. The current lane already fails closed on missing `foods`, missing required source columns, malformed JSON, and legacy snapshots without optional JSON columns; the suggested empty-snapshot, wrong-container-shape, and missing-required-column additions are valid future hardening ideas but do not indicate that the current implementation is incorrect.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1413#discussion_r3073550005
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1413#discussion_r3073550015
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1413#discussion_r3073550032
+
+Disposition: NOT-A-BUG
+Evidence: `scripts/promote_foods_snapshot_to_postgres.py:29`; `scripts/promote_foods_snapshot_to_postgres.py:35`; `scripts/promote_foods_snapshot_to_postgres.py:205`; `scripts/promote_foods_snapshot_to_postgres.py:287`; `docs/orchestration/FOODS_POSTGRES_PROMOTION_PR_B1_TASK_PACKET_2026-04-13.md:40`
+Reason: The flagged SQL strings interpolate only repo-owned constants (`SOURCE_TABLE_NAME = "foods"`, `CHECKSUM_SORT_KEY = "id"`) inside a packet that fixes the source contract to `data/food.sqlite::foods`. There is no user-controlled identifier or query fragment here, so the opengrep SQL-injection heuristic is a false positive for this offline promotion helper.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1413#discussion_r3073550045
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1413#discussion_r3073550050
 
 ## Merge Readiness
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4665,25 +4665,34 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - The change introduces no runtime, schema, or OpenAPI behavior
 
 <a id="ledger-p1-foods-postgres-foundation-followthrough"></a>
-- [ ] P1: Foods PostgreSQL foundation follow-through (ETL, importer rewiring, runtime cutover)
+- [ ] P1: Foods PostgreSQL follow-through train (B1 -> infra -> B2, B3 deferred)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FOODS-POSTGRES-FOLLOWTHROUGH
+  - Target PR: PR-B1 (`feat/pr-b1-foods-offline-etl-postgres`) -> `ledger-p0-self-hosted-postgres-droplet-foundation` -> PR-B2 (`feat/pr-b2-restaurant-relational-bridge`); B3 runtime cutover stays deferred outside B2
   - Status: 📋 Planned
   - Area: backend / data platform / restaurant ingestion
   - Finding Type: post-foundation execution gap
-  - Reason: The additive Alembic foundation lane intentionally creates `foods`, `restaurant_chains`, and `restaurant_menu_items` without changing the current SQLite/local-first runtime, ETL path, or MenuStat importer. Those operational changes must land later as a separate follow-through wave instead of widening the foundation PR.
+  - Reason: The additive Alembic foundation lane intentionally creates `foods`, `restaurant_chains`, and `restaurant_menu_items` without changing the current SQLite/local-first runtime, ETL path, or MenuStat importer. The canonical follow-through now executes as a governed train: B1 promotes the existing SQLite snapshot into PostgreSQL `foods`; the self-hosted Droplet foundation lands as a narrow infra blocker before any importer bridge; B2 rewires restaurant ingestion into the relational catalog; B3 keeps runtime read-switch / cutover out of B2 as its own deferred rollout lane.
+  - Sequence:
+    - B1: offline snapshot promotion from `data/food.sqlite::foods` into PostgreSQL `foods` with deterministic upsert/report coverage and no runtime/importer drift
+    - Infra wave: close `ledger-p0-self-hosted-postgres-droplet-foundation` before any restaurant bridge or runtime claims
+    - B2: bridge `scripts/import_restaurant_menu.py` and restaurant persistence toward `restaurant_chains` / `restaurant_menu_items` additively, without runtime cutover
+    - B3 (deferred): decide and govern any runtime read-switch / PostgreSQL cutover as a later dedicated lane
   - Links:
     - `docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md`
+    - `docs/orchestration/FOODS_POSTGRES_PROMOTION_PR_B1_TASK_PACKET_2026-04-13.md`
+    - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p0-self-hosted-postgres-droplet-foundation`
+    - `docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md`
     - `app/services/food_store.py`
     - `scripts/build_food_db.py`
     - `app/services/restaurant_store.py`
     - `scripts/import_restaurant_menu.py`
   - DoD:
-    - PostgreSQL foods/catalog backfill or snapshot promotion path is defined and tested
-    - Restaurant importer rewiring targets the new relational tables with deterministic compatibility coverage
-    - Runtime contract decision is explicit: keep SQLite as baseline or switch reads to PostgreSQL behind a governed rollout
-    - Search / catalog follow-up lanes reference the same canonical table source without parallel schema drift
+    - B1 packet and backlog sequencing explicitly lock the first executable lane to deterministic SQLite snapshot promotion into PostgreSQL `foods`
+    - The self-hosted Droplet foundation remains the blocking infra step between B1 and B2, with no direct B1 -> B2 execution path
+    - B2 scope is explicit: restaurant importer rewiring targets `restaurant_chains` / `restaurant_menu_items` with deterministic compatibility coverage and no runtime cutover claim
+    - B3 runtime cutover / read-switch remains explicitly deferred outside B2
+    - Search / catalog follow-up lanes continue to reference the same canonical PostgreSQL table source without parallel schema drift
 
 <a id="ledger-p1-foods-foundation-downgrade-ownership"></a>
 - [ ] P1: Make foods foundation downgrade ownership-aware for pre-existing catalog objects

--- a/scripts/promote_foods_snapshot_to_postgres.py
+++ b/scripts/promote_foods_snapshot_to_postgres.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Promote offline SQLite foods snapshot into PostgreSQL foods.
+
+RU: Продвигает локальный SQLite snapshot `foods` в PostgreSQL-таблицу `foods`
+через детерминированный batched upsert.
+EN: Promotes the local SQLite `foods` snapshot into the PostgreSQL `foods`
+table using deterministic batched upserts.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from decimal import Decimal
+import hashlib
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import MetaData, Table, bindparam, create_engine, inspect, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.engine import Connection, Engine
+
+SOURCE_TABLE_NAME = "foods"
+TARGET_TABLE_NAME = "foods"
+DEFAULT_SQLITE_PATH = Path("data/food.sqlite")
+DEFAULT_REPORT_PATH = Path("artifacts/food_lane/foods_postgres_promotion_report.json")
+DEFAULT_BATCH_SIZE = 5000
+MIN_BATCH_SIZE = 1
+CHECKSUM_SORT_KEY = "id"
+
+FOODS_COLUMN_ALLOWLIST: tuple[str, ...] = (
+    "id",
+    "canonical_name",
+    "group_name",
+    "per_g",
+    "kcal",
+    "protein_g",
+    "fat_g",
+    "carbs_g",
+    "fiber_g",
+    "Fe_mg",
+    "Ca_mg",
+    "K_mg",
+    "Mg_mg",
+    "VitD_IU",
+    "B12_ug",
+    "Folate_ug",
+    "Iodine_ug",
+    "flags",
+    "brand",
+    "gtin",
+    "fdc_id",
+    "source",
+    "source_priority",
+    "version_date",
+    "price_per_100g",
+    "nutrition_inputs_json",
+    "nutrition_provenance_json",
+    "nutrition_confidence",
+    "nutrition_nutrient_confidence_json",
+)
+REQUIRED_SOURCE_COLUMNS: frozenset[str] = frozenset(FOODS_COLUMN_ALLOWLIST)
+REQUIRED_TARGET_COLUMNS: frozenset[str] = frozenset(FOODS_COLUMN_ALLOWLIST)
+JSON_COLUMN_TYPES: dict[str, type[list[Any]] | type[dict[str, Any]]] = {
+    "flags": list,
+    "nutrition_inputs_json": list,
+    "nutrition_provenance_json": dict,
+    "nutrition_nutrient_confidence_json": dict,
+}
+LEGACY_OPTIONAL_SOURCE_COLUMNS: frozenset[str] = frozenset(
+    {
+        "nutrition_inputs_json",
+        "nutrition_provenance_json",
+        "nutrition_confidence",
+        "nutrition_nutrient_confidence_json",
+    }
+)
+REQUIRED_SOURCE_COLUMNS = frozenset(
+    column for column in FOODS_COLUMN_ALLOWLIST if column not in LEGACY_OPTIONAL_SOURCE_COLUMNS
+)
+
+
+class PromotionError(RuntimeError):
+    """RU: Детерминированная ошибка promotion lane. EN: Deterministic promotion-lane error."""
+
+
+@dataclass(frozen=True)
+class PromotionConfig:
+    """Runtime configuration for snapshot promotion."""
+
+    sqlite_path: Path
+    pg_url: str
+    batch_size: int
+    report_path: Path
+
+
+@dataclass(frozen=True)
+class PromotionSummary:
+    """Serializable promotion execution summary."""
+
+    sqlite_path: str
+    target_table: str
+    source_count: int
+    inserted_count: int
+    updated_count: int
+    batch_count: int
+    source_checksum: str
+
+    def to_json_dict(self) -> dict[str, Any]:
+        """Return JSON-safe dict representation."""
+        return {
+            "sqlite_path": self.sqlite_path,
+            "target_table": self.target_table,
+            "source_count": self.source_count,
+            "inserted_count": self.inserted_count,
+            "updated_count": self.updated_count,
+            "batch_count": self.batch_count,
+            "checksum": self.source_checksum,
+            "source_checksum": self.source_checksum,
+        }
+
+
+def _json_default(value: Any) -> str:
+    """Serialize Decimal values deterministically for checksum and reports."""
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    raise TypeError(f"Unsupported JSON serialization type: {type(value)!r}")
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> PromotionConfig:
+    """Parse CLI arguments into a validated config object."""
+    parser = argparse.ArgumentParser(
+        description="Promote SQLite foods snapshot into PostgreSQL foods via deterministic upsert."
+    )
+    parser.add_argument(
+        "--sqlite-path",
+        type=Path,
+        default=DEFAULT_SQLITE_PATH,
+        help=f"Source SQLite database path (default: {DEFAULT_SQLITE_PATH}).",
+    )
+    parser.add_argument(
+        "--pg-url",
+        required=True,
+        help="Target PostgreSQL DATABASE_URL / SQLAlchemy URL.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help=f"Batch size for PostgreSQL upsert (default: {DEFAULT_BATCH_SIZE}).",
+    )
+    parser.add_argument(
+        "--report-path",
+        type=Path,
+        default=DEFAULT_REPORT_PATH,
+        help=f"JSON report output path (default: {DEFAULT_REPORT_PATH}).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.batch_size < MIN_BATCH_SIZE:
+        raise PromotionError(f"batch-size must be >= {MIN_BATCH_SIZE}, got {args.batch_size}")
+
+    return PromotionConfig(
+        sqlite_path=args.sqlite_path,
+        pg_url=args.pg_url,
+        batch_size=args.batch_size,
+        report_path=args.report_path,
+    )
+
+
+@contextmanager
+def _connect_sqlite(path: Path) -> Iterator[sqlite3.Connection]:
+    """Open source SQLite connection with row access enabled."""
+    if not path.exists():
+        raise PromotionError(f"SQLite source does not exist: {path}")
+    if not path.is_file():
+        raise PromotionError(f"SQLite source path is not a file: {path}")
+
+    connection = sqlite3.connect(path)
+    connection.row_factory = sqlite3.Row
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _build_pg_engine(pg_url: str) -> Engine:
+    """Create and validate a PostgreSQL SQLAlchemy engine."""
+    engine = create_engine(pg_url, future=True, pool_pre_ping=True)
+    if engine.dialect.name != "postgresql":
+        engine.dispose()
+        raise PromotionError(
+            f"Target database must be PostgreSQL, got dialect {engine.dialect.name!r}"
+        )
+    return engine
+
+
+def _fetch_sqlite_columns(connection: sqlite3.Connection) -> set[str]:
+    """Return source SQLite table column names."""
+    try:
+        rows = connection.execute(f"PRAGMA table_info({SOURCE_TABLE_NAME})").fetchall()
+    except sqlite3.Error as exc:
+        raise PromotionError(
+            f"Unable to inspect source SQLite table {SOURCE_TABLE_NAME!r}: {exc}"
+        ) from exc
+
+    if not rows:
+        raise PromotionError(
+            f"Source SQLite table {SOURCE_TABLE_NAME!r} is missing in the snapshot database."
+        )
+    return {str(row["name"]) for row in rows}
+
+
+def _reflect_target_table(connection: Connection) -> Table:
+    """Reflect the target PostgreSQL foods table and validate required columns."""
+    inspector = inspect(connection)
+    if not inspector.has_table(TARGET_TABLE_NAME):
+        raise PromotionError(
+            f"Target PostgreSQL table {TARGET_TABLE_NAME!r} is missing. "
+            "Run the foods foundation migrations before promotion."
+        )
+
+    metadata = MetaData()
+    table = Table(TARGET_TABLE_NAME, metadata, autoload_with=connection)
+    target_columns = {column.name for column in table.columns}
+    missing_columns = sorted(REQUIRED_TARGET_COLUMNS - target_columns)
+    if missing_columns:
+        missing_str = ", ".join(missing_columns)
+        raise PromotionError(
+            f"Target PostgreSQL table {TARGET_TABLE_NAME!r} is missing required columns: {missing_str}"
+        )
+    return table
+
+
+def _normalize_json_column(
+    *,
+    row_id: str,
+    column_name: str,
+    raw_value: Any,
+    expected_type: type[list[Any]] | type[dict[str, Any]],
+) -> list[Any] | dict[str, Any]:
+    """Parse and validate JSON-encoded source columns."""
+    if raw_value is None:
+        return expected_type()
+    if not isinstance(raw_value, str):
+        raise PromotionError(
+            f"Row {row_id!r} column {column_name!r} must be TEXT JSON in SQLite source."
+        )
+    try:
+        parsed = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise PromotionError(
+            f"Row {row_id!r} column {column_name!r} contains invalid JSON: {exc.msg}"
+        ) from exc
+    if not isinstance(parsed, expected_type):
+        raise PromotionError(
+            f"Row {row_id!r} column {column_name!r} must decode to "
+            f"{expected_type.__name__}, got {type(parsed).__name__}."
+        )
+    return parsed
+
+
+def _normalize_source_row(row: sqlite3.Row) -> dict[str, Any]:
+    """Normalize a SQLite row into a PostgreSQL-ready payload."""
+    row_keys = set(row.keys())
+    normalized = {
+        column: row[column] if column in row_keys else None for column in FOODS_COLUMN_ALLOWLIST
+    }
+    row_id = str(normalized["id"])
+    for column_name, expected_type in JSON_COLUMN_TYPES.items():
+        normalized[column_name] = _normalize_json_column(
+            row_id=row_id,
+            column_name=column_name,
+            raw_value=normalized[column_name],
+            expected_type=expected_type,
+        )
+    return normalized
+
+
+def _iter_source_rows(
+    connection: sqlite3.Connection,
+    source_columns: set[str] | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield normalized source rows in deterministic primary-key order."""
+    active_source_columns = source_columns or _fetch_sqlite_columns(connection)
+    select_columns = [
+        column_name
+        for column_name in FOODS_COLUMN_ALLOWLIST
+        if column_name in active_source_columns
+    ]
+    query = (
+        "SELECT "
+        + ", ".join(select_columns)
+        + f" FROM {SOURCE_TABLE_NAME} ORDER BY {CHECKSUM_SORT_KEY}"
+    )
+    try:
+        cursor = connection.execute(query)
+    except sqlite3.Error as exc:
+        raise PromotionError(f"Unable to read source rows from SQLite: {exc}") from exc
+    for row in cursor:
+        yield _normalize_source_row(row)
+
+
+def _chunk_rows(rows: list[dict[str, Any]], batch_size: int) -> Iterator[list[dict[str, Any]]]:
+    """Yield fixed-size row batches."""
+    for start in range(0, len(rows), batch_size):
+        yield rows[start : start + batch_size]
+
+
+def _compute_checksum(rows: list[dict[str, Any]]) -> str:
+    """Compute deterministic checksum over normalized source rows."""
+    digest = hashlib.sha256()
+    for row in rows:
+        encoded = json.dumps(
+            row,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=_json_default,
+        ).encode("utf-8")
+        digest.update(encoded)
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _count_existing_ids(
+    connection: Connection,
+    target_table: Table,
+    ids: Sequence[str],
+) -> set[str]:
+    """Return target ids already present in PostgreSQL."""
+    if not ids:
+        return set()
+    stmt = select(target_table.c.id).where(target_table.c.id.in_(bindparam("ids", expanding=True)))
+    rows = connection.execute(stmt, {"ids": list(ids)}).scalars().all()
+    return {str(value) for value in rows}
+
+
+def _build_upsert_statement(target_table: Table):
+    """Build PostgreSQL UPSERT statement for the foods target table."""
+    insert_stmt = pg_insert(target_table)
+    update_columns = {
+        column: insert_stmt.excluded[column] for column in FOODS_COLUMN_ALLOWLIST if column != "id"
+    }
+    return insert_stmt.on_conflict_do_update(
+        index_elements=["id"],
+        set_=update_columns,
+    )
+
+
+def _promote_rows(
+    *,
+    source_rows: list[dict[str, Any]],
+    connection: Connection,
+    target_table: Table,
+    batch_size: int,
+) -> tuple[int, int, int]:
+    """Promote rows to PostgreSQL and return insert/update/batch counts."""
+    inserted_total = 0
+    updated_total = 0
+    batch_total = 0
+    upsert_stmt = _build_upsert_statement(target_table)
+
+    for batch in _chunk_rows(source_rows, batch_size):
+        batch_total += 1
+        batch_ids = [str(row["id"]) for row in batch]
+        existing_ids = _count_existing_ids(connection, target_table, batch_ids)
+        inserted_total += len(batch_ids) - len(existing_ids)
+        updated_total += len(existing_ids)
+        connection.execute(upsert_stmt, batch)
+
+    return inserted_total, updated_total, batch_total
+
+
+def _write_report(summary: PromotionSummary, report_path: Path) -> None:
+    """Persist execution summary as tracked-out artifact JSON."""
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        json.dumps(summary.to_json_dict(), indent=2, ensure_ascii=False, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def run_promotion(config: PromotionConfig) -> PromotionSummary:
+    """Execute snapshot promotion and return a deterministic summary."""
+    with _connect_sqlite(config.sqlite_path) as sqlite_connection:
+        source_columns = _fetch_sqlite_columns(sqlite_connection)
+        missing_source_columns = sorted(REQUIRED_SOURCE_COLUMNS - source_columns)
+        if missing_source_columns:
+            missing_str = ", ".join(missing_source_columns)
+            raise PromotionError(
+                f"Source SQLite table {SOURCE_TABLE_NAME!r} is missing required columns: {missing_str}"
+            )
+        source_rows = list(_iter_source_rows(sqlite_connection, source_columns))
+
+    engine = _build_pg_engine(config.pg_url)
+    try:
+        with engine.begin() as pg_connection:
+            target_table = _reflect_target_table(pg_connection)
+            inserted_count, updated_count, batch_count = _promote_rows(
+                source_rows=source_rows,
+                connection=pg_connection,
+                target_table=target_table,
+                batch_size=config.batch_size,
+            )
+    finally:
+        engine.dispose()
+
+    summary = PromotionSummary(
+        sqlite_path=str(config.sqlite_path),
+        target_table=TARGET_TABLE_NAME,
+        source_count=len(source_rows),
+        inserted_count=inserted_count,
+        updated_count=updated_count,
+        batch_count=batch_count,
+        source_checksum=_compute_checksum(source_rows),
+    )
+    _write_report(summary, config.report_path)
+    return summary
+
+
+def promote_foods_snapshot_to_postgres(
+    *,
+    sqlite_path: str | Path,
+    pg_url: str,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    report_path: str | Path = DEFAULT_REPORT_PATH,
+) -> dict[str, Any]:
+    """Run the canonical B1 promotion interface and return the JSON summary."""
+    config = PromotionConfig(
+        sqlite_path=Path(sqlite_path),
+        pg_url=pg_url,
+        batch_size=batch_size,
+        report_path=Path(report_path),
+    )
+    if config.batch_size < MIN_BATCH_SIZE:
+        raise PromotionError(f"batch-size must be >= {MIN_BATCH_SIZE}, got {config.batch_size}")
+    summary = run_promotion(config)
+    return summary.to_json_dict()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint."""
+    try:
+        config = _parse_args(argv)
+        summary = promote_foods_snapshot_to_postgres(
+            sqlite_path=config.sqlite_path,
+            pg_url=config.pg_url,
+            batch_size=config.batch_size,
+            report_path=config.report_path,
+        )
+    except PromotionError as exc:
+        print(f"Promotion failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(summary, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/promote_foods_snapshot_to_postgres.py
+++ b/scripts/promote_foods_snapshot_to_postgres.py
@@ -65,7 +65,6 @@ FOODS_COLUMN_ALLOWLIST: tuple[str, ...] = (
     "nutrition_confidence",
     "nutrition_nutrient_confidence_json",
 )
-REQUIRED_SOURCE_COLUMNS: frozenset[str] = frozenset(FOODS_COLUMN_ALLOWLIST)
 REQUIRED_TARGET_COLUMNS: frozenset[str] = frozenset(FOODS_COLUMN_ALLOWLIST)
 JsonContainerType: TypeAlias = type[list[Any]] | type[dict[str, Any]]
 
@@ -194,7 +193,7 @@ def _connect_sqlite(path: Path) -> Iterator[sqlite3.Connection]:
 
 def _build_pg_engine(pg_url: str) -> Engine:
     """Create and validate a PostgreSQL SQLAlchemy engine."""
-    engine = create_engine(pg_url, future=True, pool_pre_ping=True)
+    engine = create_engine(pg_url, pool_pre_ping=True)
     if engine.dialect.name != "postgresql":
         engine.dispose()
         raise PromotionError(

--- a/scripts/promote_foods_snapshot_to_postgres.py
+++ b/scripts/promote_foods_snapshot_to_postgres.py
@@ -20,7 +20,7 @@ import json
 import sqlite3
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeAlias, cast
 
 from sqlalchemy import MetaData, Table, bindparam, create_engine, inspect, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -67,11 +67,13 @@ FOODS_COLUMN_ALLOWLIST: tuple[str, ...] = (
 )
 REQUIRED_SOURCE_COLUMNS: frozenset[str] = frozenset(FOODS_COLUMN_ALLOWLIST)
 REQUIRED_TARGET_COLUMNS: frozenset[str] = frozenset(FOODS_COLUMN_ALLOWLIST)
-JSON_COLUMN_TYPES: dict[str, type[list[Any]] | type[dict[str, Any]]] = {
+JsonContainerType: TypeAlias = type[list[Any]] | type[dict[str, Any]]
+
+JSON_COLUMN_TYPES: dict[str, JsonContainerType] = {
     "flags": list,
     "nutrition_inputs_json": list,
-    "nutrition_provenance_json": dict,
-    "nutrition_nutrient_confidence_json": dict,
+    "nutrition_provenance_json": cast(JsonContainerType, dict),
+    "nutrition_nutrient_confidence_json": cast(JsonContainerType, dict),
 }
 LEGACY_OPTIONAL_SOURCE_COLUMNS: frozenset[str] = frozenset(
     {
@@ -243,7 +245,7 @@ def _normalize_json_column(
     row_id: str,
     column_name: str,
     raw_value: Any,
-    expected_type: type[list[Any]] | type[dict[str, Any]],
+    expected_type: JsonContainerType,
 ) -> list[Any] | dict[str, Any]:
     """Parse and validate JSON-encoded source columns."""
     if raw_value is None:
@@ -263,7 +265,7 @@ def _normalize_json_column(
             f"Row {row_id!r} column {column_name!r} must decode to "
             f"{expected_type.__name__}, got {type(parsed).__name__}."
         )
-    return parsed
+    return cast(list[Any] | dict[str, Any], parsed)
 
 
 def _normalize_source_row(row: sqlite3.Row) -> dict[str, Any]:

--- a/tests/test_promote_foods_snapshot_to_postgres.py
+++ b/tests/test_promote_foods_snapshot_to_postgres.py
@@ -212,7 +212,7 @@ def _sample_source_rows() -> list[dict[str, object]]:
             "source_priority": 10,
             "version_date": "2026-04-12T12:00:00+00:00",
             "price_per_100g": 0.49,
-            "nutrition_inputs_json": {"serving_basis": "100g", "source": "usda"},
+            "nutrition_inputs_json": [{"serving_basis": "100g", "source": "usda"}],
             "nutrition_provenance_json": {"provider": "usda", "pipeline": "build_food_db"},
             "nutrition_confidence": 0.981,
             "nutrition_nutrient_confidence_json": {"kcal": 0.99, "fiber_g": 0.97},
@@ -243,10 +243,12 @@ def _sample_source_rows() -> list[dict[str, object]]:
             "source_priority": 5,
             "version_date": "2026-04-12T12:00:00+00:00",
             "price_per_100g": 1.09,
-            "nutrition_inputs_json": {
-                "serving_basis": "100g",
-                "package_size_g": 450,
-            },
+            "nutrition_inputs_json": [
+                {
+                    "serving_basis": "100g",
+                    "package_size_g": 450,
+                },
+            ],
             "nutrition_provenance_json": {
                 "provider": "off",
                 "pipeline": "build_food_db",
@@ -540,7 +542,7 @@ def test_main_forwards_cli_arguments_to_promotion_function(
         ],
     )
 
-    assert result in (0, None)
+    assert result == 0
     assert str(captured["sqlite_path"]) == str(sqlite_path)
     assert str(captured["pg_url"]) == test_pg_url
     assert captured["batch_size"] == 7

--- a/tests/test_promote_foods_snapshot_to_postgres.py
+++ b/tests/test_promote_foods_snapshot_to_postgres.py
@@ -7,12 +7,11 @@ EN: Deterministic harness for offline foods snapshot -> PostgreSQL promotion.
 from __future__ import annotations
 
 from dataclasses import dataclass
-import importlib.util
 import json
 import os
 from pathlib import Path
+import runpy
 import sqlite3
-import sys
 import uuid
 
 import pytest
@@ -164,6 +163,22 @@ class RawJsonText:
     value: str
 
 
+class ScriptModuleProxy:
+    """Expose a runpy namespace as a mutable module-like object."""
+
+    def __init__(self, namespace: dict[str, object]) -> None:
+        object.__setattr__(self, "_namespace", namespace)
+
+    def __getattr__(self, name: str) -> object:
+        try:
+            return self._namespace[name]
+        except KeyError as exc:  # pragma: no cover - defensive parity with modules
+            raise AttributeError(name) from exc
+
+    def __setattr__(self, name: str, value: object) -> None:
+        self._namespace[name] = value
+
+
 def _load_script_module():
     """Load the non-package promotion script lazily per test."""
 
@@ -171,17 +186,13 @@ def _load_script_module():
         "Expected script scripts/promote_foods_snapshot_to_postgres.py to exist. "
         "Implement the script before running this harness."
     )
-    spec = importlib.util.spec_from_file_location(
-        "promote_foods_snapshot_to_postgres",
-        SCRIPT_PATH,
+    loaded_namespace = runpy.run_path(
+        str(SCRIPT_PATH),
+        run_name="promote_foods_snapshot_to_postgres",
     )
-    if spec is None or spec.loader is None:
-        raise ImportError("Could not load promote_foods_snapshot_to_postgres module")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    sys.modules["scripts.promote_foods_snapshot_to_postgres"] = module
-    return module
+    main_function = loaded_namespace["main"]
+    module_globals = getattr(main_function, "__globals__", loaded_namespace)
+    return ScriptModuleProxy(module_globals)
 
 
 def _sample_source_rows() -> list[dict[str, object]]:

--- a/tests/test_promote_foods_snapshot_to_postgres.py
+++ b/tests/test_promote_foods_snapshot_to_postgres.py
@@ -1,0 +1,746 @@
+"""Contract tests for scripts/promote_foods_snapshot_to_postgres.py.
+
+RU: Детерминированный harness для offline promotion foods snapshot -> PostgreSQL.
+EN: Deterministic harness for offline foods snapshot -> PostgreSQL promotion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sqlite3
+import sys
+import uuid
+
+import pytest
+from sqlalchemy import Column, Integer, MetaData, Numeric, Table, Text, create_engine, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.engine import URL, make_url
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "promote_foods_snapshot_to_postgres.py"
+
+SQLITE_FOODS_DDL = """
+CREATE TABLE foods (
+    id TEXT PRIMARY KEY,
+    canonical_name TEXT NOT NULL,
+    group_name TEXT,
+    per_g REAL,
+    kcal REAL,
+    protein_g REAL,
+    fat_g REAL,
+    carbs_g REAL,
+    fiber_g REAL,
+    Fe_mg REAL,
+    Ca_mg REAL,
+    K_mg REAL,
+    Mg_mg REAL,
+    VitD_IU REAL,
+    B12_ug REAL,
+    Folate_ug REAL,
+    Iodine_ug REAL,
+    flags TEXT,
+    brand TEXT,
+    gtin TEXT,
+    fdc_id TEXT,
+    source TEXT,
+    source_priority INTEGER,
+    version_date TEXT,
+    price_per_100g REAL,
+    nutrition_inputs_json TEXT,
+    nutrition_provenance_json TEXT,
+    nutrition_confidence REAL,
+    nutrition_nutrient_confidence_json TEXT
+)
+"""
+
+SQLITE_FOODS_DDL_LEGACY = """
+CREATE TABLE foods (
+    id TEXT PRIMARY KEY,
+    canonical_name TEXT NOT NULL,
+    group_name TEXT,
+    per_g REAL,
+    kcal REAL,
+    protein_g REAL,
+    fat_g REAL,
+    carbs_g REAL,
+    fiber_g REAL,
+    Fe_mg REAL,
+    Ca_mg REAL,
+    K_mg REAL,
+    Mg_mg REAL,
+    VitD_IU REAL,
+    B12_ug REAL,
+    Folate_ug REAL,
+    Iodine_ug REAL,
+    flags TEXT,
+    brand TEXT,
+    gtin TEXT,
+    fdc_id TEXT,
+    source TEXT,
+    source_priority INTEGER,
+    version_date TEXT,
+    price_per_100g REAL
+)
+"""
+
+JSON_TEXT_COLUMNS = {
+    "flags",
+    "nutrition_inputs_json",
+    "nutrition_provenance_json",
+    "nutrition_nutrient_confidence_json",
+}
+
+INSERT_COLUMNS = [
+    "id",
+    "canonical_name",
+    "group_name",
+    "per_g",
+    "kcal",
+    "protein_g",
+    "fat_g",
+    "carbs_g",
+    "fiber_g",
+    "Fe_mg",
+    "Ca_mg",
+    "K_mg",
+    "Mg_mg",
+    "VitD_IU",
+    "B12_ug",
+    "Folate_ug",
+    "Iodine_ug",
+    "flags",
+    "brand",
+    "gtin",
+    "fdc_id",
+    "source",
+    "source_priority",
+    "version_date",
+    "price_per_100g",
+    "nutrition_inputs_json",
+    "nutrition_provenance_json",
+    "nutrition_confidence",
+    "nutrition_nutrient_confidence_json",
+]
+
+LEGACY_INSERT_COLUMNS = [
+    "id",
+    "canonical_name",
+    "group_name",
+    "per_g",
+    "kcal",
+    "protein_g",
+    "fat_g",
+    "carbs_g",
+    "fiber_g",
+    "Fe_mg",
+    "Ca_mg",
+    "K_mg",
+    "Mg_mg",
+    "VitD_IU",
+    "B12_ug",
+    "Folate_ug",
+    "Iodine_ug",
+    "flags",
+    "brand",
+    "gtin",
+    "fdc_id",
+    "source",
+    "source_priority",
+    "version_date",
+    "price_per_100g",
+]
+
+REPORT_PATH_RELATIVE = Path("artifacts/food_lane/foods_postgres_promotion_report.json")
+
+
+@dataclass(frozen=True)
+class RawJsonText:
+    """Preserve raw JSON text for malformed-payload fixtures."""
+
+    value: str
+
+
+def _load_script_module():
+    """Load the non-package promotion script lazily per test."""
+
+    assert SCRIPT_PATH.exists(), (
+        "Expected script scripts/promote_foods_snapshot_to_postgres.py to exist. "
+        "Implement the script before running this harness."
+    )
+    spec = importlib.util.spec_from_file_location(
+        "promote_foods_snapshot_to_postgres",
+        SCRIPT_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError("Could not load promote_foods_snapshot_to_postgres module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    sys.modules["scripts.promote_foods_snapshot_to_postgres"] = module
+    return module
+
+
+def _sample_source_rows() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "food.apple.raw",
+            "canonical_name": "Apple, raw",
+            "group_name": "fruit",
+            "per_g": 100.0,
+            "kcal": 52.0,
+            "protein_g": 0.3,
+            "fat_g": 0.2,
+            "carbs_g": 14.0,
+            "fiber_g": 2.4,
+            "Fe_mg": 0.12,
+            "Ca_mg": 6.0,
+            "K_mg": 107.0,
+            "Mg_mg": 5.0,
+            "VitD_IU": 0.0,
+            "B12_ug": 0.0,
+            "Folate_ug": 3.0,
+            "Iodine_ug": 0.0,
+            "flags": ["fruit", "fresh"],
+            "brand": None,
+            "gtin": "000111222333",
+            "fdc_id": "171688",
+            "source": "usda",
+            "source_priority": 10,
+            "version_date": "2026-04-12T12:00:00+00:00",
+            "price_per_100g": 0.49,
+            "nutrition_inputs_json": {"serving_basis": "100g", "source": "usda"},
+            "nutrition_provenance_json": {"provider": "usda", "pipeline": "build_food_db"},
+            "nutrition_confidence": 0.981,
+            "nutrition_nutrient_confidence_json": {"kcal": 0.99, "fiber_g": 0.97},
+        },
+        {
+            "id": "food.yogurt.greek.plain",
+            "canonical_name": "Greek yogurt, plain",
+            "group_name": "dairy",
+            "per_g": 100.0,
+            "kcal": 97.0,
+            "protein_g": 9.0,
+            "fat_g": 5.0,
+            "carbs_g": 3.9,
+            "fiber_g": 0.0,
+            "Fe_mg": 0.05,
+            "Ca_mg": 100.0,
+            "K_mg": 141.0,
+            "Mg_mg": 11.0,
+            "VitD_IU": 44.0,
+            "B12_ug": 0.75,
+            "Folate_ug": 7.0,
+            "Iodine_ug": 0.0,
+            "flags": ["protein", "breakfast"],
+            "brand": "PulsePlate Test",
+            "gtin": "999888777666",
+            "fdc_id": "123456",
+            "source": "off",
+            "source_priority": 5,
+            "version_date": "2026-04-12T12:00:00+00:00",
+            "price_per_100g": 1.09,
+            "nutrition_inputs_json": {
+                "serving_basis": "100g",
+                "package_size_g": 450,
+            },
+            "nutrition_provenance_json": {
+                "provider": "off",
+                "pipeline": "build_food_db",
+            },
+            "nutrition_confidence": 0.874,
+            "nutrition_nutrient_confidence_json": {"protein_g": 0.95, "Ca_mg": 0.9},
+        },
+    ]
+
+
+def _legacy_source_rows() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "food.legacy.apple",
+            "canonical_name": "Apple legacy",
+            "group_name": "fruit",
+            "per_g": 100.0,
+            "kcal": 51.0,
+            "protein_g": 0.2,
+            "fat_g": 0.1,
+            "carbs_g": 13.9,
+            "fiber_g": 2.2,
+            "Fe_mg": 0.11,
+            "Ca_mg": 5.0,
+            "K_mg": 106.0,
+            "Mg_mg": 4.0,
+            "VitD_IU": 0.0,
+            "B12_ug": 0.0,
+            "Folate_ug": 2.0,
+            "Iodine_ug": 0.0,
+            "flags": ["legacy", "fruit"],
+            "brand": None,
+            "gtin": "111222333444",
+            "fdc_id": "171689",
+            "source": "sqlite-snapshot",
+            "source_priority": 3,
+            "version_date": "2026-04-12T12:00:00+00:00",
+            "price_per_100g": 0.39,
+        },
+    ]
+
+
+def _serialize_source_cell(value: object) -> object:
+    if isinstance(value, RawJsonText):
+        return value.value
+    if value is None:
+        return None
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _create_source_sqlite(
+    sqlite_path: Path,
+    rows: list[dict[str, object]],
+    *,
+    include_foods_table: bool,
+    legacy_shape: bool = False,
+) -> Path:
+    ddl = SQLITE_FOODS_DDL_LEGACY if legacy_shape else SQLITE_FOODS_DDL
+    insert_columns = LEGACY_INSERT_COLUMNS if legacy_shape else INSERT_COLUMNS
+
+    with sqlite3.connect(sqlite_path) as connection:
+        cursor = connection.cursor()
+        if include_foods_table:
+            cursor.execute(ddl)
+            placeholders = ",".join("?" for _ in insert_columns)
+            insert_sql = (
+                f"INSERT INTO foods ({','.join(insert_columns)}) " f"VALUES ({placeholders})"
+            )
+            for row in rows:
+                values = []
+                for column_name in insert_columns:
+                    value = row[column_name]
+                    if column_name in JSON_TEXT_COLUMNS:
+                        values.append(_serialize_source_cell(value))
+                    else:
+                        values.append(value)
+                cursor.execute(insert_sql, values)
+        connection.commit()
+    return sqlite_path
+
+
+def _postgres_url_or_skip() -> str:
+    env_url = os.environ.get("DATABASE_URL")
+    if not env_url:
+        pytest.skip("DATABASE_URL must be set for PostgreSQL promotion integration tests")
+    backend_name = make_url(env_url).get_backend_name()
+    if backend_name != "postgresql":
+        pytest.skip("Promotion integration tests require a PostgreSQL DATABASE_URL")
+    return env_url
+
+
+def _schema_search_path_url(base_url: str, schema_name: str) -> str:
+    url = make_url(base_url)
+    query: dict[str, str] = {key: value for key, value in url.query.items()}
+    existing_options = query.get("options", "").strip()
+    search_path_option = f"-csearch_path={schema_name}"
+    query["options"] = (
+        f"{existing_options} {search_path_option}".strip()
+        if existing_options
+        else search_path_option
+    )
+    updated_url: URL = url.set(query=query)
+    return updated_url.render_as_string(hide_password=False)
+
+
+def _foods_table_metadata(schema_name: str) -> MetaData:
+    metadata = MetaData()
+    Table(
+        "foods",
+        metadata,
+        # RU: Тестовая таблица повторяет колонковый контракт Alembic revision.
+        # EN: Test table mirrors the Alembic revision column contract.
+        Column("id", Text, primary_key=True, nullable=False),
+        Column("canonical_name", Text, nullable=False),
+        Column("group_name", Text, nullable=False),
+        Column("per_g", Numeric(8, 2), nullable=False),
+        Column("kcal", Numeric(8, 2), nullable=False),
+        Column("protein_g", Numeric(8, 2), nullable=False),
+        Column("fat_g", Numeric(8, 2), nullable=False),
+        Column("carbs_g", Numeric(8, 2), nullable=False),
+        Column("fiber_g", Numeric(8, 2), nullable=False),
+        Column("Fe_mg", Numeric(10, 3), nullable=False),
+        Column("Ca_mg", Numeric(10, 3), nullable=False),
+        Column("K_mg", Numeric(10, 3), nullable=False),
+        Column("Mg_mg", Numeric(10, 3), nullable=False),
+        Column("VitD_IU", Numeric(10, 3), nullable=False),
+        Column("B12_ug", Numeric(10, 3), nullable=False),
+        Column("Folate_ug", Numeric(10, 3), nullable=False),
+        Column("Iodine_ug", Numeric(10, 3), nullable=False),
+        Column("flags", JSONB, nullable=False),
+        Column("brand", Text, nullable=True),
+        Column("gtin", Text, nullable=True),
+        Column("fdc_id", Text, nullable=True),
+        Column("source", Text, nullable=False),
+        Column("source_priority", Integer, nullable=False),
+        Column("version_date", Text, nullable=False),
+        Column("price_per_100g", Numeric(10, 2), nullable=True),
+        Column("nutrition_inputs_json", JSONB, nullable=True),
+        Column("nutrition_provenance_json", JSONB, nullable=True),
+        Column("nutrition_confidence", Numeric(4, 3), nullable=True),
+        Column("nutrition_nutrient_confidence_json", JSONB, nullable=True),
+        schema=schema_name,
+    )
+    return metadata
+
+
+def _create_target_schema(
+    base_url: str,
+    schema_name: str,
+    *,
+    create_foods_table: bool,
+) -> tuple[str, str]:
+    schema_url = _schema_search_path_url(base_url, schema_name)
+    admin_engine = create_engine(base_url, pool_pre_ping=True, future=True)
+    metadata = _foods_table_metadata(schema_name)
+    try:
+        with admin_engine.begin() as connection:
+            connection.execute(text(f"CREATE SCHEMA {schema_name}"))
+            if create_foods_table:
+                metadata.create_all(connection)
+    finally:
+        admin_engine.dispose()
+    return schema_name, schema_url
+
+
+def _drop_target_schema(base_url: str, schema_name: str) -> None:
+    admin_engine = create_engine(base_url, pool_pre_ping=True, future=True)
+    try:
+        with admin_engine.begin() as connection:
+            connection.execute(text(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE"))
+    finally:
+        admin_engine.dispose()
+
+
+def _query_target_rows(base_url: str, schema_name: str) -> list[dict[str, object]]:
+    engine = create_engine(base_url, pool_pre_ping=True, future=True)
+    try:
+        with engine.connect() as connection:
+            rows = connection.execute(
+                text(
+                    "SELECT id, flags, nutrition_inputs_json, "
+                    "nutrition_provenance_json, nutrition_nutrient_confidence_json "
+                    f"FROM {schema_name}.foods ORDER BY id"
+                ),
+            ).mappings()
+            return [dict(row) for row in rows]
+    finally:
+        engine.dispose()
+
+
+def _query_target_count(base_url: str, schema_name: str) -> int:
+    engine = create_engine(base_url, pool_pre_ping=True, future=True)
+    try:
+        with engine.connect() as connection:
+            return int(
+                connection.execute(
+                    text(f"SELECT COUNT(*) FROM {schema_name}.foods"),
+                ).scalar_one(),
+            )
+    finally:
+        engine.dispose()
+
+
+def _run_promotion(
+    module,
+    *,
+    sqlite_path: Path,
+    pg_url: str,
+    batch_size: int,
+    report_path: Path,
+) -> dict[str, object]:
+    promote = getattr(module, "promote_foods_snapshot_to_postgres")
+    result = promote(
+        sqlite_path=sqlite_path,
+        pg_url=pg_url,
+        batch_size=batch_size,
+        report_path=report_path,
+    )
+    assert report_path.exists(), "Promotion script must write a JSON report"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    if isinstance(result, dict):
+        assert result == report
+    return report
+
+
+def _assert_report_shape(report: dict[str, object]) -> None:
+    assert isinstance(report["source_count"], int)
+    assert isinstance(report["batch_count"], int)
+    assert report["batch_count"] >= 1
+    checksum = report["checksum"]
+    assert isinstance(checksum, str)
+    assert checksum
+
+
+def test_script_exports_expected_entrypoints() -> None:
+    module = _load_script_module()
+
+    assert callable(getattr(module, "promote_foods_snapshot_to_postgres", None))
+    assert callable(getattr(module, "main", None))
+
+
+def test_main_forwards_cli_arguments_to_promotion_function(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_script_module()
+    captured: dict[str, object] = {}
+    test_pg_url = "postgresql://" + "user" + ":" + "pass" + "@localhost/db"
+
+    def fake_promote_foods_snapshot_to_postgres(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        report_path = Path(str(kwargs["report_path"]))
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(
+            json.dumps(
+                {
+                    "source_count": 0,
+                    "inserted_count": 0,
+                    "updated_count": 0,
+                    "batch_count": 0,
+                    "checksum": "stub",
+                },
+            ),
+            encoding="utf-8",
+        )
+        return {
+            "source_count": 0,
+            "inserted_count": 0,
+            "updated_count": 0,
+            "batch_count": 0,
+            "checksum": "stub",
+        }
+
+    monkeypatch.setattr(
+        module,
+        "promote_foods_snapshot_to_postgres",
+        fake_promote_foods_snapshot_to_postgres,
+    )
+    sqlite_path = tmp_path / "source.sqlite"
+    report_path = tmp_path / REPORT_PATH_RELATIVE
+    result = module.main(
+        [
+            "--sqlite-path",
+            str(sqlite_path),
+            "--pg-url",
+            test_pg_url,
+            "--batch-size",
+            "7",
+            "--report-path",
+            str(report_path),
+        ],
+    )
+
+    assert result in (0, None)
+    assert str(captured["sqlite_path"]) == str(sqlite_path)
+    assert str(captured["pg_url"]) == test_pg_url
+    assert captured["batch_size"] == 7
+    assert str(captured["report_path"]) == str(report_path)
+
+
+@pytest.mark.integration
+def test_promotion_happy_path_preserves_json_fields(tmp_path: Path) -> None:
+    module = _load_script_module()
+    base_url = _postgres_url_or_skip()
+    sqlite_path = _create_source_sqlite(
+        tmp_path / "foods-source.sqlite",
+        _sample_source_rows(),
+        include_foods_table=True,
+    )
+    schema_name = f"test_promote_foods_{uuid.uuid4().hex[:12]}"
+    _, schema_url = _create_target_schema(base_url, schema_name, create_foods_table=True)
+    report_path = tmp_path / REPORT_PATH_RELATIVE
+
+    try:
+        report = _run_promotion(
+            module,
+            sqlite_path=sqlite_path,
+            pg_url=schema_url,
+            batch_size=1,
+            report_path=report_path,
+        )
+        _assert_report_shape(report)
+        assert report["source_count"] == 2
+        assert report["inserted_count"] == 2
+        assert report["updated_count"] == 0
+        assert report["batch_count"] == 2
+
+        rows = _query_target_rows(base_url, schema_name)
+        assert len(rows) == 2
+        row_by_id = {str(row["id"]): row for row in rows}
+        expected_by_id = {row["id"]: row for row in _sample_source_rows()}
+        for food_id, expected in expected_by_id.items():
+            stored = row_by_id[food_id]
+            assert stored["flags"] == expected["flags"]
+            assert stored["nutrition_inputs_json"] == expected["nutrition_inputs_json"]
+            assert stored["nutrition_provenance_json"] == expected["nutrition_provenance_json"]
+            assert (
+                stored["nutrition_nutrient_confidence_json"]
+                == expected["nutrition_nutrient_confidence_json"]
+            )
+    finally:
+        _drop_target_schema(base_url, schema_name)
+
+
+@pytest.mark.integration
+def test_promotion_is_idempotent_for_same_snapshot(tmp_path: Path) -> None:
+    module = _load_script_module()
+    base_url = _postgres_url_or_skip()
+    sqlite_path = _create_source_sqlite(
+        tmp_path / "foods-source.sqlite",
+        _sample_source_rows(),
+        include_foods_table=True,
+    )
+    schema_name = f"test_promote_foods_{uuid.uuid4().hex[:12]}"
+    _, schema_url = _create_target_schema(base_url, schema_name, create_foods_table=True)
+
+    try:
+        first_report = _run_promotion(
+            module,
+            sqlite_path=sqlite_path,
+            pg_url=schema_url,
+            batch_size=2,
+            report_path=tmp_path / "artifacts/food_lane/first_report.json",
+        )
+        second_report = _run_promotion(
+            module,
+            sqlite_path=sqlite_path,
+            pg_url=schema_url,
+            batch_size=2,
+            report_path=tmp_path / "artifacts/food_lane/second_report.json",
+        )
+
+        assert first_report["inserted_count"] == 2
+        assert first_report["updated_count"] == 0
+        assert second_report["inserted_count"] == 0
+        assert second_report["updated_count"] == 2
+        assert first_report["checksum"] == second_report["checksum"]
+        assert _query_target_count(base_url, schema_name) == 2
+    finally:
+        _drop_target_schema(base_url, schema_name)
+
+
+@pytest.mark.integration
+def test_promotion_supports_legacy_snapshot_without_optional_json_columns(
+    tmp_path: Path,
+) -> None:
+    module = _load_script_module()
+    base_url = _postgres_url_or_skip()
+    sqlite_path = _create_source_sqlite(
+        tmp_path / "foods-source-legacy.sqlite",
+        _legacy_source_rows(),
+        include_foods_table=True,
+        legacy_shape=True,
+    )
+    schema_name = f"test_promote_foods_{uuid.uuid4().hex[:12]}"
+    _, schema_url = _create_target_schema(base_url, schema_name, create_foods_table=True)
+
+    try:
+        report = _run_promotion(
+            module,
+            sqlite_path=sqlite_path,
+            pg_url=schema_url,
+            batch_size=100,
+            report_path=tmp_path / "artifacts/food_lane/legacy_report.json",
+        )
+        _assert_report_shape(report)
+        assert report["source_count"] == 1
+        assert report["inserted_count"] == 1
+        rows = _query_target_rows(base_url, schema_name)
+        assert rows[0]["flags"] == ["legacy", "fruit"]
+        assert rows[0]["nutrition_inputs_json"] == []
+        assert rows[0]["nutrition_provenance_json"] == {}
+        assert rows[0]["nutrition_nutrient_confidence_json"] == {}
+    finally:
+        _drop_target_schema(base_url, schema_name)
+
+
+@pytest.mark.integration
+def test_promotion_fails_when_source_foods_table_is_missing(tmp_path: Path) -> None:
+    module = _load_script_module()
+    base_url = _postgres_url_or_skip()
+    sqlite_path = _create_source_sqlite(
+        tmp_path / "foods-source-missing.sqlite",
+        [],
+        include_foods_table=False,
+    )
+    schema_name = f"test_promote_foods_{uuid.uuid4().hex[:12]}"
+    _, schema_url = _create_target_schema(base_url, schema_name, create_foods_table=True)
+
+    try:
+        with pytest.raises(Exception, match="foods"):
+            _run_promotion(
+                module,
+                sqlite_path=sqlite_path,
+                pg_url=schema_url,
+                batch_size=100,
+                report_path=tmp_path / "artifacts/food_lane/missing_source_report.json",
+            )
+        assert _query_target_count(base_url, schema_name) == 0
+    finally:
+        _drop_target_schema(base_url, schema_name)
+
+
+@pytest.mark.integration
+def test_promotion_fails_when_target_foods_table_is_missing(tmp_path: Path) -> None:
+    module = _load_script_module()
+    base_url = _postgres_url_or_skip()
+    sqlite_path = _create_source_sqlite(
+        tmp_path / "foods-source.sqlite",
+        _sample_source_rows(),
+        include_foods_table=True,
+    )
+    schema_name = f"test_promote_foods_{uuid.uuid4().hex[:12]}"
+    _, schema_url = _create_target_schema(base_url, schema_name, create_foods_table=False)
+
+    try:
+        with pytest.raises(Exception, match="foods"):
+            _run_promotion(
+                module,
+                sqlite_path=sqlite_path,
+                pg_url=schema_url,
+                batch_size=100,
+                report_path=tmp_path / "artifacts/food_lane/missing_target_report.json",
+            )
+    finally:
+        _drop_target_schema(base_url, schema_name)
+
+
+@pytest.mark.integration
+def test_promotion_fails_deterministically_on_malformed_json(tmp_path: Path) -> None:
+    module = _load_script_module()
+    base_url = _postgres_url_or_skip()
+    malformed_rows = _sample_source_rows()
+    malformed_rows[0] = {
+        **malformed_rows[0],
+        "nutrition_inputs_json": RawJsonText('{"bad_json": '),
+    }
+    sqlite_path = _create_source_sqlite(
+        tmp_path / "foods-source-malformed.sqlite",
+        malformed_rows,
+        include_foods_table=True,
+    )
+    schema_name = f"test_promote_foods_{uuid.uuid4().hex[:12]}"
+    _, schema_url = _create_target_schema(base_url, schema_name, create_foods_table=True)
+
+    try:
+        with pytest.raises(Exception, match="JSON|json|nutrition_inputs_json"):
+            _run_promotion(
+                module,
+                sqlite_path=sqlite_path,
+                pg_url=schema_url,
+                batch_size=100,
+                report_path=tmp_path / "artifacts/food_lane/malformed_report.json",
+            )
+        assert _query_target_count(base_url, schema_name) == 0
+    finally:
+        _drop_target_schema(base_url, schema_name)


### PR DESCRIPTION
## Summary
B1 adds a narrow offline promotion lane from `data/food.sqlite::foods` into PostgreSQL `foods`.

## Scope
- add `scripts/promote_foods_snapshot_to_postgres.py`
- add deterministic tests for snapshot promotion
- update backlog sequencing and add the B1 task packet
- add canonical review artifact `docs/review/PR_1413_FIXED_MAPPING.md`
- keep runtime/API/schema/importer scope unchanged

## Split Justification
This PR stays within a single B1 lane and one execution surface: offline promotion from the SQLite foods snapshot into the existing PostgreSQL `foods` table. The diff is mechanically larger because it combines the promotion script, deterministic tests, the coordinator packet, backlog sequencing updates, and the required review artifact, but it deliberately excludes infra work, importer rewiring, runtime read cutover, Alembic/model changes, and API drift. Splitting this PR further would separate tightly coupled lane-governance artifacts from the only code path they govern without reducing product or review risk.

## Validation
- `python3 scripts/orchestration/check_preflight.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `pre-commit run --all-files` PASS
- `pytest -q tests/test_promote_foods_snapshot_to_postgres.py` PASS with integration tests skipped when `DATABASE_URL` is unset
- `make verify`: local run reached `verify-env`, `flake8`, `mypy`, and smoke subset successfully; full coverage/diff-cover leg is still pending completion in the next loop before merge-readiness evaluation

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1413_FIXED_MAPPING.md`

## Deferred / Follow-ups
- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p0-self-hosted-postgres-droplet-foundation`
- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-postgres-foundation-followthrough`

## Merge Readiness
- [ ] Current-head CI green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `docs/review/PR_1413_FIXED_MAPPING.md`

## Notes
This PR intentionally does not change Alembic, `core/models.py`, runtime read paths, or restaurant importer wiring.

## Summary by Sourcery

Ввести офлайн-лану для продвижения существующего снимка SQLite foods в таблицу PostgreSQL foods с детерминированным, подотчётным процессом upsert, а также сопутствующей документацией по governance и последовательности.

New Features:
- Добавить скрипт промоушена для upsert’a данных foods из локального снимка SQLite в таблицу PostgreSQL foods с детерминированной пакетной обработкой и отчётностью по контрольным суммам.

Enhancements:
- Добавить детерминированные модульные и интеграционные тесты, которые проверяют поведение промоушена, идемпотентность, поддержку легаси-снимков и режимы отказа при проблемах со схемой или JSON.
- Уточнить порядок выполнения в бэклоге, определив исполнение по этапам B1/B2/B3 для продолжения работ по PostgreSQL для foods и прояснив границы областей между промоушеном, инфраструктурой и переключением рантайма.
- Добавить пакет задач и артефакт обзора fixed-in-commit для управления и документирования ланы B1 по промоушену foods в PostgreSQL.

Documentation:
- Задокументировать пакет задач B1 по промоушену foods в PostgreSQL и обновить реестр бэклога, чтобы описать последовательность дальнейших работ и явный перенос переключения рантайма на более поздний этап.

Tests:
- Добавить специализированный тестовый хернесс для скрипта промоушена снимка foods с фикстурами SQLite и опциональным интеграционным покрытием на базе PostgreSQL.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an offline lane to promote the existing SQLite foods snapshot into the PostgreSQL foods table with a deterministic, reportable upsert process, along with governance and sequencing docs.

New Features:
- Add a promotion script to upsert foods data from the local SQLite snapshot into the PostgreSQL foods table with deterministic batching and checksum reporting.

Enhancements:
- Add deterministic unit and integration tests that validate promotion behavior, idempotency, legacy snapshot support, and failure modes for schema or JSON issues.
- Refine backlog sequencing to define the B1/B2/B3 execution train for foods PostgreSQL follow-through and clarify scope boundaries between promotion, infra, and runtime cutover.
- Add a task packet and fixed-in-commit review artifact to govern and document the B1 foods PostgreSQL promotion lane.

Documentation:
- Document the B1 foods PostgreSQL promotion task packet and update the backlog ledger to describe the follow-through train and explicit deferral of runtime cutover.

Tests:
- Add a dedicated test harness for the foods snapshot promotion script with SQLite fixtures and optional PostgreSQL-backed integration coverage.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool to promote a foods snapshot from SQLite into PostgreSQL with batched, idempotent upserts, deterministic JSON handling, validation checks, and a JSON summary report.

* **Documentation**
  * Added an orchestration task packet and a review disposition page; updated the roadmap to define a governed multi-stage follow-through sequence (B1 → infra → B2) and clarified scope, ordering, and acceptance criteria.

* **Tests**
  * Added integration tests for happy-path promotion, idempotency, legacy-schema handling, and deterministic failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->