### PR TITLE
fix(ci): deduplicate exact pinned constraints per surface

### DIFF
--- a/docs/review/PR_1426_FIXED_MAPPING.md
+++ b/docs/review/PR_1426_FIXED_MAPPING.md
@@ -12,6 +12,8 @@ Bot and human review threads must be dispositioned here before they are resolved
 
 - FIXED `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080134887` -> `ec813602a`
 - FIXED `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080134896` -> `ec813602a`
+- FIXED `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080145564` -> `1d2ad1244`
+- FIXED `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080175001` -> `1d2ad1244`
 
 ## Merge Readiness
 

--- a/docs/review/PR_1426_FIXED_MAPPING.md
+++ b/docs/review/PR_1426_FIXED_MAPPING.md
@@ -3,8 +3,8 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 Bot and human review threads must be dispositioned here before they are resolved on GitHub.
 

--- a/docs/review/PR_1426_FIXED_MAPPING.md
+++ b/docs/review/PR_1426_FIXED_MAPPING.md
@@ -10,10 +10,14 @@ Bot and human review threads must be dispositioned here before they are resolved
 
 ## Fixed in Commit Mapping
 
-- FIXED `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080134887` -> `ec813602a`
-- FIXED `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080134896` -> `ec813602a`
-- FIXED `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080145564` -> `1d2ad1244`
-- FIXED `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080175001` -> `1d2ad1244`
+Disposition: FIXED
+Commit: ec813602a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080134887 -> ec813602a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080134896 -> ec813602a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#pullrequestreview-4106659425 -> ec813602a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080145564 -> 1d2ad1244
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080175001 -> 1d2ad1244
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#pullrequestreview-4106703810 -> 1d2ad1244
 
 ## Merge Readiness
 

--- a/docs/review/PR_1426_FIXED_MAPPING.md
+++ b/docs/review/PR_1426_FIXED_MAPPING.md
@@ -10,14 +10,35 @@ Bot and human review threads must be dispositioned here before they are resolved
 
 ## Fixed in Commit Mapping
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080134887
 Disposition: FIXED
 Commit: ec813602a
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080134887 -> ec813602a
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080134896 -> ec813602a
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#pullrequestreview-4106659425 -> ec813602a
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080145564 -> 1d2ad1244
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080175001 -> 1d2ad1244
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#pullrequestreview-4106703810 -> 1d2ad1244
+Evidence: `tests/test_install_locked_python_requirements.py:317`, `tests/test_install_locked_python_requirements.py:348`, and `tests/test_install_locked_python_requirements.py:374` now assert original-constraints path reuse and symmetric `install_from_wheelhouse` coverage for the testing gap Sourcery flagged.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080134896
+Disposition: FIXED
+Commit: ec813602a
+Evidence: `docs/review/PR_1426_FIXED_MAPPING.md:24` now uses the grammatically complete merge-readiness wording `Current-head CI is green for PR branch head`, matching the review request.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#pullrequestreview-4106659425
+Disposition: FIXED
+Commit: ec813602a
+Evidence: `tests/test_install_locked_python_requirements.py:317`, `tests/test_install_locked_python_requirements.py:348`, `tests/test_install_locked_python_requirements.py:374`, and `docs/review/PR_1426_FIXED_MAPPING.md:24` cover the actionable Sourcery review items summarized in this review.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080145564
+Disposition: FIXED
+Commit: 1d2ad1244
+Evidence: `scripts/ci/install_locked_python_requirements.py:623` now creates the effective constraints file beside the original constraints file, and `tests/test_install_locked_python_requirements.py:254` verifies relative include paths remain resolvable.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080175001
+Disposition: FIXED
+Commit: 1d2ad1244
+Evidence: `scripts/ci/install_locked_python_requirements.py:623` and `tests/test_install_locked_python_requirements.py:254` implement and verify the relative-include-safe effective constraints rewrite requested in the CodeRabbit thread.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#pullrequestreview-4106703810
+Disposition: FIXED
+Commit: 1d2ad1244
+Evidence: `scripts/ci/install_locked_python_requirements.py:623` and `tests/test_install_locked_python_requirements.py:254` address the actionable CodeRabbit review summary by preserving sibling include resolution in the rewritten constraints file and covering it with a regression test.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1426_FIXED_MAPPING.md
+++ b/docs/review/PR_1426_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1426 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+Bot and human review threads must be dispositioned here before they are resolved on GitHub.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1426_FIXED_MAPPING.md
+++ b/docs/review/PR_1426_FIXED_MAPPING.md
@@ -14,7 +14,7 @@ Bot and human review threads must be dispositioned here before they are resolved
 
 ## Merge Readiness
 
-- [ ] Current-head CI green for PR branch head
+- [ ] Current-head CI is green for PR branch head
 - [ ] Required checks complete (no pending jobs)
 - [ ] All review threads resolved on GitHub after disposition updates
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`

--- a/docs/review/PR_1426_FIXED_MAPPING.md
+++ b/docs/review/PR_1426_FIXED_MAPPING.md
@@ -10,7 +10,8 @@ Bot and human review threads must be dispositioned here before they are resolved
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- FIXED `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080134887` -> `ec813602a`
+- FIXED `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1426#discussion_r3080134896` -> `ec813602a`
 
 ## Merge Readiness
 

--- a/scripts/ci/install_locked_python_requirements.py
+++ b/scripts/ci/install_locked_python_requirements.py
@@ -620,13 +620,21 @@ def effective_constraints_file_for_requirement(
         yield None
         return
 
-    with tempfile.TemporaryDirectory(prefix="pulseplate-effective-constraints-") as temp_dir:
-        effective_constraints_path = Path(temp_dir) / validated_constraints_file.name
+    temp_fd, temp_name = tempfile.mkstemp(
+        prefix=f".{validated_constraints_file.stem}.effective-",
+        suffix=validated_constraints_file.suffix,
+        dir=validated_constraints_file.parent,
+    )
+    effective_constraints_path = Path(temp_name)
+    try:
+        os.close(temp_fd)
         effective_constraints_path.write_text(
             "".join(filtered_constraint_lines),
             encoding="utf-8",
         )
         yield effective_constraints_path
+    finally:
+        effective_constraints_path.unlink(missing_ok=True)
 
 
 def normalize_trusted_host(trusted_host: str | None) -> str | None:

--- a/scripts/ci/install_locked_python_requirements.py
+++ b/scripts/ci/install_locked_python_requirements.py
@@ -585,6 +585,50 @@ def validate_constraints_file(constraints_file: Path | None) -> Path | None:
     return constraints_file
 
 
+@contextmanager
+def effective_constraints_file_for_requirement(
+    requirement_file: Path,
+    constraints_file: Path | None,
+) -> Iterator[Path | None]:
+    """Yield constraints with duplicate exact pins removed for one requirement surface."""
+    validated_constraints_file = validate_constraints_file(constraints_file)
+    if validated_constraints_file is None:
+        yield None
+        return
+
+    requirement_exact_pins = _load_exact_requirement_pins(requirement_file)
+    if not requirement_exact_pins:
+        yield validated_constraints_file
+        return
+
+    constraint_lines = validated_constraints_file.read_text(encoding="utf-8").splitlines(
+        keepends=True
+    )
+    filtered_constraint_lines = []
+    removed_duplicate_pin = False
+    for line in constraint_lines:
+        normalized_line = line.split("#", 1)[0].strip().lower()
+        if normalized_line and normalized_line in requirement_exact_pins:
+            removed_duplicate_pin = True
+            continue
+        filtered_constraint_lines.append(line)
+
+    if not removed_duplicate_pin:
+        yield validated_constraints_file
+        return
+    if not filtered_constraint_lines:
+        yield None
+        return
+
+    with tempfile.TemporaryDirectory(prefix="pulseplate-effective-constraints-") as temp_dir:
+        effective_constraints_path = Path(temp_dir) / validated_constraints_file.name
+        effective_constraints_path.write_text(
+            "".join(filtered_constraint_lines),
+            encoding="utf-8",
+        )
+        yield effective_constraints_path
+
+
 def normalize_trusted_host(trusted_host: str | None) -> str | None:
     """Return a normalized trusted-host value or None when unset."""
     if trusted_host is None:
@@ -763,14 +807,18 @@ def install_from_wheelhouse(
     wheelhouse_dir: Path,
 ) -> None:
     for requirement_file in requirement_files:
-        run_command(
-            build_pip_install_command(
-                python_executable=python_executable,
-                requirement_file=requirement_file,
-                wheelhouse_dir=wheelhouse_dir,
-                constraints_file=constraints_file,
+        with effective_constraints_file_for_requirement(
+            requirement_file,
+            constraints_file,
+        ) as effective_constraints_file:
+            run_command(
+                build_pip_install_command(
+                    python_executable=python_executable,
+                    requirement_file=requirement_file,
+                    wheelhouse_dir=wheelhouse_dir,
+                    constraints_file=effective_constraints_file,
+                )
             )
-        )
 
 
 def install_from_proxy(
@@ -784,17 +832,21 @@ def install_from_proxy(
     allow_pip_download_cache: bool | None = None,
 ) -> None:
     for requirement_file in requirement_files:
-        run_command(
-            build_pip_proxy_install_command(
-                python_executable=python_executable,
-                requirement_file=requirement_file,
-                constraints_file=constraints_file,
-                index_url=index_url,
-                trusted_host=trusted_host,
-                find_links_dir=find_links_dir,
-                allow_pip_download_cache=allow_pip_download_cache,
+        with effective_constraints_file_for_requirement(
+            requirement_file,
+            constraints_file,
+        ) as effective_constraints_file:
+            run_command(
+                build_pip_proxy_install_command(
+                    python_executable=python_executable,
+                    requirement_file=requirement_file,
+                    constraints_file=effective_constraints_file,
+                    index_url=index_url,
+                    trusted_host=trusted_host,
+                    find_links_dir=find_links_dir,
+                    allow_pip_download_cache=allow_pip_download_cache,
+                )
             )
-        )
 
 
 def build_wheelhouse(
@@ -808,16 +860,20 @@ def build_wheelhouse(
 ) -> None:
     wheelhouse_dir.mkdir(parents=True, exist_ok=True)
     for requirement_file in requirement_files:
-        run_command(
-            build_pip_download_command(
-                python_executable=python_executable,
-                requirement_file=requirement_file,
-                wheelhouse_dir=wheelhouse_dir,
-                constraints_file=constraints_file,
-                index_url=index_url,
-                trusted_host=trusted_host,
+        with effective_constraints_file_for_requirement(
+            requirement_file,
+            constraints_file,
+        ) as effective_constraints_file:
+            run_command(
+                build_pip_download_command(
+                    python_executable=python_executable,
+                    requirement_file=requirement_file,
+                    wheelhouse_dir=wheelhouse_dir,
+                    constraints_file=effective_constraints_file,
+                    index_url=index_url,
+                    trusted_host=trusted_host,
+                )
             )
-        )
 
 
 def build_wheelhouse_with_emergency_fallback(

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -251,6 +251,27 @@ def test_effective_constraints_file_for_requirement_filters_duplicate_exact_pin(
         assert effective_constraints.read_text(encoding="utf-8") == "httpx>=0.28.1\n"
 
 
+def test_effective_constraints_file_for_requirement_keeps_relative_includes_resolvable(
+    tmp_path: Path,
+) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("pillow==12.2.0\n", encoding="utf-8")
+    constraints = tmp_path / "constraints.txt"
+    nested_constraints = tmp_path / "nested.txt"
+    nested_constraints.write_text("httpx>=0.28.1\n", encoding="utf-8")
+    constraints.write_text("-c nested.txt\npillow==12.2.0\n", encoding="utf-8")
+
+    with installer.effective_constraints_file_for_requirement(
+        requirements,
+        constraints,
+    ) as effective_constraints:
+        assert effective_constraints is not None
+        assert effective_constraints != constraints
+        assert effective_constraints.parent == constraints.parent
+        assert (effective_constraints.parent / "nested.txt").exists()
+        assert effective_constraints.read_text(encoding="utf-8") == "-c nested.txt\n"
+
+
 def test_effective_constraints_file_for_requirement_drops_constraint_when_only_duplicate_pin(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -320,6 +320,62 @@ def test_build_wheelhouse_preserves_non_duplicate_constraints(
     assert len(observed_commands) == 1
     assert "--constraint" in observed_commands[0]
     constraint_path = Path(observed_commands[0][observed_commands[0].index("--constraint") + 1])
+    assert constraint_path == constraints
+    assert constraint_path.read_text(encoding="utf-8") == "httpx>=0.28.1\n"
+
+
+def test_install_from_wheelhouse_omits_duplicate_exact_constraint_for_same_requirement_surface(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("pillow==12.2.0\n", encoding="utf-8")
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("pillow==12.2.0\n", encoding="utf-8")
+    observed_commands: list[list[str]] = []
+
+    def fake_run_command(command: list[str]) -> None:
+        observed_commands.append(command)
+
+    monkeypatch.setattr(installer, "run_command", fake_run_command)
+
+    installer.install_from_wheelhouse(
+        python_executable="python",
+        requirement_files=[requirements],
+        constraints_file=constraints,
+        wheelhouse_dir=tmp_path / "wheelhouse",
+    )
+
+    assert len(observed_commands) == 1
+    assert "--constraint" not in observed_commands[0]
+
+
+def test_install_from_wheelhouse_preserves_non_duplicate_constraints(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("pillow==12.2.0\n", encoding="utf-8")
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("httpx>=0.28.1\n", encoding="utf-8")
+    observed_commands: list[list[str]] = []
+
+    def fake_run_command(command: list[str]) -> None:
+        observed_commands.append(command)
+
+    monkeypatch.setattr(installer, "run_command", fake_run_command)
+
+    installer.install_from_wheelhouse(
+        python_executable="python",
+        requirement_files=[requirements],
+        constraints_file=constraints,
+        wheelhouse_dir=tmp_path / "wheelhouse",
+    )
+
+    assert len(observed_commands) == 1
+    assert "--constraint" in observed_commands[0]
+    constraint_path = Path(observed_commands[0][observed_commands[0].index("--constraint") + 1])
+    assert constraint_path == constraints
     assert constraint_path.read_text(encoding="utf-8") == "httpx>=0.28.1\n"
 
 

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -231,6 +231,98 @@ def test_build_pip_install_command_is_hermetic(tmp_path: Path) -> None:
     assert "--find-links" in command
 
 
+def test_effective_constraints_file_for_requirement_filters_duplicate_exact_pin(
+    tmp_path: Path,
+) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("pillow==12.2.0\nopenai==2.8.1\n", encoding="utf-8")
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text(
+        "pillow==12.2.0  # Security floor\nhttpx>=0.28.1\n",
+        encoding="utf-8",
+    )
+
+    with installer.effective_constraints_file_for_requirement(
+        requirements,
+        constraints,
+    ) as effective_constraints:
+        assert effective_constraints is not None
+        assert effective_constraints != constraints
+        assert effective_constraints.read_text(encoding="utf-8") == "httpx>=0.28.1\n"
+
+
+def test_effective_constraints_file_for_requirement_drops_constraint_when_only_duplicate_pin(
+    tmp_path: Path,
+) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("pillow==12.2.0\n", encoding="utf-8")
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("pillow==12.2.0\n", encoding="utf-8")
+
+    with installer.effective_constraints_file_for_requirement(
+        requirements,
+        constraints,
+    ) as effective_constraints:
+        assert effective_constraints is None
+
+
+def test_install_from_proxy_omits_duplicate_exact_constraint_for_same_requirement_surface(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("pillow==12.2.0\n", encoding="utf-8")
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("pillow==12.2.0\n", encoding="utf-8")
+    observed_commands: list[list[str]] = []
+
+    def fake_run_command(command: list[str]) -> None:
+        observed_commands.append(command)
+
+    monkeypatch.setattr(installer, "run_command", fake_run_command)
+
+    installer.install_from_proxy(
+        python_executable="python",
+        requirement_files=[requirements],
+        constraints_file=constraints,
+        index_url=APPROVED_PROXY_URL,
+        trusted_host="packages.example.internal",
+    )
+
+    assert len(observed_commands) == 1
+    assert "--constraint" not in observed_commands[0]
+
+
+def test_build_wheelhouse_preserves_non_duplicate_constraints(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("pillow==12.2.0\n", encoding="utf-8")
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("httpx>=0.28.1\n", encoding="utf-8")
+    observed_commands: list[list[str]] = []
+
+    def fake_run_command(command: list[str]) -> None:
+        observed_commands.append(command)
+
+    monkeypatch.setattr(installer, "run_command", fake_run_command)
+
+    installer.build_wheelhouse(
+        python_executable="python",
+        requirement_files=[requirements],
+        constraints_file=constraints,
+        wheelhouse_dir=tmp_path / "wheelhouse",
+        index_url=APPROVED_PROXY_URL,
+        trusted_host="packages.example.internal",
+    )
+
+    assert len(observed_commands) == 1
+    assert "--constraint" in observed_commands[0]
+    constraint_path = Path(observed_commands[0][observed_commands[0].index("--constraint") + 1])
+    assert constraint_path.read_text(encoding="utf-8") == "httpx>=0.28.1\n"
+
+
 def test_build_pip_proxy_install_command_uses_approved_proxy_without_cache(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- remove duplicate exact pins from `constraints.txt` when the same exact pin already exists in the active requirements surface
- apply the effective per-surface constraints handling to wheelhouse download, wheelhouse install, and proxy install paths
- add regression tests for duplicate filtering, constraints removal when only duplicates remain, and preservation of non-duplicate constraints

## Test plan
- [x] `pytest -q tests/test_install_locked_python_requirements.py`
- [x] `pre-commit run --files scripts/ci/install_locked_python_requirements.py tests/test_install_locked_python_requirements.py`
- [x] pre-push hooks on `git push -u origin HEAD`
- [x] post-open review lane (`qa-engineer-agent -> bug-hunter`)

## Risks
- keeps constraints enforcement enabled for non-duplicate entries and only strips exact duplicates that would otherwise cause `pip` `ResolutionImpossible`
- full `make verify` remains separately blocked by an unrelated repo-wide diff-cover/coverage issue referencing missing path `app/services/restaurant_postgres_bridge.py`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1426_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Current-head CI is green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`

## Deferred / Follow-ups
- None.

## Summary by Sourcery

Устраняет дублирование одинаковых фиксированных ограничений (pinned constraints) для каждой «поверхности требований» при установке или сборке wheelhouse в CI, что позволяет избежать проблем с разрешением зависимостей в pip из-за дублирующихся пинов.

Bug Fixes:
- Удалять точные дубликаты пинов из файлов constraints, если они уже присутствуют в активной «поверхности требований», предотвращая ошибки ResolutionImpossible.
- Гарантировать, что пути скачивания wheelhouse, установки из wheelhouse и proxy-установки придерживаются эффективных ограничений для каждой поверхности, не теряя недублирующиеся записи.

Documentation:
- Добавлен файл документации по ревью, фиксирующий соответствие «исправлено-в-коммите» для PR 1426.

Tests:
- Добавлены регрессионные тесты, покрывающие фильтрацию дублирующихся ограничений, удаление ограничений, когда остаются только дубликаты, и сохранение недублирующихся ограничений в потоках proxy-установки и работы с wheelhouse.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Deduplicate exact pinned constraints per requirement surface when installing or building wheelhouses in CI, avoiding pip resolution issues from duplicate pins.

Bug Fixes:
- Strip exact duplicate pins from constraints files when they already exist in the active requirements surface, preventing ResolutionImpossible errors.
- Ensure wheelhouse download, wheelhouse install, and proxy install paths all respect per-surface effective constraints without losing non-duplicate entries.

Documentation:
- Add review documentation file capturing the fixed-in-commit mapping for PR 1426.

Tests:
- Add regression tests covering duplicate constraint filtering, dropping constraints when only duplicates remain, and preserving non-duplicate constraints in proxy install and wheelhouse flows.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-requirement constraint handling for Python installs that generates an effective constraints file, removes duplicate exact package pins, and omits constraint usage when only duplicates remain.

* **Tests**
  * Added tests covering constraint de-duplication, preservation of non-duplicate constraints, and correct install/build command behavior with or without effective constraints.

* **Documentation**
  * Added review disposition and merge-readiness documentation for PR tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->