### PR TITLE
fix(deps): run dependency floor preflight before locked install

### DIFF
--- a/.github/actions/python-setup/action.yml
+++ b/.github/actions/python-setup/action.yml
@@ -57,7 +57,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        set -euxo pipefail
+        set -euo pipefail
         : "${PULSEPLATE_PYTHON_INDEX_URL:?Set PULSEPLATE_PYTHON_INDEX_URL to the approved private package proxy URL.}"
         preflight_args=()
         preflight_args+=(--index-url "$PULSEPLATE_PYTHON_INDEX_URL")
@@ -75,7 +75,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        set -euxo pipefail
+        set -euo pipefail
         : "${PULSEPLATE_PYTHON_INDEX_URL:?Set PULSEPLATE_PYTHON_INDEX_URL to the approved private package proxy URL.}"
         install_args=()
         install_args+=(--index-url "$PULSEPLATE_PYTHON_INDEX_URL")
@@ -163,7 +163,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        set -euxo pipefail
+        set -euo pipefail
         echo "::notice::Pinned development tooling is provided by requirements-dev.txt via install_locked_python_requirements.py"
 
     # Backward-compatibility no-op: pinned test tooling comes from
@@ -173,5 +173,5 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        set -euxo pipefail
+        set -euo pipefail
         echo "::notice::Pinned test tooling is provided by ${{ inputs.test-requirements-file }} via install_locked_python_requirements.py"

--- a/.github/actions/python-setup/action.yml
+++ b/.github/actions/python-setup/action.yml
@@ -52,6 +52,24 @@ runs:
         cache-dependency-path: |
           ${{ inputs.working-directory }}/requirements*.txt
 
+    - name: Preflight dependency floors via approved proxy
+      if: ${{ inputs.skip-base-install != 'true' }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euxo pipefail
+        : "${PULSEPLATE_PYTHON_INDEX_URL:?Set PULSEPLATE_PYTHON_INDEX_URL to the approved private package proxy URL.}"
+        preflight_args=()
+        preflight_args+=(--index-url "$PULSEPLATE_PYTHON_INDEX_URL")
+        if [[ -n "${PULSEPLATE_PYTHON_TRUSTED_HOST:-}" ]]; then
+          preflight_args+=(--trusted-host "$PULSEPLATE_PYTHON_TRUSTED_HOST")
+        fi
+        python "${{ github.workspace }}/scripts/ci/install_locked_python_requirements.py" \
+          --python-executable python \
+          --preflight-only \
+          --emergency-wheel-manifest "${{ github.workspace }}/scripts/ci/emergency_python_wheels.json" \
+          "${preflight_args[@]}"
+
     - name: Install base dependencies
       if: ${{ inputs.skip-base-install != 'true' }}
       shell: bash

--- a/docs/review/PR_1429_FIXED_MAPPING.md
+++ b/docs/review/PR_1429_FIXED_MAPPING.md
@@ -47,6 +47,10 @@ Evidence: `tests/test_install_locked_python_requirements.py` already exercises `
 Disposition: NOT-A-BUG
 Evidence: `run_command` captures output only where subprocess diagnostics are required (pip failure analysis / preflight). Long installs in CI are bounded by workflow `timeout-minutes` and step logs; switching wheelhouse paths back to inherited stdio would lose stderr needed for this PR’s resolver-miss contract.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085702790
+Disposition: NOT-A-BUG
+Evidence: `scripts/ci/install_locked_python_requirements.py` `run_command` intentionally captures subprocess text so failures include pip stderr for resolver-miss and floor preflight; streaming install logs is a separate UX trade-off from this PR’s diagnostic contract (same rationale as `discussion_r3085630237`).
+
 ## Merge Readiness
 
 - [ ] Current-head CI is green for PR branch head

--- a/docs/review/PR_1429_FIXED_MAPPING.md
+++ b/docs/review/PR_1429_FIXED_MAPPING.md
@@ -1,0 +1,10 @@
+# PR #1429 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments

--- a/docs/review/PR_1429_FIXED_MAPPING.md
+++ b/docs/review/PR_1429_FIXED_MAPPING.md
@@ -32,7 +32,7 @@ Evidence: `.github/actions/python-setup/action.yml:60`, `:78`, `:166`, and `:176
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085646506
 Disposition: FIXED
-Commit: b34e2f5c9
+Commit: bddb80887
 Evidence: `docs/review/PR_1429_FIXED_MAPPING.md` evidence lines for `discussion_r3085436155` and `discussion_r3085477602` now use strict `file:line` anchors (`tests/test_install_locked_python_requirements.py:18-24`, `:1720`, `:1806`, `:1046-1062`; `.github/actions/python-setup/action.yml:60`, `:78`, `:166`, `:176`).
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085622859

--- a/docs/review/PR_1429_FIXED_MAPPING.md
+++ b/docs/review/PR_1429_FIXED_MAPPING.md
@@ -30,6 +30,41 @@ Disposition: FIXED
 Commit: 79c21ea02
 Evidence: `.github/actions/python-setup/action.yml:60`, `:78`, `:166`, and `:176` replace `set -euxo pipefail` with `set -euo pipefail` so bash xtrace cannot echo expanded `PULSEPLATE_PYTHON_INDEX_URL` values into logs.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085436142
+Disposition: FIXED
+Commit: 81bf0b975
+Evidence: `docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md:169` qualifies that policy/guard checks stay deterministic while the optional `--preflight-only` path performs network reads against `PULSEPLATE_PYTHON_INDEX_URL` (and may use `scripts/ci/emergency_python_wheels.json`).
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085436146
+Disposition: FIXED
+Commit: 81bf0b975
+Evidence: `scripts/ci/install_locked_python_requirements.py:722-724` rejects non-object JSON roots before `payload.get("min_versions")`, so malformed schema files raise the script’s stable `RuntimeError` shape.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085436150
+Disposition: FIXED
+Commit: 81bf0b975
+Evidence: `scripts/ci/install_locked_python_requirements.py:879-904` (`run_command`) folds captured pip stdout/stderr into `RuntimeError` text so `_resolver_miss_error` can match “No matching distribution …” output on real resolver misses.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085477600
+Disposition: FIXED
+Commit: 81bf0b975
+Evidence: same as `discussion_r3085436150`: `scripts/ci/install_locked_python_requirements.py:879-904` preserves pip stderr/stdout on non-zero exits for floor-preflight resolver-miss matching.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085477615
+Disposition: FIXED
+Commit: 79c21ea02
+Evidence: `scripts/ci/install_locked_python_requirements.py:1277-1284` enforces `args.require_virtualenv` + `is_virtualenv_python(...)` before `args.upgrade_pip` / `upgrade_pip(...)`, so pip is not upgraded outside the guarded interpreter refusal path.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085477622
+Disposition: FIXED
+Commit: 81bf0b975
+Evidence: same as `discussion_r3085436146`: `scripts/ci/install_locked_python_requirements.py:722-724`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085477628
+Disposition: FIXED
+Commit: 79c21ea02
+Evidence: same as `discussion_r3085436155`: `tests/test_install_locked_python_requirements.py:18-24` (`_resolver_miss_runtimeerror_like_run_command`), `:1720`, `:1806`, and `:1046-1062` align stubbed failures with the production `run_command` error contract.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085646506
 Disposition: FIXED
 Commit: bddb80887
@@ -50,6 +85,41 @@ Evidence: `run_command` captures output only where subprocess diagnostics are re
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085702790
 Disposition: NOT-A-BUG
 Evidence: `scripts/ci/install_locked_python_requirements.py` `run_command` intentionally captures subprocess text so failures include pip stderr for resolver-miss and floor preflight; streaming install logs is a separate UX trade-off from this PR’s diagnostic contract (same rationale as `discussion_r3085630237`).
+
+
+
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#pullrequestreview-4112374782
+Disposition: NOT-A-BUG
+Evidence: `tests/fixtures/dependency_security_schema.json` remains the canonical on-disk schema path exercised by `tests/test_dependency_security_guard.py`; `build_floor_preflight_command`/`run_dependency_floor_preflight` pairing is an internal helper seam for this PR and does not change intake correctness.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#pullrequestreview-4112412648
+Disposition: FIXED
+Commit: 81bf0b975
+Evidence: CodeRabbit umbrella “Actionable comments posted: 4” maps to the same fixes as inline threads `discussion_r3085436142`, `discussion_r3085436146`, `discussion_r3085436150`, and `discussion_r3085436155` (`docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md:169`; `scripts/ci/install_locked_python_requirements.py:722-724` and `:879-904`; tests cited under `discussion_r3085436155`).
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#pullrequestreview-4112460492
+Disposition: FIXED
+Commit: 81bf0b975
+Evidence: Cubic umbrella maps to inline threads `discussion_r3085477600`, `discussion_r3085477602`, `discussion_r3085477615`, `discussion_r3085477622`, and `discussion_r3085477628` (see disposition evidence on those URLs).
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#pullrequestreview-4112490721
+Disposition: FIXED
+Commit: 79c21ea02
+Evidence: CodeRabbit duplicate-review summary tracks the resolver-miss test contract updates captured under `discussion_r3085436155` and `discussion_r3085477628`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#pullrequestreview-4112611397
+Disposition: NOT-A-BUG
+Evidence: Follow-up refactors (explicit schema path injection, explicit `--dest` parameterization, short-circuit emergency downloads) are optional hardening; this PR’s behavior is covered by tests and does not change the dependency intake contract.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#pullrequestreview-4112637471
+Disposition: FIXED
+Commit: bddb80887
+Evidence: mapping evidence tightened to strict `file:line` anchors as described under `discussion_r3085646506`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#pullrequestreview-4112701663
+Disposition: NOT-A-BUG
+Evidence: same rationale as `discussion_r3085702790`: captured subprocess text is required for resolver-miss diagnostics; streaming logs is a separate UX follow-up.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1429_FIXED_MAPPING.md
+++ b/docs/review/PR_1429_FIXED_MAPPING.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD034 -->
 # PR #1429 — Fixed in Commit Mapping (canonical)
 
 ## Discussion Thread Pass
@@ -5,6 +6,34 @@
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
+Bot and human review threads are dispositioned here before they are resolved on GitHub.
+
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085416208
+Disposition: FIXED
+Commit: 81bf0b975
+Evidence: `scripts/ci/install_locked_python_requirements.py:873` (`run_command` captures subprocess stdout/stderr and folds them into `RuntimeError` text so `_resolver_miss_error` can match pip “No matching distribution …” output).
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085416213
+Disposition: FIXED
+Commit: 81bf0b975
+Evidence: `scripts/ci/install_locked_python_requirements.py:1273` enforces `--require-virtualenv` before `scripts/ci/install_locked_python_requirements.py:1278` (`--upgrade-pip`), so pip is not upgraded outside an interpreter refusal path.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085436155
+Disposition: FIXED
+Commit: 79c21ea02
+Evidence: `tests/test_install_locked_python_requirements.py` adds `_resolver_miss_runtimeerror_like_run_command`, wires it into emergency preflight resolver-miss tests, and extends `test_run_command_wraps_subprocess_failures` to assert stderr text is included in the `RuntimeError` message (production-shaped failure string).
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085477602
+Disposition: FIXED
+Commit: 79c21ea02
+Evidence: `.github/actions/python-setup/action.yml:60` (and parallel composite `run` blocks) replace `set -euxo pipefail` with `set -euo pipefail` so bash xtrace cannot echo expanded `PULSEPLATE_PYTHON_INDEX_URL` values into logs.
+
+## Merge Readiness
+
+- [ ] Current-head CI is green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1429_FIXED_MAPPING.md
+++ b/docs/review/PR_1429_FIXED_MAPPING.md
@@ -23,12 +23,17 @@ Evidence: `scripts/ci/install_locked_python_requirements.py:1273` enforces `--re
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085436155
 Disposition: FIXED
 Commit: 79c21ea02
-Evidence: `tests/test_install_locked_python_requirements.py` adds `_resolver_miss_runtimeerror_like_run_command`, wires it into emergency preflight resolver-miss tests, and extends `test_run_command_wraps_subprocess_failures` to assert stderr text is included in the `RuntimeError` message (production-shaped failure string).
+Evidence: `tests/test_install_locked_python_requirements.py:18-24` defines `_resolver_miss_runtimeerror_like_run_command`; `tests/test_install_locked_python_requirements.py:1720` and `tests/test_install_locked_python_requirements.py:1806` raise it in emergency preflight resolver-miss tests; `tests/test_install_locked_python_requirements.py:1046-1062` extends `test_run_command_wraps_subprocess_failures` to assert stderr text is included in the `RuntimeError` message.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085477602
 Disposition: FIXED
 Commit: 79c21ea02
-Evidence: `.github/actions/python-setup/action.yml:60` (and parallel composite `run` blocks) replace `set -euxo pipefail` with `set -euo pipefail` so bash xtrace cannot echo expanded `PULSEPLATE_PYTHON_INDEX_URL` values into logs.
+Evidence: `.github/actions/python-setup/action.yml:60`, `:78`, `:166`, and `:176` replace `set -euxo pipefail` with `set -euo pipefail` so bash xtrace cannot echo expanded `PULSEPLATE_PYTHON_INDEX_URL` values into logs.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085646506
+Disposition: FIXED
+Commit: b34e2f5c9
+Evidence: `docs/review/PR_1429_FIXED_MAPPING.md` evidence lines for `discussion_r3085436155` and `discussion_r3085477602` now use strict `file:line` anchors (`tests/test_install_locked_python_requirements.py:18-24`, `:1720`, `:1806`, `:1046-1062`; `.github/actions/python-setup/action.yml:60`, `:78`, `:166`, `:176`).
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085622859
 Disposition: NOT-A-BUG

--- a/docs/review/PR_1429_FIXED_MAPPING.md
+++ b/docs/review/PR_1429_FIXED_MAPPING.md
@@ -30,6 +30,18 @@ Disposition: FIXED
 Commit: 79c21ea02
 Evidence: `.github/actions/python-setup/action.yml:60` (and parallel composite `run` blocks) replace `set -euxo pipefail` with `set -euo pipefail` so bash xtrace cannot echo expanded `PULSEPLATE_PYTHON_INDEX_URL` values into logs.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085622859
+Disposition: NOT-A-BUG
+Evidence: `scripts/ci/install_locked_python_requirements.py` (`run_command`): including captured stderr in `RuntimeError` is required for resolver-miss detection and CI triage; index URLs come from CI env (not user paste). Heuristic redaction/truncation of subprocess output is product-hardening scope—track separately if we want bounded error blobs policy-wide.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085622872
+Disposition: NOT-A-BUG
+Evidence: `tests/test_install_locked_python_requirements.py` already exercises `--preflight-only` through `main` with proxy/emergency flags; adding sentinel monkeypatches for every forwarded argument is optional coverage expansion, not a correctness gap for this PR.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1429#discussion_r3085630237
+Disposition: NOT-A-BUG
+Evidence: `run_command` captures output only where subprocess diagnostics are required (pip failure analysis / preflight). Long installs in CI are bounded by workflow `timeout-minutes` and step logs; switching wheelhouse paths back to inherited stdio would lose stderr needed for this PR’s resolver-miss contract.
+
 ## Merge Readiness
 
 - [ ] Current-head CI is green for PR branch head

--- a/docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md
+++ b/docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md
@@ -166,7 +166,7 @@ make verify
 
 - Guard runs in `make test-fast` -> `make verify`
 - PR cannot merge if guard fails
-- Deterministic: no network calls, no external state
+- Deterministic for policy checks: no network calls and no external state in the guard itself; the optional CI preflight (`scripts/ci/install_locked_python_requirements.py --preflight-only`) performs network reads against `PULSEPLATE_PYTHON_INDEX_URL` and may use `scripts/ci/emergency_python_wheels.json` for verified emergency fallbacks
 
 ## Validated Surfaces
 

--- a/docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md
+++ b/docs/security/DEPENDENCY_SECURITY_GUARD_WORKFLOW.md
@@ -17,7 +17,8 @@ The guard runs as part of `make verify` and validates all 5 requirement surfaces
 ```json
 {
   "min_versions": {
-    "cryptography": "46.0.5"
+    "cryptography": "46.0.7",
+    "pillow": "12.2.0"
   },
   "blocked_packages": [],
   "blocked_versions": {}
@@ -60,6 +61,19 @@ Choose the appropriate schema section:
 
 Dev-only dependencies (like `marshmallow`) cannot currently be tracked in `min_versions` because they don't exist in runtime surfaces. This is a known limitation.
 
+### 2a. Preflight source availability before install
+
+Before full dependency install in CI, run fail-fast availability preflight through the same
+approved proxy path used by canonical install:
+
+- `scripts/ci/install_locked_python_requirements.py --preflight-only`
+- Uses `PULSEPLATE_PYTHON_INDEX_URL` (+ optional `PULSEPLATE_PYTHON_TRUSTED_HOST`)
+- Checks floor versions from `min_versions`
+- Allows only exact emergency fallback artifacts from `scripts/ci/emergency_python_wheels.json`
+
+This separates **security floor policy** from **source availability** and fails early when
+the proxy is stale.
+
 ### 3. Update Requirement Surfaces
 
 1. Bump version in `requirements.in` or `requirements-dev.in`
@@ -92,21 +106,22 @@ make verify
 
 ### Example 1: Minimum Version Floor (cryptography CVE)
 
-**Scenario:** CVE-2026-26007 fixed in cryptography 46.0.5
+**Scenario:** CVE-2026-26007 fixed in cryptography 46.0.7 and GHSA-whj4-6x5x-4v2j fixed in pillow 12.2.0
 
 **Schema update:**
 ```json
 {
   "min_versions": {
-    "cryptography": "46.0.5"
+    "cryptography": "46.0.7",
+    "pillow": "12.2.0"
   }
 }
 ```
 
 **Requirement updates:**
-- `requirements.in`: `cryptography>=46.0.5,<47.0.0`
-- `requirements-dev.in`: `cryptography>=46.0.5`
-- `constraints.txt`: `cryptography>=46.0.5`
+- `requirements.in`: `cryptography>=46.0.7,<47.0.0` and `pillow>=12.2.0,<13.0.0`
+- `requirements-dev.in`: `cryptography>=46.0.7`
+- `constraints.txt`: `cryptography>=46.0.7` and `pillow>=12.2.0`
 - Regenerate locks
 
 ### Example 2: Blocked Package

--- a/scripts/ci/install_locked_python_requirements.py
+++ b/scripts/ci/install_locked_python_requirements.py
@@ -720,15 +720,21 @@ def load_dependency_security_floors(
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"Dependency security schema is not valid JSON: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Dependency security schema must be a JSON object: {path}")
     min_versions = payload.get("min_versions")
     if not isinstance(min_versions, dict) or not min_versions:
-        raise RuntimeError("Dependency security schema must define non-empty min_versions.")
+        raise RuntimeError(f"Dependency security schema must define non-empty min_versions: {path}")
     floors: dict[str, str] = {}
     for package, version in min_versions.items():
         if not isinstance(package, str) or not package.strip():
-            raise RuntimeError("Dependency security schema contains invalid package name.")
+            raise RuntimeError(
+                f"Dependency security schema contains invalid package name in {path}: {package!r}"
+            )
         if not isinstance(version, str) or not version.strip():
-            raise RuntimeError(f"Dependency security schema has invalid version for {package!r}.")
+            raise RuntimeError(
+                f"Dependency security schema has invalid version for {package!r} in {path}"
+            )
         floors[package.strip().lower()] = version.strip()
     return floors
 
@@ -865,14 +871,27 @@ def is_virtualenv_python(python_executable: str) -> bool:
 
 
 def run_command(command: Sequence[str]) -> None:
+    """Run a subprocess command; include captured stdout/stderr on failure for pip diagnostics."""
+    command_text = " ".join(str(part) for part in command)
     try:
-        subprocess.run(  # nosec B603: commands are built internally from pinned requirement/install helpers only (remove-by: 2026-07-31, ref: PR-litellm-hardening)
+        result = subprocess.run(  # nosec B603: commands are built internally from pinned requirement/install helpers only (remove-by: 2026-07-31, ref: PR-litellm-hardening)
             list(command),
-            check=True,
+            check=False,
+            capture_output=True,
+            text=True,
         )
-    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
-        command_text = " ".join(str(part) for part in command)
+    except FileNotFoundError as exc:
         raise RuntimeError(f"Command failed: {command_text}: {exc}") from exc
+    if result.returncode != 0:
+        parts: list[str] = [f"exit {result.returncode}"]
+        stderr = (result.stderr or "").strip()
+        stdout = (result.stdout or "").strip()
+        if stderr:
+            parts.append(stderr)
+        if stdout:
+            parts.append(stdout)
+        detail = "\n".join(parts)
+        raise RuntimeError(f"Command failed: {command_text}: {detail}")
 
 
 def upgrade_pip(
@@ -1251,6 +1270,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             trusted_host=args.trusted_host,
         )
 
+        if args.require_virtualenv and not is_virtualenv_python(args.python_executable):
+            print("ERROR: refusing to install packages with a non-virtualenv interpreter.")
+            print(f"Python executable: {args.python_executable}")
+            return 1
+
         if args.upgrade_pip:
             upgrade_pip(
                 args.python_executable,
@@ -1277,11 +1301,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             install_test=args.install_test,
             requirements_profile=args.requirements_profile,
         )
-
-        if args.require_virtualenv and not is_virtualenv_python(args.python_executable):
-            print("ERROR: refusing to install packages with a non-virtualenv interpreter.")
-            print(f"Python executable: {args.python_executable}")
-            return 1
 
         if args.install_mode == "direct-proxy":
             return install_with_guard_from_proxy(

--- a/scripts/ci/install_locked_python_requirements.py
+++ b/scripts/ci/install_locked_python_requirements.py
@@ -26,6 +26,10 @@ DEFAULT_CI_LITE_REQUIREMENTS_FILE = REPO_ROOT / "requirements-ci-lite.txt"
 DEFAULT_CONSTRAINTS_FILE = REPO_ROOT / "constraints.txt"
 DEFAULT_STARTUP_HOOK_GUARD_PATH = REPO_ROOT / "scripts" / "ci" / "check_python_startup_hooks.py"
 DEFAULT_EMERGENCY_WHEEL_MANIFEST = REPO_ROOT / "scripts" / "ci" / "emergency_python_wheels.json"
+
+DEFAULT_DEPENDENCY_SECURITY_SCHEMA = (
+    REPO_ROOT / "tests" / "fixtures" / "dependency_security_schema.json"
+)
 APPROVED_INDEX_ENV_VAR = "PULSEPLATE_PYTHON_INDEX_URL"
 TRUSTED_HOST_ENV_VAR = "PULSEPLATE_PYTHON_TRUSTED_HOST"
 EMERGENCY_WHEEL_MANIFEST_ENV_VAR = "PULSEPLATE_PYTHON_EMERGENCY_WHEEL_MANIFEST"
@@ -170,6 +174,15 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help=(
             "Installation transport. 'wheelhouse' keeps the hermetic local wheelhouse path; "
             "'direct-proxy' installs from the approved proxy without creating a local wheelhouse."
+        ),
+    )
+
+    parser.add_argument(
+        "--preflight-only",
+        action="store_true",
+        help=(
+            "Validate min dependency floor versions against approved proxy/fallback and exit "
+            "without installing any requirements."
         ),
     )
     return parser.parse_args(argv)
@@ -696,6 +709,140 @@ def resolve_private_proxy_settings(
     )
 
 
+def load_dependency_security_floors(
+    schema_path: Path | None = None,
+) -> dict[str, str]:
+    """Load min dependency floors from canonical schema."""
+    path = schema_path or DEFAULT_DEPENDENCY_SECURITY_SCHEMA
+    if not path.exists():
+        raise FileNotFoundError(f"Dependency security schema not found: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Dependency security schema is not valid JSON: {path}: {exc}") from exc
+    min_versions = payload.get("min_versions")
+    if not isinstance(min_versions, dict) or not min_versions:
+        raise RuntimeError("Dependency security schema must define non-empty min_versions.")
+    floors: dict[str, str] = {}
+    for package, version in min_versions.items():
+        if not isinstance(package, str) or not package.strip():
+            raise RuntimeError("Dependency security schema contains invalid package name.")
+        if not isinstance(version, str) or not version.strip():
+            raise RuntimeError(f"Dependency security schema has invalid version for {package!r}.")
+        floors[package.strip().lower()] = version.strip()
+    return floors
+
+
+def _resolver_miss_error(runtime_error: RuntimeError, *, package: str, version: str) -> bool:
+    """Return True when pip failed because package floor is unavailable on index."""
+    message = str(runtime_error)
+    requirement_text = f"{package}=={version}"
+    resolver_markers = (
+        f"No matching distribution found for {requirement_text}",
+        f"Could not find a version that satisfies the requirement {requirement_text}",
+    )
+    return any(marker in message for marker in resolver_markers)
+
+
+def verify_emergency_artifact_for_floor(
+    *,
+    manifest_path: Path | None,
+    package: str,
+    version: str,
+) -> bool:
+    """Return True when exact emergency fallback artifact exists and verifies."""
+    artifacts = [
+        artifact
+        for artifact in load_emergency_wheel_manifest(manifest_path)
+        if artifact["package"].lower() == package.lower() and artifact["version"] == version
+    ]
+    if not artifacts:
+        return False
+    with tempfile.TemporaryDirectory(prefix="pulseplate-floor-emergency-") as temp_dir:
+        for artifact in artifacts:
+            destination = Path(temp_dir) / artifact["filename"]
+            _download_with_sha256(
+                url=artifact["url"],
+                destination=destination,
+                expected_sha256=artifact["sha256"],
+            )
+    return True
+
+
+def build_floor_preflight_command(
+    *,
+    python_executable: str,
+    package: str,
+    version: str,
+    index_url: str,
+    trusted_host: str | None,
+) -> list[str]:
+    """Build pip command for one floor availability check."""
+    command = [
+        python_executable,
+        "-m",
+        "pip",
+        "download",
+        "--retries",
+        str(PIP_NETWORK_RETRIES),
+        "--timeout",
+        str(PIP_NETWORK_TIMEOUT_SECONDS),
+        "--only-binary",
+        ":all:",
+        "--no-deps",
+        "--dest",
+        ".",
+        "--index-url",
+        index_url,
+        f"{package}=={version}",
+    ]
+    if trusted_host:
+        command.extend(["--trusted-host", trusted_host])
+    return command
+
+
+def run_dependency_floor_preflight(
+    *,
+    python_executable: str,
+    index_url: str,
+    trusted_host: str | None,
+    emergency_wheel_manifest: Path | None,
+) -> None:
+    """Fail fast when dependency floors are unavailable through approved path."""
+    floors = load_dependency_security_floors()
+    with tempfile.TemporaryDirectory(prefix="pulseplate-floor-preflight-") as temp_dir:
+        destination_dir = Path(temp_dir)
+        for package, version in sorted(floors.items()):
+            command = build_floor_preflight_command(
+                python_executable=python_executable,
+                package=package,
+                version=version,
+                index_url=index_url,
+                trusted_host=trusted_host,
+            )
+            dest_index = command.index("--dest")
+            command[dest_index + 1] = str(destination_dir)
+            try:
+                run_command(command)
+            except RuntimeError as exc:
+                if _resolver_miss_error(exc, package=package, version=version) and (
+                    verify_emergency_artifact_for_floor(
+                        manifest_path=emergency_wheel_manifest,
+                        package=package,
+                        version=version,
+                    )
+                ):
+                    print(
+                        "WARNING: floor preflight proxy miss tolerated via emergency fallback: "
+                        f"{package}=={version}"
+                    )
+                    continue
+                raise RuntimeError(
+                    "Dependency floor preflight failed for approved proxy: "
+                    f"{package}=={version}: {exc}"
+                ) from exc
+
+
 def is_virtualenv_python(python_executable: str) -> bool:
     """Return True when the target interpreter runs inside a virtualenv."""
     probe = (
@@ -1098,6 +1245,28 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "--install-dev or --install-test."
             )
             return 1
+
+        index_url, trusted_host = resolve_private_proxy_settings(
+            index_url=args.index_url,
+            trusted_host=args.trusted_host,
+        )
+
+        if args.upgrade_pip:
+            upgrade_pip(
+                args.python_executable,
+                index_url=index_url,
+                trusted_host=trusted_host,
+            )
+
+        if args.preflight_only:
+            run_dependency_floor_preflight(
+                python_executable=args.python_executable,
+                index_url=index_url,
+                trusted_host=trusted_host,
+                emergency_wheel_manifest=args.emergency_wheel_manifest,
+            )
+            return 0
+
         validated_constraints_file = validate_constraints_file(args.constraints_file)
         requirement_files = resolve_requirement_files(
             requirements_file=args.requirements_file,
@@ -1113,18 +1282,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("ERROR: refusing to install packages with a non-virtualenv interpreter.")
             print(f"Python executable: {args.python_executable}")
             return 1
-
-        index_url, trusted_host = resolve_private_proxy_settings(
-            index_url=args.index_url,
-            trusted_host=args.trusted_host,
-        )
-
-        if args.upgrade_pip:
-            upgrade_pip(
-                args.python_executable,
-                index_url=index_url,
-                trusted_host=trusted_host,
-            )
 
         if args.install_mode == "direct-proxy":
             return install_with_guard_from_proxy(

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -1037,10 +1037,15 @@ def test_is_virtualenv_python_wraps_probe_errors(
 def test_run_command_wraps_subprocess_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def raise_called_process_error(*args: object, **kwargs: object) -> object:
-        raise subprocess.CalledProcessError(returncode=1, cmd=["python", "-m", "pip"])
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=list(args[0]) if args else [],
+            returncode=1,
+            stdout="",
+            stderr="pip stderr here",
+        )
 
-    monkeypatch.setattr(installer.subprocess, "run", raise_called_process_error)
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
 
     with pytest.raises(RuntimeError, match="Command failed: python -m pip"):
         installer.run_command(["python", "-m", "pip"])

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -1060,6 +1060,7 @@ def test_main_fails_when_virtualenv_is_required(
     monkeypatch.setattr(installer, "DEFAULT_TEST_REQUIREMENTS_FILE", tmp_path / "missing-test.txt")
     monkeypatch.setattr(installer, "DEFAULT_CONSTRAINTS_FILE", constraints)
     monkeypatch.setattr(installer, "is_virtualenv_python", lambda python_executable: False)
+    monkeypatch.setenv(installer.APPROVED_INDEX_ENV_VAR, APPROVED_PROXY_URL)
 
     result = installer.main(
         [
@@ -1632,3 +1633,209 @@ def test_main_rejects_mixing_explicit_profile_with_legacy_flags(
 
     assert result == 1
     assert "requirements-profile cannot be combined" in capsys.readouterr().out
+
+
+def test_run_dependency_floor_preflight_checks_each_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_commands: list[list[str]] = []
+    monkeypatch.setattr(
+        installer,
+        "load_dependency_security_floors",
+        lambda: {"cryptography": "46.0.7", "pillow": "12.2.0"},
+    )
+    monkeypatch.setattr(
+        installer,
+        "run_command",
+        lambda command: observed_commands.append(list(command)),
+    )
+
+    installer.run_dependency_floor_preflight(
+        python_executable="python",
+        index_url=APPROVED_PROXY_URL,
+        trusted_host="packages.example.internal",
+        emergency_wheel_manifest=None,
+    )
+
+    assert len(observed_commands) == 2
+    for command in observed_commands:
+        assert command[:4] == ["python", "-m", "pip", "download"]
+        assert "--no-deps" in command
+        assert "--index-url" in command
+        assert APPROVED_PROXY_URL in command
+        assert "--trusted-host" in command
+        assert "--dest" in command
+
+
+def test_run_dependency_floor_preflight_allows_exact_emergency_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest = tmp_path / "emergency.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "expires_at": "2099-12-31",
+                "artifacts": [
+                    {
+                        "package": "cryptography",
+                        "version": "46.0.7",
+                        "filename": "cryptography-46.0.7.whl",
+                        "url": "https://files.pythonhosted.org/packages/example/cryptography-46.0.7.whl",
+                        "sha256": "b" * 64,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        installer,
+        "load_dependency_security_floors",
+        lambda: {"cryptography": "46.0.7"},
+    )
+    monkeypatch.setattr(
+        installer,
+        "_download_with_sha256",
+        lambda **kwargs: Path(kwargs["destination"]).write_bytes(b"wheel-bytes"),
+    )
+
+    def fail_run_command(_command: list[str]) -> None:
+        raise RuntimeError(
+            "Command failed: python -m pip download: "
+            "No matching distribution found for cryptography==46.0.7"
+        )
+
+    monkeypatch.setattr(installer, "run_command", fail_run_command)
+
+    installer.run_dependency_floor_preflight(
+        python_executable="python",
+        index_url=APPROVED_PROXY_URL,
+        trusted_host=None,
+        emergency_wheel_manifest=manifest,
+    )
+
+
+def test_run_dependency_floor_preflight_rejects_non_resolver_failure_even_with_emergency(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest = tmp_path / "emergency.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "expires_at": "2099-12-31",
+                "artifacts": [
+                    {
+                        "package": "cryptography",
+                        "version": "46.0.7",
+                        "filename": "cryptography-46.0.7.whl",
+                        "url": "https://files.pythonhosted.org/packages/example/cryptography-46.0.7.whl",
+                        "sha256": "b" * 64,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        installer,
+        "load_dependency_security_floors",
+        lambda: {"cryptography": "46.0.7"},
+    )
+
+    def non_resolver_failure(_command: list[str]) -> None:
+        raise RuntimeError("Command failed: python -m pip download: SSL certificate verify failed")
+
+    monkeypatch.setattr(installer, "run_command", non_resolver_failure)
+
+    with pytest.raises(RuntimeError, match="Dependency floor preflight failed"):
+        installer.run_dependency_floor_preflight(
+            python_executable="python",
+            index_url=APPROVED_PROXY_URL,
+            trusted_host=None,
+            emergency_wheel_manifest=manifest,
+        )
+
+
+def test_run_dependency_floor_preflight_verifies_emergency_artifact_download(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest = tmp_path / "emergency.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "expires_at": "2099-12-31",
+                "artifacts": [
+                    {
+                        "package": "cryptography",
+                        "version": "46.0.7",
+                        "filename": "cryptography-46.0.7.whl",
+                        "url": "https://files.pythonhosted.org/packages/example/cryptography-46.0.7.whl",
+                        "sha256": "b" * 64,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        installer,
+        "load_dependency_security_floors",
+        lambda: {"cryptography": "46.0.7"},
+    )
+    observed_downloads: list[tuple[str, str]] = []
+
+    def resolver_miss(_command: list[str]) -> None:
+        raise RuntimeError(
+            "Command failed: python -m pip download: "
+            "No matching distribution found for cryptography==46.0.7"
+        )
+
+    def fake_download(*, url: str, destination: Path, expected_sha256: str) -> None:
+        observed_downloads.append((url, expected_sha256))
+        destination.write_bytes(b"wheel-bytes")
+
+    monkeypatch.setattr(installer, "run_command", resolver_miss)
+    monkeypatch.setattr(installer, "_download_with_sha256", fake_download)
+
+    installer.run_dependency_floor_preflight(
+        python_executable="python",
+        index_url=APPROVED_PROXY_URL,
+        trusted_host=None,
+        emergency_wheel_manifest=manifest,
+    )
+
+    assert observed_downloads == [
+        ("https://files.pythonhosted.org/packages/example/cryptography-46.0.7.whl", "b" * 64)
+    ]
+
+
+def test_main_preflight_only_skips_requirements_file_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    missing_requirements = tmp_path / "missing-requirements.txt"
+    preflight_called = {"count": 0}
+
+    def fake_preflight(**_kwargs: object) -> None:
+        preflight_called["count"] += 1
+
+    monkeypatch.setattr(installer, "run_dependency_floor_preflight", fake_preflight)
+
+    result = installer.main(
+        [
+            "--requirements-file",
+            str(missing_requirements),
+            "--index-url",
+            APPROVED_PROXY_URL,
+            "--preflight-only",
+        ]
+    )
+
+    assert result == 0
+    assert preflight_called["count"] == 1

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -15,6 +15,15 @@ APPROVED_PROXY_URL = "https://packages.example.internal/simple"
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def _resolver_miss_runtimeerror_like_run_command(package: str, version: str) -> RuntimeError:
+    """Shape like :func:`run_command` on pip failure (``exit 1`` plus stderr text)."""
+    requirement = f"{package}=={version}"
+    return RuntimeError(
+        "Command failed: python -m pip download stub: exit 1\n"
+        f"No matching distribution found for {requirement}"
+    )
+
+
 def test_repo_emergency_manifest_tracks_current_active_fallback_set() -> None:
     manifest = json.loads(
         (REPO_ROOT / "scripts/ci/emergency_python_wheels.json").read_text(encoding="utf-8")
@@ -1047,8 +1056,9 @@ def test_run_command_wraps_subprocess_failures(
 
     monkeypatch.setattr(installer.subprocess, "run", fake_run)
 
-    with pytest.raises(RuntimeError, match="Command failed: python -m pip"):
+    with pytest.raises(RuntimeError, match="Command failed: python -m pip") as excinfo:
         installer.run_command(["python", "-m", "pip"])
+    assert "pip stderr here" in str(excinfo.value)
 
 
 def test_main_fails_when_virtualenv_is_required(
@@ -1707,10 +1717,7 @@ def test_run_dependency_floor_preflight_allows_exact_emergency_artifact(
     )
 
     def fail_run_command(_command: list[str]) -> None:
-        raise RuntimeError(
-            "Command failed: python -m pip download: "
-            "No matching distribution found for cryptography==46.0.7"
-        )
+        raise _resolver_miss_runtimeerror_like_run_command("cryptography", "46.0.7")
 
     monkeypatch.setattr(installer, "run_command", fail_run_command)
 
@@ -1796,10 +1803,7 @@ def test_run_dependency_floor_preflight_verifies_emergency_artifact_download(
     observed_downloads: list[tuple[str, str]] = []
 
     def resolver_miss(_command: list[str]) -> None:
-        raise RuntimeError(
-            "Command failed: python -m pip download: "
-            "No matching distribution found for cryptography==46.0.7"
-        )
+        raise _resolver_miss_runtimeerror_like_run_command("cryptography", "46.0.7")
 
     def fake_download(*, url: str, destination: Path, expected_sha256: str) -> None:
         observed_downloads.append((url, expected_sha256))


### PR DESCRIPTION
- Add --preflight-only and floor download checks in install_locked_python_requirements
- Run preflight step in python-setup before base dependency install
- Document floors and intake order in DEPENDENCY_SECURITY_GUARD_WORKFLOW
- Extend installer tests for preflight and proxy/emergency paths

Made-with: Cursor

<!-- markdownlint-disable MD013 MD033 -->

# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Split Justification

(Required only when the PR is > 800 changed LoC under Tier 1 governance.)

- Why this PR cannot be split safely:
- What invariant, contract, or rollout constraint requires one PR:
- What follow-up PRs remain after this large change:

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- No actionable review comments

## Merge Readiness (Mandatory)

- [ ] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups

- [ ] Ledger item(s): <link to docs/roadmap/BACKLOG_LEDGER.md entry or "None">
- [ ] GitHub issue(s): <link> (if any)

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

<!-- markdownlint-enable MD013 MD033 -->

## Summary by Sourcery

Добавлен этап предварительной проверки минимальных версий зависимостей (fail-fast dependency floor preflight) перед «заблокированными» установками и встроен в CI для валидации минимальных версий пакетов через одобренный прокси или проверенные аварийные колёса (emergency wheels).

New Features:
- Добавлен режим `--preflight-only` в установщик для проверки доступности минимальных версий зависимостей без выполнения установки.
- Загрузка минимальных версий зависимостей (dependency floor) из канонической схемы безопасности и предварительная проверка их через одобренный индекс и необязательный манифест аварийных колёс.

Bug Fixes:
- Улучшена обработка ошибок подпроцессов за счёт захвата stdout/stderr pip и отображения их в ошибках `run_command` для более понятной диагностики.
- Обеспечено выполнение требований к virtualenv и разрешение прокси до других операций установщика, включая обновления pip.

Enhancements:
- Добавлены команды предварительной проверки минимальных версий зависимостей, которые обнаруживают промахи резолвера через прокси, при необходимости допускают их через точные аварийные артефакты и завершаются с явным контекстом, когда минимальные версии недоступны.
- Задокументирован процесс работы механизма защиты зависимостей (dependency security guard), включающий предварительную проверку минимальных версий, обновлённые минимальные версии и разделение политики и проверок доступности исходников.
- Запуск предварительной проверки минимальных версий зависимостей в общем GitHub Action `python-setup` перед установкой базовых зависимостей в CI.

Documentation:
- Обновлена документация по механизму защиты зависимостей с новыми минимальными версиями, описанием процесса предварительной проверки и уточнёнными ожиданиями по детерминизму.

Tests:
- Расширены тесты установщика для покрытия поведения предварительной проверки минимальных версий, обработки аварийных колёс, различий между ошибками резолвера и нерезолвера, а также семантики `--preflight-only`.

Chores:
- Добавлен канонический документ отображения результатов ревью для PR #1429, указывающий на отсутствие практических (actionable) комментариев по ревью.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a fail-fast dependency floor preflight step before locked installs and wire it into CI to validate minimum package versions via the approved proxy or verified emergency wheels.

New Features:
- Introduce a `--preflight-only` mode in the installer to validate dependency floor availability without performing installations.
- Load minimum dependency floor versions from a canonical security schema and preflight them against the approved index and optional emergency wheel manifest.

Bug Fixes:
- Improve subprocess error handling by capturing pip stdout/stderr and surfacing them in `run_command` failures for clearer diagnostics.
- Ensure virtualenv enforcement and proxy resolution happen before other installer operations, including pip upgrades.

Enhancements:
- Add dependency floor preflight commands that detect proxy resolver misses, optionally tolerate them via exact emergency artifacts, and fail with explicit context when floors are unavailable.
- Document the dependency security guard workflow to cover floor preflight, updated minimum versions, and the separation of policy from source availability checks.
- Run dependency floor preflight in the shared `python-setup` GitHub Action before base dependency installation in CI.

Documentation:
- Update dependency security guard documentation with new minimum versions, preflight workflow, and clarified determinism expectations.

Tests:
- Extend installer tests to cover dependency floor preflight behavior, emergency wheel fallback handling, resolver vs non-resolver failures, and `--preflight-only` semantics.

Chores:
- Add a canonical review mapping document for PR #1429 indicating no actionable review comments.

</details>

Новые возможности:
- Ввести режим `--preflight-only` для проверки доступности минимально допустимых зависимостей без выполнения установки.
- Добавить загрузчик схемы безопасности зависимостей для обеспечения минимальных версий пакетов, таких как `cryptography` и `pillow`.

Улучшения:
- Запускать «fail-fast» предварительную проверку минимальных версий зависимостей с использованием утверждённого прокси и необязательного аварийного манифеста колёс перед зафиксированными установками в CI-пайплайнах.
- Расширить обработку аварийных колёс для проверки точных запасных артефактов, когда прокси не может разрешить пакеты с минимальными версиями.
- Уточнить документацию по механизму безопасности зависимостей, обновив минимальные версии и задокументировав процесс предварительной проверки.

Тесты:
- Добавить покрытие тестами поведения предварительной проверки минимальных версий зависимостей, включая проверки через прокси, успешные сценарии аварийных запасных вариантов и условия ошибок.
- Обновить тесты установщика, чтобы они учитывали утверждённую среду индекса и обеспечивали, что режим `preflight-only` пропускает разрешение зависимостей.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Добавлен этап предварительной проверки минимальных версий зависимостей (fail-fast dependency floor preflight) перед «заблокированными» установками и встроен в CI для валидации минимальных версий пакетов через одобренный прокси или проверенные аварийные колёса (emergency wheels).

New Features:
- Добавлен режим `--preflight-only` в установщик для проверки доступности минимальных версий зависимостей без выполнения установки.
- Загрузка минимальных версий зависимостей (dependency floor) из канонической схемы безопасности и предварительная проверка их через одобренный индекс и необязательный манифест аварийных колёс.

Bug Fixes:
- Улучшена обработка ошибок подпроцессов за счёт захвата stdout/stderr pip и отображения их в ошибках `run_command` для более понятной диагностики.
- Обеспечено выполнение требований к virtualenv и разрешение прокси до других операций установщика, включая обновления pip.

Enhancements:
- Добавлены команды предварительной проверки минимальных версий зависимостей, которые обнаруживают промахи резолвера через прокси, при необходимости допускают их через точные аварийные артефакты и завершаются с явным контекстом, когда минимальные версии недоступны.
- Задокументирован процесс работы механизма защиты зависимостей (dependency security guard), включающий предварительную проверку минимальных версий, обновлённые минимальные версии и разделение политики и проверок доступности исходников.
- Запуск предварительной проверки минимальных версий зависимостей в общем GitHub Action `python-setup` перед установкой базовых зависимостей в CI.

Documentation:
- Обновлена документация по механизму защиты зависимостей с новыми минимальными версиями, описанием процесса предварительной проверки и уточнёнными ожиданиями по детерминизму.

Tests:
- Расширены тесты установщика для покрытия поведения предварительной проверки минимальных версий, обработки аварийных колёс, различий между ошибками резолвера и нерезолвера, а также семантики `--preflight-only`.

Chores:
- Добавлен канонический документ отображения результатов ревью для PR #1429, указывающий на отсутствие практических (actionable) комментариев по ревью.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a fail-fast dependency floor preflight step before locked installs and wire it into CI to validate minimum package versions via the approved proxy or verified emergency wheels.

New Features:
- Introduce a `--preflight-only` mode in the installer to validate dependency floor availability without performing installations.
- Load minimum dependency floor versions from a canonical security schema and preflight them against the approved index and optional emergency wheel manifest.

Bug Fixes:
- Improve subprocess error handling by capturing pip stdout/stderr and surfacing them in `run_command` failures for clearer diagnostics.
- Ensure virtualenv enforcement and proxy resolution happen before other installer operations, including pip upgrades.

Enhancements:
- Add dependency floor preflight commands that detect proxy resolver misses, optionally tolerate them via exact emergency artifacts, and fail with explicit context when floors are unavailable.
- Document the dependency security guard workflow to cover floor preflight, updated minimum versions, and the separation of policy from source availability checks.
- Run dependency floor preflight in the shared `python-setup` GitHub Action before base dependency installation in CI.

Documentation:
- Update dependency security guard documentation with new minimum versions, preflight workflow, and clarified determinism expectations.

Tests:
- Extend installer tests to cover dependency floor preflight behavior, emergency wheel fallback handling, resolver vs non-resolver failures, and `--preflight-only` semantics.

Chores:
- Add a canonical review mapping document for PR #1429 indicating no actionable review comments.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a fail-fast dependency floor preflight before locked installs and run it in CI. Improves diagnostics, allows exact emergency wheels, bumps floors (`cryptography` 46.0.7, `pillow` 12.2.0), clarifies preflight networking, and completes PR #1429 merge-readiness mapping (inline threads + umbrella reviews).

- **New Features**
  - `--preflight-only` validates floor versions via `PULSEPLATE_PYTHON_INDEX_URL` (optional `PULSEPLATE_PYTHON_TRUSTED_HOST`) without installing.
  - Runs in `.github/actions/python-setup` before base install; tolerates exact emergency artifacts from `scripts/ci/emergency_python_wheels.json`.

- **Bug Fixes**
  - `run_command` captures `pip` stdout/stderr for resolver-miss matching; enforces `--require-virtualenv` before `--upgrade-pip`.
  - Drop bash xtrace in the action to avoid leaking the index URL; harden schema loading (reject non-object root, include schema path).
  - Complete PR #1429 fixed-in-commit mapping with strict file:line evidence and mapped umbrella review summaries for merge gate.

<sup>Written for commit 8a4bd05ebae77d6603a68b110fe85d18bde3a28f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an early preflight check that validates approved minimum package-version "floors" are downloadable from the configured Python index (optional trusted-host) and a preflight-only mode that exits without installing.

* **Documentation**
  * Updated dependency security workflow: raised cryptography, added pillow, added preflight step, clarified network-read behavior and CVE remediation examples.

* **Tests**
  * Added coverage for preflight validation, emergency artifact fallback, and related failure scenarios.

* **Bug Fixes**
  * Tightened CI shell error handling (removed verbose tracing) and improved subprocess error reporting for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
