### PR TITLE
fix(ci): add emergency Pillow wheels for py311/py312

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -380,65 +380,93 @@
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "72146717d6aa4ffbf855688626409a7c18de0955",
+        "hashed_secret": "0d4f2fe72200b7c3338cd6e014701d43dcf9e3de",
         "is_verified": false,
         "line_number": 26
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "6f18faded2b844679c2c0f1f99afdc77b800c19e",
+        "hashed_secret": "996cf6ea725d60e02f32fdd2b02f5709da5ae475",
         "is_verified": false,
         "line_number": 33
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "6e28f729cbeb4622984174b6db155786a8a8b049",
+        "hashed_secret": "cad2f158edf0cf8c4b75ac5aa0bf12f0c4d7ceb9",
         "is_verified": false,
         "line_number": 40
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "11fa369ea25c92cfacecf793ca6707593f856da3",
+        "hashed_secret": "c0b61811baed7358a5c710e8b2e2c0c8169a5e55",
         "is_verified": false,
         "line_number": 47
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "92fe9f57d606f0b3ff03d7f0966583a4af7ab9b4",
+        "hashed_secret": "72146717d6aa4ffbf855688626409a7c18de0955",
         "is_verified": false,
         "line_number": 54
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "2076e11d2c97809442c670c0fa33dc906a00f031",
+        "hashed_secret": "6f18faded2b844679c2c0f1f99afdc77b800c19e",
         "is_verified": false,
         "line_number": 61
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "d09f8c85f8e347671e7b4f4bc76b3341fa0727b9",
+        "hashed_secret": "6e28f729cbeb4622984174b6db155786a8a8b049",
         "is_verified": false,
         "line_number": 68
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "d17b1dc21afd47e49ba9ece8f526d561059f8a7d",
+        "hashed_secret": "11fa369ea25c92cfacecf793ca6707593f856da3",
         "is_verified": false,
         "line_number": 75
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "10348e267e1ebfa1fe55c0c0a11a9e78088119b2",
+        "hashed_secret": "92fe9f57d606f0b3ff03d7f0966583a4af7ab9b4",
         "is_verified": false,
         "line_number": 82
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "scripts/ci/emergency_python_wheels.json",
+        "hashed_secret": "2076e11d2c97809442c670c0fa33dc906a00f031",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "scripts/ci/emergency_python_wheels.json",
+        "hashed_secret": "d09f8c85f8e347671e7b4f4bc76b3341fa0727b9",
+        "is_verified": false,
+        "line_number": 96
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "scripts/ci/emergency_python_wheels.json",
+        "hashed_secret": "d17b1dc21afd47e49ba9ece8f526d561059f8a7d",
+        "is_verified": false,
+        "line_number": 103
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "scripts/ci/emergency_python_wheels.json",
+        "hashed_secret": "10348e267e1ebfa1fe55c0c0a11a9e78088119b2",
+        "is_verified": false,
+        "line_number": 110
       }
     ],
     "scripts/ensure_database_versions.py": [
@@ -1590,5 +1618,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-13T11:30:39Z"
+  "generated_at": "2026-04-15T13:03:16Z"
 }

--- a/docs/review/PR_1430_FIXED_MAPPING.md
+++ b/docs/review/PR_1430_FIXED_MAPPING.md
@@ -10,7 +10,15 @@ Bot and human review threads are dispositioned here before they are resolved on 
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1430#pullrequestreview-4113803767
+Disposition: NOT-A-BUG
+Evidence: `scripts/ci/emergency_python_wheels.json:22-61` now groups Pillow emergency entries together and orders them by CPython ABI (`cp311` -> `cp312` -> `cp313`) and manylinux tag variants.
+Reason: this review requested maintainability ordering/documentation improvements; grouping and deterministic ordering are already applied in the committed manifest update.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1430#pullrequestreview-4113822410
+Disposition: FIXED
+Commit: 4b2575f99
+Evidence: `docs/review/PR_1430_FIXED_MAPPING.md:13` now uses the canonical sentinel `- No actionable review comments`, which satisfies `scripts/orchestration/review_mapping_artifact.py:35` (`NO_ACTIONABLE_LINE`) and avoids non-canonical wording.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1430_FIXED_MAPPING.md
+++ b/docs/review/PR_1430_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+<!-- markdownlint-disable MD034 -->
+# PR #1430 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Bot and human review threads are dispositioned here before they are resolved on GitHub.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments at initial PR open.
+
+## Merge Readiness
+
+- [ ] Current-head CI is green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1430_FIXED_MAPPING.md
+++ b/docs/review/PR_1430_FIXED_MAPPING.md
@@ -10,7 +10,7 @@ Bot and human review threads are dispositioned here before they are resolved on 
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments at initial PR open.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1430_FIXED_MAPPING.md
+++ b/docs/review/PR_1430_FIXED_MAPPING.md
@@ -18,7 +18,7 @@ Reason: this review requested maintainability ordering/documentation improvement
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1430#pullrequestreview-4113822410
 Disposition: FIXED
 Commit: 4b2575f99
-Evidence: `docs/review/PR_1430_FIXED_MAPPING.md:13` now uses the canonical sentinel `- No actionable review comments`, which satisfies `scripts/orchestration/review_mapping_artifact.py:35` (`NO_ACTIONABLE_LINE`) and avoids non-canonical wording.
+Evidence: `docs/review/PR_1430_FIXED_MAPPING.md:13` now uses the canonical no-actionable sentinel line required by `scripts/orchestration/review_mapping_artifact.py:35` (`NO_ACTIONABLE_LINE`) and avoids non-canonical wording.
 
 ## Merge Readiness
 

--- a/scripts/ci/emergency_python_wheels.json
+++ b/scripts/ci/emergency_python_wheels.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-04-13",
+  "generated_at": "2026-04-15",
   "expires_at": "2026-05-15",
   "reason": "Temporary exact-wheel fallback for cryptography, Pillow, pytest, faker, hypothesis, sentence-transformers, ruff, types-pyyaml, and transformers while the approved private proxy lags the patched upstream releases used by active dependency PRs.",
   "artifacts": [
@@ -17,6 +17,34 @@
       "filename": "cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl",
       "url": "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl",
       "sha256": "42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b"
+    },
+    {
+      "package": "pillow",
+      "version": "12.2.0",
+      "filename": "pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+      "sha256": "8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e"
+    },
+    {
+      "package": "pillow",
+      "version": "12.2.0",
+      "filename": "pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "sha256": "e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176"
+    },
+    {
+      "package": "pillow",
+      "version": "12.2.0",
+      "filename": "pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+      "sha256": "b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76"
+    },
+    {
+      "package": "pillow",
+      "version": "12.2.0",
+      "filename": "pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "sha256": "62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780"
     },
     {
       "package": "pillow",


### PR DESCRIPTION
## Summary
- add `pillow==12.2.0` emergency wheel artifacts for CPython 3.11 and 3.12 Linux x86_64 in `scripts/ci/emergency_python_wheels.json`
- keep the security floor unchanged (`pillow>=12.2.0`) and unblock `python-setup` fallback when the private proxy only exposes older Pillow wheels
- refresh `.secrets.baseline` for new hash-pinned wheel entries so `detect-secrets` remains deterministic

## Root cause evidence
- run `24450871967` jobs `71439156351` / `71439156333` failed during `Setup Python environment`
- pip error in logs: `Could not find a version that satisfies the requirement pillow==12.2.0 (from versions: 12.1.1)`
- current emergency manifest had only `cp313` Pillow wheels, so py311/py312 fallback remained unresolved under `--only-binary :all:`

## Test plan
- [x] `pytest -q tests/test_dependency_security_guard.py tests/test_install_locked_python_requirements.py`
- [x] `pre-commit run --all-files`
- [x] `make validate-min`
- [x] pre-push hooks (pip-audit, pytest, bandit, docker build test)

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1430_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Current-head CI is green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`

## Notes
- this PR does not downgrade Pillow and does not change app/runtime logic; it only extends CI emergency wheel coverage for already pinned secure version `12.2.0`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add emergency `pillow==12.2.0` wheels for CPython 3.11/3.12 on Linux x86_64 to unblock CI when the private proxy lags. Keeps the security floor at `pillow>=12.2.0` and adds a fixed-mapping doc with correct sentinel handling; no runtime changes.

- **Bug Fixes**
  - Extend `scripts/ci/emergency_python_wheels.json` with cp311/cp312 manylinux2014 and manylinux_2_27/_2_28 wheels to satisfy `--only-binary :all:` fallback.
  - Add `docs/review/PR_1430_FIXED_MAPPING.md` with mapped bot review dispositions and canonical sentinel usage to avoid no-actionable false-positives in governance checks.
  - Refresh `.secrets.baseline` for new hash-pinned entries to keep `detect-secrets` deterministic.

<sup>Written for commit 4f502ed677dcfb4a266f604feb067e129f5f8e3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a PR review tracking document with a "Fixed in Commit Mapping" section and a merge-readiness checklist.

* **Chores**
  * Expanded the emergency Python wheel manifest with four additional Pillow 12.2.0 wheel entries covering Python 3.11 and 3.12 across multiple manylinux variants.
  * Updated secret baseline entries (multiple high-entropy hash values replaced/added) and advanced the baseline's generated timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->