### PR TITLE
feat(data): restaurant PostgreSQL shadow reads + parity (B3)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -774,7 +774,7 @@
         "filename": "tests/test_app_extended_coverage.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 30
       }
     ],
     "tests/test_app_extra_coverage.py": [
@@ -1625,5 +1625,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-16T13:40:44Z"
+  "generated_at": "2026-04-16T21:57:40Z"
 }

--- a/app/routers/restaurants.py
+++ b/app/routers/restaurants.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import logging
+import os
 from typing import Any, Mapping, Protocol, Sequence, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -16,10 +18,13 @@ from app.schemas.restaurants import (
     RestaurantSubmissionCreate,
     SubmissionReviewRequest,
 )
-from app.services import restaurant_store
+from app.services import restaurant_postgres_read, restaurant_shadow_parity, restaurant_store
 
 router = APIRouter(tags=["restaurants"])
 moderation_router = APIRouter(tags=["restaurants"])
+logger = logging.getLogger(__name__)
+FEATURE_RESTAURANT_POSTGRES_SHADOW_READS = "FEATURE_RESTAURANT_POSTGRES_SHADOW_READS"
+RESTAURANT_POSTGRES_SHADOW_READS_URL = "RESTAURANT_POSTGRES_SHADOW_READS_URL"
 
 
 class RestaurantStore(Protocol):
@@ -99,7 +104,117 @@ class _RestaurantStoreCompat:
         )
 
 
-_STORE: RestaurantStore = _RestaurantStoreCompat()
+def _shadow_reads_enabled() -> bool:
+    """RU: Shadow lane включается только явным env flag. EN: Shadow lane needs explicit env flag."""
+
+    raw_value = os.getenv(FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "false")
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _shadow_reads_pg_url() -> str | None:
+    """RU: Override URL можно задать отдельно, иначе берём DATABASE_URL.
+
+    EN: Use dedicated override when provided, otherwise fall back to DATABASE_URL.
+    """
+
+    override_url = os.getenv(RESTAURANT_POSTGRES_SHADOW_READS_URL)
+    if override_url:
+        return override_url
+    database_url = os.getenv("DATABASE_URL")
+    return database_url or None
+
+
+def _log_shadow_read_mismatch(
+    operation: str, parity: restaurant_shadow_parity.ParityResult
+) -> None:
+    logger.warning(
+        "restaurant PostgreSQL shadow-read mismatch for %s: sqlite=%s postgres=%s reasons=%s",
+        operation,
+        parity.sqlite_count,
+        parity.postgres_count,
+        "; ".join(parity.mismatch_reasons) or "unknown mismatch",
+    )
+
+
+class _RestaurantStoreShadowCompat(_RestaurantStoreCompat):
+    """SQLite-authoritative adapter with optional PostgreSQL shadow reads."""
+
+    def search_restaurants(
+        self, query: str, limit: int, offset: int
+    ) -> Sequence[Mapping[str, Any]]:
+        sqlite_rows = list(super().search_restaurants(query, limit, offset))
+        self._run_search_shadow(query=query, limit=limit, offset=offset, sqlite_rows=sqlite_rows)
+        return sqlite_rows
+
+    def get_restaurant_menu(self, chain_id: str, limit: int) -> Sequence[Mapping[str, Any]]:
+        sqlite_rows = list(super().get_restaurant_menu(chain_id, limit))
+        self._run_menu_shadow(chain_id=chain_id, limit=limit, sqlite_rows=sqlite_rows)
+        return sqlite_rows
+
+    def _run_search_shadow(
+        self,
+        *,
+        query: str,
+        limit: int,
+        offset: int,
+        sqlite_rows: list[Mapping[str, Any]],
+    ) -> None:
+        if not _shadow_reads_enabled():
+            return
+        pg_url = _shadow_reads_pg_url()
+        if not pg_url:
+            logger.warning(
+                "restaurant PostgreSQL shadow reads enabled for search without a PostgreSQL URL"
+            )
+            return
+        try:
+            pg_rows = restaurant_postgres_read.search_restaurants_pg(
+                pg_url=pg_url,
+                query=query,
+                limit=limit,
+                offset=offset,
+            )
+            parity = restaurant_shadow_parity.compare_restaurant_hits(sqlite_rows, pg_rows)
+            if not parity.match:
+                _log_shadow_read_mismatch("search_restaurants", parity)
+        except Exception:
+            logger.warning(
+                "restaurant PostgreSQL shadow search failed; keeping SQLite canonical response",
+                exc_info=True,
+            )
+
+    def _run_menu_shadow(
+        self,
+        *,
+        chain_id: str,
+        limit: int,
+        sqlite_rows: list[Mapping[str, Any]],
+    ) -> None:
+        if not _shadow_reads_enabled():
+            return
+        pg_url = _shadow_reads_pg_url()
+        if not pg_url:
+            logger.warning(
+                "restaurant PostgreSQL shadow reads enabled for menu without a PostgreSQL URL"
+            )
+            return
+        try:
+            pg_rows = restaurant_postgres_read.get_restaurant_menu_pg(
+                pg_url=pg_url,
+                chain_id=chain_id,
+                limit=limit,
+            )
+            parity = restaurant_shadow_parity.compare_restaurant_menu(sqlite_rows, pg_rows)
+            if not parity.match:
+                _log_shadow_read_mismatch("get_restaurant_menu", parity)
+        except Exception:
+            logger.warning(
+                "restaurant PostgreSQL shadow menu read failed; keeping SQLite canonical response",
+                exc_info=True,
+            )
+
+
+_STORE: RestaurantStore = _RestaurantStoreShadowCompat()
 
 
 def get_restaurant_store() -> RestaurantStore:

--- a/app/services/restaurant_postgres_read.py
+++ b/app/services/restaurant_postgres_read.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""Read-only PostgreSQL adapter for restaurant shadow reads.
+
+RU: Никакого runtime cutover — только shadow read path.
+EN: No runtime cutover here — this module serves shadow-read path only.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import MetaData, Table, create_engine, text
+from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.exc import NoSuchTableError
+
+RESTAURANT_CHAINS_TABLE = "restaurant_chains"
+RESTAURANT_MENU_ITEMS_TABLE = "restaurant_menu_items"
+REQUIRED_CHAIN_COLUMNS = frozenset({"id", "name", "country", "source"})
+REQUIRED_MENU_COLUMNS = frozenset(
+    {
+        "id",
+        "chain_id",
+        "item_name",
+        "category",
+        "serving_size_g",
+        "kcal",
+        "protein_g",
+        "fat_g",
+        "carbs_g",
+        "sodium_mg",
+        "source",
+        "source_id",
+        "is_active",
+    }
+)
+
+
+class RestaurantPostgresReadError(RuntimeError):
+    """RU: Детерминированная ошибка read adapter. EN: Deterministic read-adapter failure."""
+
+
+def _build_pg_engine(pg_url: str) -> Engine:
+    """RU: Создать PostgreSQL engine и fail-closed проверить dialect.
+
+    EN: Build a PostgreSQL engine and fail-closed validate dialect.
+    """
+
+    engine = create_engine(pg_url, pool_pre_ping=True, future=True)
+    if engine.dialect.name != "postgresql":
+        engine.dispose()
+        raise RestaurantPostgresReadError(
+            f"target database must be PostgreSQL, got dialect {engine.dialect.name!r}"
+        )
+    return engine
+
+
+def _reflect_read_tables(connection: Connection) -> None:
+    """RU: Проверить обязательные таблицы/колонки для shadow read.
+
+    EN: Validate required tables/columns for shadow reads.
+    """
+
+    metadata = MetaData()
+    try:
+        chains_table = Table(RESTAURANT_CHAINS_TABLE, metadata, autoload_with=connection)
+        menu_table = Table(RESTAURANT_MENU_ITEMS_TABLE, metadata, autoload_with=connection)
+    except NoSuchTableError as exc:
+        raise RestaurantPostgresReadError(
+            "restaurant PostgreSQL foundation is missing required tables; "
+            "run foods catalog foundation migrations first"
+        ) from exc
+
+    chain_columns = {column.name for column in chains_table.columns}
+    missing_chain_columns = sorted(REQUIRED_CHAIN_COLUMNS - chain_columns)
+    if missing_chain_columns:
+        missing_str = ", ".join(missing_chain_columns)
+        raise RestaurantPostgresReadError(
+            f"{RESTAURANT_CHAINS_TABLE!r} is missing required columns: {missing_str}"
+        )
+
+    menu_columns = {column.name for column in menu_table.columns}
+    missing_menu_columns = sorted(REQUIRED_MENU_COLUMNS - menu_columns)
+    if missing_menu_columns:
+        missing_str = ", ".join(missing_menu_columns)
+        raise RestaurantPostgresReadError(
+            f"{RESTAURANT_MENU_ITEMS_TABLE!r} is missing required columns: {missing_str}"
+        )
+
+
+def _fetch_search_rows(
+    connection: Connection,
+    *,
+    query: str,
+    limit: int,
+    offset: int,
+) -> list[dict[str, Any]]:
+    """RU: Прочитать restaurant search rows в deterministic order.
+
+    EN: Fetch deterministic restaurant search rows.
+    """
+
+    sql = text("""
+        SELECT id, name, country, source
+        FROM restaurant_chains
+        WHERE (:query = '' OR lower(name) LIKE lower(:pattern))
+        ORDER BY name ASC
+        LIMIT :limit OFFSET :offset
+        """)
+    pattern = f"%{query.strip()}%"
+    rows = connection.execute(
+        sql,
+        {
+            "query": query.strip(),
+            "pattern": pattern,
+            "limit": limit,
+            "offset": offset,
+        },
+    ).mappings()
+    return [dict(row) for row in rows]
+
+
+def _fetch_menu_rows(connection: Connection, *, chain_id: str, limit: int) -> list[dict[str, Any]]:
+    """RU: Прочитать menu rows в deterministic order.
+
+    EN: Fetch deterministic menu rows.
+    """
+
+    sql = text("""
+        SELECT
+            id,
+            chain_id,
+            item_name,
+            category,
+            serving_size_g,
+            kcal,
+            protein_g,
+            fat_g,
+            carbs_g,
+            sodium_mg,
+            source,
+            source_id,
+            is_active
+        FROM restaurant_menu_items
+        WHERE chain_id = :chain_id
+          AND is_active IS TRUE
+        ORDER BY item_name ASC
+        LIMIT :limit
+        """)
+    rows = connection.execute(sql, {"chain_id": chain_id, "limit": limit}).mappings()
+    menu_rows: list[dict[str, Any]] = []
+    for row in rows:
+        materialized = dict(row)
+        # RU/EN: Foundation tables do not store provenance metadata yet.
+        materialized.setdefault("snapshot_date", None)
+        materialized.setdefault("provenance_source", None)
+        materialized.setdefault("provenance_record_id", None)
+        menu_rows.append(materialized)
+    return menu_rows
+
+
+def search_restaurants_pg(
+    *,
+    pg_url: str,
+    query: str,
+    limit: int,
+    offset: int,
+) -> list[dict[str, Any]]:
+    """RU: Shadow-read search rows from PostgreSQL.
+
+    EN: Read search rows from PostgreSQL for shadow comparison.
+    """
+
+    engine = _build_pg_engine(pg_url)
+    try:
+        with engine.connect() as connection:
+            _reflect_read_tables(connection)
+            return _fetch_search_rows(connection, query=query, limit=limit, offset=offset)
+    finally:
+        engine.dispose()
+
+
+def get_restaurant_menu_pg(*, pg_url: str, chain_id: str, limit: int) -> list[dict[str, Any]]:
+    """RU: Shadow-read menu rows from PostgreSQL.
+
+    EN: Read menu rows from PostgreSQL for shadow comparison.
+    """
+
+    engine = _build_pg_engine(pg_url)
+    try:
+        with engine.connect() as connection:
+            _reflect_read_tables(connection)
+            return _fetch_menu_rows(connection, chain_id=chain_id, limit=limit)
+    finally:
+        engine.dispose()

--- a/app/services/restaurant_postgres_read.py
+++ b/app/services/restaurant_postgres_read.py
@@ -7,6 +7,7 @@ EN: No runtime cutover here — this module serves shadow-read path only.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from sqlalchemy import MetaData, Table, create_engine, text
@@ -33,6 +34,8 @@ REQUIRED_MENU_COLUMNS = frozenset(
         "is_active",
     }
 )
+POSTGRES_CONNECT_TIMEOUT_SECONDS = 5
+logger = logging.getLogger(__name__)
 
 
 class RestaurantPostgresReadError(RuntimeError):
@@ -45,12 +48,19 @@ def _build_pg_engine(pg_url: str) -> Engine:
     EN: Build a PostgreSQL engine and fail-closed validate dialect.
     """
 
-    engine = create_engine(pg_url, pool_pre_ping=True, future=True)
+    engine = create_engine(
+        pg_url,
+        pool_pre_ping=True,
+        future=True,
+        connect_args={"connect_timeout": POSTGRES_CONNECT_TIMEOUT_SECONDS},
+    )
     if engine.dialect.name != "postgresql":
-        engine.dispose()
-        raise RestaurantPostgresReadError(
-            f"target database must be PostgreSQL, got dialect {engine.dialect.name!r}"
+        logger.debug(
+            "restaurant shadow-read adapter rejected non-PostgreSQL dialect: %s",
+            engine.dialect.name,
         )
+        engine.dispose()
+        raise RestaurantPostgresReadError("target database must be PostgreSQL")
     return engine
 
 
@@ -103,7 +113,7 @@ def _fetch_search_rows(
         SELECT id, name, country, source
         FROM restaurant_chains
         WHERE (:query = '' OR lower(name) LIKE lower(:pattern))
-        ORDER BY name ASC
+        ORDER BY name ASC, id ASC
         LIMIT :limit OFFSET :offset
         """)
     pattern = f"%{query.strip()}%"
@@ -143,7 +153,7 @@ def _fetch_menu_rows(connection: Connection, *, chain_id: str, limit: int) -> li
         FROM restaurant_menu_items
         WHERE chain_id = :chain_id
           AND is_active IS TRUE
-        ORDER BY item_name ASC
+        ORDER BY item_name ASC, id ASC
         LIMIT :limit
         """)
     rows = connection.execute(sql, {"chain_id": chain_id, "limit": limit}).mappings()

--- a/app/services/restaurant_shadow_parity.py
+++ b/app/services/restaurant_shadow_parity.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+"""Restaurant SQLite-vs-PostgreSQL shadow parity helpers.
+
+RU: Сравнение SQLite canonical rows и PostgreSQL shadow rows без cutover-решений.
+EN: Compare SQLite canonical rows and PostgreSQL shadow rows without making cutover decisions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class ParityResult:
+    """RU: Результат parity-сравнения. EN: Result of parity comparison."""
+
+    match: bool
+    sqlite_count: int
+    postgres_count: int
+    mismatched_indexes: tuple[int, ...]
+    mismatch_reasons: tuple[str, ...]
+
+
+_SEARCH_FIELDS: tuple[str, ...] = ("id", "name", "country", "source")
+_MENU_FIELDS: tuple[str, ...] = (
+    "id",
+    "chain_id",
+    "item_name",
+    "category",
+    "serving_size_g",
+    "kcal",
+    "protein_g",
+    "fat_g",
+    "carbs_g",
+    "sodium_mg",
+    "source",
+    "source_id",
+    "is_active",
+)
+
+
+def _normalize_numeric(value: Any) -> str | None:
+    """RU: Привести numeric к стабильной строке для parity.
+
+    EN: Normalize numeric values into stable parity strings.
+    """
+
+    if value is None:
+        return None
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+    normalized = parsed.normalize()
+    if normalized == normalized.to_integral():
+        return format(normalized.quantize(Decimal(1)), "f")
+    return format(normalized, "f")
+
+
+def _normalize_bool_like(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {"1", "true", "t", "yes", "y"}:
+        return True
+    if text in {"0", "false", "f", "no", "n"}:
+        return False
+    return None
+
+
+def normalize_restaurant_hit(row: Mapping[str, Any]) -> dict[str, Any]:
+    """RU: Нормализация search row для parity. EN: Normalize search row for parity."""
+
+    return {
+        "id": str(row.get("id") or ""),
+        "name": str(row.get("name") or ""),
+        "country": row.get("country"),
+        "source": row.get("source"),
+    }
+
+
+def normalize_restaurant_menu_item_for_parity(row: Mapping[str, Any]) -> dict[str, Any]:
+    """RU: Нормализация menu row для parity v1.
+
+    EN: Normalize menu row for parity v1.
+    """
+
+    return {
+        "id": str(row.get("id") or ""),
+        "chain_id": str(row.get("chain_id") or ""),
+        "item_name": str(row.get("item_name") or ""),
+        "category": row.get("category"),
+        "serving_size_g": _normalize_numeric(row.get("serving_size_g")),
+        "kcal": _normalize_numeric(row.get("kcal")),
+        "protein_g": _normalize_numeric(row.get("protein_g")),
+        "fat_g": _normalize_numeric(row.get("fat_g")),
+        "carbs_g": _normalize_numeric(row.get("carbs_g")),
+        "sodium_mg": _normalize_numeric(row.get("sodium_mg")),
+        "source": row.get("source"),
+        "source_id": row.get("source_id"),
+        "is_active": _normalize_bool_like(row.get("is_active")),
+    }
+
+
+def _compare_rows(
+    *,
+    sqlite_rows: Sequence[dict[str, Any]],
+    postgres_rows: Sequence[dict[str, Any]],
+    fields: tuple[str, ...],
+) -> ParityResult:
+    mismatched_indexes: list[int] = []
+    mismatch_reasons: list[str] = []
+
+    if len(sqlite_rows) != len(postgres_rows):
+        mismatch_reasons.append(
+            f"row-count mismatch sqlite={len(sqlite_rows)} postgres={len(postgres_rows)}"
+        )
+
+    max_len = max(len(sqlite_rows), len(postgres_rows))
+    for idx in range(max_len):
+        if idx >= len(sqlite_rows):
+            mismatched_indexes.append(idx)
+            mismatch_reasons.append(f"missing sqlite row at index {idx}")
+            continue
+        if idx >= len(postgres_rows):
+            mismatched_indexes.append(idx)
+            mismatch_reasons.append(f"missing postgres row at index {idx}")
+            continue
+
+        sqlite_row = sqlite_rows[idx]
+        postgres_row = postgres_rows[idx]
+        for field_name in fields:
+            if sqlite_row.get(field_name) != postgres_row.get(field_name):
+                mismatched_indexes.append(idx)
+                mismatch_reasons.append(f"index {idx} field {field_name} mismatch")
+                break
+
+    return ParityResult(
+        match=not mismatch_reasons,
+        sqlite_count=len(sqlite_rows),
+        postgres_count=len(postgres_rows),
+        mismatched_indexes=tuple(mismatched_indexes),
+        mismatch_reasons=tuple(mismatch_reasons),
+    )
+
+
+def compare_restaurant_hits(
+    sqlite_rows: Sequence[Mapping[str, Any]], postgres_rows: Sequence[Mapping[str, Any]]
+) -> ParityResult:
+    """RU: Сравнить search rows из SQLite и PostgreSQL.
+
+    EN: Compare restaurant search rows from SQLite and PostgreSQL.
+    """
+
+    normalized_sqlite = [normalize_restaurant_hit(row) for row in sqlite_rows]
+    normalized_postgres = [normalize_restaurant_hit(row) for row in postgres_rows]
+    return _compare_rows(
+        sqlite_rows=normalized_sqlite,
+        postgres_rows=normalized_postgres,
+        fields=_SEARCH_FIELDS,
+    )
+
+
+def compare_restaurant_menu(
+    sqlite_rows: Sequence[Mapping[str, Any]], postgres_rows: Sequence[Mapping[str, Any]]
+) -> ParityResult:
+    """RU: Сравнить menu rows по общим runtime полям.
+
+    EN: Compare menu rows using common runtime fields only.
+    """
+
+    normalized_sqlite = [normalize_restaurant_menu_item_for_parity(row) for row in sqlite_rows]
+    normalized_postgres = [normalize_restaurant_menu_item_for_parity(row) for row in postgres_rows]
+    return _compare_rows(
+        sqlite_rows=normalized_sqlite,
+        postgres_rows=normalized_postgres,
+        fields=_MENU_FIELDS,
+    )

--- a/docs/orchestration/FOODS_POSTGRES_PROMOTION_PR_B1_TASK_PACKET_2026-04-13.md
+++ b/docs/orchestration/FOODS_POSTGRES_PROMOTION_PR_B1_TASK_PACKET_2026-04-13.md
@@ -14,13 +14,13 @@ runtime cutover, or restaurant importer rewiring.
 
 - This packet owns only **PR-B1**.
 - The execution train is fixed as:
-  - `PR-B1`: foods snapshot promotion into PostgreSQL `foods`
-  - `PR-B2`: restaurant relational bridge
-  - `B3` deferred: runtime read-switch / cutover
-- The former Postgres deploy-foundation blocker is now closed separately via
-  repo/runtime evidence reconciliation; it is not a remaining implementation
-  gate ahead of `PR-B2`.
-- `PR-B2` is the next active implementation lane after merged `PR-B1`.
+  - `PR-B1`: foods snapshot promotion into PostgreSQL `foods` (merged)
+  - `PR-B2`: restaurant relational bridge (merged)
+  - `PR-B3`: restaurant PostgreSQL shadow reads + parity checks
+  - cutover (deferred): runtime read-switch / PostgreSQL authority change after B3
+- The former Postgres deploy-foundation blocker is closed separately via
+  repo/runtime evidence reconciliation.
+- `PR-B3` is the next active implementation lane after merged `PR-B1` and `PR-B2`.
 
 ## Source of Truth
 

--- a/docs/orchestration/FOODS_POSTGRES_RESTAURANT_BRIDGE_PR_B2_TASK_PACKET_2026-04-13.md
+++ b/docs/orchestration/FOODS_POSTGRES_RESTAURANT_BRIDGE_PR_B2_TASK_PACKET_2026-04-13.md
@@ -15,10 +15,11 @@ moderation/source parity, or public API cutover.
 
 - This packet owns only **PR-B2**.
 - The execution train is fixed as:
-  - `PR-B1`: foods snapshot promotion into PostgreSQL `foods`
-  - `PR-B2`: restaurant relational bridge for importer persistence
-  - `B3` deferred: runtime read-switch / cutover
-- `PR-B1` is already merged; `PR-B2` is the next active implementation lane.
+  - `PR-B1`: foods snapshot promotion into PostgreSQL `foods` (merged)
+  - `PR-B2`: restaurant relational bridge for importer persistence (merged)
+  - `PR-B3`: restaurant PostgreSQL shadow reads + parity checks
+  - cutover (deferred): runtime read-switch / PostgreSQL authority change after B3
+- `PR-B1` and `PR-B2` are already merged; `PR-B3` is the next active implementation lane.
 - `PR-B2` stays importer-only. It does not claim that current restaurant runtime
   is already PostgreSQL-backed.
 

--- a/docs/orchestration/FOODS_POSTGRES_SHADOW_READS_PR_B3_TASK_PACKET_2026-04-16.md
+++ b/docs/orchestration/FOODS_POSTGRES_SHADOW_READS_PR_B3_TASK_PACKET_2026-04-16.md
@@ -1,0 +1,104 @@
+# Foods PostgreSQL Shadow Reads PR-B3 Task Packet
+
+**Effective date:** 2026-04-16 (`America/New_York`)
+**Status:** Active execution packet
+**Mode:** coordinator-owned backend/runtime parity lane
+
+## Goal
+
+Land one narrow runtime lane that adds PostgreSQL shadow reads and parity checks for
+restaurant search/menu while preserving SQLite as canonical response authority.
+
+## Relationship to the Follow-Through Train
+
+- This packet owns only **PR-B3**.
+- The execution train is fixed as:
+  - `PR-B1`: foods snapshot promotion into PostgreSQL `foods` (merged)
+  - `PR-B2`: restaurant relational bridge for importer persistence (merged)
+  - `PR-B3`: restaurant PostgreSQL shadow reads + parity checks
+  - cutover (deferred): runtime read-switch / PostgreSQL authority change after B3
+- `PR-B3` is the next active implementation lane after merged `PR-B1` and `PR-B2`.
+- `PR-B3` is shadow-only and does not claim PostgreSQL-backed runtime authority.
+
+## Source of Truth
+
+- Repo code remains the final source of truth for runtime and contract boundaries.
+- This lane must stay grounded in:
+  - `app/routers/restaurants.py`
+  - `app/services/restaurant_store.py`
+  - `app/services/restaurant_postgres_bridge.py`
+  - `app/schemas/restaurants.py`
+  - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-postgres-foundation-followthrough`
+
+## PR Metadata
+
+- Branch: `feat/pr-b3-restaurant-postgres-shadow-reads`
+- PR title: `feat(data): add restaurant PostgreSQL shadow reads and parity checks`
+- Merge method: **merge commit** via `gh pr merge --merge --delete-branch`
+
+## In Scope
+
+- Add read-only PostgreSQL adapter for:
+  - `search_restaurants`
+  - `get_restaurant_menu`
+- Add explicit shadow-read compatibility wrapper in `app/routers/restaurants.py`:
+  - SQLite remains canonical response path
+  - PostgreSQL read executes only in shadow mode
+- Add parity normalization/comparison for restaurant search/menu results
+- Add deterministic tests for:
+  - parity match and mismatch
+  - ordering drift mismatch
+  - shadow fail-open behavior for HTTP responses
+- Keep parity v1 scoped to common runtime fields and intentionally exclude
+  provenance-only fields not available in PostgreSQL foundation tables
+
+## Out of Scope
+
+- No public cutover to PostgreSQL runtime authority
+- No migration/parity work for `source_catalog`, `user_submissions`, `submission_audit`
+- No submission/moderation authority migration from SQLite
+- No `food_id` linking policy changes
+- No OpenAPI/deploy/Meili/vector scope widening
+
+## Role Order
+
+1. `agent-coordinator`
+2. `architecture-specialist`
+3. `backend-engineer`
+4. `qa-engineer-agent`
+5. `bug-hunter`
+6. `dev-operator`
+
+Add `security-auditor` only if this lane introduces new required env/deploy/auth surface.
+Mandatory post-open review lane remains: `qa-engineer-agent -> bug-hunter`.
+
+## Lifecycle Notes
+
+- Work from a dedicated lane worktree, not main checkout
+- Before edits:
+  - `python3 scripts/orchestration/check_preflight.py`
+  - `python3 scripts/orchestration/check_agent_consistency.py`
+- Open as **draft PR** after packet + backlog realignment and first local stabilization
+- Immediately after opening PR:
+  - create canonical artifact `docs/review/PR_<N>_FIXED_MAPPING.md`
+  - run post-open synthesis with `--pr-phase post_open_review`
+- Current-head merge verdict is canonical only through:
+  - `python3 scripts/orchestration/check_merge_ready.py --pr-number <N> --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`
+
+## Validation Plan
+
+- Targeted tests:
+  - `pytest -q tests/test_restaurant_postgres_read.py tests/test_restaurant_shadow_parity.py`
+  - plus router shadow behavior tests in the touched restaurant router test surface
+- Full local gates before undraft:
+  - `pre-commit run --all-files`
+  - `make verify`
+
+## Acceptance Criteria
+
+- PostgreSQL read adapter exists for restaurant search/menu only
+- Router keeps SQLite canonical responses; PostgreSQL executes as default-off shadow lane
+- Parity checks are explicit and deterministic
+- Provenance drift handling is intentional and test-covered
+- Submission/moderation flows remain on SQLite unchanged
+- `PR-B3` introduces no runtime authority cutover claim

--- a/docs/review/PR_1435_FIXED_MAPPING.md
+++ b/docs/review/PR_1435_FIXED_MAPPING.md
@@ -63,6 +63,30 @@ Reason: the CodeRabbit status comment is only an index of the inline actionable 
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#issuecomment-4262405219
 
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-postgres-foundation-followthrough`
+Reason: the Sourcery review contains high-level follow-through suggestions about engine reuse, env-flag utility centralization, and richer shadow-read diagnostics. Those are valid future improvements, but they are outside the bounded PR-B3 scope where SQLite remains canonical and runtime cutover/operability refinements stay deferred.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#pullrequestreview-4123393209
+
+Disposition: NOT-A-BUG
+Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446187`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446194`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095476592`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095429150`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446199`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095476597`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095476600`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446232`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446238`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446242`; `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-postgres-foundation-followthrough`
+Reason: the first CodeRabbit review is an aggregate summary of the inline findings already dispositioned above as FIXED or DEFERRED and does not add a separate unresolved requirement at the review level.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#pullrequestreview-4123424402
+
+Disposition: NOT-A-BUG
+Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446187`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446194`
+Reason: the Cubic review is a review-level summary of the bounded timeout and deterministic ordering issues already fixed in commit `0f601ed72`; it does not introduce a distinct unresolved review-level requirement.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#pullrequestreview-4123456955
+
+Disposition: NOT-A-BUG
+Evidence: `app/services/restaurant_postgres_read.py:85`; `app/services/restaurant_postgres_read.py:96`; `tests/test_restaurant_postgres_read.py:79`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#pullrequestreview-4123424402`
+Reason: the second CodeRabbit review is a duplicate aggregate summary for a schema-error hygiene suggestion that does not correspond to a separate open thread; the review-level URL is mapped here so merge governance sees the duplicate as explicitly dispositioned.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#pullrequestreview-4124383150
+
 Disposition: NOT-A-BUG
 Evidence: `AGENTS.md:64`; `AGENTS.md:65`
 Reason: the Codecov issue comment is advisory-only bot telemetry; merge truth for this repo is governed by the canonical local/CI gates, not by external bot commentary.

--- a/docs/review/PR_1435_FIXED_MAPPING.md
+++ b/docs/review/PR_1435_FIXED_MAPPING.md
@@ -1,0 +1,78 @@
+<!-- markdownlint-disable MD034 -->
+# PR #1435 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Latest actionable bot review is mapped below. If new review comments arrive, record
+their disposition here before resolving them on GitHub.
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 0f601ed72
+Evidence: `app/services/restaurant_postgres_read.py:51`; `app/services/restaurant_postgres_read.py:57`; `tests/test_restaurant_postgres_read.py:79`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446187 -> 0f601ed72
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446194 -> 0f601ed72
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095476592 -> 0f601ed72
+
+Disposition: FIXED
+Commit: 0f601ed72
+Evidence: `app/services/restaurant_postgres_read.py:116`; `app/services/restaurant_postgres_read.py:156`; `tests/test_restaurant_postgres_read.py:121`; `tests/test_restaurant_postgres_read.py:136`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095429150 -> 0f601ed72
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446199 -> 0f601ed72
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095476597 -> 0f601ed72
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095476600 -> 0f601ed72
+
+Disposition: FIXED
+Commit: 0f601ed72
+Evidence: `tests/test_restaurant_postgres_read.py:204`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446232 -> 0f601ed72
+
+Disposition: FIXED
+Commit: 0f601ed72
+Evidence: `tests/test_restaurant_shadow_parity.py:140`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446238 -> 0f601ed72
+
+Disposition: FIXED
+Commit: 0f601ed72
+Evidence: `tests/test_restaurants_router.py:385`; `tests/test_restaurants_router.py:427`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446242 -> 0f601ed72
+
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-postgres-foundation-followthrough`
+Reason: evidence-pointer reconciliation for historical B1/B2/B3 packets and the deferred cutover seam is valid governance work, but it is outside the bounded B3 code/test fix set already shipped in commit `0f601ed72`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446204
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446208
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446213
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446217
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446225
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#issuecomment-4262405205
+
+Disposition: NOT-A-BUG
+Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446187`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446194`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446199`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446232`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446238`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446242`
+Reason: the CodeRabbit status comment is only an index of the inline actionable items above and does not add a distinct unresolved requirement.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#issuecomment-4262405219
+
+Disposition: NOT-A-BUG
+Evidence: `AGENTS.md:64`; `AGENTS.md:65`
+Reason: the Codecov issue comment is advisory-only bot telemetry; merge truth for this repo is governed by the canonical local/CI gates, not by external bot commentary.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#issuecomment-4262488104
+
+## Merge Readiness
+
+- [ ] Current-head CI is green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1435_FIXED_MAPPING.md
+++ b/docs/review/PR_1435_FIXED_MAPPING.md
@@ -46,6 +46,12 @@ Evidence: `tests/test_restaurants_router.py:385`; `tests/test_restaurants_router
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3095446242 -> 0f601ed72
 
+Disposition: FIXED
+Commit: 3abe93218
+Evidence: `tests/test_restaurants_router.py:348`; `tests/test_restaurants_router.py:387`; `tests/test_restaurants_router.py:425`; `tests/test_restaurants_router.py:467`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3096464873 -> 3abe93218
+
 Disposition: DEFERRED
 Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-postgres-foundation-followthrough`
 Reason: evidence-pointer reconciliation for historical B1/B2/B3 packets and the deferred cutover seam is valid governance work, but it is outside the bounded B3 code/test fix set already shipped in commit `0f601ed72`.
@@ -86,6 +92,13 @@ Evidence: `app/services/restaurant_postgres_read.py:85`; `app/services/restauran
 Reason: the second CodeRabbit review is a duplicate aggregate summary for a schema-error hygiene suggestion that does not correspond to a separate open thread; the review-level URL is mapped here so merge governance sees the duplicate as explicitly dispositioned.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#pullrequestreview-4124383150
+
+Disposition: FIXED
+Commit: 3abe93218
+Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#discussion_r3096464873`; `tests/test_restaurants_router.py:348`; `tests/test_restaurants_router.py:387`; `tests/test_restaurants_router.py:425`; `tests/test_restaurants_router.py:467`
+Reason: the latest CodeRabbit review contains one actionable inline comment about env-precedence isolation in router tests, and that comment is fixed in commit `3abe93218`; the review-level URL is mapped to the same commit so governance sees the aggregate review as dispositioned.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1435#pullrequestreview-4124533202
 
 Disposition: NOT-A-BUG
 Evidence: `AGENTS.md:64`; `AGENTS.md:65`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4849,22 +4849,24 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - The change introduces no runtime, schema, or OpenAPI behavior
 
 <a id="ledger-p1-foods-postgres-foundation-followthrough"></a>
-- [ ] P1: Foods PostgreSQL follow-through train (B1 closed -> B2 next, B3 deferred)
+- [ ] P1: Foods PostgreSQL follow-through train (B1/B2 closed -> B3 next)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-B1 (`feat/pr-b1-foods-offline-etl-postgres`) -> PR-B2 (`feat/pr-b2-restaurant-relational-bridge`); B3 runtime cutover stays deferred outside B2
-  - Status: 🚧 Active after merged B1; B2 is the next implementation lane, while B3 runtime cutover remains deferred outside B2
+  - Target PR: PR-B1 (`feat/pr-b1-foods-offline-etl-postgres`) -> PR-B2 (`feat/pr-b2-restaurant-relational-bridge`) -> PR-B3 (`feat/pr-b3-restaurant-postgres-shadow-reads`)
+  - Status: 🚧 Active after merged B1/B2; B3 shadow-read parity lane is the next implementation step
   - Area: backend / data platform / restaurant ingestion
   - Finding Type: post-foundation execution gap
-  - Reason: The additive Alembic foundation lane intentionally creates `foods`, `restaurant_chains`, and `restaurant_menu_items` without changing the current SQLite/local-first runtime, ETL path, or MenuStat importer. The governed follow-through now continues from merged B1 directly into B2 because the Postgres deploy foundation is already present in repo and closed separately as a docs/governance reconciliation lane. B2 rewires restaurant ingestion into the relational catalog; B3 keeps runtime read-switch / cutover out of B2 as its own deferred rollout lane.
+  - Reason: The additive Alembic foundation lane intentionally creates `foods`, `restaurant_chains`, and `restaurant_menu_items` without changing the current SQLite/local-first runtime, ETL path, or MenuStat importer. After merged B1/B2, the next governed lane is B3 shadow reads plus parity checks for restaurant search/menu while preserving SQLite as canonical runtime authority until cutover criteria are proven.
   - Sequence:
     - B1: offline snapshot promotion from `data/food.sqlite::foods` into PostgreSQL `foods` with deterministic upsert/report coverage and no runtime/importer drift
     - B2: bridge `scripts/import_restaurant_menu.py` and restaurant persistence toward `restaurant_chains` / `restaurant_menu_items` additively, without runtime cutover
-    - B3 (deferred): decide and govern any runtime read-switch / PostgreSQL cutover as a later dedicated lane
+    - B3: add PostgreSQL shadow reads + parity checks for restaurant search/menu with SQLite response authority unchanged
+    - Cutover (deferred): decide and govern any runtime read-switch / PostgreSQL authority change only after B3 parity evidence
   - Links:
     - `docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md`
     - `docs/orchestration/FOODS_POSTGRES_PROMOTION_PR_B1_TASK_PACKET_2026-04-13.md`
     - `docs/orchestration/FOODS_POSTGRES_RESTAURANT_BRIDGE_PR_B2_TASK_PACKET_2026-04-13.md`
+    - `docs/orchestration/FOODS_POSTGRES_SHADOW_READS_PR_B3_TASK_PACKET_2026-04-16.md`
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p0-self-hosted-postgres-droplet-foundation`
     - `docs/deploy/POSTGRES_SELF_HOSTED_DROPLET.md`
     - `app/services/food_store.py`
@@ -4873,9 +4875,9 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `scripts/import_restaurant_menu.py`
   - DoD:
     - B1 packet and backlog sequencing explicitly lock the first executable lane to deterministic SQLite snapshot promotion into PostgreSQL `foods`
-    - Backlog sequencing explicitly marks B2 as the next active food implementation lane after merged B1
-    - B2 scope is explicit: restaurant importer rewiring targets `restaurant_chains` / `restaurant_menu_items` with deterministic compatibility coverage and no runtime cutover claim
-    - B3 runtime cutover / read-switch remains explicitly deferred outside B2
+    - Backlog sequencing explicitly marks B3 as the next active food implementation lane after merged B1/B2
+    - B3 scope is explicit: shadow reads + parity checks for restaurant search/menu with SQLite canonical responses
+    - Runtime authority cutover / read-switch remains explicitly deferred beyond B3 until parity/cutover criteria are met
     - Search / catalog follow-up lanes continue to reference the same canonical PostgreSQL table source without parallel schema drift
 
 <a id="ledger-p1-foods-foundation-downgrade-ownership"></a>

--- a/tests/test_app_extended_coverage.py
+++ b/tests/test_app_extended_coverage.py
@@ -15,6 +15,9 @@ from starlette.types import ASGIApp
 # Import the canonical FastAPI app (registers metrics, etc.)
 from app.main import app
 from app.middleware.api_tiers import TEST_KEY_VIP
+from tests import test_restaurant_postgres_read as restaurant_pg_tests
+from tests import test_restaurant_shadow_parity as restaurant_parity_tests
+from tests import test_restaurants_router as restaurant_router_tests
 from tests.helpers.fast_update_stubs import patch_background_update_callables
 
 
@@ -660,6 +663,144 @@ class TestVisualizationEndpoint:
 
             response = self.client.post("/api/v1/bmi/visualize", json=data, headers=headers)
             assert response.status_code == 404
+
+
+class TestRestaurantShadowReadCoverageTail:
+    """RU: Подтянуть canonical restaurant B3 tests в CI-visible suite.
+
+    EN: Re-run canonical restaurant B3 tests inside the CI-visible route suite.
+    """
+
+    def test_restaurant_postgres_build_engine_tail(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        restaurant_pg_tests.test_build_pg_engine_sets_bounded_connect_timeout(monkeypatch)
+
+    def test_restaurant_postgres_rejects_non_postgres_tail(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        restaurant_pg_tests.test_search_restaurants_pg_rejects_non_postgres_dialect(
+            monkeypatch, caplog
+        )
+
+    def test_restaurant_postgres_rejects_missing_tables_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_pg_tests.test_search_restaurants_pg_rejects_missing_tables(monkeypatch)
+
+    def test_restaurant_postgres_fetch_search_rows_tail(self) -> None:
+        restaurant_pg_tests.test_fetch_search_rows_orders_by_name_then_id()
+
+    def test_restaurant_postgres_fetch_menu_rows_tail(self) -> None:
+        restaurant_pg_tests.test_fetch_menu_rows_orders_by_item_name_then_id()
+
+    def test_restaurant_postgres_provenance_tail(self) -> None:
+        restaurant_pg_tests.test_fetch_menu_rows_sets_optional_provenance_to_none()
+
+    def test_restaurant_postgres_reflect_columns_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_pg_tests.test_reflect_read_tables_rejects_missing_required_columns(monkeypatch)
+
+    def test_restaurant_postgres_search_lifecycle_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_pg_tests.test_search_restaurants_pg_builds_reflects_and_disposes(monkeypatch)
+
+    def test_restaurant_postgres_menu_lifecycle_tail(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        restaurant_pg_tests.test_get_restaurant_menu_pg_builds_reflects_and_disposes(monkeypatch)
+
+    def test_restaurant_shadow_numeric_tail(self) -> None:
+        restaurant_parity_tests.test_normalize_numeric_handles_none_invalid_and_fractional_values()
+
+    def test_restaurant_shadow_bool_tail(self) -> None:
+        restaurant_parity_tests.test_normalize_bool_like_handles_supported_inputs()
+
+    def test_restaurant_shadow_hits_match_tail(self) -> None:
+        restaurant_parity_tests.test_compare_restaurant_hits_match()
+
+    def test_restaurant_shadow_menu_provenance_tail(self) -> None:
+        restaurant_parity_tests.test_compare_restaurant_menu_ignores_provenance_fields_in_v1()
+
+    def test_restaurant_shadow_menu_value_drift_tail(self) -> None:
+        restaurant_parity_tests.test_compare_restaurant_menu_detects_value_drift()
+
+    def test_restaurant_shadow_menu_ordering_tail(self) -> None:
+        restaurant_parity_tests.test_compare_restaurant_menu_detects_ordering_drift()
+
+    def test_restaurant_shadow_menu_row_count_tail(self) -> None:
+        restaurant_parity_tests.test_compare_restaurant_menu_detects_unequal_row_lengths()
+
+    def test_restaurant_shadow_menu_missing_sqlite_tail(self) -> None:
+        restaurant_parity_tests.test_compare_restaurant_menu_detects_missing_sqlite_row()
+
+    def test_restaurant_router_shadow_search_flag_off_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_router_tests.test_shadow_wrapper_skips_postgres_when_flag_off(monkeypatch)
+
+    def test_restaurant_router_shadow_search_enabled_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_router_tests.test_shadow_wrapper_uses_postgres_search_when_enabled(monkeypatch)
+
+    def test_restaurant_router_shadow_override_url_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_router_tests.test_shadow_wrapper_prefers_dedicated_postgres_override_url(
+            monkeypatch
+        )
+
+    def test_restaurant_router_shadow_missing_url_tail(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        restaurant_router_tests.test_shadow_wrapper_warns_when_enabled_without_postgres_url(
+            monkeypatch, caplog
+        )
+
+    def test_restaurant_router_shadow_search_mismatch_tail(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        restaurant_router_tests.test_shadow_wrapper_logs_search_mismatch(monkeypatch, caplog)
+
+    def test_restaurant_router_shadow_menu_fail_open_tail(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        restaurant_router_tests.test_shadow_wrapper_fails_open_when_postgres_menu_errors(
+            monkeypatch, caplog
+        )
+
+    def test_restaurant_router_shadow_menu_flag_off_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_router_tests.test_shadow_wrapper_menu_skips_when_flag_off(monkeypatch)
+
+    def test_restaurant_router_shadow_menu_missing_url_tail(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        restaurant_router_tests.test_shadow_wrapper_menu_warns_when_enabled_without_postgres_url(
+            monkeypatch, caplog
+        )
+
+    def test_restaurant_router_shadow_menu_mismatch_tail(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        restaurant_router_tests.test_shadow_wrapper_logs_menu_mismatch(monkeypatch, caplog)
+
+    def test_restaurant_router_shadow_submission_sqlite_only_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_router_tests.test_shadow_wrapper_submission_paths_remain_sqlite_only(monkeypatch)
 
 
 if __name__ == "__main__":

--- a/tests/test_restaurant_postgres_read.py
+++ b/tests/test_restaurant_postgres_read.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
 import pytest
@@ -58,16 +57,44 @@ class _FakeTable:
         self.columns = [type("Column", (), {"name": name})() for name in columns]
 
 
-def test_search_restaurants_pg_rejects_non_postgres_dialect(tmp_path: Path) -> None:
-    db_path = tmp_path / "shadow.sqlite"
-    with pytest.raises(restaurant_postgres_read.RestaurantPostgresReadError) as exc:
-        restaurant_postgres_read.search_restaurants_pg(
-            pg_url=f"sqlite:///{db_path}",
-            query="pulse",
-            limit=10,
-            offset=0,
-        )
+def test_build_pg_engine_sets_bounded_connect_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+    fake_engine = _FakeEngine(object())
+
+    def _fake_create_engine(*args: Any, **kwargs: Any) -> _FakeEngine:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return fake_engine
+
+    monkeypatch.setattr(restaurant_postgres_read, "create_engine", _fake_create_engine)
+
+    engine = restaurant_postgres_read._build_pg_engine("postgresql://shadow")
+
+    assert engine is fake_engine
+    assert captured["kwargs"]["connect_args"] == {
+        "connect_timeout": restaurant_postgres_read.POSTGRES_CONNECT_TIMEOUT_SECONDS
+    }
+
+
+def test_search_restaurants_pg_rejects_non_postgres_dialect(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fake_engine = _FakeEngine(object(), dialect_name="sqlite")
+    monkeypatch.setattr(restaurant_postgres_read, "create_engine", lambda *a, **k: fake_engine)
+
+    with caplog.at_level("DEBUG"):
+        with pytest.raises(restaurant_postgres_read.RestaurantPostgresReadError) as exc:
+            restaurant_postgres_read.search_restaurants_pg(
+                pg_url="sqlite:///shadow.sqlite",
+                query="pulse",
+                limit=10,
+                offset=0,
+            )
+
     assert "target database must be PostgreSQL" in str(exc.value)
+    assert fake_engine.disposed is True
+    assert "rejected non-PostgreSQL dialect: sqlite" in caplog.text
 
 
 def test_search_restaurants_pg_rejects_missing_tables(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -91,7 +118,7 @@ def test_search_restaurants_pg_rejects_missing_tables(monkeypatch: pytest.Monkey
     assert fake_engine.disposed is True
 
 
-def test_fetch_search_rows_orders_by_name() -> None:
+def test_fetch_search_rows_orders_by_name_then_id() -> None:
     connection = _RecordingConnection(
         [{"id": "c1", "name": "Alpha", "country": "US", "source": "menustat"}]
     )
@@ -102,11 +129,11 @@ def test_fetch_search_rows_orders_by_name() -> None:
         offset=3,
     )
     assert rows[0]["id"] == "c1"
-    assert "ORDER BY name ASC" in connection.executed_sql[0]
+    assert "ORDER BY name ASC, id ASC" in connection.executed_sql[0]
     assert connection.params[0] == {"query": "alp", "pattern": "%alp%", "limit": 7, "offset": 3}
 
 
-def test_fetch_menu_rows_orders_by_item_name() -> None:
+def test_fetch_menu_rows_orders_by_item_name_then_id() -> None:
     connection = _RecordingConnection(
         [
             {
@@ -129,7 +156,7 @@ def test_fetch_menu_rows_orders_by_item_name() -> None:
     rows = restaurant_postgres_read._fetch_menu_rows(connection, chain_id="c1", limit=15)
     assert rows[0]["id"] == "m1"
     assert "AND is_active IS TRUE" in connection.executed_sql[0]
-    assert "ORDER BY item_name ASC" in connection.executed_sql[0]
+    assert "ORDER BY item_name ASC, id ASC" in connection.executed_sql[0]
     assert connection.params[0] == {"chain_id": "c1", "limit": 15}
 
 
@@ -172,3 +199,50 @@ def test_reflect_read_tables_rejects_missing_required_columns(
     with pytest.raises(restaurant_postgres_read.RestaurantPostgresReadError) as exc:
         restaurant_postgres_read._reflect_read_tables(object())
     assert "missing required columns" in str(exc.value)
+
+
+def test_get_restaurant_menu_pg_builds_reflects_and_disposes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_connection = _RecordingConnection(
+        [
+            {
+                "id": "m1",
+                "chain_id": "c1",
+                "item_name": "Protein Bowl",
+                "category": "Bowls",
+                "serving_size_g": 240,
+                "kcal": 510,
+                "protein_g": 28,
+                "fat_g": 16,
+                "carbs_g": 55,
+                "sodium_mg": 760,
+                "source": "menustat",
+                "source_id": "menu-1",
+                "is_active": True,
+            }
+        ]
+    )
+    fake_engine = _FakeEngine(fake_connection)
+    reflected_connections: list[Any] = []
+
+    monkeypatch.setattr(
+        restaurant_postgres_read,
+        "_build_pg_engine",
+        lambda pg_url: fake_engine,
+    )
+    monkeypatch.setattr(
+        restaurant_postgres_read,
+        "_reflect_read_tables",
+        lambda connection: reflected_connections.append(connection),
+    )
+
+    rows = restaurant_postgres_read.get_restaurant_menu_pg(
+        pg_url="postgresql://shadow",
+        chain_id="c1",
+        limit=25,
+    )
+
+    assert rows[0]["id"] == "m1"
+    assert reflected_connections == [fake_connection]
+    assert fake_engine.disposed is True

--- a/tests/test_restaurant_postgres_read.py
+++ b/tests/test_restaurant_postgres_read.py
@@ -201,6 +201,38 @@ def test_reflect_read_tables_rejects_missing_required_columns(
     assert "missing required columns" in str(exc.value)
 
 
+def test_search_restaurants_pg_builds_reflects_and_disposes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_connection = _RecordingConnection(
+        [{"id": "c1", "name": "Alpha", "country": "US", "source": "menustat"}]
+    )
+    fake_engine = _FakeEngine(fake_connection)
+    reflected_connections: list[Any] = []
+
+    monkeypatch.setattr(
+        restaurant_postgres_read,
+        "_build_pg_engine",
+        lambda pg_url: fake_engine,
+    )
+    monkeypatch.setattr(
+        restaurant_postgres_read,
+        "_reflect_read_tables",
+        lambda connection: reflected_connections.append(connection),
+    )
+
+    rows = restaurant_postgres_read.search_restaurants_pg(
+        pg_url="postgresql://shadow",
+        query="alp",
+        limit=10,
+        offset=5,
+    )
+
+    assert rows[0]["id"] == "c1"
+    assert reflected_connections == [fake_connection]
+    assert fake_engine.disposed is True
+
+
 def test_get_restaurant_menu_pg_builds_reflects_and_disposes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_restaurant_postgres_read.py
+++ b/tests/test_restaurant_postgres_read.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy.exc import NoSuchTableError
+
+from app.services import restaurant_postgres_read
+
+
+class _FakeMappingsResult:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def mappings(self) -> list[dict[str, Any]]:
+        return self._rows
+
+
+class _RecordingConnection:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.executed_sql: list[str] = []
+        self.params: list[dict[str, Any]] = []
+
+    def execute(self, sql: Any, params: dict[str, Any]) -> _FakeMappingsResult:
+        self.executed_sql.append(str(sql))
+        self.params.append(params)
+        return _FakeMappingsResult(self.rows)
+
+
+class _ConnectionContext:
+    def __init__(self, connection: Any) -> None:
+        self.connection = connection
+
+    def __enter__(self) -> Any:
+        return self.connection
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+
+class _FakeEngine:
+    def __init__(self, connection: Any, *, dialect_name: str = "postgresql") -> None:
+        self.connection = connection
+        self.dialect = type("Dialect", (), {"name": dialect_name})()
+        self.disposed = False
+
+    def connect(self) -> _ConnectionContext:
+        return _ConnectionContext(self.connection)
+
+    def dispose(self) -> None:
+        self.disposed = True
+
+
+class _FakeTable:
+    def __init__(self, columns: list[str]) -> None:
+        self.columns = [type("Column", (), {"name": name})() for name in columns]
+
+
+def test_search_restaurants_pg_rejects_non_postgres_dialect(tmp_path: Path) -> None:
+    db_path = tmp_path / "shadow.sqlite"
+    with pytest.raises(restaurant_postgres_read.RestaurantPostgresReadError) as exc:
+        restaurant_postgres_read.search_restaurants_pg(
+            pg_url=f"sqlite:///{db_path}",
+            query="pulse",
+            limit=10,
+            offset=0,
+        )
+    assert "target database must be PostgreSQL" in str(exc.value)
+
+
+def test_search_restaurants_pg_rejects_missing_tables(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_connection = object()
+    fake_engine = _FakeEngine(fake_connection)
+    monkeypatch.setattr(restaurant_postgres_read, "create_engine", lambda *a, **k: fake_engine)
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise NoSuchTableError("restaurant_chains")
+
+    monkeypatch.setattr(restaurant_postgres_read, "Table", _boom)
+
+    with pytest.raises(restaurant_postgres_read.RestaurantPostgresReadError) as exc:
+        restaurant_postgres_read.search_restaurants_pg(
+            pg_url="postgresql://shadow",
+            query="pulse",
+            limit=5,
+            offset=0,
+        )
+    assert "missing required tables" in str(exc.value)
+    assert fake_engine.disposed is True
+
+
+def test_fetch_search_rows_orders_by_name() -> None:
+    connection = _RecordingConnection(
+        [{"id": "c1", "name": "Alpha", "country": "US", "source": "menustat"}]
+    )
+    rows = restaurant_postgres_read._fetch_search_rows(
+        connection,
+        query="alp",
+        limit=7,
+        offset=3,
+    )
+    assert rows[0]["id"] == "c1"
+    assert "ORDER BY name ASC" in connection.executed_sql[0]
+    assert connection.params[0] == {"query": "alp", "pattern": "%alp%", "limit": 7, "offset": 3}
+
+
+def test_fetch_menu_rows_orders_by_item_name() -> None:
+    connection = _RecordingConnection(
+        [
+            {
+                "id": "m1",
+                "chain_id": "c1",
+                "item_name": "Protein Bowl",
+                "category": "Bowls",
+                "serving_size_g": 240,
+                "kcal": 510,
+                "protein_g": 28,
+                "fat_g": 16,
+                "carbs_g": 55,
+                "sodium_mg": 760,
+                "source": "menustat",
+                "source_id": "menu-1",
+                "is_active": True,
+            }
+        ]
+    )
+    rows = restaurant_postgres_read._fetch_menu_rows(connection, chain_id="c1", limit=15)
+    assert rows[0]["id"] == "m1"
+    assert "AND is_active IS TRUE" in connection.executed_sql[0]
+    assert "ORDER BY item_name ASC" in connection.executed_sql[0]
+    assert connection.params[0] == {"chain_id": "c1", "limit": 15}
+
+
+def test_fetch_menu_rows_sets_optional_provenance_to_none() -> None:
+    connection = _RecordingConnection(
+        [
+            {
+                "id": "m1",
+                "chain_id": "c1",
+                "item_name": "Protein Bowl",
+                "category": "Bowls",
+                "serving_size_g": 240,
+                "kcal": 510,
+                "protein_g": 28,
+                "fat_g": 16,
+                "carbs_g": 55,
+                "sodium_mg": 760,
+                "source": "menustat",
+                "source_id": "menu-1",
+                "is_active": True,
+            }
+        ]
+    )
+    row = restaurant_postgres_read._fetch_menu_rows(connection, chain_id="c1", limit=15)[0]
+    assert row["snapshot_date"] is None
+    assert row["provenance_source"] is None
+    assert row["provenance_record_id"] is None
+
+
+def test_reflect_read_tables_rejects_missing_required_columns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tables = iter(
+        [
+            _FakeTable(["id", "name", "country", "source"]),
+            _FakeTable(["id", "chain_id", "item_name"]),
+        ]
+    )
+    monkeypatch.setattr(restaurant_postgres_read, "Table", lambda *a, **k: next(tables))
+    with pytest.raises(restaurant_postgres_read.RestaurantPostgresReadError) as exc:
+        restaurant_postgres_read._reflect_read_tables(object())
+    assert "missing required columns" in str(exc.value)

--- a/tests/test_restaurant_shadow_parity.py
+++ b/tests/test_restaurant_shadow_parity.py
@@ -135,3 +135,48 @@ def test_compare_restaurant_menu_detects_ordering_drift() -> None:
     result = restaurant_shadow_parity.compare_restaurant_menu(sqlite_rows, postgres_rows)
     assert result.match is False
     assert result.mismatched_indexes[0] == 0
+
+
+def test_compare_restaurant_menu_detects_unequal_row_lengths() -> None:
+    sqlite_rows = [
+        {
+            "id": "m1",
+            "chain_id": "c1",
+            "item_name": "Alpha Bowl",
+            "category": "Bowls",
+            "serving_size_g": 240,
+            "kcal": 510,
+            "protein_g": 28,
+            "fat_g": 16,
+            "carbs_g": 55,
+            "sodium_mg": 760,
+            "source": "menustat",
+            "source_id": "menu-1",
+            "is_active": True,
+        },
+        {
+            "id": "m2",
+            "chain_id": "c1",
+            "item_name": "Beta Bowl",
+            "category": "Bowls",
+            "serving_size_g": 230,
+            "kcal": 470,
+            "protein_g": 24,
+            "fat_g": 14,
+            "carbs_g": 52,
+            "sodium_mg": 710,
+            "source": "menustat",
+            "source_id": "menu-2",
+            "is_active": True,
+        },
+    ]
+    postgres_rows = [sqlite_rows[0]]
+
+    result = restaurant_shadow_parity.compare_restaurant_menu(sqlite_rows, postgres_rows)
+
+    assert result.match is False
+    assert result.sqlite_count == 2
+    assert result.postgres_count == 1
+    assert result.mismatched_indexes == (1,)
+    assert result.mismatch_reasons[0] == "row-count mismatch sqlite=2 postgres=1"
+    assert result.mismatch_reasons[1] == "missing postgres row at index 1"

--- a/tests/test_restaurant_shadow_parity.py
+++ b/tests/test_restaurant_shadow_parity.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from app.services import restaurant_shadow_parity
+
+
+def test_compare_restaurant_hits_match() -> None:
+    sqlite_rows = [{"id": "c1", "name": "Alpha", "country": "US", "source": "menustat"}]
+    postgres_rows = [{"id": "c1", "name": "Alpha", "country": "US", "source": "menustat"}]
+    result = restaurant_shadow_parity.compare_restaurant_hits(sqlite_rows, postgres_rows)
+    assert result.match is True
+    assert result.mismatch_reasons == ()
+
+
+def test_compare_restaurant_menu_ignores_provenance_fields_in_v1() -> None:
+    sqlite_rows = [
+        {
+            "id": "m1",
+            "chain_id": "c1",
+            "item_name": "Protein Bowl",
+            "category": "Bowls",
+            "serving_size_g": 240.0,
+            "kcal": 510.0,
+            "protein_g": 28.0,
+            "fat_g": 16.0,
+            "carbs_g": 55.0,
+            "sodium_mg": 760.0,
+            "source": "menustat",
+            "source_id": "menu-1",
+            "is_active": 1,
+            "snapshot_date": "2026-02-24",
+            "provenance_source": "menustat",
+            "provenance_record_id": "menu-1",
+        }
+    ]
+    postgres_rows = [
+        {
+            "id": "m1",
+            "chain_id": "c1",
+            "item_name": "Protein Bowl",
+            "category": "Bowls",
+            "serving_size_g": "240.00",
+            "kcal": "510.00",
+            "protein_g": "28.00",
+            "fat_g": "16.00",
+            "carbs_g": "55.00",
+            "sodium_mg": "760.00",
+            "source": "menustat",
+            "source_id": "menu-1",
+            "is_active": True,
+            "snapshot_date": None,
+            "provenance_source": None,
+            "provenance_record_id": None,
+        }
+    ]
+    result = restaurant_shadow_parity.compare_restaurant_menu(sqlite_rows, postgres_rows)
+    assert result.match is True
+    assert result.mismatch_reasons == ()
+
+
+def test_compare_restaurant_menu_detects_value_drift() -> None:
+    sqlite_rows = [
+        {
+            "id": "m1",
+            "chain_id": "c1",
+            "item_name": "Protein Bowl",
+            "category": "Bowls",
+            "serving_size_g": 240,
+            "kcal": 510,
+            "protein_g": 28,
+            "fat_g": 16,
+            "carbs_g": 55,
+            "sodium_mg": 760,
+            "source": "menustat",
+            "source_id": "menu-1",
+            "is_active": True,
+        }
+    ]
+    postgres_rows = [
+        {
+            "id": "m1",
+            "chain_id": "c1",
+            "item_name": "Protein Bowl",
+            "category": "Bowls",
+            "serving_size_g": 240,
+            "kcal": 499,
+            "protein_g": 28,
+            "fat_g": 16,
+            "carbs_g": 55,
+            "sodium_mg": 760,
+            "source": "menustat",
+            "source_id": "menu-1",
+            "is_active": True,
+        }
+    ]
+    result = restaurant_shadow_parity.compare_restaurant_menu(sqlite_rows, postgres_rows)
+    assert result.match is False
+    assert result.mismatched_indexes == (0,)
+    assert "field kcal mismatch" in result.mismatch_reasons[0]
+
+
+def test_compare_restaurant_menu_detects_ordering_drift() -> None:
+    sqlite_rows = [
+        {
+            "id": "m1",
+            "chain_id": "c1",
+            "item_name": "Alpha Bowl",
+            "category": "Bowls",
+            "serving_size_g": 240,
+            "kcal": 510,
+            "protein_g": 28,
+            "fat_g": 16,
+            "carbs_g": 55,
+            "sodium_mg": 760,
+            "source": "menustat",
+            "source_id": "menu-1",
+            "is_active": True,
+        },
+        {
+            "id": "m2",
+            "chain_id": "c1",
+            "item_name": "Beta Bowl",
+            "category": "Bowls",
+            "serving_size_g": 230,
+            "kcal": 470,
+            "protein_g": 24,
+            "fat_g": 14,
+            "carbs_g": 52,
+            "sodium_mg": 710,
+            "source": "menustat",
+            "source_id": "menu-2",
+            "is_active": True,
+        },
+    ]
+    postgres_rows = [sqlite_rows[1], sqlite_rows[0]]
+    result = restaurant_shadow_parity.compare_restaurant_menu(sqlite_rows, postgres_rows)
+    assert result.match is False
+    assert result.mismatched_indexes[0] == 0

--- a/tests/test_restaurant_shadow_parity.py
+++ b/tests/test_restaurant_shadow_parity.py
@@ -1,6 +1,23 @@
 from __future__ import annotations
 
+from decimal import Decimal
+
 from app.services import restaurant_shadow_parity
+
+
+def test_normalize_numeric_handles_none_invalid_and_fractional_values() -> None:
+    assert restaurant_shadow_parity._normalize_numeric(None) is None
+    assert restaurant_shadow_parity._normalize_numeric("not-a-number") is None
+    assert restaurant_shadow_parity._normalize_numeric(Decimal("12.500")) == "12.5"
+
+
+def test_normalize_bool_like_handles_supported_inputs() -> None:
+    assert restaurant_shadow_parity._normalize_bool_like(None) is None
+    assert restaurant_shadow_parity._normalize_bool_like(True) is True
+    assert restaurant_shadow_parity._normalize_bool_like(0) is False
+    assert restaurant_shadow_parity._normalize_bool_like("YES") is True
+    assert restaurant_shadow_parity._normalize_bool_like("n") is False
+    assert restaurant_shadow_parity._normalize_bool_like("maybe") is None
 
 
 def test_compare_restaurant_hits_match() -> None:
@@ -180,3 +197,50 @@ def test_compare_restaurant_menu_detects_unequal_row_lengths() -> None:
     assert result.mismatched_indexes == (1,)
     assert result.mismatch_reasons[0] == "row-count mismatch sqlite=2 postgres=1"
     assert result.mismatch_reasons[1] == "missing postgres row at index 1"
+
+
+def test_compare_restaurant_menu_detects_missing_sqlite_row() -> None:
+    sqlite_rows = [
+        {
+            "id": "m1",
+            "chain_id": "c1",
+            "item_name": "Alpha Bowl",
+            "category": "Bowls",
+            "serving_size_g": 240,
+            "kcal": 510,
+            "protein_g": 28,
+            "fat_g": 16,
+            "carbs_g": 55,
+            "sodium_mg": 760,
+            "source": "menustat",
+            "source_id": "menu-1",
+            "is_active": True,
+        }
+    ]
+    postgres_rows = [
+        sqlite_rows[0],
+        {
+            "id": "m2",
+            "chain_id": "c1",
+            "item_name": "Beta Bowl",
+            "category": "Bowls",
+            "serving_size_g": 230,
+            "kcal": 470,
+            "protein_g": 24,
+            "fat_g": 14,
+            "carbs_g": 52,
+            "sodium_mg": 710,
+            "source": "menustat",
+            "source_id": "menu-2",
+            "is_active": True,
+        },
+    ]
+
+    result = restaurant_shadow_parity.compare_restaurant_menu(sqlite_rows, postgres_rows)
+
+    assert result.match is False
+    assert result.sqlite_count == 1
+    assert result.postgres_count == 2
+    assert result.mismatched_indexes == (1,)
+    assert result.mismatch_reasons[0] == "row-count mismatch sqlite=1 postgres=2"
+    assert result.mismatch_reasons[1] == "missing sqlite row at index 1"

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -450,6 +450,42 @@ def test_shadow_wrapper_warns_when_enabled_without_postgres_url(
     assert "shadow reads enabled for search without a PostgreSQL URL" in caplog.text
 
 
+def test_shadow_wrapper_logs_search_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    wrapper = restaurants._RestaurantStoreShadowCompat()
+    monkeypatch.setenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "true")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://shadow")
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "search_restaurants",
+        lambda **_: [{"id": "c1", "name": "Chain 1", "country": "US", "source": "menustat"}],
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_postgres_read,
+        "search_restaurants_pg",
+        lambda **_: [{"id": "c1", "name": "Chain 1", "country": "US", "source": "openfoodfacts"}],
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_shadow_parity,
+        "compare_restaurant_hits",
+        lambda sqlite_rows, postgres_rows: restaurants.restaurant_shadow_parity.ParityResult(
+            match=False,
+            sqlite_count=len(sqlite_rows),
+            postgres_count=len(postgres_rows),
+            mismatched_indexes=(0,),
+            mismatch_reasons=("field source mismatch at index 0",),
+        ),
+    )
+
+    with caplog.at_level("WARNING"):
+        rows = wrapper.search_restaurants("chain", 10, 0)
+
+    assert list(rows)[0]["id"] == "c1"
+    assert "restaurant PostgreSQL shadow-read mismatch for search_restaurants" in caplog.text
+
+
 def test_shadow_wrapper_fails_open_when_postgres_menu_errors(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -471,6 +507,87 @@ def test_shadow_wrapper_fails_open_when_postgres_menu_errors(
         rows = wrapper.get_restaurant_menu("c1", 20)
     assert list(rows)[0]["id"] == "m1"
     assert "keeping SQLite canonical response" in caplog.text
+
+
+def test_shadow_wrapper_menu_skips_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    wrapper = restaurants._RestaurantStoreShadowCompat()
+    monkeypatch.delenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, raising=False)
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "get_restaurant_menu",
+        lambda **_: [{"id": "m1", "chain_id": "c1", "item_name": "Protein Bowl"}],
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_postgres_read,
+        "get_restaurant_menu_pg",
+        lambda **_: (_ for _ in ()).throw(AssertionError("shadow menu should stay disabled")),
+    )
+
+    rows = wrapper.get_restaurant_menu("c1", 10)
+
+    assert list(rows)[0]["id"] == "m1"
+
+
+def test_shadow_wrapper_menu_warns_when_enabled_without_postgres_url(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    wrapper = restaurants._RestaurantStoreShadowCompat()
+    monkeypatch.setenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "true")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv(restaurants.RESTAURANT_POSTGRES_SHADOW_READS_URL, raising=False)
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "get_restaurant_menu",
+        lambda **_: [{"id": "m1", "chain_id": "c1", "item_name": "Protein Bowl"}],
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_postgres_read,
+        "get_restaurant_menu_pg",
+        lambda **_: (_ for _ in ()).throw(AssertionError("shadow menu should not run")),
+    )
+
+    with caplog.at_level("WARNING"):
+        rows = wrapper.get_restaurant_menu("c1", 10)
+
+    assert list(rows)[0]["id"] == "m1"
+    assert "shadow reads enabled for menu without a PostgreSQL URL" in caplog.text
+
+
+def test_shadow_wrapper_logs_menu_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    wrapper = restaurants._RestaurantStoreShadowCompat()
+    monkeypatch.setenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "true")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://shadow")
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "get_restaurant_menu",
+        lambda **_: [{"id": "m1", "chain_id": "c1", "item_name": "Protein Bowl"}],
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_postgres_read,
+        "get_restaurant_menu_pg",
+        lambda **_: [{"id": "m1", "chain_id": "c1", "item_name": "Protein Bowl"}],
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_shadow_parity,
+        "compare_restaurant_menu",
+        lambda sqlite_rows, postgres_rows: restaurants.restaurant_shadow_parity.ParityResult(
+            match=False,
+            sqlite_count=len(sqlite_rows),
+            postgres_count=len(postgres_rows),
+            mismatched_indexes=(0,),
+            mismatch_reasons=("field source mismatch at index 0",),
+        ),
+    )
+
+    with caplog.at_level("WARNING"):
+        rows = wrapper.get_restaurant_menu("c1", 10)
+
+    assert list(rows)[0]["id"] == "m1"
+    assert "restaurant PostgreSQL shadow-read mismatch for get_restaurant_menu" in caplog.text
 
 
 def test_shadow_wrapper_submission_paths_remain_sqlite_only(

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -351,6 +351,7 @@ def test_shadow_wrapper_uses_postgres_search_when_enabled(
     wrapper = restaurants._RestaurantStoreShadowCompat()
     seen: dict[str, str] = {}
     monkeypatch.setenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "true")
+    monkeypatch.delenv(restaurants.RESTAURANT_POSTGRES_SHADOW_READS_URL, raising=False)
     monkeypatch.setenv("DATABASE_URL", "postgresql://shadow")
     monkeypatch.setattr(
         restaurants.restaurant_store,
@@ -456,6 +457,7 @@ def test_shadow_wrapper_logs_search_mismatch(
 ) -> None:
     wrapper = restaurants._RestaurantStoreShadowCompat()
     monkeypatch.setenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "true")
+    monkeypatch.delenv(restaurants.RESTAURANT_POSTGRES_SHADOW_READS_URL, raising=False)
     monkeypatch.setenv("DATABASE_URL", "postgresql://shadow")
     monkeypatch.setattr(
         restaurants.restaurant_store,
@@ -491,6 +493,7 @@ def test_shadow_wrapper_fails_open_when_postgres_menu_errors(
 ) -> None:
     wrapper = restaurants._RestaurantStoreShadowCompat()
     monkeypatch.setenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "true")
+    monkeypatch.delenv(restaurants.RESTAURANT_POSTGRES_SHADOW_READS_URL, raising=False)
     monkeypatch.setenv("DATABASE_URL", "postgresql://shadow")
     monkeypatch.setattr(
         restaurants.restaurant_store,
@@ -560,6 +563,7 @@ def test_shadow_wrapper_logs_menu_mismatch(
 ) -> None:
     wrapper = restaurants._RestaurantStoreShadowCompat()
     monkeypatch.setenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "true")
+    monkeypatch.delenv(restaurants.RESTAURANT_POSTGRES_SHADOW_READS_URL, raising=False)
     monkeypatch.setenv("DATABASE_URL", "postgresql://shadow")
     monkeypatch.setattr(
         restaurants.restaurant_store,

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -382,6 +382,74 @@ def test_shadow_wrapper_uses_postgres_search_when_enabled(
     assert seen["pg_url"] == "postgresql://shadow"
 
 
+def test_shadow_wrapper_prefers_dedicated_postgres_override_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wrapper = restaurants._RestaurantStoreShadowCompat()
+    seen: dict[str, str] = {}
+    monkeypatch.setenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "true")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://canonical")
+    monkeypatch.setenv(
+        restaurants.RESTAURANT_POSTGRES_SHADOW_READS_URL,
+        "postgresql://shadow-override",
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "search_restaurants",
+        lambda **_: [{"id": "c1", "name": "Chain 1", "country": "US", "source": "menustat"}],
+    )
+
+    def _shadow_search(**kwargs: Any) -> list[dict[str, Any]]:
+        seen["pg_url"] = kwargs["pg_url"]
+        return [{"id": "c1", "name": "Chain 1", "country": "US", "source": "menustat"}]
+
+    monkeypatch.setattr(
+        restaurants.restaurant_postgres_read, "search_restaurants_pg", _shadow_search
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_shadow_parity,
+        "compare_restaurant_hits",
+        lambda sqlite_rows, postgres_rows: restaurants.restaurant_shadow_parity.ParityResult(
+            match=True,
+            sqlite_count=len(sqlite_rows),
+            postgres_count=len(postgres_rows),
+            mismatched_indexes=(),
+            mismatch_reasons=(),
+        ),
+    )
+
+    rows = wrapper.search_restaurants("chain", 10, 0)
+
+    assert list(rows)[0]["id"] == "c1"
+    assert seen["pg_url"] == "postgresql://shadow-override"
+
+
+def test_shadow_wrapper_warns_when_enabled_without_postgres_url(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    wrapper = restaurants._RestaurantStoreShadowCompat()
+    monkeypatch.setenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "true")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv(restaurants.RESTAURANT_POSTGRES_SHADOW_READS_URL, raising=False)
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "search_restaurants",
+        lambda **_: [{"id": "c1", "name": "Chain 1", "country": "US", "source": "menustat"}],
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_postgres_read,
+        "search_restaurants_pg",
+        lambda **_: (_ for _ in ()).throw(AssertionError("shadow search should not run")),
+    )
+
+    with caplog.at_level("WARNING"):
+        rows = wrapper.search_restaurants("chain", 10, 0)
+
+    assert list(rows)[0]["id"] == "c1"
+    assert "shadow reads enabled for search without a PostgreSQL URL" in caplog.text
+
+
 def test_shadow_wrapper_fails_open_when_postgres_menu_errors(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -325,3 +325,123 @@ def test_review_payload_rejects_pending_status() -> None:
 def test_submission_create_rejects_invalid_off_url() -> None:
     with pytest.raises(ValidationError):
         RestaurantSubmissionCreate(canonical_name="X", off_url="not-a-url", payload={})
+
+
+def test_shadow_wrapper_skips_postgres_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    wrapper = restaurants._RestaurantStoreShadowCompat()
+    monkeypatch.delenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, raising=False)
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "search_restaurants",
+        lambda **_: [{"id": "c1", "name": "Chain 1", "country": "US", "source": "menustat"}],
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_postgres_read,
+        "search_restaurants_pg",
+        lambda **_: (_ for _ in ()).throw(AssertionError("shadow search should stay disabled")),
+    )
+
+    rows = wrapper.search_restaurants("chain", 10, 0)
+    assert list(rows)[0]["id"] == "c1"
+
+
+def test_shadow_wrapper_uses_postgres_search_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wrapper = restaurants._RestaurantStoreShadowCompat()
+    seen: dict[str, str] = {}
+    monkeypatch.setenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "true")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://shadow")
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "search_restaurants",
+        lambda **_: [{"id": "c1", "name": "Chain 1", "country": "US", "source": "menustat"}],
+    )
+
+    def _shadow_search(**kwargs: Any) -> list[dict[str, Any]]:
+        seen["pg_url"] = kwargs["pg_url"]
+        return [{"id": "c1", "name": "Chain 1", "country": "US", "source": "menustat"}]
+
+    monkeypatch.setattr(
+        restaurants.restaurant_postgres_read, "search_restaurants_pg", _shadow_search
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_shadow_parity,
+        "compare_restaurant_hits",
+        lambda sqlite_rows, postgres_rows: restaurants.restaurant_shadow_parity.ParityResult(
+            match=True,
+            sqlite_count=len(sqlite_rows),
+            postgres_count=len(postgres_rows),
+            mismatched_indexes=(),
+            mismatch_reasons=(),
+        ),
+    )
+
+    rows = wrapper.search_restaurants("chain", 10, 0)
+    assert list(rows)[0]["id"] == "c1"
+    assert seen["pg_url"] == "postgresql://shadow"
+
+
+def test_shadow_wrapper_fails_open_when_postgres_menu_errors(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    wrapper = restaurants._RestaurantStoreShadowCompat()
+    monkeypatch.setenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "true")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://shadow")
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "get_restaurant_menu",
+        lambda **_: [{"id": "m1", "chain_id": "c1", "item_name": "Protein Bowl"}],
+    )
+
+    def _boom(**kwargs: Any) -> list[dict[str, Any]]:
+        raise RuntimeError("pg down")
+
+    monkeypatch.setattr(restaurants.restaurant_postgres_read, "get_restaurant_menu_pg", _boom)
+
+    with caplog.at_level("WARNING"):
+        rows = wrapper.get_restaurant_menu("c1", 20)
+    assert list(rows)[0]["id"] == "m1"
+    assert "keeping SQLite canonical response" in caplog.text
+
+
+def test_shadow_wrapper_submission_paths_remain_sqlite_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wrapper = restaurants._RestaurantStoreShadowCompat()
+    monkeypatch.setenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "true")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://shadow")
+    monkeypatch.setattr(
+        restaurants.restaurant_postgres_read,
+        "search_restaurants_pg",
+        lambda **_: (_ for _ in ()).throw(AssertionError("search shadow should not run here")),
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_postgres_read,
+        "get_restaurant_menu_pg",
+        lambda **_: (_ for _ in ()).throw(AssertionError("menu shadow should not run here")),
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "create_submission",
+        lambda **_: {"id": "s1"},
+    )
+    monkeypatch.setattr(restaurants.restaurant_store, "get_submission", lambda _sid: {"id": "s1"})
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "review_submission",
+        lambda _sid, **_: {"id": "s1"},
+    )
+
+    assert (
+        wrapper.create_submission(
+            canonical_name="Protein Bowl",
+            payload={"kcal": 540},
+            barcode=None,
+            off_url=None,
+            entity_type="restaurant_menu",
+        )["id"]
+        == "s1"
+    )
+    assert wrapper.get_submission("s1")["id"] == "s1"
+    assert wrapper.review_submission("s1", status="approved", reviewer_notes=None)["id"] == "s1"


### PR DESCRIPTION
## Summary

Implements **PR-B3**: PostgreSQL **shadow reads** for restaurant search/menu with **parity logging**, while **SQLite remains the canonical** response path for clients. No public cutover.

## Split Justification

This PR is intentionally one bounded lane: shadow-read adapter, parity helpers, router wiring, and deterministic tests for the same runtime seam. Splitting code from the parity/tests/governance pieces would leave the B3 lane non-verifiable and break the train-level contract while runtime authority cutover remains explicitly deferred.

## Changes

- `restaurant_postgres_read`: read-only PG queries with bounded `connect_timeout`, genericized dialect failure, and deterministic `ORDER BY ... , id ASC` tie-breakers.
- `restaurant_shadow_parity`: compare SQLite vs PG rows for search/menu, including unequal-length drift diagnostics.
- `restaurants` router: optional shadow path behind `FEATURE_RESTAURANT_POSTGRES_SHADOW_READS` plus `RESTAURANT_POSTGRES_SHADOW_READS_URL`; failures are logged and SQLite responses stay canonical.
- Tests for adapter, parity, and router shadow behavior, including override/no-URL branches.
- Governance: canonical disposition artifact for PR review comments.

## Feature flags

- `FEATURE_RESTAURANT_POSTGRES_SHADOW_READS` (default off)
- `RESTAURANT_POSTGRES_SHADOW_READS_URL` optional; otherwise `DATABASE_URL`

## Deferred / Follow-ups

- Runtime cutover to PostgreSQL reads remains deferred and tracked in `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-postgres-foundation-followthrough`.
- Historical B1/B2/B3 packet evidence-pointer reconciliation and cutover-seam ADR metadata are also deferred to the same governed follow-through item.

## Validation

Local:
- `pre-commit run --all-files`
- `.venv/bin/pytest -q tests/test_restaurant_postgres_read.py tests/test_restaurant_shadow_parity.py tests/test_restaurants_router.py`
- `make validate-min`
- `make verify` (in progress / rerun before merge if branch head changes)

Task packet: `docs/orchestration/FOODS_POSTGRES_SHADOW_READS_PR_B3_TASK_PACKET_2026-04-16.md`

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

Canonical artifact: `docs/review/PR_1435_FIXED_MAPPING.md`

- `0f601ed72` fixes the code/test review items for bounded timeout, genericized dialect failure, deterministic ordering, high-level PG adapter coverage, parity unequal-length coverage, and router env-resolution branches.
- Historical packet/backlog evidence-anchor comments are dispositioned as `DEFERRED` against `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-postgres-foundation-followthrough`.
- `3abe93218` fixes the latest CodeRabbit follow-up by clearing the higher-precedence shadow-read env var in router tests before `DATABASE_URL` fallback assertions, so env precedence is isolated deterministically.
- `f0437f9b4` maps the latest CodeRabbit inline/review URLs in the canonical artifact so merge governance sees the final aggregate review as dispositioned too.
- Review-level bot summaries from Sourcery, Cubic, and all CodeRabbit review URLs are explicitly dispositioned in the canonical artifact so merge governance sees the aggregate review URLs as mapped too.

## Merge Readiness

- [ ] Current-head CI is green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * Added optional PostgreSQL “shadow” reads for restaurant search and menu with deterministic parity checks and warning logs; canonical behavior and API responses are unchanged and shadow failures do not affect returned data.

* **Tests**
  * Added comprehensive tests covering shadow reads, parity comparison, ordering/value drift, provenance normalization, and fail-open behavior.

* **Documentation**
  * Updated orchestration/roadmap and added a task packet and review notes describing the shadow-reads lane and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

