### PR TITLE
feat(orchestration): add app store release skill

### DIFF
--- a/.agents/skills/pulseplate-app-store-release
+++ b/.agents/skills/pulseplate-app-store-release
@@ -1,0 +1,1 @@
+../../tools/codex_skills/pulseplate-app-store-release

--- a/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
+++ b/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
@@ -135,7 +135,7 @@ When `envelope_mode_hint` is `docs_only` (all candidate paths are contract/docs-
 | Experimentation / eval / optimization | `pulseplate-workflow`, `docs-sync`, `pulseplate-gates` | `bug-triage`, `code-review-expert`, `openai-docs` |
 | Backend / API / contracts | `pulseplate-backend-endpoints`, `pulseplate-openapi-sync`, `pulseplate-gates` | `bug-triage`, `security-best-practices`, `openai-docs` |
 | Frontend / web UX | `pulseplate-frontend-ui`, `pulseplate-gates`, `build-web-apps:frontend-skill` | `pulseplate-playwright-e2e`, `playwright`, `figma`, `figma-implement-design`, `vercel-react-best-practices`, `build-web-apps:web-design-guidelines`, `build-web-apps:react-best-practices` |
-| iOS / App Store / Fastlane | `build-ios-apps:swiftui-ui-patterns`, `build-ios-apps:swiftui-view-refactor` | `build-ios-apps:ios-debugger-agent`, `build-ios-apps:swiftui-performance-audit`, `pulseplate-app-store-release` (planned) |
+| iOS / App Store / Fastlane | `build-ios-apps:swiftui-ui-patterns`, `build-ios-apps:swiftui-view-refactor` | `build-ios-apps:ios-debugger-agent`, `build-ios-apps:swiftui-performance-audit`, `pulseplate-app-store-release` |
 | Docs / runbooks / policy | `docs-sync` | `agents-md`, `release-notes`, `code-review-expert` |
 | QA / CI / remediation | `bug-triage`, `pulseplate-gates` | `ci-fix`, `gh-fix-ci`, `gh-address-comments`, `code-review-expert` |
 | Reports / wellness / GTM research | `pulseplate-ai-reports`, `docs-sync` | `notion-research-documentation`, `notion-knowledge-capture`, `linear`, `openai-docs`, `pulseplate-monetization-gtm` (planned) |

--- a/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
+++ b/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
@@ -125,6 +125,11 @@ CV routing note:
 
 When `envelope_mode_hint` is `docs_only` (all candidate paths are contract/docs-only surfaces and none require privileged security review per `bootstrap_sync_policy`), `scripts/orchestration/skill_router.py` **removes** implementation-oriented skills from `recommended` and `conditional` so selection stays aligned with root `AGENTS.md` docs-only PR scope and with `inputs.message_envelope.mode` (`docs-only`) on the bootstrap packet. The excluded slug set is `DOCS_ONLY_EXCLUDED_ROUTING_SKILLS` in `scripts/orchestration/skill_router.py:120`.
 
+For `pulseplate-app-store-release`, docs-only suppression still applies even when
+`docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md` matches a routing prefix. Promote
+that skill only for mixed or implementation envelopes that also carry App Store
+metadata, screenshot-pack, App Privacy, or release-evidence intent.
+
 ---
 
 ## 3. Project-Fit Skill Lanes

--- a/docs/orchestration/CODEX_SKILLS_ALIGNMENT_MATRIX.md
+++ b/docs/orchestration/CODEX_SKILLS_ALIGNMENT_MATRIX.md
@@ -60,6 +60,7 @@ Interpretation:
 
 ### Tier 2: Useful and should route conditionally
 
+- `pulseplate-app-store-release`
 - `build-web-apps:react-best-practices`
 - `build-ios-apps:swiftui-performance-audit`
 - `linear`
@@ -79,7 +80,6 @@ Interpretation:
 
 ### Tier 3: Missing custom PulsePlate skills
 
-- `pulseplate-app-store-release`
 - `pulseplate-monetization-gtm`
 - `pulseplate-design-launch-system`
 - `pulseplate-agent-product`
@@ -89,7 +89,7 @@ Interpretation:
 
 ### Wave 1
 
-- `pulseplate-app-store-release`
+- `pulseplate-app-store-release` (active in this wave)
 - `pulseplate-monetization-gtm`
 
 ### Wave 2

--- a/docs/review/PR_1436_FIXED_MAPPING.md
+++ b/docs/review/PR_1436_FIXED_MAPPING.md
@@ -9,13 +9,27 @@ Bot and human review threads must be dispositioned here before they are resolved
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1436#discussion_r3096626954 -> 6d7b993da
+Disposition: FIXED
+Evidence: `scripts/orchestration/skill_router.py:120-126` now excludes `pulseplate-app-store-release` from the docs-only envelope, and `tests/test_skill_router.py:1371-1385` locks the App Store runbook docs-only regression called out in the Codex thread.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1436#pullrequestreview-4124715979 -> 6d7b993da
+Disposition: FIXED
+Evidence: `scripts/orchestration/skill_router.py:120-126` and `tests/test_skill_router.py:1371-1385` close Cubic's docs-only routing concern for the new release skill.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1436#discussion_r3096643833 -> 6d7b993da
+Disposition: FIXED
+Evidence: `scripts/orchestration/skill_router.py:120-126` adds the missing docs-only exclusion, while `tests/test_skill_router.py:1352-1385` proves the filtered envelope contract stays deterministic for generic docs and App Store rollout docs.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1436#pullrequestreview-4124688108 -> 6d7b993da
+Disposition: FIXED
+Evidence: `tools/codex_skills/pulseplate-app-store-release/SKILL.md:24-27` replaces brittle `sed -n '1,220p'` snippets with pattern-based `rg -n -C 2` lookups, and the file-specific rollout-runbook prefix remains intentional because `scripts/orchestration/skill_router.py:120-126` now strips docs-only App Store runbook edits from implementation routing.
 
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head
 - [ ] Required checks complete (no pending jobs)
 - [ ] All review threads resolved on GitHub after disposition updates
-- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-- [x] Pre-commit green on latest pushed head
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green on latest pushed head
 - [ ] `make verify` green on latest pushed head

--- a/docs/review/PR_1436_FIXED_MAPPING.md
+++ b/docs/review/PR_1436_FIXED_MAPPING.md
@@ -29,6 +29,26 @@ Disposition: FIXED
 Commit: 6d7b993da
 Evidence: `tools/codex_skills/pulseplate-app-store-release/SKILL.md:24-27` replaces brittle `sed -n '1,220p'` snippets with pattern-based `rg -n -C 2` lookups, and the file-specific rollout-runbook prefix remains intentional because `scripts/orchestration/skill_router.py:120-126` now strips docs-only App Store runbook edits from implementation routing.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1436#discussion_r3096698261 -> 68d860bb9
+Disposition: FIXED
+Commit: 68d860bb9
+Evidence: `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md:124-131` now documents the docs-only suppression and promotion criteria for `pulseplate-app-store-release`, and commit `68d860bb9` satisfies the root `AGENTS.md:2101-2104` requirement for a `docs(agents): update instructions` commit on routing-behavior changes.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1436#pullrequestreview-4124772172 -> 68d860bb9
+Disposition: FIXED
+Commit: 68d860bb9
+Evidence: `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md:124-131` adds the required operator routing guidance for the new skill, while `tools/codex_skills/pulseplate-app-store-release/SKILL.md:55-58` also incorporates the remaining guardrail wording cleanup from the CodeRabbit review.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1436#discussion_r3096706208 -> 68d860bb9
+Disposition: FIXED
+Commit: 68d860bb9
+Evidence: `tools/codex_skills/pulseplate-app-store-release/SKILL.md:24-27` now uses a case-insensitive pattern that matches `Validation-Only Path`, `Reviewer Notes Update Procedure`, protected-upload guidance, App Privacy, and rollback sections from the App Store rollout runbook.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1436#pullrequestreview-4124780246 -> 68d860bb9
+Disposition: FIXED
+Commit: 68d860bb9
+Evidence: `tools/codex_skills/pulseplate-app-store-release/SKILL.md:24-27` fixes the runbook-section matcher called out by Cubic, and `tools/codex_skills/pulseplate-app-store-release/SKILL.md:55-58` keeps the updated guardrail wording aligned with the latest review pass.
+
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head

--- a/docs/review/PR_1436_FIXED_MAPPING.md
+++ b/docs/review/PR_1436_FIXED_MAPPING.md
@@ -11,18 +11,22 @@ Bot and human review threads must be dispositioned here before they are resolved
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1436#discussion_r3096626954 -> 6d7b993da
 Disposition: FIXED
+Commit: 6d7b993da
 Evidence: `scripts/orchestration/skill_router.py:120-126` now excludes `pulseplate-app-store-release` from the docs-only envelope, and `tests/test_skill_router.py:1371-1385` locks the App Store runbook docs-only regression called out in the Codex thread.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1436#pullrequestreview-4124715979 -> 6d7b993da
 Disposition: FIXED
+Commit: 6d7b993da
 Evidence: `scripts/orchestration/skill_router.py:120-126` and `tests/test_skill_router.py:1371-1385` close Cubic's docs-only routing concern for the new release skill.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1436#discussion_r3096643833 -> 6d7b993da
 Disposition: FIXED
+Commit: 6d7b993da
 Evidence: `scripts/orchestration/skill_router.py:120-126` adds the missing docs-only exclusion, while `tests/test_skill_router.py:1352-1385` proves the filtered envelope contract stays deterministic for generic docs and App Store rollout docs.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1436#pullrequestreview-4124688108 -> 6d7b993da
 Disposition: FIXED
+Commit: 6d7b993da
 Evidence: `tools/codex_skills/pulseplate-app-store-release/SKILL.md:24-27` replaces brittle `sed -n '1,220p'` snippets with pattern-based `rg -n -C 2` lookups, and the file-specific rollout-runbook prefix remains intentional because `scripts/orchestration/skill_router.py:120-126` now strips docs-only App Store runbook edits from implementation routing.
 
 ## Merge Readiness

--- a/docs/review/PR_1436_FIXED_MAPPING.md
+++ b/docs/review/PR_1436_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+# PR #1436 — Fixed in Commit Mapping (SoT)
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Bot and human review threads must be dispositioned here before they are resolved on GitHub.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green on latest pushed head
+- [ ] `make verify` green on latest pushed head

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4572,7 +4572,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR-TBD-CODEX-SKILL-WAVE1A
-  - Status: Planned
+  - Status: In progress
   - Area: iOS / release / orchestration
   - Finding Type: capability expansion
   - Reason: PulsePlate needs a project-specific App Store release skill that understands Fastlane, release truth, metadata parity, screenshot packs, and the repo's non-interference contract with coordinator-first orchestration.

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -655,6 +655,30 @@ SKILL_RULES: tuple[SkillRule, ...] = (
         ),
     ),
     SkillRule(
+        skill="pulseplate-app-store-release",
+        category="repo-tracked",
+        rationale=(
+            "App Store metadata, screenshot packs, App Privacy uploads, and "
+            "release-evidence work should use the dedicated PulsePlate release skill."
+        ),
+        min_score=6,
+        domain_weights={"release": 2, "qa": 1},
+        path_prefixes=("ios/fastlane/", "docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md"),
+        keywords=(
+            "app store metadata",
+            "app store screenshot",
+            "app store screenshots",
+            "app store connect",
+            "app privacy",
+            "review information",
+            "review notes",
+            "fastlane metadata",
+            "fastlane screenshots",
+            "app store submission",
+            "release evidence",
+        ),
+    ),
+    SkillRule(
         skill="build-ios-apps:swiftui-performance-audit",
         category="global",
         rationale="SwiftUI performance and rendering issues should use the dedicated audit skill.",

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -122,6 +122,7 @@ DOCS_ONLY_EXCLUDED_ROUTING_SKILLS: frozenset[str] = frozenset(
         "pulseplate-backend-endpoints",
         "pulseplate-openapi-sync",
         "pulseplate-frontend-ui",
+        "pulseplate-app-store-release",
         "vercel-react-best-practices",
         "build-web-apps:frontend-skill",
         "build-web-apps:web-design-guidelines",

--- a/tests/test_install_codex_skills.py
+++ b/tests/test_install_codex_skills.py
@@ -266,6 +266,7 @@ def test_repo_agents_skills_mirror_points_to_codex_skill_sources() -> None:
 
     expected_skills = (
         "pulseplate-ai-reports",
+        "pulseplate-app-store-release",
         "pulseplate-backend-endpoints",
         "pulseplate-frontend-ui",
         "pulseplate-gates",

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -659,6 +659,7 @@ def test_skill_router_selects_ios_app_store_skill_stack() -> None:
     assert "build-ios-apps:swiftui-ui-patterns" in skills
     assert "build-ios-apps:swiftui-view-refactor" in skills
     assert "build-ios-apps:ios-debugger-agent" in skills
+    assert "pulseplate-app-store-release" in skills
     assert "build-web-apps:stripe-best-practices" not in skills
 
 
@@ -673,6 +674,7 @@ def test_skill_router_selects_swiftui_refactor_for_ios_domain() -> None:
     )
 
     assert "build-ios-apps:swiftui-view-refactor" in skills
+    assert "pulseplate-app-store-release" not in skills
 
 
 def test_skill_router_selects_ios_app_store_screenshot_lane() -> None:
@@ -686,6 +688,7 @@ def test_skill_router_selects_ios_app_store_screenshot_lane() -> None:
     )
 
     assert "build-ios-apps:ios-debugger-agent" in skills
+    assert "pulseplate-app-store-release" in skills
 
 
 def test_skill_router_does_not_double_count_fastlane_prefixes() -> None:
@@ -699,6 +702,7 @@ def test_skill_router_does_not_double_count_fastlane_prefixes() -> None:
     )
 
     assert "build-ios-apps:ios-debugger-agent" not in skills
+    assert "pulseplate-app-store-release" in skills
 
 
 def test_skill_router_selects_swiftui_performance_audit_skill() -> None:

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -1368,6 +1368,23 @@ def test_docs_only_envelope_strips_implementation_skills() -> None:
         assert skill not in conditional
 
 
+def test_docs_only_app_store_runbook_updates_do_not_route_release_skill() -> None:
+    """docs_only App Store runbook edits must not surface release implementation helpers."""
+
+    decision = route_skills(
+        goal="Refresh App Store metadata and review notes wording in the rollout runbook",
+        task_class="Documentation",
+        candidate_paths=["docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md"],
+        domain="docs",
+    )
+
+    assert decision["envelope_mode_hint"] == DOCS_ONLY_ENVELOPE_MODE
+    recommended = {item["skill"] for item in decision["recommended"]}
+    conditional = {item["skill"] for item in decision["conditional"]}
+    assert "pulseplate-app-store-release" not in recommended
+    assert "pulseplate-app-store-release" not in conditional
+
+
 def test_privileged_docs_paths_use_analysis_envelope_for_routing() -> None:
     """Privileged orchestration docs stay in analysis envelope; implementation skills remain eligible."""
 

--- a/tools/codex_skills/README.md
+++ b/tools/codex_skills/README.md
@@ -23,6 +23,7 @@ Skills remain passive/discovery-only helpers and do not replace coordinator boot
 - `pulseplate-guards`
 - `pulseplate-backend-endpoints`
 - `pulseplate-ai-reports`
+- `pulseplate-app-store-release`
 - `pulseplate-graphmap`
 - `pulseplate-playwright-e2e`
 

--- a/tools/codex_skills/pulseplate-app-store-release/SKILL.md
+++ b/tools/codex_skills/pulseplate-app-store-release/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: pulseplate-app-store-release
+description: Handle PulsePlate App Store release work covering Fastlane metadata, screenshot packs, review evidence, and protected rollout notes without bypassing coordinator-first policy.
+---
+
+# PulsePlate App Store Release
+
+## When to use
+
+- Preparing or updating App Store metadata under `ios/fastlane/metadata/`.
+- Working on screenshot packs, App Store Connect upload flow, or App Privacy assets.
+- Reviewing release evidence, rollback notes, or protected upload readiness for iOS release ops.
+
+## Inputs required
+
+- Release surface in scope (`metadata`, `screenshots`, `app_privacy`, `review_notes`, or `evidence`).
+- Candidate file paths or workflow paths being changed.
+- Expected release outcome (`draft-ready`, `validation-only`, or `protected-upload follow-up`).
+
+## Procedure (commands)
+
+1. Load release-policy context:
+
+   ```bash
+   sed -n '1,220p' ios/AGENTS.md
+   sed -n '1,220p' docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md
+   ```
+
+2. Verify Fastlane and validator surfaces before editing:
+
+   ```bash
+   rg -n "upload_metadata|upload_screenshots|upload_app_privacy|review_information" ios/fastlane
+   pytest -q tests/test_ios_appstore_assets_workflow_contract.py
+   pytest -q tests/test_ios_appstore_asset_validators.py
+   ```
+
+3. Keep rollout claims fail-closed:
+
+   ```bash
+   python3 scripts/orchestration/check_preflight.py
+   python3 scripts/orchestration/check_agent_consistency.py
+   pre-commit run --all-files
+   make verify
+   ```
+
+## Output format
+
+- `Release surface`: exact App Store surface touched.
+- `Evidence`: validator/tests/workflow proof and protected-run dependencies.
+- `Risk notes`: reviewer impact, secret/environment dependency, rollback note.
+- `Follow-up`: whether protected upload remains operator-only after merge.
+
+## Guardrails
+
+- Do not bypass coordinator-first routing or convert this skill into release authority.
+- Do not claim App Store rollout completion without protected-run evidence.
+- Do not mix backend billing truth or entitlement logic into iOS/App Store asset work.
+- Keep protected secrets and upload credentials outside repo branches and worktrees.
+
+## SoT links
+
+- `AGENTS.md`
+- `ios/AGENTS.md`
+- `docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md`
+- `ios/fastlane/Fastfile`
+- `tests/test_ios_appstore_assets_workflow_contract.py`
+- `tests/test_ios_appstore_asset_validators.py`

--- a/tools/codex_skills/pulseplate-app-store-release/SKILL.md
+++ b/tools/codex_skills/pulseplate-app-store-release/SKILL.md
@@ -23,7 +23,7 @@ description: Handle PulsePlate App Store release work covering Fastlane metadata
 
    ```bash
    rg -n -C 2 "App Store|Fastlane|release" ios/AGENTS.md
-   rg -n -C 2 "Validation-only|Protected upload|App Privacy|review information|rollback" docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md
+   rg -n -C 2 -i "validation-only|protected upload|app privacy|review information|reviewer notes|rollback" docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md
    ```
 
 2. Verify Fastlane and validator surfaces before editing:
@@ -53,8 +53,8 @@ description: Handle PulsePlate App Store release work covering Fastlane metadata
 ## Guardrails
 
 - Do not bypass coordinator-first routing or convert this skill into release authority.
-- Do not claim App Store rollout completion without protected-run evidence.
-- Do not mix backend billing truth or entitlement logic into iOS/App Store asset work.
+- App Store rollout completion always requires protected-run evidence.
+- Keep backend billing truth and entitlement logic out of iOS/App Store asset work.
 - Keep protected secrets and upload credentials outside repo branches and worktrees.
 
 ## SoT links

--- a/tools/codex_skills/pulseplate-app-store-release/SKILL.md
+++ b/tools/codex_skills/pulseplate-app-store-release/SKILL.md
@@ -22,8 +22,8 @@ description: Handle PulsePlate App Store release work covering Fastlane metadata
 1. Load release-policy context:
 
    ```bash
-   sed -n '1,220p' ios/AGENTS.md
-   sed -n '1,220p' docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md
+   rg -n -C 2 "App Store|Fastlane|release" ios/AGENTS.md
+   rg -n -C 2 "Validation-only|Protected upload|App Privacy|review information|rollback" docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md
    ```
 
 2. Verify Fastlane and validator surfaces before editing:


### PR DESCRIPTION
## Summary
- add the repo-tracked `pulseplate-app-store-release` skill for PulsePlate App Store / Fastlane / release-evidence work
- wire deterministic skill routing for App Store metadata, screenshots, App Privacy, and release-evidence cues
- update docs, backlog status, and installer mirror tests so the new skill is discoverable and policy-aligned

## Why
Wave 1A of the Codex skills alignment roadmap requires a dedicated PulsePlate App Store release skill instead of relying only on generic iOS helpers. This keeps App Store release work coordinator-first, additive, and repo-specific.

## How to validate
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pytest -q tests/test_skill_router.py tests/test_install_codex_skills.py`
- `pre-commit run --all-files`
- `make lint`
- `make typecheck`
- `make test-fast`
- `python -m coverage run -m pytest -q tests/test_skill_router.py tests/test_install_codex_skills.py tests/edges tests/test_remaining_modules.py && python -m coverage xml && diff-cover coverage.xml --compare-branch=origin/main --fail-under=97`

## Screenshots / GIF (if UI changes)
- none

## Risk / rollout notes
- no runtime product behavior change; this is skill-routing, docs, and test-surface only
- full `make verify` reached `diff-cov`, but the full-suite `coverage run -m pytest -q` exceeded the interactive shell runtime budget in this environment and was terminated before completion
- targeted diff-cover for the changed Python surface passed; full-suite diff-cover should be re-run in CI / a longer-lived shell before merge readiness

## Summary by Sourcery

Представить выделенный отслеживаемый в репозитории навык релиза в App Store для PulsePlate и подключить его к оркестрации маршрутизации, документации и обнаружению установщика для работы, связанной с iOS App Store и Fastlane.

Новые возможности:
- Добавить навык-кодекс `pulseplate-app-store-release` с задокументированным использованием, защитными ограничениями (guardrails) и источниками истины для рабочих процессов релиза в App Store.
- Открыть новый навык релиза в App Store через зеркало навыков repo agents, чтобы он был доступен оркестрируемым агентам.

Улучшения:
- Маршрутизировать запросы, связанные с iOS App Store, Fastlane и доказательствами релиза (release-evidence), к новому навыку релиза в App Store PulsePlate через роутер навыков с соответствующим весом домена.
- Обновить политику оркестрации и матрицу соответствия навыков, чтобы отразить новый активный навык релиза в App Store и статус его дорожной карты.
- Добавить артефакт ревью fixed-in-commit, документирующий итог обсуждений в тредах для этого PR.

Тесты:
- Расширить тесты роутера навыков, чтобы проверять, когда навык релиза в App Store PulsePlate выбирается или исключается для соответствующих сценариев iOS App Store.
- Обновить тесты установщика навыков, чтобы убедиться, что новый навык релиза в App Store PulsePlate корректно зеркалируется в директорию навыков агентов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated repo-tracked PulsePlate App Store release skill and wire it into orchestration routing, documentation, and installer discovery for iOS App Store and Fastlane-related work.

New Features:
- Add the `pulseplate-app-store-release` codex skill with documented usage, guardrails, and sources of truth for App Store release workflows.
- Expose the new App Store release skill via the repo agents skills mirror so it is available to orchestrated agents.

Enhancements:
- Route iOS App Store, Fastlane, and release-evidence cues to the new PulsePlate App Store release skill through the skill router with appropriate domain weighting.
- Update orchestration policy and skills alignment matrix to reflect the new active App Store release skill and its roadmap status.
- Add a fixed-in-commit review artifact documenting discussion-thread disposition for this PR.

Tests:
- Extend skill router tests to verify when the PulsePlate App Store release skill is selected or excluded for relevant iOS App Store scenarios.
- Update skill installer tests to ensure the new PulsePlate App Store release skill is mirrored correctly into the agents skills directory.

</details>

Новые возможности:
- Добавлен отслеживаемый в репозитории скилл `pulseplate-app-store-release` для работы с релизами в PulsePlate App Store / Fastlane с определёнными рекомендациями по использованию и защитными ограничениями.

Улучшения:
- Детеминированно направлять сигналы, связанные с iOS App Store и Fastlane, в новый скилл релизов PulsePlate App Store в роутере скиллов.
- Обновить политику оркестрации и документацию по согласованию скиллов, чтобы отразить новый активный скилл релизов App Store и его статус в дорожной карте.
- Гарантировать, что новый скилл включён в зеркало установщика скиллов Codex для улучшения обнаруживаемости.

Тесты:
- Расширить тесты роутера скиллов, чтобы покрыть случаи выбора и невыбора нового скилла релизов PulsePlate App Store.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Представить выделенный отслеживаемый в репозитории навык релиза в App Store для PulsePlate и подключить его к оркестрации маршрутизации, документации и обнаружению установщика для работы, связанной с iOS App Store и Fastlane.

Новые возможности:
- Добавить навык-кодекс `pulseplate-app-store-release` с задокументированным использованием, защитными ограничениями (guardrails) и источниками истины для рабочих процессов релиза в App Store.
- Открыть новый навык релиза в App Store через зеркало навыков repo agents, чтобы он был доступен оркестрируемым агентам.

Улучшения:
- Маршрутизировать запросы, связанные с iOS App Store, Fastlane и доказательствами релиза (release-evidence), к новому навыку релиза в App Store PulsePlate через роутер навыков с соответствующим весом домена.
- Обновить политику оркестрации и матрицу соответствия навыков, чтобы отразить новый активный навык релиза в App Store и статус его дорожной карты.
- Добавить артефакт ревью fixed-in-commit, документирующий итог обсуждений в тредах для этого PR.

Тесты:
- Расширить тесты роутера навыков, чтобы проверять, когда навык релиза в App Store PulsePlate выбирается или исключается для соответствующих сценариев iOS App Store.
- Обновить тесты установщика навыков, чтобы убедиться, что новый навык релиза в App Store PulsePlate корректно зеркалируется в директорию навыков агентов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated repo-tracked PulsePlate App Store release skill and wire it into orchestration routing, documentation, and installer discovery for iOS App Store and Fastlane-related work.

New Features:
- Add the `pulseplate-app-store-release` codex skill with documented usage, guardrails, and sources of truth for App Store release workflows.
- Expose the new App Store release skill via the repo agents skills mirror so it is available to orchestrated agents.

Enhancements:
- Route iOS App Store, Fastlane, and release-evidence cues to the new PulsePlate App Store release skill through the skill router with appropriate domain weighting.
- Update orchestration policy and skills alignment matrix to reflect the new active App Store release skill and its roadmap status.
- Add a fixed-in-commit review artifact documenting discussion-thread disposition for this PR.

Tests:
- Extend skill router tests to verify when the PulsePlate App Store release skill is selected or excluded for relevant iOS App Store scenarios.
- Update skill installer tests to ensure the new PulsePlate App Store release skill is mirrored correctly into the agents skills directory.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the repo-tracked `pulseplate-app-store-release` skill and routes App Store metadata, screenshots, App Privacy, and release-evidence tasks to it. Documents and enforces docs-only suppression so runbook edits don’t trigger this implementation lane.

- **New Features**
  - Added `tools/codex_skills/pulseplate-app-store-release/SKILL.md` with mirror at `.agents/skills/pulseplate-app-store-release`; updated skills README and installer mirror tests; marked active (Tier 2, Wave 1) in alignment docs; moved backlog to In progress; expanded operator guidance in `AGENT_SKILL_ROUTING_POLICY.md`.
  - Introduced routing rule in `scripts/orchestration/skill_router.py` (min_score 6; `release`/`qa` weights) with `ios/fastlane/` and `docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md` prefixes and App Store keywords.

- **Bug Fixes**
  - Excluded `pulseplate-app-store-release` from the docs-only envelope (including when the rollout runbook path matches); added a regression test to lock this behavior.

<sup>Written for commit 3a999963650ab526a7ceb1d8009cf6b0f70bf3d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1436_FIXED_MAPPING.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated the pulseplate-app-store-release skill with conditional routing for App Store release contexts.

* **Documentation**
  * Updated routing policy, alignment matrix, rollout guidance, backlog status, and added a skill usage doc and review record.

* **Tests**
  * Added and extended tests to validate the skill’s routing and docs-only exclusion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->