### PR TITLE
docs(orchestration): sync Wave 1 Codex skills canon

### DIFF
--- a/docs/dev/CODEX_SKILLS.md
+++ b/docs/dev/CODEX_SKILLS.md
@@ -106,6 +106,8 @@ For explainability, the packet also carries `skill_routing` metadata with weight
 - Triage architecture/policy guards: `pulseplate-guards`
 - Add backend endpoints with policy checks: `pulseplate-backend-endpoints`
 - Produce AI trend reports: `pulseplate-ai-reports`
+- Prepare App Store metadata, screenshot packs, and release evidence: `pulseplate-app-store-release`
+- Guide monetization, paywall, pricing, and wellness-safe GTM work: `pulseplate-monetization-gtm`
 - Build/update architecture graph artifact: `pulseplate-graphmap`
 - Run browser E2E flows (step 3 extension): `pulseplate-playwright-e2e`
 
@@ -114,6 +116,8 @@ For explainability, the packet also carries `skill_routing` metadata with weight
 Recommended now for PulsePlate:
 
 - `pulseplate-ai-reports` for founder/wellness/AI reporting
+- `pulseplate-app-store-release` for App Store metadata, screenshot packs, and release evidence
+- `pulseplate-monetization-gtm` for monetization, paywall, pricing, and wellness-safe GTM work
 - `docs-sync` for orchestration, runbooks, and PR support docs
 - `bug-triage` and `pulseplate-gates` for remediation and gate closure
 - `figma` as the first design-system and prototype lane

--- a/docs/orchestration/CODEX_SKILLS_ALIGNMENT_MATRIX.md
+++ b/docs/orchestration/CODEX_SKILLS_ALIGNMENT_MATRIX.md
@@ -85,19 +85,19 @@ Interpretation:
 - `pulseplate-agent-product`
 - `pulseplate-web-launch-site`
 
-## Planned Creation Waves
+## Skill Delivery Waves
 
-### Wave 1
+### Wave 1 — Delivered
 
-- `pulseplate-app-store-release` (active in this wave; evidence: `docs/roadmap/BACKLOG_LEDGER.md:4571`, `tools/codex_skills/pulseplate-app-store-release/SKILL.md:1`)
-- `pulseplate-monetization-gtm` (active in this wave; evidence: `docs/roadmap/BACKLOG_LEDGER.md:4588`, `tools/codex_skills/pulseplate-monetization-gtm/SKILL.md:1`)
+- `pulseplate-app-store-release` (merged via PR `#1436` / `0b3f2de82892a230789d70648fccfd0f7806641f`; evidence: `docs/review/PR_1436_FIXED_MAPPING.md:1`, `tools/codex_skills/pulseplate-app-store-release/SKILL.md:1`)
+- `pulseplate-monetization-gtm` (merged via PR `#1439` / `28c2bd2dd18e57a058386670161b0e350e078c5a`; PR `#1438` closed as superseded; evidence: `docs/review/PR_1439_FIXED_MAPPING.md:1`, `tools/codex_skills/pulseplate-monetization-gtm/SKILL.md:1`)
 
-### Wave 2
+### Wave 2 — Planned
 
 - `pulseplate-design-launch-system`
 - `pulseplate-web-launch-site`
 
-### Wave 3
+### Wave 3 — Planned
 
 - `pulseplate-agent-product`
 

--- a/docs/orchestration/CODEX_SKILLS_ALIGNMENT_MATRIX.md
+++ b/docs/orchestration/CODEX_SKILLS_ALIGNMENT_MATRIX.md
@@ -90,7 +90,7 @@ Interpretation:
 ### Wave 1 — Delivered
 
 - `pulseplate-app-store-release` (merged via PR `#1436` / `0b3f2de82892a230789d70648fccfd0f7806641f`; evidence: `docs/review/PR_1436_FIXED_MAPPING.md:1`, `tools/codex_skills/pulseplate-app-store-release/SKILL.md:1`)
-- `pulseplate-monetization-gtm` (merged via PR `#1439` / `28c2bd2dd18e57a058386670161b0e350e078c5a`; PR `#1438` closed as superseded; evidence: `docs/review/PR_1439_FIXED_MAPPING.md:1`, `tools/codex_skills/pulseplate-monetization-gtm/SKILL.md:1`)
+- `pulseplate-monetization-gtm` (merged via PR `#1439` / `28c2bd2dd18e57a058386670161b0e350e078c5a`; PR `#1438` closed as superseded; evidence: `docs/roadmap/BACKLOG_LEDGER.md:4752`, `docs/review/PR_1439_FIXED_MAPPING.md:1`, `tools/codex_skills/pulseplate-monetization-gtm/SKILL.md:1`)
 
 ### Wave 2 — Planned
 

--- a/docs/review/PR_1441_FIXED_MAPPING.md
+++ b/docs/review/PR_1441_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+# PR #1441 — Fixed in Commit Mapping (SoT)
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+Bot and human review threads must be dispositioned here before they are resolved on GitHub.
+
+## Fixed in Commit Mapping
+
+No actionable review threads yet.
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green on latest pushed head
+- [ ] `make verify` green on latest pushed head

--- a/docs/review/PR_1441_FIXED_MAPPING.md
+++ b/docs/review/PR_1441_FIXED_MAPPING.md
@@ -9,7 +9,29 @@ Bot and human review threads must be dispositioned here before they are resolved
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: ede22924b
+Evidence: `docs/orchestration/CODEX_SKILLS_ALIGNMENT_MATRIX.md:93`, `docs/roadmap/BACKLOG_LEDGER.md:4752`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1441#discussion_r3102563701 -> ede22924b
+
+Disposition: FIXED
+Commit: 0c2037964
+Evidence: `docs/review/PR_1441_FIXED_MAPPING.md:5`, `docs/review/PR_1441_FIXED_MAPPING.md:6`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1441#discussion_r3102563710 -> 0c2037964
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1441#discussion_r3102584675 -> 0c2037964
+
+Disposition: NOT-A-BUG
+Evidence: `scripts/ci/check_pr_body_phase2_gates.py:123`, `scripts/ci/check_pr_body_phase2_gates.py:148`, `AGENTS.md:5`, `AGENTS.md:8`
+Reason: The canonical Phase2 contract requires the discussion and mapping mirror sections in the PR body, but it does not enforce merge-readiness checkbox parity there; the repo hard gate still requires `make verify`, so keeping `make verify` as the canonical wording is contract-correct.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1441#discussion_r3102563705
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1441#discussion_r3102584692
+
+Disposition: NOT-A-BUG
+Evidence: `scripts/orchestration/review_mapping_artifact.py:24`, `scripts/orchestration/review_mapping_artifact.py:31`, `scripts/ci/check_pr_body_phase2_gates.py:123`, `scripts/ci/check_pr_body_phase2_gates.py:148`
+Reason: The review container comments aggregate the inline findings already dispositioned in this artifact; they do not represent additional unresolved defects beyond the mapped review-thread URLs.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1441#pullrequestreview-4131316125
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1441#pullrequestreview-4131321622
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1441#pullrequestreview-4131343842
 
 ## Merge Readiness
 

--- a/docs/review/PR_1441_FIXED_MAPPING.md
+++ b/docs/review/PR_1441_FIXED_MAPPING.md
@@ -2,14 +2,14 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 Bot and human review threads must be dispositioned here before they are resolved on GitHub.
 
 ## Fixed in Commit Mapping
 
-No actionable review threads yet.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1441_FIXED_MAPPING.md
+++ b/docs/review/PR_1441_FIXED_MAPPING.md
@@ -18,7 +18,11 @@ Disposition: FIXED
 Commit: 0c2037964
 Evidence: `docs/review/PR_1441_FIXED_MAPPING.md:5`, `docs/review/PR_1441_FIXED_MAPPING.md:6`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1441#discussion_r3102563710 -> 0c2037964
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1441#discussion_r3102584675 -> 0c2037964
+
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1441_FIXED_MAPPING.md:5`, `docs/review/PR_1441_FIXED_MAPPING.md:6`
+Reason: The Cubic duplicate arrived after the checkbox fix commit had already landed, so the current branch head already carries the checked artifact state it requested.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1441#discussion_r3102584675
 
 Disposition: NOT-A-BUG
 Evidence: `scripts/ci/check_pr_body_phase2_gates.py:123`, `scripts/ci/check_pr_body_phase2_gates.py:148`, `AGENTS.md:5`, `AGENTS.md:8`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4727,34 +4727,36 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Tests cover allow (SHA touches file) and deny (SHA does not touch file)
 
 <a id="ledger-p1-codex-skill-pulseplate-app-store-release"></a>
-- [ ] P1: Add custom Codex skill `pulseplate-app-store-release` (Wave 1)
+- [x] P1: Add custom Codex skill `pulseplate-app-store-release` (Wave 1)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-CODEX-SKILL-WAVE1A
-  - Status: In progress
+  - Target PR: PR #1436
+  - Status: ✅ Merged via PR #1436 (`0b3f2de82892a230789d70648fccfd0f7806641f`) on 17 April 2026
   - Area: iOS / release / orchestration
   - Finding Type: capability expansion
   - Reason: PulsePlate needs a project-specific App Store release skill that understands Fastlane, release truth, metadata parity, screenshot packs, and the repo's non-interference contract with coordinator-first orchestration.
   - Links:
     - `docs/orchestration/CODEX_SKILLS_ALIGNMENT_MATRIX.md`
     - `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`
+    - `docs/review/PR_1436_FIXED_MAPPING.md`
   - DoD:
     - Skill exists under `tools/codex_skills/pulseplate-app-store-release/`
     - Skill covers App Store metadata, Fastlane, release evidence, and rollback notes
     - Skill docs explicitly preserve coordinator-first and transport-only bridge invariants
 
 <a id="ledger-p1-codex-skill-pulseplate-monetization-gtm"></a>
-- [ ] P1: Add custom Codex skill `pulseplate-monetization-gtm` (Wave 1)
+- [x] P1: Add custom Codex skill `pulseplate-monetization-gtm` (Wave 1)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR #1439
-  - Status: In progress
+  - Status: ✅ Merged via PR #1439 (`28c2bd2dd18e57a058386670161b0e350e078c5a`) on 17 April 2026; PR #1438 closed as superseded
   - Area: monetization / growth / orchestration
   - Finding Type: capability expansion
   - Reason: PulsePlate needs a project-specific monetization/GTM skill for subscriptions, paywalls, pricing experiments, launch channels, and wellness-safe growth recommendations without relying on generic advice alone.
   - Links:
     - `docs/orchestration/CODEX_SKILLS_ALIGNMENT_MATRIX.md`
     - `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`
+    - `docs/review/PR_1439_FIXED_MAPPING.md`
   - DoD:
     - Skill exists under `tools/codex_skills/pulseplate-monetization-gtm/`
     - Skill covers paywall, subscription, pricing, ASO/SEO/Product Hunt, and wellness-safe disclaimers


### PR DESCRIPTION
## Summary
- sync Wave 1 Codex skill canon to the merged `#1436` / `#1439` state
- close the remaining backlog/alignment drift for `pulseplate-app-store-release` and `pulseplate-monetization-gtm`
- refresh `docs/dev/CODEX_SKILLS.md` so the task map and whitelist include both merged skills

## Scope
- `docs/dev/CODEX_SKILLS.md`
- `docs/orchestration/CODEX_SKILLS_ALIGNMENT_MATRIX.md`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/review/PR_1441_FIXED_MAPPING.md`

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pre-commit run --all-files`
- `make verify`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1441_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Current-head CI green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Pre-commit green on latest pushed head
- [ ] `make verify` green on latest pushed head

## Notes
- current scope is docs-only by design; no runtime/router semantics changed
- `#1438` remains referenced only as superseded lineage for `#1439`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two PulsePlate skills to project docs: App Store release tooling (metadata, screenshots, release evidence) and monetization (paywall, pricing, GTM).
  * Marked the initial skill delivery wave as delivered in the roadmap and updated backlog entries to reflect merged PRs.
  * Added review-tracking and fixed-in-commit mapping documentation to support disposition and merge-readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->