### PR TITLE
fix(ci): pin Trivy action and scanner version in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,24 +103,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
-      - name: Install Trivy via apt
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y wget apt-transport-https gnupg lsb-release
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
-          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update
-          sudo apt-get install -y trivy
-          trivy --version
-
       - name: Run Trivy vulnerability scanner (filesystem scan)
-        run: |
-          trivy fs . \
-            --db-repository ghcr.io/aquasecurity/trivy-db \
-            --ignore-policy "${{ github.workspace }}/trivy/ignore-policy.rego" \
-            --scanners vuln \
-            --format sarif --output trivy-results.sarif --severity CRITICAL,HIGH \
-            --ignore-unfixed --exit-code 0 --ignorefile .trivyignore
+        uses: aquasecurity/trivy-action@6e89b1098f9c01019393bcbba88e5a0fcd5f8f4a # v0.33.1
+        with:
+          scan-type: fs
+          scan-ref: .
+          db-repository: ghcr.io/aquasecurity/trivy-db
+          ignore-policy: trivy/ignore-policy.rego
+          scanners: vuln
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+          ignorefile: .trivyignore
+          version: v0.68.1
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
@@ -194,24 +191,18 @@ jobs:
         run: |
           echo "ref=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}:sha-${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
-      - name: Install Trivy via apt
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y wget apt-transport-https gnupg lsb-release
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
-          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update
-          sudo apt-get install -y trivy
-          trivy --version
-
       - name: Run Trivy vulnerability scanner (image scan, report-only)
         continue-on-error: true
-        run: |
-          trivy image \
-            --ignore-policy "${{ github.workspace }}/trivy/ignore-policy.rego" \
-            --format sarif --output trivy-image.sarif --severity CRITICAL,HIGH \
-            --ignorefile .trivyignore \
-            '${{ steps.image-ref.outputs.ref }}'
+        uses: aquasecurity/trivy-action@6e89b1098f9c01019393bcbba88e5a0fcd5f8f4a # v0.33.1
+        with:
+          scan-type: image
+          image-ref: ${{ steps.image-ref.outputs.ref }}
+          ignore-policy: trivy/ignore-policy.rego
+          format: sarif
+          output: trivy-image.sarif
+          severity: CRITICAL,HIGH
+          ignorefile: .trivyignore
+          version: v0.68.1
 
       - name: Upload Trivy image scan results
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -43,27 +43,19 @@ jobs:
           tags: pulseplate:trivy-scan-${{ github.sha }}
           target: production
 
-      - name: Install Trivy via apt
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y wget apt-transport-https gnupg lsb-release
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
-          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update
-          sudo apt-get install -y trivy
-          trivy --version
-
       - name: Run Trivy vulnerability scanner
-        run: |
-          trivy image \
-            --db-repository ghcr.io/aquasecurity/trivy-db \
-            --format sarif \
-            --output trivy-results.sarif \
-            --severity CRITICAL,HIGH \
-            --ignore-unfixed \
-            --ignorefile .trivyignore \
-            --ignore-policy trivy/ignore-policy.rego \
-            'pulseplate:trivy-scan-${{ github.sha }}'
+        uses: aquasecurity/trivy-action@6e89b1098f9c01019393bcbba88e5a0fcd5f8f4a # v0.33.1
+        with:
+          scan-type: image
+          image-ref: pulseplate:trivy-scan-${{ github.sha }}
+          db-repository: ghcr.io/aquasecurity/trivy-db
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          ignorefile: .trivyignore
+          ignore-policy: trivy/ignore-policy.rego
+          version: v0.68.1
 
       - name: Verify SARIF file exists
         run: ls -la trivy-results.sarif


### PR DESCRIPTION
### Motivation
- Remediate a supply-chain risk where workflows installed `trivy` from the Aquasecurity apt repo without pinning a package version or validating the signing key fingerprint.
- Prevent CI-runner exposure where a compromised apt repo/key could deliver a malicious binary executed with repository/package permissions.

### Description
- Replaced apt-based installation of Trivy in `.github/workflows/build.yml` with the pinned GitHub Action `aquasecurity/trivy-action@6e89b1098f9c01019393bcbba88e5a0fcd5f8f4a` and set the scanner `version: v0.68.1` for filesystem and image scans.
- Replaced apt-based installation of Trivy in `.github/workflows/trivy.yml` with the same pinned `aquasecurity/trivy-action` and `version: v0.68.1` to remove unpinned package fetches.
- The changes preserve existing scan behavior (SARIF output, ignore-policy usage) while eliminating the unverified apt key + unpinned package steps.
- Files modified: `.github/workflows/build.yml`, `.github/workflows/trivy.yml`.

### Testing
- Ran `python3 scripts/orchestration/check_preflight.py` which passed the required preflight checks.
- Verified the unpinned apt installation blocks were removed via `rg -n "Install Trivy via apt|apt-get install -y trivy|aquasecurity.github.io/trivy-repo" .github/workflows/build.yml .github/workflows/trivy.yml` (no matches).
- Attempted repository quality gates: `make verify` failed in this environment due to missing `flake8` (`flake8: command not found`).
- Attempted `pre-commit run --all-files` which failed in this environment due to `pre-commit: command not found` (CI environment differences); these failures are environmental and unrelated to the workflow YAML edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ab5929e0a08333b450b4ac7507b5ba)

## Summary by Sourcery

Зафиксировать использование Trivy в CI‑воркфлоу, переключившись с установки через apt на версионизированный GitHub Action `aquasecurity/trivy` для сканирования файловой системы и образов.

CI:
- Заменить установку Trivy через apt в сборочном воркфлоу на зафиксированный GitHub Action `aquasecurity/trivy` с фиксированной версией сканера для сканирования файловой системы и образов.
- Обновить отдельный воркфлоу Trivy для использования зафиксированного GitHub Action `aquasecurity/trivy` и версии сканера, сохранив при этом существующую конфигурацию сканирования и форматы выводимых результатов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Pin Trivy usage in CI workflows by switching from apt-based installation to the versioned aquasecurity/trivy GitHub Action for both filesystem and image scans.

CI:
- Replace apt-based Trivy installation in build workflow with the pinned aquasecurity/trivy GitHub Action using a fixed scanner version for filesystem and image scans.
- Update dedicated Trivy workflow to use the pinned aquasecurity/trivy GitHub Action and scanner version while preserving existing scan configuration and outputs.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced apt-based `trivy` installs in CI with pinned `aquasecurity/trivy-action@6e89b1098f9c01019393bcbba88e5a0fcd5f8f4a` and locked the scanner to `v0.68.1` to mitigate supply-chain risk. Updated `.github/workflows/build.yml` and `.github/workflows/trivy.yml` while keeping scan behavior unchanged (filesystem/image scans, SARIF output, `trivy/ignore-policy.rego`, severities, `ignore-unfixed`, `.trivyignore`).

<sup>Written for commit 0abef3ef7afb678afb211e7682af5555e2269098. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability scanning process in CI/CD pipelines with improved tooling integration and explicit version pinning for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->