### PR TITLE
fix(metrics): require app-level auth guard for /metrics in non-test environments

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -198,28 +198,28 @@
         "filename": "conftest.py",
         "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
         "is_verified": false,
-        "line_number": 251
+        "line_number": 250
       },
       {
         "type": "Secret Keyword",
         "filename": "conftest.py",
         "hashed_secret": "ca902fc4b2b2907cb3668d01b43407a168623ea7",
         "is_verified": false,
-        "line_number": 252
+        "line_number": 251
       },
       {
         "type": "Secret Keyword",
         "filename": "conftest.py",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 276
+        "line_number": 275
       },
       {
         "type": "Secret Keyword",
         "filename": "conftest.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 277
+        "line_number": 276
       }
     ],
     "core/integrated_bayesian_analyzer.py": [
@@ -1632,5 +1632,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-21T18:08:41Z"
+  "generated_at": "2026-04-21T18:20:27Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -198,28 +198,28 @@
         "filename": "conftest.py",
         "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
         "is_verified": false,
-        "line_number": 250
+        "line_number": 257
       },
       {
         "type": "Secret Keyword",
         "filename": "conftest.py",
         "hashed_secret": "ca902fc4b2b2907cb3668d01b43407a168623ea7",
         "is_verified": false,
-        "line_number": 251
+        "line_number": 258
       },
       {
         "type": "Secret Keyword",
         "filename": "conftest.py",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 275
+        "line_number": 282
       },
       {
         "type": "Secret Keyword",
         "filename": "conftest.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 276
+        "line_number": 283
       }
     ],
     "core/integrated_bayesian_analyzer.py": [
@@ -575,7 +575,7 @@
         "filename": "tests/conftest.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 433
+        "line_number": 434
       }
     ],
     "tests/disabled_hypothesis/test_life_stage_error_branches_hypothesis.py": [
@@ -1632,5 +1632,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-21T18:20:27Z"
+  "generated_at": "2026-04-21T18:56:11Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -198,28 +198,28 @@
         "filename": "conftest.py",
         "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
         "is_verified": false,
-        "line_number": 250
+        "line_number": 251
       },
       {
         "type": "Secret Keyword",
         "filename": "conftest.py",
         "hashed_secret": "ca902fc4b2b2907cb3668d01b43407a168623ea7",
         "is_verified": false,
-        "line_number": 251
+        "line_number": 252
       },
       {
         "type": "Secret Keyword",
         "filename": "conftest.py",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 275
+        "line_number": 276
       },
       {
         "type": "Secret Keyword",
         "filename": "conftest.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 276
+        "line_number": 277
       }
     ],
     "core/integrated_bayesian_analyzer.py": [
@@ -1632,5 +1632,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-20T10:00:11Z"
+  "generated_at": "2026-04-21T18:08:41Z"
 }

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -95,7 +95,7 @@ curl -fsS https://.../metrics | grep http_requests_total
 
 **Implementation:**
 - Middleware: `app/middleware/metrics.py`
-- Endpoint: `legacy_app.py` (hidden from OpenAPI via `include_in_schema=False`)
+- Endpoint: `app/bootstrap/metrics.py` (hidden from OpenAPI via `include_in_schema=False`)
 
 **Limitations:**
 - Multiprocess mode not enabled: `/metrics` returns per-process metrics only.
@@ -108,14 +108,15 @@ curl -fsS https://.../metrics | grep http_requests_total
 - If route template is unavailable → use `"unknown"` (never fallback to `request.url.path`).
 
 **Observability security policy:**
-- `/metrics` MUST NOT enforce application-level authentication (API keys, auth middleware).
-- Protection of `/metrics` is an infrastructure concern:
+- `/metrics` MUST enforce application-level authentication via the shared API key guard.
+- Protection of `/metrics` is defense-in-depth and includes infrastructure controls:
   - ingress ACLs (Cloudflare, Caddy)
   - firewall rules
   - private networks
   - Prometheus scrape configs
-- App-level guards are forbidden for `/metrics` to preserve testability and backward compatibility.
-- If infrastructure-level protection is needed, implement it in a dedicated infra PR (e.g., PR-506).
+- App-level guards are required to reduce reconnaissance surface when infrastructure ACLs drift.
+- Explicit test bypass is allowed only via `METRICS_TEST_BYPASS=true` during pytest-scoped execution.
+- `METRICS_TEST_BYPASS` is test-only and MUST NOT be enabled in staging or production.
 
 **Testing requirements:**
 - Tests MUST assert `/metrics` returns a Prometheus exposition response (`Content-Type` starts with `text/plain`) on happy path.

--- a/app/bootstrap/metrics.py
+++ b/app/bootstrap/metrics.py
@@ -20,7 +20,7 @@ from fastapi.responses import JSONResponse, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.middleware.metrics import metrics_middleware
-from app.routers.api_key import api_key_header
+from app.routers.api_key import api_key_header, validate_app_api_key
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +28,7 @@ _Importer = Callable[[str], ModuleType]
 _STATE_REGISTRATION_KEY = "pulseplate_metrics_registered"
 _METRICS_TEST_BYPASS_ENV = "METRICS_TEST_BYPASS"
 _PYTEST_CURRENT_TEST_ENV = "PYTEST_CURRENT_TEST"
+_TEST_ENV_NAMES = frozenset({"test", "testing", "ci"})
 
 
 def _import_prometheus_client(importer: _Importer = import_module) -> ModuleType:
@@ -56,15 +57,18 @@ def _metrics_api_key_guard(raw_api_key: str | None = Security(api_key_header)) -
     """
     bypass_enabled = os.getenv(_METRICS_TEST_BYPASS_ENV, "").lower() == "true"
     in_pytest = os.getenv(_PYTEST_CURRENT_TEST_ENV) is not None
+    runtime_env = (os.getenv("APP_ENV") or os.getenv("ENVIRONMENT") or "").strip().lower()
+    in_test_env = os.getenv("TESTING", "").lower() == "true" or runtime_env in _TEST_ENV_NAMES
 
-    if bypass_enabled and in_pytest:
+    if bypass_enabled and in_pytest and in_test_env:
         return "testing-bypass"
-    if bypass_enabled and not in_pytest:
-        logger.warning("%s ignored outside pytest-scoped execution", _METRICS_TEST_BYPASS_ENV)
+    if bypass_enabled and (not in_pytest or not in_test_env):
+        logger.warning(
+            "%s ignored outside explicit pytest test env",
+            _METRICS_TEST_BYPASS_ENV,
+        )
 
-    from legacy_app import _get_api_key_dynamic
-
-    validated_api_key: str = _get_api_key_dynamic(raw_api_key or "")
+    validated_api_key = validate_app_api_key(raw_api_key)
     return validated_api_key
 
 

--- a/app/bootstrap/metrics.py
+++ b/app/bootstrap/metrics.py
@@ -10,20 +10,24 @@ not from legacy_app.py, to keep legacy as a thin compatibility proxy.
 from __future__ import annotations
 
 import logging
+import os
 from importlib import import_module
 from types import ModuleType
 from typing import Callable
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Security
 from fastapi.responses import JSONResponse, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.middleware.metrics import metrics_middleware
+from app.routers.api_key import api_key_header
 
 logger = logging.getLogger(__name__)
 
 _Importer = Callable[[str], ModuleType]
 _STATE_REGISTRATION_KEY = "pulseplate_metrics_registered"
+_METRICS_TEST_BYPASS_ENV = "METRICS_TEST_BYPASS"
+_PYTEST_CURRENT_TEST_ENV = "PYTEST_CURRENT_TEST"
 
 
 def _import_prometheus_client(importer: _Importer = import_module) -> ModuleType:
@@ -42,15 +46,37 @@ def _import_prometheus_client(importer: _Importer = import_module) -> ModuleType
     return importer("prometheus_client")
 
 
+def _metrics_api_key_guard(raw_api_key: str | None = Security(api_key_header)) -> str:
+    """Protect `/metrics` outside explicit pytest-scoped bypass mode.
+
+    RU: Тестовый bypass разрешён только при явном `METRICS_TEST_BYPASS=true`
+    внутри pytest-scoped execution.
+    EN: Tests may bypass auth only with explicit `METRICS_TEST_BYPASS=true`
+    during pytest-scoped execution.
+    """
+    bypass_enabled = os.getenv(_METRICS_TEST_BYPASS_ENV, "").lower() == "true"
+    in_pytest = os.getenv(_PYTEST_CURRENT_TEST_ENV) is not None
+
+    if bypass_enabled and in_pytest:
+        return "testing-bypass"
+    if bypass_enabled and not in_pytest:
+        logger.warning("%s ignored outside pytest-scoped execution", _METRICS_TEST_BYPASS_ENV)
+
+    from legacy_app import _get_api_key_dynamic
+
+    validated_api_key: str = _get_api_key_dynamic(raw_api_key or "")
+    return validated_api_key
+
+
 def metrics_endpoint() -> Response:
     """Prometheus metrics endpoint (exposition format) with JSON fallback.
 
     Returns Prometheus text format (CONTENT_TYPE_LATEST) when available.
     Falls back to a JSON error envelope if the exporter is unavailable.
 
-    Security: Protected at infrastructure level (ingress ACLs, firewall, private networks).
-    Application-level authentication is intentionally NOT enforced to preserve
-    testability and backward compatibility.
+    Security: Protected at application level via API key dependency and may be
+    additionally restricted at infrastructure level (ingress ACLs, firewall,
+    private networks).
     """
     try:
         prometheus_client = _import_prometheus_client()
@@ -118,7 +144,13 @@ def register_metrics(app: FastAPI) -> None:
         for r in getattr(app, "routes", None) or []
     )
     if not has_metrics_route:
-        app.add_api_route("/metrics", metrics_endpoint, methods=["GET"], include_in_schema=False)
+        app.add_api_route(
+            "/metrics",
+            metrics_endpoint,
+            methods=["GET"],
+            dependencies=[Depends(_metrics_api_key_guard)],
+            include_in_schema=False,
+        )
         has_metrics_route = True
 
     if state is not None and has_middleware and has_metrics_route:

--- a/app/routers/api_key.py
+++ b/app/routers/api_key.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import secrets
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import APIKeyHeader
@@ -11,6 +13,66 @@ from core.utils import resolve_attr
 api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 logger = logging.getLogger(__name__)
+_TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+_DEVELOPER_LIKE_ENVS = frozenset({"local", "dev", "development", "test", "testing", "ci"})
+
+
+def _is_truthy(value: str | None) -> bool:
+    """Return whether a raw environment value is truthy."""
+
+    return (value or "").strip().lower() in _TRUTHY_ENV_VALUES
+
+
+def _get_runtime_env_name() -> str:
+    """Return the canonical runtime environment label without importing settings."""
+
+    app_env = (os.getenv("APP_ENV") or "").strip().lower()
+    runtime_env = (os.getenv("ENVIRONMENT") or "").strip().lower()
+    if app_env in {"production", "prod", "staging"}:
+        return app_env
+    if runtime_env:
+        return runtime_env
+    if app_env:
+        return app_env
+    return "local"
+
+
+def _is_explicit_developer_env() -> bool:
+    """Mirror the repo's explicit developer-env semantics without settings import."""
+
+    return _get_runtime_env_name() in _DEVELOPER_LIKE_ENVS
+
+
+def validate_app_api_key(api_key: str | None) -> str:
+    """Validate an app-level API key without importing legacy bootstrap surfaces."""
+
+    api_key_value = api_key or ""
+    dev_mode = _is_explicit_developer_env() and _is_truthy(os.getenv("ALLOW_DEV_API_KEY", "true"))
+    if expected := os.getenv("API_KEY"):
+        if secrets.compare_digest(api_key_value, expected):
+            return api_key_value
+        allow_normalize = dev_mode and _is_truthy(os.getenv("ALLOW_DEV_API_KEY_NORMALIZE"))
+        if (
+            allow_normalize
+            and api_key_value
+            and secrets.compare_digest(api_key_value.replace("-", "_"), expected.replace("-", "_"))
+        ):
+            return expected
+        raise HTTPException(status_code=403, detail="Invalid API Key")
+
+    if _is_truthy(os.getenv("API_KEY_REQUIRED")):
+        raise HTTPException(status_code=403, detail="API key required but not configured")
+
+    if not dev_mode:
+        raise HTTPException(status_code=403, detail="API key required but not configured")
+
+    if not api_key_value:
+        raise HTTPException(status_code=403, detail="Missing API Key")
+    token = api_key_value.strip()
+    forbidden_tokens = {"invalid", "invalid_key", "wrong", "bad", "null"}
+    if len(token) < 4 or token.lower() in forbidden_tokens:
+        raise HTTPException(status_code=403, detail="Invalid API Key")
+    return token
 
 
 def require_app_api_key(api_key: str | None = Depends(api_key_header)) -> str:

--- a/app/routers/api_key.py
+++ b/app/routers/api_key.py
@@ -63,16 +63,7 @@ def validate_app_api_key(api_key: str | None) -> str:
     if _is_truthy(os.getenv("API_KEY_REQUIRED")):
         raise HTTPException(status_code=403, detail="API key required but not configured")
 
-    if not dev_mode:
-        raise HTTPException(status_code=403, detail="API key required but not configured")
-
-    if not api_key_value:
-        raise HTTPException(status_code=403, detail="Missing API Key")
-    token = api_key_value.strip()
-    forbidden_tokens = {"invalid", "invalid_key", "wrong", "bad", "null"}
-    if len(token) < 4 or token.lower() in forbidden_tokens:
-        raise HTTPException(status_code=403, detail="Invalid API Key")
-    return token
+    raise HTTPException(status_code=403, detail="API key required but not configured")
 
 
 def require_app_api_key(api_key: str | None = Depends(api_key_header)) -> str:

--- a/conftest.py
+++ b/conftest.py
@@ -338,9 +338,10 @@ def isolated_test_client():
     Instead, create a fresh TestClient and clear dependency_overrides in teardown.
     """
     from app.main import app as main_app
+    from tests._client import make_test_client
 
-    # Create TestClient with current app state (no reload to avoid dual-Base)
-    client = TestClient(cast(ASGIApp, main_app))
+    # Create canonical metrics-aware client with current app state.
+    client = make_test_client(main_app)
 
     try:
         yield client

--- a/conftest.py
+++ b/conftest.py
@@ -52,7 +52,6 @@ def pytest_configure(config: pytest.Config) -> None:
     os.environ.setdefault("APP_ENV", "test")
     os.environ.setdefault("ENVIRONMENT", "test")
     os.environ.setdefault("TESTING", "true")  # Enable export endpoints
-    os.environ.setdefault("METRICS_TEST_BYPASS", "true")
     os.environ.setdefault("FEATURE_PREMIUM_NUTRITION", "true")
     os.environ.setdefault("VIP_MODULE_ENABLED", "true")
     os.environ.setdefault("ALLOW_DEV_API_KEY", "true")

--- a/conftest.py
+++ b/conftest.py
@@ -58,6 +58,13 @@ def pytest_configure(config: pytest.Config) -> None:
     os.environ.setdefault("PYTHONPATH", ".:core:app:tests")
     os.environ.setdefault("CLIENT_FINGERPRINT_SALT", "test-salt-for-ci-only-not-for-production")
 
+    # Ensure all pytest-imported FastAPI TestClient instances inherit the canonical
+    # /metrics test-auth behavior before test modules import TestClient symbols.
+    import fastapi.testclient as fastapi_testclient
+    from tests._client import MetricsAwareTestClient
+
+    fastapi_testclient.TestClient = MetricsAwareTestClient
+
     # Configure test database path BEFORE core.db is imported
     # This ensures DATABASE_URL is set before any SQLAlchemy initialization
     db_path_env = os.environ.get("TEST_DB_PATH", "cache/test_app.sqlite")

--- a/conftest.py
+++ b/conftest.py
@@ -52,6 +52,7 @@ def pytest_configure(config: pytest.Config) -> None:
     os.environ.setdefault("APP_ENV", "test")
     os.environ.setdefault("ENVIRONMENT", "test")
     os.environ.setdefault("TESTING", "true")  # Enable export endpoints
+    os.environ.setdefault("METRICS_TEST_BYPASS", "true")
     os.environ.setdefault("FEATURE_PREMIUM_NUTRITION", "true")
     os.environ.setdefault("VIP_MODULE_ENABLED", "true")
     os.environ.setdefault("ALLOW_DEV_API_KEY", "true")

--- a/docs/review/PR_1445_FIXED_MAPPING.md
+++ b/docs/review/PR_1445_FIXED_MAPPING.md
@@ -74,6 +74,11 @@ Commit: be2c68076
 Evidence: `app/routers/api_key.py:51-66`; `tests/test_business_router.py:247-322`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3120330101 -> be2c68076
 
+Disposition: FIXED
+Commit: be2c68076
+Evidence: `app/bootstrap/metrics.py:151-156`; `app/routers/api_key.py:51-66`; `tests/test_business_router.py:247-322`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#pullrequestreview-4150798034 -> be2c68076
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/review/PR_1445_FIXED_MAPPING.md
+++ b/docs/review/PR_1445_FIXED_MAPPING.md
@@ -17,6 +17,9 @@ drops the stale dependency/docs carryover drift from the old branch head.
 Follow-up test-harness commit `dea9de69a` keeps legacy pytest `/metrics` probes
 on the real auth path by auto-injecting the deterministic test API key instead
 of relying on a global bypass.
+Follow-up security-hardening commit `be2c68076` removes the weak developer-mode
+fallback in `validate_app_api_key(...)` so `/metrics` fails closed when
+`API_KEY` is unset outside the explicit pytest-scoped bypass path.
 
 ## Fixed in Commit Mapping
 
@@ -65,6 +68,11 @@ Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discus
 Reason: These bot review bodies are summary wrappers for the stale-artifact and stale-audit-anchor issues dispositioned immediately above.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#pullrequestreview-4136491644
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#pullrequestreview-4141527107
+
+Disposition: FIXED
+Commit: be2c68076
+Evidence: `app/routers/api_key.py:51-66`; `tests/test_business_router.py:247-322`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3120330101 -> be2c68076
 
 ## Merge Readiness
 

--- a/docs/review/PR_1445_FIXED_MAPPING.md
+++ b/docs/review/PR_1445_FIXED_MAPPING.md
@@ -14,6 +14,9 @@ restart of PR #1445. The canonical current code-fix commit is `b97d4c15e`,
 which preserves the `/metrics` auth lane on top of current `main`, restores the
 late-bootstrap route contract without `legacy_app` request-path imports, and
 drops the stale dependency/docs carryover drift from the old branch head.
+Follow-up test-harness commit `dea9de69a` keeps legacy pytest `/metrics` probes
+on the real auth path by auto-injecting the deterministic test API key instead
+of relying on a global bypass.
 
 ## Fixed in Commit Mapping
 
@@ -51,11 +54,11 @@ Reason: This review shell only summarizes the pytest-scoped bypass hardening thr
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#pullrequestreview-4136489304
 
 Disposition: FIXED
-Commit: b97d4c15e
-Evidence: `git diff --name-only origin/main...b97d4c15e` now limits the rebuilt PR delta to `.secrets.baseline`, `app/AGENTS.md`, `app/bootstrap/metrics.py`, `app/routers/api_key.py`, `tests/test_metrics.py`, and this canonical mapping artifact, removing the prior stale mapping/audit/dependency carryover from scope.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3107442735 -> b97d4c15e
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#pullrequestreview-4136502221 -> b97d4c15e
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3111979921 -> b97d4c15e
+Commit: dea9de69a
+Evidence: `git diff --name-only origin/main...dea9de69a` now limits the rebuilt PR delta to `.secrets.baseline`, `app/AGENTS.md`, `app/bootstrap/metrics.py`, `app/routers/api_key.py`, `conftest.py`, `tests/_client.py`, `tests/conftest.py`, `tests/test_app_main_import.py`, `tests/test_metrics.py`, and this canonical mapping artifact, removing the prior stale mapping/audit/dependency carryover from scope.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3107442735 -> dea9de69a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#pullrequestreview-4136502221 -> dea9de69a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3111979921 -> dea9de69a
 
 Disposition: NOT-A-BUG
 Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3107442735`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3111979921`

--- a/docs/review/PR_1445_FIXED_MAPPING.md
+++ b/docs/review/PR_1445_FIXED_MAPPING.md
@@ -100,5 +100,4 @@ Merge-readiness contract:
 
 ## Deferred / Follow-ups
 
-- post-push mandatory `qa-engineer-agent -> bug-hunter` review cycle still required before any merge-ready claim
 - stale PR body metadata and current-head SHA references must be rewritten to match the rebuilt branch before merge readiness is re-checked

--- a/docs/review/PR_1445_FIXED_MAPPING.md
+++ b/docs/review/PR_1445_FIXED_MAPPING.md
@@ -1,0 +1,88 @@
+# PR #1445 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+This artifact is rebuilt from live review truth for the clean-room `origin/main`
+restart of PR #1445. The canonical current code-fix commit is `b97d4c15e`,
+which preserves the `/metrics` auth lane on top of current `main`, restores the
+late-bootstrap route contract without `legacy_app` request-path imports, and
+drops the stale dependency/docs carryover drift from the old branch head.
+
+## Fixed in Commit Mapping
+
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1445_FIXED_MAPPING.md`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3102736762`
+Reason: This Sourcery review body is a generated summary shell around the single actionable inline metrics-bypass finding dispositioned immediately below.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#pullrequestreview-4131505785
+
+Disposition: FIXED
+Commit: b97d4c15e
+Evidence: `app/bootstrap/metrics.py:50-72`; `app/AGENTS.md:110-119`; `tests/test_metrics.py:21-39`; `tests/test_metrics.py:764-807`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3102736762 -> b97d4c15e
+
+Disposition: FIXED
+Commit: b97d4c15e
+Evidence: `app/bootstrap/metrics.py:50-72`; `app/routers/api_key.py:46-75`; `tests/test_metrics.py:269-329`; `tests/test_metrics.py:753-833` <!-- pragma: allowlist secret -->
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3102740429 -> b97d4c15e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3102774098 -> b97d4c15e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3102779019 -> b97d4c15e
+
+Disposition: NOT-A-BUG
+Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3102740429`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3102774098`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3102779019`
+Reason: These bot review submissions are aggregate wrappers for the DI/auth-runtime findings dispositioned above and add no separate unresolved obligation on the rebuilt branch.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#pullrequestreview-4131553263
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#pullrequestreview-4131559979
+
+Disposition: FIXED
+Commit: b97d4c15e
+Evidence: `app/bootstrap/metrics.py:58-71`; `app/AGENTS.md:117-119`; `tests/test_metrics.py:775-807`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3107439328 -> b97d4c15e
+
+Disposition: NOT-A-BUG
+Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3107439328`
+Reason: This review shell only summarizes the pytest-scoped bypass hardening thread dispositioned immediately above.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#pullrequestreview-4136489304
+
+Disposition: FIXED
+Commit: b97d4c15e
+Evidence: `git diff --name-only origin/main...b97d4c15e` now limits the rebuilt PR delta to `.secrets.baseline`, `app/AGENTS.md`, `app/bootstrap/metrics.py`, `app/routers/api_key.py`, `tests/test_metrics.py`, and this canonical mapping artifact, removing the prior stale mapping/audit/dependency carryover from scope.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3107442735 -> b97d4c15e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#pullrequestreview-4136502221 -> b97d4c15e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3111979921 -> b97d4c15e
+
+Disposition: NOT-A-BUG
+Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3107442735`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#discussion_r3111979921`
+Reason: These bot review bodies are summary wrappers for the stale-artifact and stale-audit-anchor issues dispositioned immediately above.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#pullrequestreview-4136491644
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1445#pullrequestreview-4141527107
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+  Evidence: current-head GitHub checks after push.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: current-head GitHub checks after push.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: `gh api graphql` review-thread snapshot before merge.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: this artifact plus current PR timeline after push.
+- [ ] Pre-commit green on latest pushed head
+  Evidence: local `pre-commit run --all-files` on rebuilt branch head.
+- [ ] `make verify` green on latest pushed head
+  Evidence: local `make verify` on rebuilt branch head.
+
+## Deferred / Follow-ups
+
+- post-push mandatory `qa-engineer-agent -> bug-hunter` review cycle still required before any merge-ready claim
+- stale PR body metadata and current-head SHA references must be rewritten to match the rebuilt branch before merge readiness is re-checked

--- a/tests/_client.py
+++ b/tests/_client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import inspect
 import os
 from typing import Any
+from urllib.parse import urlparse
 
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
@@ -127,6 +128,31 @@ def override_rate_limit_identity_for_test_app(
             )
 
 
+class MetricsAwareTestClient(TestClient):
+    """TestClient that auto-adds the test API key for implicit `/metrics` probes."""
+
+    auto_metrics_api_key = True
+
+    def request(self, method: str, url: str | object, *args: Any, **kwargs: Any):  # type: ignore[override]
+        headers = dict(kwargs.get("headers") or {})
+        path = urlparse(str(url)).path or str(url)
+        has_explicit_api_key = any(key.lower() == "x-api-key" for key in headers)
+        if (
+            getattr(self, "auto_metrics_api_key", True)
+            and path == "/metrics"
+            and not has_explicit_api_key
+        ):
+            headers["X-API-Key"] = os.getenv("API_KEY", "test_key")
+            kwargs["headers"] = headers
+        return super().request(method, url, *args, **kwargs)
+
+
+def make_test_client(app_instance: FastAPI, **kwargs: Any) -> MetricsAwareTestClient:
+    """Create the canonical metrics-aware test client."""
+
+    return MetricsAwareTestClient(app_instance, **kwargs)
+
+
 def get_client(**kwargs: Any) -> TestClient:
     """Create TestClient with canonical entrypoint (app.main:app).
 
@@ -154,4 +180,4 @@ def get_client(**kwargs: Any) -> TestClient:
     import app.main
 
     disable_rate_limiting_for_test_app(app.main.app)
-    return TestClient(app.main.app, **kwargs)
+    return make_test_client(app.main.app, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ from sqlalchemy.exc import OperationalError, ProgrammingError, UnboundExecutionE
 
 import core.recipe_synth as recipe_synth
 from core.test_guards import EXTERNAL_HTTP_BLOCKED_IN_TESTS_MESSAGE
+from tests._client import make_test_client
 from tests._client import disable_rate_limiting_for_test_app
 
 # ============================================================================
@@ -512,7 +513,7 @@ def client(app: FastAPI) -> Generator[TestClient, None, None]:
     Using TestClient as a context manager ensures lifespan startup/shutdown runs
     deterministically and prevents leaking background threads across tests.
     """
-    with TestClient(app) as test_client:
+    with make_test_client(app) as test_client:
         yield test_client
 
 

--- a/tests/test_app_main_import.py
+++ b/tests/test_app_main_import.py
@@ -35,6 +35,7 @@ def test_app_main_late_import_restores_metrics_route() -> None:
         main_module = importlib.import_module("app.main")
 
         with TestClient(main_module.app) as client:
+            client.headers["X-API-Key"] = "test_key"
             metrics_response = client.get("/metrics")
             assert metrics_response.status_code == 200
         """)

--- a/tests/test_business_router.py
+++ b/tests/test_business_router.py
@@ -200,6 +200,122 @@ class TestBusinessRouterIsolated:
         assert exc_info.value.status_code == 403
         assert exc_info.value.detail == "Missing API Key"
 
+    def test_get_runtime_env_name_falls_back_to_app_env_and_local(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.routers import api_key as api_key_mod
+
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.setenv("APP_ENV", "qa")
+        assert api_key_mod._get_runtime_env_name() == "qa"
+
+        monkeypatch.delenv("APP_ENV", raising=False)
+        assert api_key_mod._get_runtime_env_name() == "local"
+
+    def test_get_runtime_env_name_prefers_environment_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.routers import api_key as api_key_mod
+
+        monkeypatch.setenv("APP_ENV", "qa")
+        monkeypatch.setenv("ENVIRONMENT", "review")
+
+        assert api_key_mod._get_runtime_env_name() == "review"
+
+    def test_validate_app_api_key_accepts_exact_configured_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.routers import api_key as api_key_mod
+
+        monkeypatch.setenv("API_KEY", "exact-key")
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+
+        assert api_key_mod.validate_app_api_key("exact-key") == "exact-key"
+
+    def test_validate_app_api_key_normalizes_dev_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.routers import api_key as api_key_mod
+
+        monkeypatch.setenv("APP_ENV", "development")
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.setenv("ALLOW_DEV_API_KEY", "true")
+        monkeypatch.setenv("ALLOW_DEV_API_KEY_NORMALIZE", "true")
+        monkeypatch.setenv("API_KEY", "test_key")
+
+        assert api_key_mod.validate_app_api_key("test-key") == "test_key"
+
+    def test_validate_app_api_key_rejects_required_but_unconfigured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.routers import api_key as api_key_mod
+
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setenv("API_KEY_REQUIRED", "true")
+        monkeypatch.setenv("APP_ENV", "development")
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+
+        with pytest.raises(HTTPException) as exc_info:
+            api_key_mod.validate_app_api_key("dev-key")
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "API key required but not configured"
+
+    def test_validate_app_api_key_rejects_without_dev_mode_when_unconfigured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.routers import api_key as api_key_mod
+
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.delenv("API_KEY_REQUIRED", raising=False)
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+
+        with pytest.raises(HTTPException) as exc_info:
+            api_key_mod.validate_app_api_key("prod-key")
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "API key required but not configured"
+
+    def test_validate_app_api_key_rejects_wrong_configured_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.routers import api_key as api_key_mod
+
+        monkeypatch.setenv("API_KEY", "expected-key")
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.delenv("ALLOW_DEV_API_KEY_NORMALIZE", raising=False)
+
+        with pytest.raises(HTTPException) as exc_info:
+            api_key_mod.validate_app_api_key("wrong-key")
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Invalid API Key"
+
+    def test_validate_app_api_key_dev_fallback_token_rules(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.routers import api_key as api_key_mod
+
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.delenv("API_KEY_REQUIRED", raising=False)
+        monkeypatch.setenv("APP_ENV", "development")
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.setenv("ALLOW_DEV_API_KEY", "true")
+
+        with pytest.raises(HTTPException) as missing_exc:
+            api_key_mod.validate_app_api_key(None)
+
+        assert missing_exc.value.status_code == 403
+        assert missing_exc.value.detail == "Missing API Key"
+
+        with pytest.raises(HTTPException) as invalid_exc:
+            api_key_mod.validate_app_api_key("bad")
+
+        assert invalid_exc.value.status_code == 403
+        assert invalid_exc.value.detail == "Invalid API Key"
+        assert api_key_mod.validate_app_api_key("dev_key") == "dev_key"
+
     def test_analyze_503_when_module_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._auth_ok()
         monkeypatch.setattr(self.mod, "BUSINESS_MODULE_ENABLED", False)

--- a/tests/test_business_router.py
+++ b/tests/test_business_router.py
@@ -292,7 +292,7 @@ class TestBusinessRouterIsolated:
         assert exc_info.value.status_code == 403
         assert exc_info.value.detail == "Invalid API Key"
 
-    def test_validate_app_api_key_dev_fallback_token_rules(
+    def test_validate_app_api_key_dev_mode_still_fails_closed_without_configured_key(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from app.routers import api_key as api_key_mod
@@ -307,14 +307,19 @@ class TestBusinessRouterIsolated:
             api_key_mod.validate_app_api_key(None)
 
         assert missing_exc.value.status_code == 403
-        assert missing_exc.value.detail == "Missing API Key"
+        assert missing_exc.value.detail == "API key required but not configured"
 
         with pytest.raises(HTTPException) as invalid_exc:
             api_key_mod.validate_app_api_key("bad")
 
         assert invalid_exc.value.status_code == 403
-        assert invalid_exc.value.detail == "Invalid API Key"
-        assert api_key_mod.validate_app_api_key("dev_key") == "dev_key"
+        assert invalid_exc.value.detail == "API key required but not configured"
+
+        with pytest.raises(HTTPException) as present_but_unconfigured_exc:
+            api_key_mod.validate_app_api_key("dev_key")
+
+        assert present_but_unconfigured_exc.value.status_code == 403
+        assert present_but_unconfigured_exc.value.detail == "API key required but not configured"
 
     def test_analyze_503_when_module_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._auth_ok()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -18,6 +18,12 @@ from app.bootstrap.metrics import register_metrics
 # Use conftest.py client fixture (don't define local one to avoid bypassing test setup)
 
 
+@pytest.fixture(autouse=True)
+def _enable_metrics_test_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the historic `/metrics` happy path available in pytest by default."""
+    monkeypatch.setenv("METRICS_TEST_BYPASS", "true")
+
+
 def _get_metrics_get_routes(app_instance: FastAPI) -> list[object]:
     """Collect registered GET routes for the canonical /metrics endpoint."""
 
@@ -723,3 +729,100 @@ def test_ws_observability_helpers_swallow_metrics_backend_errors(
     metrics_mod.record_ws_message("/ws", direction="out")
     metrics_mod.inc_ws_active_connections("/ws")
     metrics_mod.dec_ws_active_connections("/ws")
+
+
+def test_metrics_guard_requires_api_key_outside_testing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """/metrics guard delegates to the shared API key guard outside test bypass."""
+    from app.bootstrap import metrics as metrics_bootstrap
+
+    monkeypatch.setenv("METRICS_TEST_BYPASS", "false")
+    monkeypatch.setattr(
+        "legacy_app._get_api_key_dynamic", lambda raw_api_key: f"prod:{raw_api_key}"
+    )
+
+    assert metrics_bootstrap._metrics_api_key_guard("raw-prod-key") == "prod:raw-prod-key"
+
+
+def test_metrics_guard_bypasses_in_testing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """/metrics guard bypasses API key only in explicit pytest-scoped test mode."""
+    from app.bootstrap import metrics as metrics_bootstrap
+
+    monkeypatch.setenv("METRICS_TEST_BYPASS", "true")
+
+    assert metrics_bootstrap._metrics_api_key_guard(None) == "testing-bypass"
+
+
+def test_metrics_guard_ignores_bypass_outside_pytest(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """/metrics guard ignores leaked bypass env outside pytest-scoped execution."""
+    from app.bootstrap import metrics as metrics_bootstrap
+
+    monkeypatch.setenv("METRICS_TEST_BYPASS", "true")
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(
+        "legacy_app._get_api_key_dynamic", lambda raw_api_key: f"prod:{raw_api_key}"
+    )
+
+    with caplog.at_level("WARNING"):
+        result = metrics_bootstrap._metrics_api_key_guard("raw-prod-key")
+
+    assert result == "prod:raw-prod-key"
+    assert "METRICS_TEST_BYPASS ignored outside pytest-scoped execution" in caplog.text
+
+
+def test_metrics_http_guard_rejects_missing_api_key_when_bypass_disabled(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """/metrics must reject requests without an API key when bypass is disabled."""
+    monkeypatch.setenv("TESTING", "false")
+    monkeypatch.setenv("METRICS_TEST_BYPASS", "false")
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
+    monkeypatch.setenv("API_KEY", "test_key")
+    monkeypatch.setenv("API_KEY_REQUIRED", "true")
+
+    response = client.get("/metrics")
+
+    assert response.status_code == 403
+    assert response.headers["content-type"].startswith("application/json")
+
+
+def test_metrics_http_guard_allows_valid_api_key_when_bypass_disabled(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """/metrics must keep Prometheus happy path with a valid API key."""
+    monkeypatch.setenv("TESTING", "false")
+    monkeypatch.setenv("METRICS_TEST_BYPASS", "false")
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
+    monkeypatch.setenv("API_KEY", "test_key")
+    monkeypatch.setenv("API_KEY_REQUIRED", "true")
+
+    response = client.get("/metrics", headers={"X-API-Key": "test_key"})
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+
+
+def test_metrics_http_guard_rejects_wrong_api_key_when_bypass_disabled(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """/metrics must reject an incorrect API key when bypass is disabled."""
+    monkeypatch.setenv("TESTING", "false")
+    monkeypatch.setenv("METRICS_TEST_BYPASS", "false")
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
+    monkeypatch.setenv("API_KEY", "test_key")
+    monkeypatch.setenv("API_KEY_REQUIRED", "true")
+
+    response = client.get("/metrics", headers={"X-API-Key": "wrong"})
+
+    assert response.status_code == 403
+    assert response.headers["content-type"].startswith("application/json")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -19,9 +19,24 @@ from app.bootstrap.metrics import register_metrics
 
 
 @pytest.fixture(autouse=True)
-def _enable_metrics_test_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep the historic `/metrics` happy path available in pytest by default."""
-    monkeypatch.setenv("METRICS_TEST_BYPASS", "true")
+def _enable_metrics_client_auth(
+    request: pytest.FixtureRequest,
+) -> None:
+    """Exercise `/metrics` happy paths through the real auth dependency."""
+    if "client" not in request.fixturenames:
+        return
+    client = request.getfixturevalue("client")
+    client.headers["X-API-Key"] = "test_key"
+
+
+def _configure_metrics_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set deterministic auth env for guarded `/metrics` route tests."""
+    monkeypatch.setenv("TESTING", "false")
+    monkeypatch.setenv("METRICS_TEST_BYPASS", "false")
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
+    monkeypatch.setenv("API_KEY", "test_key")
+    monkeypatch.setenv("API_KEY_REQUIRED", "true")
 
 
 def _get_metrics_get_routes(app_instance: FastAPI) -> list[object]:
@@ -253,6 +268,7 @@ def test_metrics_json_fallback_when_exporter_raises(
 
 def test_register_metrics_adds_route_after_stack_is_built() -> None:
     """Late bootstrap must still restore /metrics without mutating middleware."""
+    from starlette.testclient import TestClient as RawTestClient
 
     app_instance = FastAPI()
 
@@ -260,7 +276,7 @@ def test_register_metrics_adds_route_after_stack_is_built() -> None:
     def root() -> dict[str, str]:
         return {"status": "ok"}
 
-    with TestClient(app_instance) as client:
+    with RawTestClient(app_instance) as client:
         response = client.get("/")
         assert response.status_code == 200
 
@@ -274,7 +290,8 @@ def test_register_metrics_adds_route_after_stack_is_built() -> None:
     assert len(_get_metrics_get_routes(app_instance)) == 1
     assert len(getattr(app_instance, "user_middleware", [])) == before_user_middleware
 
-    with TestClient(app_instance) as client:
+    with RawTestClient(app_instance) as client:
+        client.headers["X-API-Key"] = "test_key"
         metrics_response = client.get("/metrics")
 
     assert metrics_response.status_code == 200
@@ -293,11 +310,13 @@ def test_register_metrics_is_idempotent_for_route_registration() -> None:
 
 def test_register_metrics_is_idempotent_after_stack_is_built() -> None:
     """Repeated late bootstrap must not duplicate the /metrics route."""
+    from starlette.testclient import TestClient as RawTestClient
 
     app_instance = FastAPI()
     register_metrics(app_instance)
 
-    with TestClient(app_instance) as client:
+    with RawTestClient(app_instance) as client:
+        client.headers["X-API-Key"] = "test_key"
         metrics_response = client.get("/metrics")
         assert metrics_response.status_code == 200
 
@@ -737,12 +756,9 @@ def test_metrics_guard_requires_api_key_outside_testing(
     """/metrics guard delegates to the shared API key guard outside test bypass."""
     from app.bootstrap import metrics as metrics_bootstrap
 
-    monkeypatch.setenv("METRICS_TEST_BYPASS", "false")
-    monkeypatch.setattr(
-        "legacy_app._get_api_key_dynamic", lambda raw_api_key: f"prod:{raw_api_key}"
-    )
+    _configure_metrics_auth_env(monkeypatch)
 
-    assert metrics_bootstrap._metrics_api_key_guard("raw-prod-key") == "prod:raw-prod-key"
+    assert metrics_bootstrap._metrics_api_key_guard("test_key") == "test_key"
 
 
 def test_metrics_guard_bypasses_in_testing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -750,6 +766,8 @@ def test_metrics_guard_bypasses_in_testing(monkeypatch: pytest.MonkeyPatch) -> N
     from app.bootstrap import metrics as metrics_bootstrap
 
     monkeypatch.setenv("METRICS_TEST_BYPASS", "true")
+    monkeypatch.setenv("TESTING", "true")
+    monkeypatch.setenv("APP_ENV", "test")
 
     assert metrics_bootstrap._metrics_api_key_guard(None) == "testing-bypass"
 
@@ -761,17 +779,32 @@ def test_metrics_guard_ignores_bypass_outside_pytest(
     """/metrics guard ignores leaked bypass env outside pytest-scoped execution."""
     from app.bootstrap import metrics as metrics_bootstrap
 
+    _configure_metrics_auth_env(monkeypatch)
     monkeypatch.setenv("METRICS_TEST_BYPASS", "true")
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
-    monkeypatch.setattr(
-        "legacy_app._get_api_key_dynamic", lambda raw_api_key: f"prod:{raw_api_key}"
-    )
 
-    with caplog.at_level("WARNING"):
-        result = metrics_bootstrap._metrics_api_key_guard("raw-prod-key")
+    with caplog.at_level("WARNING", logger="app.bootstrap.metrics"):
+        result = metrics_bootstrap._metrics_api_key_guard("test_key")
 
-    assert result == "prod:raw-prod-key"
-    assert "METRICS_TEST_BYPASS ignored outside pytest-scoped execution" in caplog.text
+    assert result == "test_key"
+    assert "METRICS_TEST_BYPASS ignored outside explicit pytest test env" in caplog.text
+
+
+def test_metrics_guard_ignores_bypass_outside_test_env(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """/metrics bypass must not activate in production-like envs even under pytest."""
+    from app.bootstrap import metrics as metrics_bootstrap
+
+    _configure_metrics_auth_env(monkeypatch)
+    monkeypatch.setenv("METRICS_TEST_BYPASS", "true")
+
+    with caplog.at_level("WARNING", logger="app.bootstrap.metrics"):
+        result = metrics_bootstrap._metrics_api_key_guard("test_key")
+
+    assert result == "test_key"
+    assert "METRICS_TEST_BYPASS ignored outside explicit pytest test env" in caplog.text
 
 
 def test_metrics_http_guard_rejects_missing_api_key_when_bypass_disabled(
@@ -779,12 +812,8 @@ def test_metrics_http_guard_rejects_missing_api_key_when_bypass_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """/metrics must reject requests without an API key when bypass is disabled."""
-    monkeypatch.setenv("TESTING", "false")
-    monkeypatch.setenv("METRICS_TEST_BYPASS", "false")
-    monkeypatch.setenv("APP_ENV", "production")
-    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
-    monkeypatch.setenv("API_KEY", "test_key")
-    monkeypatch.setenv("API_KEY_REQUIRED", "true")
+    _configure_metrics_auth_env(monkeypatch)
+    client.headers.pop("X-API-Key", None)
 
     response = client.get("/metrics")
 
@@ -797,12 +826,7 @@ def test_metrics_http_guard_allows_valid_api_key_when_bypass_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """/metrics must keep Prometheus happy path with a valid API key."""
-    monkeypatch.setenv("TESTING", "false")
-    monkeypatch.setenv("METRICS_TEST_BYPASS", "false")
-    monkeypatch.setenv("APP_ENV", "production")
-    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
-    monkeypatch.setenv("API_KEY", "test_key")
-    monkeypatch.setenv("API_KEY_REQUIRED", "true")
+    _configure_metrics_auth_env(monkeypatch)
 
     response = client.get("/metrics", headers={"X-API-Key": "test_key"})
 
@@ -815,12 +839,7 @@ def test_metrics_http_guard_rejects_wrong_api_key_when_bypass_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """/metrics must reject an incorrect API key when bypass is disabled."""
-    monkeypatch.setenv("TESTING", "false")
-    monkeypatch.setenv("METRICS_TEST_BYPASS", "false")
-    monkeypatch.setenv("APP_ENV", "production")
-    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
-    monkeypatch.setenv("API_KEY", "test_key")
-    monkeypatch.setenv("API_KEY_REQUIRED", "true")
+    _configure_metrics_auth_env(monkeypatch)
 
     response = client.get("/metrics", headers={"X-API-Key": "wrong"})
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -813,6 +813,7 @@ def test_metrics_http_guard_rejects_missing_api_key_when_bypass_disabled(
 ) -> None:
     """/metrics must reject requests without an API key when bypass is disabled."""
     _configure_metrics_auth_env(monkeypatch)
+    client.auto_metrics_api_key = False
     client.headers.pop("X-API-Key", None)
 
     response = client.get("/metrics")
@@ -840,6 +841,7 @@ def test_metrics_http_guard_rejects_wrong_api_key_when_bypass_disabled(
 ) -> None:
     """/metrics must reject an incorrect API key when bypass is disabled."""
     _configure_metrics_auth_env(monkeypatch)
+    client.auto_metrics_api_key = False
 
     response = client.get("/metrics", headers={"X-API-Key": "wrong"})
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 import app
@@ -847,3 +847,112 @@ def test_metrics_http_guard_rejects_wrong_api_key_when_bypass_disabled(
 
     assert response.status_code == 403
     assert response.headers["content-type"].startswith("application/json")
+
+
+def test_metrics_shared_api_key_runtime_env_falls_back_to_app_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared API key helper must honor APP_ENV when ENVIRONMENT is unset."""
+    from app.routers import api_key as api_key_mod
+
+    monkeypatch.setenv("APP_ENV", "qa")
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+
+    assert api_key_mod._get_runtime_env_name() == "qa"
+
+
+def test_metrics_shared_api_key_runtime_env_prefers_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared API key helper must prefer ENVIRONMENT over non-prod APP_ENV."""
+    from app.routers import api_key as api_key_mod
+
+    monkeypatch.setenv("APP_ENV", "qa")
+    monkeypatch.setenv("ENVIRONMENT", "review")
+
+    assert api_key_mod._get_runtime_env_name() == "review"
+
+
+def test_metrics_shared_api_key_runtime_env_defaults_to_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared API key helper must default to local when env labels are absent."""
+    from app.routers import api_key as api_key_mod
+
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+
+    assert api_key_mod._get_runtime_env_name() == "local"
+
+
+def test_metrics_shared_api_key_normalizes_dev_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared API key helper must preserve normalize-only dev matching."""
+    from app.routers import api_key as api_key_mod
+
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "true")
+    monkeypatch.setenv("ALLOW_DEV_API_KEY_NORMALIZE", "true")
+    monkeypatch.setenv("API_KEY", "test_key")
+
+    assert api_key_mod.validate_app_api_key("test-key") == "test_key"
+
+
+def test_metrics_shared_api_key_fails_closed_without_configured_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared API key helper must reject unconfigured access in all branches."""
+    from app.routers import api_key as api_key_mod
+
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.setenv("API_KEY_REQUIRED", "true")
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+
+    with pytest.raises(HTTPException) as required_exc:
+        api_key_mod.validate_app_api_key("dev-key")
+
+    assert required_exc.value.status_code == 403
+    assert required_exc.value.detail == "API key required but not configured"
+
+    monkeypatch.delenv("API_KEY_REQUIRED", raising=False)
+
+    with pytest.raises(HTTPException) as default_exc:
+        api_key_mod.validate_app_api_key("dev-key")
+
+    assert default_exc.value.status_code == 403
+    assert default_exc.value.detail == "API key required but not configured"
+
+
+def test_metrics_guard_bypasses_with_environment_test_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """/metrics bypass must activate for explicit pytest-scoped ENVIRONMENT=test."""
+    from app.bootstrap import metrics as metrics_bootstrap
+
+    monkeypatch.setenv("METRICS_TEST_BYPASS", "true")
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+
+    assert metrics_bootstrap._metrics_api_key_guard(None) == "testing-bypass"
+
+
+def test_metrics_guard_warns_when_bypass_leaks_in_non_test_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """/metrics bypass must warn and fall back to auth outside test environments."""
+    from app.bootstrap import metrics as metrics_bootstrap
+
+    _configure_metrics_auth_env(monkeypatch)
+    monkeypatch.setenv("METRICS_TEST_BYPASS", "true")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+
+    with caplog.at_level("WARNING", logger="app.bootstrap.metrics"):
+        result = metrics_bootstrap._metrics_api_key_guard("test_key")
+
+    assert result == "test_key"
+    assert "METRICS_TEST_BYPASS ignored outside explicit pytest test env" in caplog.text


### PR DESCRIPTION
## Scope
- Rebuild PR #1445 from current `main` to restore the intended `/metrics` auth lane and remove stale scope drift from the old branch history.
- Require app-level auth for `/metrics` outside an explicit pytest-scoped test bypass.
- Preserve hidden-from-OpenAPI behavior, Prometheus exposition, and late-bootstrap route registration.

## Files
- `app/bootstrap/metrics.py`
- `app/routers/api_key.py`
- `app/AGENTS.md`
- `conftest.py`
- `tests/_client.py`
- `tests/conftest.py`
- `tests/test_app_main_import.py`
- `tests/test_metrics.py`
- `tests/test_business_router.py`
- `docs/review/PR_1445_FIXED_MAPPING.md`
- `.secrets.baseline`

## DoD
- [x] `/metrics` rejects missing and invalid app API keys outside explicit test-only bypass.
- [x] Route-level HTTP tests cover missing, valid, and invalid key flows plus leaked bypass rejection outside explicit pytest test env.
- [x] Shared app API-key helper now fails closed when `API_KEY` is unset.
- [x] Canonical review artifact rebuilt from live review truth.
- [x] Mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed with no findings.
- [x] Local `pre-commit run --all-files` green on rebuilt head `71b4b4164`.
- [x] Local `pytest -q tests/test_metrics.py` green on rebuilt head `71b4b4164`.
- [x] Local `diff-cover` against `origin/main` is green for changed Python lines on rebuilt head `71b4b4164`.
- [ ] Local `make verify` fully green on rebuilt head `71b4b4164`.
- [ ] Current-head GitHub CI green on rebuilt head `71b4b4164`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1445_FIXED_MAPPING.md`

## Merge Readiness
- Current rebuilt head: `71b4b416403de28049daf124ddaeaceb5f5ce82c`.
- Stale current-head references to `3732f1c4...`, `c9e197...`, and `9872a97...` from previous branch history are superseded by this clean-room rebuild stack:
  - `6f84a4034` `fix(metrics): guard /metrics outside pytest`
  - `b97d4c15e` `fix(metrics): preserve guarded late bootstrap`
  - `0108175f8` `docs(review): rebuild PR 1445 mapping`
  - `dea9de69a` `test(metrics): auto-auth legacy metrics probes`
  - `cb2b3de88` `docs(review): refresh PR 1445 artifact head`
  - `c9e197464` `test(metrics): align isolated client fixture`
  - `36b856d6c` `test(metrics): cover app api key helper branches`
  - `be2c68076` `fix(metrics): fail closed without API key`
  - `9872a97d3` `docs(review): update PR 1445 thread mapping`
  - `a9fb15cc2` `docs(review): map coderabbit summary review`
  - `71b4b4164` `test(metrics): close diff coverage gaps`
- GitHub current-head CI is still in progress on `71b4b4164`; merge readiness remains withheld until fresh `diff-coverage`, `coverage-pr`, `lint`, `test-pr`, and remaining current-head checks settle on this head.
- Local merge readiness is still withheld until `make verify` and `check_merge_ready.py --require-auth` are re-run on the latest pushed head with valid GitHub auth env.

## Deferred / Follow-ups
- If any newly rerun current-head job regresses on `71b4b4164`, treat it as a blocker and remediate on-branch.
