### PR TITLE
fix(cbt): await async LLM providers correctly in CBT insight endpoint

### DIFF
--- a/app/services/fitchef_runtime.py
+++ b/app/services/fitchef_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import inspect
 import logging
 import os
 from dataclasses import dataclass
@@ -107,6 +108,36 @@ def _require_llm_provider() -> Any:
             detail="LLM provider not available",
         )
     return provider
+
+
+async def _await_provider_generate(provider: Any, prompt: str) -> object:
+    """Call provider.generate across sync/async implementations.
+
+    RU: Поддерживает async provider, sync provider и sync provider, который
+    возвращает coroutine object.
+    EN: Supports async providers, sync providers, and sync providers that
+    return a coroutine object.
+    """
+
+    generate = provider.generate
+    raw_payload: object
+    if inspect.iscoroutinefunction(generate):
+        raw_payload = generate(prompt)
+    else:
+        raw_payload = await run_in_threadpool(generate, prompt)
+
+    if asyncio.iscoroutine(raw_payload):
+        raw_payload = await raw_payload
+    return raw_payload
+
+
+async def _generate_with_timeout(provider: Any, prompt: str) -> object:
+    """Apply the canonical outer timeout to provider.generate()."""
+
+    return await asyncio.wait_for(
+        _await_provider_generate(provider, prompt),
+        timeout=LLM_TIMEOUT_SECONDS,
+    )
 
 
 def _build_fitchef_reflection_query(summary: str, goal: str | None) -> str:
@@ -839,11 +870,14 @@ async def run_coach_insight_task(
             route=endpoint,
             prompt_text=prompt,
         ) as span:
-            insight_text = await asyncio.wait_for(
-                run_in_threadpool(provider.generate, prompt),
-                timeout=LLM_TIMEOUT_SECONDS,
+            raw_insight = await _generate_with_timeout(provider, prompt)
+            finalize_llm_span(span, raw_insight if isinstance(raw_insight, str) else "")
+        if not isinstance(raw_insight, str):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Failed to generate CBT insight",
             )
-            finalize_llm_span(span, insight_text or "")
+        insight_text = raw_insight
         if not insight_text:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/docs/review/PR_1449_FIXED_MAPPING.md
+++ b/docs/review/PR_1449_FIXED_MAPPING.md
@@ -1,0 +1,58 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1449 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-57`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-112`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+This stale-branch recovery lane rebased the old router-level fix onto current
+`main`, re-landed the runtime fix on the live `fitchef_runtime` seam, and maps
+all current bot review surfaces before any merge-readiness claim.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1449#pullrequestreview-4131516546 -> 0bb4b3f4e30ea89c375d076e17d2b68cf2cd9ec9
+Disposition: FIXED
+Commit: 0bb4b3f4e30ea89c375d076e17d2b68cf2cd9ec9
+Evidence: `app/services/fitchef_runtime.py:113-140`; `app/services/fitchef_runtime.py:873-884`; `tests/test_cbt_insight_api.py:896-975`; `tests/test_cbt_insight_api.py:1182-1230`
+Reason: Sourcery requested a single timeout wrapper and support for providers whose sync `generate()` returns a coroutine. The recovery commit moved that fix onto the live runtime seam by factoring provider dispatch into `_await_provider_generate()` / `_generate_with_timeout()` and adding route-level regression tests for async providers, sync providers, sync providers returning coroutine objects, and real timeout coverage.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1449#pullrequestreview-4131514505
+Disposition: NOT-A-BUG
+Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1449#pullrequestreview-4131514505`
+Reason: cubic found no issues in its review shell. It does not add a separate actionable delta once the live runtime fix and regression tests above are present.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1449#issuecomment-4270677375
+Disposition: NOT-A-BUG
+Evidence: `tests/test_cbt_insight_api.py:896-975`; `tests/test_cbt_insight_api.py:1182-1230`
+Reason: The CodeRabbit issue comment is a rate-limit shell plus beta finishing-touch checkboxes, not a concrete correctness defect on the current head. The current branch already includes the requested unit coverage in the committed runtime/test fix, so no separate follow-up is required for this shell comment.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1449#issuecomment-4270679742
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1449_FIXED_MAPPING.md`
+Reason: The Sourcery review-guide issue comment is informational documentation for reviewers and mirrors the stale router-level shape of the original PR. It does not introduce a separate actionable requirement beyond the concrete Sourcery review already fixed above.
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:31-45`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+  Evidence: remote PR head is still stale until the rebased branch is force-pushed.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: remote PR head is still stale until the rebased branch is force-pushed.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: GraphQL currently reports zero review threads, but final re-check is still required after push.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: this artifact now maps the live bot review surfaces; strict wrapper re-check is still pending.
+- [x] Pre-commit green on latest local head
+  Evidence: `pre-commit run --all-files` passed before commit `0bb4b3f4e30ea89c375d076e17d2b68cf2cd9ec9`.
+- [ ] `make verify` green on latest local head
+  Evidence: `make verify` reached `diff-cov` after passing `verify-env`, `lint`, `typecheck`, and `test-fast`, but the host terminated the full coverage rebuild with `make: *** [diff-cov] Terminated: 15`; rerun on the committed branch head remains required.
+<!-- markdownlint-enable MD034 -->

--- a/tests/test_cbt_insight_api.py
+++ b/tests/test_cbt_insight_api.py
@@ -10,6 +10,7 @@ Verifies:
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
@@ -892,6 +893,87 @@ class TestCBTInsightLLMIntegration:
         data = _json_body(response)
         assert "failed" in data["detail"].lower()
 
+    def test_async_provider_generate_returns_200(self) -> None:
+        """Async provider implementations must be awaited directly."""
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            lambda *args, **kwargs: _make_rag_context(),
+        )
+
+        class _AsyncProvider:
+            name = "async-provider"
+
+            async def generate(self, prompt: str) -> str:
+                assert "Test query" in prompt
+                return "Async CBT response"
+
+        self.monkeypatch.setattr("llm.get_provider", lambda: _AsyncProvider())
+
+        response = self.client.post(
+            self.url,
+            json={"query": "Test query"},
+            headers=self.pro_headers,
+        )
+
+        assert response.status_code == 200
+        assert _json_body(response)["insight"] == "Async CBT response"
+
+    def test_sync_provider_generate_returns_200(self) -> None:
+        """Sync provider implementations must keep working via threadpool."""
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            lambda *args, **kwargs: _make_rag_context(),
+        )
+
+        class _SyncProvider:
+            name = "sync-provider"
+
+            def generate(self, prompt: str) -> str:
+                assert "Test query" in prompt
+                return "Sync CBT response"
+
+        self.monkeypatch.setattr("llm.get_provider", lambda: _SyncProvider())
+
+        response = self.client.post(
+            self.url,
+            json={"query": "Test query"},
+            headers=self.pro_headers,
+        )
+
+        assert response.status_code == 200
+        assert _json_body(response)["insight"] == "Sync CBT response"
+
+    def test_sync_provider_returning_coroutine_returns_200(self) -> None:
+        """Sync provider.generate may return a coroutine object."""
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            lambda *args, **kwargs: _make_rag_context(),
+        )
+
+        async def _async_payload() -> str:
+            return "Coroutine CBT response"
+
+        class _CoroutineProvider:
+            name = "coroutine-provider"
+
+            def generate(self, prompt: str) -> object:
+                assert "Test query" in prompt
+                return _async_payload()
+
+        self.monkeypatch.setattr("llm.get_provider", lambda: _CoroutineProvider())
+
+        response = self.client.post(
+            self.url,
+            json={"query": "Test query"},
+            headers=self.pro_headers,
+        )
+
+        assert response.status_code == 200
+        assert _json_body(response)["insight"] == "Coroutine CBT response"
+
     def test_execution_mode_blocked_returns_503(self) -> None:
         """Blocked execution mode must fail closed before privileged work."""
         self.monkeypatch.setenv("CBT_AGENT_EXECUTION_MODE", "blocked")
@@ -1096,6 +1178,68 @@ class TestCBTInsightLLMIntegration:
         assert response.status_code == 504
         data = _json_body(response)
         assert "timed out" in data["detail"].lower()
+
+    def test_async_provider_timeout_returns_504(self) -> None:
+        """Async providers must still obey the same outer timeout contract."""
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            lambda *args, **kwargs: _make_rag_context(),
+        )
+        self.monkeypatch.setattr(
+            "app.services.fitchef_runtime.LLM_TIMEOUT_SECONDS",
+            0.001,
+        )
+
+        class _AsyncTimeoutProvider:
+            name = "async-timeout-provider"
+
+            async def generate(self, prompt: str) -> str:
+                await asyncio.sleep(0.01)
+                return "late"
+
+        self.monkeypatch.setattr("llm.get_provider", lambda: _AsyncTimeoutProvider())
+
+        response = self.client.post(
+            self.url,
+            json={"query": "Test query"},
+            headers=self.pro_headers,
+        )
+
+        assert response.status_code == 504
+        assert "timed out" in _json_body(response)["detail"].lower()
+
+    def test_sync_provider_timeout_returns_504(self) -> None:
+        """Slow sync providers must still be covered by the outer timeout."""
+
+        import time
+
+        self.monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            lambda *args, **kwargs: _make_rag_context(),
+        )
+        self.monkeypatch.setattr(
+            "app.services.fitchef_runtime.LLM_TIMEOUT_SECONDS",
+            0.001,
+        )
+
+        class _SyncTimeoutProvider:
+            name = "sync-timeout-provider"
+
+            def generate(self, prompt: str) -> str:
+                time.sleep(0.01)
+                return "late"
+
+        self.monkeypatch.setattr("llm.get_provider", lambda: _SyncTimeoutProvider())
+
+        response = self.client.post(
+            self.url,
+            json={"query": "Test query"},
+            headers=self.pro_headers,
+        )
+
+        assert response.status_code == 504
+        assert "timed out" in _json_body(response)["detail"].lower()
 
 
 class TestCBTInsightRouteDelegation:

--- a/tests/test_fitchef_insight_api.py
+++ b/tests/test_fitchef_insight_api.py
@@ -18,6 +18,8 @@ from fastapi.testclient import TestClient
 
 from app.middleware.api_tiers import TEST_KEY_VIP
 from app.schemas.fitchef import (
+    FitChefCoachInsightInput,
+    FitChefCoachInsightTaskEnvelope,
     FitChefMascotInsightInput,
     FitChefMascotInsightResult,
     FitChefMascotInsightTaskEnvelope,
@@ -57,6 +59,20 @@ def _make_rag_context(
         confidence=confidence,
         hops=1,
         latency_ms=10,
+    )
+
+
+def _make_coach_insight_task() -> FitChefCoachInsightTaskEnvelope:
+    """Create deterministic CBT coach-insight task envelope for runtime tests."""
+
+    return FitChefCoachInsightTaskEnvelope(
+        mode="auto-safe",
+        input=FitChefCoachInsightInput(
+            safe_query="Need help with spiraling thoughts",
+            api_key=TEST_KEY_VIP,
+            endpoint="/api/v1/pro/cbt/insight",
+            method="POST",
+        ),
     )
 
 
@@ -2284,6 +2300,138 @@ async def test_fitchef_text_tasks_use_task_specific_draft_builder(
 
     assert result.message == expected_message
     assert draft_calls == expected_calls
+
+
+class TestFitChefCoachInsightRuntimeCoverage:
+    """Targeted runtime tests for CBT provider dispatch branches."""
+
+    @staticmethod
+    def _patch_shared_runtime_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "app.services.fitchef_runtime.get_transparency_registry",
+            lambda: {
+                "ai_generated_insight": {
+                    "surface_id": "ai_generated_insight",
+                    "boundary": "Wellness coaching only.",
+                }
+            },
+        )
+        monkeypatch.setattr(
+            "app.services.fitchef_runtime._persist_privileged_action_audit",
+            lambda **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "core.rag.vector_rag.retrieve_context_structured",
+            lambda *args, **kwargs: _make_rag_context(),
+        )
+        monkeypatch.setattr(
+            "app.services.fitchef_runtime.attempt_consume_llm_monthly_quota",
+            lambda *args, **kwargs: True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_runtime_sync_provider_returns_string(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sync provider.generate should work through the shared CBT runtime."""
+
+        from app.services import fitchef_runtime
+
+        self._patch_shared_runtime_dependencies(monkeypatch)
+
+        class _SyncProvider:
+            name = "sync-provider"
+
+            def generate(self, prompt: str) -> str:
+                assert "Need help with spiraling thoughts" in prompt
+                return "Steady CBT support"
+
+        monkeypatch.setattr("llm.get_provider", lambda: _SyncProvider())
+
+        result = await fitchef_runtime.run_coach_insight_task(_make_coach_insight_task())
+
+        assert result.insight == "Steady CBT support"
+        assert result.quota_state == "consumed"
+
+    @pytest.mark.asyncio
+    async def test_runtime_async_provider_returns_string(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Async provider.generate should be awaited directly."""
+
+        from app.services import fitchef_runtime
+
+        self._patch_shared_runtime_dependencies(monkeypatch)
+
+        class _AsyncProvider:
+            name = "async-provider"
+
+            async def generate(self, prompt: str) -> str:
+                assert "Need help with spiraling thoughts" in prompt
+                return "Async CBT support"
+
+        monkeypatch.setattr("llm.get_provider", lambda: _AsyncProvider())
+
+        result = await fitchef_runtime.run_coach_insight_task(_make_coach_insight_task())
+
+        assert result.insight == "Async CBT support"
+        assert result.quota_state == "consumed"
+
+    @pytest.mark.asyncio
+    async def test_runtime_sync_provider_returning_coroutine_returns_string(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sync provider.generate may still return a coroutine object."""
+
+        from app.services import fitchef_runtime
+
+        self._patch_shared_runtime_dependencies(monkeypatch)
+
+        async def _payload() -> str:
+            return "Coroutine CBT support"
+
+        class _CoroutineProvider:
+            name = "coroutine-provider"
+
+            def generate(self, prompt: str) -> object:
+                assert "Need help with spiraling thoughts" in prompt
+                return _payload()
+
+        monkeypatch.setattr("llm.get_provider", lambda: _CoroutineProvider())
+
+        result = await fitchef_runtime.run_coach_insight_task(_make_coach_insight_task())
+
+        assert result.insight == "Coroutine CBT support"
+        assert result.quota_state == "consumed"
+
+    @pytest.mark.asyncio
+    async def test_runtime_non_string_provider_payload_fails_closed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Non-string payloads must preserve the stable CBT 503 contract."""
+
+        from app.services import fitchef_runtime
+
+        self._patch_shared_runtime_dependencies(monkeypatch)
+
+        class _BadProvider:
+            name = "bad-provider"
+
+            def generate(self, prompt: str) -> object:
+                assert "Need help with spiraling thoughts" in prompt
+                return {"message": "not-a-string"}
+
+        monkeypatch.setattr("llm.get_provider", lambda: _BadProvider())
+
+        with pytest.raises(HTTPException) as exc_info:
+            await fitchef_runtime.run_coach_insight_task(_make_coach_insight_task())
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Failed to generate CBT insight"
 
 
 def test_prepare_mascot_draft_preserves_bulleted_action_items() -> None:


### PR DESCRIPTION
### Motivation
- PR #1449 originally fixed the old router-level CBT provider path, but after rebasing onto current `main` on April 22, 2026, the live provider dispatch now runs through `app/services/fitchef_runtime.py`.
- The stale branch still needed the same correctness fix on the current runtime seam: preserve one outer timeout, support async providers directly, and correctly await sync providers that return coroutine objects.

### Description
- Rebased `codex/fix-cbt-insight-endpoint-async-misuse` onto current `main` and dropped the stale router-only patch because the route is now a thin delegator.
- Added `_await_provider_generate()` and `_generate_with_timeout()` in `app/services/fitchef_runtime.py` so `run_coach_insight_task()` supports async `generate`, sync `generate`, and sync `generate` returning coroutine objects without duplicating timeout logic.
- Added route-level regression coverage in `tests/test_cbt_insight_api.py` for async provider success, sync provider success, sync provider returning coroutine success, async timeout, and slow sync timeout.
- Preserved the existing public route contract, quota ordering, audit ordering, and fail-closed error mapping.

### Testing
- `pre-commit run --all-files` passed on the rebased branch.
- `pytest -q tests/test_cbt_insight_api.py -k 'async_provider_generate_returns_200 or sync_provider_generate_returns_200 or sync_provider_returning_coroutine_returns_200 or async_provider_timeout_returns_504 or sync_provider_timeout_returns_504 or llm_timeout_returns_504 or llm_generation_failure_returns_503 or llm_empty_response_returns_503'` passed (`8 passed`).
- `make verify` passed `verify-env`, `lint`, `typecheck`, and `test-fast`, then reached `diff-cov`; the host terminated the full coverage rebuild with `make: *** [diff-cov] Terminated: 15`, so the canonical local bundle still needs one clean rerun on the committed branch head.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ab5e5048748333a87aa2f714868f5f)

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1449_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Current-head CI green for the rebased branch head
- [ ] Required checks complete with no pending jobs
- [ ] Strict merge wrapper passes on current head
- [ ] Local `make verify` rerun completes cleanly on the committed branch head


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of CBT insight generation with enhanced timeout handling and error management.
  * Strengthened validation of AI-generated insights to ensure quality and provide clearer error messages when generation fails.

* **Tests**
  * Added comprehensive test coverage for CBT insight API behavior across various provider scenarios and timeout conditions.

* **Documentation**
  * Added internal review mapping documentation for governance and traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->