### PR TITLE
fix(security): enforce blocked_packages on unpinned requirements

### DIFF
--- a/docs/review/PR_1451_FIXED_MAPPING.md
+++ b/docs/review/PR_1451_FIXED_MAPPING.md
@@ -1,0 +1,87 @@
+# PR #1451 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+Current GitHub review surface for PR `#1451` was re-checked on `23 April 2026`:
+
+- `reviewThreads`: three unresolved inline threads on the active head
+- actionable Sourcery review identified by Sourcery:
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4131518820`
+- actionable inline comments on current head:
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102747673`,
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102747787`,
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102790380`
+- actionable Cubic review identified by cubic:
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4131575203`
+- informational / non-actionable bot comments:
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#issuecomment-4270679765`,
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4131519004`,
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#issuecomment-4270680915`,
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#issuecomment-4270724458`
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102747673
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102747787
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102790380
+Disposition: FIXED
+Commit: 213c85449fbae42b412a475d0743369bb931c571
+Evidence: `tests/test_dependency_security_guard.py:179-187` keeps blocked-package detection on `_packages_present_in_file(...)`, while `tests/test_dependency_security_guard.py:318-341` now proves both pinned and unpinned blocked-package coverage and ignores short-form pip flags. Local proof: `python3 -m pytest -q tests/test_dependency_security_guard.py`, `pre-commit run --all-files`, and `make verify` all passed on the current head after this commit.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102747787 -> 213c85449fbae42b412a475d0743369bb931c571
+Disposition: FIXED
+Commit: 213c85449fbae42b412a475d0743369bb931c571
+Evidence: `tests/test_dependency_security_guard.py:102-125` now skips dash-prefixed pip directives before parsing, and `tests/test_dependency_security_guard.py:335-341` locks the `-i` / `-f` regression with a dedicated temp-requirements test. Local proof: `python3 -m pytest -q tests/test_dependency_security_guard.py`, `pre-commit run --all-files`, and `make verify` all passed on the current head after this commit.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102790380 -> 213c85449fbae42b412a475d0743369bb931c571
+Disposition: FIXED
+Commit: 213c85449fbae42b412a475d0743369bb931c571
+Evidence: `tests/test_dependency_security_guard.py:136-186` now canonicalizes package-name comparisons with `_normalized_package_name(...)`, and `tests/test_dependency_security_guard.py:325-332` proves `_`, `.`, and `-` aliases collapse to the same blocked package identity. Local proof: `python3 -m pytest -q tests/test_dependency_security_guard.py`, `pre-commit run --all-files`, and `make verify` all passed on the current head after this commit.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4131518820
+Disposition: NOT-A-BUG
+Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102747673`
+Reason: the aggregate Sourcery review shell only wraps the same pinned-vs-unpinned testing request already dispositioned as `FIXED` in the inline thread above; it does not add a separate defect once that inline comment is mapped with proof.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4131575203
+Disposition: NOT-A-BUG
+Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102790380`
+Reason: the aggregate Cubic review shell repeats the same normalization defect already identified by cubic in the inline thread above; no separate unresolved obligation remains once that inline comment is mapped with proof.
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+  Evidence: `AGENTS.md:42-49`;
+  `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:95-112`.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: `AGENTS.md:46-49`;
+  `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:155-163`.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: actionable current-head threads are dispositioned above but still
+  require explicit GitHub resolution after the updated branch head is pushed.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: current actionable review shells and inline comments are mapped in
+  `## Fixed in Commit Mapping`; final merge gate still requires a fresh
+  current-head re-check after push.
+- [ ] Pre-commit green on latest pushed head
+  Evidence: local `pre-commit run --all-files` on the latest PR head.
+- [ ] `make verify` green on latest pushed head
+  Evidence: `AGENTS.md:1-16`;
+  `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:175-180`.
+
+## Deferred / Follow-ups
+
+- Add entries here only after a `DEFERRED` disposition is chosen above; each
+  follow-up must reuse the same ledger anchor recorded in `Fixed in Commit
+  Mapping`.

--- a/docs/review/PR_1451_FIXED_MAPPING.md
+++ b/docs/review/PR_1451_FIXED_MAPPING.md
@@ -8,7 +8,8 @@ Canonical review-governance artifact and PR-body mirror requirements:
 
 Current GitHub review surface for PR `#1451` was re-checked on `23 April 2026`:
 
-- `reviewThreads`: three unresolved inline threads on the active head
+- `reviewThreads`: original three actionable inline threads plus one CodeRabbit
+  follow-up thread after the first merge-ready push
 - actionable Sourcery review identified by Sourcery:
   `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4131518820`
 - actionable inline comments on current head:
@@ -22,28 +23,28 @@ Current GitHub review surface for PR `#1451` was re-checked on `23 April 2026`:
   `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4131519004`,
   `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#issuecomment-4270680915`,
   `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#issuecomment-4270724458`
+- CodeRabbit follow-up on the merge-ready push:
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3133000980`
 
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102747673
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102747787
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102790380
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102747673 -> 213c85449fbae42b412a475d0743369bb931c571
 Disposition: FIXED
 Commit: 213c85449fbae42b412a475d0743369bb931c571
-Evidence: `tests/test_dependency_security_guard.py:179-187` keeps blocked-package detection on `_packages_present_in_file(...)`, while `tests/test_dependency_security_guard.py:318-341` now proves both pinned and unpinned blocked-package coverage and ignores short-form pip flags. Local proof: `python3 -m pytest -q tests/test_dependency_security_guard.py`, `pre-commit run --all-files`, and `make verify` all passed on the current head after this commit.
+Evidence: `tests/test_dependency_security_guard.py:179-187` keeps blocked-package detection on `_packages_present_in_file(...)`, while `tests/test_dependency_security_guard.py:311-322` proves both unpinned and pinned blocked-package coverage. Local proof: `python3 -m pytest -q tests/test_dependency_security_guard.py`, `pre-commit run --all-files`, and `make verify` all passed after this commit.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102747787 -> 213c85449fbae42b412a475d0743369bb931c571
 Disposition: FIXED
 Commit: 213c85449fbae42b412a475d0743369bb931c571
-Evidence: `tests/test_dependency_security_guard.py:102-125` now skips dash-prefixed pip directives before parsing, and `tests/test_dependency_security_guard.py:335-341` locks the `-i` / `-f` regression with a dedicated temp-requirements test. Local proof: `python3 -m pytest -q tests/test_dependency_security_guard.py`, `pre-commit run --all-files`, and `make verify` all passed on the current head after this commit.
+Evidence: `tests/test_dependency_security_guard.py:102-125` now skips dash-prefixed pip directives before parsing, and `tests/test_dependency_security_guard.py:346-352` locks the `-i` / `-f` regression with a dedicated temp-requirements test. Local proof: `python3 -m pytest -q tests/test_dependency_security_guard.py`, `pre-commit run --all-files`, and `make verify` all passed after this commit.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102790380 -> 213c85449fbae42b412a475d0743369bb931c571
 Disposition: FIXED
 Commit: 213c85449fbae42b412a475d0743369bb931c571
-Evidence: `tests/test_dependency_security_guard.py:136-186` now canonicalizes package-name comparisons with `_normalized_package_name(...)`, and `tests/test_dependency_security_guard.py:325-332` proves `_`, `.`, and `-` aliases collapse to the same blocked package identity. Local proof: `python3 -m pytest -q tests/test_dependency_security_guard.py`, `pre-commit run --all-files`, and `make verify` all passed on the current head after this commit.
+Evidence: `tests/test_dependency_security_guard.py:136-186` now canonicalizes package-name comparisons with `_normalized_package_name(...)`, and `tests/test_dependency_security_guard.py:325-332` proves `_`, `.`, and `-` aliases collapse to the same blocked package identity. Local proof: `python3 -m pytest -q tests/test_dependency_security_guard.py`, `pre-commit run --all-files`, and `make verify` all passed after this commit.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4131518820
 Disposition: NOT-A-BUG
@@ -54,6 +55,11 @@ Reason: the aggregate Sourcery review shell only wraps the same pinned-vs-unpinn
 Disposition: NOT-A-BUG
 Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102790380`
 Reason: the aggregate Cubic review shell repeats the same normalization defect already identified by cubic in the inline thread above; no separate unresolved obligation remains once that inline comment is mapped with proof.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3133000980 -> cb665b37ab5c49b6a613c6540076a0765c9ac5fb
+Disposition: FIXED
+Commit: cb665b37ab5c49b6a613c6540076a0765c9ac5fb
+Evidence: `tests/test_dependency_security_guard.py:200-203` and `tests/test_dependency_security_guard.py:372-375` now read canonicalized package-name keys with `_normalized_package_name(pkg)`, matching the way `_effective_min_versions_per_package(...)` stores keys. Regression coverage in `tests/test_dependency_security_guard.py:335-343` and `tests/test_dependency_security_guard.py:386-395` proves alias-equivalent schema lookups for both minimum-version and blocked-version guard paths. Local proof before mapping: `python3 -m pytest -q tests/test_dependency_security_guard.py`.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1451_FIXED_MAPPING.md
+++ b/docs/review/PR_1451_FIXED_MAPPING.md
@@ -26,6 +26,8 @@ Current GitHub review surface for PR `#1451` was re-checked on `23 April 2026`:
 - CodeRabbit follow-up on the merge-ready push:
   `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4164951419`,
   `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3133000980`
+- CodeRabbit follow-up on the later current-head push:
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4165116534`
 
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
@@ -66,6 +68,11 @@ Evidence: `tests/test_dependency_security_guard.py:200-203` and `tests/test_depe
 Disposition: NOT-A-BUG
 Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3133000980`
 Reason: the aggregate CodeRabbit review shell wraps the same inline canonicalization follow-up already dispositioned as `FIXED`; it adds no separate defect after the inline comment is mapped with proof.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4165116534 -> 136d7ff935b0394767bf77fec213d90382df9056
+Disposition: FIXED
+Commit: 136d7ff935b0394767bf77fec213d90382df9056
+Evidence: `tests/test_dependency_security_guard.py:179-189` adds `_pinned_versions_per_package(...)`, `tests/test_dependency_security_guard.py:385-397` now evaluates every pinned version against blocked-version specifiers, and `tests/test_dependency_security_guard.py:412-423` proves marker-split pins cannot hide a blocked version. The duplicate `pkg.lower()` regression path is fixed at `tests/test_dependency_security_guard.py:486-498`. Local proof before mapping: `python3 -m pytest -q tests/test_dependency_security_guard.py`.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1451_FIXED_MAPPING.md
+++ b/docs/review/PR_1451_FIXED_MAPPING.md
@@ -24,6 +24,7 @@ Current GitHub review surface for PR `#1451` was re-checked on `23 April 2026`:
   `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#issuecomment-4270680915`,
   `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#issuecomment-4270724458`
 - CodeRabbit follow-up on the merge-ready push:
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4164951419`,
   `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3133000980`
 
 - [x] Discussion-thread pass completed
@@ -60,6 +61,11 @@ Reason: the aggregate Cubic review shell repeats the same normalization defect a
 Disposition: FIXED
 Commit: cb665b37ab5c49b6a613c6540076a0765c9ac5fb
 Evidence: `tests/test_dependency_security_guard.py:200-203` and `tests/test_dependency_security_guard.py:372-375` now read canonicalized package-name keys with `_normalized_package_name(pkg)`, matching the way `_effective_min_versions_per_package(...)` stores keys. Regression coverage in `tests/test_dependency_security_guard.py:335-343` and `tests/test_dependency_security_guard.py:386-395` proves alias-equivalent schema lookups for both minimum-version and blocked-version guard paths. Local proof before mapping: `python3 -m pytest -q tests/test_dependency_security_guard.py`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4164951419
+Disposition: NOT-A-BUG
+Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3133000980`
+Reason: the aggregate CodeRabbit review shell wraps the same inline canonicalization follow-up already dispositioned as `FIXED`; it adds no separate defect after the inline comment is mapped with proof.
 
 ## Merge Readiness
 

--- a/tests/test_dependency_security_guard.py
+++ b/tests/test_dependency_security_guard.py
@@ -119,7 +119,7 @@ def _parse_requirement(line: str, path: Optional[Path] = None) -> Optional[Requi
         return None
     if s.startswith(("-r ", "--requirement", "-c ", "--constraint")):
         return None
-    if "://" in s or s.startswith(("-e ", "--editable", "git+", "hg+", "svn+", "bzr+")):
+    if s.startswith(("-e ", "--editable", "git+", "hg+", "svn+", "bzr+")):
         return None
     try:
         return Requirement(s)
@@ -170,6 +170,17 @@ def _effective_min_versions_per_package(path: Path) -> dict[str, Version]:
         if v_str is not None:
             by_pkg.setdefault(req.name.lower(), []).append(Version(v_str))
     return {pkg: min(vers) for pkg, vers in by_pkg.items()}
+
+
+def _packages_present_in_file(path: Path) -> set[str]:
+    """Parse file once; return normalized package names present in this surface."""
+    packages: set[str] = set()
+    for line in _iter_requirement_lines(path):
+        req = _parse_requirement(line, path)
+        if req is None:
+            continue
+        packages.add(req.name.lower())
+    return packages
 
 
 @pytest.mark.parametrize("surface", REQUIREMENT_SURFACES)
@@ -284,13 +295,20 @@ def test_dependency_security_guard_enforces_blocked_packages(surface: Path) -> N
     blocked_packages = schema.get("blocked_packages", [])
     if not blocked_packages:
         pytest.skip("No blocked packages defined in schema.")
-    all_reqs = _effective_min_versions_per_package(surface)
+    all_reqs = _packages_present_in_file(surface)
     for pkg in blocked_packages:
         if pkg.lower() in all_reqs:
             pytest.fail(
                 f"{surface.name}: package {pkg!r} is blocked by security policy. "
                 f"Remove it from this surface."
             )
+
+
+def test_blocked_packages_detects_unpinned_requirements(tmp_path: Path) -> None:
+    """Blocked package detection must include bare package names without specifiers."""
+    req = tmp_path / "requirements.txt"
+    req.write_text("unsafe-pkg\n", encoding="utf-8")
+    assert "unsafe-pkg" in _packages_present_in_file(req)
 
 
 @pytest.mark.parametrize("surface", REQUIREMENT_SURFACES)

--- a/tests/test_dependency_security_guard.py
+++ b/tests/test_dependency_security_guard.py
@@ -163,7 +163,7 @@ def _effective_min_version_in_file(path: Path, package: str) -> Optional[Version
 
 
 def _effective_min_versions_per_package(path: Path) -> dict[str, Version]:
-    """Parse file once; return package_lower -> effective min version."""
+    """Parse file once; return normalized package name -> effective min version."""
     pinned = not _is_constraint_style(path)
     by_pkg: dict[str, list[Version]] = {}
     for line in _iter_requirement_lines(path):
@@ -174,6 +174,19 @@ def _effective_min_versions_per_package(path: Path) -> dict[str, Version]:
         if v_str is not None:
             by_pkg.setdefault(_normalized_package_name(req.name), []).append(Version(v_str))
     return {pkg: min(vers) for pkg, vers in by_pkg.items()}
+
+
+def _pinned_versions_per_package(path: Path) -> dict[str, set[Version]]:
+    """Parse file once; return every pinned version by normalized package name."""
+    by_pkg: dict[str, set[Version]] = {}
+    for line in _iter_requirement_lines(path):
+        req = _parse_requirement(line, path)
+        if req is None:
+            continue
+        pins = {Version(sp.version) for sp in req.specifier if sp.operator == "=="}
+        if pins:
+            by_pkg.setdefault(_normalized_package_name(req.name), set()).update(pins)
+    return by_pkg
 
 
 def _packages_present_in_file(path: Path) -> set[str]:
@@ -369,18 +382,19 @@ def test_dependency_security_guard_enforces_blocked_versions(surface: Path) -> N
             f"{surface.name} is constraint-style; blocked versions check skipped "
             "(only pinned surfaces checked)."
         )
-    all_reqs = _effective_min_versions_per_package(surface)
+    pinned_versions = _pinned_versions_per_package(surface)
     for pkg, specifiers in blocked_versions.items():
-        effective = all_reqs.get(_normalized_package_name(pkg))
-        if effective is None:
+        versions = pinned_versions.get(_normalized_package_name(pkg))
+        if not versions:
             continue  # Package not in this surface
         for spec_str in specifiers:
             spec = SpecifierSet(spec_str)
-            if str(effective) in spec:
-                pytest.fail(
-                    f"{surface.name}: {pkg}=={effective} matches blocked specifier "
-                    f"{spec_str!r}. Update to a safe version."
-                )
+            for effective in sorted(versions):
+                if str(effective) in spec:
+                    pytest.fail(
+                        f"{surface.name}: {pkg}=={effective} matches blocked specifier "
+                        f"{spec_str!r}. Update to a safe version."
+                    )
 
 
 def test_blocked_versions_lookup_uses_canonical_package_names(tmp_path: Path) -> None:
@@ -388,11 +402,25 @@ def test_blocked_versions_lookup_uses_canonical_package_names(tmp_path: Path) ->
     req = tmp_path / "requirements.txt"
     req.write_text("unsafe_pkg==2.0.3\n", encoding="utf-8")
 
-    all_reqs = _effective_min_versions_per_package(req)
-    effective = all_reqs.get(_normalized_package_name("unsafe-pkg"))
+    pinned_versions = _pinned_versions_per_package(req)
+    versions = pinned_versions.get(_normalized_package_name("unsafe-pkg"))
 
-    assert effective is not None
-    assert str(effective) in SpecifierSet(">=2.0.0,<2.1.0")
+    assert versions == {Version("2.0.3")}
+    assert any(str(version) in SpecifierSet(">=2.0.0,<2.1.0") for version in versions)
+
+
+def test_blocked_versions_check_all_pinned_versions(tmp_path: Path) -> None:
+    """Blocked-version guard must not collapse marker-split pins to one version."""
+    req = tmp_path / "requirements.txt"
+    req.write_text(
+        'some-pkg==2.0.3; python_version < "3.13"\n' 'some_pkg==3.0.0; python_version >= "3.13"\n',
+        encoding="utf-8",
+    )
+
+    versions = _pinned_versions_per_package(req).get(_normalized_package_name("some-pkg"))
+
+    assert versions == {Version("2.0.3"), Version("3.0.0")}
+    assert any(str(version) in SpecifierSet(">=2.0.0,<2.1.0") for version in versions)
 
 
 def test_validate_blocked_packages_fails_on_invalid_type(tmp_path: Path) -> None:
@@ -455,18 +483,19 @@ def test_blocked_version_enforcement_with_fake_surface(tmp_path: Path) -> None:
     """Regression: blocked version match in surface should be detected."""
     fake_req = tmp_path / "requirements.txt"
     fake_req.write_text("some-pkg==2.0.3\n", encoding="utf-8")
-    all_reqs = _effective_min_versions_per_package(fake_req)
+    pinned_versions = _pinned_versions_per_package(fake_req)
     blocked_versions = {"some-pkg": [">=2.0.0,<2.1.0"]}
     # Simulate the guard check
     violations = []
     for pkg, specifiers in blocked_versions.items():
-        effective = all_reqs.get(pkg.lower())
-        if effective is None:
+        versions = pinned_versions.get(_normalized_package_name(pkg))
+        if not versions:
             continue
         for spec_str in specifiers:
             spec = SpecifierSet(spec_str)
-            if str(effective) in spec:
-                violations.append((pkg, str(effective), spec_str))
+            for effective in sorted(versions):
+                if str(effective) in spec:
+                    violations.append((pkg, str(effective), spec_str))
     assert violations == [
         ("some-pkg", "2.0.3", ">=2.0.0,<2.1.0")
     ], "Blocked version match should be detected."

--- a/tests/test_dependency_security_guard.py
+++ b/tests/test_dependency_security_guard.py
@@ -11,6 +11,7 @@ from packaging.requirements import InvalidRequirement
 from packaging.requirements import Requirement
 from packaging.specifiers import InvalidSpecifier
 from packaging.specifiers import SpecifierSet
+from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion
 from packaging.version import Version
 
@@ -29,6 +30,11 @@ REQUIREMENT_SURFACES = (
 def _is_constraint_style(path: Path) -> bool:
     """Constraint-style (>=) by filename; e.g. requirements.in, constraints*.txt."""
     return path.name == "requirements.in" or path.name.startswith("constraints")
+
+
+def _normalized_package_name(package_name: str) -> str:
+    """PEP 503-style canonical package names keep guard comparisons stable."""
+    return canonicalize_name(package_name)
 
 
 def _load_schema(path: Path) -> dict:
@@ -101,9 +107,7 @@ def _iter_requirement_lines(path: Path) -> Iterable[str]:
         line = raw.split("#", 1)[0].strip()
         if not line:
             continue
-        if line.startswith(("-r ", "--requirement ", "-c ", "--constraint ")):
-            continue
-        if line.startswith(("--find-links", "--index-url", "--extra-index-url")):
+        if line.startswith("-"):
             continue
         yield line
 
@@ -117,9 +121,9 @@ def _parse_requirement(line: str, path: Optional[Path] = None) -> Optional[Requi
     s = line.strip()
     if not s or s.startswith("#"):
         return None
-    if s.startswith(("-r ", "--requirement", "-c ", "--constraint")):
+    if s.startswith("-"):
         return None
-    if s.startswith(("-e ", "--editable", "git+", "hg+", "svn+", "bzr+")):
+    if s.startswith(("git+", "hg+", "svn+", "bzr+")):
         return None
     try:
         return Requirement(s)
@@ -130,7 +134,7 @@ def _parse_requirement(line: str, path: Optional[Path] = None) -> Optional[Requi
 
 
 def _min_version_for_pkg(req: Requirement, pkg: str, *, pinned: bool) -> Optional[str]:
-    if req.name.lower() != pkg.lower():
+    if _normalized_package_name(req.name) != _normalized_package_name(pkg):
         return None
     if pinned:
         equals = [sp.version for sp in req.specifier if sp.operator == "=="]
@@ -168,7 +172,7 @@ def _effective_min_versions_per_package(path: Path) -> dict[str, Version]:
             continue
         v_str = _min_version_for_pkg(req, req.name, pinned=pinned)
         if v_str is not None:
-            by_pkg.setdefault(req.name.lower(), []).append(Version(v_str))
+            by_pkg.setdefault(_normalized_package_name(req.name), []).append(Version(v_str))
     return {pkg: min(vers) for pkg, vers in by_pkg.items()}
 
 
@@ -179,7 +183,7 @@ def _packages_present_in_file(path: Path) -> set[str]:
         req = _parse_requirement(line, path)
         if req is None:
             continue
-        packages.add(req.name.lower())
+        packages.add(_normalized_package_name(req.name))
     return packages
 
 
@@ -297,7 +301,7 @@ def test_dependency_security_guard_enforces_blocked_packages(surface: Path) -> N
         pytest.skip("No blocked packages defined in schema.")
     all_reqs = _packages_present_in_file(surface)
     for pkg in blocked_packages:
-        if pkg.lower() in all_reqs:
+        if _normalized_package_name(pkg) in all_reqs:
             pytest.fail(
                 f"{surface.name}: package {pkg!r} is blocked by security policy. "
                 f"Remove it from this surface."
@@ -309,6 +313,32 @@ def test_blocked_packages_detects_unpinned_requirements(tmp_path: Path) -> None:
     req = tmp_path / "requirements.txt"
     req.write_text("unsafe-pkg\n", encoding="utf-8")
     assert "unsafe-pkg" in _packages_present_in_file(req)
+
+
+def test_blocked_packages_detects_pinned_requirements(tmp_path: Path) -> None:
+    """Blocked package detection must still catch pinned package requirements."""
+    req = tmp_path / "requirements.txt"
+    req.write_text("unsafe-pkg==1.2.3\n", encoding="utf-8")
+    assert "unsafe-pkg" in _packages_present_in_file(req)
+
+
+def test_blocked_packages_canonicalize_equivalent_package_names(tmp_path: Path) -> None:
+    """Equivalent _, ., and - package spellings must match the same blocked package."""
+    req = tmp_path / "requirements.txt"
+    req.write_text("unsafe_pkg==1.2.3\nunsafe.pkg\n", encoding="utf-8")
+    all_reqs = _packages_present_in_file(req)
+    assert "unsafe-pkg" in all_reqs
+    assert _normalized_package_name("unsafe_pkg") in all_reqs
+    assert _normalized_package_name("unsafe.pkg") in all_reqs
+
+
+def test_parse_requirement_skips_short_form_pip_flags(tmp_path: Path) -> None:
+    """Short-form pip directives must not be parsed as package requirements."""
+    req = tmp_path / "requirements.txt"
+    req.write_text(
+        "-i https://example.com/simple\n-f https://example.com/wheels\n", encoding="utf-8"
+    )
+    assert _packages_present_in_file(req) == set()
 
 
 @pytest.mark.parametrize("surface", REQUIREMENT_SURFACES)
@@ -391,10 +421,10 @@ def test_blocked_package_enforcement_with_fake_surface(tmp_path: Path) -> None:
     """Regression: blocked package in surface should be detected."""
     fake_req = tmp_path / "requirements.txt"
     fake_req.write_text("unsafe-pkg==1.0.0\nsome-other==2.0.0\n", encoding="utf-8")
-    all_reqs = _effective_min_versions_per_package(fake_req)
+    all_reqs = _packages_present_in_file(fake_req)
     blocked_packages = ["unsafe-pkg"]
     # Simulate the guard check
-    violations = [pkg for pkg in blocked_packages if pkg.lower() in all_reqs]
+    violations = [pkg for pkg in blocked_packages if _normalized_package_name(pkg) in all_reqs]
     assert violations == ["unsafe-pkg"], "Blocked package should be detected."
 
 

--- a/tests/test_dependency_security_guard.py
+++ b/tests/test_dependency_security_guard.py
@@ -199,7 +199,7 @@ def test_dependency_security_guard_enforces_min_versions(surface: Path) -> None:
 
     for pkg, min_v_str in min_versions.items():
         required_min = Version(str(min_v_str))
-        effective = all_reqs.get(pkg.lower())
+        effective = all_reqs.get(_normalized_package_name(pkg))
         if effective is None:
             pytest.fail(
                 f"{surface.name}: expected {pkg} to be pinned (==) or constrained (>=) "
@@ -332,6 +332,17 @@ def test_blocked_packages_canonicalize_equivalent_package_names(tmp_path: Path) 
     assert _normalized_package_name("unsafe.pkg") in all_reqs
 
 
+def test_min_versions_lookup_uses_canonical_package_names(tmp_path: Path) -> None:
+    """Schema names using - must match requirement names using _ or . spellings."""
+    req = tmp_path / "requirements.txt"
+    req.write_text("unsafe_pkg==1.2.3\n", encoding="utf-8")
+
+    all_reqs = _effective_min_versions_per_package(req)
+    effective = all_reqs.get(_normalized_package_name("unsafe-pkg"))
+
+    assert effective == Version("1.2.3")
+
+
 def test_parse_requirement_skips_short_form_pip_flags(tmp_path: Path) -> None:
     """Short-form pip directives must not be parsed as package requirements."""
     req = tmp_path / "requirements.txt"
@@ -360,7 +371,7 @@ def test_dependency_security_guard_enforces_blocked_versions(surface: Path) -> N
         )
     all_reqs = _effective_min_versions_per_package(surface)
     for pkg, specifiers in blocked_versions.items():
-        effective = all_reqs.get(pkg.lower())
+        effective = all_reqs.get(_normalized_package_name(pkg))
         if effective is None:
             continue  # Package not in this surface
         for spec_str in specifiers:
@@ -370,6 +381,18 @@ def test_dependency_security_guard_enforces_blocked_versions(surface: Path) -> N
                     f"{surface.name}: {pkg}=={effective} matches blocked specifier "
                     f"{spec_str!r}. Update to a safe version."
                 )
+
+
+def test_blocked_versions_lookup_uses_canonical_package_names(tmp_path: Path) -> None:
+    """Blocked version schema names must match equivalent requirement spellings."""
+    req = tmp_path / "requirements.txt"
+    req.write_text("unsafe_pkg==2.0.3\n", encoding="utf-8")
+
+    all_reqs = _effective_min_versions_per_package(req)
+    effective = all_reqs.get(_normalized_package_name("unsafe-pkg"))
+
+    assert effective is not None
+    assert str(effective) in SpecifierSet(">=2.0.0,<2.1.0")
 
 
 def test_validate_blocked_packages_fails_on_invalid_type(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- The `blocked_packages` guard still needed follow-through for the active PR `#1451` review blockers: short-form pip flags were being parsed as requirements, blocked-package matching only normalized with lowercase, and the regression coverage only proved the unpinned path.

### Description
- Skip dash-prefixed pip directive lines before `Requirement(...)` parsing so `-i` / `-f` and similar options are ignored safely.
- Canonicalize dependency guard matching so equivalent `_`, `.`, and `-` package spellings collapse to one security identity across blocked-package, min-version, and blocked-version guard paths.
- Add explicit pinned and unpinned blocked-package regression coverage plus alias-equivalent min-version and blocked-version lookup coverage.
- Add the canonical review-governance artifact at `docs/review/PR_1451_FIXED_MAPPING.md` with live dispositions for the actionable PR comments.

### Testing
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 -m pytest -q tests/test_dependency_security_guard.py`
- `pre-commit run --all-files`
- `make verify`

### Notes
- Local pre-push `pip-audit` still reports repo-wide baseline vulnerabilities in existing dependencies (`cryptography`, `pillow`, `pygments`, `python-dotenv`, `python-multipart`). That baseline is outside the narrow scope of PR `#1451`, so it was not folded into this branch; current-head GitHub CI remains the merge truth for this lane.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102747673 -> 213c85449fbae42b412a475d0743369bb931c571
Disposition: FIXED
Commit: 213c85449fbae42b412a475d0743369bb931c571
Evidence: `tests/test_dependency_security_guard.py:179-187`, `tests/test_dependency_security_guard.py:311-322`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102747787 -> 213c85449fbae42b412a475d0743369bb931c571
Disposition: FIXED
Commit: 213c85449fbae42b412a475d0743369bb931c571
Evidence: `tests/test_dependency_security_guard.py:102-125`, `tests/test_dependency_security_guard.py:346-352`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102790380 -> 213c85449fbae42b412a475d0743369bb931c571
Disposition: FIXED
Commit: 213c85449fbae42b412a475d0743369bb931c571
Evidence: `tests/test_dependency_security_guard.py:136-186`, `tests/test_dependency_security_guard.py:325-332`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3133000980 -> cb665b37ab5c49b6a613c6540076a0765c9ac5fb
Disposition: FIXED
Commit: cb665b37ab5c49b6a613c6540076a0765c9ac5fb
Evidence: `tests/test_dependency_security_guard.py:200-203`, `tests/test_dependency_security_guard.py:372-375`, `tests/test_dependency_security_guard.py:335-343`, `tests/test_dependency_security_guard.py:386-395`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4164951419 -> 422411adcdaa62237e54e17b5462cd56f6a39fc7
Disposition: NOT-A-BUG
Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3133000980`
Reason: aggregate CodeRabbit review shell wraps the same inline canonicalization follow-up already mapped as FIXED.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4131518820 -> 45038d564701d97be70d83c5148cc70bb9a88901
Disposition: NOT-A-BUG
Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102747673`
Reason: aggregate Sourcery review shell wraps the same inline testing request already mapped as FIXED.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4131575203 -> 45038d564701d97be70d83c5148cc70bb9a88901
Disposition: NOT-A-BUG
Evidence: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#discussion_r3102790380`
Reason: aggregate Cubic review shell repeats the same inline normalization defect already mapped as FIXED.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1451#pullrequestreview-4165116534 -> 136d7ff935b0394767bf77fec213d90382df9056
Disposition: FIXED
Commit: 136d7ff935b0394767bf77fec213d90382df9056
Evidence: `tests/test_dependency_security_guard.py:179-189`, `tests/test_dependency_security_guard.py:385-397`, `tests/test_dependency_security_guard.py:412-423`, `tests/test_dependency_security_guard.py:486-498`

Canonical artifact: `docs/review/PR_1451_FIXED_MAPPING.md`

## Merge Readiness

- [ ] Current-head CI is green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped after the final current-head re-check
- [x] Pre-commit green on latest pushed head
- [x] `make verify` green on latest pushed head


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency security checks: canonicalized package-name matching (underscore/dot/dash variants), stricter requirement parsing, and more accurate blocked-package and pinned-version enforcement.

* **Documentation**
  * Added a canonical review artifact documenting mapping of review threads to fixes, merge-readiness checklist, and deferred-followup rules.

* **Tests**
  * Added tests covering canonicalization, requirement parsing, and blocked-version matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
