### PR TITLE
fix(security): require authenticated context for paywall analytics ingestion

### DIFF
--- a/app/routers/paywall_analytics.py
+++ b/app/routers/paywall_analytics.py
@@ -6,11 +6,9 @@ EN: First-party hidden ingestion surface for paywall exposure instrumentation.
 
 from __future__ import annotations
 
-import os
 from typing import Optional, TYPE_CHECKING
-from urllib.parse import urlparse
 
-from fastapi import APIRouter, Header, HTTPException, Request, status
+from fastapi import APIRouter, Header, HTTPException, Request
 
 from app.middleware.api_tiers import (
     TierAuthContext,
@@ -28,9 +26,6 @@ if TYPE_CHECKING:
     from app.services.paywall_exposure_ledger import PaywallExposureAuthContext
 
 router = APIRouter(prefix="/api/v1/internal/paywall", include_in_schema=False)
-_PAYWALL_ALLOWED_ORIGINS_ENV = "PAYWALL_ANALYTICS_ALLOWED_ORIGINS"
-_FALLBACK_ALLOWED_ORIGINS_ENV = "WORKER_ALLOWED_ORIGINS"
-_LOCAL_ENV_NAMES = {"local", "dev", "development", "test"}
 
 
 def _resolve_optional_auth_context(
@@ -51,13 +46,10 @@ def _resolve_optional_auth_context(
         return None
 
 
-def _to_ledger_auth_context(context: TierAuthContext | None) -> "PaywallExposureAuthContext":
+def _to_ledger_auth_context(context: TierAuthContext) -> "PaywallExposureAuthContext":
     """Translate request auth context into ledger-safe fields."""
 
     from app.services.paywall_exposure_ledger import PaywallExposureAuthContext
-
-    if context is None:
-        return PaywallExposureAuthContext()
 
     tier_snapshot = context.tier.value.upper()
     auth_source = context.source.value
@@ -67,69 +59,6 @@ def _to_ledger_auth_context(context: TierAuthContext | None) -> "PaywallExposure
         auth_source=auth_source,
         tier_snapshot=tier_snapshot,
     )
-
-
-def _normalized_origin(value: str | None) -> str | None:
-    """Normalize Origin/Referer to ``scheme://netloc`` for exact allowlisting."""
-
-    if value is None:
-        return None
-    raw = value.strip()
-    if not raw:
-        return None
-    parsed = urlparse(raw)
-    if not parsed.scheme or not parsed.netloc:
-        return None
-    return f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
-
-
-def _configured_allowed_origins() -> set[str]:
-    """Resolve exact trusted origins from paywall-specific or worker fallback env."""
-
-    raw = (
-        os.getenv(_PAYWALL_ALLOWED_ORIGINS_ENV) or os.getenv(_FALLBACK_ALLOWED_ORIGINS_ENV) or ""
-    ).strip()
-    return {
-        normalized
-        for normalized in (_normalized_origin(item) for item in raw.split(","))
-        if normalized is not None
-    }
-
-
-def _is_local_or_test_environment() -> bool:
-    """Allow local/test fallback to the request host when no explicit allowlist exists."""
-
-    app_env = (os.getenv("APP_ENV") or "").strip().lower()
-    runtime_env = (os.getenv("ENVIRONMENT") or "").strip().lower()
-    return app_env in _LOCAL_ENV_NAMES or runtime_env in _LOCAL_ENV_NAMES
-
-
-def _trusted_browser_origin(request: Request) -> str | None:
-    """Return a trusted first-party origin or ``None`` when provenance is missing."""
-
-    allowed_origins = _configured_allowed_origins()
-    request_origin = _normalized_origin(request.headers.get("Origin"))
-    referer_origin = _normalized_origin(request.headers.get("Referer"))
-
-    candidates = tuple(
-        candidate for candidate in (request_origin, referer_origin) if candidate is not None
-    )
-    if allowed_origins:
-        for candidate in candidates:
-            if candidate in allowed_origins:
-                return candidate
-        return None
-
-    if not _is_local_or_test_environment():
-        return None
-
-    expected_origin = _normalized_origin(str(request.base_url))
-    if expected_origin is None:
-        return None
-    for candidate in candidates:
-        if candidate == expected_origin:
-            return candidate
-    return None
 
 
 @router.post(
@@ -146,10 +75,7 @@ def ingest_paywall_event(
 
     context = _resolve_optional_auth_context(request=request, x_api_key=x_api_key)
     if context is None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Authenticated session required.",
-        )
+        return PaywallExposureAckResponse()
 
     from app.services.paywall_exposure_ledger import (
         PaywallExposureRecordInput,

--- a/app/routers/paywall_analytics.py
+++ b/app/routers/paywall_analytics.py
@@ -145,11 +145,10 @@ def ingest_paywall_event(
     """Persist paywall exposure events behind a hidden first-party route."""
 
     context = _resolve_optional_auth_context(request=request, x_api_key=x_api_key)
-    trusted_origin = _trusted_browser_origin(request)
-    if context is None and trusted_origin is None:
+    if context is None:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Trusted first-party origin or authenticated session required.",
+            detail="Authenticated session required.",
         )
 
     from app.services.paywall_exposure_ledger import (

--- a/docs/review/PR_1454_FIXED_MAPPING.md
+++ b/docs/review/PR_1454_FIXED_MAPPING.md
@@ -1,0 +1,75 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1454 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Bot and human review comments must be dispositioned here before they are resolved on GitHub.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1454#discussion_r3102808476 -> 52ff01631
+Disposition: FIXED
+Commit: 52ff01631
+Evidence: `app/routers/paywall_analytics.py` no longer raises the misleading hard-403 session-only error for unauthenticated analytics; `tests/test_paywall_exposure_ledger_api.py` covers the replacement ack/no-op behavior.
+Reason: Sourcery identified that `Authenticated session required.` did not match the route's accepted auth mechanisms. The route now avoids that misleading response entirely for valid unauthenticated telemetry and returns the stable ack without writing a ledger row.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1454#discussion_r3102822695 -> 52ff01631
+Disposition: FIXED
+Commit: 52ff01631
+Evidence: `tests/test_paywall_exposure_ledger_api.py` asserts unauthenticated valid requests return `200 {"status": "ok"}` and leave `PaywallExposureLedger` empty for missing, first-party, spoofed, and referer-only provenance.
+Reason: Codex flagged that a hard `403` could redirect anonymous `/pro` users away from the conversion path. The route now preserves UX with a no-op acknowledgement while still blocking unauthenticated ledger writes.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1454#discussion_r3102822703 -> 52ff01631
+Disposition: FIXED
+Commit: 52ff01631
+Evidence: `tests/test_paywall_exposure_ledger_api.py` now asserts authenticated header writes persist `auth_source == "header"` and the targeted suite passes with 19 tests.
+Reason: Codex identified that header auth resolves to canonical source value `header`, not `api_key`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1454#discussion_r3102850062 -> 52ff01631
+Disposition: FIXED
+Commit: 52ff01631
+Evidence: `tests/test_paywall_exposure_ledger_api.py` now asserts `auth_source == "header"` for PRO header-authenticated ingestion.
+Reason: cubic identified the same failing assertion as Codex; the expected value now matches the runtime ledger contract.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1454#discussion_r3102850072 -> 52ff01631
+Disposition: FIXED
+Commit: 52ff01631
+Evidence: `app/routers/paywall_analytics.py` removes the hard-403 branch and no longer emits the misleading session-only detail for valid unauthenticated telemetry.
+Reason: cubic identified the misleading error message. The revised route contract returns an ack/no-op for unauthenticated telemetry and keeps writes restricted to resolved auth contexts.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1454#issuecomment-4270743286
+Disposition: NOT-A-BUG
+Evidence: Sourcery review-guide issue comment summarizes the PR diff and contains no additional actionable defect beyond the inline thread already mapped above.
+Reason: Informational bot guide only; no separate code change is required.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1454#issuecomment-4270743367
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit aggregate comment includes a walkthrough, one advisory docstring-coverage warning, and finishing-touch options, but no concrete blocking code defect for the current narrow lane.
+Reason: Non-actionable bot aggregate comment; any later CodeRabbit actionable review must be mapped separately.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1454#pullrequestreview-4131598342
+Disposition: NOT-A-BUG
+Evidence: Sourcery review-level feedback aggregates the inline message mismatch already dispositioned as FIXED above plus optional cleanup/logging suggestions.
+Reason: The actionable inline defect is fixed; optional logging is intentionally not added to avoid logging payload/auth/provenance details on this hidden analytics route.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1454#pullrequestreview-4131616112
+Disposition: NOT-A-BUG
+Evidence: Codex review aggregates the P1 UX regression and P2 `auth_source` findings, both mapped to `52ff01631` above.
+Reason: No additional actionable defect remains outside the mapped inline threads.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1454#pullrequestreview-4131644781
+Disposition: NOT-A-BUG
+Evidence: cubic review aggregates the P2 `auth_source` and P3 message findings, both mapped to `52ff01631` above.
+Reason: No additional actionable defect remains outside the mapped inline threads.
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+
+<!-- markdownlint-enable MD034 -->

--- a/tests/test_paywall_exposure_ledger_api.py
+++ b/tests/test_paywall_exposure_ledger_api.py
@@ -28,11 +28,6 @@ def _reset_paywall_ledger() -> None:
         session.close()
 
 
-@pytest.fixture(autouse=True)
-def _set_allowed_origins(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("PAYWALL_ANALYTICS_ALLOWED_ORIGINS", FIRST_PARTY_ORIGIN)
-
-
 def _payload(
     *,
     client_event_id: str = "event-0001",
@@ -117,22 +112,6 @@ def test_paywall_event_hidden_route_is_registered_but_not_in_openapi(client: Tes
     assert ROUTE_PATH not in app.openapi().get("paths", {})
 
 
-@pytest.mark.parametrize("raw_value", [None, "", "   ", "not-a-url"])
-def test_normalized_origin_rejects_empty_or_invalid_values(raw_value: str | None) -> None:
-    assert paywall_analytics._normalized_origin(raw_value) is None
-
-
-def test_local_environment_helper_uses_app_or_runtime_env(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("APP_ENV", raising=False)
-    monkeypatch.delenv("ENVIRONMENT", raising=False)
-    assert paywall_analytics._is_local_or_test_environment() is False
-
-    monkeypatch.setenv("ENVIRONMENT", "test")
-    assert paywall_analytics._is_local_or_test_environment() is True
-
-
 def test_resolve_optional_auth_context_propagates_unexpected_resolver_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -169,40 +148,6 @@ def test_resolve_optional_auth_context_returns_none_on_expected_auth_rejection(
     )
 
 
-def test_trusted_browser_origin_uses_local_request_host_when_allowlist_missing(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("PAYWALL_ANALYTICS_ALLOWED_ORIGINS", raising=False)
-    monkeypatch.delenv("WORKER_ALLOWED_ORIGINS", raising=False)
-    monkeypatch.setenv("APP_ENV", "local")
-
-    request = _request(headers={"Origin": "https://api.pulseplate.test"})
-
-    assert paywall_analytics._trusted_browser_origin(request) == "https://api.pulseplate.test"
-
-
-def test_trusted_browser_origin_returns_none_when_local_base_origin_cannot_be_normalized(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(paywall_analytics, "_configured_allowed_origins", lambda: set())
-    monkeypatch.setattr(paywall_analytics, "_is_local_or_test_environment", lambda: True)
-
-    original_normalized_origin = paywall_analytics._normalized_origin
-
-    def _normalized_origin(value: str | None) -> str | None:
-        if value == "https://api.pulseplate.test":
-            return "https://api.pulseplate.test"
-        if value == "https://api.pulseplate.test/":
-            return None
-        return original_normalized_origin(value)
-
-    monkeypatch.setattr(paywall_analytics, "_normalized_origin", _normalized_origin)
-
-    request = _request(headers={"Origin": "https://api.pulseplate.test"})
-
-    assert paywall_analytics._trusted_browser_origin(request) is None
-
-
 def test_paywall_shown_event_persists_for_authenticated_request(
     client: TestClient,
     pro_headers: dict[str, str],
@@ -220,7 +165,7 @@ def test_paywall_shown_event_persists_for_authenticated_request(
     assert rows[0].trigger_reason == "post_bmi_result"
     expected_subject_id = derive_subject_id_from_api_key(pro_headers["X-API-Key"])
     assert rows[0].subject_id == expected_subject_id
-    assert rows[0].auth_source == "api_key"
+    assert rows[0].auth_source == "header"
     assert rows[0].tier_snapshot == "PRO"
 
 
@@ -279,22 +224,54 @@ def test_paywall_cta_clicked_is_idempotent_by_client_event_id(
     assert rows[0].client_event_id == "event-2001"
 
 
-def test_paywall_event_rejects_anonymous_request_without_authentication(client: TestClient) -> None:
-    response = client.post(ROUTE_PATH, json=_payload())
+@pytest.mark.parametrize(
+    "headers",
+    [
+        None,
+        _first_party_headers(),
+        _first_party_headers("https://evil.example.com"),
+        {"Referer": f"{FIRST_PARTY_ORIGIN}/pro"},
+    ],
+)
+def test_paywall_event_noops_without_authentication(
+    client: TestClient,
+    headers: dict[str, str] | None,
+) -> None:
+    response = client.post(ROUTE_PATH, json=_payload(), headers=headers)
 
-    assert response.status_code == 403, response.text
+    assert response.status_code == 200, response.text
+    assert response.json() == {"status": "ok"}
     assert _load_events() == []
 
 
-def test_paywall_event_rejects_untrusted_origin_without_auth(client: TestClient) -> None:
+def test_paywall_event_noops_when_explicit_api_key_is_invalid(client: TestClient) -> None:
     response = client.post(
         ROUTE_PATH,
         json=_payload(),
-        headers=_first_party_headers("https://evil.example.com"),
+        headers={"X-API-Key": "invalid-paywall-key"},  # pragma: allowlist secret
     )
 
-    assert response.status_code == 403, response.text
+    assert response.status_code == 200, response.text
+    assert response.json() == {"status": "ok"}
     assert _load_events() == []
+
+
+def test_anonymous_noop_does_not_block_later_authenticated_idempotent_write(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    body = _payload(client_event_id="event-noop-then-auth")
+
+    anonymous_response = client.post(ROUTE_PATH, json=body, headers=_first_party_headers())
+    authenticated_response = client.post(ROUTE_PATH, json=body, headers=pro_headers)
+
+    assert anonymous_response.status_code == 200, anonymous_response.text
+    assert authenticated_response.status_code == 200, authenticated_response.text
+
+    rows = _load_events()
+    assert len(rows) == 1
+    assert rows[0].client_event_id == "event-noop-then-auth"
+    assert rows[0].auth_source == "header"
 
 
 def test_paywall_event_rejects_invalid_event_name(

--- a/tests/test_paywall_exposure_ledger_api.py
+++ b/tests/test_paywall_exposure_ledger_api.py
@@ -203,8 +203,11 @@ def test_trusted_browser_origin_returns_none_when_local_base_origin_cannot_be_no
     assert paywall_analytics._trusted_browser_origin(request) is None
 
 
-def test_paywall_shown_event_persists_for_anonymous_request(client: TestClient) -> None:
-    response = client.post(ROUTE_PATH, json=_payload(), headers=_first_party_headers())
+def test_paywall_shown_event_persists_for_authenticated_request(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
+    response = client.post(ROUTE_PATH, json=_payload(), headers=pro_headers)
 
     assert response.status_code == 200, response.text
     assert response.headers.get("content-type", "").startswith("application/json")
@@ -215,18 +218,22 @@ def test_paywall_shown_event_persists_for_anonymous_request(client: TestClient) 
     assert rows[0].event_name == "shown"
     assert rows[0].source_surface == "bmi_soft_paywall"
     assert rows[0].trigger_reason == "post_bmi_result"
-    assert rows[0].subject_id is None
-    assert rows[0].auth_source is None
-    assert rows[0].tier_snapshot is None
+    expected_subject_id = derive_subject_id_from_api_key(pro_headers["X-API-Key"])
+    assert rows[0].subject_id == expected_subject_id
+    assert rows[0].auth_source == "api_key"
+    assert rows[0].tier_snapshot == "PRO"
 
 
-def test_paywall_dismissed_event_keeps_shared_exposure_id(client: TestClient) -> None:
+def test_paywall_dismissed_event_keeps_shared_exposure_id(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
     response_shown = client.post(
         ROUTE_PATH,
         json=_payload(
             client_event_id="event-1001", exposure_id="exposure-1000", event_name="shown"
         ),
-        headers=_first_party_headers(),
+        headers=pro_headers,
     )
     response_dismissed = client.post(
         ROUTE_PATH,
@@ -236,7 +243,7 @@ def test_paywall_dismissed_event_keeps_shared_exposure_id(client: TestClient) ->
             event_name="dismissed",
             metadata={"dismissal_method": "escape"},
         ),
-        headers=_first_party_headers(),
+        headers=pro_headers,
     )
 
     assert response_shown.status_code == 200, response_shown.text
@@ -249,16 +256,19 @@ def test_paywall_dismissed_event_keeps_shared_exposure_id(client: TestClient) ->
     assert rows[1].metadata_json == {"dismissal_method": "escape"}
 
 
-def test_paywall_cta_clicked_is_idempotent_by_client_event_id(client: TestClient) -> None:
+def test_paywall_cta_clicked_is_idempotent_by_client_event_id(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
     first = client.post(
         ROUTE_PATH,
         json=_payload(client_event_id="event-2001", event_name="cta_clicked"),
-        headers=_first_party_headers(),
+        headers=pro_headers,
     )
     second = client.post(
         ROUTE_PATH,
         json=_payload(client_event_id="event-2001", event_name="cta_clicked"),
-        headers=_first_party_headers(),
+        headers=pro_headers,
     )
 
     assert first.status_code == 200, first.text
@@ -269,16 +279,14 @@ def test_paywall_cta_clicked_is_idempotent_by_client_event_id(client: TestClient
     assert rows[0].client_event_id == "event-2001"
 
 
-def test_paywall_event_rejects_anonymous_request_without_first_party_provenance(
-    client: TestClient,
-) -> None:
+def test_paywall_event_rejects_anonymous_request_without_authentication(client: TestClient) -> None:
     response = client.post(ROUTE_PATH, json=_payload())
 
     assert response.status_code == 403, response.text
     assert _load_events() == []
 
 
-def test_paywall_event_rejects_untrusted_origin(client: TestClient) -> None:
+def test_paywall_event_rejects_untrusted_origin_without_auth(client: TestClient) -> None:
     response = client.post(
         ROUTE_PATH,
         json=_payload(),
@@ -289,11 +297,14 @@ def test_paywall_event_rejects_untrusted_origin(client: TestClient) -> None:
     assert _load_events() == []
 
 
-def test_paywall_event_rejects_invalid_event_name(client: TestClient) -> None:
+def test_paywall_event_rejects_invalid_event_name(
+    client: TestClient,
+    pro_headers: dict[str, str],
+) -> None:
     response = client.post(
         ROUTE_PATH,
         json=_payload(event_name="not_real"),
-        headers=_first_party_headers(),
+        headers=pro_headers,
     )
 
     assert response.status_code == 422, response.text
@@ -302,12 +313,13 @@ def test_paywall_event_rejects_invalid_event_name(client: TestClient) -> None:
 @pytest.mark.parametrize("event_name", ["upgrade_started", "upgrade_completed"])
 def test_paywall_event_rejects_server_authored_upgrade_events(
     client: TestClient,
+    pro_headers: dict[str, str],
     event_name: str,
 ) -> None:
     response = client.post(
         ROUTE_PATH,
         json=_payload(event_name=event_name),
-        headers=_first_party_headers(),
+        headers=pro_headers,
     )
 
     assert response.status_code == 422, response.text
@@ -322,13 +334,14 @@ def test_paywall_event_rejects_server_authored_upgrade_events(
 )
 def test_paywall_event_rejects_invalid_slug_fields(
     client: TestClient,
+    pro_headers: dict[str, str],
     field_name: str,
     bad_value: str,
 ) -> None:
     body = _payload()
     body[field_name] = bad_value
 
-    response = client.post(ROUTE_PATH, json=body, headers=_first_party_headers())
+    response = client.post(ROUTE_PATH, json=body, headers=pro_headers)
 
     assert response.status_code == 422, response.text
 


### PR DESCRIPTION
### Motivation
- The hidden paywall analytics ingestion route accepted unauthenticated ledger writes when a request presented a matching `Origin`/`Referer`, which is spoofable by non-browser clients.
- PR #1454 closes that ledger-pollution vector while preserving the anonymous `/pro` conversion path: unauthenticated telemetry is acknowledged as a no-op instead of becoming a hard redirect-triggering auth failure.

### Description
- Remove Origin/Referer as write authorization for `ingest_paywall_event`.
- Return the stable paywall analytics ack for valid unauthenticated telemetry without creating a ledger row.
- Keep authenticated header/session ingestion intact and continue storing canonical auth metadata in the paywall exposure ledger.
- Fix the authenticated header assertion to use canonical `auth_source == "header"`.

### Testing
- `python3 -m pytest -q tests/test_paywall_exposure_ledger_api.py` -> 19 tests passed.
- Commit hook on `52ff01631` passed changed-file checks, including backend pytest for changed files.
- Blocking pre-push gates still required before merge: `pre-commit run --all-files`, `make verify`, and strict merge wrapper.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- Canonical artifact: `docs/review/PR_1454_FIXED_MAPPING.md`
- Fixed code/test commit: `52ff01631`
- Mapped actionable review threads:
  - Sourcery `discussion_r3102808476`
  - Codex P1 `discussion_r3102822695`
  - Codex P2 `discussion_r3102822703`
  - cubic P2 `discussion_r3102850062`
  - cubic P3 `discussion_r3102850072`

## Merge Readiness

- [ ] Current-head CI green for PR branch head
- [ ] Required checks complete with no pending required jobs
- [ ] Strict merge wrapper passes with auth
- [ ] All GitHub review threads resolved after pushed proof exists
- [ ] No actionable CodeRabbit/Sourcery/Cubic/Codex comments remain unmapped
