### PR TITLE
fix(authz): remove env-key fallback from manual billing transport auth

### DIFF
--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -17,9 +17,6 @@ from fastapi.responses import JSONResponse
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
-from app.middleware.api_tiers import (
-    SubscriptionTier,
-)
 from app.routers.api_key import api_key_header
 from app.security.rate_limit import (
     RATE_LIMIT_429_RESPONSES,

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -19,8 +19,6 @@ if TYPE_CHECKING:
 
 from app.middleware.api_tiers import (
     SubscriptionTier,
-    resolve_tier_from_env,
-    tier_allows_access,
 )
 from app.routers.api_key import api_key_header
 from app.security.rate_limit import (
@@ -39,8 +37,6 @@ from app.schemas.payments import (
     SubscriptionActivationResponse,
 )
 from app.services import payments_activation
-from settings import is_explicit_developer_env, is_truthy_env_var
-
 billing_router = APIRouter(prefix="/api/v1/billing", tags=["billing"])
 router = APIRouter(prefix="/api/v1/pro/payments", tags=["pro", "payments"])
 
@@ -239,53 +235,22 @@ def _get_effective_app_get_api_key():
     return app_get_api_key
 
 
-def _resolve_manual_transport_key_fallback(api_key: str) -> str | None:
-    """Accept issued PRO/VIP transport keys for pre-entitlement manual billing routes.
-
-    RU: Pre-entitlement manual rails принимают валидированный transport key через
-    app-level validator или через выданный PRO/VIP key из env/test surface, но не
-    используют persisted entitlement как источник истины.
-    EN: Pre-entitlement manual rails accept a validated transport key via the
-    app-level validator or an issued PRO/VIP key from the env/test surface, but
-    they do not use persisted entitlement as the source of truth.
-    """
-    allow_test_keys = is_explicit_developer_env() and is_truthy_env_var(
-        "ALLOW_DEV_API_KEY",
-        "true",
-    )
-    resolved_tier = resolve_tier_from_env(api_key, allow_test_keys=allow_test_keys)
-    if resolved_tier is not None and tier_allows_access(resolved_tier, SubscriptionTier.PRO):
-        return api_key
-    return None
-
-
 def _get_effective_manual_billing_key_validator() -> Callable[..., str]:
-    """Resolve manual-route validator without reintroducing entitlement-gated auth.
+    """Resolve manual-route validator from the strict app-level auth surface.
 
-    RU: Manual RU/BY routes должны принимать transport-auth до entitlment, поэтому
-    fallback ограничен issued PRO/VIP keys и не ходит в persisted entitlement lookup.
-    EN: Manual RU/BY routes must accept transport auth before entitlement exists, so
-    the fallback is limited to issued PRO/VIP keys and never consults persisted
-    entitlement lookup.
+    RU: Manual RU/BY routes требуют transport-auth с канонического app-level validator;
+    fallback по env ключам здесь запрещён.
+    EN: Manual RU/BY routes require transport auth via the canonical app-level
+    validator; env-key fallback is forbidden on this path.
     """
     app_get_api_key = cast(Callable[[str], str] | None, _get_effective_app_get_api_key())
+    if callable(app_get_api_key):
+        return app_get_api_key
 
-    def _validate_manual_transport_key(api_key: str) -> str:
-        last_http_error: HTTPException | None = None
-        if callable(app_get_api_key):
-            try:
-                return app_get_api_key(api_key)
-            except HTTPException as exc:
-                last_http_error = exc
-
-        fallback_key = _resolve_manual_transport_key_fallback(api_key)
-        if fallback_key is not None:
-            return fallback_key
-        if last_http_error is not None:
-            raise last_http_error
+    def _reject_manual_transport_key(_: str) -> str:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid API Key")
 
-    return _validate_manual_transport_key
+    return _reject_manual_transport_key
 
 
 def _apple_operational_error_response(

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -37,6 +37,7 @@ from app.schemas.payments import (
     SubscriptionActivationResponse,
 )
 from app.services import payments_activation
+
 billing_router = APIRouter(prefix="/api/v1/billing", tags=["billing"])
 router = APIRouter(prefix="/api/v1/pro/payments", tags=["pro", "payments"])
 

--- a/docs/review/PR_1455_FIXED_MAPPING.md
+++ b/docs/review/PR_1455_FIXED_MAPPING.md
@@ -1,0 +1,46 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1455 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Bot and human review comments must be dispositioned here before they are resolved on GitHub.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1455#issuecomment-4270810071 -> 280ad0d27
+Disposition: FIXED
+Commit: 280ad0d27
+Evidence: `tests/test_payment_source_contract_api.py` adds strict manual RU/BY billing transport-auth coverage for missing app-level validator behavior; `python3 -m pytest -q tests/test_payment_source_contract_api.py` passes with 11 tests.
+Reason: Codecov reported 3 uncovered changed lines in `app/routers/billing.py`; the added regression coverage exercises the no-env-fallback validator path and preserves the public route-level 401 contract.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1455#issuecomment-4270744305
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit comment is a rate-limit/system wrapper and does not contain a concrete code or documentation defect request.
+Reason: Non-actionable bot system comment; no review thread or requested fix to resolve unless a later CodeRabbit review posts actionable findings.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1455#issuecomment-4270744865
+Disposition: NOT-A-BUG
+Evidence: Sourcery review-guide issue comment describes the PR diff and contains no actionable defect request.
+Reason: Informational bot guide only; no separate code change is required.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1455#pullrequestreview-4131602975
+Disposition: NOT-A-BUG
+Evidence: Sourcery review says the changes look great and includes no actionable inline findings.
+Reason: Approval-style bot review only; no separate fix was requested.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1455#pullrequestreview-4131613792
+Disposition: NOT-A-BUG
+Evidence: cubic identified no issues across the reviewed files.
+Reason: Informational approval-only bot review; no defect or follow-up required.
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+
+<!-- markdownlint-enable MD034 -->

--- a/tests/test_payment_source_contract_api.py
+++ b/tests/test_payment_source_contract_api.py
@@ -77,6 +77,55 @@ def test_manual_intent_rejects_env_configured_pro_key_without_app_validator_over
     assert session_response.status_code == 403
 
 
+def test_manual_intent_rejects_transport_key_when_app_validator_is_missing(
+    app: FastAPI,
+    pro_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app as app_module
+
+    original_get_api_key = app_module.get_api_key
+    original_override = app.dependency_overrides.pop(original_get_api_key, None)
+    monkeypatch.setattr(app_module, "get_api_key", None)
+
+    try:
+        with TestClient(app) as isolated_client:
+            response = isolated_client.post(
+                "/api/v1/pro/payments/ru-by/manual-intent",
+                headers=pro_headers,
+                json={
+                    "source": "swift_manual",
+                    "plan": "pro_monthly",
+                    "client_event_id": "evt-missing-app-validator",
+                    "external_txn_id": "missing-app-validator",
+                    "amount_minor": 1999,
+                    "currency": "RUB",
+                },
+            )
+    finally:
+        if original_override is not None:
+            app.dependency_overrides[original_get_api_key] = original_override
+
+    assert response.status_code == 401, response.text
+    assert response.json()["detail"] == "API key required for billing verification"
+
+
+def test_manual_billing_validator_fails_closed_when_app_validator_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.routers import billing
+
+    monkeypatch.setattr(billing, "_get_effective_app_get_api_key", lambda: None)
+
+    validator = billing._get_effective_manual_billing_key_validator()
+
+    with pytest.raises(HTTPException) as exc_info:
+        validator("env-configured-pro-key")
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Invalid API Key"
+
+
 def test_manual_intent_happy_path(
     client: TestClient,
     pro_headers: dict[str, str],

--- a/tests/test_payment_source_contract_api.py
+++ b/tests/test_payment_source_contract_api.py
@@ -38,7 +38,7 @@ def test_manual_intent_rejects_invalid_transport_key_behaviorally(
     assert response.json()["detail"] == "API key required for billing verification"
 
 
-def test_manual_intent_accepts_env_configured_pro_key_without_entitlement_in_db_mode(
+def test_manual_intent_rejects_env_configured_pro_key_without_app_validator_override(
     app: FastAPI,
     pro_headers: dict[str, str],
     monkeypatch: pytest.MonkeyPatch,
@@ -72,7 +72,8 @@ def test_manual_intent_accepts_env_configured_pro_key_without_entitlement_in_db_
         if original_override is not None:
             app.dependency_overrides[app_module.get_api_key] = original_override
 
-    assert response.status_code == 201, response.text
+    assert response.status_code == 401, response.text
+    assert response.json()["detail"] == "API key required for billing verification"
     assert session_response.status_code == 403
 
 


### PR DESCRIPTION
### Motivation

- Close an authorization bypass where manual RU/BY billing routes accepted PRO/VIP keys resolved from environment and could be used to reconcile or activate subscriptions without the canonical app-level API-key validator.

### Description

- Removed the env-key fallback path from the manual billing transport validator in `app/routers/billing.py`.
- Manual RU/BY routes now use the effective app-level API-key validator when present and fail closed when it is missing.
- Added focused regression coverage for the route-level missing-validator path and the raw fail-closed validator branch.

### Testing

- `python3 -m pytest -q tests/test_payment_source_contract_api.py` -> `11 passed`
- Commit hook on `280ad0d27` passed changed-file checks, including Black, Ruff, Bandit, and backend changed-file pytest.
- Full local blocking gates before merge: `pre-commit run --all-files`, `make verify`, and strict merge-readiness wrapper.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_1455_FIXED_MAPPING.md`

## Merge Readiness

- [ ] Current-head CI green for PR branch head
- [ ] Required checks complete with no pending jobs
- [ ] Strict merge-readiness wrapper passes
- [ ] No unresolved review threads or actionable bot comments remain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened billing API key validation to enforce stricter authentication checks and reject invalid credentials with `403 Invalid API Key` response.

* **Documentation**
  * Added review tracking documentation for resolution status and merge readiness checklist.

* **Tests**
  * Updated test suite to validate API key validation rejection behavior for billing endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->