### PR TITLE
fix(ci): classify root backend modules and providers as backend-shared

### DIFF
--- a/scripts/ci/ci_risk_profile.py
+++ b/scripts/ci/ci_risk_profile.py
@@ -31,6 +31,7 @@ BACKEND_SHARED_EXACT: tuple[str, ...] = (
     "Makefile",
     "constraints.txt",
     "legacy_app.py",
+    "llm.py",
     "mcp_pulseplate_server.py",
     "pyproject.toml",
     "pytest.ini",
@@ -38,10 +39,14 @@ BACKEND_SHARED_EXACT: tuple[str, ...] = (
     "requirements-ci-lite.txt",
     "requirements-dev.txt",
     "requirements.txt",
+    "secure_config.py",
+    "settings.py",
+    "signed_links.py",
 )
 BACKEND_SHARED_PREFIXES: tuple[str, ...] = (
     "app/",
     "core/",
+    "providers/",
     "scripts/ci/",
     "scripts/orchestration/",
     "tests/",

--- a/tests/test_ci_risk_profile.py
+++ b/tests/test_ci_risk_profile.py
@@ -189,6 +189,27 @@ def test_generic_backend_change_hits_route_contract_safety_group() -> None:
     assert profile.contract_risk_groups == ("route_contract_safety",)
 
 
+@pytest.mark.parametrize(
+    "changed_file",
+    [
+        "signed_links.py",
+        "settings.py",
+        "llm.py",
+        "providers/ollama.py",
+    ],
+)
+def test_root_and_provider_backend_surfaces_are_backend_shared(
+    changed_file: str,
+) -> None:
+    profile = risk_profile.build_risk_profile([changed_file])
+
+    assert profile.backend_shared is True
+    assert profile.run_backend_blocking is True
+    assert profile.run_security is True
+    assert profile.route_contract_safety is True
+    assert profile.contract_risk_groups == ("route_contract_safety",)
+
+
 def test_food_schema_change_hits_food_catalog_openapi_and_route_groups() -> None:
     profile = risk_profile.build_risk_profile(
         ["app/schemas/food.py"],


### PR DESCRIPTION
### Motivation
- The CI risk classifier omitted several backend-sensitive root modules and the `providers/` directory, which allowed PRs touching files like `signed_links.py`, `settings.py`, `llm.py`, and `providers/*` to skip backend-blocking and security jobs.
- CI workflow conditionals derive `run_backend_blocking`/`run_security` from the classifier, so the narrow path list represented a security/testing bypass risk. 

### Description
- Expanded `BACKEND_SHARED_EXACT` in `scripts/ci/ci_risk_profile.py` to include `llm.py`, `secure_config.py`, `settings.py`, and `signed_links.py` so root backend files are treated as backend-shared.
- Added `"providers/"` to `BACKEND_SHARED_PREFIXES` so provider implementations trigger backend/shared routing.
- Added a regression test in `tests/test_ci_risk_profile.py` that parameterizes `signed_links.py`, `settings.py`, `llm.py`, and `providers/ollama.py` to assert `backend_shared`, `run_backend_blocking`, and `run_security` are set.
- The change is conservative and only affects CI routing decisions; it does not alter runtime application behavior.

### Testing
- Ran the classifier directly with `python3 scripts/ci/ci_risk_profile.py --file signed_links.py --as-json`, `--file settings.py --as-json`, and `--file providers/ollama.py --as-json`, and each invocation returned `run_backend_blocking=true` and `run_security=true` (succeeded).
- Added unit-level regression coverage in `tests/test_ci_risk_profile.py`; these tests were added but local `pytest` execution in this environment failed due to missing test tooling (`pyenv`/`pytest` not installed), so full test execution is pending locally/CI.
- `pre-commit` and `make verify` were not executed here because the environment is missing `.venv` and `pre-commit`, so the canonical `make verify` bundle has not been run; CI is expected to run the full gates where the new tests should pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28904882c8333a0a6dc8d2a7a0c67)

## Summary by Sourcery

Ужесточить классификацию рисков в CI для файлов, связанных с backend, чтобы проверки, блокирующие backend, и проверки безопасности запускались при изменении чувствительных корневых модулей и реализаций провайдеров.

Bug Fixes:
- Считать корневые backend-модули, такие как llm.py, secure_config.py, settings.py и signed_links.py, общими для backend, чтобы связанные изменения вызывали запуск backend-джоб и джоб безопасности.
- Классифицировать файлы в директории providers/ как общие для backend, чтобы избежать обхода блокирующих backend и security-пайплайнов при изменениях провайдеров.

Tests:
- Добавить регрессионный тест, который гарантирует, что выбранные корневые backend-файлы и показательный файл провайдера классифицируются как общие для backend и запускают группы backend-blocking, security и route contract safety.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten CI risk classification for backend-related files to ensure backend-blocking and security checks run when sensitive root modules and provider implementations change.

Bug Fixes:
- Treat root backend modules such as llm.py, secure_config.py, settings.py, and signed_links.py as backend-shared so related changes trigger backend and security jobs.
- Classify files under the providers/ directory as backend-shared to avoid bypassing backend-blocking and security workflows on provider changes.

Tests:
- Add a regression test ensuring selected root backend files and a representative provider file are classified as backend-shared and trigger backend-blocking, security, and route contract safety groups.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a CI gap by classifying root backend modules and the `providers/` directory as backend-shared so backend-blocking and security jobs run when these files change. Prevents PRs from skipping critical backend/security checks.

- **Bug Fixes**
  - Added `llm.py`, `secure_config.py`, `settings.py`, and `signed_links.py` to `BACKEND_SHARED_EXACT`.
  - Added `providers/` to `BACKEND_SHARED_PREFIXES`.
  - Added a regression test to ensure these paths set `backend_shared`, `run_backend_blocking`, and `run_security`.

<sup>Written for commit 72056fe76338eb3306cd7ed9dbcd1d1d3b0c08d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

