### PR TITLE
fix(orchestration): prevent wiki_ingest symlink escapes outside corpus

### DIFF
--- a/docs/review/PR_1457_FIXED_MAPPING.md
+++ b/docs/review/PR_1457_FIXED_MAPPING.md
@@ -1,0 +1,52 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1457 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Bot and human review comments must be dispositioned here before they are resolved on GitHub.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1457#discussion_r3102830939 -> 957bbdbe04c09bc8017b0c472540eef1fde99539
+Disposition: FIXED
+Commit: 957bbdbe04c09bc8017b0c472540eef1fde99539
+Evidence: `scripts/orchestration/wiki_ingest.py` validates `index.md` and `log.md` with `_ensure_within_corpus` before writes, and `tests/test_wiki_ingest.py` covers symlink escapes for directory and leaf-file write sinks.
+Reason: cubic identified that `log` and `index` write targets were not contained. The fix validates those targets, resolves `corpus_base` inside the helper, and adds focused regression tests for `index.md`, `log.md`, `pages/<slug>.md`, and `raw/<sha>.md` symlink escapes.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1457#pullrequestreview-4131625616
+Disposition: NOT-A-BUG
+Evidence: The cubic aggregate review summarizes the inline finding mapped to `957bbdbe04c09bc8017b0c472540eef1fde99539` above.
+Reason: No separate actionable item remains outside the mapped inline discussion.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1457#pullrequestreview-4131613029 -> 957bbdbe04c09bc8017b0c472540eef1fde99539
+Disposition: FIXED
+Commit: 957bbdbe04c09bc8017b0c472540eef1fde99539
+Evidence: `_ensure_within_corpus` now resolves `corpus_base` internally before checking the resolved target path; stable terse error markers remain intentionally preserved for tests and CLI callers.
+Reason: Sourcery suggested making the helper robust to unresolved future base-path call sites. The implementation now does that without changing the established error marker contract.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1457#issuecomment-4270750134
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit reported a temporary review rate limit and finishing-touch options only; no concrete blocking defect was included in this aggregate comment.
+Reason: Informational bot status, not an actionable code review item.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1457#issuecomment-4270750888
+Disposition: NOT-A-BUG
+Evidence: Sourcery review guide summarizes the initial PR diff and does not add an actionable defect beyond the review-level suggestion and cubic inline issue already mapped above.
+Reason: Informational generated reviewer guide.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1457#issuecomment-4270817909
+Disposition: NOT-A-BUG
+Evidence: Codecov reported that all modified and coverable lines were covered by tests.
+Reason: Informational coverage report, not an actionable change request.
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1457_FIXED_MAPPING.md
+++ b/docs/review/PR_1457_FIXED_MAPPING.md
@@ -44,6 +44,8 @@ Reason: Informational coverage report, not an actionable change request.
 
 ## Merge Readiness
 
+- [x] Operator deferred full local `make verify`; GitHub current-head CI is the heavy signal for the full suite.
+- [x] Narrow local gates completed: preflight, agent consistency, targeted compile/tests, formatting/lint checks, `make validate-changed`, and `pre-commit run --all-files`.
 - [ ] Current-head CI green for PR branch head
 - [ ] Required checks complete (no pending jobs)
 - [ ] All review threads resolved on GitHub after disposition updates

--- a/scripts/orchestration/wiki_ingest.py
+++ b/scripts/orchestration/wiki_ingest.py
@@ -25,6 +25,7 @@ EXIT_USAGE: Final[int] = 2
 def _ensure_within_corpus(path: Path, *, corpus_base: Path, error: str) -> None:
     """Reject symlink/path escapes that resolve outside the corpus base."""
 
+    corpus_base = corpus_base.resolve()
     resolved = path.resolve(strict=False)
     try:
         resolved.relative_to(corpus_base)
@@ -72,8 +73,14 @@ def ingest_paths(
     corpus_base = layout["base"].resolve()
     layout["pages"].mkdir(parents=True, exist_ok=True)
     layout["raw"].mkdir(parents=True, exist_ok=True)
-    _ensure_within_corpus(layout["pages"], corpus_base=corpus_base, error="pages_path_outside_corpus")
+    _ensure_within_corpus(
+        layout["pages"], corpus_base=corpus_base, error="pages_path_outside_corpus"
+    )
     _ensure_within_corpus(layout["raw"], corpus_base=corpus_base, error="raw_path_outside_corpus")
+    _ensure_within_corpus(
+        layout["index"], corpus_base=corpus_base, error="index_path_outside_corpus"
+    )
+    _ensure_within_corpus(layout["log"], corpus_base=corpus_base, error="log_path_outside_corpus")
     slug_first_source: dict[str, str] = {}
 
     active_allowlist = allowlist
@@ -131,6 +138,9 @@ def ingest_paths(
         page_path.write_text(page_body, encoding="utf-8")
         written.append(slug)
 
+        _ensure_within_corpus(
+            layout["log"], corpus_base=corpus_base, error="log_path_outside_corpus"
+        )
         _append_log(
             layout["log"],
             f"{ingested_at} ingest corpus={corpus} slug={slug} hash={digest} path={rel.as_posix()}",
@@ -180,6 +190,9 @@ def ingest_paths(
             except (PermissionError, ValueError, OSError) as exc:
                 warnings.append(f"support_plane_skip:{slug}:{exc}")
 
+    _ensure_within_corpus(
+        layout["index"], corpus_base=corpus_base, error="index_path_outside_corpus"
+    )
     _rebuild_index(layout["pages"], layout["index"], corpus)
     return written, warnings
 

--- a/scripts/orchestration/wiki_ingest.py
+++ b/scripts/orchestration/wiki_ingest.py
@@ -22,6 +22,16 @@ EXIT_OK: Final[int] = 0
 EXIT_USAGE: Final[int] = 2
 
 
+def _ensure_within_corpus(path: Path, *, corpus_base: Path, error: str) -> None:
+    """Reject symlink/path escapes that resolve outside the corpus base."""
+
+    resolved = path.resolve(strict=False)
+    try:
+        resolved.relative_to(corpus_base)
+    except ValueError as exc:
+        raise ValueError(error) from exc
+
+
 def _append_log(log_path: Path, line: str) -> None:
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open("a", encoding="utf-8") as fh:
@@ -59,8 +69,11 @@ def ingest_paths(
     wiki_resolved = wiki_root.resolve()
     layout = wcs.corpus_layout(wcs.corpus_base(wiki_root, corpus))
     wcs.reject_if_under_canonical_docs(layout["base"], repo_root=repo_root)
+    corpus_base = layout["base"].resolve()
     layout["pages"].mkdir(parents=True, exist_ok=True)
     layout["raw"].mkdir(parents=True, exist_ok=True)
+    _ensure_within_corpus(layout["pages"], corpus_base=corpus_base, error="pages_path_outside_corpus")
+    _ensure_within_corpus(layout["raw"], corpus_base=corpus_base, error="raw_path_outside_corpus")
     slug_first_source: dict[str, str] = {}
 
     active_allowlist = allowlist
@@ -89,6 +102,7 @@ def ingest_paths(
         slug_first_source[slug] = rel_posix
         raw_name = f"{digest}.md"
         raw_path = layout["raw"] / raw_name
+        _ensure_within_corpus(raw_path, corpus_base=corpus_base, error="raw_path_outside_corpus")
         raw_path.write_bytes(data)
 
         ingested_at = wcs.utc_now_iso()
@@ -105,6 +119,7 @@ def ingest_paths(
             text = data.decode("utf-8", errors="replace")
             warnings.append(f"utf8_replace:{rel.as_posix()}")
         page_path = layout["pages"] / f"{slug}.md"
+        _ensure_within_corpus(page_path, corpus_base=corpus_base, error="pages_path_outside_corpus")
         if page_path.is_file():
             existing_meta, _ = wcs.parse_frontmatter(page_path.read_text(encoding="utf-8"))
             prior_src = existing_meta.get("source_rel_path")

--- a/tests/test_wiki_ingest.py
+++ b/tests/test_wiki_ingest.py
@@ -72,6 +72,34 @@ def test_ingest_rejects_wiki_root_under_canonical_docs(tmp_path: Path) -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("dirname", "match"),
+    [("pages", "pages_path_outside_corpus"), ("raw", "raw_path_outside_corpus")],
+)
+def test_ingest_rejects_symlink_escape_dirs(tmp_path: Path, dirname: str, match: str) -> None:
+    repo = tmp_path / "repo"
+    (repo / "docs").mkdir(parents=True)
+    src = repo / "docs" / "note.md"
+    src.write_text("hello", encoding="utf-8")
+    wiki_root = repo / "wiki"
+    corpus_base = wiki_root / "project_internal"
+    corpus_base.mkdir(parents=True)
+    escape = tmp_path / f"escape_{dirname}"
+    escape.mkdir(parents=True)
+    try:
+        (corpus_base / dirname).symlink_to(escape, target_is_directory=True)
+    except (NotImplementedError, OSError):
+        pytest.skip("symlink unsupported in this environment")
+    with pytest.raises(ValueError, match=match):
+        wiki_ingest.ingest_paths(
+            [src],
+            corpus="project_internal",
+            wiki_root=wiki_root,
+            repo_root=repo,
+            write_support_plane=False,
+        )
+
+
 def test_ingest_rejects_path_outside_repo(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/test_wiki_ingest.py
+++ b/tests/test_wiki_ingest.py
@@ -100,6 +100,87 @@ def test_ingest_rejects_symlink_escape_dirs(tmp_path: Path, dirname: str, match:
         )
 
 
+@pytest.mark.parametrize(
+    ("filename", "match"),
+    [("index.md", "index_path_outside_corpus"), ("log.md", "log_path_outside_corpus")],
+)
+def test_ingest_rejects_symlink_escape_files(tmp_path: Path, filename: str, match: str) -> None:
+    repo = tmp_path / "repo"
+    (repo / "docs").mkdir(parents=True)
+    src = repo / "docs" / "note.md"
+    src.write_text("hello", encoding="utf-8")
+    wiki_root = repo / "wiki"
+    corpus_base = wiki_root / "project_internal"
+    corpus_base.mkdir(parents=True)
+    escape = tmp_path / f"escape_{filename}"
+    escape.write_text("outside", encoding="utf-8")
+    try:
+        (corpus_base / filename).symlink_to(escape)
+    except (NotImplementedError, OSError):
+        pytest.skip("symlink unsupported in this environment")
+    with pytest.raises(ValueError, match=match):
+        wiki_ingest.ingest_paths(
+            [src],
+            corpus="project_internal",
+            wiki_root=wiki_root,
+            repo_root=repo,
+            write_support_plane=False,
+        )
+
+
+def test_ingest_rejects_page_leaf_symlink_escape(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "docs").mkdir(parents=True)
+    src = repo / "docs" / "note.md"
+    src.write_text("hello", encoding="utf-8")
+    wiki_root = repo / "wiki"
+    corpus_base = wiki_root / "project_internal"
+    pages = corpus_base / "pages"
+    pages.mkdir(parents=True)
+    outside = tmp_path / "outside_page.md"
+    outside.write_text("outside", encoding="utf-8")
+    try:
+        (pages / "docs.note.md").symlink_to(outside)
+    except (NotImplementedError, OSError):
+        pytest.skip("symlink unsupported in this environment")
+    with pytest.raises(ValueError, match="pages_path_outside_corpus"):
+        wiki_ingest.ingest_paths(
+            [src],
+            corpus="project_internal",
+            wiki_root=wiki_root,
+            repo_root=repo,
+            write_support_plane=False,
+        )
+    assert outside.read_text(encoding="utf-8") == "outside"
+
+
+def test_ingest_rejects_raw_leaf_symlink_escape(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "docs").mkdir(parents=True)
+    src = repo / "docs" / "note.md"
+    src.write_text("hello", encoding="utf-8")
+    wiki_root = repo / "wiki"
+    corpus_base = wiki_root / "project_internal"
+    raw = corpus_base / "raw"
+    raw.mkdir(parents=True)
+    digest = hashlib.sha256(b"hello").hexdigest()
+    outside = tmp_path / "outside_raw.md"
+    outside.write_text("outside", encoding="utf-8")
+    try:
+        (raw / f"{digest}.md").symlink_to(outside)
+    except (NotImplementedError, OSError):
+        pytest.skip("symlink unsupported in this environment")
+    with pytest.raises(ValueError, match="raw_path_outside_corpus"):
+        wiki_ingest.ingest_paths(
+            [src],
+            corpus="project_internal",
+            wiki_root=wiki_root,
+            repo_root=repo,
+            write_support_plane=False,
+        )
+    assert outside.read_text(encoding="utf-8") == "outside"
+
+
 def test_ingest_rejects_path_outside_repo(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
### Motivation
- The `wiki_ingest` workflow created and wrote into wiki corpus paths without fully enforcing that every write target remains inside the corpus base, allowing local symlinks to redirect writes outside the intended corpus.

### Description
- Add path-containment validation for `pages/`, `raw/`, per-file raw/page targets, `index.md`, and `log.md`.
- Resolve `corpus_base` inside `_ensure_within_corpus` so future call sites cannot pass an unresolved base accidentally.
- Add regression coverage for directory, leaf-file, index, and log symlink escapes.
- Add the canonical review disposition artifact for PR #1457.

### Testing
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 -m py_compile scripts/orchestration/wiki_ingest.py tests/test_wiki_ingest.py`
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pytest -q tests/test_wiki_ingest.py`
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/black --check scripts/orchestration/wiki_ingest.py tests/test_wiki_ingest.py`
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/ruff check scripts/orchestration/wiki_ingest.py tests/test_wiki_ingest.py`
- `make VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python validate-changed`
- `pre-commit run --all-files`
- `make verify` / `make diff-cov`: operator-deferred locally; GitHub current-head CI is the heavy signal.
- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1457 --body "$(...)"`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1457_FIXED_MAPPING.md`

## Merge Readiness (Mandatory)

- [ ] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups

- [x] Ledger item(s): None
- [x] GitHub issue(s): None
