### PR TITLE
fix(frontend): restore brace-expansion remediation for minimatch v3

### DIFF
--- a/docs/review/PR_1458_FIXED_MAPPING.md
+++ b/docs/review/PR_1458_FIXED_MAPPING.md
@@ -1,0 +1,22 @@
+# PR 1458 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1458#pullrequestreview-4131606211 -> e643760c7c51349fbded791b6ff141dd635bd4fc
+Disposition: FIXED
+Commit: e643760c7c51349fbded791b6ff141dd635bd4fc
+Evidence: `frontend/package.json:88-90` now applies the security override to `minimatch@3`, and local verification confirmed the legacy `minimatch@3.1.5` subtree resolves `brace-expansion@2.0.3` while modern `brace-expansion@5.0.5` trees remain intact via `npm ls minimatch brace-expansion --all`; targeted frontend validation also passed with `npm test -- --run src/api/__tests__/thin-client-guards.test.ts` and `npm run build`.
+
+## Merge Readiness
+
+- [ ] All required checks pass
+- [x] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green
+- [ ] `make verify` green
+- [x] Mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed
+- Scope: frontend dependency-security override lane for PR `#1458`, limited to the `minimatch@3 -> brace-expansion@2.0.3` mitigation and its canonical review-governance mapping.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5453,13 +5453,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -8142,17 +8135,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/minimist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,7 +86,7 @@
     "vitest": "^3.2.4"
   },
   "overrides": {
-    "minimatch@3.1.5": {
+    "minimatch@3": {
       "brace-expansion": "2.0.3"
     },
     "dompurify": "3.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,6 +86,9 @@
     "vitest": "^3.2.4"
   },
   "overrides": {
+    "minimatch@3.1.5": {
+      "brace-expansion": "2.0.3"
+    },
     "dompurify": "3.4.0",
     "path-to-regexp": "8.4.0"
   },


### PR DESCRIPTION
### Motivation
- A security scan flagged that the frontend override was too narrowly scoped to a single `minimatch@3.1.5` patch, which would require another manual follow-up if the legacy `3.x` subtree moved within that range.
- This PR keeps the mitigation focused on the legacy `minimatch@3` chain while preserving modern `brace-expansion@5.x` trees used by newer packages.

### Description
- Widened the frontend npm override from `minimatch@3.1.5 -> brace-expansion@2.0.3` to `minimatch@3 -> brace-expansion@2.0.3`.
- Kept the existing lockfile-safe dependency shape intact so the legacy `minimatch@3.1.5` subtree resolves `brace-expansion@2.0.3` and newer package trees continue to use modern `brace-expansion` releases.
- Added the canonical review-governance artifact at `docs/review/PR_1458_FIXED_MAPPING.md`.
- Modified files: `frontend/package.json`, `frontend/package-lock.json`, `docs/review/PR_1458_FIXED_MAPPING.md`.

### Testing
- Ran `python3 scripts/orchestration/check_preflight.py`.
- Ran `python3 scripts/orchestration/check_agent_consistency.py`.
- Ran `npx -y -p node@22.22.1 -c 'cd frontend && npm install --package-lock-only --ignore-scripts'`.
- Ran `npx -y -p node@22.22.1 -c 'cd frontend && npm ci'`.
- Ran `npx -y -p node@22.22.1 -c 'cd frontend && npm ls minimatch brace-expansion --all'` and confirmed the `minimatch@3.1.5` subtree resolves `brace-expansion@2.0.3` while modern `brace-expansion@5.0.5` trees remain intact.
- Ran `npx -y -p node@22.22.1 -c 'cd frontend && npm test -- --run src/api/__tests__/thin-client-guards.test.ts'`.
- Ran `npx -y -p node@22.22.1 -c 'cd frontend && npm run build'`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1458#pullrequestreview-4131606211 -> e643760c7c51349fbded791b6ff141dd635bd4fc

## Merge Readiness
- [ ] All required checks pass
- [ ] No actionable bot comments remain
- [ ] Pre-commit green
- [ ] `make verify` green
- [x] Mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed
