### PR TITLE
fix(frontend): resolve WebSocket base URL when VITE_API_BASE is relative

### DIFF
--- a/docs/review/PR_1459_FIXED_MAPPING.md
+++ b/docs/review/PR_1459_FIXED_MAPPING.md
@@ -1,0 +1,46 @@
+# PR #1459 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+This artifact is created immediately after the PR is opened per repo governance.
+Record every actionable human/bot disposition here before resolving threads on GitHub.
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 34429eb5c
+Evidence: `frontend/src/api/wsClient.ts:24`; `frontend/src/api/__tests__/wsClient.test.ts:59`
+Reason: The follow-up commit adds a fail-closed empty-base guard and a matching regression test on the same PR branch head, satisfying both live Sourcery inline findings with post-comment proof.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1459#discussion_r3102820122 -> 34429eb5c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1459#discussion_r3102820133 -> 34429eb5c
+
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1459_FIXED_MAPPING.md:16`
+Reason: The Sourcery review shell is an aggregate wrapper around the two inline review threads mapped immediately above, so it adds no separate unresolved obligation once those thread-level fixes are recorded.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1459#pullrequestreview-4131612862
+
+## Merge Readiness
+
+- [ ] Current-head CI is green for PR branch head
+  Evidence: current-head GitHub checks after the latest push.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: `gh pr checks 1459 --repo Katsiarynakavaleuskaya/PulsePlate`.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: GraphQL `reviewThreads` for PR `#1459`.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: `python3 scripts/orchestration/check_merge_ready.py --pr-number 1459 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`.
+- [ ] Pre-commit green on latest pushed head
+  Evidence: local `pre-commit run --all-files`.
+- [ ] `make verify` green on latest pushed head
+  Evidence: local `make verify`.
+
+## Deferred / Follow-ups
+
+- None for this narrow PR lane.

--- a/frontend/src/api/__tests__/wsClient.test.ts
+++ b/frontend/src/api/__tests__/wsClient.test.ts
@@ -44,6 +44,18 @@ describe("wsClient", (): void => {
     expect(buildRealtimeWsUrl("/api/v1/pro/ws", "abc123")).toBe("ws://localhost:8000/api/v1/pro/ws?token=abc123");
   });
 
+  it("buildRealtimeWsUrl resolves origin-relative API base against current origin", (): void => {
+    const deps: ApiClientDependencies = {
+      getStoredApiKey: (): string | null => null,
+      clearStoredApiKey: (): void => undefined,
+      apiBase: "/api/v1",
+    };
+    setApiClientDependencies(deps);
+    vi.stubGlobal("window", { location: { origin: "https://staging.example" } });
+
+    expect(buildRealtimeWsUrl("/api/v1/pro/ws")).toBe("wss://staging.example/api/v1/pro/ws");
+  });
+
   it("connectRealtimeWs emits state transitions and parses messages", (): void => {
     const deps: ApiClientDependencies = {
       getStoredApiKey: (): string | null => null,

--- a/frontend/src/api/__tests__/wsClient.test.ts
+++ b/frontend/src/api/__tests__/wsClient.test.ts
@@ -56,6 +56,17 @@ describe("wsClient", (): void => {
     expect(buildRealtimeWsUrl("/api/v1/pro/ws")).toBe("wss://staging.example/api/v1/pro/ws");
   });
 
+  it("buildRealtimeWsUrl rejects empty API base after trimming", (): void => {
+    const deps: ApiClientDependencies = {
+      getStoredApiKey: (): string | null => null,
+      clearStoredApiKey: (): void => undefined,
+      apiBase: "   ",
+    };
+    setApiClientDependencies(deps);
+
+    expect(() => buildRealtimeWsUrl("/api/v1/pro/ws")).toThrow("VITE_API_BASE must not be empty");
+  });
+
   it("connectRealtimeWs emits state transitions and parses messages", (): void => {
     const deps: ApiClientDependencies = {
       getStoredApiKey: (): string | null => null,

--- a/frontend/src/api/wsClient.ts
+++ b/frontend/src/api/wsClient.ts
@@ -23,6 +23,9 @@ const DEFAULT_WS_PATH = "/api/v1/pro/ws";
 
 function toWsBaseUrl(apiBase: string): string {
   const trimmedBase = apiBase.trim();
+  if (!trimmedBase) {
+    throw new Error("VITE_API_BASE must not be empty");
+  }
   const origin =
     typeof window !== "undefined" && window.location?.origin
       ? window.location.origin

--- a/frontend/src/api/wsClient.ts
+++ b/frontend/src/api/wsClient.ts
@@ -22,7 +22,12 @@ const DEFAULT_WS_PATH = "/api/v1/pro/ws";
 // Legacy path "/ws" is deprecated; migrate to canonical PRO namespace
 
 function toWsBaseUrl(apiBase: string): string {
-  const parsed = new URL(apiBase);
+  const trimmedBase = apiBase.trim();
+  const origin =
+    typeof window !== "undefined" && window.location?.origin
+      ? window.location.origin
+      : "http://localhost";
+  const parsed = new URL(trimmedBase, `${origin}/`);
   const protocol = parsed.protocol === "https:" ? "wss:" : "ws:";
   return `${protocol}//${parsed.host}`;
 }


### PR DESCRIPTION
### Motivation
- `frontend/src/api/wsClient.ts` must support origin-relative `VITE_API_BASE` values such as `/api/v1` for same-origin SPA deployments.
- The initial PR head still allowed an empty or whitespace-only API base to collapse into the current origin, which could hide configuration errors.
- PR governance was incomplete: the canonical review mapping artifact and Phase 2 mirror were missing.

### Description
- Preserve the original PR scope: resolve origin-relative API bases against `window.location.origin` while keeping existing `http -> ws` and `https -> wss` behavior.
- Add a fail-closed guard for empty or whitespace-only API bases in `toWsBaseUrl()`.
- Add regression coverage for the empty-base guard and keep the existing test-global cleanup in `wsClient.test.ts`.
- Add the canonical review-governance artifact at `docs/review/PR_1459_FIXED_MAPPING.md`.

### Testing
- `npm --prefix frontend run test -- --run src/api/__tests__/wsClient.test.ts`
- `npm --prefix frontend run test -- --run src/api/__tests__/client.normalizeUrl.test.ts`
- `npm --prefix frontend run build`
- `pre-commit run --all-files`
- `make verify` equivalent local bundle:
  - `make verify-env`
  - `make lint`
  - `make typecheck`
  - `make test-fast`
  - full `coverage run -m pytest` + `coverage xml` + `diff_cover.diff_cover_tool coverage.xml --compare-branch=origin/main --fail-under=97`
- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1459`
- `python3 scripts/orchestration/check_merge_ready.py --pr-number 1459 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1459_FIXED_MAPPING.md`

## Merge Readiness
- [x] Current-head CI is green for PR branch head
- [x] Required checks complete (no pending jobs)
- [x] All review threads resolved on GitHub after disposition updates
- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green on latest pushed head
- [x] Local verify bundle green on latest pushed head

## Deferred / Follow-ups
- None for this narrow PR lane.
