### PR TITLE
fix(ci): classify root backend modules and providers as backend-shared

### DIFF
--- a/docs/review/PR_1460_FIXED_MAPPING.md
+++ b/docs/review/PR_1460_FIXED_MAPPING.md
@@ -26,6 +26,11 @@ Evidence: `AGENTS.md:1-16`, `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX
 Reason: The CodeRabbit walkthrough comment includes a docstring-coverage warning, but this repo's merge gate is the canonical `pre-commit` plus `make verify` contract on the current head; docstring coverage is not an additional required gate for this CI-risk-profile lane.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1460#issuecomment-4270971648
 
+Disposition: FIXED
+Commit: ce041eb86
+Evidence: `tests/test_ci_risk_profile.py:192`, `tests/test_ci_risk_profile.py:201`, `tests/test_ci_risk_profile.py:210`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1460#pullrequestreview-4132048646 -> ce041eb86
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/review/PR_1460_FIXED_MAPPING.md
+++ b/docs/review/PR_1460_FIXED_MAPPING.md
@@ -18,7 +18,7 @@ comments can be dispositioned here before any thread resolution.
 
 Disposition: FIXED
 Commit: 3818b0eb0
-Evidence: `scripts/ci/ci_risk_profile.py:31`, `scripts/ci/ci_risk_profile.py:42`, `tests/test_ci_risk_profile.py:73`
+Evidence: `scripts/ci/ci_risk_profile.py:31`, `scripts/ci/ci_risk_profile.py:42`, `tests/test_ci_risk_profile.py:210`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1460#pullrequestreview-4131985967 -> 3818b0eb0
 
 Disposition: NOT-A-BUG
@@ -30,6 +30,7 @@ Disposition: FIXED
 Commit: ce041eb86
 Evidence: `tests/test_ci_risk_profile.py:192`, `tests/test_ci_risk_profile.py:201`, `tests/test_ci_risk_profile.py:210`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1460#pullrequestreview-4132048646 -> ce041eb86
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1460#discussion_r3103204062 -> ce041eb86
 
 ## Merge Readiness
 

--- a/docs/review/PR_1460_FIXED_MAPPING.md
+++ b/docs/review/PR_1460_FIXED_MAPPING.md
@@ -1,0 +1,41 @@
+<!-- markdownlint-disable MD034 -->
+# PR #1460 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+This replacement PR supersedes `#1456` from a fresh `origin/main` worktree.
+The canonical mapping file is created immediately so all future human/bot
+comments can be dispositioned here before any thread resolution.
+
+## Fixed in Commit Mapping
+
+No actionable review threads exist on PR `#1460` yet.
+Update this section with one entry per actionable comment as soon as review
+starts, using `FIXED`, `NOT-A-BUG`, or `DEFERRED` with required proof.
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+  Evidence: `AGENTS.md:42-49`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:95-112`.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: `AGENTS.md:46-49`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:155-163`.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: `AGENTS.md:43-45`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:95-112`.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: `AGENTS.md:44-45`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:95-112`.
+- [ ] Pre-commit green on latest pushed head
+  Evidence: `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:175-180`.
+- [ ] `make verify` green on latest pushed head
+  Evidence: `AGENTS.md:1-16`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:175-180`.
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1460_FIXED_MAPPING.md
+++ b/docs/review/PR_1460_FIXED_MAPPING.md
@@ -16,7 +16,15 @@ comments can be dispositioned here before any thread resolution.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 3818b0eb0
+Evidence: `scripts/ci/ci_risk_profile.py:31`, `scripts/ci/ci_risk_profile.py:42`, `tests/test_ci_risk_profile.py:73`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1460#pullrequestreview-4131985967 -> 3818b0eb0
+
+Disposition: NOT-A-BUG
+Evidence: `AGENTS.md:1-16`, `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:175-180`
+Reason: The CodeRabbit walkthrough comment includes a docstring-coverage warning, but this repo's merge gate is the canonical `pre-commit` plus `make verify` contract on the current head; docstring coverage is not an additional required gate for this CI-risk-profile lane.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1460#issuecomment-4270971648
 
 ## Merge Readiness
 

--- a/docs/review/PR_1460_FIXED_MAPPING.md
+++ b/docs/review/PR_1460_FIXED_MAPPING.md
@@ -7,8 +7,8 @@ Canonical review-governance artifact and PR-body mirror requirements:
 `AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
 `docs/orchestration/AGENTS.md:79-82`.
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 This replacement PR supersedes `#1456` from a fresh `origin/main` worktree.
 The canonical mapping file is created immediately so all future human/bot
@@ -16,9 +16,7 @@ comments can be dispositioned here before any thread resolution.
 
 ## Fixed in Commit Mapping
 
-No actionable review threads exist on PR `#1460` yet.
-Update this section with one entry per actionable comment as soon as review
-starts, using `FIXED`, `NOT-A-BUG`, or `DEFERRED` with required proof.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/scripts/ci/ci_risk_profile.py
+++ b/scripts/ci/ci_risk_profile.py
@@ -31,6 +31,7 @@ BACKEND_SHARED_EXACT: tuple[str, ...] = (
     "Makefile",
     "constraints.txt",
     "legacy_app.py",
+    "llm.py",
     "mcp_pulseplate_server.py",
     "pyproject.toml",
     "pytest.ini",
@@ -38,10 +39,14 @@ BACKEND_SHARED_EXACT: tuple[str, ...] = (
     "requirements-ci-lite.txt",
     "requirements-dev.txt",
     "requirements.txt",
+    "secure_config.py",
+    "settings.py",
+    "signed_links.py",
 )
 BACKEND_SHARED_PREFIXES: tuple[str, ...] = (
     "app/",
     "core/",
+    "providers/",
     "scripts/ci/",
     "scripts/orchestration/",
     "tests/",

--- a/scripts/ci/ci_risk_profile.py
+++ b/scripts/ci/ci_risk_profile.py
@@ -28,13 +28,20 @@ ALL_RISK_GROUPS: tuple[str, ...] = (
 
 # Root-level backend modules that influence shared runtime or security posture
 # must route through backend-blocking CI even when they do not live under app/core.
+ROOT_BACKEND_SHARED_MODULES: tuple[str, ...] = (
+    "llm.py",
+    "main.py",
+    "secure_config.py",
+    "settings.py",
+    "signed_links.py",
+)
+
 BACKEND_SHARED_EXACT: tuple[str, ...] = (
     "Dockerfile",
     "Makefile",
     "constraints.txt",
     "legacy_app.py",
-    "llm.py",
-    "main.py",
+    *ROOT_BACKEND_SHARED_MODULES,
     "mcp_pulseplate_server.py",
     "pyproject.toml",
     "pytest.ini",
@@ -42,10 +49,9 @@ BACKEND_SHARED_EXACT: tuple[str, ...] = (
     "requirements-ci-lite.txt",
     "requirements-dev.txt",
     "requirements.txt",
-    "secure_config.py",
-    "settings.py",
-    "signed_links.py",
 )
+# Provider implementations can change auth, network, or model routing behavior,
+# so provider-path changes always go through backend-blocking and security CI.
 BACKEND_SHARED_PREFIXES: tuple[str, ...] = (
     "app/",
     "core/",

--- a/scripts/ci/ci_risk_profile.py
+++ b/scripts/ci/ci_risk_profile.py
@@ -34,6 +34,7 @@ BACKEND_SHARED_EXACT: tuple[str, ...] = (
     "constraints.txt",
     "legacy_app.py",
     "llm.py",
+    "main.py",
     "mcp_pulseplate_server.py",
     "pyproject.toml",
     "pytest.ini",

--- a/scripts/ci/ci_risk_profile.py
+++ b/scripts/ci/ci_risk_profile.py
@@ -26,6 +26,8 @@ ALL_RISK_GROUPS: tuple[str, ...] = (
     "merge_governance",
 )
 
+# Root-level backend modules that influence shared runtime or security posture
+# must route through backend-blocking CI even when they do not live under app/core.
 BACKEND_SHARED_EXACT: tuple[str, ...] = (
     "Dockerfile",
     "Makefile",

--- a/tests/test_ci_risk_profile.py
+++ b/tests/test_ci_risk_profile.py
@@ -191,14 +191,7 @@ def test_generic_backend_change_hits_route_contract_safety_group() -> None:
 
 @pytest.mark.parametrize(
     "changed_file",
-    [
-        "signed_links.py",
-        "settings.py",
-        "llm.py",
-        "main.py",
-        "secure_config.py",
-        "providers/ollama.py",
-    ],
+    [*risk_profile.ROOT_BACKEND_SHARED_MODULES, "providers/ollama.py"],
 )
 def test_root_and_provider_backend_surfaces_are_backend_shared(
     changed_file: str,

--- a/tests/test_ci_risk_profile.py
+++ b/tests/test_ci_risk_profile.py
@@ -189,9 +189,24 @@ def test_generic_backend_change_hits_route_contract_safety_group() -> None:
     assert profile.contract_risk_groups == ("route_contract_safety",)
 
 
+EXPECTED_ROOT_BACKEND_SHARED_MODULES = (
+    "llm.py",
+    "main.py",
+    "secure_config.py",
+    "settings.py",
+    "signed_links.py",
+)
+
+
+def test_root_backend_shared_module_contract_matches_classifier_constant() -> None:
+    # Keep an explicit oracle here so membership regressions fail
+    # even if the production constant changes.
+    assert risk_profile.ROOT_BACKEND_SHARED_MODULES == EXPECTED_ROOT_BACKEND_SHARED_MODULES
+
+
 @pytest.mark.parametrize(
     "changed_file",
-    [*risk_profile.ROOT_BACKEND_SHARED_MODULES, "providers/ollama.py"],
+    [*EXPECTED_ROOT_BACKEND_SHARED_MODULES, "providers/ollama.py"],
 )
 def test_root_and_provider_backend_surfaces_are_backend_shared(
     changed_file: str,

--- a/tests/test_ci_risk_profile.py
+++ b/tests/test_ci_risk_profile.py
@@ -189,6 +189,27 @@ def test_generic_backend_change_hits_route_contract_safety_group() -> None:
     assert profile.contract_risk_groups == ("route_contract_safety",)
 
 
+@pytest.mark.parametrize(
+    "changed_file",
+    [
+        "signed_links.py",
+        "settings.py",
+        "llm.py",
+        "providers/ollama.py",
+    ],
+)
+def test_root_and_provider_backend_surfaces_are_backend_shared(
+    changed_file: str,
+) -> None:
+    profile = risk_profile.build_risk_profile([changed_file])
+
+    assert profile.backend_shared is True
+    assert profile.run_backend_blocking is True
+    assert profile.run_security is True
+    assert profile.route_contract_safety is True
+    assert profile.contract_risk_groups == ("route_contract_safety",)
+
+
 def test_food_schema_change_hits_food_catalog_openapi_and_route_groups() -> None:
     profile = risk_profile.build_risk_profile(
         ["app/schemas/food.py"],

--- a/tests/test_ci_risk_profile.py
+++ b/tests/test_ci_risk_profile.py
@@ -195,6 +195,8 @@ def test_generic_backend_change_hits_route_contract_safety_group() -> None:
         "signed_links.py",
         "settings.py",
         "llm.py",
+        "main.py",
+        "secure_config.py",
         "providers/ollama.py",
     ],
 )

--- a/tests/test_ci_risk_profile.py
+++ b/tests/test_ci_risk_profile.py
@@ -206,8 +206,8 @@ def test_root_and_provider_backend_surfaces_are_backend_shared(
     assert profile.backend_shared is True
     assert profile.run_backend_blocking is True
     assert profile.run_security is True
-    assert profile.route_contract_safety is True
-    assert profile.contract_risk_groups == ("route_contract_safety",)
+    assert profile.route_contract_safety is False
+    assert profile.contract_risk_groups == ()
 
 
 def test_food_schema_change_hits_food_catalog_openapi_and_route_groups() -> None:


### PR DESCRIPTION
## Summary
- supersedes #1456 from a fresh `origin/main` worktree because the original PR drifted and mixed a valid backend-shared routing fix with an invalid `route_contract_safety` test expectation
- keeps the intended CI-routing hardening for root backend modules and `providers/`
- narrows regression coverage to the backend-shared / backend-blocking / security outputs that this slice actually guarantees on current `main`

## Why Replacement
- old PR `#1456` is `UNSTABLE` and fails current-head CI
- live triage showed the old test was asserting `route_contract_safety=True` for root/provider paths even though current classifier semantics only grant that to `legacy_app.py`, `app/**`, and `core/**`
- replacement from fresh `origin/main` is lower-risk than reviving the stale branch in place

## Testing
- targeted classifier repro on fresh branch for `settings.py`, `signed_links.py`, `llm.py`, and `providers/ollama.py`
- `pytest -q tests/test_ci_risk_profile.py -k "root_and_provider_backend_surfaces_are_backend_shared or generic_backend_change_hits_route_contract_safety_group"`
- `pre-commit run --all-files`
- `make verify` (in progress / to be recorded before merge-ready claim)

## Carryover
- Supersedes #1456 after drift on the original branch.

## Deferred / Follow-ups
- None.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- Canonical artifact: `docs/review/PR_1460_FIXED_MAPPING.md`

### Fixed in Commit Mapping
- No actionable review comments

## Merge Readiness
- [ ] Current-head CI is green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Pre-commit green on latest pushed head
- [ ] `make verify` green on latest pushed head

## Summary by Sourcery

Классифицировать определённые корневые backend-модули и файлы провайдеров как backend-shared в профиле рисков CI, а также добавить регрессионные тесты и документацию по governance для принудительного обеспечения такого маршрутизирующего поведения.

Bug Fixes:
- Гарантировать, что изменения ключевых корневых backend-модулей и файлов провайдеров стабильно запускают проверки CI для backend-shared, backend-blocking и security, не делая при этом некорректных предположений о безопасности контрактов маршрутов.

Enhancements:
- Расширить списки классификации CI backend-shared, чтобы охватить дополнительные корневые backend-модули и дерево `providers/`.

Documentation:
- Добавить каноничный документ Fixed in Commit Mapping для PR #1460 с описанием требований к статусу ревью и готовности к слиянию.

Tests:
- Добавить параметризованные тесты, проверяющие, что выбранные корневые backend- и provider-«поверхности» обрабатываются как backend-shared без присоединения к группам безопасности контрактов маршрутов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Classify specific root-level backend modules and provider files as backend-shared in the CI risk profile and add regression tests and governance docs to enforce this routing behavior.

Bug Fixes:
- Ensure changes to key root backend modules and provider files consistently trigger backend-shared, backend-blocking, and security CI checks without incorrectly asserting route contract safety.

Enhancements:
- Expand CI backend-shared classification lists to cover additional root backend modules and the providers/ tree.

Documentation:
- Add a canonical Fixed in Commit Mapping document for PR #1460 describing review status and merge readiness requirements.

Tests:
- Add parametrized tests verifying that selected root backend and provider surfaces are treated as backend-shared without joining route contract safety groups.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a canonical review/merge-readiness document to centralize PR discussion disposition, evidence, and a merge checklist.

* **Chores**
  * Broadened backend/shared change detection to treat additional backend modules and provider code as higher-risk, triggering stricter CI/security checks.

* **Tests**
  * Added tests to validate the updated risk-profile classification and ensure expected CI flags for those files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->