### PR TITLE
feat(analytics): add planning paywall exposure ledger

### DIFF
--- a/docs/analytics/METRICS_CATALOG.md
+++ b/docs/analytics/METRICS_CATALOG.md
@@ -837,7 +837,7 @@ treated as emitted runtime telemetry yet.
 Planning paywall ledger note:
 - Hidden first-party paywall ledger payloads may decorate these funnel families with planning-specific `source_surface` / `trigger_reason` pairs without renaming the canonical growth-event families above.
 - Planning vocabulary currently reserved for runtime wiring:
-  - `bmi_soft_paywall` / `post_bmi_result`
+  - `bmi_soft_paywall` / `post_bmi`
   - `pro_daily_plate` / `targets_ready`
 
 ### Base payload (optional on all events)

--- a/docs/analytics/METRICS_CATALOG.md
+++ b/docs/analytics/METRICS_CATALOG.md
@@ -834,6 +834,12 @@ treated as emitted runtime telemetry yet.
 | vip_gate_interacted | featureName, interactionType, isVip | Gate interaction |
 | vip_badge_viewed | component, variant, isVip | Badge/upsell component view |
 
+Planning paywall ledger note:
+- Hidden first-party paywall ledger payloads may decorate these funnel families with planning-specific `source_surface` / `trigger_reason` pairs without renaming the canonical growth-event families above.
+- Planning vocabulary currently reserved for runtime wiring:
+  - `bmi_soft_paywall` / `post_bmi_result`
+  - `pro_daily_plate` / `targets_ready`
+
 ### Base payload (optional on all events)
 
 - timestamp (number)

--- a/docs/analytics/METRICS_CATALOG.md
+++ b/docs/analytics/METRICS_CATALOG.md
@@ -835,10 +835,10 @@ treated as emitted runtime telemetry yet.
 | vip_badge_viewed | component, variant, isVip | Badge/upsell component view |
 
 Planning paywall ledger note:
-- Hidden first-party paywall ledger payloads may decorate these funnel families with planning-specific `source_surface` / `trigger_reason` pairs without renaming the canonical growth-event families above.
-- Planning vocabulary currently reserved for runtime wiring:
-  - `bmi_soft_paywall` / `post_bmi`
-  - `pro_daily_plate` / `targets_ready`
+- Hidden first-party paywall ledger payloads may decorate these funnel families with planning-specific `source_surface` / `trigger_reason` pairs without renaming the canonical growth-event families above (see `app/routers/paywall_analytics.py:140`, `app/models/paywall_analytics.py:18`).
+- Planning vocabulary wired for this lane:
+  - `bmi_soft_paywall` / `post_bmi` (see `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:9`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:10`, `app/schemas/intervention.py:12`)
+  - `pro_daily_plate` / `targets_ready` (see `app/services/intervention_trigger_engine.py:41`, `app/services/intervention_trigger_engine.py:43`, `app/schemas/intervention.py:11`, `app/schemas/intervention.py:12`)
 
 ### Base payload (optional on all events)
 

--- a/docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md
+++ b/docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md
@@ -55,7 +55,9 @@ This wave is intentionally not:
 - PR `#1296` merged on `2026-04-02` (`America/New_York`) and closed the activation/subscription persistence baseline.
 - PR `#1312` merged on `2026-04-03` (`America/New_York`) and landed App Store pricing-truth governance.
 - PR `#1381` merged on `2026-04-09` (`America/New_York`) and moved web premium truth to canonical backend/store session state.
-- Local `main` is synced to `origin/main` at `6096c1a35` before this wave starts.
+- PR `#1416` merged on `2026-04-15` (`America/New_York`) and landed the general paywall exposure ledger foundation (`app/schemas/paywall_analytics.py`, `app/routers/paywall_analytics.py`, `app/services/paywall_exposure_ledger.py`).
+- PR `#1434` merged on `2026-04-17` (`America/New_York`) and landed intervention trigger engine v1 as the current execution baseline for PR-2.
+- Execution-time `main` baseline for PR-2 is synced to `origin/main` at `7bf5d8819e33b40b35cef1aac7c7fcc76c32229f`.
 
 ## PR Series
 
@@ -87,10 +89,20 @@ This wave is intentionally not:
 - Worktree: `worktrees/monetization_planning_pr2`
 - Branch: `feat/planning-paywall-exposure-ledger`
 - Scope:
-  - add deterministic exposure events (`shown`, `dismissed`, `cta_clicked`,
-    `upgrade_started`, `upgrade_completed`) aligned to analytics docs canon.
+  - planning-specific wiring/taxonomy on top of the already-merged ledger foundation from PR `#1416`,
+  - keep the hidden route `/api/v1/internal/paywall/events`,
+  - keep the canonical event set unchanged:
+    - `shown`
+    - `dismissed`
+    - `cta_clicked`
+    - `upgrade_started`
+    - `upgrade_completed`,
+  - align concrete planning surfaces only:
+    - BMI -> PRO targets: `source_surface=bmi_soft_paywall`, `trigger_reason=post_bmi_result`
+    - targets -> daily plate: `source_surface=pro_daily_plate`, `trigger_reason=targets_ready`
 - Hard boundary:
   - no vendor SDK rollout, no checkout semantics change, no pricing-truth change.
+  - no widening of client/server event authority split.
 
 ### PR-3: Consume `next_best_action` Hints
 
@@ -127,6 +139,16 @@ Do not start these until PR-3 is merged and `main` is stable:
 3. `backend-engineer`
 4. `security-auditor`
 
+### PR-2 pre-open role order
+
+1. `agent-coordinator`
+2. `backend-engineer`
+3. `frontend-engineer`
+4. `security-auditor`
+5. `qa-engineer-agent`
+6. `bug-hunter`
+7. `agent-coordinator`
+
 ### Mandatory post-open review lane
 
 - `qa-engineer-agent -> bug-hunter -> agent-coordinator`
@@ -150,6 +172,7 @@ Do not start these until PR-3 is merged and `main` is stable:
    - intervention trigger engine is deterministic and fail-closed,
    - BMI / targets / weekly plan responses remain additive only.
 3. **PR-2 analytics seam**
+   - planning-surface ledger wiring reuses the merged PR `#1416` foundation,
    - exposure ledger event naming matches analytics canon,
    - no fake checkout or pricing truth enters the runtime.
 4. **PR-3 client consumption**

--- a/docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md
+++ b/docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md
@@ -98,7 +98,7 @@ This wave is intentionally not:
     - `upgrade_started`
     - `upgrade_completed`,
   - align concrete planning surfaces only:
-    - BMI -> PRO targets: `source_surface=bmi_soft_paywall`, `trigger_reason=post_bmi_result`
+    - BMI -> PRO targets: `source_surface=bmi_soft_paywall`, `trigger_reason=post_bmi`
     - targets -> daily plate: `source_surface=pro_daily_plate`, `trigger_reason=targets_ready`
 - Hard boundary:
   - no vendor SDK rollout, no checkout semantics change, no pricing-truth change.

--- a/docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md
+++ b/docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md
@@ -91,7 +91,7 @@ This wave is intentionally not:
 - Scope:
   - planning-specific wiring/taxonomy on top of the already-merged ledger foundation from PR `#1416`,
   - keep the hidden route `/api/v1/internal/paywall/events`,
-  - keep the canonical event set unchanged:
+  - keep the canonical event set unchanged (see `app/schemas/paywall_analytics.py:36`, `app/schemas/paywall_analytics.py:41`):
     - `shown`
     - `dismissed`
     - `cta_clicked`

--- a/docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md
+++ b/docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md
@@ -90,7 +90,7 @@ This wave is intentionally not:
 - Branch: `feat/planning-paywall-exposure-ledger`
 - Scope:
   - planning-specific wiring/taxonomy on top of the already-merged ledger foundation from PR `#1416`,
-  - keep the hidden route `/api/v1/internal/paywall/events`,
+  - keep the hidden route `/api/v1/internal/paywall/events` (see `app/main.py:48`, `app/main.py:205`),
   - keep the canonical event set unchanged (see `app/schemas/paywall_analytics.py:36`, `app/schemas/paywall_analytics.py:41`):
     - `shown`
     - `dismissed`
@@ -98,8 +98,8 @@ This wave is intentionally not:
     - `upgrade_started`
     - `upgrade_completed`,
   - align concrete planning surfaces only:
-    - BMI -> PRO targets: `source_surface=bmi_soft_paywall`, `trigger_reason=post_bmi`
-    - targets -> daily plate: `source_surface=pro_daily_plate`, `trigger_reason=targets_ready`
+    - BMI -> PRO targets: `source_surface=bmi_soft_paywall`, `trigger_reason=post_bmi` (see `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:9`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:10`, `app/schemas/intervention.py:12`)
+    - targets -> daily plate: `source_surface=pro_daily_plate`, `trigger_reason=targets_ready` (see `app/services/intervention_trigger_engine.py:41`, `app/services/intervention_trigger_engine.py:43`, `app/schemas/intervention.py:11`, `app/schemas/intervention.py:12`)
 - Hard boundary:
   - no vendor SDK rollout, no checkout semantics change, no pricing-truth change.
   - no widening of client/server event authority split.

--- a/docs/orchestration/MONETIZATION_PLANNING_WAVE_TASK_PACKET_2026-04-13.md
+++ b/docs/orchestration/MONETIZATION_PLANNING_WAVE_TASK_PACKET_2026-04-13.md
@@ -90,9 +90,9 @@ Deferred until after PR-3:
 - PR `#1296` merged `2026-04-02` (`America/New_York`)
 - PR `#1312` merged `2026-04-03` (`America/New_York`)
 - PR `#1381` merged `2026-04-09` (`America/New_York`)
-- PR `#1416` merged `2026-04-15` (`America/New_York`) and closed the general paywall exposure ledger foundation
-- PR `#1434` merged `2026-04-17` (`America/New_York`) and closed intervention trigger engine v1
-- execution-time `main` / `origin/main` baseline for PR-2: `7bf5d8819e33b40b35cef1aac7c7fcc76c32229f`
+- PR `#1416` merged `2026-04-15` (`America/New_York`) and closed the general paywall exposure ledger foundation (`docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md:58`)
+- PR `#1434` merged `2026-04-17` (`America/New_York`) and closed intervention trigger engine v1 (`docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md:59`, `docs/review/PR_1434_FIXED_MAPPING.md:2`)
+- execution-time `main` / `origin/main` baseline for PR-2: `7bf5d8819e33b40b35cef1aac7c7fcc76c32229f` (`docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md:60`)
 
 ## PR-1 Contract Snapshot
 
@@ -154,7 +154,7 @@ Do not wire through billing or checkout paths.
 2. PR-1 introduces one backend-owned additive monetization seam without breaking
    current API payloads.
 3. PR-2 adds planning paywall exposure measurement before client experiments.
-   - This is a narrow planning-specific delta on top of PR `#1416`, not a second ledger-foundation PR.
+   - This is a narrow planning-specific delta on top of PR `#1416`, not a second ledger-foundation PR (`docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md:58`, `docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md:92`).
 4. PR-3 consumes backend hints while preserving fail-closed web checkout.
 5. Each PR starts from a fresh worktree off synced `origin/main`.
 6. After each merge, local `main` is fast-forward synced and old worktree artifacts

--- a/docs/orchestration/MONETIZATION_PLANNING_WAVE_TASK_PACKET_2026-04-13.md
+++ b/docs/orchestration/MONETIZATION_PLANNING_WAVE_TASK_PACKET_2026-04-13.md
@@ -63,6 +63,16 @@ Deferred until after PR-3:
 3. `backend-engineer`
 4. `security-auditor`
 
+### PR-2 pre-open
+
+1. `agent-coordinator`
+2. `backend-engineer`
+3. `frontend-engineer`
+4. `security-auditor`
+5. `qa-engineer-agent`
+6. `bug-hunter`
+7. `agent-coordinator`
+
 ### Mandatory post-open review lane
 
 - `qa-engineer-agent -> bug-hunter -> agent-coordinator`
@@ -80,7 +90,9 @@ Deferred until after PR-3:
 - PR `#1296` merged `2026-04-02` (`America/New_York`)
 - PR `#1312` merged `2026-04-03` (`America/New_York`)
 - PR `#1381` merged `2026-04-09` (`America/New_York`)
-- local `main` / `origin/main` baseline for wave start: `6096c1a35`
+- PR `#1416` merged `2026-04-15` (`America/New_York`) and closed the general paywall exposure ledger foundation
+- PR `#1434` merged `2026-04-17` (`America/New_York`) and closed intervention trigger engine v1
+- execution-time `main` / `origin/main` baseline for PR-2: `7bf5d8819e33b40b35cef1aac7c7fcc76c32229f`
 
 ## PR-1 Contract Snapshot
 
@@ -142,6 +154,7 @@ Do not wire through billing or checkout paths.
 2. PR-1 introduces one backend-owned additive monetization seam without breaking
    current API payloads.
 3. PR-2 adds planning paywall exposure measurement before client experiments.
+   - This is a narrow planning-specific delta on top of PR `#1416`, not a second ledger-foundation PR.
 4. PR-3 consumes backend hints while preserving fail-closed web checkout.
 5. Each PR starts from a fresh worktree off synced `origin/main`.
 6. After each merge, local `main` is fast-forward synced and old worktree artifacts

--- a/docs/review/PR_1464_FIXED_MAPPING.md
+++ b/docs/review/PR_1464_FIXED_MAPPING.md
@@ -7,10 +7,10 @@
 ## Fixed in Commit Mapping
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105596267 -> f3686ad47
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105599240 -> f3686ad47
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105603191 -> f3686ad47
-Disposition: FIXED
-Commit: f3686ad47
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105603191
+Disposition: NOT-A-BUG
 Evidence: `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:51`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:67`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:105`, `frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx:129`
+Reason: The cubic inline comment was posted after `f3686ad47` had already landed on the PR branch, and the current code already persists a single `exposureIdRef` for both analytics and navigation. This thread therefore documents an already-correct branch state rather than a post-comment defect that required a new follow-up commit.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105603192 -> 7759b5a49
 Disposition: FIXED

--- a/docs/review/PR_1464_FIXED_MAPPING.md
+++ b/docs/review/PR_1464_FIXED_MAPPING.md
@@ -7,6 +7,50 @@
 ## Fixed in Commit Mapping
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105596267 -> f3686ad47
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105599240 -> f3686ad47
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105603191 -> f3686ad47
+Disposition: FIXED
+Commit: f3686ad47
+Evidence: `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:51`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:67`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:105`, `frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx:129`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105603192 -> 7759b5a49
+Disposition: FIXED
+Commit: 7759b5a49
+Evidence: `frontend/src/pages/Pro/ProPaywallPage.tsx:8`, `frontend/src/pages/Pro/ProPaywallPage.tsx:22`, `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:71`, `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:111`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105604423 -> 7759b5a49
+Disposition: FIXED
+Commit: 7759b5a49
+Evidence: `docs/analytics/METRICS_CATALOG.md:837`, `app/routers/paywall_analytics.py:140`, `app/models/paywall_analytics.py:18`, `app/services/intervention_trigger_engine.py:41`, `app/schemas/intervention.py:12`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105604431
+Disposition: NOT-A-BUG
+Evidence: `docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md:94`, `app/schemas/paywall_analytics.py:36`, `app/schemas/paywall_analytics.py:41`
+Reason: The canonical paywall event names were already correct (`shown`, `dismissed`, `cta_clicked`, `upgrade_started`, `upgrade_completed`). This lane only hardened the runbook with the missing schema citation, so there was no event-name defect to fix.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105604433 -> 7759b5a49
+Disposition: FIXED
+Commit: 7759b5a49
+Evidence: `docs/orchestration/MONETIZATION_PLANNING_WAVE_TASK_PACKET_2026-04-13.md:93`, `docs/orchestration/MONETIZATION_PLANNING_WAVE_TASK_PACKET_2026-04-13.md:157`, `docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md:58`, `docs/review/PR_1434_FIXED_MAPPING.md:2`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105604434 -> 7759b5a49
+Disposition: FIXED
+Commit: 7759b5a49
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:342`, `docs/roadmap/BACKLOG_LEDGER.md:343`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#pullrequestreview-4134861106
+Disposition: NOT-A-BUG
+Evidence: `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:51`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:105`
+Reason: This Sourcery review is an aggregate wrapper for inline thread `#discussion_r3105596267`, which is already fixed in `f3686ad47`; it does not introduce a separate standalone defect.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#pullrequestreview-4134866854
+Disposition: NOT-A-BUG
+Evidence: `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:51`, `frontend/src/pages/Pro/ProPaywallPage.tsx:22`
+Reason: This cubic review is an aggregate wrapper for inline threads `#discussion_r3105603191` and `#discussion_r3105603192`, which are dispositioned individually above.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#pullrequestreview-4134867791
+Disposition: NOT-A-BUG
+Evidence: `docs/analytics/METRICS_CATALOG.md:837`, `docs/orchestration/MONETIZATION_PLANNING_WAVE_TASK_PACKET_2026-04-13.md:93`, `docs/roadmap/BACKLOG_LEDGER.md:342`
+Reason: This CodeRabbit review is an aggregate wrapper for the inline doc comments handled above; once those individual comments are dispositioned, no separate unresolved defect remains at the review level.
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1464_FIXED_MAPPING.md
+++ b/docs/review/PR_1464_FIXED_MAPPING.md
@@ -37,6 +37,16 @@ Disposition: FIXED
 Commit: 7759b5a49
 Evidence: `docs/roadmap/BACKLOG_LEDGER.md:342`, `docs/roadmap/BACKLOG_LEDGER.md:343`
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105792515 -> 5edeaeb7b
+Disposition: FIXED
+Commit: 5edeaeb7b
+Evidence: `docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md:93`, `app/main.py:48`, `app/main.py:205`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105792517 -> 5edeaeb7b
+Disposition: FIXED
+Commit: 5edeaeb7b
+Evidence: `docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md:101`, `docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md:102`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:9`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:10`, `app/services/intervention_trigger_engine.py:41`, `app/services/intervention_trigger_engine.py:43`, `app/schemas/intervention.py:11`, `app/schemas/intervention.py:12`
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#pullrequestreview-4134861106
 Disposition: NOT-A-BUG
 Evidence: `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:51`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:105`
@@ -51,6 +61,11 @@ Reason: This cubic review is an aggregate wrapper for inline threads `#discussio
 Disposition: NOT-A-BUG
 Evidence: `docs/analytics/METRICS_CATALOG.md:837`, `docs/orchestration/MONETIZATION_PLANNING_WAVE_TASK_PACKET_2026-04-13.md:93`, `docs/roadmap/BACKLOG_LEDGER.md:342`
 Reason: This CodeRabbit review is an aggregate wrapper for the inline doc comments handled above; once those individual comments are dispositioned, no separate unresolved defect remains at the review level.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#pullrequestreview-4135049981
+Disposition: NOT-A-BUG
+Evidence: `docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md:93`, `docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md:101`, `docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md:102`
+Reason: This later CodeRabbit review is an aggregate wrapper for inline threads `#discussion_r3105792515` and `#discussion_r3105792517`, which are fixed in `5edeaeb7b`; it does not introduce an additional standalone defect beyond those thread-level findings.
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1464_FIXED_MAPPING.md
+++ b/docs/review/PR_1464_FIXED_MAPPING.md
@@ -5,7 +5,8 @@
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105596267 -> f3686ad47
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105599240 -> f3686ad47
 
 ## Merge Readiness
 - [ ] All required checks pass

--- a/docs/review/PR_1464_FIXED_MAPPING.md
+++ b/docs/review/PR_1464_FIXED_MAPPING.md
@@ -1,0 +1,16 @@
+# PR 1464 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Merge Readiness
+- [ ] All required checks pass
+- [ ] No unresolved review threads (re-check on current head before merge)
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green
+- [ ] `make verify` green
+Notes: Local validation for this lane used targeted frontend paywall tests plus `pre-commit run --all-files`. Full `make verify` was intentionally not used as the default local gate because it expands into the full project-level suite, so merge readiness for this PR is governed by current-head CI and review disposition checks.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -339,8 +339,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Planning-flow monetization wave over the canonical FREE -> PRO -> VIP ladder
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-DOCS-MONETIZATION-PLANNING-WAVE-BOOTSTRAP -> PR-TBD-MONETIZATION-TRIGGER-ENGINE-V1 -> PR-TBD-PLANNING-PAYWALL-EXPOSURE-LEDGER -> PR-TBD-PLANNING-NEXT-BEST-ACTION-CONSUMERS
-  - Status: 🟡 Active epic. Bootstrap governance opens the wave on `2026-04-13` (`America/New_York`); runtime execution begins with PR-1 `feat(growth): add intervention trigger engine v1`.
+  - Target PR: PR `#1416` -> PR `#1434` -> current PR-2 `feat/planning-paywall-exposure-ledger` -> planned PR-3 `feat/planning-next-best-action-consumers`
+  - Status: 🟡 Active epic. Bootstrap governance opened the wave on `2026-04-13` (`America/New_York`); PR `#1416` merged the general paywall exposure ledger foundation on `2026-04-15`, PR `#1434` merged intervention trigger engine v1 on `2026-04-17`, and PR-2 is now the narrow planning-specific ledger wiring/taxonomy delta.
   - Area: product / growth / monetization / planning flow
   - Finding Type: monetization value-capture orchestration
   - Reason (EN): `origin/main` already closed the backend monetization spine through merged PRs `#1296` (`2026-04-02`), `#1312` (`2026-04-03`), and `#1381` (`2026-04-09`). The next profitable lane is not another receipt/entitlement rewrite; it is deterministic monetization over the planning-first journey `BMI -> targets -> daily plate -> weekly plan -> export/recipe follow-through`. The epic must stay thin-client-safe, additive, and worktree-isolated so billing/provider modernization does not get reopened by accident. (RU: Биллинг-спайн уже закрыт на `main`; следующий шаг — monetization поверх planning flow, а не новый receipt/entitlement PR.)
@@ -357,7 +357,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - DoD:
     - Bootstrap docs PR reconciles stale ledger wording and records the monetization PR train under explicit coordinator-owned governance
     - PR-1 adds backend-owned `next_best_action` hints on canonical BMI / PRO planning surfaces without touching billing, provider verification, or client-side pricing truth
-    - PR-2 adds deterministic planning paywall exposure ledger instrumentation aligned to `docs/analytics/*` canon
+    - PR-2 adds deterministic planning-surface paywall exposure wiring/taxonomy on top of merged ledger foundation PR `#1416`, aligned to `docs/analytics/*` canon
     - PR-3 consumes backend `next_best_action` hints on web/iOS while preserving fail-closed web checkout semantics
     - Every PR in the wave runs from a fresh `worktree`, merges only after current-head merge-readiness passes, then fast-forward syncs local `main` before the next PR starts
     - Follow-up surfaces (`paywall-copy-alignment`, CBT premium packaging, business-wave follow-through) remain explicitly deferred until after PR-3

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -339,7 +339,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Planning-flow monetization wave over the canonical FREE -> PRO -> VIP ladder
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR `#1416` -> PR `#1434` -> current PR-2 `feat/planning-paywall-exposure-ledger` -> planned PR-3 `feat/planning-next-best-action-consumers`
+  - Target PR: PR `#1416` -> PR `#1434` -> PR `#1464` -> PR-TBD-planning-next-best-action-consumers
+  - Lane note: current branch `feat/planning-paywall-exposure-ledger`; planned follow-up branch `feat/planning-next-best-action-consumers`
   - Status: 🟡 Active epic. Bootstrap governance opened the wave on `2026-04-13` (`America/New_York`); PR `#1416` merged the general paywall exposure ledger foundation on `2026-04-15`, PR `#1434` merged intervention trigger engine v1 on `2026-04-17`, and PR-2 is now the narrow planning-specific ledger wiring/taxonomy delta.
   - Area: product / growth / monetization / planning flow
   - Finding Type: monetization value-capture orchestration

--- a/frontend/src/components/Paywall/BeforeAfter.tsx
+++ b/frontend/src/components/Paywall/BeforeAfter.tsx
@@ -15,6 +15,7 @@ type Props = {
   purchaseLabel?: string;
   processingLabel?: string;
   purchaseDisabled?: boolean;
+  initialExposureId?: string;
   source?: string;
   triggerReason?: string;
   via?: string;
@@ -57,6 +58,7 @@ export default function BeforeAfter({
   purchaseLabel,
   processingLabel,
   purchaseDisabled = false,
+  initialExposureId,
   source = "unknown",
   triggerReason = "unknown",
   via = "paywall",
@@ -64,7 +66,7 @@ export default function BeforeAfter({
   const { t } = useTranslation();
   const [isPurchasing, setIsPurchasing] = useState(false);
   const [purchaseError, setPurchaseError] = useState<string | null>(null);
-  const exposureIdRef = useRef<string>(createAnalyticsEventId());
+  const exposureIdRef = useRef<string>(initialExposureId ?? createAnalyticsEventId());
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const primaryButtonRef = useRef<HTMLButtonElement | null>(null);
   const cancelButtonRef = useRef<HTMLButtonElement | null>(null);

--- a/frontend/src/components/PremiumGate.tsx
+++ b/frontend/src/components/PremiumGate.tsx
@@ -10,6 +10,8 @@ type Props = {
   isPremium: boolean;
   children: React.ReactNode;
   source?: string;
+  paywallSource?: string;
+  triggerReason?: string;
 };
 
 /**
@@ -21,10 +23,18 @@ type Props = {
  *
  * @param isPremium - If `true`, renders `children` without gating.
  * @param children - Content to render inside the gate or preview.
- * @param source - Optional source identifier forwarded to the Paywall; defaults to `"unknown"`.
+ * @param source - Optional legacy telemetry source identifier; defaults to `"unknown"`.
+ * @param paywallSource - Optional paywall/ledger source identifier. Falls back to `source` when omitted.
+ * @param triggerReason - Optional trigger reason forwarded to the Paywall analytics seam.
  * @returns The PremiumGate React element containing either the unmodified children (for premium users) or a gated preview with a CTA and paywall dialog.
  */
-export default function PremiumGate({ isPremium, children, source = "unknown" }: Props) {
+export default function PremiumGate({
+  isPremium,
+  children,
+  source = "unknown",
+  paywallSource,
+  triggerReason,
+}: Props) {
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
   const { track } = useTelemetry();
@@ -43,6 +53,7 @@ export default function PremiumGate({ isPremium, children, source = "unknown" }:
 
   const supportsNativeInert =
     typeof document !== "undefined" && "inert" in HTMLElement.prototype;
+  const effectivePaywallSource = paywallSource ?? source;
 
   const restoreCtaFocus = (): void => {
     const el = ctaRef.current;
@@ -91,7 +102,8 @@ export default function PremiumGate({ isPremium, children, source = "unknown" }:
 
       {open && (
         <Paywall
-          source={source}
+          source={effectivePaywallSource}
+          triggerReason={triggerReason}
           via="paywall_cta"
           onClose={() => {
             safeTrack(() => track.paywallDismissed(source, "close_button"));
@@ -99,7 +111,7 @@ export default function PremiumGate({ isPremium, children, source = "unknown" }:
             restoreCtaFocus();
           }}
           onPurchase={async () => {
-            await purchasePremium({ source, via: "paywall_cta" });
+            await purchasePremium({ source: effectivePaywallSource, via: "paywall_cta" });
             safeTrack(() => track.upgradeClicked(source, "paywall"));
             setOpen(false);
             restoreCtaFocus();

--- a/frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx
+++ b/frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx
@@ -7,7 +7,7 @@ import type { components } from '../../api/schema';
 import { createAnalyticsEventId, logPaywallExposure } from '../../lib/analytics';
 
 const BMI_SOFT_PAYWALL_SOURCE = 'bmi_soft_paywall';
-const BMI_SOFT_PAYWALL_TRIGGER_REASON = 'post_bmi_result';
+const BMI_SOFT_PAYWALL_TRIGGER_REASON = 'post_bmi';
 
 interface SoftPaywallHookProps {
   hook?: components['schemas']['SoftPaywallHook'] | null;
@@ -99,8 +99,18 @@ export default function SoftPaywallHook({ hook, onCtaClick }: SoftPaywallHookPro
     if (onCtaClick) {
       onCtaClick();
     } else {
+      const exposureId = exposureIdRef.current ?? createAnalyticsEventId();
+      exposureIdRef.current = exposureId;
+
       // Default: navigate to /pro (paywall page)
-      navigate('/pro');
+      navigate('/pro', {
+        state: {
+          exposureId,
+          source: BMI_SOFT_PAYWALL_SOURCE,
+          triggerReason: BMI_SOFT_PAYWALL_TRIGGER_REASON,
+          via: 'pro_page',
+        },
+      });
     }
   };
 

--- a/frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx
+++ b/frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx
@@ -1,8 +1,13 @@
 // RU: Компонент Soft Paywall Hook - отображает предложение PRO функций после BMI расчета
 // EN: Soft Paywall Hook component - displays PRO feature offer after BMI calculation
 
+import { useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { components } from '../../api/schema';
+import { createAnalyticsEventId, logPaywallExposure } from '../../lib/analytics';
+
+const BMI_SOFT_PAYWALL_SOURCE = 'bmi_soft_paywall';
+const BMI_SOFT_PAYWALL_TRIGGER_REASON = 'post_bmi_result';
 
 interface SoftPaywallHookProps {
   hook?: components['schemas']['SoftPaywallHook'] | null;
@@ -22,6 +27,62 @@ interface SoftPaywallHookProps {
  */
 export default function SoftPaywallHook({ hook, onCtaClick }: SoftPaywallHookProps): JSX.Element | null {
   const navigate = useNavigate();
+  const exposureIdRef = useRef<string | null>(null);
+  const hookIdRef = useRef<string | null>(null);
+  const hasLoggedShownRef = useRef(false);
+  const hookId = hook?.id ?? null;
+  const isRenderable = Boolean(hook?.availability?.pro_available);
+
+  useEffect(() => {
+    if (!isRenderable || !hookId) {
+      hookIdRef.current = null;
+      exposureIdRef.current = null;
+      hasLoggedShownRef.current = false;
+      return;
+    }
+
+    if (hookIdRef.current !== hookId) {
+      hookIdRef.current = hookId;
+      exposureIdRef.current = createAnalyticsEventId();
+      hasLoggedShownRef.current = false;
+    }
+  }, [hookId, isRenderable]);
+
+  const safeLogPaywallEvent = useCallback(
+    (eventName: 'shown' | 'cta_clicked'): void => {
+      if (!hook || !isRenderable) {
+        return;
+      }
+
+      try {
+        logPaywallExposure({
+          client_event_id: createAnalyticsEventId(),
+          exposure_id: exposureIdRef.current ?? createAnalyticsEventId(),
+          event_name: eventName,
+          source_surface: BMI_SOFT_PAYWALL_SOURCE,
+          trigger_reason: BMI_SOFT_PAYWALL_TRIGGER_REASON,
+          via: 'soft_paywall_hook',
+          metadata: {
+            hook_id: hook.id,
+            position: hook.position,
+            target: hook.target,
+          },
+        });
+      } catch {
+        // RU: Ошибки analytics не должны ломать teaser/paywall UX.
+        // EN: Analytics failures must never break teaser/paywall UX.
+      }
+    },
+    [hook, isRenderable]
+  );
+
+  useEffect(() => {
+    if (!isRenderable || !hookId || hasLoggedShownRef.current) {
+      return;
+    }
+    safeLogPaywallEvent('shown');
+    hasLoggedShownRef.current = true;
+  }, [hookId, isRenderable, safeLogPaywallEvent]);
 
   // Guard: do not render if hook is null/undefined
   if (!hook) {
@@ -34,6 +95,7 @@ export default function SoftPaywallHook({ hook, onCtaClick }: SoftPaywallHookPro
   }
 
   const handleClick = (): void => {
+    safeLogPaywallEvent('cta_clicked');
     if (onCtaClick) {
       onCtaClick();
     } else {

--- a/frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx
+++ b/frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx
@@ -48,6 +48,13 @@ export default function SoftPaywallHook({ hook, onCtaClick }: SoftPaywallHookPro
     }
   }, [hookId, isRenderable]);
 
+  const ensureExposureId = useCallback((): string => {
+    if (!exposureIdRef.current) {
+      exposureIdRef.current = createAnalyticsEventId();
+    }
+    return exposureIdRef.current;
+  }, []);
+
   const safeLogPaywallEvent = useCallback(
     (eventName: 'shown' | 'cta_clicked'): void => {
       if (!hook || !isRenderable) {
@@ -57,7 +64,7 @@ export default function SoftPaywallHook({ hook, onCtaClick }: SoftPaywallHookPro
       try {
         logPaywallExposure({
           client_event_id: createAnalyticsEventId(),
-          exposure_id: exposureIdRef.current ?? createAnalyticsEventId(),
+          exposure_id: ensureExposureId(),
           event_name: eventName,
           source_surface: BMI_SOFT_PAYWALL_SOURCE,
           trigger_reason: BMI_SOFT_PAYWALL_TRIGGER_REASON,
@@ -73,7 +80,7 @@ export default function SoftPaywallHook({ hook, onCtaClick }: SoftPaywallHookPro
         // EN: Analytics failures must never break teaser/paywall UX.
       }
     },
-    [hook, isRenderable]
+    [ensureExposureId, hook, isRenderable]
   );
 
   useEffect(() => {
@@ -95,13 +102,11 @@ export default function SoftPaywallHook({ hook, onCtaClick }: SoftPaywallHookPro
   }
 
   const handleClick = (): void => {
+    const exposureId = ensureExposureId();
     safeLogPaywallEvent('cta_clicked');
     if (onCtaClick) {
       onCtaClick();
     } else {
-      const exposureId = exposureIdRef.current ?? createAnalyticsEventId();
-      exposureIdRef.current = exposureId;
-
       // Default: navigate to /pro (paywall page)
       navigate('/pro', {
         state: {

--- a/frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx
+++ b/frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx
@@ -114,7 +114,14 @@ describe("SoftPaywallHook", () => {
 
     // Assert exactly one navigation call with correct path
     expect(mockNavigate).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith("/pro");
+    expect(mockNavigate).toHaveBeenCalledWith("/pro", {
+      state: {
+        exposureId: "analytics-id-1",
+        source: "bmi_soft_paywall",
+        triggerReason: "post_bmi",
+        via: "pro_page",
+      },
+    });
   });
 
   it("reuses one exposure lifecycle id for shown and CTA events", (): void => {
@@ -134,7 +141,7 @@ describe("SoftPaywallHook", () => {
     expect(shownPayload).toMatchObject({
       event_name: "shown",
       source_surface: "bmi_soft_paywall",
-      trigger_reason: "post_bmi_result",
+      trigger_reason: "post_bmi",
       via: "soft_paywall_hook",
       metadata: {
         hook_id: "bmi.pro_interpretation_v1",
@@ -145,7 +152,7 @@ describe("SoftPaywallHook", () => {
     expect(ctaPayload).toMatchObject({
       event_name: "cta_clicked",
       source_surface: "bmi_soft_paywall",
-      trigger_reason: "post_bmi_result",
+      trigger_reason: "post_bmi",
       via: "soft_paywall_hook",
       metadata: {
         hook_id: "bmi.pro_interpretation_v1",

--- a/frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx
+++ b/frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx
@@ -112,6 +112,10 @@ describe("SoftPaywallHook", () => {
     const ctaButton = screen.getByTestId("soft-paywall-cta");
     fireEvent.click(ctaButton);
 
+    const ctaPayload = logPaywallExposure.mock.calls.at(-1)?.[0] as
+      | Record<string, unknown>
+      | undefined;
+
     // Assert exactly one navigation call with correct path
     expect(mockNavigate).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith("/pro", {
@@ -122,6 +126,8 @@ describe("SoftPaywallHook", () => {
         via: "pro_page",
       },
     });
+    expect(ctaPayload?.event_name).toBe("cta_clicked");
+    expect(ctaPayload?.exposure_id).toBe("analytics-id-1");
   });
 
   it("reuses one exposure lifecycle id for shown and CTA events", (): void => {

--- a/frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx
+++ b/frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx
@@ -1,10 +1,17 @@
 /** @vitest-environment jsdom */
 import "@testing-library/jest-dom/vitest";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import SoftPaywallHook from "../SoftPaywallHook";
 import type { components } from "../../../api/schema";
+
+const analyticsMock = vi.hoisted(() => ({
+  createAnalyticsEventId: vi.fn(),
+  logPaywallExposure: vi.fn(),
+}));
+
+vi.mock("../../../lib/analytics", () => analyticsMock);
 
 // Mock react-router-dom useNavigate
 const mockNavigate = vi.fn();
@@ -17,6 +24,8 @@ vi.mock("react-router-dom", async () => {
 });
 
 describe("SoftPaywallHook", () => {
+  const { createAnalyticsEventId, logPaywallExposure } = analyticsMock;
+  let analyticsIdCounter = 0;
   const mockHook: components["schemas"]["SoftPaywallHook"] = {
     id: "bmi.pro_interpretation_v1",
     kind: "cta",
@@ -37,6 +46,12 @@ describe("SoftPaywallHook", () => {
 
   beforeEach((): void => {
     vi.clearAllMocks();
+    analyticsIdCounter = 0;
+    createAnalyticsEventId.mockImplementation(() => `analytics-id-${++analyticsIdCounter}`);
+  });
+
+  afterEach((): void => {
+    cleanup();
   });
 
   it("renders when hook provided", (): void => {
@@ -100,6 +115,73 @@ describe("SoftPaywallHook", () => {
     // Assert exactly one navigation call with correct path
     expect(mockNavigate).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith("/pro");
+  });
+
+  it("reuses one exposure lifecycle id for shown and CTA events", (): void => {
+    render(
+      <MemoryRouter>
+        <SoftPaywallHook hook={mockHook} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByTestId("soft-paywall-cta"));
+    expect(logPaywallExposure).toHaveBeenCalledTimes(2);
+
+    const [shownPayload, ctaPayload] = logPaywallExposure.mock.calls.map(
+      ([payload]) => payload as Record<string, unknown>
+    );
+
+    expect(shownPayload).toMatchObject({
+      event_name: "shown",
+      source_surface: "bmi_soft_paywall",
+      trigger_reason: "post_bmi_result",
+      via: "soft_paywall_hook",
+      metadata: {
+        hook_id: "bmi.pro_interpretation_v1",
+        position: "post_result",
+        target: "pro_paywall",
+      },
+    });
+    expect(ctaPayload).toMatchObject({
+      event_name: "cta_clicked",
+      source_surface: "bmi_soft_paywall",
+      trigger_reason: "post_bmi_result",
+      via: "soft_paywall_hook",
+      metadata: {
+        hook_id: "bmi.pro_interpretation_v1",
+        position: "post_result",
+        target: "pro_paywall",
+      },
+    });
+    expect(shownPayload.exposure_id).toBe(ctaPayload.exposure_id);
+    expect(shownPayload.client_event_id).not.toBe(ctaPayload.client_event_id);
+  });
+
+  it("starts a fresh exposure lifecycle when the hook is hidden and shown again", (): void => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <SoftPaywallHook hook={mockHook} />
+      </MemoryRouter>
+    );
+
+    rerender(
+      <MemoryRouter>
+        <SoftPaywallHook hook={null} />
+      </MemoryRouter>
+    );
+
+    rerender(
+      <MemoryRouter>
+        <SoftPaywallHook hook={mockHook} />
+      </MemoryRouter>
+    );
+
+    const shownCalls = logPaywallExposure.mock.calls
+      .map(([payload]) => payload as Record<string, unknown>)
+      .filter((payload) => payload.event_name === "shown");
+
+    expect(shownCalls).toHaveLength(2);
+    expect(shownCalls[0].exposure_id).not.toBe(shownCalls[1].exposure_id);
   });
 
   it("calls custom onCtaClick handler when provided", (): void => {

--- a/frontend/src/components/__tests__/PremiumGate.test.tsx
+++ b/frontend/src/components/__tests__/PremiumGate.test.tsx
@@ -17,6 +17,8 @@ const telemetryTrack = vi.hoisted(() => ({
   badgeViewed: vi.fn(),
 }));
 
+const beforeAfterPropsSpy = vi.hoisted(() => vi.fn());
+
 const { gateInteracted, upgradeClicked, paywallDismissed } = telemetryTrack;
 
 vi.mock("../../lib/useTelemetry", () => ({
@@ -29,12 +31,15 @@ vi.mock("../../lib/useTelemetry", () => ({
 
 vi.mock("../Paywall/BeforeAfter", () => {
   return {
-    default: ({ onClose }: { onClose: () => void }) => (
-      <div role="dialog">
+    default: (props: { onClose: () => void; source?: string; triggerReason?: string }) => {
+      beforeAfterPropsSpy(props);
+      return (
+        <div role="dialog">
         Mocked Paywall
-        <button onClick={onClose}>Close</button>
-      </div>
-    ),
+        <button onClick={props.onClose}>Close</button>
+        </div>
+      );
+    },
   };
 });
 
@@ -94,5 +99,27 @@ describe("PremiumGate", () => {
     await waitFor(() => {
       expect(document.activeElement).toBe(unlock);
     });
+  });
+
+  test("forwards planning trigger reason to the paywall seam when provided", () => {
+    render(
+      <PremiumGate
+        isPremium={false}
+        source="plate_page"
+        paywallSource="pro_daily_plate"
+        triggerReason="targets_ready"
+      >
+        <div data-testid="content">Gated content</div>
+      </PremiumGate>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(beforeAfterPropsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "pro_daily_plate",
+        triggerReason: "targets_ready",
+      })
+    );
   });
 });

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -6,6 +6,7 @@
  */
 export const PREMIUM_GATE_SOURCES = {
   PLATE_PAGE: 'plate_page',
+  PRO_DAILY_PLATE: 'pro_daily_plate',
   // Add other premium gate sources here as needed
   // PROGRESS_PAGE: 'progress_page',
   // PROFILE_PAGE: 'profile_page',

--- a/frontend/src/pages/Plate.tsx
+++ b/frontend/src/pages/Plate.tsx
@@ -42,7 +42,12 @@ export default function Plate() {
       {/* Premium Gate Section */}
       <section className="flex-1 px-4 py-6 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-4xl">
-          <PremiumGate isPremium={isPremium} source={PREMIUM_GATE_SOURCES.PLATE_PAGE}>
+          <PremiumGate
+            isPremium={isPremium}
+            source={PREMIUM_GATE_SOURCES.PLATE_PAGE}
+            paywallSource={PREMIUM_GATE_SOURCES.PRO_DAILY_PLATE}
+            triggerReason="targets_ready"
+          >
             {/* Pro Controls */}
             <Card className="mb-6 overflow-hidden">
               <CardContent className="p-6">

--- a/frontend/src/pages/Plate.tsx
+++ b/frontend/src/pages/Plate.tsx
@@ -1,12 +1,19 @@
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import PremiumGate from "../components/PremiumGate";
 import { Card, CardContent, buttonClasses } from "../components/ui";
 import LiveProgressIndicator from '../features/progress/LiveProgressIndicator';
 import { usePremium } from "../lib/usePremium";
 import { PREMIUM_GATE_SOURCES } from "../config/constants";
 
+type PlateLocationState = {
+  triggerReason?: string;
+};
+
 export default function Plate() {
   const isPremium = usePremium();
+  const location = useLocation();
+  const state = (location.state as PlateLocationState | null) ?? null;
+  const planningTriggerReason = state?.triggerReason;
 
   if (isPremium === undefined) {
     return (
@@ -46,7 +53,7 @@ export default function Plate() {
             isPremium={isPremium}
             source={PREMIUM_GATE_SOURCES.PLATE_PAGE}
             paywallSource={PREMIUM_GATE_SOURCES.PRO_DAILY_PLATE}
-            triggerReason="targets_ready"
+            triggerReason={planningTriggerReason}
           >
             {/* Pro Controls */}
             <Card className="mb-6 overflow-hidden">

--- a/frontend/src/pages/Pro/ProPaywallPage.tsx
+++ b/frontend/src/pages/Pro/ProPaywallPage.tsx
@@ -1,19 +1,31 @@
 // RU: Страница PRO paywall - отображает модальное окно с предложением PRO функций
 // EN: PRO paywall page - displays modal dialog with PRO feature offer
 
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import BeforeAfter from '../../components/Paywall/BeforeAfter';
 import { purchasePremium } from '../../lib/paywallPurchase';
 
+type ProPaywallLocationState = {
+  exposureId?: string;
+  source?: string;
+  triggerReason?: string;
+  via?: string;
+};
+
 export default function ProPaywallPage(): JSX.Element {
+  const location = useLocation();
   const navigate = useNavigate();
+  const state = (location.state as ProPaywallLocationState | null) ?? null;
+  const source = state?.source ?? 'bmi_soft_paywall';
+  const triggerReason = state?.triggerReason ?? 'post_bmi';
+  const via = state?.via ?? 'pro_page';
 
   const handleClose = (): void => {
     navigate(-1); // Go back to previous page
   };
 
   const handlePurchase = async (): Promise<void> => {
-    await purchasePremium({ source: "bmi_soft_paywall", via: "pro_page" });
+    await purchasePremium({ source, via });
     navigate(-1);
   };
 
@@ -21,9 +33,10 @@ export default function ProPaywallPage(): JSX.Element {
     <BeforeAfter
       onClose={handleClose}
       onPurchase={handlePurchase}
-      source="bmi_soft_paywall"
-      triggerReason="post_bmi_result"
-      via="pro_page"
+      initialExposureId={state?.exposureId}
+      source={source}
+      triggerReason={triggerReason}
+      via={via}
     />
   );
 }

--- a/frontend/src/pages/Pro/ProPaywallPage.tsx
+++ b/frontend/src/pages/Pro/ProPaywallPage.tsx
@@ -5,6 +5,9 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import BeforeAfter from '../../components/Paywall/BeforeAfter';
 import { purchasePremium } from '../../lib/paywallPurchase';
 
+const DEFAULT_PRO_PAYWALL_SOURCE = 'pro_page';
+const DEFAULT_PRO_PAYWALL_TRIGGER_REASON = 'unknown';
+
 type ProPaywallLocationState = {
   exposureId?: string;
   source?: string;
@@ -16,8 +19,8 @@ export default function ProPaywallPage(): JSX.Element {
   const location = useLocation();
   const navigate = useNavigate();
   const state = (location.state as ProPaywallLocationState | null) ?? null;
-  const source = state?.source ?? 'bmi_soft_paywall';
-  const triggerReason = state?.triggerReason ?? 'post_bmi';
+  const source = state?.source ?? DEFAULT_PRO_PAYWALL_SOURCE;
+  const triggerReason = state?.triggerReason ?? DEFAULT_PRO_PAYWALL_TRIGGER_REASON;
   const via = state?.via ?? 'pro_page';
 
   const handleClose = (): void => {

--- a/frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx
+++ b/frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx
@@ -68,7 +68,7 @@ describe("ProPaywallPage", () => {
       .mockReturnValueOnce("event-pro-cta");
   });
 
-  it("surfaces the release-safe checkout message and does not navigate on failed web purchase", async () => {
+  it("uses direct /pro defaults without BMI-specific analytics on failed web purchase", async () => {
     purchasePremiumMock.mockRejectedValueOnce(new Error(WEB_CHECKOUT_UNAVAILABLE_MESSAGE));
 
     renderAtProRoute();
@@ -82,22 +82,22 @@ describe("ProPaywallPage", () => {
     });
 
     expect(purchasePremiumMock).toHaveBeenCalledWith({
-      source: "bmi_soft_paywall",
+      source: "pro_page",
       via: "pro_page",
     });
     expect(logPaywallExposureMock).toHaveBeenCalledWith("paywall_view", {
       client_event_id: "event-pro-view",
       exposure_id: "exposure-pro",
-      source_surface: "bmi_soft_paywall",
-      trigger_reason: "post_bmi",
+      source_surface: "pro_page",
+      trigger_reason: "unknown",
       via: "pro_page",
       metadata: undefined,
     });
     expect(logPaywallExposureMock).toHaveBeenCalledWith("purchase_attempt", {
       client_event_id: "event-pro-cta",
       exposure_id: "exposure-pro",
-      source_surface: "bmi_soft_paywall",
-      trigger_reason: "post_bmi",
+      source_surface: "pro_page",
+      trigger_reason: "unknown",
       via: "pro_page",
       metadata: undefined,
     });
@@ -108,7 +108,7 @@ describe("ProPaywallPage", () => {
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
-  it("reuses the same exposure id across paywall view and purchase attempt on success", async () => {
+  it("reuses the same exposure id across direct /pro paywall view and purchase attempt", async () => {
     purchasePremiumMock.mockResolvedValueOnce(undefined);
 
     renderAtProRoute();
@@ -117,23 +117,23 @@ describe("ProPaywallPage", () => {
 
     await waitFor(() => {
       expect(purchasePremiumMock).toHaveBeenCalledWith({
-        source: "bmi_soft_paywall",
+        source: "pro_page",
         via: "pro_page",
       });
       expect(logPaywallExposureMock).toHaveBeenCalledTimes(2);
       expect(logPaywallExposureMock).toHaveBeenNthCalledWith(1, "paywall_view", {
         client_event_id: "event-pro-view",
         exposure_id: "exposure-pro",
-        source_surface: "bmi_soft_paywall",
-        trigger_reason: "post_bmi",
+        source_surface: "pro_page",
+        trigger_reason: "unknown",
         via: "pro_page",
         metadata: undefined,
       });
       expect(logPaywallExposureMock).toHaveBeenNthCalledWith(2, "purchase_attempt", {
         client_event_id: "event-pro-cta",
         exposure_id: "exposure-pro",
-        source_surface: "bmi_soft_paywall",
-        trigger_reason: "post_bmi",
+        source_surface: "pro_page",
+        trigger_reason: "unknown",
         via: "pro_page",
         metadata: undefined,
       });

--- a/frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx
+++ b/frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx
@@ -2,6 +2,7 @@
 import "../../../test/setup";
 import "../../../i18n";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ProPaywallPage from "../ProPaywallPage";
 import { WEB_CHECKOUT_UNAVAILABLE_MESSAGE } from "../../../lib/paywallPurchase";
@@ -43,6 +44,21 @@ vi.mock("../../../lib/analytics", () => ({
   logLegacyPaywallExposure: (...args: unknown[]) => logPaywallExposureMock(...args),
 }));
 
+function renderAtProRoute(state?: {
+  exposureId?: string;
+  source?: string;
+  triggerReason?: string;
+  via?: string;
+}) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: "/pro", state }]}>
+      <Routes>
+        <Route path="/pro" element={<ProPaywallPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
 describe("ProPaywallPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -55,7 +71,7 @@ describe("ProPaywallPage", () => {
   it("surfaces the release-safe checkout message and does not navigate on failed web purchase", async () => {
     purchasePremiumMock.mockRejectedValueOnce(new Error(WEB_CHECKOUT_UNAVAILABLE_MESSAGE));
 
-    render(<ProPaywallPage />);
+    renderAtProRoute();
 
     fireEvent.click(screen.getByTestId("paywall-cta"));
 
@@ -73,7 +89,7 @@ describe("ProPaywallPage", () => {
       client_event_id: "event-pro-view",
       exposure_id: "exposure-pro",
       source_surface: "bmi_soft_paywall",
-      trigger_reason: "post_bmi_result",
+      trigger_reason: "post_bmi",
       via: "pro_page",
       metadata: undefined,
     });
@@ -81,7 +97,7 @@ describe("ProPaywallPage", () => {
       client_event_id: "event-pro-cta",
       exposure_id: "exposure-pro",
       source_surface: "bmi_soft_paywall",
-      trigger_reason: "post_bmi_result",
+      trigger_reason: "post_bmi",
       via: "pro_page",
       metadata: undefined,
     });
@@ -95,7 +111,7 @@ describe("ProPaywallPage", () => {
   it("reuses the same exposure id across paywall view and purchase attempt on success", async () => {
     purchasePremiumMock.mockResolvedValueOnce(undefined);
 
-    render(<ProPaywallPage />);
+    renderAtProRoute();
 
     fireEvent.click(screen.getByTestId("paywall-cta"));
 
@@ -109,7 +125,7 @@ describe("ProPaywallPage", () => {
         client_event_id: "event-pro-view",
         exposure_id: "exposure-pro",
         source_surface: "bmi_soft_paywall",
-        trigger_reason: "post_bmi_result",
+        trigger_reason: "post_bmi",
         via: "pro_page",
         metadata: undefined,
       });
@@ -117,7 +133,7 @@ describe("ProPaywallPage", () => {
         client_event_id: "event-pro-cta",
         exposure_id: "exposure-pro",
         source_surface: "bmi_soft_paywall",
-        trigger_reason: "post_bmi_result",
+        trigger_reason: "post_bmi",
         via: "pro_page",
         metadata: undefined,
       });
@@ -132,11 +148,47 @@ describe("ProPaywallPage", () => {
   });
 
   it("navigates back when the user closes the paywall", async (): Promise<void> => {
-    render(<ProPaywallPage />);
+    renderAtProRoute();
 
     fireEvent.click(screen.getByTestId("paywall-cancel"));
 
     expect(purchasePremiumMock).not.toHaveBeenCalled();
     expect(navigateMock).toHaveBeenCalledWith(-1);
+  });
+
+  it("reuses teaser-provided route state for the paywall exposure lifecycle", async () => {
+    purchasePremiumMock.mockResolvedValueOnce(undefined);
+
+    renderAtProRoute({
+      exposureId: "upstream-exposure-id",
+      source: "bmi_soft_paywall",
+      triggerReason: "post_bmi",
+      via: "pro_page",
+    });
+
+    fireEvent.click(screen.getByTestId("paywall-cta"));
+
+    await waitFor(() => {
+      expect(logPaywallExposureMock).toHaveBeenNthCalledWith(1, "paywall_view", {
+        client_event_id: "exposure-pro",
+        exposure_id: "upstream-exposure-id",
+        source_surface: "bmi_soft_paywall",
+        trigger_reason: "post_bmi",
+        via: "pro_page",
+        metadata: undefined,
+      });
+      expect(logPaywallExposureMock).toHaveBeenNthCalledWith(2, "purchase_attempt", {
+        client_event_id: "event-pro-view",
+        exposure_id: "upstream-exposure-id",
+        source_surface: "bmi_soft_paywall",
+        trigger_reason: "post_bmi",
+        via: "pro_page",
+        metadata: undefined,
+      });
+      expect(purchasePremiumMock).toHaveBeenCalledWith({
+        source: "bmi_soft_paywall",
+        via: "pro_page",
+      });
+    });
   });
 });

--- a/frontend/src/pages/__tests__/Plate.test.tsx
+++ b/frontend/src/pages/__tests__/Plate.test.tsx
@@ -15,39 +15,64 @@ vi.mock('../../lib/usePremium', () => ({
 }));
 
 // Mock PremiumGate component
-vi.mock('../../components/PremiumGate', () => ({
-  default: ({
-    children,
-    isPremium,
-    source,
-  }: {
-    children: ReactNode;
-    isPremium: boolean;
-    source: string;
-  }): JSX.Element =>
-    isPremium ? (
-      <div data-testid="premium-gate" data-premium={String(isPremium)} data-source={source}>
-        {children}
-      </div>
-    ) : (
-      <div data-testid="premium-gate-locked" data-premium={String(isPremium)} data-source={source}>
+vi.mock('../../components/PremiumGate', () => {
+  const premiumGatePropsSpy = vi.fn();
+
+  return {
+    premiumGatePropsSpy,
+    default: ({
+      children,
+      isPremium,
+      source,
+      paywallSource,
+      triggerReason,
+    }: {
+      children: ReactNode;
+      isPremium: boolean;
+      source: string;
+      paywallSource?: string;
+      triggerReason?: string;
+    }): JSX.Element => {
+      premiumGatePropsSpy({ isPremium, source, paywallSource, triggerReason });
+
+      return isPremium ? (
         <div
-          data-testid="premium-gate-preview"
-          aria-hidden="true"
-          className="opacity-60 pointer-events-none"
+          data-testid="premium-gate"
+          data-premium={String(isPremium)}
+          data-source={source}
+          data-paywall-source={paywallSource ?? ''}
+          data-trigger-reason={triggerReason ?? ''}
         >
           {children}
         </div>
-        <button type="button">Continue</button>
-      </div>
-    )
-}));
+      ) : (
+        <div
+          data-testid="premium-gate-locked"
+          data-premium={String(isPremium)}
+          data-source={source}
+          data-paywall-source={paywallSource ?? ''}
+          data-trigger-reason={triggerReason ?? ''}
+        >
+          <div
+            data-testid="premium-gate-preview"
+            aria-hidden="true"
+            className="opacity-60 pointer-events-none"
+          >
+            {children}
+          </div>
+          <button type="button">Continue</button>
+        </div>
+      );
+    }
+  };
+});
 
 import { usePremium } from '../../lib/usePremium';
+import { premiumGatePropsSpy } from '../../components/PremiumGate';
 
-function renderPlateRoutes(): ReturnType<typeof render> {
+function renderPlateRoutes(routeState?: { triggerReason?: string }): ReturnType<typeof render> {
   return render(
-    <MemoryRouter initialEntries={['/plate']}>
+    <MemoryRouter initialEntries={[{ pathname: '/plate', state: routeState }]}>
       <Routes>
         <Route path="/plate" element={<Plate />} />
         <Route path="/setup" element={<div data-testid="setup-route">Setup route</div>} />
@@ -146,6 +171,15 @@ describe('Plate', () => {
 
     const premiumGate = screen.getByTestId('premium-gate');
     expect(premiumGate).toHaveAttribute('data-source', PREMIUM_GATE_SOURCES.PLATE_PAGE);
+    expect(premiumGate).toHaveAttribute('data-paywall-source', PREMIUM_GATE_SOURCES.PRO_DAILY_PLATE);
+    expect(premiumGate).toHaveAttribute('data-trigger-reason', '');
+    expect(premiumGatePropsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: PREMIUM_GATE_SOURCES.PLATE_PAGE,
+        paywallSource: PREMIUM_GATE_SOURCES.PRO_DAILY_PLATE,
+        triggerReason: undefined,
+      })
+    );
   });
 
   it('routes premium Plate CTAs to setup and progress screens', async () => {
@@ -160,5 +194,21 @@ describe('Plate', () => {
     renderPlateRoutes();
     await user.click(screen.getByRole('link', { name: 'View Progress' }));
     expect(screen.getByTestId('progress-route')).toBeInTheDocument();
+  });
+
+  it('forwards planning trigger reason only when the route provides it', () => {
+    vi.mocked(usePremium).mockReturnValue(true);
+
+    renderPlateRoutes({ triggerReason: 'targets_ready' });
+
+    const premiumGate = screen.getByTestId('premium-gate');
+    expect(premiumGate).toHaveAttribute('data-trigger-reason', 'targets_ready');
+    expect(premiumGatePropsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: PREMIUM_GATE_SOURCES.PLATE_PAGE,
+        paywallSource: PREMIUM_GATE_SOURCES.PRO_DAILY_PLATE,
+        triggerReason: 'targets_ready',
+      })
+    );
   });
 });

--- a/frontend/src/pages/__tests__/Plate.test.tsx
+++ b/frontend/src/pages/__tests__/Plate.test.tsx
@@ -1,10 +1,13 @@
+/* @vitest-environment jsdom */
 import type { JSX, ReactNode } from 'react';
+import '@testing-library/jest-dom/vitest';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import Plate from '../Plate';
 import { PREMIUM_GATE_SOURCES } from '../../config/constants';
+import '../../test/setup';
 
 // Mock usePremium hook
 vi.mock('../../lib/usePremium', () => ({


### PR DESCRIPTION
## Summary
- wire PR-2 as a narrow planning-surface delta on top of the already-merged paywall exposure ledger foundation from PR #1416
- align planning taxonomy and flow continuity for the concrete entrypoints implemented in this branch: BMI soft paywall and daily plate
- keep hidden paywall route, canonical event families, and client/server event authority split unchanged

## Scope
- BMI -> PRO targets: `source_surface=bmi_soft_paywall`, `trigger_reason=post_bmi`
- soft-hook -> `/pro` reuses one `exposure_id` across teaser, paywall view, and purchase attempt
- daily plate keeps `source_surface=pro_daily_plate`; `trigger_reason=targets_ready` is forwarded only when a planning caller provides it via route state
- direct `/pro` entries default to `source_surface=pro_page`, `trigger_reason=unknown` when no planning route state is present
- preserve legacy telemetry semantics while separating paywall ledger source where needed
- align monetization docs/runbook and canonical review artifact with the actual PR-2 delta

## Explicit Non-Scope
- no new public API endpoints
- no vendor SDK rollout
- no checkout transport or pricing-truth changes
- no widening of hidden paywall route schema beyond planning payload values
- no weekly-plan `vip_export` runtime wiring in this PR

## Validation
- `npm exec vitest run --environment jsdom src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx src/components/__tests__/PremiumGate.test.tsx src/pages/__tests__/Plate.test.tsx src/pages/Pro/__tests__/ProPaywallPage.test.tsx`
- `pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed

### Fixed in Commit Mapping
- [x] Fixed in commit mapping completed
- Canonical artifact: `docs/review/PR_1464_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105596267 -> f3686ad47
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105599240 -> f3686ad47
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105603191
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105603192 -> 7759b5a49
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105604423 -> 7759b5a49
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105604431
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105604433 -> 7759b5a49
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105604434 -> 7759b5a49
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105792515 -> 5edeaeb7b
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#discussion_r3105792517 -> 5edeaeb7b
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#pullrequestreview-4134861106
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#pullrequestreview-4134866854
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#pullrequestreview-4134867791
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1464#pullrequestreview-4135049981

## Notes
- local `make verify` was intentionally not used as the default gate for this lane because the project-level suite currently expands into the full ~10k test run; current PR handling for this lane is online/current-head CI first unless a full local verify is explicitly requested

## Summary by Sourcery

Реализована аналитика показа платёжной стены, специфичная для планирования, для потоков BMI и дневной тарелки поверх существующего фундамента paywall ledger, а также приведена документация в соответствие с новой таксономией планирования и базовым сценарием исполнения.

Новые возможности:
- Пробрасывать контекст платёжной стены планирования от BMI soft paywall teaser до PRO paywall, переиспользуя единый идентификатор жизненного цикла показа для тизера, просмотра paywall и попытки покупки.
- Добавить проводку источника платёжной стены и причины триггера, специфичных для планирования, для поверхности daily plate при сохранении существующей семантики легаси‑телеметрии.

Улучшения:
- Расширить компоненты платёжной стены `PremiumGate` и `BeforeAfter` для принятия метаданных источника и причины триггера, учитывающих планирование, при этом сохранив обратную совместимость значений по умолчанию.
- Определять поведение PRO paywall из состояния `router location`, когда оно присутствует, с откатом к значениям по умолчанию BMI soft paywall для поддержки вызывающих сторон планирования выше по потоку.
- Задокументировать проводку ledger показа платёжной стены планирования, словарь метрик и последовательность волн монетизации как узкий дельта‑слой поверх ранее влитых PR‑ов с фундаментом ledger.

Документация:
- Обновить runbook по монетизационному планированию, task packet, каталог метрик и backlog ledger, чтобы отразить проводку ledger показа платёжной стены планирования, зарезервированный словарь планирования и последовательность PR‑ов, а также добавить артефакт ревью fixed-in-commit для этого PR.

Тесты:
- Добавить и обновить модульные тесты для `SoftPaywallHook`, `PremiumGate`, `Plate` и `ProPaywallPage`, чтобы валидировать роутинг платёжной стены планирования, переиспользование идентификатора показа и распространение причины триггера по всей воронке.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Wire planning-specific paywall exposure analytics for BMI and daily plate flows on top of the existing paywall ledger foundation, and align documentation with the new planning taxonomy and execution baseline.

New Features:
- Propagate planning paywall context from BMI soft paywall teaser through the PRO paywall, reusing a single exposure lifecycle identifier across teaser, paywall view, and purchase attempt.
- Introduce planning-specific paywall source and trigger reason wiring for the daily plate surface while preserving existing legacy telemetry semantics.

Enhancements:
- Extend PremiumGate and BeforeAfter paywall components to accept planning-aware source and trigger reason metadata while keeping defaults backward compatible.
- Derive PRO paywall behavior from router location state when present, while direct `/pro` entries fall back to `pro_page` / `unknown` instead of BMI-specific analytics defaults.
- Document the planning paywall exposure ledger wiring, metrics vocabulary, and monetization wave sequencing as a narrow delta on top of the previously merged ledger foundation PRs.

Documentation:
- Update monetization planning runbook, task packet, metrics catalog, and backlog ledger to reflect the planning paywall exposure ledger wiring, reserved planning vocabulary, and PR sequencing, and add a fixed-in-commit review artifact for this PR.

Tests:
- Add and update unit tests for SoftPaywallHook, PremiumGate, Plate, and ProPaywallPage to validate planning paywall routing, exposure id reuse, and trigger reason propagation across the funnel.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paywall analytics/state propagation: exposure IDs, source, triggerReason and via persist across views, CTAs, navigation and purchases; PremiumGate and paywall components accept optional paywallSource, triggerReason and initial exposure ID.

* **Documentation**
  * Updated metrics taxonomy, runbooks, task packet and backlog with planning-specific paywall taxonomy, wiring notes, and a fixed-mapping review document.

* **Tests**
  * Expanded tests for analytics lifecycle, routing-state reuse, prop forwarding, and paywall integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

