### PR TITLE
feat(ci): split generic test install profile

### DIFF
--- a/.github/actions/python-setup/action.yml
+++ b/.github/actions/python-setup/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: 'requirements-ci-lite.txt'
   requirements-profile:
-    description: 'Explicit pinned dependency profile (runtime, runtime-dev, runtime-test, ci-lite)'
+    description: 'Explicit pinned dependency profile (runtime, runtime-dev, runtime-test, ci-test, ci-lite)'
     required: false
     default: ''
   constraints-file:
@@ -112,6 +112,16 @@ runs:
               fi
               if [[ ! -f "${{ inputs.test-requirements-file }}" ]]; then
                 echo "::error::Expected ${{ inputs.test-requirements-file }} when requirements-profile is runtime-test"
+                exit 1
+              fi
+              ;;
+            ci-test)
+              if [[ ! -f "${{ inputs.ci-lite-requirements-file }}" ]]; then
+                echo "::error::Expected ${{ inputs.ci-lite-requirements-file }} when requirements-profile is ci-test"
+                exit 1
+              fi
+              if [[ ! -f "${{ inputs.test-requirements-file }}" ]]; then
+                echo "::error::Expected ${{ inputs.test-requirements-file }} when requirements-profile is ci-test"
                 exit 1
               fi
               ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,7 +540,7 @@ jobs:
         uses: ./.github/actions/python-setup
         with:
           python-version: ${{ matrix.python-version }}
-          requirements-profile: runtime-test
+          requirements-profile: ci-test
           install-mode: direct-proxy
 
       - name: Setup Node.js
@@ -771,7 +771,7 @@ jobs:
         uses: ./.github/actions/python-setup
         with:
           python-version: ${{ matrix.python-version }}
-          requirements-profile: runtime-test
+          requirements-profile: ci-test
           install-mode: direct-proxy
 
       - name: Setup Node.js
@@ -1009,7 +1009,7 @@ jobs:
         uses: ./.github/actions/python-setup
         with:
           python-version: ${{ matrix.python-version }}
-          requirements-profile: runtime-test
+          requirements-profile: ci-test
           install-mode: direct-proxy
 
       - name: Setup Node.js

--- a/docs/review/PR_1465_FIXED_MAPPING.md
+++ b/docs/review/PR_1465_FIXED_MAPPING.md
@@ -19,7 +19,7 @@ Disposition: FIXED
 Commit: 44d90acbe1cae76b0f92e2dc85d3dcf543a8cd0f
 Evidence: `docs/review/PR_1465_FIXED_MAPPING.md:1`, `docs/roadmap/BACKLOG_LEDGER.md:562`, `scripts/ci/install_locked_python_requirements.py:213`, `tests/test_install_locked_python_requirements.py:259`
 Reason: Bot feedback was addressed by removing the redundant markdownlint suppression, adding evidence-driven backlog anchors plus the grammar fix, clarifying the `ci-test` missing-file failure path, and adding the complementary fail-closed test coverage.
-
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1465#discussion_r3105587884 -> 44d90acbe1cae76b0f92e2dc85d3dcf543a8cd0f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1465#pullrequestreview-4134851830 -> 44d90acbe1cae76b0f92e2dc85d3dcf543a8cd0f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1465#discussion_r3105590662 -> 44d90acbe1cae76b0f92e2dc85d3dcf543a8cd0f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1465#pullrequestreview-4134855122 -> 44d90acbe1cae76b0f92e2dc85d3dcf543a8cd0f

--- a/docs/review/PR_1465_FIXED_MAPPING.md
+++ b/docs/review/PR_1465_FIXED_MAPPING.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable MD034 -->
 # PR #1465 — Fixed in Commit Mapping (canonical)
 
 ## Discussion Thread Pass
@@ -11,12 +10,10 @@ Canonical review-governance artifact and PR-body mirror requirements:
 - [x] Fixed in commit mapping completed
 
 This artifact is created immediately after PR open per repo governance.
-No actionable human or bot review threads are recorded on the current head yet.
-Add every future disposition here before resolving threads on GitHub.
+Current-head bot review activity is now present.
+Record every new disposition here before resolving threads on GitHub.
 
 ## Fixed in Commit Mapping
-
-- No actionable review comments
 
 ## Merge Readiness
 
@@ -36,4 +33,3 @@ Merge-readiness contract:
   Evidence: `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:175-180`.
 - [ ] `make verify` green on latest pushed head
   Evidence: `AGENTS.md:1-16`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:175-180`.
-<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1465_FIXED_MAPPING.md
+++ b/docs/review/PR_1465_FIXED_MAPPING.md
@@ -15,6 +15,15 @@ Record every new disposition here before resolving threads on GitHub.
 
 ## Fixed in Commit Mapping
 
+Disposition: FIXED
+Commit: 44d90acbe1cae76b0f92e2dc85d3dcf543a8cd0f
+Evidence: `docs/review/PR_1465_FIXED_MAPPING.md:1`, `docs/roadmap/BACKLOG_LEDGER.md:562`, `scripts/ci/install_locked_python_requirements.py:213`, `tests/test_install_locked_python_requirements.py:259`
+Reason: Bot feedback was addressed by removing the redundant markdownlint suppression, adding evidence-driven backlog anchors plus the grammar fix, clarifying the `ci-test` missing-file failure path, and adding the complementary fail-closed test coverage.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1465#pullrequestreview-4134851830 -> 44d90acbe1cae76b0f92e2dc85d3dcf543a8cd0f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1465#discussion_r3105590662 -> 44d90acbe1cae76b0f92e2dc85d3dcf543a8cd0f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1465#pullrequestreview-4134855122 -> 44d90acbe1cae76b0f92e2dc85d3dcf543a8cd0f
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/review/PR_1465_FIXED_MAPPING.md
+++ b/docs/review/PR_1465_FIXED_MAPPING.md
@@ -1,0 +1,39 @@
+<!-- markdownlint-disable MD034 -->
+# PR #1465 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+This artifact is created immediately after PR open per repo governance.
+No actionable human or bot review threads are recorded on the current head yet.
+Add every future disposition here before resolving threads on GitHub.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+  Evidence: `AGENTS.md:42-49`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:95-112`.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: `AGENTS.md:46-49`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:155-163`.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: `AGENTS.md:43-45`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:95-112`.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: `AGENTS.md:44-45`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:95-112`.
+- [ ] Pre-commit green on latest pushed head
+  Evidence: `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:175-180`.
+- [ ] `make verify` green on latest pushed head
+  Evidence: `AGENTS.md:1-16`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:175-180`.
+<!-- markdownlint-enable MD034 -->

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -559,6 +559,26 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Operator rebuild / diagnose-web / `IMAGE_REF` flows match the live contract
     - `docker compose` v2 wording is canonical on touched surfaces
 
+<a id="ledger-p1-pr-scoped-validation-contract-and-hook-fix"></a>
+- [ ] P1: PR-scoped validation contract and pre-push hook fix
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD-PR-SCOPED-VALIDATION-CONTRACT
+  - Area: CI / tooling / governance
+  - Status note: Keep `make verify` as the hard merge-claim gate until this follow-up lands. Use this item to separate iterative PR-scope validation from final merge evidence and to fix the pre-push hook failure shape before changing agent/runbook guidance.
+  - Reason: The current repo-wide `make verify` loop is too broad for day-to-day PR iteration, while `scripts/run-backend-tests-pre-commit.sh` has surfaced an `FOUND_FOR_FILE[@]: unbound variable` failure on merge-commit paths. The follow-up must tighten the local PR-scoped validation contract around `make validate-changed` or an equivalent touched-scope path without weakening the canonical merge-readiness requirement.
+  - Links:
+    - `AGENTS.md`
+    - `RUNBOOK_AGENT.md`
+    - `Makefile`
+    - `.pre-commit-config.yaml`
+    - `scripts/run-backend-tests-pre-commit.sh`
+  - DoD:
+    - The pre-push backend test hook no longer fails with `FOUND_FOR_FILE[@]: unbound variable`
+    - Repo docs distinguish iterative PR-scoped validation from the final `make verify` merge-claim gate
+    - Agent/runbook guidance points at the correct local validation path for PR iteration
+    - Deterministic tests cover the hook fix and the promoted validation contract
+
 <a id="ledger-p1-docker-runtime-slimming-after-profile-split"></a>
 - [ ] P1: Docker runtime slimming after CI install-profile split
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -566,7 +566,15 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Target PR: PR-TBD-PR-SCOPED-VALIDATION-CONTRACT
   - Area: CI / tooling / governance
   - Status note: Keep `make verify` as the hard merge-claim gate until this follow-up lands. Use this item to separate iterative PR-scope validation from final merge evidence and to fix the pre-push hook failure shape before changing agent/runbook guidance.
-  - Reason: The current repo-wide `make verify` loop is too broad for day-to-day PR iteration, while `scripts/run-backend-tests-pre-commit.sh` has surfaced an `FOUND_FOR_FILE[@]: unbound variable` failure on merge-commit paths. The follow-up must tighten the local PR-scoped validation contract around `make validate-changed` or an equivalent touched-scope path without weakening the canonical merge-readiness requirement.
+  - Reason: The current repo-wide `make verify` loop is too broad for day-to-day PR iteration, while `scripts/run-backend-tests-pre-commit.sh` has surfaced a `FOUND_FOR_FILE[@]: unbound variable` failure on merge-commit paths. The follow-up must tighten the local PR-scoped validation contract around `make validate-changed` or an equivalent touched-scope path without weakening the canonical merge-readiness requirement.
+  - Evidence:
+    - `AGENTS.md:5-8`
+    - `AGENTS.md:27-30`
+    - `RUNBOOK_AGENT.md:377-383`
+    - `RUNBOOK_AGENT.md:600-603`
+    - `Makefile:130-134`
+    - `Makefile:175-175`
+    - `scripts/run-backend-tests-pre-commit.sh:174-204`
   - Links:
     - `AGENTS.md`
     - `RUNBOOK_AGENT.md`

--- a/scripts/ci/install_locked_python_requirements.py
+++ b/scripts/ci/install_locked_python_requirements.py
@@ -50,6 +50,7 @@ REQUIREMENTS_PROFILES: tuple[str, ...] = (
     "runtime",
     "runtime-dev",
     "runtime-test",
+    "ci-test",
     "ci-lite",
 )
 PIP_NETWORK_RETRIES = 5
@@ -207,6 +208,10 @@ def resolve_requirement_files(
         ],
         "runtime-test": [
             ("Requirements file", requirements_file),
+            ("Test requirements file", test_requirements_file),
+        ],
+        "ci-test": [
+            ("CI lite requirements file", ci_lite_requirements_file),
             ("Test requirements file", test_requirements_file),
         ],
         "ci-lite": [("CI lite requirements file", ci_lite_requirements_file)],

--- a/scripts/ci/install_locked_python_requirements.py
+++ b/scripts/ci/install_locked_python_requirements.py
@@ -212,7 +212,7 @@ def resolve_requirement_files(
         ],
         "ci-test": [
             ("CI lite requirements file", ci_lite_requirements_file),
-            ("Test requirements file", test_requirements_file),
+            ("CI test requirements file", test_requirements_file),
         ],
         "ci-lite": [("CI lite requirements file", ci_lite_requirements_file)],
     }

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -140,6 +140,29 @@ def test_resolve_requirement_files_supports_explicit_ci_lite_profile(tmp_path: P
     assert files == [requirements_ci_lite]
 
 
+def test_resolve_requirement_files_supports_explicit_ci_test_profile(tmp_path: Path) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("openai==2.29.0\n", encoding="utf-8")
+    requirements_dev = tmp_path / "requirements-dev.txt"
+    requirements_dev.write_text("pre-commit==4.5.1\n", encoding="utf-8")
+    requirements_test = tmp_path / "requirements-test.txt"
+    requirements_test.write_text("pytest==9.0.3\n", encoding="utf-8")
+    requirements_ci_lite = tmp_path / "requirements-ci-lite.txt"
+    requirements_ci_lite.write_text("pre-commit==4.5.1\n", encoding="utf-8")
+
+    files = installer.resolve_requirement_files(
+        requirements_file=requirements,
+        dev_requirements_file=requirements_dev,
+        test_requirements_file=requirements_test,
+        ci_lite_requirements_file=requirements_ci_lite,
+        install_dev=False,
+        install_test=False,
+        requirements_profile="ci-test",
+    )
+
+    assert files == [requirements_ci_lite, requirements_test]
+
+
 def test_resolve_requirement_files_fails_when_runtime_file_is_missing(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError, match="Requirements file not found"):
         installer.resolve_requirement_files(
@@ -210,6 +233,26 @@ def test_resolve_requirement_files_fails_when_ci_lite_profile_is_requested_but_m
             install_dev=False,
             install_test=False,
             requirements_profile="ci-lite",
+        )
+
+
+def test_resolve_requirement_files_fails_when_ci_test_profile_is_requested_but_missing(
+    tmp_path: Path,
+) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("openai==2.29.0\n", encoding="utf-8")
+    requirements_dev = tmp_path / "requirements-dev.txt"
+    requirements_dev.write_text("pre-commit==4.5.1\n", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError, match="CI lite requirements file not found"):
+        installer.resolve_requirement_files(
+            requirements_file=requirements,
+            dev_requirements_file=requirements_dev,
+            test_requirements_file=tmp_path / "requirements-test.txt",
+            ci_lite_requirements_file=tmp_path / "requirements-ci-lite.txt",
+            install_dev=False,
+            install_test=False,
+            requirements_profile="ci-test",
         )
 
 

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -256,6 +256,28 @@ def test_resolve_requirement_files_fails_when_ci_test_profile_is_requested_but_m
         )
 
 
+def test_resolve_requirement_files_fails_when_ci_test_test_file_is_missing(
+    tmp_path: Path,
+) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("openai==2.29.0\n", encoding="utf-8")
+    requirements_dev = tmp_path / "requirements-dev.txt"
+    requirements_dev.write_text("pre-commit==4.5.1\n", encoding="utf-8")
+    requirements_ci_lite = tmp_path / "requirements-ci-lite.txt"
+    requirements_ci_lite.write_text("pre-commit==4.5.1\n", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError, match="CI test requirements file not found"):
+        installer.resolve_requirement_files(
+            requirements_file=requirements,
+            dev_requirements_file=requirements_dev,
+            test_requirements_file=tmp_path / "requirements-test.txt",
+            ci_lite_requirements_file=requirements_ci_lite,
+            install_dev=False,
+            install_test=False,
+            requirements_profile="ci-test",
+        )
+
+
 def test_build_pip_download_command_uses_constraint_when_present(tmp_path: Path) -> None:
     constraints = tmp_path / "constraints.txt"
     constraints.write_text("openai>=2.29.0\n", encoding="utf-8")

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -94,6 +94,14 @@ def test_python_setup_action_uses_locked_installer_not_floating_tools() -> None:
         in action_text
     )
     assert (
+        "::error::Expected ${{ inputs.ci-lite-requirements-file }} when requirements-profile is ci-test"
+        in action_text
+    )
+    assert (
+        "::error::Expected ${{ inputs.test-requirements-file }} when requirements-profile is ci-test"
+        in action_text
+    )
+    assert (
         "::error::Expected ${{ inputs.ci-lite-requirements-file }} when requirements-profile is ci-lite"
         in action_text
     )
@@ -281,7 +289,7 @@ def test_ci_workflow_uses_single_direct_proxy_python_install_path_per_job() -> N
 
     for job_name in ("test-pr", "test-feature", "test-main"):
         setup_step = _python_setup_step(".github/workflows/ci.yml", job_name)
-        assert setup_step["with"]["requirements-profile"] == "runtime-test"
+        assert setup_step["with"]["requirements-profile"] == "ci-test"
         assert "install-test-deps" not in setup_step["with"]
         assert all(step.get("name") != "Install dependencies" for step in jobs[job_name]["steps"])
 


### PR DESCRIPTION
## Scope
- land PR-2 of the Docker / CI discipline packet without widening into runtime or deploy-shape changes
- add a dedicated locked `ci-test` profile for generic backend/shared CI test lanes
- keep runtime install semantics unchanged in this slice and defer broader local validation contract changes to backlog

## Files
- `.github/actions/python-setup/action.yml`
- `.github/workflows/ci.yml`
- `scripts/ci/install_locked_python_requirements.py`
- `tests/test_install_locked_python_requirements.py`
- `tests/test_python_supply_chain_controls.py`
- `docs/review/PR_1465_FIXED_MAPPING.md`
- `docs/roadmap/BACKLOG_LEDGER.md`

## DoD
- generic backend/shared CI test jobs use `requirements-profile: ci-test` instead of `runtime-test`
- locked installer resolves `ci-test` to `requirements-ci-lite.txt + requirements-test.txt`
- action-level validation fails closed when `ci-test` inputs are missing
- deterministic tests cover installer semantics and CI wiring for the new profile
- canonical review-governance artifact exists for PR `#1465`

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pytest -q tests/test_install_locked_python_requirements.py tests/test_python_supply_chain_controls.py`
- `make validate-min VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python`
- `pre-commit run --all-files`
- fresh-env representative proof on `python3.13` via `scripts/ci/install_locked_python_requirements.py --requirements-profile ci-test --install-mode direct-proxy --index-url "$PULSEPLATE_PYTHON_INDEX_URL"`
- fresh-env proof targets passed:
- `pytest -q tests/edges tests/test_remaining_modules.py --maxfail=3`
- `pytest -q tests/test_insight_error_hygiene.py --maxfail=1`
- `pytest -q tests/test_vector_rag.py --maxfail=1`
- pre-push hooks passed, including backend tests, Bandit, and docker build test

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- Canonical artifact: `docs/review/PR_1465_FIXED_MAPPING.md`

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1465_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Current-head CI is green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green on latest pushed head
- [ ] `make verify` green on latest pushed head

## Deferred / Follow-ups
- PR-scoped local validation contract and `scripts/run-backend-tests-pre-commit.sh` hook fix remain tracked in `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-pr-scoped-validation-contract-and-hook-fix`

## Packet
- `docs/orchestration/DOCKER_CI_DISCIPLINE_PR_SERIES_PACKET_2026-04-16.md`

## Summary by Sourcery

Введение специализированного заблокированного профиля Python-зависимостей `ci-test` для CI-тестовых задач и его интеграция с инсталлятором, GitHub Action и CI‑воркфлоу, вместе с сопутствующими обновлениями по управлению и бэклогу.

New Features:
- Добавлена поддержка нового заблокированного профиля требований `ci-test`, который объединяет файлы требований CI-lite и тестов для установки Python-зависимостей в CI.
- Создан канонический документ соответствия «фикс-в-коммите» для PR #1465 для отслеживания процесса ревью и готовности к слиянию.

Enhancements:
- Расширен инсталлятор заблокированных требований для разрешения и валидации файлов для профиля `ci-test` наряду с существующими профилями.
- Обновлен action настройки Python в CI для проверки обязательных входных параметров и «fail closed» поведения при использовании профиля `ci-test`.
- Скорректированы CI‑воркфлоу так, чтобы обобщённые backend‑задачи и общие тестовые задачи использовали профиль требований `ci-test` вместо `runtime-test`.
- Добавлен пункт P1 в бэклог для переработки контрактов валидации в рамках PR и исправления режима отказа pre-push hook’а backend‑тестов.

Tests:
- Добавлены модульные тесты, покрывающие поведение инсталлятора и режимы отказа для нового профиля `ci-test`.
- Расширены тесты контроля цепочки поставок, чтобы гарантировать, что GitHub Action выдаёт строгие ошибки валидации для профиля `ci-test` и что CI‑задачи его используют.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated locked `ci-test` Python requirements profile for CI test jobs and wire it through the installer, GitHub Action, and CI workflow with accompanying governance and backlog updates.

New Features:
- Add support for a new `ci-test` locked requirements profile that combines CI-lite and test requirement files for Python dependency installation in CI.
- Create a canonical fixed-in-commit mapping document for PR #1465 to track review governance and merge readiness.

Enhancements:
- Extend the locked requirements installer to resolve and validate files for the `ci-test` profile alongside existing profiles.
- Update the CI Python setup action to validate required inputs and fail closed when using the `ci-test` profile.
- Adjust CI workflows so generic backend and shared test jobs use the `ci-test` requirements profile instead of `runtime-test`.
- Record a P1 backlog item to redesign PR-scoped validation contracts and fix the pre-push backend test hook failure mode.

Tests:
- Add unit tests covering installer behavior and failure modes for the new `ci-test` profile.
- Extend supply-chain control tests to ensure the GitHub Action exposes strict validation errors for the `ci-test` profile and that CI jobs use it.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new dependency profile option for CI workflows.
* **Updates**
  * CI workflows switched to the new profile.
  * Dependency installation now enforces additional profile-specific validations.
* **Tests**
  * Added tests covering the new profile behavior and validation failure cases.
* **Documentation**
  * Added PR governance notes and a backlog entry describing follow-up validation work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->