### PR TITLE
fix(ci): pin Trivy action and scanner version in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,8 @@ jobs:
           scan-type: fs
           scan-ref: .
           cache-dir: /tmp/trivy-cache
-          ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
+          # Keep the policy path repo-relative; the action reads it from the checked-out workspace.
+          ignore-policy: trivy/ignore-policy.rego
           scanners: vuln
           format: sarif
           output: trivy-results.sarif

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
           ignore-unfixed: true
           exit-code: '0'
           trivyignores: .trivyignore
-          version: v0.68.1
+          version: v0.69.3
 
       - name: Warn when Trivy filesystem SARIF is missing
         if: ${{ hashFiles('trivy-results.sarif') == '' }}
@@ -260,7 +260,7 @@ jobs:
           limit-severities-for-sarif: true
           trivyignores: .trivyignore
           exit-code: '0'
-          version: v0.68.1
+          version: v0.69.3
 
       - name: Warn when Trivy image SARIF is missing
         if: ${{ hashFiles('trivy-image.sarif') == '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Prepare Trivy ignore policy
+        run: |
+          set -euo pipefail
+          test -f trivy/ignore-policy.rego
+          cp trivy/ignore-policy.rego .trivy-ignore-policy.rego
+          ls -la .trivy-ignore-policy.rego
+
       - name: Free disk space (Ubuntu hosted runner)
         continue-on-error: true
         run: |
@@ -260,7 +267,8 @@ jobs:
           scan-type: image
           image-ref: ${{ steps.image-ref.outputs.ref }}
           cache-dir: /tmp/trivy-cache
-          ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
+          ignore-policy: .trivy-ignore-policy.rego
+          scanners: vuln
           format: sarif
           output: trivy-image.sarif
           severity: CRITICAL,HIGH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,7 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           ignore-unfixed: true
           exit-code: '0'
           trivyignores: .trivyignore
@@ -254,6 +255,7 @@ jobs:
           format: sarif
           output: trivy-image.sarif
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           trivyignores: .trivyignore
           exit-code: '0'
           version: v0.68.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,25 +132,23 @@ jobs:
             echo "::warning::GHCR_READ_TOKEN is set but docker login was denied; continuing without registry auth."
           fi
 
-      - name: Install Trivy via apt
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y wget apt-transport-https gnupg lsb-release
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
-          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update
-          sudo apt-get install -y trivy
-          trivy --version
-
       # SARIF path must stay relative to GITHUB_WORKSPACE (hashFiles/upload-sarif assume repo root).
       - name: Run Trivy vulnerability scanner (filesystem scan)
-        run: |
-          trivy fs . \
-            --db-repository ghcr.io/aquasecurity/trivy-db \
-            --ignore-policy "${{ github.workspace }}/trivy/ignore-policy.rego" \
-            --scanners vuln \
-            --format sarif --output trivy-results.sarif --severity CRITICAL,HIGH \
-            --ignore-unfixed --exit-code 0 --ignorefile .trivyignore
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db
+        with:
+          scan-type: fs
+          scan-ref: .
+          ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
+          scanners: vuln
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+          trivyignores: .trivyignore
+          version: v0.68.1
 
       - name: Warn when Trivy filesystem SARIF is missing
         if: ${{ hashFiles('trivy-results.sarif') == '' }}
@@ -240,29 +238,25 @@ jobs:
         run: |
           echo "ref=${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}:sha-${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
-      - name: Install Trivy via apt
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y wget apt-transport-https gnupg lsb-release
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
-          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update
-          sudo apt-get install -y trivy
-          trivy --version
-
       # Image scan: --exit-code 0 makes findings report-only (no fail on vuln count).
       # continue-on-error: true keeps the publish job moving when Trivy fails before SARIF exists
       # (DB/network/registry); hashFiles guards upload-sarif. Do not change output path without
       # updating hashFiles('trivy-image.sarif') and upload/warn steps (paths are workspace-relative).
       - name: Run Trivy vulnerability scanner (image scan, report-only)
         continue-on-error: true
-        run: |
-          trivy image \
-            --ignore-policy "${{ github.workspace }}/trivy/ignore-policy.rego" \
-            --format sarif --output trivy-image.sarif --severity CRITICAL,HIGH \
-            --ignorefile .trivyignore \
-            --exit-code 0 \
-            '${{ steps.image-ref.outputs.ref }}'
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db
+        with:
+          scan-type: image
+          image-ref: ${{ steps.image-ref.outputs.ref }}
+          ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
+          format: sarif
+          output: trivy-image.sarif
+          severity: CRITICAL,HIGH
+          trivyignores: .trivyignore
+          exit-code: '0'
+          version: v0.68.1
 
       - name: Warn when Trivy image SARIF is missing
         if: ${{ hashFiles('trivy-image.sarif') == '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,6 +192,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Prepare Trivy ignore policy
+        run: |
+          set -euo pipefail
+          test -f trivy/ignore-policy.rego
+          cp trivy/ignore-policy.rego .trivy-ignore-policy.rego
+          ls -la .trivy-ignore-policy.rego
+
       - name: Free disk space (Ubuntu hosted runner)
         continue-on-error: true
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,13 @@ jobs:
           fi
 
       # SARIF path must stay relative to GITHUB_WORKSPACE (hashFiles/upload-sarif assume repo root).
+      - name: Prepare Trivy ignore policy
+        run: |
+          set -euo pipefail
+          test -f trivy/ignore-policy.rego
+          cp trivy/ignore-policy.rego .trivy-ignore-policy.rego
+          ls -la .trivy-ignore-policy.rego
+
       - name: Run Trivy vulnerability scanner (filesystem scan)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
@@ -141,8 +148,7 @@ jobs:
           scan-type: fs
           scan-ref: .
           cache-dir: /tmp/trivy-cache
-          # Keep the policy path repo-relative; the action reads it from the checked-out workspace.
-          ignore-policy: trivy/ignore-policy.rego
+          ignore-policy: .trivy-ignore-policy.rego
           scanners: vuln
           format: sarif
           output: trivy-results.sarif

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,7 @@ jobs:
         with:
           scan-type: fs
           scan-ref: .
+          cache-dir: /tmp/trivy-cache
           ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
           scanners: vuln
           format: sarif
@@ -251,6 +252,7 @@ jobs:
         with:
           scan-type: image
           image-ref: ${{ steps.image-ref.outputs.ref }}
+          cache-dir: /tmp/trivy-cache
           ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
           format: sarif
           output: trivy-image.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -73,6 +73,13 @@ jobs:
             echo "::warning::GHCR_READ_TOKEN is set but docker login was denied; continuing without registry auth."
           fi
 
+      - name: Prepare Trivy ignore policy
+        run: |
+          set -euo pipefail
+          test -f trivy/ignore-policy.rego
+          cp trivy/ignore-policy.rego .trivy-ignore-policy.rego
+          ls -la .trivy-ignore-policy.rego
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
@@ -89,8 +96,7 @@ jobs:
           limit-severities-for-sarif: true
           ignore-unfixed: true
           trivyignores: .trivyignore
-          # Keep the policy path repo-relative; the action reads it from the checked-out workspace.
-          ignore-policy: trivy/ignore-policy.rego
+          ignore-policy: .trivy-ignore-policy.rego
           version: v0.69.3
 
       - name: Fail when Trivy SARIF is missing

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -103,6 +103,6 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
-        if: ${{ hashFiles('trivy-results.sarif') != '' }}
+        if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -61,16 +61,6 @@ jobs:
           provenance: false
           target: production
 
-      - name: Install Trivy via apt
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y wget apt-transport-https gnupg lsb-release
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
-          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update
-          sudo apt-get install -y trivy
-          trivy --version
-
       # PAT may be present but expired/revoked; anonymous pull still works for public trivy-db.
       - name: Log in to GHCR (Trivy DB)
         if: ${{ env.GHCR_READ_TOKEN_AVAILABLE == 'true' }}
@@ -84,20 +74,21 @@ jobs:
           fi
 
       - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
-          TRIVY_TIMEOUT: 15m
-        run: |
-          trivy image \
-            --db-repository ghcr.io/aquasecurity/trivy-db \
-            --scanners vuln \
-            --timeout "${TRIVY_TIMEOUT}" \
-            --format sarif \
-            --output trivy-results.sarif \
-            --severity CRITICAL,HIGH \
-            --ignore-unfixed \
-            --ignorefile .trivyignore \
-            --ignore-policy trivy/ignore-policy.rego \
-            'pulseplate:trivy-scan-${{ github.sha }}'
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db
+        with:
+          scan-type: image
+          image-ref: pulseplate:trivy-scan-${{ github.sha }}
+          scanners: vuln
+          timeout: 15m
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+          ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
+          version: v0.68.1
 
       - name: Verify SARIF file exists
         run: ls -la trivy-results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -92,9 +92,14 @@ jobs:
           ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
           version: v0.68.1
 
-      - name: Warn when Trivy SARIF is missing
-        if: ${{ hashFiles('trivy-results.sarif') == '' }}
-        run: echo "::warning::Trivy SARIF missing; skipping upload."
+      - name: Fail when Trivy SARIF is missing
+        if: ${{ always() }}
+        run: |
+          if [ ! -f trivy-results.sarif ]; then
+            echo "::error::Trivy SARIF missing after scan; failing closed."
+            exit 1
+          fi
+          ls -la trivy-results.sarif
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -85,6 +85,7 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           ignore-unfixed: true
           trivyignores: .trivyignore
           ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -90,7 +90,7 @@ jobs:
           ignore-unfixed: true
           trivyignores: .trivyignore
           ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
-          version: v0.68.1
+          version: v0.69.3
 
       - name: Fail when Trivy SARIF is missing
         if: ${{ always() }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           scan-type: image
           image-ref: pulseplate:trivy-scan-${{ github.sha }}
+          cache-dir: /tmp/trivy-cache
           scanners: vuln
           timeout: 15m
           format: sarif
@@ -91,11 +92,12 @@ jobs:
           ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
           version: v0.68.1
 
-      - name: Verify SARIF file exists
-        run: ls -la trivy-results.sarif
+      - name: Warn when Trivy SARIF is missing
+        if: ${{ hashFiles('trivy-results.sarif') == '' }}
+        run: echo "::warning::Trivy SARIF missing; skipping upload."
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
-        if: always()
+        if: ${{ hashFiles('trivy-results.sarif') != '' }}
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -89,7 +89,8 @@ jobs:
           limit-severities-for-sarif: true
           ignore-unfixed: true
           trivyignores: .trivyignore
-          ignore-policy: ${{ github.workspace }}/trivy/ignore-policy.rego
+          # Keep the policy path repo-relative; the action reads it from the checked-out workspace.
+          ignore-policy: trivy/ignore-policy.rego
           version: v0.69.3
 
       - name: Fail when Trivy SARIF is missing

--- a/docs/review/PR_1467_FIXED_MAPPING.md
+++ b/docs/review/PR_1467_FIXED_MAPPING.md
@@ -33,5 +33,5 @@ Merge-readiness contract:
 - [ ] Pre-commit green on latest pushed head
   Evidence: `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:175-180`.
 - [ ] `make verify` green on latest pushed head
-  Evidence: `AGENTS.md:1-16`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:175-180`.
+  Evidence: `Makefile:164-176`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:175-180`.
 <!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1467_FIXED_MAPPING.md
+++ b/docs/review/PR_1467_FIXED_MAPPING.md
@@ -34,6 +34,11 @@ Disposition: NOT-A-BUG
 Evidence: `.github/workflows/trivy.yml:102-113` already implements the deliberate fail-closed SARIF contract discussed in `discussion_r3105782286`; the broader centralization suggestions in the review are advisory refactor ideas, not merge-blocking correctness defects for this narrow replacement PR.
 Reason: The actionable correctness concern from the review is fully addressed by the documented fail-closed design above, and the remaining deduplication suggestions do not require additional code changes in this lane.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1467#pullrequestreview-4135102360 -> 2601527e7aca1b4abc3b32a6ee241258a2108c69
+Disposition: FIXED
+Commit: 2601527e7aca1b4abc3b32a6ee241258a2108c69
+Evidence: `docs/review/PR_1467_FIXED_MAPPING.md:17-25` now uses full 40-character commit SHAs in both the mapping arrows and `Commit:` fields, matching the audit-durability request from the latest CodeRabbit review summary.
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/review/PR_1467_FIXED_MAPPING.md
+++ b/docs/review/PR_1467_FIXED_MAPPING.md
@@ -19,10 +19,10 @@ Disposition: FIXED
 Commit: 6d18f5fbf
 Evidence: `docs/review/PR_1467_FIXED_MAPPING.md:51-54` now cites `Makefile:164-176` directly for the `make verify` hard gate, matching the CodeRabbit request for a precise evidence anchor.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1467#pullrequestreview-4135044228 -> 6d18f5fbf
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1467#pullrequestreview-4135044228 -> 6b09ab380
 Disposition: FIXED
-Commit: 6d18f5fbf
-Evidence: `.github/workflows/build.yml:268-278` now pins the publish image scan to `scanners: vuln` and uses the relative `.trivy-ignore-policy.rego` path, while `docs/review/PR_1467_FIXED_MAPPING.md:51-54` fixes the direct `make verify` evidence anchor requested in the review.
+Commit: 6b09ab380
+Evidence: `.github/workflows/build.yml:195-200` now prepares `.trivy-ignore-policy.rego` inside `publish`, `.github/workflows/build.yml:268-278` pins the publish image scan to `scanners: vuln` and the relative ignore-policy path, and `docs/review/PR_1467_FIXED_MAPPING.md:51-54` fixes the direct `make verify` evidence anchor requested in the review.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1467#discussion_r3105782286
 Disposition: NOT-A-BUG

--- a/docs/review/PR_1467_FIXED_MAPPING.md
+++ b/docs/review/PR_1467_FIXED_MAPPING.md
@@ -1,0 +1,37 @@
+<!-- markdownlint-disable MD034 -->
+# PR #1467 - Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:47-57`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`.
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+This replacement PR starts with no actionable review comments. New human or bot
+feedback must be dispositioned here before any GitHub thread is resolved.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:38-45`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+  Evidence: `AGENTS.md:38-45`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: `AGENTS.md:41-45`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-163`.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: `AGENTS.md:54-57`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: `AGENTS.md:54-57`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`.
+- [ ] Pre-commit green on latest pushed head
+  Evidence: `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:175-180`.
+- [ ] `make verify` green on latest pushed head
+  Evidence: `AGENTS.md:1-16`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:175-180`.
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1467_FIXED_MAPPING.md
+++ b/docs/review/PR_1467_FIXED_MAPPING.md
@@ -14,14 +14,14 @@ feedback is now dispositioned here before any GitHub thread is resolved.
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1467#discussion_r3105784083 -> 6d18f5fbf
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1467#discussion_r3105784083 -> 6d18f5fbff78ac70ee52bf464bab7c3bcdc578b0
 Disposition: FIXED
-Commit: 6d18f5fbf
+Commit: 6d18f5fbff78ac70ee52bf464bab7c3bcdc578b0
 Evidence: `docs/review/PR_1467_FIXED_MAPPING.md:51-54` now cites `Makefile:164-176` directly for the `make verify` hard gate, matching the CodeRabbit request for a precise evidence anchor.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1467#pullrequestreview-4135044228 -> 6b09ab380
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1467#pullrequestreview-4135044228 -> 6b09ab38067af2233b5afc8370f9e8aaa8b13453
 Disposition: FIXED
-Commit: 6b09ab380
+Commit: 6b09ab38067af2233b5afc8370f9e8aaa8b13453
 Evidence: `.github/workflows/build.yml:195-200` now prepares `.trivy-ignore-policy.rego` inside `publish`, `.github/workflows/build.yml:268-278` pins the publish image scan to `scanners: vuln` and the relative ignore-policy path, and `docs/review/PR_1467_FIXED_MAPPING.md:51-54` fixes the direct `make verify` evidence anchor requested in the review.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1467#discussion_r3105782286

--- a/docs/review/PR_1467_FIXED_MAPPING.md
+++ b/docs/review/PR_1467_FIXED_MAPPING.md
@@ -9,12 +9,30 @@ Canonical review-governance artifact and PR-body mirror requirements:
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-This replacement PR starts with no actionable review comments. New human or bot
-feedback must be dispositioned here before any GitHub thread is resolved.
+This replacement PR started without actionable review comments, but later bot
+feedback is now dispositioned here before any GitHub thread is resolved.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1467#discussion_r3105784083 -> 6d18f5fbf
+Disposition: FIXED
+Commit: 6d18f5fbf
+Evidence: `docs/review/PR_1467_FIXED_MAPPING.md:51-54` now cites `Makefile:164-176` directly for the `make verify` hard gate, matching the CodeRabbit request for a precise evidence anchor.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1467#pullrequestreview-4135044228 -> 6d18f5fbf
+Disposition: FIXED
+Commit: 6d18f5fbf
+Evidence: `.github/workflows/build.yml:268-278` now pins the publish image scan to `scanners: vuln` and uses the relative `.trivy-ignore-policy.rego` path, while `docs/review/PR_1467_FIXED_MAPPING.md:51-54` fixes the direct `make verify` evidence anchor requested in the review.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1467#discussion_r3105782286
+Disposition: NOT-A-BUG
+Evidence: `.github/workflows/trivy.yml:102-113` keeps both the explicit fail-closed SARIF existence step and the `hashFiles('trivy-results.sarif') != ''` upload guard in place.
+Reason: The two checks are intentionally retained as defense-in-depth so the scan fails closed when SARIF is absent while the upload step remains safe if future path wiring or step conditions change.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1467#pullrequestreview-4135042984
+Disposition: NOT-A-BUG
+Evidence: `.github/workflows/trivy.yml:102-113` already implements the deliberate fail-closed SARIF contract discussed in `discussion_r3105782286`; the broader centralization suggestions in the review are advisory refactor ideas, not merge-blocking correctness defects for this narrow replacement PR.
+Reason: The actionable correctness concern from the review is fully addressed by the documented fail-closed design above, and the remaining deduplication suggestions do not require additional code changes in this lane.
 
 ## Merge Readiness
 


### PR DESCRIPTION
## Summary
- supersedes #1444 with a fresh replacement branch from current `origin/main`
- refreshes Trivy workflow hardening by pinning the GitHub Action to a reviewed commit SHA and locking the scanner version
- keeps the functional workflow delta limited to `.github/workflows/build.yml` and `.github/workflows/trivy.yml`, with the canonical review artifact added for governance

## Why Replacement
- old #1444 is an open stale branch and no longer matches current `main`
- the intended security/CI hardening is still valid, but it needs to land from a fresh branch with only the minimal workflow delta
- replacement is lower-risk than continuing the conflicting stale branch in place

## Scope In
- pin `aquasecurity/trivy-action` by commit SHA in the two workflow files
- lock the Trivy scanner version
- preserve current-main workflow semantics such as report-only image scan behavior, SARIF paths, GHCR DB fallback, timeout handling, and SARIF severity filtering
- keep `docs/review/PR_1467_FIXED_MAPPING.md` in sync as the canonical governance artifact

## Scope Out
- no workflow redesign beyond the Trivy pin/refresh slice
- no functional code changes outside the two workflow files
- no continuation of the stale branch history from old #1444

## Testing
- `pre-commit run --all-files`
- `make verify` (in progress on latest local head; final result will be recorded before any merge-ready claim)

## Carryover
- Supersedes #1444.

## Deferred / Follow-ups
- None.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- Canonical artifact: `docs/review/PR_1467_FIXED_MAPPING.md`

### Fixed in Commit Mapping
- No actionable review comments

## Merge Readiness
- [ ] Current-head CI is green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Pre-commit green on latest pushed head
- [ ] `make verify` green on latest pushed head

## Summary by Sourcery

Закрепить сканирование Trivy в CI‑воркфлоу на конкретном коммите GitHub Action и версии сканера, сохранив текущее поведение сканирования и обработку SARIF.

CI:
- Заменить ручную установку Trivy в воркфлоу `build` и `Trivy` на зафиксированный `aquasecurity/trivy-action` и заблокированную версию сканера Trivy.
- Скорректировать шаги Trivy так, чтобы использовать локальный для workspace скопированный файл политики игнорирования и сохранить существующие пути к SARIF, пороги серьёзности и семантику сканирования образов в режиме “только отчёт”.
- Ужесточить обработку SARIF в выделенном Trivy‑воркфлоу, завершая его с ошибкой при отсутствии файла SARIF и загружая результаты только при наличии файла SARIF.

Документация:
- Добавить документ по управлению (governance), фиксирующий сопоставление “исправлено‑в‑коммите” и чеклист готовности к слиянию (merge readiness checklist) для этого PR.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Pin Trivy scanning in CI workflows to a specific GitHub Action commit and scanner version while preserving existing scan behavior and SARIF handling.

CI:
- Replace manual Trivy installation in build and Trivy workflows with the pinned aquasecurity/trivy-action and a locked Trivy scanner version.
- Adjust Trivy steps to use a copied workspace-local ignore policy file and maintain existing SARIF paths, severity limits, and report-only image scan semantics.
- Tighten SARIF handling in the dedicated Trivy workflow by failing when the SARIF file is missing and only uploading results when a SARIF file exists.

Documentation:
- Add a governance document recording the fixed-in-commit mapping and merge readiness checklist for this PR.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched CI to the maintained Trivy Action for scans, standardized SARIF output and scan configuration, moved ignore-policy handling to workspace-relative paths, tightened post-scan existence checks, and made SARIF upload conditional.

* **Documentation**
  * Added a PR review/governance document recording review dispositions, mapping review anchors to commits with evidence, and including a merge-readiness checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->