### PR TITLE
fix(data): make foods foundation downgrade ownership-aware

### DIFF
--- a/alembic/versions/202604120001_add_foods_catalog_foundation.py
+++ b/alembic/versions/202604120001_add_foods_catalog_foundation.py
@@ -22,6 +22,36 @@ down_revision = "202604060001"
 branch_labels = None
 depends_on = None
 
+_OWNERSHIP_REGISTRY_TABLE = "pulseplate_migration_ownership"
+_OBJECT_TYPE_TABLE = "table"
+_OBJECT_TYPE_INDEX = "index"
+_INSERT_OWNED_OBJECT_SQL = sa.text("""
+    INSERT INTO pulseplate_migration_ownership
+        (revision_id, object_type, table_name, object_name)
+    VALUES
+        (:revision_id, :object_type, :table_name, :object_name)
+    """)
+_SELECT_OWNED_OBJECT_SQL = sa.text("""
+    SELECT 1
+    FROM pulseplate_migration_ownership
+    WHERE revision_id = :revision_id
+      AND object_type = :object_type
+      AND table_name = :table_name
+      AND object_name = :object_name
+    LIMIT 1
+    """)
+_DELETE_OWNED_OBJECT_SQL = sa.text("""
+    DELETE FROM pulseplate_migration_ownership
+    WHERE revision_id = :revision_id
+      AND object_type = :object_type
+      AND table_name = :table_name
+      AND object_name = :object_name
+    """)
+_COUNT_OWNED_OBJECTS_SQL = sa.text("""
+    SELECT COUNT(*)
+    FROM pulseplate_migration_ownership
+    """)
+
 
 def _json_type() -> sa.JSON:
     """RU: Диалект-безопасный JSON/JSONB. EN: Dialect-safe JSON/JSONB."""
@@ -44,183 +74,284 @@ def _index_exists(table_name: str, index_name: str) -> bool:
     return any(index.get("name") == index_name for index in inspector.get_indexes(table_name))
 
 
-_UPGRADE_TRIGRAM_INDEXES = r"""
-DO $pulseplate_pg_trgm$
-BEGIN
-  IF to_regclass('public.foods') IS NOT NULL THEN
-    EXECUTE $sql$
-CREATE INDEX IF NOT EXISTS ix_foods_canonical_name_gin_trgm
-ON public.foods USING gin (canonical_name gin_trgm_ops)
-$sql$;
-    EXECUTE $sql$
-CREATE INDEX IF NOT EXISTS ix_foods_group_name_gin_trgm
-ON public.foods USING gin (group_name gin_trgm_ops)
-$sql$;
-    EXECUTE $sql$
-CREATE INDEX IF NOT EXISTS ix_foods_brand_gin_trgm
-ON public.foods USING gin (brand gin_trgm_ops)
-$sql$;
-  END IF;
-END
-$pulseplate_pg_trgm$;
-"""
+def _ownership_registry_exists() -> bool:
+    """RU: Проверить наличие реестра владения. EN: Check whether ownership registry exists."""
+
+    return _table_exists(_OWNERSHIP_REGISTRY_TABLE)
+
+
+def _ensure_ownership_registry() -> None:
+    """RU: Создать реестр владения при первом owned object. EN: Create registry on first owned object."""
+
+    if _ownership_registry_exists():
+        return
+    op.create_table(
+        _OWNERSHIP_REGISTRY_TABLE,
+        sa.Column("revision_id", sa.String(length=32), nullable=False),
+        sa.Column("object_type", sa.String(length=16), nullable=False),
+        sa.Column("table_name", sa.String(length=128), nullable=False),
+        sa.Column("object_name", sa.String(length=128), nullable=False),
+        sa.PrimaryKeyConstraint("revision_id", "object_type", "object_name"),
+    )
+
+
+def _record_owned_object(object_type: str, table_name: str, object_name: str) -> None:
+    """RU: Записать объект, созданный этой ревизией. EN: Record object created by this revision."""
+
+    _ensure_ownership_registry()
+    bind = op.get_bind()
+    if _owned_object_exists(object_type, table_name, object_name):
+        return
+    bind.execute(
+        _INSERT_OWNED_OBJECT_SQL,
+        {
+            "revision_id": revision,
+            "object_type": object_type,
+            "table_name": table_name,
+            "object_name": object_name,
+        },
+    )
+
+
+def _owned_object_exists(object_type: str, table_name: str, object_name: str) -> bool:
+    """RU: Проверить, что объект принадлежит ревизии. EN: Check whether object is owned by revision."""
+
+    if not _ownership_registry_exists():
+        return False
+    bind = op.get_bind()
+    result = bind.execute(
+        _SELECT_OWNED_OBJECT_SQL,
+        {
+            "revision_id": revision,
+            "object_type": object_type,
+            "table_name": table_name,
+            "object_name": object_name,
+        },
+    ).scalar()
+    return result is not None
+
+
+def _remove_owned_object_record(object_type: str, table_name: str, object_name: str) -> None:
+    """RU: Удалить ownership marker после rollback. EN: Remove ownership marker after rollback."""
+
+    if not _ownership_registry_exists():
+        return
+    op.get_bind().execute(
+        _DELETE_OWNED_OBJECT_SQL,
+        {
+            "revision_id": revision,
+            "object_type": object_type,
+            "table_name": table_name,
+            "object_name": object_name,
+        },
+    )
+
+
+def _drop_ownership_registry_if_empty() -> None:
+    """RU: Убрать пустой registry. EN: Drop empty ownership registry."""
+
+    if not _ownership_registry_exists():
+        return
+    remaining = op.get_bind().execute(_COUNT_OWNED_OBJECTS_SQL).scalar_one()
+    if remaining == 0:
+        op.drop_table(_OWNERSHIP_REGISTRY_TABLE)
+
+
+def _create_owned_table(
+    table_name: str,
+    *columns: sa.Column | sa.ForeignKeyConstraint | sa.PrimaryKeyConstraint,
+) -> None:
+    """RU: Создать таблицу и пометить ownership. EN: Create table and mark ownership."""
+
+    if _table_exists(table_name):
+        return
+    op.create_table(table_name, *columns)
+    _record_owned_object(_OBJECT_TYPE_TABLE, table_name, table_name)
+
+
+def _create_owned_index(index_name: str, table_name: str, columns: list[str]) -> None:
+    """RU: Создать индекс и пометить ownership. EN: Create index and mark ownership."""
+
+    if _index_exists(table_name, index_name):
+        return
+    op.create_index(index_name, table_name, columns, unique=False)
+    _record_owned_object(_OBJECT_TYPE_INDEX, table_name, index_name)
+
+
+def _create_owned_postgres_index(index_name: str, ddl: str) -> None:
+    """RU: Создать postgres-only индекс и пометить ownership.
+
+    EN: Create Postgres-only index and mark ownership.
+    """
+
+    if _index_exists("foods", index_name):
+        return
+    op.execute(ddl)
+    _record_owned_object(_OBJECT_TYPE_INDEX, "foods", index_name)
+
+
+def _drop_owned_index(index_name: str, table_name: str) -> None:
+    """RU: Удалить только owned index. EN: Drop only revision-owned index."""
+
+    if not _owned_object_exists(_OBJECT_TYPE_INDEX, table_name, index_name):
+        return
+    if _index_exists(table_name, index_name):
+        op.drop_index(index_name, table_name=table_name)
+    _remove_owned_object_record(_OBJECT_TYPE_INDEX, table_name, index_name)
+
+
+def _drop_owned_table(table_name: str) -> None:
+    """RU: Удалить только owned table. EN: Drop only revision-owned table."""
+
+    if not _owned_object_exists(_OBJECT_TYPE_TABLE, table_name, table_name):
+        return
+    if _table_exists(table_name):
+        op.drop_table(table_name)
+    _remove_owned_object_record(_OBJECT_TYPE_TABLE, table_name, table_name)
 
 
 def upgrade() -> None:
     """Create repo-aligned foods catalog foundation tables."""
 
-    if not _table_exists("foods"):
-        op.create_table(
-            "foods",
-            sa.Column("id", sa.Text(), nullable=False),
-            sa.Column("canonical_name", sa.Text(), nullable=False),
-            sa.Column("group_name", sa.Text(), nullable=False),
-            sa.Column("per_g", sa.Numeric(8, 2), nullable=False, server_default="100.00"),
-            sa.Column("kcal", sa.Numeric(8, 2), nullable=False),
-            sa.Column("protein_g", sa.Numeric(8, 2), nullable=False, server_default="0.00"),
-            sa.Column("fat_g", sa.Numeric(8, 2), nullable=False, server_default="0.00"),
-            sa.Column("carbs_g", sa.Numeric(8, 2), nullable=False, server_default="0.00"),
-            sa.Column("fiber_g", sa.Numeric(8, 2), nullable=False, server_default="0.00"),
-            sa.Column("Fe_mg", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
-            sa.Column("Ca_mg", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
-            sa.Column("K_mg", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
-            sa.Column("Mg_mg", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
-            sa.Column("VitD_IU", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
-            sa.Column("B12_ug", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
-            sa.Column("Folate_ug", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
-            sa.Column("Iodine_ug", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
-            sa.Column("flags", _json_type(), nullable=False, server_default="[]"),
-            sa.Column("brand", sa.Text(), nullable=True),
-            sa.Column("gtin", sa.Text(), nullable=True),
-            sa.Column("fdc_id", sa.Text(), nullable=True),
-            sa.Column("source", sa.Text(), nullable=False),
-            sa.Column("source_priority", sa.Integer(), nullable=False, server_default="0"),
-            sa.Column("version_date", sa.String(length=64), nullable=False),
-            sa.Column("price_per_100g", sa.Numeric(10, 2), nullable=True),
-            sa.Column("nutrition_inputs_json", _json_type(), nullable=True),
-            sa.Column("nutrition_provenance_json", _json_type(), nullable=True),
-            sa.Column("nutrition_confidence", sa.Numeric(4, 3), nullable=True),
-            sa.Column("nutrition_nutrient_confidence_json", _json_type(), nullable=True),
-            sa.PrimaryKeyConstraint("id"),
-        )
-    if not _index_exists("foods", "ix_foods_canonical_name"):
-        op.create_index("ix_foods_canonical_name", "foods", ["canonical_name"], unique=False)
-    if not _index_exists("foods", "ix_foods_group_name"):
-        op.create_index("ix_foods_group_name", "foods", ["group_name"], unique=False)
-    if not _index_exists("foods", "ix_foods_source"):
-        op.create_index("ix_foods_source", "foods", ["source"], unique=False)
-    if not _index_exists("foods", "ix_foods_gtin"):
-        op.create_index("ix_foods_gtin", "foods", ["gtin"], unique=False)
+    _create_owned_table(
+        "foods",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("canonical_name", sa.Text(), nullable=False),
+        sa.Column("group_name", sa.Text(), nullable=False),
+        sa.Column("per_g", sa.Numeric(8, 2), nullable=False, server_default="100.00"),
+        sa.Column("kcal", sa.Numeric(8, 2), nullable=False),
+        sa.Column("protein_g", sa.Numeric(8, 2), nullable=False, server_default="0.00"),
+        sa.Column("fat_g", sa.Numeric(8, 2), nullable=False, server_default="0.00"),
+        sa.Column("carbs_g", sa.Numeric(8, 2), nullable=False, server_default="0.00"),
+        sa.Column("fiber_g", sa.Numeric(8, 2), nullable=False, server_default="0.00"),
+        sa.Column("Fe_mg", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+        sa.Column("Ca_mg", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+        sa.Column("K_mg", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+        sa.Column("Mg_mg", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+        sa.Column("VitD_IU", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+        sa.Column("B12_ug", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+        sa.Column("Folate_ug", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+        sa.Column("Iodine_ug", sa.Numeric(10, 3), nullable=False, server_default="0.000"),
+        sa.Column("flags", _json_type(), nullable=False, server_default="[]"),
+        sa.Column("brand", sa.Text(), nullable=True),
+        sa.Column("gtin", sa.Text(), nullable=True),
+        sa.Column("fdc_id", sa.Text(), nullable=True),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("source_priority", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("version_date", sa.String(length=64), nullable=False),
+        sa.Column("price_per_100g", sa.Numeric(10, 2), nullable=True),
+        sa.Column("nutrition_inputs_json", _json_type(), nullable=True),
+        sa.Column("nutrition_provenance_json", _json_type(), nullable=True),
+        sa.Column("nutrition_confidence", sa.Numeric(4, 3), nullable=True),
+        sa.Column("nutrition_nutrient_confidence_json", _json_type(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    _create_owned_index("ix_foods_canonical_name", "foods", ["canonical_name"])
+    _create_owned_index("ix_foods_group_name", "foods", ["group_name"])
+    _create_owned_index("ix_foods_source", "foods", ["source"])
+    _create_owned_index("ix_foods_gtin", "foods", ["gtin"])
 
-    if not _table_exists("restaurant_chains"):
-        op.create_table(
-            "restaurant_chains",
-            sa.Column("id", sa.Text(), nullable=False),
-            sa.Column("name", sa.Text(), nullable=False),
-            sa.Column("country", sa.String(length=16), nullable=True),
-            sa.Column("source", sa.Text(), nullable=False),
-            sa.Column("source_id", sa.Text(), nullable=True),
-            sa.Column(
-                "updated_at",
-                sa.DateTime(timezone=True),
-                server_default=sa.text("(CURRENT_TIMESTAMP)"),
-                nullable=False,
-            ),
-            sa.PrimaryKeyConstraint("id"),
-        )
-    if not _index_exists("restaurant_chains", "ix_restaurant_chains_name"):
-        op.create_index("ix_restaurant_chains_name", "restaurant_chains", ["name"], unique=False)
+    _create_owned_table(
+        "restaurant_chains",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("country", sa.String(length=16), nullable=True),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("source_id", sa.Text(), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    _create_owned_index("ix_restaurant_chains_name", "restaurant_chains", ["name"])
 
-    if not _table_exists("restaurant_menu_items"):
-        op.create_table(
-            "restaurant_menu_items",
-            sa.Column("id", sa.Text(), nullable=False),
-            sa.Column("chain_id", sa.Text(), nullable=False),
-            sa.Column("food_id", sa.Text(), nullable=True),
-            sa.Column("item_name", sa.Text(), nullable=False),
-            sa.Column("category", sa.Text(), nullable=True),
-            sa.Column("serving_size_g", sa.Numeric(10, 2), nullable=True),
-            sa.Column("kcal", sa.Numeric(8, 2), nullable=True),
-            sa.Column("protein_g", sa.Numeric(8, 2), nullable=True),
-            sa.Column("fat_g", sa.Numeric(8, 2), nullable=True),
-            sa.Column("carbs_g", sa.Numeric(8, 2), nullable=True),
-            sa.Column("sodium_mg", sa.Numeric(10, 2), nullable=True),
-            sa.Column("source", sa.Text(), nullable=False),
-            sa.Column("source_id", sa.Text(), nullable=True),
-            sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
-            sa.Column(
-                "updated_at",
-                sa.DateTime(timezone=True),
-                server_default=sa.text("(CURRENT_TIMESTAMP)"),
-                nullable=False,
-            ),
-            sa.ForeignKeyConstraint(
-                ["chain_id"],
-                ["restaurant_chains.id"],
-                ondelete="CASCADE",
-            ),
-            sa.ForeignKeyConstraint(
-                ["food_id"],
-                ["foods.id"],
-                ondelete="SET NULL",
-            ),
-            sa.PrimaryKeyConstraint("id"),
-        )
-    if not _index_exists("restaurant_menu_items", "ix_restaurant_menu_items_chain_id"):
-        op.create_index(
-            "ix_restaurant_menu_items_chain_id",
-            "restaurant_menu_items",
+    _create_owned_table(
+        "restaurant_menu_items",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("chain_id", sa.Text(), nullable=False),
+        sa.Column("food_id", sa.Text(), nullable=True),
+        sa.Column("item_name", sa.Text(), nullable=False),
+        sa.Column("category", sa.Text(), nullable=True),
+        sa.Column("serving_size_g", sa.Numeric(10, 2), nullable=True),
+        sa.Column("kcal", sa.Numeric(8, 2), nullable=True),
+        sa.Column("protein_g", sa.Numeric(8, 2), nullable=True),
+        sa.Column("fat_g", sa.Numeric(8, 2), nullable=True),
+        sa.Column("carbs_g", sa.Numeric(8, 2), nullable=True),
+        sa.Column("sodium_mg", sa.Numeric(10, 2), nullable=True),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("source_id", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
             ["chain_id"],
-            unique=False,
-        )
-    if not _index_exists("restaurant_menu_items", "ix_restaurant_menu_items_item_name"):
-        op.create_index(
-            "ix_restaurant_menu_items_item_name",
-            "restaurant_menu_items",
-            ["item_name"],
-            unique=False,
-        )
-    if not _index_exists("restaurant_menu_items", "ix_restaurant_menu_items_food_id"):
-        op.create_index(
-            "ix_restaurant_menu_items_food_id",
-            "restaurant_menu_items",
+            ["restaurant_chains.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
             ["food_id"],
-            unique=False,
-        )
+            ["foods.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    _create_owned_index(
+        "ix_restaurant_menu_items_chain_id",
+        "restaurant_menu_items",
+        ["chain_id"],
+    )
+    _create_owned_index(
+        "ix_restaurant_menu_items_item_name",
+        "restaurant_menu_items",
+        ["item_name"],
+    )
+    _create_owned_index(
+        "ix_restaurant_menu_items_food_id",
+        "restaurant_menu_items",
+        ["food_id"],
+    )
 
     dialect = op.get_bind().dialect.name
     if dialect == "postgresql":
         op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
-        op.execute(_UPGRADE_TRIGRAM_INDEXES)
+        _create_owned_postgres_index(
+            "ix_foods_canonical_name_gin_trgm",
+            "CREATE INDEX ix_foods_canonical_name_gin_trgm ON public.foods USING gin (canonical_name gin_trgm_ops)",
+        )
+        _create_owned_postgres_index(
+            "ix_foods_group_name_gin_trgm",
+            "CREATE INDEX ix_foods_group_name_gin_trgm ON public.foods USING gin (group_name gin_trgm_ops)",
+        )
+        _create_owned_postgres_index(
+            "ix_foods_brand_gin_trgm",
+            "CREATE INDEX ix_foods_brand_gin_trgm ON public.foods USING gin (brand gin_trgm_ops)",
+        )
 
 
 def downgrade() -> None:
     """Drop repo-aligned foods catalog foundation tables."""
 
-    if _index_exists("restaurant_menu_items", "ix_restaurant_menu_items_food_id"):
-        op.drop_index("ix_restaurant_menu_items_food_id", table_name="restaurant_menu_items")
-    if _index_exists("restaurant_menu_items", "ix_restaurant_menu_items_item_name"):
-        op.drop_index("ix_restaurant_menu_items_item_name", table_name="restaurant_menu_items")
-    if _index_exists("restaurant_menu_items", "ix_restaurant_menu_items_chain_id"):
-        op.drop_index(
-            "ix_restaurant_menu_items_chain_id",
-            table_name="restaurant_menu_items",
-        )
-    if _table_exists("restaurant_menu_items"):
-        op.drop_table("restaurant_menu_items")
+    _drop_owned_index("ix_restaurant_menu_items_food_id", "restaurant_menu_items")
+    _drop_owned_index("ix_restaurant_menu_items_item_name", "restaurant_menu_items")
+    _drop_owned_index("ix_restaurant_menu_items_chain_id", "restaurant_menu_items")
+    _drop_owned_table("restaurant_menu_items")
 
-    if _index_exists("restaurant_chains", "ix_restaurant_chains_name"):
-        op.drop_index("ix_restaurant_chains_name", table_name="restaurant_chains")
-    if _table_exists("restaurant_chains"):
-        op.drop_table("restaurant_chains")
+    _drop_owned_index("ix_restaurant_chains_name", "restaurant_chains")
+    _drop_owned_table("restaurant_chains")
 
-    if _index_exists("foods", "ix_foods_gtin"):
-        op.drop_index("ix_foods_gtin", table_name="foods")
-    if _index_exists("foods", "ix_foods_source"):
-        op.drop_index("ix_foods_source", table_name="foods")
-    if _index_exists("foods", "ix_foods_group_name"):
-        op.drop_index("ix_foods_group_name", table_name="foods")
-    if _index_exists("foods", "ix_foods_canonical_name"):
-        op.drop_index("ix_foods_canonical_name", table_name="foods")
-    if _table_exists("foods"):
-        op.drop_table("foods")
+    _drop_owned_index("ix_foods_brand_gin_trgm", "foods")
+    _drop_owned_index("ix_foods_group_name_gin_trgm", "foods")
+    _drop_owned_index("ix_foods_canonical_name_gin_trgm", "foods")
+    _drop_owned_index("ix_foods_gtin", "foods")
+    _drop_owned_index("ix_foods_source", "foods")
+    _drop_owned_index("ix_foods_group_name", "foods")
+    _drop_owned_index("ix_foods_canonical_name", "foods")
+    _drop_owned_table("foods")
+    _drop_ownership_registry_if_empty()

--- a/alembic/versions/202604120001_add_foods_catalog_foundation.py
+++ b/alembic/versions/202604120001_add_foods_catalog_foundation.py
@@ -91,7 +91,7 @@ def _ensure_ownership_registry() -> None:
         sa.Column("object_type", sa.String(length=16), nullable=False),
         sa.Column("table_name", sa.String(length=128), nullable=False),
         sa.Column("object_name", sa.String(length=128), nullable=False),
-        sa.PrimaryKeyConstraint("revision_id", "object_type", "object_name"),
+        sa.PrimaryKeyConstraint("revision_id", "object_type", "table_name", "object_name"),
     )
 
 

--- a/docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md
+++ b/docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md
@@ -1,0 +1,133 @@
+# Foods Foundation Downgrade Ownership Task Packet
+
+**Effective date:** 2026-04-18 (`America/New_York`)
+**Status:** Active execution packet
+**Mode:** coordinator-owned backend/data migration follow-up lane
+
+## Goal
+
+Land one narrow follow-up lane that makes revision `202604120001` downgrade
+behavior ownership-aware so rollback removes only schema objects created by the
+revision and preserves pre-existing compatible `foods` catalog objects.
+
+## Relationship to the Food Epic Data Train
+
+- This packet owns only the downgrade-ownership follow-up lane for backlog item
+  `ledger-p1-foods-foundation-downgrade-ownership`.
+- The prior foundation lane (`PR-A`) already landed the additive schema and
+  upgrade-time existence guards.
+- This lane does not reopen runtime cutover, importer rewiring, or restaurant
+  shadow-read work.
+- Immediately after this lane closes, coordinator opens the next planning lane
+  for the following food epic data PR from the current backlog order.
+
+## Source of Truth
+
+- Repo code remains the final source of truth for migration semantics and
+  rollback safety.
+- This lane must stay grounded in:
+  - `alembic/versions/202604120001_add_foods_catalog_foundation.py`
+  - `tests/test_foods_catalog_foundation_migration.py`
+  - `docs/review/PR_1409_FIXED_MAPPING.md`
+  - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-foundation-downgrade-ownership`
+  - `docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md`
+
+## PR Metadata
+
+- Branch: `codex/foods-foundation-downgrade-ownership`
+- PR title: `fix(data): make foods foundation downgrade ownership-aware`
+- Merge method: **merge commit** via `gh pr merge --merge --delete-branch`
+
+## In Scope
+
+- Edit revision `202604120001` in place; do not add a new Alembic revision
+- Add explicit revision-owned object tracking for objects created by
+  `202604120001`
+- Make downgrade delete only revision-owned tables and indexes
+- Preserve compatible pre-existing `foods` and companion indexes on downgrade
+- Keep downgrade ordering dependency-safe across child/parent tables
+- Add deterministic migration-focused tests for:
+  - clean-room upgrade/downgrade ownership
+  - pre-existing `foods` table preservation
+  - pre-existing index preservation
+  - owned index removal when created by the revision
+- Add packet/governance artifacts for this PR lane
+
+## Out of Scope
+
+- No runtime cutover from SQLite/local-first authority
+- No importer rewiring
+- No OpenAPI/public API changes
+- No mutation or rename of `food_items`
+- No Meilisearch/vector/deploy widening
+- No retroactive repair path for databases that already applied the old
+  `202604120001` without ownership tracking
+
+## Primary Implementation Files
+
+- `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md`
+- `docs/roadmap/BACKLOG_LEDGER.md`
+- `alembic/versions/202604120001_add_foods_catalog_foundation.py`
+- `tests/test_foods_catalog_foundation_migration.py`
+- `docs/review/PR_<N>_FIXED_MAPPING.md`
+
+## Role Order
+
+1. `agent-coordinator`
+2. `backend-engineer`
+3. `security-auditor`
+4. `qa-engineer-agent`
+5. `bug-hunter`
+6. `dev-operator`
+
+Mandatory post-open review lane remains: `qa-engineer-agent -> bug-hunter`.
+
+## Skills / Workflow Notes
+
+- Start the lane with `pulseplate-workflow` discipline
+- Use migration/test scoped `AGENTS.md` rules as the implementation SoT
+- Use PR-governance wrappers for current-head truth and mapping discipline
+- Use cheap local bundles for iteration; do not widen into unrelated full-suite
+  exploration on this machine
+
+## Lifecycle Notes
+
+- Work only from this dedicated lane branch/worktree; do not mutate the dirty
+  root checkout or colleague-owned files
+- Before edits:
+  - `python3 scripts/orchestration/check_preflight.py`
+  - `python3 scripts/orchestration/check_agent_consistency.py`
+- Pre-open bootstrap:
+  - `python3 scripts/orchestration/task_bootstrap.py --goal "Make revision 202604120001 downgrade ownership-aware without dropping pre-existing foods catalog objects" --task-class backend --path alembic/versions/202604120001_add_foods_catalog_foundation.py --path tests/test_foods_catalog_foundation_migration.py --pr-phase pre_open`
+- Open as **draft PR** after packet scope lock and first local stabilization
+- Immediately after opening the PR:
+  - create canonical artifact `docs/review/PR_<N>_FIXED_MAPPING.md`
+  - run post-open synthesis with `--pr-phase post_open_review`
+- Current-head merge verdict remains canonical only through:
+  - `python3 scripts/orchestration/check_merge_ready.py --pr-number <N> --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`
+
+## Validation Plan
+
+- Mandatory every iteration:
+  - `python3 scripts/orchestration/check_preflight.py`
+  - `python3 scripts/orchestration/check_agent_consistency.py`
+  - `pytest -q tests/test_foods_catalog_foundation_migration.py`
+  - `pre-commit run --all-files`
+- Optional cheap reinforcement when needed:
+  - `make validate-min`
+  - `make validate-changed`
+- Canonical repo policy still treats `make verify` as the hard merge-ready gate,
+  but this lane does not wait for green `main` and does not promise full local
+  `make verify` on this machine before the operational merge decision is handed
+  to the user.
+
+## Acceptance Criteria
+
+- Revision `202604120001` tracks which objects it created during upgrade
+- Downgrade no longer blind-drops `foods` or companion indexes
+- Clean-room downgrade still fully removes revision-owned objects
+- Pre-existing compatible `foods` table survives downgrade
+- Pre-existing companion indexes survive downgrade
+- Revision-owned indexes created against a pre-existing `foods` table are
+  removed on downgrade
+- No runtime/API contract drift is introduced

--- a/docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md
+++ b/docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md
@@ -34,6 +34,8 @@ revision and preserves pre-existing compatible `foods` catalog objects.
 
 ## PR Metadata
 
+- PR number: `1468`
+- PR URL: `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468`
 - Branch: `codex/foods-foundation-downgrade-ownership`
 - PR title: `fix(data): make foods foundation downgrade ownership-aware`
 - Merge method: **merge commit** via `gh pr merge --merge --delete-branch`

--- a/docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md
+++ b/docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md
@@ -28,7 +28,7 @@ revision and preserves pre-existing compatible `foods` catalog objects.
 - This lane must stay grounded in:
   - `alembic/versions/202604120001_add_foods_catalog_foundation.py`
   - `tests/test_foods_catalog_foundation_migration.py`
-  - `docs/review/PR_1409_FIXED_MAPPING.md`
+  - `docs/review/PR_1468_FIXED_MAPPING.md`
   - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-foundation-downgrade-ownership`
   - `docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md`
 

--- a/docs/review/PR_1468_FIXED_MAPPING.md
+++ b/docs/review/PR_1468_FIXED_MAPPING.md
@@ -1,0 +1,41 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1468 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+No review threads are recorded yet for PR #1468.
+
+When review or bot comments arrive, update this file before resolving any
+actionable thread:
+
+- `Disposition: FIXED` with commit SHA and evidence
+- `Disposition: NOT-A-BUG` with evidence and rationale
+- `Disposition: DEFERRED` with backlog link and rationale
+
+Initial implementation baseline:
+
+- Commit: `9e8164a7759c910b6848af23374ce8b3de588942`
+- Scope:
+  - `alembic/versions/202604120001_add_foods_catalog_foundation.py`
+  - `tests/test_foods_catalog_foundation_migration.py`
+  - `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md`
+  - `docs/roadmap/BACKLOG_LEDGER.md`
+- Validation:
+  - `python3 scripts/orchestration/check_preflight.py`
+  - `python3 scripts/orchestration/check_agent_consistency.py`
+  - `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_foods_catalog_foundation_migration.py`
+  - `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pre_commit run --all-files`
+  - `git push -u origin codex/foods-foundation-downgrade-ownership`
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1468_FIXED_MAPPING.md
+++ b/docs/review/PR_1468_FIXED_MAPPING.md
@@ -10,7 +10,7 @@
 
 Disposition: FIXED
 Commit: a8695cf3669da38ab1b79d5766c606b329066d55
-Evidence: `alembic/versions/202604120001_add_foods_catalog_foundation.py:94`; `alembic/versions/202604120001_add_foods_catalog_foundation.py:123`; `tests/test_foods_catalog_foundation_migration.py:28`; `tests/test_foods_catalog_foundation_migration.py:214`; `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md:31`; `docs/review/PR_1468_FIXED_MAPPING.md:15`; `docs/review/PR_1468_FIXED_MAPPING.md:26`; `docs/review/PR_1468_FIXED_MAPPING.md:57`; `docs/review/PR_1468_FIXED_MAPPING.md:58`
+Evidence: `alembic/versions/202604120001_add_foods_catalog_foundation.py:94`; `alembic/versions/202604120001_add_foods_catalog_foundation.py:123`; `tests/test_foods_catalog_foundation_migration.py:28`; `tests/test_foods_catalog_foundation_migration.py:214`; `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md:31`; `docs/review/PR_1468_FIXED_MAPPING.md:15`; `docs/review/PR_1468_FIXED_MAPPING.md:26`; `docs/review/PR_1468_FIXED_MAPPING.md:63`; `docs/review/PR_1468_FIXED_MAPPING.md:64`
 Reason: The ownership registry primary key now includes `table_name`, the fake migration runtime parses `CREATE INDEX` statements with a table-aware regex, the task packet points at the current PR mapping artifact, and this canonical review artifact now uses explicit disposition/evidence entries plus repo-relative validation commands.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#pullrequestreview-4135046538 -> a8695cf3669da38ab1b79d5766c606b329066d55
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#pullrequestreview-4135048529 -> a8695cf3669da38ab1b79d5766c606b329066d55
@@ -28,6 +28,12 @@ Commit: ee88a8d4482fdd049c59b6e0fe2353642d3ddeef
 Evidence: `docs/roadmap/BACKLOG_LEDGER.md:5071`; `docs/roadmap/BACKLOG_LEDGER.md:5072`; `docs/roadmap/BACKLOG_LEDGER.md:5073`; `docs/roadmap/BACKLOG_LEDGER.md:5074`
 Reason: The deferred legacy-ownership backlog item now carries direct `file:line` anchors for the claim about absent ownership registry semantics and the explicit out-of-scope boundary for retroactive repair.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105804909 -> ee88a8d4482fdd049c59b6e0fe2353642d3ddeef
+
+Disposition: FIXED
+Commit: 5034adab5ea47bca15b5ff05a1a191b1177a8a4a
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:9374`; `docs/review/PR_1468_FIXED_MAPPING.md:15`; `docs/review/PR_1468_FIXED_MAPPING.md:16`; `docs/review/PR_1468_FIXED_MAPPING.md:17`
+Reason: The canonical mapping artifact now includes the previously missing review-level bot URLs, and the backlog footer date has been refreshed to the April 18, 2026 review follow-up state referenced by the latest CodeRabbit review summary.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#pullrequestreview-4135061915 -> 5034adab5ea47bca15b5ff05a1a191b1177a8a4a
 
 Disposition: DEFERRED
 Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-foundation-legacy-ownership-backfill`

--- a/docs/review/PR_1468_FIXED_MAPPING.md
+++ b/docs/review/PR_1468_FIXED_MAPPING.md
@@ -16,6 +16,9 @@ Reason: The ownership registry primary key now includes `table_name`, the fake m
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105790288 -> a8695cf3669da38ab1b79d5766c606b329066d55
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105790295 -> a8695cf3669da38ab1b79d5766c606b329066d55
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105790299 -> a8695cf3669da38ab1b79d5766c606b329066d55
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105794329 -> a8695cf3669da38ab1b79d5766c606b329066d55
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105794330 -> a8695cf3669da38ab1b79d5766c606b329066d55
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105794331 -> a8695cf3669da38ab1b79d5766c606b329066d55
 
 Disposition: DEFERRED
 Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-foundation-legacy-ownership-backfill`

--- a/docs/review/PR_1468_FIXED_MAPPING.md
+++ b/docs/review/PR_1468_FIXED_MAPPING.md
@@ -10,8 +10,11 @@
 
 Disposition: FIXED
 Commit: a8695cf3669da38ab1b79d5766c606b329066d55
-Evidence: `alembic/versions/202604120001_add_foods_catalog_foundation.py:94`; `alembic/versions/202604120001_add_foods_catalog_foundation.py:123`; `tests/test_foods_catalog_foundation_migration.py:28`; `tests/test_foods_catalog_foundation_migration.py:214`; `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md:31`; `docs/review/PR_1468_FIXED_MAPPING.md:11`; `docs/review/PR_1468_FIXED_MAPPING.md:22`; `docs/review/PR_1468_FIXED_MAPPING.md:43`; `docs/review/PR_1468_FIXED_MAPPING.md:44`
+Evidence: `alembic/versions/202604120001_add_foods_catalog_foundation.py:94`; `alembic/versions/202604120001_add_foods_catalog_foundation.py:123`; `tests/test_foods_catalog_foundation_migration.py:28`; `tests/test_foods_catalog_foundation_migration.py:214`; `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md:31`; `docs/review/PR_1468_FIXED_MAPPING.md:15`; `docs/review/PR_1468_FIXED_MAPPING.md:26`; `docs/review/PR_1468_FIXED_MAPPING.md:57`; `docs/review/PR_1468_FIXED_MAPPING.md:58`
 Reason: The ownership registry primary key now includes `table_name`, the fake migration runtime parses `CREATE INDEX` statements with a table-aware regex, the task packet points at the current PR mapping artifact, and this canonical review artifact now uses explicit disposition/evidence entries plus repo-relative validation commands.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#pullrequestreview-4135046538 -> a8695cf3669da38ab1b79d5766c606b329066d55
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#pullrequestreview-4135048529 -> a8695cf3669da38ab1b79d5766c606b329066d55
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#pullrequestreview-4135051316 -> a8695cf3669da38ab1b79d5766c606b329066d55
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105787460 -> a8695cf3669da38ab1b79d5766c606b329066d55
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105790288 -> a8695cf3669da38ab1b79d5766c606b329066d55
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105790295 -> a8695cf3669da38ab1b79d5766c606b329066d55
@@ -41,7 +44,7 @@ Reason: Retroactive rollback repair for databases that already applied the old `
 
 ## Implementation Baseline
 
-- Latest PR head: `a8695cf3669da38ab1b79d5766c606b329066d55`
+- Latest PR head: `e28c6eeae7d1fc5b242ced88ac060ad964a42ea5`
 - Earlier implementation baseline: `9e8164a7759c910b6848af23374ce8b3de588942`
 - Scope:
   - `alembic/versions/202604120001_add_foods_catalog_foundation.py`

--- a/docs/review/PR_1468_FIXED_MAPPING.md
+++ b/docs/review/PR_1468_FIXED_MAPPING.md
@@ -9,17 +9,17 @@
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
-Commit: PENDING
+Commit: a8695cf3669da38ab1b79d5766c606b329066d55
 Evidence: `alembic/versions/202604120001_add_foods_catalog_foundation.py:94`; `alembic/versions/202604120001_add_foods_catalog_foundation.py:123`; `tests/test_foods_catalog_foundation_migration.py:28`; `tests/test_foods_catalog_foundation_migration.py:214`; `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md:31`; `docs/review/PR_1468_FIXED_MAPPING.md:11`; `docs/review/PR_1468_FIXED_MAPPING.md:22`; `docs/review/PR_1468_FIXED_MAPPING.md:43`; `docs/review/PR_1468_FIXED_MAPPING.md:44`
 Reason: The ownership registry primary key now includes `table_name`, the fake migration runtime parses `CREATE INDEX` statements with a table-aware regex, the task packet points at the current PR mapping artifact, and this canonical review artifact now uses explicit disposition/evidence entries plus repo-relative validation commands.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105787460 -> PENDING
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105790288 -> PENDING
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105790295 -> PENDING
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105790299 -> PENDING
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105787460 -> a8695cf3669da38ab1b79d5766c606b329066d55
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105790288 -> a8695cf3669da38ab1b79d5766c606b329066d55
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105790295 -> a8695cf3669da38ab1b79d5766c606b329066d55
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105790299 -> a8695cf3669da38ab1b79d5766c606b329066d55
 
 Disposition: DEFERRED
 Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-foundation-legacy-ownership-backfill`
-Evidence: `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md:65`; `docs/roadmap/BACKLOG_LEDGER.md:5061`
+Evidence: `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md:65`; `docs/roadmap/BACKLOG_LEDGER.md:5062`
 Reason: Retroactive rollback repair for databases that already applied the old `202604120001` without ownership tracking is explicitly outside the current PR lane and now tracked as a dedicated follow-up item.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105789040
 
@@ -32,7 +32,7 @@ Reason: Retroactive rollback repair for databases that already applied the old `
 
 ## Implementation Baseline
 
-- Latest PR head: `0c84b48320d395043043a1634fd33fe0dcad14d7`
+- Latest PR head: `a8695cf3669da38ab1b79d5766c606b329066d55`
 - Earlier implementation baseline: `9e8164a7759c910b6848af23374ce8b3de588942`
 - Scope:
   - `alembic/versions/202604120001_add_foods_catalog_foundation.py`

--- a/docs/review/PR_1468_FIXED_MAPPING.md
+++ b/docs/review/PR_1468_FIXED_MAPPING.md
@@ -20,6 +20,12 @@ Reason: The ownership registry primary key now includes `table_name`, the fake m
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105794330 -> a8695cf3669da38ab1b79d5766c606b329066d55
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105794331 -> a8695cf3669da38ab1b79d5766c606b329066d55
 
+Disposition: FIXED
+Commit: ee88a8d4482fdd049c59b6e0fe2353642d3ddeef
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:5071`; `docs/roadmap/BACKLOG_LEDGER.md:5072`; `docs/roadmap/BACKLOG_LEDGER.md:5073`; `docs/roadmap/BACKLOG_LEDGER.md:5074`
+Reason: The deferred legacy-ownership backlog item now carries direct `file:line` anchors for the claim about absent ownership registry semantics and the explicit out-of-scope boundary for retroactive repair.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105804909 -> ee88a8d4482fdd049c59b6e0fe2353642d3ddeef
+
 Disposition: DEFERRED
 Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-foundation-legacy-ownership-backfill`
 Evidence: `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md:65`; `docs/roadmap/BACKLOG_LEDGER.md:5062`

--- a/docs/review/PR_1468_FIXED_MAPPING.md
+++ b/docs/review/PR_1468_FIXED_MAPPING.md
@@ -3,23 +3,24 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-No review threads are recorded yet for PR #1468.
+- No actionable review comments
 
-When review or bot comments arrive, update this file before resolving any
-actionable thread:
+## Merge Readiness
 
-- `Disposition: FIXED` with commit SHA and evidence
-- `Disposition: NOT-A-BUG` with evidence and rationale
-- `Disposition: DEFERRED` with backlog link and rationale
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 
-Initial implementation baseline:
+## Implementation Baseline
 
-- Commit: `9e8164a7759c910b6848af23374ce8b3de588942`
+- Latest PR head: `d4f23fa331f4fe12d04191d8e4f4bcbbb32180b4`
+- Earlier implementation baseline: `9e8164a7759c910b6848af23374ce8b3de588942`
 - Scope:
   - `alembic/versions/202604120001_add_foods_catalog_foundation.py`
   - `tests/test_foods_catalog_foundation_migration.py`
@@ -31,11 +32,4 @@ Initial implementation baseline:
   - `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_foods_catalog_foundation_migration.py`
   - `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pre_commit run --all-files`
   - `git push -u origin codex/foods-foundation-downgrade-ownership`
-
-## Merge Readiness
-
-- [ ] Current-head CI green for PR branch head
-- [ ] Required checks complete (no pending jobs)
-- [ ] All review threads resolved on GitHub after disposition updates
-- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 <!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1468_FIXED_MAPPING.md
+++ b/docs/review/PR_1468_FIXED_MAPPING.md
@@ -8,7 +8,20 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: PENDING
+Evidence: `alembic/versions/202604120001_add_foods_catalog_foundation.py:94`; `alembic/versions/202604120001_add_foods_catalog_foundation.py:123`; `tests/test_foods_catalog_foundation_migration.py:28`; `tests/test_foods_catalog_foundation_migration.py:214`; `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md:31`; `docs/review/PR_1468_FIXED_MAPPING.md:11`; `docs/review/PR_1468_FIXED_MAPPING.md:22`; `docs/review/PR_1468_FIXED_MAPPING.md:43`; `docs/review/PR_1468_FIXED_MAPPING.md:44`
+Reason: The ownership registry primary key now includes `table_name`, the fake migration runtime parses `CREATE INDEX` statements with a table-aware regex, the task packet points at the current PR mapping artifact, and this canonical review artifact now uses explicit disposition/evidence entries plus repo-relative validation commands.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105787460 -> PENDING
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105790288 -> PENDING
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105790295 -> PENDING
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105790299 -> PENDING
+
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-foundation-legacy-ownership-backfill`
+Evidence: `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md:65`; `docs/roadmap/BACKLOG_LEDGER.md:5061`
+Reason: Retroactive rollback repair for databases that already applied the old `202604120001` without ownership tracking is explicitly outside the current PR lane and now tracked as a dedicated follow-up item.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1468#discussion_r3105789040
 
 ## Merge Readiness
 
@@ -19,7 +32,7 @@
 
 ## Implementation Baseline
 
-- Latest PR head: `d4f23fa331f4fe12d04191d8e4f4bcbbb32180b4`
+- Latest PR head: `0c84b48320d395043043a1634fd33fe0dcad14d7`
 - Earlier implementation baseline: `9e8164a7759c910b6848af23374ce8b3de588942`
 - Scope:
   - `alembic/versions/202604120001_add_foods_catalog_foundation.py`
@@ -29,7 +42,7 @@
 - Validation:
   - `python3 scripts/orchestration/check_preflight.py`
   - `python3 scripts/orchestration/check_agent_consistency.py`
-  - `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_foods_catalog_foundation_migration.py`
-  - `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pre_commit run --all-files`
+  - `.venv/bin/python -m pytest -q tests/test_foods_catalog_foundation_migration.py`
+  - `.venv/bin/python -m pre_commit run --all-files`
   - `git push -u origin codex/foods-foundation-downgrade-ownership`
 <!-- markdownlint-enable MD034 -->

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5043,14 +5043,15 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Make foods foundation downgrade ownership-aware for pre-existing catalog objects
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FOODS-FOUNDATION-DOWNGRADE-OWNERSHIP
-  - Status: 📋 Planned
+  - Target PR: PR-TBD-FOODS-FOUNDATION-DOWNGRADE-OWNERSHIP -> `codex/foods-foundation-downgrade-ownership`
+  - Status: 🚧 In progress
   - Area: backend / migrations / PostgreSQL
   - Finding Type: downgrade symmetry / object ownership
   - Reason: Revision `202604120001` now guards upgrade-time creation of `foods` and companion indexes when a supported colocated catalog shape already exists, but the downgrade path still assumes ownership of those objects. A follow-up lane must make the downgrade ownership-aware so rolling back the revision does not drop pre-existing `foods`/index artifacts that were not created by this revision.
   - Links:
     - `alembic/versions/202604120001_add_foods_catalog_foundation.py`
     - `docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md`
+    - `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md`
     - `docs/review/PR_1409_FIXED_MAPPING.md`
   - DoD:
     - Downgrade behavior is explicit for both clean-room and pre-existing `foods` catalog shapes

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5068,6 +5068,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Area: backend / migrations / PostgreSQL
   - Finding Type: legacy downgrade / ownership backfill
   - Reason: Databases that already applied the pre-ownership version of revision `202604120001` do not have `pulseplate_migration_ownership`, so downgrade cannot distinguish revision-owned objects from pre-existing catalog artifacts. PR `#1468` intentionally fixes forward-looking ownership-aware behavior for new upgrade runs only; retroactive repair for already-applied environments requires a separate design lane.
+  - Evidence:
+    - `alembic/versions/202604120001_add_foods_catalog_foundation.py:83`
+    - `alembic/versions/202604120001_add_foods_catalog_foundation.py:119`
+    - `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md:65`
   - Links:
     - `alembic/versions/202604120001_add_foods_catalog_foundation.py`
     - `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5059,6 +5059,25 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - The revision no longer drops pre-existing `foods`/index artifacts that it did not create
     - Migration tests cover both the clean-room downgrade cycle and the pre-existing-table ownership scenario
 
+<a id="ledger-p1-foods-foundation-legacy-ownership-backfill"></a>
+- [ ] P1: Define retroactive rollback behavior for legacy-applied foods foundation revision
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD
+  - Status: Deferred from PR `#1468` review loop
+  - Area: backend / migrations / PostgreSQL
+  - Finding Type: legacy downgrade / ownership backfill
+  - Reason: Databases that already applied the pre-ownership version of revision `202604120001` do not have `pulseplate_migration_ownership`, so downgrade cannot distinguish revision-owned objects from pre-existing catalog artifacts. PR `#1468` intentionally fixes forward-looking ownership-aware behavior for new upgrade runs only; retroactive repair for already-applied environments requires a separate design lane.
+  - Links:
+    - `alembic/versions/202604120001_add_foods_catalog_foundation.py`
+    - `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md`
+    - `docs/review/PR_1468_FIXED_MAPPING.md`
+    - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-foundation-downgrade-ownership`
+  - DoD:
+    - A separate design records the authoritative rollback contract when `pulseplate_migration_ownership` is absent on an already-applied `202604120001` database
+    - The chosen path explicitly defines whether legacy environments use ownership backfill, guarded legacy fallback, or an operator-driven/manual repair contract
+    - Deterministic tests cover the chosen legacy-applied rollback path without regressing clean-room or pre-existing-catalog scenarios
+
 ## Completed Items
 
 Entries are sorted by priority, then theme, then title. Theme uses `Area:` when present and a deterministic title/domain fallback otherwise.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -9371,6 +9371,6 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - empty selections remain an explicit no-op with stable logs
     - workflow contract tests cover the shared helper wiring end to end
 
-**Last updated:** 2026-04-12 (feature-branch CI feedback routing follow-up)
+**Last updated:** 2026-04-18 (foods foundation downgrade ownership review follow-up)
 **Maintainer:** @katsiaryna_kavaleuskaya
 <!-- markdownlint-enable MD013 -->

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -5043,7 +5043,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Make foods foundation downgrade ownership-aware for pre-existing catalog objects
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FOODS-FOUNDATION-DOWNGRADE-OWNERSHIP -> `codex/foods-foundation-downgrade-ownership`
+  - Target PR: PR #1468 -> `codex/foods-foundation-downgrade-ownership`
   - Status: 🚧 In progress
   - Area: backend / migrations / PostgreSQL
   - Finding Type: downgrade symmetry / object ownership
@@ -5053,6 +5053,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/FOODS_CATALOG_FOUNDATION_PR_A_TASK_PACKET_2026-04-12.md`
     - `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md`
     - `docs/review/PR_1409_FIXED_MAPPING.md`
+    - `docs/review/PR_1468_FIXED_MAPPING.md`
   - DoD:
     - Downgrade behavior is explicit for both clean-room and pre-existing `foods` catalog shapes
     - The revision no longer drops pre-existing `foods`/index artifacts that it did not create

--- a/tests/test_foods_catalog_foundation_migration.py
+++ b/tests/test_foods_catalog_foundation_migration.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import configparser
 import os
 from pathlib import Path
+import re
 import runpy
 import subprocess
 import sys
@@ -24,6 +25,10 @@ TRIGRAM_SEAM_REVISION = "202604060001"
 MIGRATION_PATH = REPO_ROOT / "alembic" / "versions" / "202604120001_add_foods_catalog_foundation.py"
 ALEMBIC_SUBPROCESS_TIMEOUT_SECONDS = 60
 OWNERSHIP_REGISTRY_TABLE = "pulseplate_migration_ownership"
+CREATE_INDEX_RE = re.compile(
+    r"^CREATE\s+INDEX(?:\s+IF\s+NOT\s+EXISTS)?\s+(?P<index_name>[A-Za-z_][A-Za-z0-9_]*)\s+ON\s+(?:(?P<schema>[A-Za-z_][A-Za-z0-9_]*)\.)?(?P<table_name>[A-Za-z_][A-Za-z0-9_]*)\b",
+    re.IGNORECASE,
+)
 
 
 def _write_temp_alembic_ini(tmp_path: Path) -> Path:
@@ -209,9 +214,11 @@ class _FakeMigrationOp:
     def execute(self, statement: object) -> None:
         sql = str(statement).strip()
         self._state["executed_sql"].append(sql)
-        if sql.startswith("CREATE INDEX "):
-            index_name = sql.split()[2]
-            self._state["indexes"].setdefault("foods", set()).add(index_name)
+        create_index_match = CREATE_INDEX_RE.match(sql)
+        if create_index_match:
+            index_name = create_index_match.group("index_name")
+            table_name = create_index_match.group("table_name")
+            self._state["indexes"].setdefault(table_name, set()).add(index_name)
 
 
 def _load_foundation_migration_runtime(

--- a/tests/test_foods_catalog_foundation_migration.py
+++ b/tests/test_foods_catalog_foundation_migration.py
@@ -21,6 +21,7 @@ FOUNDATION_REVISION = "202604120001"
 TRIGRAM_SEAM_REVISION = "202604060001"
 MIGRATION_PATH = REPO_ROOT / "alembic" / "versions" / "202604120001_add_foods_catalog_foundation.py"
 ALEMBIC_SUBPROCESS_TIMEOUT_SECONDS = 60
+OWNERSHIP_REGISTRY_TABLE = "pulseplate_migration_ownership"
 
 
 def _write_temp_alembic_ini(tmp_path: Path) -> Path:
@@ -88,6 +89,71 @@ def _fk_signature(
         str(referred_table) if referred_table is not None else None,
         referred_columns,
     )
+
+
+def _ownership_signature(
+    row: tuple[object, object, object, object],
+) -> tuple[str, str, str, str]:
+    """Normalize ownership rows for deterministic assertions."""
+
+    return tuple(str(value) for value in row)  # type: ignore[return-value]
+
+
+def _read_ownership_rows(database_url: str) -> set[tuple[str, str, str, str]]:
+    """RU: Считать ownership registry. EN: Read ownership registry rows."""
+
+    engine = create_engine(database_url)
+    try:
+        with engine.begin() as connection:
+            inspector = inspect(connection)
+            if OWNERSHIP_REGISTRY_TABLE not in inspector.get_table_names():
+                return set()
+            rows = connection.exec_driver_sql(f"""
+                SELECT revision_id, object_type, table_name, object_name
+                FROM {OWNERSHIP_REGISTRY_TABLE}
+                """).fetchall()
+    finally:
+        engine.dispose()
+    return {_ownership_signature(row) for row in rows}
+
+
+def _seed_preexisting_foods_catalog(
+    database_url: str,
+    *,
+    preexisting_indexes: tuple[str, ...] = (),
+) -> None:
+    """Create a minimal compatible foods table before running the migration."""
+
+    engine = create_engine(database_url)
+    try:
+        with engine.begin() as connection:
+            connection.exec_driver_sql("""
+                CREATE TABLE foods (
+                    id TEXT NOT NULL PRIMARY KEY,
+                    canonical_name TEXT NOT NULL,
+                    group_name TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    gtin TEXT,
+                    brand TEXT
+                )
+                """)
+            for index_name in preexisting_indexes:
+                if index_name == "ix_foods_canonical_name":
+                    connection.exec_driver_sql(
+                        "CREATE INDEX ix_foods_canonical_name ON foods (canonical_name)"
+                    )
+                elif index_name == "ix_foods_group_name":
+                    connection.exec_driver_sql(
+                        "CREATE INDEX ix_foods_group_name ON foods (group_name)"
+                    )
+                elif index_name == "ix_foods_source":
+                    connection.exec_driver_sql("CREATE INDEX ix_foods_source ON foods (source)")
+                elif index_name == "ix_foods_gtin":
+                    connection.exec_driver_sql("CREATE INDEX ix_foods_gtin ON foods (gtin)")
+                else:
+                    raise AssertionError(f"Unsupported preexisting index seed: {index_name}")
+    finally:
+        engine.dispose()
 
 
 def test_foods_catalog_foundation_migration_sqlite_smoke(
@@ -193,6 +259,36 @@ def test_foods_catalog_foundation_migration_sqlite_downgrade_cycle(
         }
     finally:
         engine.dispose()
+    ownership_rows_after_upgrade = _read_ownership_rows(database_url)
+
+    assert {
+        (FOUNDATION_REVISION, "table", "foods", "foods"),
+        (FOUNDATION_REVISION, "table", "restaurant_chains", "restaurant_chains"),
+        (FOUNDATION_REVISION, "table", "restaurant_menu_items", "restaurant_menu_items"),
+        (FOUNDATION_REVISION, "index", "foods", "ix_foods_canonical_name"),
+        (FOUNDATION_REVISION, "index", "foods", "ix_foods_group_name"),
+        (FOUNDATION_REVISION, "index", "foods", "ix_foods_source"),
+        (FOUNDATION_REVISION, "index", "foods", "ix_foods_gtin"),
+        (FOUNDATION_REVISION, "index", "restaurant_chains", "ix_restaurant_chains_name"),
+        (
+            FOUNDATION_REVISION,
+            "index",
+            "restaurant_menu_items",
+            "ix_restaurant_menu_items_chain_id",
+        ),
+        (
+            FOUNDATION_REVISION,
+            "index",
+            "restaurant_menu_items",
+            "ix_restaurant_menu_items_item_name",
+        ),
+        (
+            FOUNDATION_REVISION,
+            "index",
+            "restaurant_menu_items",
+            "ix_restaurant_menu_items_food_id",
+        ),
+    } <= ownership_rows_after_upgrade
 
     _run_alembic_command(
         temp_alembic_ini,
@@ -212,6 +308,7 @@ def test_foods_catalog_foundation_migration_sqlite_downgrade_cycle(
     assert "foods" not in tables_after_downgrade
     assert "restaurant_chains" not in tables_after_downgrade
     assert "restaurant_menu_items" not in tables_after_downgrade
+    assert OWNERSHIP_REGISTRY_TABLE not in tables_after_downgrade
 
     _run_alembic_command(
         temp_alembic_ini,
@@ -244,6 +341,150 @@ def test_foods_catalog_foundation_migration_sqlite_downgrade_cycle(
     assert initial_menu_indexes == final_menu_indexes
 
 
+def test_foods_catalog_foundation_preserves_preexisting_foods_table_on_downgrade(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "foods-foundation-preexisting-table.sqlite3"
+    database_url = f"sqlite:///{db_path}"
+    temp_alembic_ini = _write_temp_alembic_ini(tmp_path)
+
+    _seed_preexisting_foods_catalog(database_url)
+
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    env.pop("PYTHONPATH", None)
+
+    _run_alembic_command(
+        temp_alembic_ini,
+        REPO_ROOT,
+        "upgrade",
+        FOUNDATION_REVISION,
+        env,
+    )
+
+    ownership_rows_after_upgrade = _read_ownership_rows(database_url)
+    assert (FOUNDATION_REVISION, "table", "foods", "foods") not in ownership_rows_after_upgrade
+    assert (
+        FOUNDATION_REVISION,
+        "index",
+        "foods",
+        "ix_foods_canonical_name",
+    ) in ownership_rows_after_upgrade
+    assert (
+        FOUNDATION_REVISION,
+        "index",
+        "foods",
+        "ix_foods_group_name",
+    ) in ownership_rows_after_upgrade
+    assert (
+        FOUNDATION_REVISION,
+        "index",
+        "foods",
+        "ix_foods_source",
+    ) in ownership_rows_after_upgrade
+    assert (FOUNDATION_REVISION, "index", "foods", "ix_foods_gtin") in ownership_rows_after_upgrade
+
+    _run_alembic_command(
+        temp_alembic_ini,
+        REPO_ROOT,
+        "downgrade",
+        TRIGRAM_SEAM_REVISION,
+        env,
+    )
+
+    engine = create_engine(database_url)
+    try:
+        inspector = inspect(engine)
+        tables_after_downgrade = set(inspector.get_table_names())
+        foods_indexes_after_downgrade = {
+            index["name"] for index in inspector.get_indexes("foods") if index.get("name")
+        }
+    finally:
+        engine.dispose()
+
+    assert "foods" in tables_after_downgrade
+    assert "restaurant_chains" not in tables_after_downgrade
+    assert "restaurant_menu_items" not in tables_after_downgrade
+    assert foods_indexes_after_downgrade == set()
+    assert OWNERSHIP_REGISTRY_TABLE not in tables_after_downgrade
+
+
+def test_foods_catalog_foundation_preserves_preexisting_foods_indexes_on_downgrade(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "foods-foundation-preexisting-indexes.sqlite3"
+    database_url = f"sqlite:///{db_path}"
+    temp_alembic_ini = _write_temp_alembic_ini(tmp_path)
+
+    _seed_preexisting_foods_catalog(
+        database_url,
+        preexisting_indexes=("ix_foods_canonical_name", "ix_foods_group_name"),
+    )
+
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    env.pop("PYTHONPATH", None)
+
+    _run_alembic_command(
+        temp_alembic_ini,
+        REPO_ROOT,
+        "upgrade",
+        FOUNDATION_REVISION,
+        env,
+    )
+
+    ownership_rows_after_upgrade = _read_ownership_rows(database_url)
+    assert (FOUNDATION_REVISION, "table", "foods", "foods") not in ownership_rows_after_upgrade
+    assert (
+        FOUNDATION_REVISION,
+        "index",
+        "foods",
+        "ix_foods_canonical_name",
+    ) not in ownership_rows_after_upgrade
+    assert (
+        FOUNDATION_REVISION,
+        "index",
+        "foods",
+        "ix_foods_group_name",
+    ) not in ownership_rows_after_upgrade
+    assert (
+        FOUNDATION_REVISION,
+        "index",
+        "foods",
+        "ix_foods_source",
+    ) in ownership_rows_after_upgrade
+    assert (FOUNDATION_REVISION, "index", "foods", "ix_foods_gtin") in ownership_rows_after_upgrade
+
+    _run_alembic_command(
+        temp_alembic_ini,
+        REPO_ROOT,
+        "downgrade",
+        TRIGRAM_SEAM_REVISION,
+        env,
+    )
+
+    engine = create_engine(database_url)
+    try:
+        inspector = inspect(engine)
+        tables_after_downgrade = set(inspector.get_table_names())
+        foods_indexes_after_downgrade = {
+            index["name"] for index in inspector.get_indexes("foods") if index.get("name")
+        }
+    finally:
+        engine.dispose()
+
+    assert "foods" in tables_after_downgrade
+    assert foods_indexes_after_downgrade == {
+        "ix_foods_canonical_name",
+        "ix_foods_group_name",
+    }
+    assert OWNERSHIP_REGISTRY_TABLE not in tables_after_downgrade
+
+
 def test_foods_catalog_foundation_migration_contract_text() -> None:
     migration_text = MIGRATION_PATH.read_text(encoding="utf-8")
 
@@ -257,6 +498,13 @@ def test_foods_catalog_foundation_migration_contract_text() -> None:
     assert "ix_foods_canonical_name_gin_trgm" in migration_text
     assert "ix_foods_group_name_gin_trgm" in migration_text
     assert "ix_foods_brand_gin_trgm" in migration_text
-    assert '_table_exists("foods")' in migration_text
     assert "food_items" not in migration_text
     assert "rename_table" not in migration_text
+    assert "pulseplate_migration_ownership" in migration_text
+    assert "_create_owned_table(" in migration_text
+    assert "_create_owned_index(" in migration_text
+    assert "_record_owned_object(" in migration_text
+    assert "_drop_owned_index(" in migration_text
+    assert "_drop_owned_table(" in migration_text
+    assert 'op.drop_table("foods")' not in migration_text
+    assert 'op.drop_index("ix_foods_canonical_name", table_name="foods")' not in migration_text

--- a/tests/test_foods_catalog_foundation_migration.py
+++ b/tests/test_foods_catalog_foundation_migration.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import configparser
 import os
 from pathlib import Path
+import runpy
 import subprocess
 import sys
+from types import ModuleType, SimpleNamespace
 
 import pytest
 from sqlalchemy import create_engine, inspect
@@ -154,6 +156,101 @@ def _seed_preexisting_foods_catalog(
                     raise AssertionError(f"Unsupported preexisting index seed: {index_name}")
     finally:
         engine.dispose()
+
+
+class _FakeMigrationInspector:
+    """Deterministic inspector for stateful migration unit tests."""
+
+    def __init__(self, state: dict[str, object]) -> None:
+        self._state = state
+
+    def has_table(self, table_name: str) -> bool:
+        return table_name in self._state["tables"]
+
+    def get_indexes(self, table_name: str) -> list[dict[str, str]]:
+        table_indexes = self._state["indexes"].get(table_name, set())
+        return [{"name": index_name} for index_name in sorted(table_indexes)]
+
+
+class _FakeMigrationOp:
+    """Stateful fake Alembic `op` surface for deterministic revision tests."""
+
+    def __init__(self, state: dict[str, object]) -> None:
+        self._state = state
+        self._bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+
+    def get_bind(self) -> SimpleNamespace:
+        return self._bind
+
+    def create_table(self, table_name: str, *args: object, **kwargs: object) -> None:
+        self._state["tables"].add(table_name)
+        self._state["indexes"].setdefault(table_name, set())
+
+    def create_index(
+        self,
+        index_name: str,
+        table_name: str,
+        columns: list[str],
+        *,
+        unique: bool = False,
+    ) -> None:
+        del columns, unique
+        self._state["indexes"].setdefault(table_name, set()).add(index_name)
+
+    def drop_index(self, index_name: str, *, table_name: str) -> None:
+        self._state["dropped_indexes"].append((table_name, index_name))
+        self._state["indexes"].setdefault(table_name, set()).discard(index_name)
+
+    def drop_table(self, table_name: str) -> None:
+        self._state["dropped_tables"].append(table_name)
+        self._state["tables"].discard(table_name)
+        self._state["indexes"].pop(table_name, None)
+
+    def execute(self, statement: object) -> None:
+        sql = str(statement).strip()
+        self._state["executed_sql"].append(sql)
+        if sql.startswith("CREATE INDEX "):
+            index_name = sql.split()[2]
+            self._state["indexes"].setdefault("foods", set()).add(index_name)
+
+
+def _load_foundation_migration_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    state: dict[str, object],
+) -> dict[str, object]:
+    """Load the migration module with a fake Alembic op binding."""
+
+    fake_alembic = ModuleType("alembic")
+    fake_alembic.op = _FakeMigrationOp(state)
+    monkeypatch.setitem(sys.modules, "alembic", fake_alembic)
+
+    runtime = runpy.run_path(str(MIGRATION_PATH))
+    runtime_globals = runtime["upgrade"].__globals__
+    monkeypatch.setattr(
+        runtime_globals["sa"],
+        "inspect",
+        lambda bind: _FakeMigrationInspector(state),
+    )
+    runtime_globals["_record_owned_object"] = lambda object_type, table_name, object_name: (
+        state["owned"].add((object_type, table_name, object_name))
+    )
+    runtime_globals["_owned_object_exists"] = (
+        lambda object_type, table_name, object_name: (
+            object_type,
+            table_name,
+            object_name,
+        )
+        in state["owned"]
+    )
+    runtime_globals["_remove_owned_object_record"] = (
+        lambda object_type, table_name, object_name: state["owned"].discard(
+            (object_type, table_name, object_name)
+        )
+    )
+    runtime_globals["_drop_ownership_registry_if_empty"] = lambda: (
+        state["registry_cleanup"].append("drop") if not state["owned"] else None
+    )
+    return runtime
 
 
 def test_foods_catalog_foundation_migration_sqlite_smoke(
@@ -483,6 +580,90 @@ def test_foods_catalog_foundation_preserves_preexisting_foods_indexes_on_downgra
         "ix_foods_group_name",
     }
     assert OWNERSHIP_REGISTRY_TABLE not in tables_after_downgrade
+
+
+def test_foods_catalog_foundation_postgres_trigram_mixed_preexisting_cycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = {
+        "tables": {"foods"},
+        "indexes": {
+            "foods": {
+                "ix_foods_canonical_name_gin_trgm",
+            }
+        },
+        "owned": set(),
+        "executed_sql": [],
+        "dropped_indexes": [],
+        "dropped_tables": [],
+        "registry_cleanup": [],
+    }
+    runtime = _load_foundation_migration_runtime(monkeypatch, state)
+
+    runtime["upgrade"]()
+
+    assert any("CREATE EXTENSION IF NOT EXISTS pg_trgm" in sql for sql in state["executed_sql"])
+    assert (
+        runtime["_OBJECT_TYPE_INDEX"],
+        "foods",
+        "ix_foods_canonical_name_gin_trgm",
+    ) not in state["owned"]
+    assert (
+        runtime["_OBJECT_TYPE_INDEX"],
+        "foods",
+        "ix_foods_group_name_gin_trgm",
+    ) in state["owned"]
+    assert (
+        runtime["_OBJECT_TYPE_INDEX"],
+        "foods",
+        "ix_foods_brand_gin_trgm",
+    ) in state["owned"]
+
+    runtime["downgrade"]()
+
+    assert "foods" in state["tables"]
+    assert "restaurant_chains" not in state["tables"]
+    assert "restaurant_menu_items" not in state["tables"]
+    assert state["indexes"]["foods"] == {"ix_foods_canonical_name_gin_trgm"}
+    assert ("foods", "ix_foods_group_name_gin_trgm") in state["dropped_indexes"]
+    assert ("foods", "ix_foods_brand_gin_trgm") in state["dropped_indexes"]
+    assert ("foods", "ix_foods_canonical_name_gin_trgm") not in state["dropped_indexes"]
+    assert state["registry_cleanup"] == ["drop"]
+
+
+def test_foods_catalog_foundation_postgres_clean_room_cycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = {
+        "tables": set(),
+        "indexes": {},
+        "owned": set(),
+        "executed_sql": [],
+        "dropped_indexes": [],
+        "dropped_tables": [],
+        "registry_cleanup": [],
+    }
+    runtime = _load_foundation_migration_runtime(monkeypatch, state)
+
+    runtime["upgrade"]()
+
+    assert {
+        "foods",
+        "restaurant_chains",
+        "restaurant_menu_items",
+    } <= state["tables"]
+    assert {
+        "ix_foods_canonical_name_gin_trgm",
+        "ix_foods_group_name_gin_trgm",
+        "ix_foods_brand_gin_trgm",
+    } <= state["indexes"]["foods"]
+
+    runtime["downgrade"]()
+
+    assert state["tables"] == set()
+    assert state["indexes"] == {}
+    assert state["owned"] == set()
+    assert state["registry_cleanup"] == ["drop"]
 
 
 def test_foods_catalog_foundation_migration_contract_text() -> None:


### PR DESCRIPTION
## Summary
- make revision `202604120001` track only schema objects it creates during upgrade
- make downgrade remove only revision-owned tables/indexes and preserve pre-existing compatible `foods` artifacts
- add narrow lane packet and deterministic migration coverage for clean-room and pre-existing catalog shapes, including PostgreSQL trigram ownership paths

## Scope
- `alembic/versions/202604120001_add_foods_catalog_foundation.py`
- `tests/test_foods_catalog_foundation_migration.py`
- `docs/orchestration/FOODS_FOUNDATION_DOWNGRADE_OWNERSHIP_TASK_PACKET_2026-04-18.md`
- `docs/review/PR_1468_FIXED_MAPPING.md`
- `docs/roadmap/BACKLOG_LEDGER.md`

## Split Justification
- This lane intentionally stays within 5 changed files, but the ownership-aware migration and its deterministic downgrade coverage must land atomically in the same PR to avoid a half-shipped revision contract.
- The added line volume comes from narrow migration-test scaffolding for clean-room, pre-existing catalog, and PostgreSQL trigram ownership paths; splitting that coverage away from the revision change would break the downgrade-safety proof this PR is meant to provide.
- The three markdown files are contract artifacts required by repo governance for this exact lane: the task packet, backlog ledger update, and canonical fixed-mapping artifact.

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `.venv/bin/python -m pytest -q tests/test_foods_catalog_foundation_migration.py`
- `.venv/bin/python -m pre_commit run --all-files`
- `git push -u origin codex/foods-foundation-downgrade-ownership` (passed pre-push hooks)

## Operational Note
- This lane intentionally uses targeted local validation on the current machine and does not claim canonical repo `make verify` completion.
- `main` was not used as a blocking green gate for starting or iterating this PR, per lane packet policy.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1468_FIXED_MAPPING.md`

## Merge Readiness (Mandatory)
- [ ] Current-head CI green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Canonical `make verify` completed locally

## Deferred / Follow-ups
- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-foods-foundation-legacy-ownership-backfill` — retroactive rollback behavior for databases that already applied the pre-ownership version of revision `202604120001` remains out of scope for this lane and requires a separate design follow-up.

## Follow-up
- Immediately after this PR lane closes, coordinator opens planning for the next food epic data PR from current backlog order.

## Summary by Sourcery

Сделать так, чтобы Alembic‑ревизия фундамента каталога foods отслеживала владение создаваемыми объектами схемы, чтобы при откате удалялись только таблицы и индексы, принадлежащие ревизии, при этом сохранялись совместимые, ранее существовавшие артефакты схемы foods.

New Features:
- Ввести реестр владения миграциями, который фиксирует, какие таблицы и индексы создаются ревизией фундамента foods, включая триграммные индексы Postgres.

Bug Fixes:
- Скорректировать путь отката (downgrade) фундамента foods так, чтобы удалялись только таблицы и индексы, принадлежащие ревизии, избегая удаления ранее существовавших совместимых объектов схемы и индексов foods.

Enhancements:
- Рефакторинг миграции фундамента foods с использованием «осведомлённых о владении» вспомогательных методов для создания и удаления таблиц и индексов как в SQLite, так и в Postgres.
- Добавить детерминированные тесты миграций, охватывающие сценарии «с нуля», уже существующий каталог и владение триграммными индексами Postgres для проверки поведения при обновлении/откате.

Documentation:
- Задокументировать «полосу» (lane) отката с учётом владения (downgrade‑ownership) в отдельном пакете orchestration‑тасков и связать его с backlog‑ledger.
- Добавить документ сопоставления fixed‑in‑commit для PR 1468 с описанием охвата и проверки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the foods catalog foundation Alembic revision track ownership of created schema objects so downgrade only removes revision-owned tables and indexes while preserving compatible pre-existing foods artifacts.

New Features:
- Introduce a migration ownership registry that records which tables and indexes are created by the foods foundation revision, including Postgres trigram indexes.

Bug Fixes:
- Adjust the foods foundation downgrade path to drop only revision-owned tables and indexes, avoiding deletion of pre-existing compatible foods schema objects and indexes.

Enhancements:
- Refactor the foods foundation migration to use ownership-aware helpers for creating and dropping tables and indexes across SQLite and Postgres.
- Add deterministic migration tests covering clean-room, pre-existing catalog, and Postgres trigram index ownership scenarios to validate upgrade/downgrade behavior.

Documentation:
- Document the downgrade-ownership lane in a dedicated orchestration task packet and link it into the backlog ledger.
- Add a fixed-in-commit mapping document for PR 1468 describing scope and validation.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Migrations now record the schema objects they create so rollbacks remove only migration-owned tables and indexes while preserving pre-existing catalog objects and specialized indexes.

* **Tests**
  * Added deterministic tests that validate ownership tracking and correct upgrade/downgrade behavior across simulated SQLite and Postgres scenarios.

* **Documentation**
  * Added orchestration task packet, review mapping, and backlog updates describing ownership-aware downgrade behavior and validation/merge readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
