### PR TITLE
docs(deploy): reconcile compose v2 wording

### DIFF
--- a/deploy/WORKFLOW.md
+++ b/deploy/WORKFLOW.md
@@ -77,7 +77,7 @@ git push origin main
 **Что делаем:**
 - ✅ `docker pull` нового образа
 - ✅ one-shot migrations через release image до рестарта приложения
-- ✅ `docker-compose up -d --force-recreate` (или `docker run`)
+- ✅ `docker compose up -d --force-recreate` (или `docker run`)
 - ✅ Проверка health endpoint
 
 **Что НЕ делаем:**
@@ -93,16 +93,16 @@ ssh root@pulseplate.app
 cd /srv/pulseplate-production
 
 # 1. Подтянуть новый образ
-docker-compose -f docker-compose.production.yaml pull
+docker compose -f docker-compose.production.yaml pull
 
 # 2. Прогнать миграции через release image
 docker compose --env-file .env -f docker-compose.production.yaml run --rm --no-deps app alembic upgrade head
 
 # 3. Перезапустить сервисы
-docker-compose -f docker-compose.production.yaml up -d --force-recreate
+docker compose -f docker-compose.production.yaml up -d --force-recreate
 
 # 4. Проверить статус
-docker-compose -f docker-compose.production.yaml ps
+docker compose -f docker-compose.production.yaml ps
 
 # 5. Проверить health
 curl -fsS https://pulseplate.app/health | jq .
@@ -305,7 +305,7 @@ bash scripts/diagnose_web.sh
    # ✅ ПРАВИЛЬНО
    cd /srv/pulseplate-production
    nano .env  # добавить APP_ENV=production
-   docker-compose up -d --force-recreate app
+   docker compose up -d --force-recreate app
    ```
 
 3. **Изменить `Caddyfile.production` на сервере (это конфиг):**
@@ -313,7 +313,7 @@ bash scripts/diagnose_web.sh
    # ✅ ПРАВИЛЬНО
    cd /srv/pulseplate-production
    nano Caddyfile.production
-   docker-compose up -d --force-recreate caddy
+   docker compose up -d --force-recreate caddy
    ```
 
 ---
@@ -331,7 +331,7 @@ docker images | grep pulseplate
 
 ```bash
 # Получить container id сервиса app и посмотреть image
-APP_CID="$(docker-compose -f docker-compose.production.yaml ps -q app)"
+APP_CID="$(docker compose -f docker-compose.production.yaml ps -q app)"
 docker inspect "$APP_CID" --format '{{.Config.Image}}'
 # Должен показывать актуальный image ID
 ```
@@ -373,7 +373,7 @@ curl -fsS https://pulseplate.app/health | jq .
 ### 4. Проверить логи
 
 ```bash
-docker-compose -f docker-compose.production.yaml logs app --tail=50
+docker compose -f docker-compose.production.yaml logs app --tail=50
 # Не должно быть ошибок
 ```
 
@@ -398,10 +398,10 @@ Endpoint `/health` автоматически нормализует значе�
 **Решение:**
 ```bash
 # 1. Убедиться, что новый образ подтянут
-docker-compose -f docker-compose.production.yaml pull
+docker compose -f docker-compose.production.yaml pull
 
 # 2. Принудительно пересоздать контейнер
-docker-compose -f docker-compose.production.yaml up -d --force-recreate app
+docker compose -f docker-compose.production.yaml up -d --force-recreate app
 
 # 3. Проверить, что контейнер пересоздан
 docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.CreatedAt}}'
@@ -429,10 +429,10 @@ cat .env | grep -E 'APP_ENV|ENVIRONMENT'
 nano .env
 
 # 3. Перезапустить контейнер
-docker-compose -f docker-compose.production.yaml up -d --force-recreate app
+docker compose -f docker-compose.production.yaml up -d --force-recreate app
 
 # 4. Проверить env внутри контейнера (через service name, без хардкода)
-docker-compose -f docker-compose.production.yaml exec -T app env | grep -E 'APP_ENV|ENVIRONMENT'
+docker compose -f docker-compose.production.yaml exec -T app env | grep -E 'APP_ENV|ENVIRONMENT'
 ```
 
 ---
@@ -461,4 +461,4 @@ docker-compose -f docker-compose.production.yaml exec -T app env | grep -E 'APP_
 - Никогда не коммить `.env` файлы
 - Используй GitHub Secrets для чувствительных данных
 - Регулярно обновляй Docker images (security patches)
-- Используй `docker-compose pull` перед `up` для получения последних security updates
+- Используй `docker compose pull` перед `up` для получения последних security updates

--- a/docs/deploy/DOCKER.md
+++ b/docs/deploy/DOCKER.md
@@ -142,7 +142,7 @@ docker stop test && docker rm test
 - ✅ Read-only filesystem where possible
 - ✅ Proper file permissions
 - ✅ Health checks for monitoring
-- ✅ Resource limits in docker-compose
+- ✅ Resource limits in `docker compose`
 
 ## 📈 **Monitoring & Maintenance**
 

--- a/docs/deploy/OVERVIEW.md
+++ b/docs/deploy/OVERVIEW.md
@@ -137,7 +137,7 @@ docker compose version
 
 - Dockerfile запускает приложение через `uvicorn app.main:app`.
 - Старый entrypoint `legacy_app.py` больше не используется — обновите CI/скрипты,
-  `docker compose` command surfaces и любые runbook команды.
+  команды `docker compose` и любые runbook команды.
 - Ключевые env vars остаются прежними: `DATABASE_URL`, `API_KEY`, `API_KEY_REQUIRED`,
   `FEATURE_PREMIUM_NUTRITION`, `ENVIRONMENT`/`APP_ENV`.
 

--- a/docs/deploy/OVERVIEW.md
+++ b/docs/deploy/OVERVIEW.md
@@ -137,7 +137,7 @@ docker compose version
 
 - Dockerfile запускает приложение через `uvicorn app.main:app`.
 - Старый entrypoint `legacy_app.py` больше не используется — обновите CI/скрипты,
-  docker-compose и любые runbook команды.
+  `docker compose` command surfaces и любые runbook команды.
 - Ключевые env vars остаются прежними: `DATABASE_URL`, `API_KEY`, `API_KEY_REQUIRED`,
   `FEATURE_PREMIUM_NUTRITION`, `ENVIRONMENT`/`APP_ENV`.
 

--- a/docs/review/PR_1470_FIXED_MAPPING.md
+++ b/docs/review/PR_1470_FIXED_MAPPING.md
@@ -14,7 +14,20 @@ Record every new review or bot disposition here before resolving threads on GitH
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1470#pullrequestreview-4135081714
+Disposition: NOT-A-BUG
+Evidence: `deploy/WORKFLOW.md:435`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1470#discussion_r3105827926`; `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1470#discussion_r3105827930`
+Reason: the Sourcery review summary adds no distinct actionable beyond the two inline wording comments addressed below; the claimed trailing `docker-compose ... exec` command is not present on the current branch head because the runbook already uses `docker compose`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1470#discussion_r3105827926 -> eaab6933f
+Disposition: FIXED
+Commit: eaab6933f
+Evidence: `docs/deploy/OVERVIEW.md:140`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1470#discussion_r3105827930 -> eaab6933f
+Disposition: FIXED
+Commit: eaab6933f
+Evidence: `docs/review/PR_1470_FIXED_MAPPING.md:12`
 
 ## Merge Readiness
 

--- a/docs/review/PR_1470_FIXED_MAPPING.md
+++ b/docs/review/PR_1470_FIXED_MAPPING.md
@@ -9,7 +9,7 @@ Canonical review-governance artifact and PR-body mirror requirements:
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-This artifact is created immediately after PR open per repo governance.
+This artifact is created immediately after the PR is opened per repo governance.
 Record every new review or bot disposition here before resolving threads on GitHub.
 
 ## Fixed in Commit Mapping

--- a/docs/review/PR_1470_FIXED_MAPPING.md
+++ b/docs/review/PR_1470_FIXED_MAPPING.md
@@ -1,0 +1,36 @@
+# PR #1470 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+This artifact is created immediately after PR open per repo governance.
+Record every new review or bot disposition here before resolving threads on GitHub.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+  Evidence: `AGENTS.md:42-49`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:95-112`.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: `AGENTS.md:46-49`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:155-163`.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: `AGENTS.md:43-45`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:95-112`.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: `AGENTS.md:44-45`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:95-112`.
+- [x] Pre-commit green on latest pushed head
+  Evidence: local `pre-commit run --all-files` and commit/push hooks passed on commit `02c80790f0e07b7645cdd915dd0ee7c60787b265`.
+- [ ] `make verify` green on latest pushed head
+  Evidence: intentionally not run locally in this slice per operator instruction; GitHub CI remains source of truth for the full bundle.


### PR DESCRIPTION
## Summary
- reconcile active deploy/operator docs to use canonical `docker compose` v2 wording on touched command surfaces
- keep the split backend image plus separate frontend/Caddy topology unchanged
- avoid widening scope into runtime, CI, or compose topology edits

## Touched Files
- `deploy/WORKFLOW.md`
- `docs/deploy/OVERVIEW.md`
- `docs/deploy/DOCKER.md`
- `docs/review/PR_1470_FIXED_MAPPING.md`

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pre-commit run --files deploy/WORKFLOW.md docs/deploy/OVERVIEW.md docs/deploy/DOCKER.md`
- `pre-commit run --files docs/review/PR_1470_FIXED_MAPPING.md`
- `pre-commit run --all-files`
- local commit/push hooks passed

## Notes
- Local `make verify` was intentionally not run in this slice per operator instruction; GitHub CI remains the source of truth for the full bundle in this PR.
- No root `main` mutation was performed; work was done in an isolated worktree from `origin/main`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- Canonical artifact: `docs/review/PR_1470_FIXED_MAPPING.md`

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1470_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Current-head CI is green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green on latest pushed head
- [ ] `make verify` green on latest pushed head

## Packet
- `docs/orchestration/DOCKER_CI_DISCIPLINE_PR_SERIES_PACKET_2026-04-16.md`

## Summary by Sourcery

Привести документацию по развёртыванию в соответствие с терминологией CLI Docker Compose v2 и добавить запись сопоставления по управлению (governance) для этого PR.

Документация:
- Обновить рабочий процесс развёртывания и обзорную документацию, чтобы использовать каноничную терминологию `docker compose` v2 во всех упоминаемых командах и рекомендациях.
- Уточнить документацию по Docker для развёртывания, чтобы она ссылалась на ресурсные лимиты в `docker compose`, а не на устаревший `docker-compose`.
- Добавить каноничный документ review-governance «Fixed in Commit Mapping» для PR #1470, отражающий обсуждение, готовность к слиянию и подтверждающие материалы.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align deployment documentation with Docker Compose v2 CLI wording and add governance mapping record for this PR.

Documentation:
- Update deployment workflow and overview docs to use canonical `docker compose` v2 terminology across all referenced commands and guidance.
- Clarify deployment Docker documentation to reference resource limits in `docker compose` rather than legacy `docker-compose`.
- Add a canonical "Fixed in Commit Mapping" review-governance document for PR #1470 capturing discussion, merge readiness, and evidence.

</details>