### PR TITLE
feat(orchestration): skill routing wave 2

### DIFF
--- a/docs/dev/CODEX_SKILLS.md
+++ b/docs/dev/CODEX_SKILLS.md
@@ -95,6 +95,9 @@ When [`scripts/orchestration/task_bootstrap.py`](../../scripts/orchestration/tas
 `recommended_skills`, so coordinator and domain agents can invoke fitting
 skills as part of the workflow.
 For explainability, the packet also carries `skill_routing` metadata with weighted evidence and blocked-pattern notes.
+Wave 2 routing packets additionally expose `skill_routing.explanation` for the
+stable explanation schema and `skill_routing.research_connector_policy` for the
+approved research-only connector contract.
 
 ## Skill map (task to skill)
 

--- a/docs/dev/CODEX_SKILLS.md
+++ b/docs/dev/CODEX_SKILLS.md
@@ -97,7 +97,11 @@ skills as part of the workflow.
 For explainability, the packet also carries `skill_routing` metadata with weighted evidence and blocked-pattern notes.
 Wave 2 routing packets additionally expose `skill_routing.explanation` for the
 stable explanation schema and `skill_routing.research_connector_policy` for the
-approved research-only connector contract.
+approved research-only connector contract. Evidence:
+`scripts/orchestration/skill_router.py:1881-1888`,
+`scripts/orchestration/task_bootstrap.py:786-919`,
+`tests/test_skill_router.py:1318-1378`,
+`tests/test_task_bootstrap.py:163-183`.
 
 ## Skill map (task to skill)
 

--- a/docs/orchestration/AGENT_MESSAGE_PROTOCOL.md
+++ b/docs/orchestration/AGENT_MESSAGE_PROTOCOL.md
@@ -96,7 +96,7 @@ Minimum required keys:
 - `constraints` (array of strings)
 - `inputs.must_read_paths` (array of strings; paths)
 - `inputs.recommended_skills` (array of strings; optional but recommended when skill routing is enabled)
-- `inputs.skill_routing` (object; optional compact evidence map for why those skills were selected; when present, it should expose `task_classification`, `envelope_mode_hint` (aligned with `bootstrap_sync_policy.resolve_analysis_envelope_mode`), `required`, `recommended`, `conditional`, `blocked`, `explanation`, and `research_connector_policy`)
+- `inputs.skill_routing` (object; optional compact evidence map for why those skills were selected; when present, it should expose `task_classification`, `envelope_mode_hint` (aligned with `bootstrap_sync_policy.resolve_analysis_envelope_mode`), `required`, `recommended`, `conditional`, `blocked`, `explanation`, and `research_connector_policy`; Evidence: `scripts/orchestration/task_bootstrap.py:786-919`, `scripts/orchestration/task_bootstrap.py:849-859`, `scripts/orchestration/skill_router.py:558-615`, `scripts/orchestration/skill_router.py:659-696`, `scripts/orchestration/skill_router.py:1783-1912`, `tests/test_task_bootstrap.py:147-183`, `tests/test_skill_router.py:1339-1405`)
 - `output_requirements.must_return` (array of strings)
 - `budgets` (object; recommended when cost/latency matters)
 
@@ -232,7 +232,6 @@ Task packet:
           ]
         }
       ],
-      "envelope_mode_hint": "docs_only",
       "blocked": [],
       "explanation": {
         "schema_version": "1.0",

--- a/docs/orchestration/AGENT_MESSAGE_PROTOCOL.md
+++ b/docs/orchestration/AGENT_MESSAGE_PROTOCOL.md
@@ -193,6 +193,7 @@ Task packet:
           "lexeme:merge readiness(+2)"
         ]
       },
+      "envelope_mode_hint": "docs_only",
       "required": [
         {
           "skill": "pulseplate-workflow",

--- a/docs/orchestration/AGENT_MESSAGE_PROTOCOL.md
+++ b/docs/orchestration/AGENT_MESSAGE_PROTOCOL.md
@@ -232,6 +232,7 @@ Task packet:
           ]
         }
       ],
+      "envelope_mode_hint": "docs_only",
       "blocked": [],
       "explanation": {
         "schema_version": "1.0",

--- a/docs/orchestration/AGENT_MESSAGE_PROTOCOL.md
+++ b/docs/orchestration/AGENT_MESSAGE_PROTOCOL.md
@@ -96,7 +96,7 @@ Minimum required keys:
 - `constraints` (array of strings)
 - `inputs.must_read_paths` (array of strings; paths)
 - `inputs.recommended_skills` (array of strings; optional but recommended when skill routing is enabled)
-- `inputs.skill_routing` (object; optional compact evidence map for why those skills were selected; when present, it should expose `task_classification`, `envelope_mode_hint` (aligned with `bootstrap_sync_policy.resolve_analysis_envelope_mode`), `required`, `recommended`, `conditional`, and `blocked`)
+- `inputs.skill_routing` (object; optional compact evidence map for why those skills were selected; when present, it should expose `task_classification`, `envelope_mode_hint` (aligned with `bootstrap_sync_policy.resolve_analysis_envelope_mode`), `required`, `recommended`, `conditional`, `blocked`, `explanation`, and `research_connector_policy`)
 - `output_requirements.must_return` (array of strings)
 - `budgets` (object; recommended when cost/latency matters)
 
@@ -231,7 +231,43 @@ Task packet:
           ]
         }
       ],
-      "blocked": []
+      "blocked": [],
+      "explanation": {
+        "schema_version": "1.0",
+        "evidence_axes": [
+          "domain_prior",
+          "path_evidence",
+          "lexical_cue",
+          "semantic_group",
+          "requested_agent",
+          "privileged_surface",
+          "policy_block"
+        ],
+        "semantic_groups": [],
+        "per_skill_evidence": [
+          {
+            "skill": "pulseplate-workflow",
+            "bucket": "required",
+            "reasons": ["always-on"]
+          },
+          {
+            "skill": "docs-sync",
+            "bucket": "required",
+            "reasons": ["classification:pr_governance-required"]
+          }
+        ]
+      },
+      "research_connector_policy": {
+        "policy_version": "2026-04-18",
+        "approved": [],
+        "conditional": [],
+        "disallowed": [],
+        "matches": {
+          "approved": [],
+          "conditional": [],
+          "disallowed": []
+        }
+      }
     },
     "automation_flags": {
       "coordinator_first_required": true,

--- a/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
+++ b/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
@@ -108,9 +108,19 @@ Tie-break precedence is canonical and must stay explicit:
 - `blocked`: deterministic low-fit or disallowed patterns. Pattern-based blocks
   must carry `kind: "pattern"` for forward compatibility.
 - `explanation`: stable schema describing evidence axes, matched semantic groups,
-  and compact per-skill evidence for the skills that were surfaced.
+  and compact per-skill evidence for the skills that were surfaced. Evidence:
+  `scripts/orchestration/skill_router.py:660-697`,
+  `scripts/orchestration/skill_router.py:1887-1912`,
+  `scripts/orchestration/task_bootstrap.py:786-919`,
+  `tests/test_skill_router.py:1334-1417`,
+  `tests/test_task_bootstrap.py:163-183`.
 - `research_connector_policy`: explicit catalog of approved / conditional /
   disallowed research-only connectors, plus deterministic request-time matches.
+  Evidence: `scripts/orchestration/skill_router.py:558-609`,
+  `scripts/orchestration/skill_router.py:1887-1912`,
+  `scripts/orchestration/task_bootstrap.py:786-919`,
+  `tests/test_skill_router.py:1275-1332`,
+  `tests/test_task_bootstrap.py:163-183`.
 
 For experimentation tasks, the bootstrap packet should also reference:
 

--- a/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
+++ b/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
@@ -69,6 +69,8 @@ Packet contract note:
   - `recommended`
   - `conditional`
   - `blocked`
+  - `explanation` (stable explanation schema with compact per-skill evidence and semantic-group matches)
+  - `research_connector_policy` (approved / conditional / disallowed connector catalog plus request-time matches)
 
 ### 2a. Deterministic Task Classification
 
@@ -105,6 +107,10 @@ Tie-break precedence is canonical and must stay explicit:
   or PR/CI helpers on non-PR/non-failing tasks.
 - `blocked`: deterministic low-fit or disallowed patterns. Pattern-based blocks
   must carry `kind: "pattern"` for forward compatibility.
+- `explanation`: stable schema describing evidence axes, matched semantic groups,
+  and compact per-skill evidence for the skills that were surfaced.
+- `research_connector_policy`: explicit catalog of approved / conditional /
+  disallowed research-only connectors, plus deterministic request-time matches.
 
 For experimentation tasks, the bootstrap packet should also reference:
 

--- a/docs/review/PR_1475_FIXED_MAPPING.md
+++ b/docs/review/PR_1475_FIXED_MAPPING.md
@@ -37,6 +37,18 @@ Evidence: `docs/orchestration/AGENT_MESSAGE_PROTOCOL.md:235-252`, `docs/orchestr
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106656839 -> aa5042783
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106670372 -> aa5042783
 
+Disposition: FIXED
+Commit: 8ae5bcc45
+Evidence: `docs/orchestration/AGENT_MESSAGE_PROTOCOL.md:99`, `docs/orchestration/AGENT_MESSAGE_PROTOCOL.md:235-260`, `scripts/orchestration/task_bootstrap.py:786-919`, `scripts/orchestration/task_bootstrap.py:849-859`, `scripts/orchestration/skill_router.py:558-615`, `scripts/orchestration/skill_router.py:1783-1912`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135839024 -> 8ae5bcc45
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106702309 -> 8ae5bcc45
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106702311 -> 8ae5bcc45
+
+Disposition: NOT-A-BUG
+Evidence: `scripts/orchestration/skill_router.py:659-682`
+Reason: `_build_explanation_schema()` still emits compact per-skill entries with `skill`, `bucket`, `reasons`, and optional `score`; the protocol sample matches the runtime builder, so replacing `reasons` with `boost` would create contract drift.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106702313
+
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head

--- a/docs/review/PR_1475_FIXED_MAPPING.md
+++ b/docs/review/PR_1475_FIXED_MAPPING.md
@@ -18,13 +18,24 @@ Disposition: FIXED
 Commit: ca2c82f9c
 Evidence: `scripts/orchestration/skill_router.py:521-530`, `docs/dev/CODEX_SKILLS.md:97-104`, `docs/orchestration/AGENT_MESSAGE_PROTOCOL.md:185-266`, `tests/test_skill_router.py:461-471`, `tests/test_skill_router.py:1343-1351`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135801467 -> ca2c82f9c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106654041 -> ca2c82f9c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135803447 -> ca2c82f9c
 
 Disposition: FIXED
 Commit: a1c0bef17
-Evidence: `scripts/orchestration/skill_router.py:521-533`, `tests/test_skill_router.py:1338-1362`
+Evidence: `scripts/orchestration/skill_router.py:521-533`, `tests/test_skill_router.py:1379-1387`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135813600 -> a1c0bef17
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106670369 -> a1c0bef17
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135817214 -> a1c0bef17
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106675367 -> a1c0bef17
+
+Disposition: FIXED
+Commit: aa5042783
+Evidence: `docs/orchestration/AGENT_MESSAGE_PROTOCOL.md:235-252`, `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md:110-123`, `scripts/orchestration/skill_router.py:593-615`, `scripts/orchestration/skill_router.py:1783-1912`, `tests/test_skill_router.py:1275-1323`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106654042 -> aa5042783
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106654044 -> aa5042783
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106656839 -> aa5042783
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106670372 -> aa5042783
 
 ## Merge Readiness
 

--- a/docs/review/PR_1475_FIXED_MAPPING.md
+++ b/docs/review/PR_1475_FIXED_MAPPING.md
@@ -9,7 +9,16 @@ Bot and human review threads must be dispositioned here before they are resolved
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 0b679c82d
+Evidence: `scripts/orchestration/skill_router.py:32-39`, `scripts/orchestration/skill_router.py:160-179`, `tests/test_skill_router.py:1292-1378`, `tests/test_task_bootstrap.py:163-183`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135799129 -> 0b679c82d
+
+Disposition: FIXED
+Commit: ca2c82f9c
+Evidence: `scripts/orchestration/skill_router.py:521-530`, `docs/dev/CODEX_SKILLS.md:97-104`, `docs/orchestration/AGENT_MESSAGE_PROTOCOL.md:185-266`, `tests/test_skill_router.py:461-471`, `tests/test_skill_router.py:1343-1351`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135801467 -> ca2c82f9c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135803447 -> ca2c82f9c
 
 ## Merge Readiness
 

--- a/docs/review/PR_1475_FIXED_MAPPING.md
+++ b/docs/review/PR_1475_FIXED_MAPPING.md
@@ -20,6 +20,12 @@ Evidence: `scripts/orchestration/skill_router.py:521-530`, `docs/dev/CODEX_SKILL
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135801467 -> ca2c82f9c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135803447 -> ca2c82f9c
 
+Disposition: FIXED
+Commit: a1c0bef17
+Evidence: `scripts/orchestration/skill_router.py:521-533`, `tests/test_skill_router.py:1338-1362`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135813600 -> a1c0bef17
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135817214 -> a1c0bef17
+
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head

--- a/docs/review/PR_1475_FIXED_MAPPING.md
+++ b/docs/review/PR_1475_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+# PR #1475 — Fixed in Commit Mapping (SoT)
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Bot and human review threads must be dispositioned here before they are resolved on GitHub.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green on latest pushed head
+- [ ] `make verify` green on latest pushed head

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -523,7 +523,9 @@ def _match_lexeme_terms(*, normalized_request_text: str, keywords: tuple[str, ..
 
     matches: list[str] = []
     for keyword in keywords:
-        if keyword in normalized_request_text and keyword not in matches:
+        if keyword not in matches and re.search(
+            rf"(?<!\w){re.escape(keyword)}(?!\w)", normalized_request_text
+        ):
             matches.append(keyword)
     return matches
 

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -27,6 +27,8 @@ from scripts.orchestration.requested_agents import normalize_requested_agents
 
 ROUTING_POLICY_VERSION = "2026-03-27"
 SELECTION_MODE = "deterministic-weighted"
+ROUTING_EXPLANATION_SCHEMA_VERSION = "1.0"
+RESEARCH_CONNECTOR_POLICY_VERSION = "2026-04-18"
 
 ALWAYS_ON_SKILLS: tuple[str, ...] = ("pulseplate-workflow",)
 PR_GOVERNANCE_REQUIRED_SKILLS: tuple[str, ...] = (
@@ -145,6 +147,186 @@ SCRAPING_BLOCK_PATTERNS: tuple[tuple[str, str], ...] = (
     ("google maps", "Google Maps scraping is not approved for the current repo."),
     ("scrape any site", "Universal scraping is out of scope for PulsePlate."),
     ("entire internet", "Broad internet scraping is outside project-fit boundaries."),
+)
+
+
+@dataclass(frozen=True)
+class SemanticLexemeGroup:
+    """Deterministic ontology-style semantic group for routing explanations."""
+
+    group_id: str
+    label: str
+    rationale: str
+    keywords: tuple[str, ...]
+    skill_boosts: tuple[tuple[str, int], ...] = ()
+
+
+@dataclass(frozen=True)
+class ResearchConnectorRule:
+    """Deterministic research-only connector policy entry."""
+
+    connector: str
+    label: str
+    policy_bucket: str
+    rationale: str
+    keywords: tuple[str, ...]
+
+
+SEMANTIC_LEXEME_GROUPS: tuple[SemanticLexemeGroup, ...] = (
+    SemanticLexemeGroup(
+        group_id="orchestration.explainability",
+        label="Routing explainability",
+        rationale=(
+            "Requests about explanation schemas and evidence should strengthen "
+            "orchestration explainability surfaces without changing execution authority."
+        ),
+        keywords=(
+            "explanation schema",
+            "explainability",
+            "per-skill evidence",
+            "routing evidence",
+            "skill-routing explanation",
+        ),
+        skill_boosts=(("docs-sync", 2), ("agents-md", 1)),
+    ),
+    SemanticLexemeGroup(
+        group_id="research.connector.youtube",
+        label="YouTube transcript research",
+        rationale=(
+            "YouTube transcript and channel monitoring requests stay inside the approved "
+            "research-only founder/trend workflow."
+        ),
+        keywords=(
+            "youtube transcript",
+            "youtube transcripts",
+            "youtube channel",
+            "youtube channels",
+        ),
+        skill_boosts=(
+            ("pulseplate-ai-reports", 3),
+            ("notion-research-documentation", 2),
+        ),
+    ),
+    SemanticLexemeGroup(
+        group_id="research.connector.x_twitter",
+        label="X/Twitter official research",
+        rationale=(
+            "X/Twitter requests are allowed only through official APIs or compliant exports "
+            "inside research-only workflows."
+        ),
+        keywords=(
+            "x/twitter",
+            "x twitter",
+            "twitter official api",
+            "twitter api",
+            "compliant exports",
+        ),
+        skill_boosts=(
+            ("pulseplate-ai-reports", 3),
+            ("notion-research-documentation", 2),
+        ),
+    ),
+    SemanticLexemeGroup(
+        group_id="research.connector.google_trends",
+        label="Google Trends research",
+        rationale=(
+            "Google Trends is approved for bounded research and search-intent analysis only."
+        ),
+        keywords=(
+            "google trends",
+            "search-intent datasets",
+            "search intent datasets",
+            "search intent data",
+        ),
+        skill_boosts=(
+            ("pulseplate-ai-reports", 3),
+            ("notion-research-documentation", 2),
+        ),
+    ),
+)
+
+RESEARCH_CONNECTOR_RULES: tuple[ResearchConnectorRule, ...] = (
+    ResearchConnectorRule(
+        connector="youtube_transcripts",
+        label="YouTube transcripts",
+        policy_bucket="approved",
+        rationale=(
+            "Approved for founder research and trend tracking as a research-only connector."
+        ),
+        keywords=(
+            "youtube transcript",
+            "youtube transcripts",
+            "youtube channel",
+            "youtube channels",
+        ),
+    ),
+    ResearchConnectorRule(
+        connector="x_twitter_official_exports",
+        label="X/Twitter official API or compliant exports",
+        policy_bucket="approved",
+        rationale=("Approved for research-only use via official APIs or compliant exports."),
+        keywords=(
+            "x/twitter",
+            "x twitter",
+            "twitter official api",
+            "twitter api",
+            "compliant exports",
+        ),
+    ),
+    ResearchConnectorRule(
+        connector="google_trends",
+        label="Google Trends and search-intent datasets",
+        policy_bucket="approved",
+        rationale=("Approved for narrow research-only search-intent and trend analysis."),
+        keywords=(
+            "google trends",
+            "search-intent datasets",
+            "search intent datasets",
+            "search intent data",
+        ),
+    ),
+    ResearchConnectorRule(
+        connector="reddit_forum_mining",
+        label="Reddit or forum mining",
+        policy_bucket="conditional",
+        rationale="Conditionally allowed later after a future explicit governance promotion.",
+        keywords=("reddit", "forum mining", "forum research"),
+    ),
+    ResearchConnectorRule(
+        connector="app_store_review_mining",
+        label="App Store / Play Store review mining",
+        policy_bucket="conditional",
+        rationale="Conditionally allowed later after an explicit governance promotion.",
+        keywords=("app store reviews", "play store reviews", "review mining"),
+    ),
+    ResearchConnectorRule(
+        connector="competitor_landing_page_monitoring",
+        label="Competitor landing page monitoring",
+        policy_bucket="conditional",
+        rationale="Conditionally allowed later after an explicit governance promotion.",
+        keywords=("competitor landing page", "landing page monitoring"),
+    ),
+    ResearchConnectorRule(
+        connector="tiktok_scraping",
+        label="TikTok scraping",
+        policy_bucket="disallowed",
+        rationale="Not approved for the current repo.",
+        keywords=("tiktok",),
+    ),
+    ResearchConnectorRule(
+        connector="google_maps_scraping",
+        label="Google Maps scraping",
+        policy_bucket="disallowed",
+        rationale="Not approved for the current repo.",
+        keywords=("google maps",),
+    ),
+    ResearchConnectorRule(
+        connector="universal_free_form_scrapers",
+        label="Universal free-form scrapers for arbitrary sites",
+        policy_bucket="disallowed",
+        rationale="Broad arbitrary-site scraping is outside the PulsePlate contract.",
+        keywords=("scrape any site", "entire internet"),
+    ),
 )
 
 
@@ -324,6 +506,163 @@ def _strip_skills_for_docs_only_envelope(
     filtered_recommended = [item for item in recommended if item["skill"] not in excluded]
     filtered_conditional = [item for item in conditional if item["skill"] not in excluded]
     return filtered_recommended, filtered_conditional
+
+
+def _match_lexeme_terms(*, normalized_request_text: str, keywords: tuple[str, ...]) -> list[str]:
+    """Return matched lexeme terms in stable order."""
+
+    matches: list[str] = []
+    for keyword in keywords:
+        if keyword in normalized_request_text and keyword not in matches:
+            matches.append(keyword)
+    return matches
+
+
+def _match_semantic_groups(*, normalized_request_text: str) -> list[dict[str, Any]]:
+    """Return matched ontology-style semantic groups for explainability."""
+
+    matched_groups: list[dict[str, Any]] = []
+    for group in SEMANTIC_LEXEME_GROUPS:
+        matched_terms = _match_lexeme_terms(
+            normalized_request_text=normalized_request_text,
+            keywords=group.keywords,
+        )
+        if not matched_terms:
+            continue
+        matched_groups.append(
+            {
+                "group_id": group.group_id,
+                "label": group.label,
+                "matched_terms": matched_terms,
+                "rationale": group.rationale,
+            }
+        )
+    return matched_groups
+
+
+def _build_research_connector_policy(*, normalized_request_text: str) -> dict[str, Any]:
+    """Return deterministic research-only connector policy metadata."""
+
+    catalog: dict[str, list[dict[str, Any]]] = {
+        "approved": [],
+        "conditional": [],
+        "disallowed": [],
+    }
+    matches: dict[str, list[dict[str, Any]]] = {
+        "approved": [],
+        "conditional": [],
+        "disallowed": [],
+    }
+
+    for rule in RESEARCH_CONNECTOR_RULES:
+        entry = {
+            "connector": rule.connector,
+            "label": rule.label,
+            "rationale": rule.rationale,
+        }
+        catalog[rule.policy_bucket].append(entry)
+        matched_terms = _match_lexeme_terms(
+            normalized_request_text=normalized_request_text,
+            keywords=rule.keywords,
+        )
+        if matched_terms:
+            matches[rule.policy_bucket].append(
+                {
+                    "connector": rule.connector,
+                    "label": rule.label,
+                    "matched_terms": matched_terms,
+                }
+            )
+
+    return {
+        "policy_version": RESEARCH_CONNECTOR_POLICY_VERSION,
+        "approved": catalog["approved"],
+        "conditional": catalog["conditional"],
+        "disallowed": catalog["disallowed"],
+        "matches": matches,
+    }
+
+
+def _apply_semantic_group_boosts(
+    *,
+    selected_by_skill: dict[str, dict[str, Any]],
+    matched_semantic_groups: list[dict[str, Any]],
+    task_classification: dict[str, Any],
+    domain: str,
+    required_skill_names: set[str],
+) -> None:
+    """Apply deterministic semantic-group boosts where the lane allows it."""
+
+    research_lane = task_classification["label"] == "creative_research" or domain in {
+        "research",
+        "business",
+        "wellness",
+    }
+    orchestration_lane = domain == "orchestration"
+
+    for group in SEMANTIC_LEXEME_GROUPS:
+        matched = next(
+            (item for item in matched_semantic_groups if item["group_id"] == group.group_id),
+            None,
+        )
+        if matched is None:
+            continue
+        group_is_research_connector = group.group_id.startswith("research.connector.")
+        if group_is_research_connector and not research_lane:
+            continue
+        if group.group_id == "orchestration.explainability" and not orchestration_lane:
+            continue
+        for skill, boost in group.skill_boosts:
+            if skill in required_skill_names:
+                continue
+            _apply_bundle_reason(
+                selected_by_skill=selected_by_skill,
+                skill=skill,
+                boost=boost,
+                reason=f"semantic-group:{group.group_id}(+{boost})",
+                fallback_rationale=group.rationale,
+            )
+
+
+def _build_explanation_schema(
+    *,
+    required: list[dict[str, Any]],
+    recommended: list[dict[str, Any]],
+    conditional: list[dict[str, Any]],
+    matched_semantic_groups: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Return stable explanation metadata with compact per-skill evidence."""
+
+    per_skill_evidence: list[dict[str, Any]] = []
+    for bucket_name, items in (
+        ("required", required),
+        ("recommended", recommended),
+        ("conditional", conditional),
+    ):
+        for item in items:
+            evidence = {
+                "skill": item["skill"],
+                "bucket": bucket_name,
+                "reasons": list(item.get("reasons", [])),
+            }
+            if "score" in item:
+                evidence["score"] = int(item["score"])
+            per_skill_evidence.append(evidence)
+
+    return {
+        "schema_version": ROUTING_EXPLANATION_SCHEMA_VERSION,
+        "evidence_axes": [
+            "domain_prior",
+            "path_evidence",
+            "lexical_cue",
+            "semantic_group",
+            "requested_agent",
+            "privileged_surface",
+            "policy_block",
+        ],
+        "semantic_groups": matched_semantic_groups,
+        "per_skill_evidence": per_skill_evidence,
+    }
 
 
 @dataclass(frozen=True)
@@ -1406,6 +1745,12 @@ def route_skills(
         design_source=normalized_design_source,
         explicit_design_metadata=explicit_design_metadata,
     )
+    matched_semantic_groups = _match_semantic_groups(
+        normalized_request_text=normalized_request_text
+    )
+    research_connector_policy = _build_research_connector_policy(
+        normalized_request_text=normalized_request_text
+    )
 
     blocked = [
         {"label": pattern, "reason": reason, "kind": "pattern"}
@@ -1479,6 +1824,13 @@ def route_skills(
                 "Review and bugfix lanes require deterministic triage-helper coverage."
             ),
         )
+    _apply_semantic_group_boosts(
+        selected_by_skill=selected_by_skill,
+        matched_semantic_groups=matched_semantic_groups,
+        task_classification=task_classification,
+        domain=domain,
+        required_skill_names=required_skill_names,
+    )
     selected = list(selected_by_skill.values())
 
     if figma_execution_ready:
@@ -1511,6 +1863,12 @@ def route_skills(
         recommended=selected,
         conditional=conditional,
     )
+    explanation = _build_explanation_schema(
+        required=required,
+        recommended=selected,
+        conditional=conditional,
+        matched_semantic_groups=matched_semantic_groups,
+    )
 
     return {
         "policy_version": ROUTING_POLICY_VERSION,
@@ -1522,6 +1880,8 @@ def route_skills(
         "recommended": selected,
         "conditional": conditional,
         "blocked": blocked,
+        "explanation": explanation,
+        "research_connector_policy": research_connector_policy,
     }
 
 

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -29,6 +29,14 @@ ROUTING_POLICY_VERSION = "2026-03-27"
 SELECTION_MODE = "deterministic-weighted"
 ROUTING_EXPLANATION_SCHEMA_VERSION = "1.0"
 RESEARCH_CONNECTOR_POLICY_VERSION = "2026-04-18"
+RESEARCH_POLICY_BUCKET_APPROVED = "approved"
+RESEARCH_POLICY_BUCKET_CONDITIONAL = "conditional"
+RESEARCH_POLICY_BUCKET_DISALLOWED = "disallowed"
+RESEARCH_POLICY_BUCKETS: tuple[str, ...] = (
+    RESEARCH_POLICY_BUCKET_APPROVED,
+    RESEARCH_POLICY_BUCKET_CONDITIONAL,
+    RESEARCH_POLICY_BUCKET_DISALLOWED,
+)
 
 ALWAYS_ON_SKILLS: tuple[str, ...] = ("pulseplate-workflow",)
 PR_GOVERNANCE_REQUIRED_SKILLS: tuple[str, ...] = (
@@ -149,6 +157,40 @@ SCRAPING_BLOCK_PATTERNS: tuple[tuple[str, str], ...] = (
     ("entire internet", "Broad internet scraping is outside project-fit boundaries."),
 )
 
+# Shared keyword sources keep semantic-group boosts and connector-policy matching in lockstep.
+YOUTUBE_RESEARCH_KEYWORDS: tuple[str, ...] = (
+    "youtube transcript",
+    "youtube transcripts",
+    "youtube channel",
+    "youtube channels",
+)
+X_TWITTER_RESEARCH_KEYWORDS: tuple[str, ...] = (
+    "x/twitter",
+    "x twitter",
+    "twitter official api",
+    "twitter api",
+    "compliant exports",
+)
+GOOGLE_TRENDS_RESEARCH_KEYWORDS: tuple[str, ...] = (
+    "google trends",
+    "search-intent datasets",
+    "search intent datasets",
+    "search intent data",
+)
+REDDIT_FORUM_RESEARCH_KEYWORDS: tuple[str, ...] = ("reddit", "forum mining", "forum research")
+APP_STORE_REVIEW_MINING_KEYWORDS: tuple[str, ...] = (
+    "app store reviews",
+    "play store reviews",
+    "review mining",
+)
+COMPETITOR_LANDING_PAGE_MONITORING_KEYWORDS: tuple[str, ...] = (
+    "competitor landing page",
+    "landing page monitoring",
+)
+TIKTOK_SCRAPING_KEYWORDS: tuple[str, ...] = ("tiktok",)
+GOOGLE_MAPS_SCRAPING_KEYWORDS: tuple[str, ...] = ("google maps",)
+UNIVERSAL_SCRAPING_KEYWORDS: tuple[str, ...] = ("scrape any site", "entire internet")
+
 
 @dataclass(frozen=True)
 class SemanticLexemeGroup:
@@ -196,12 +238,7 @@ SEMANTIC_LEXEME_GROUPS: tuple[SemanticLexemeGroup, ...] = (
             "YouTube transcript and channel monitoring requests stay inside the approved "
             "research-only founder/trend workflow."
         ),
-        keywords=(
-            "youtube transcript",
-            "youtube transcripts",
-            "youtube channel",
-            "youtube channels",
-        ),
+        keywords=YOUTUBE_RESEARCH_KEYWORDS,
         skill_boosts=(
             ("pulseplate-ai-reports", 3),
             ("notion-research-documentation", 2),
@@ -214,13 +251,7 @@ SEMANTIC_LEXEME_GROUPS: tuple[SemanticLexemeGroup, ...] = (
             "X/Twitter requests are allowed only through official APIs or compliant exports "
             "inside research-only workflows."
         ),
-        keywords=(
-            "x/twitter",
-            "x twitter",
-            "twitter official api",
-            "twitter api",
-            "compliant exports",
-        ),
+        keywords=X_TWITTER_RESEARCH_KEYWORDS,
         skill_boosts=(
             ("pulseplate-ai-reports", 3),
             ("notion-research-documentation", 2),
@@ -232,12 +263,7 @@ SEMANTIC_LEXEME_GROUPS: tuple[SemanticLexemeGroup, ...] = (
         rationale=(
             "Google Trends is approved for bounded research and search-intent analysis only."
         ),
-        keywords=(
-            "google trends",
-            "search-intent datasets",
-            "search intent datasets",
-            "search intent data",
-        ),
+        keywords=GOOGLE_TRENDS_RESEARCH_KEYWORDS,
         skill_boosts=(
             ("pulseplate-ai-reports", 3),
             ("notion-research-documentation", 2),
@@ -249,83 +275,67 @@ RESEARCH_CONNECTOR_RULES: tuple[ResearchConnectorRule, ...] = (
     ResearchConnectorRule(
         connector="youtube_transcripts",
         label="YouTube transcripts",
-        policy_bucket="approved",
+        policy_bucket=RESEARCH_POLICY_BUCKET_APPROVED,
         rationale=(
             "Approved for founder research and trend tracking as a research-only connector."
         ),
-        keywords=(
-            "youtube transcript",
-            "youtube transcripts",
-            "youtube channel",
-            "youtube channels",
-        ),
+        keywords=YOUTUBE_RESEARCH_KEYWORDS,
     ),
     ResearchConnectorRule(
         connector="x_twitter_official_exports",
         label="X/Twitter official API or compliant exports",
-        policy_bucket="approved",
+        policy_bucket=RESEARCH_POLICY_BUCKET_APPROVED,
         rationale=("Approved for research-only use via official APIs or compliant exports."),
-        keywords=(
-            "x/twitter",
-            "x twitter",
-            "twitter official api",
-            "twitter api",
-            "compliant exports",
-        ),
+        keywords=X_TWITTER_RESEARCH_KEYWORDS,
     ),
     ResearchConnectorRule(
         connector="google_trends",
         label="Google Trends and search-intent datasets",
-        policy_bucket="approved",
+        policy_bucket=RESEARCH_POLICY_BUCKET_APPROVED,
         rationale=("Approved for narrow research-only search-intent and trend analysis."),
-        keywords=(
-            "google trends",
-            "search-intent datasets",
-            "search intent datasets",
-            "search intent data",
-        ),
+        keywords=GOOGLE_TRENDS_RESEARCH_KEYWORDS,
     ),
     ResearchConnectorRule(
         connector="reddit_forum_mining",
         label="Reddit or forum mining",
-        policy_bucket="conditional",
+        policy_bucket=RESEARCH_POLICY_BUCKET_CONDITIONAL,
         rationale="Conditionally allowed later after a future explicit governance promotion.",
-        keywords=("reddit", "forum mining", "forum research"),
+        keywords=REDDIT_FORUM_RESEARCH_KEYWORDS,
     ),
     ResearchConnectorRule(
         connector="app_store_review_mining",
         label="App Store / Play Store review mining",
-        policy_bucket="conditional",
+        policy_bucket=RESEARCH_POLICY_BUCKET_CONDITIONAL,
         rationale="Conditionally allowed later after an explicit governance promotion.",
-        keywords=("app store reviews", "play store reviews", "review mining"),
+        keywords=APP_STORE_REVIEW_MINING_KEYWORDS,
     ),
     ResearchConnectorRule(
         connector="competitor_landing_page_monitoring",
         label="Competitor landing page monitoring",
-        policy_bucket="conditional",
+        policy_bucket=RESEARCH_POLICY_BUCKET_CONDITIONAL,
         rationale="Conditionally allowed later after an explicit governance promotion.",
-        keywords=("competitor landing page", "landing page monitoring"),
+        keywords=COMPETITOR_LANDING_PAGE_MONITORING_KEYWORDS,
     ),
     ResearchConnectorRule(
         connector="tiktok_scraping",
         label="TikTok scraping",
-        policy_bucket="disallowed",
+        policy_bucket=RESEARCH_POLICY_BUCKET_DISALLOWED,
         rationale="Not approved for the current repo.",
-        keywords=("tiktok",),
+        keywords=TIKTOK_SCRAPING_KEYWORDS,
     ),
     ResearchConnectorRule(
         connector="google_maps_scraping",
         label="Google Maps scraping",
-        policy_bucket="disallowed",
+        policy_bucket=RESEARCH_POLICY_BUCKET_DISALLOWED,
         rationale="Not approved for the current repo.",
-        keywords=("google maps",),
+        keywords=GOOGLE_MAPS_SCRAPING_KEYWORDS,
     ),
     ResearchConnectorRule(
         connector="universal_free_form_scrapers",
         label="Universal free-form scrapers for arbitrary sites",
-        policy_bucket="disallowed",
+        policy_bucket=RESEARCH_POLICY_BUCKET_DISALLOWED,
         rationale="Broad arbitrary-site scraping is outside the PulsePlate contract.",
-        keywords=("scrape any site", "entire internet"),
+        keywords=UNIVERSAL_SCRAPING_KEYWORDS,
     ),
 )
 
@@ -543,16 +553,8 @@ def _match_semantic_groups(*, normalized_request_text: str) -> list[dict[str, An
 def _build_research_connector_policy(*, normalized_request_text: str) -> dict[str, Any]:
     """Return deterministic research-only connector policy metadata."""
 
-    catalog: dict[str, list[dict[str, Any]]] = {
-        "approved": [],
-        "conditional": [],
-        "disallowed": [],
-    }
-    matches: dict[str, list[dict[str, Any]]] = {
-        "approved": [],
-        "conditional": [],
-        "disallowed": [],
-    }
+    catalog: dict[str, list[dict[str, Any]]] = {bucket: [] for bucket in RESEARCH_POLICY_BUCKETS}
+    matches: dict[str, list[dict[str, Any]]] = {bucket: [] for bucket in RESEARCH_POLICY_BUCKETS}
 
     for rule in RESEARCH_CONNECTOR_RULES:
         entry = {
@@ -576,9 +578,9 @@ def _build_research_connector_policy(*, normalized_request_text: str) -> dict[st
 
     return {
         "policy_version": RESEARCH_CONNECTOR_POLICY_VERSION,
-        "approved": catalog["approved"],
-        "conditional": catalog["conditional"],
-        "disallowed": catalog["disallowed"],
+        RESEARCH_POLICY_BUCKET_APPROVED: catalog[RESEARCH_POLICY_BUCKET_APPROVED],
+        RESEARCH_POLICY_BUCKET_CONDITIONAL: catalog[RESEARCH_POLICY_BUCKET_CONDITIONAL],
+        RESEARCH_POLICY_BUCKET_DISALLOWED: catalog[RESEARCH_POLICY_BUCKET_DISALLOWED],
         "matches": matches,
     }
 

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -590,6 +590,31 @@ def _build_research_connector_policy(*, normalized_request_text: str) -> dict[st
     }
 
 
+def _build_blocked_patterns(*, research_connector_policy: dict[str, Any]) -> list[dict[str, str]]:
+    """Derive blocked-pattern metadata from the same disallowed connector matches."""
+
+    disallowed_reasons = {
+        rule.connector: rule.rationale
+        for rule in RESEARCH_CONNECTOR_RULES
+        if rule.policy_bucket == RESEARCH_POLICY_BUCKET_DISALLOWED
+    }
+    blocked: list[dict[str, str]] = []
+    seen_labels: set[str] = set()
+
+    for match in research_connector_policy["matches"][RESEARCH_POLICY_BUCKET_DISALLOWED]:
+        reason = disallowed_reasons.get(
+            match["connector"],
+            "Disallowed research connector pattern for the current repo.",
+        )
+        for matched_term in match.get("matched_terms", []):
+            if matched_term in seen_labels:
+                continue
+            blocked.append({"label": matched_term, "reason": reason, "kind": "pattern"})
+            seen_labels.add(matched_term)
+
+    return blocked
+
+
 def _apply_semantic_group_boosts(
     *,
     selected_by_skill: dict[str, dict[str, Any]],
@@ -1758,12 +1783,7 @@ def route_skills(
     research_connector_policy = _build_research_connector_policy(
         normalized_request_text=normalized_request_text
     )
-
-    blocked = [
-        {"label": pattern, "reason": reason, "kind": "pattern"}
-        for pattern, reason in SCRAPING_BLOCK_PATTERNS
-        if pattern in normalized_request_text
-    ]
+    blocked = _build_blocked_patterns(research_connector_policy=research_connector_policy)
 
     scored = [
         _score_rule(

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -523,10 +523,13 @@ def _match_lexeme_terms(*, normalized_request_text: str, keywords: tuple[str, ..
 
     matches: list[str] = []
     for keyword in keywords:
-        if keyword not in matches and re.search(
-            rf"(?<!\w){re.escape(keyword)}(?!\w)", normalized_request_text
+        normalized_keyword = _normalize_lexeme(keyword)
+        if (
+            normalized_keyword
+            and normalized_keyword not in matches
+            and re.search(rf"(?<!\w){re.escape(normalized_keyword)}(?!\w)", normalized_request_text)
         ):
-            matches.append(keyword)
+            matches.append(normalized_keyword)
     return matches
 
 

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -538,6 +538,12 @@ def _apply_requested_agent_overrides(
     resolved_secondary_agents = [agent for agent in [secondary_agent] if agent]
     dispositions: list[dict[str, str]] = []
     advisory_agents: list[str] = []
+    coordinator_locked = (
+        canonical_route is not None
+        and canonical_route.primary == "agent-coordinator"
+        and "agent-coordinator" in requested_agents
+        and primary_agent == "agent-coordinator"
+    )
 
     def _disposition(agent: str, status: str, reason: str) -> dict[str, str]:
         """Build a deterministic disposition payload for requested-agent handling."""
@@ -576,6 +582,32 @@ def _apply_requested_agent_overrides(
         # may appear as secondary/reviewer in AGENT_ROUTING_GRAPH.md while still being
         # listed in AGENT_NON_ROUTABLE_SPECIALISTS.md for default routing semantics.
         if agent in allowed_promotions:
+            if coordinator_locked and agent != "agent-coordinator":
+                if agent == reviewer:
+                    dispositions.append(
+                        _disposition(
+                            agent,
+                            REQUESTED_AGENT_STATUS_HONORED_REVIEWER,
+                            (
+                                "Coordinator-owned lane keeps `agent-coordinator` as primary; "
+                                "requested reviewer stays honored in reviewer."
+                            ),
+                        )
+                    )
+                    continue
+                if agent not in resolved_secondary_agents:
+                    resolved_secondary_agents.append(agent)
+                dispositions.append(
+                    _disposition(
+                        agent,
+                        REQUESTED_AGENT_STATUS_HONORED_SECONDARY,
+                        (
+                            "Coordinator-owned lane keeps `agent-coordinator` as primary; "
+                            "requested agent stays honored in secondary."
+                        ),
+                    )
+                )
+                continue
             previous_primary = resolved_primary
             resolved_primary = agent
             resolved_secondary_agents = [

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -11,6 +11,8 @@ from scripts.orchestration.skill_router import (
     CLASSIFICATION_PRECEDENCE,
     DOCS_ONLY_EXCLUDED_ROUTING_SKILLS,
     PRIVILEGED_SURFACE_PREFIXES,
+    RESEARCH_POLICY_BUCKET_APPROVED,
+    RESEARCH_POLICY_BUCKET_DISALLOWED,
     REQUESTED_AGENT_COMPANION_SKILL_BUNDLES,
     REQUESTED_AGENT_SKILL_BUNDLES,
     ROUTING_POLICY_VERSION,
@@ -1286,7 +1288,10 @@ def test_skill_router_records_blocked_scraping_patterns() -> None:
     assert "entire internet" in blocked_labels
     assert all(item["kind"] == "pattern" for item in decision["blocked"])
     disallowed = {
-        item["connector"] for item in decision["research_connector_policy"]["matches"]["disallowed"]
+        item["connector"]
+        for item in decision["research_connector_policy"]["matches"][
+            RESEARCH_POLICY_BUCKET_DISALLOWED
+        ]
     }
     assert "tiktok_scraping" in disallowed
     assert "google_maps_scraping" in disallowed
@@ -1307,7 +1312,7 @@ def test_skill_router_ignores_scraping_tokens_from_candidate_paths() -> None:
     )
 
     assert decision["blocked"] == []
-    assert decision["research_connector_policy"]["matches"]["disallowed"] == []
+    assert decision["research_connector_policy"]["matches"][RESEARCH_POLICY_BUCKET_DISALLOWED] == []
 
 
 def test_skill_router_exposes_stable_explanation_schema() -> None:
@@ -1349,7 +1354,10 @@ def test_skill_router_matches_approved_research_connectors_deterministically() -
     )
 
     matched = {
-        item["connector"] for item in decision["research_connector_policy"]["matches"]["approved"]
+        item["connector"]
+        for item in decision["research_connector_policy"]["matches"][
+            RESEARCH_POLICY_BUCKET_APPROVED
+        ]
     }
     assert matched == {
         "youtube_transcripts",

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -1337,7 +1337,7 @@ def test_skill_router_exposes_stable_explanation_schema() -> None:
     )
     per_skill = {item["skill"]: item for item in explanation["per_skill_evidence"]}
     assert per_skill["pulseplate-workflow"]["bucket"] == "required"
-    assert per_skill["docs-sync"]["bucket"] in {"recommended", "conditional"}
+    assert per_skill["docs-sync"]["bucket"] == "recommended"
 
 
 def test_match_lexeme_terms_requires_token_boundaries() -> None:
@@ -1349,6 +1349,17 @@ def test_match_lexeme_terms_requires_token_boundaries() -> None:
     )
 
     assert matches == []
+
+
+def test_match_lexeme_terms_normalizes_keywords_before_matching() -> None:
+    """Lexeme matching should use normalized keywords against normalized request text."""
+
+    matches = skill_router_module._match_lexeme_terms(
+        normalized_request_text="compare x twitter exports with search intent datasets",
+        keywords=("x/twitter", "search-intent datasets"),
+    )
+
+    assert matches == ["x twitter", "search intent datasets"]
 
 
 def test_skill_router_matches_approved_research_connectors_deterministically() -> None:

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -1340,6 +1340,17 @@ def test_skill_router_exposes_stable_explanation_schema() -> None:
     assert per_skill["docs-sync"]["bucket"] in {"recommended", "conditional"}
 
 
+def test_match_lexeme_terms_requires_token_boundaries() -> None:
+    """Lexeme matching should not trigger on connector names embedded in larger tokens."""
+
+    matches = skill_router_module._match_lexeme_terms(
+        normalized_request_text="audit myyoutubeapp packaging notes",
+        keywords=("youtube", "google trends"),
+    )
+
+    assert matches == []
+
+
 def test_skill_router_matches_approved_research_connectors_deterministically() -> None:
     """Approved research-only connectors should be explicit in the routing metadata."""
 

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -63,6 +63,8 @@ EXPECTED_ROUTING_BUCKET_POLICY_LINES: tuple[str, ...] = (
     "- `recommended`: deterministic ranked helpers that are safe to auto-promote into",
     "- `conditional`: task-fit helpers that need a stronger trigger before promotion.",
     "- `blocked`: deterministic low-fit or disallowed patterns. Pattern-based blocks",
+    "- `explanation`: stable schema describing evidence axes, matched semantic groups,",
+    "- `research_connector_policy`: explicit catalog of approved / conditional /",
 )
 
 
@@ -463,6 +465,8 @@ def test_message_protocol_example_mentions_expanded_skill_routing_contract() -> 
     assert '"required": [' in doc
     assert '"recommended": [' in doc
     assert '"conditional": [' in doc
+    assert '"explanation": {' in doc
+    assert '"research_connector_policy": {' in doc
 
 
 def test_requested_agent_bundle_boosts_existing_skill_without_duplication() -> None:
@@ -1281,6 +1285,12 @@ def test_skill_router_records_blocked_scraping_patterns() -> None:
     assert "google maps" in blocked_labels
     assert "entire internet" in blocked_labels
     assert all(item["kind"] == "pattern" for item in decision["blocked"])
+    disallowed = {
+        item["connector"] for item in decision["research_connector_policy"]["matches"]["disallowed"]
+    }
+    assert "tiktok_scraping" in disallowed
+    assert "google_maps_scraping" in disallowed
+    assert "universal_free_form_scrapers" in disallowed
 
 
 def test_skill_router_ignores_scraping_tokens_from_candidate_paths() -> None:
@@ -1297,6 +1307,61 @@ def test_skill_router_ignores_scraping_tokens_from_candidate_paths() -> None:
     )
 
     assert decision["blocked"] == []
+    assert decision["research_connector_policy"]["matches"]["disallowed"] == []
+
+
+def test_skill_router_exposes_stable_explanation_schema() -> None:
+    """Skill routing should expose compact explanation metadata and semantic-group evidence."""
+
+    decision = route_skills(
+        goal="Update skill-routing explanation schema and per-skill evidence",
+        task_class="Orchestration",
+        candidate_paths=[
+            "scripts/orchestration/skill_router.py",
+            "docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md",
+        ],
+        domain="orchestration",
+    )
+
+    explanation = decision["explanation"]
+    assert explanation["schema_version"] == "1.0"
+    assert "semantic_group" in explanation["evidence_axes"]
+    assert any(
+        item["group_id"] == "orchestration.explainability"
+        for item in explanation["semantic_groups"]
+    )
+    per_skill = {item["skill"]: item for item in explanation["per_skill_evidence"]}
+    assert per_skill["pulseplate-workflow"]["bucket"] == "required"
+    assert per_skill["docs-sync"]["bucket"] in {"recommended", "conditional"}
+
+
+def test_skill_router_matches_approved_research_connectors_deterministically() -> None:
+    """Approved research-only connectors should be explicit in the routing metadata."""
+
+    decision = route_skills(
+        goal=(
+            "Prepare founder research using YouTube transcripts, Twitter official API "
+            "exports, and Google Trends"
+        ),
+        task_class="Research",
+        candidate_paths=["docs/audience_pack/ENGINEERING_OVERVIEW.md"],
+        domain="research",
+    )
+
+    matched = {
+        item["connector"] for item in decision["research_connector_policy"]["matches"]["approved"]
+    }
+    assert matched == {
+        "youtube_transcripts",
+        "x_twitter_official_exports",
+        "google_trends",
+    }
+    assert any(
+        item["group_id"] == "research.connector.youtube"
+        for item in decision["explanation"]["semantic_groups"]
+    )
+    recommended = {item["skill"] for item in decision["recommended"]}
+    assert "pulseplate-ai-reports" in recommended
 
 
 def test_skill_router_selects_experimentation_lane_skills() -> None:

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -1287,15 +1287,40 @@ def test_skill_router_records_blocked_scraping_patterns() -> None:
     assert "google maps" in blocked_labels
     assert "entire internet" in blocked_labels
     assert all(item["kind"] == "pattern" for item in decision["blocked"])
+    disallowed_matches = decision["research_connector_policy"]["matches"][
+        RESEARCH_POLICY_BUCKET_DISALLOWED
+    ]
+    disallowed = {item["connector"] for item in disallowed_matches}
+    assert "tiktok_scraping" in disallowed
+    assert "google_maps_scraping" in disallowed
+    assert "universal_free_form_scrapers" in disallowed
+    matched_terms = {term for item in disallowed_matches for term in item.get("matched_terms", [])}
+    assert blocked_labels == matched_terms
+
+
+def test_skill_router_normalizes_blocked_patterns_with_disallowed_matches() -> None:
+    """Blocked patterns should reuse the disallowed connector matcher contract."""
+
+    decision = route_skills(
+        goal="Research TikTok, Google-Maps, and scrape any-site competitor data",
+        task_class="Research",
+        candidate_paths=["docs/audience_pack/ENGINEERING_OVERVIEW.md"],
+        domain="research",
+    )
+
+    blocked_labels = {item["label"] for item in decision["blocked"]}
+    assert blocked_labels == {"tiktok", "google maps", "scrape any site"}
     disallowed = {
         item["connector"]
         for item in decision["research_connector_policy"]["matches"][
             RESEARCH_POLICY_BUCKET_DISALLOWED
         ]
     }
-    assert "tiktok_scraping" in disallowed
-    assert "google_maps_scraping" in disallowed
-    assert "universal_free_form_scrapers" in disallowed
+    assert disallowed == {
+        "tiktok_scraping",
+        "google_maps_scraping",
+        "universal_free_form_scrapers",
+    }
 
 
 def test_skill_router_ignores_scraping_tokens_from_candidate_paths() -> None:

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -28,6 +28,7 @@ from scripts.orchestration.routing_graph_loader import (
     BootstrapLaneActivation,
     REQUIRED_BOOTSTRAP_LANE,
 )
+from scripts.orchestration.skill_router import RESEARCH_POLICY_BUCKET_APPROVED
 from scripts.orchestration.task_bootstrap import (
     REQUESTED_AGENT_STATUS_ADVISORY_DOMAIN_MISMATCH,
     REQUESTED_AGENT_STATUS_ADVISORY_NON_ROUTABLE,
@@ -176,7 +177,9 @@ def test_task_bootstrap_exposes_skill_routing_explanation_and_connector_policy()
     assert explanation["schema_version"] == "1.0"
     assert "semantic_group" in explanation["evidence_axes"]
     assert connector_policy["policy_version"] == "2026-04-18"
-    matched_connectors = {item["connector"] for item in connector_policy["matches"]["approved"]}
+    matched_connectors = {
+        item["connector"] for item in connector_policy["matches"][RESEARCH_POLICY_BUCKET_APPROVED]
+    }
     assert matched_connectors == {"youtube_transcripts", "google_trends"}
 
 

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -159,6 +159,27 @@ def test_task_bootstrap_adds_automation_metadata_defaults() -> None:
     assert packet["needs_agents_sync"] is False
 
 
+def test_task_bootstrap_exposes_skill_routing_explanation_and_connector_policy() -> None:
+    """Bootstrap packets should carry the wave 2 explanation and connector contract."""
+
+    packet = build_task_packet(
+        goal=(
+            "Prepare founder research using YouTube transcripts and Google Trends "
+            "with a stable skill-routing explanation schema"
+        ),
+        task_class="Research",
+        candidate_paths=["docs/audience_pack/ENGINEERING_OVERVIEW.md"],
+    )
+
+    explanation = packet["skill_routing"]["explanation"]
+    connector_policy = packet["skill_routing"]["research_connector_policy"]
+    assert explanation["schema_version"] == "1.0"
+    assert "semantic_group" in explanation["evidence_axes"]
+    assert connector_policy["policy_version"] == "2026-04-18"
+    matched_connectors = {item["connector"] for item in connector_policy["matches"]["approved"]}
+    assert matched_connectors == {"youtube_transcripts", "google_trends"}
+
+
 def test_task_bootstrap_sets_read_only_design_lane_for_incomplete_figma_packet() -> None:
     """Explicit Figma packets should fail closed into read-only until metadata is complete."""
 
@@ -178,6 +199,31 @@ def test_task_bootstrap_sets_read_only_design_lane_for_incomplete_figma_packet()
     assert packet["design_lane_contract"]["design_source"] == "figma_design"
     assert packet["design_lane_contract"]["blockers"] == ["blocked_by_design_url"]
     assert packet["design_lane_contract"]["code_native_design_brief_required"] is True
+
+
+def test_task_bootstrap_keeps_coordinator_primary_for_requested_orchestration_lane() -> None:
+    """Coordinator-owned orchestration lanes must not demote agent-coordinator from primary."""
+
+    packet = build_task_packet(
+        goal="Implement wave 2 routing policy and explanation schema",
+        task_class="Orchestration",
+        candidate_paths=[
+            "scripts/orchestration/skill_router.py",
+            "scripts/orchestration/task_bootstrap.py",
+        ],
+        requested_agents=[
+            "agent-coordinator",
+            "architecture-specialist",
+            "security-auditor",
+        ],
+        pr_phase="pre_open",
+    )
+
+    assert packet["primary_agent"] == "agent-coordinator"
+    dispositions = {item["agent"]: item for item in packet["requested_agent_disposition"]}
+    assert dispositions["agent-coordinator"]["status"] == REQUESTED_AGENT_STATUS_HONORED_PRIMARY
+    assert dispositions["architecture-specialist"]["status"] == "honored_reviewer"
+    assert "security-auditor" in packet["secondary_agents"]
 
 
 def test_task_bootstrap_enables_code_native_design_lane_with_valid_packet() -> None:
@@ -951,8 +997,8 @@ def test_task_bootstrap_forces_requested_security_auditor_into_executable_bridge
     ]
 
 
-def test_task_bootstrap_updates_honored_primary_after_later_promotion() -> None:
-    """Earlier honored-primary dispositions must stay aligned with final routing."""
+def test_task_bootstrap_preserves_coordinator_primary_for_requested_orchestration_lane() -> None:
+    """Coordinator-owned orchestration lanes should keep agent-coordinator as primary."""
 
     packet = build_task_packet(
         goal="Update privileged orchestration workflow",
@@ -961,18 +1007,21 @@ def test_task_bootstrap_updates_honored_primary_after_later_promotion() -> None:
         requested_agents=["agent-coordinator", "architecture-specialist"],
     )
 
-    assert packet["primary_agent"] == "architecture-specialist"
-    assert "agent-coordinator" in packet["secondary_agents"]
+    assert packet["primary_agent"] == "agent-coordinator"
+    assert "agent-coordinator" not in packet["secondary_agents"]
     assert packet["requested_agent_disposition"] == [
         {
             "agent": "agent-coordinator",
-            "status": "honored_secondary",
-            "reason": "Requested agent stayed honored but moved to secondary after a later promotion.",
+            "status": "honored_primary",
+            "reason": "Requested agent already matches the routed primary.",
         },
         {
             "agent": "architecture-specialist",
-            "status": "promoted_requested_agent",
-            "reason": "Requested agent is compatible with the routed domain and was promoted.",
+            "status": "honored_reviewer",
+            "reason": (
+                "Coordinator-owned lane keeps `agent-coordinator` as primary; "
+                "requested reviewer stays honored in reviewer."
+            ),
         },
     ]
 


### PR DESCRIPTION
## Summary
- add deterministic compositional routing semantics for skill selection
- expose stable skill routing explanation and research connector policy artifacts
- preserve coordinator-first primary routing for requested orchestration lanes

## Scope
- `scripts/orchestration/skill_router.py`
- `scripts/orchestration/task_bootstrap.py`
- routing policy / protocol docs sync
- deterministic tests for routing and bootstrap output

## Validation
- `pre-commit run --all-files`
- `.venv/bin/python -m pytest -q tests/test_skill_router.py tests/test_task_bootstrap.py`
- `make verify-env`
- `make lint`
- `make typecheck`
- `make test-fast`
- `make cov-check`

## Notes
- draft until PR governance artifacts and current-head CI are fully reconciled
- no merge-ready claim in this body yet

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135799129 -> 0b679c82d
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135801467 -> ca2c82f9c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106654041 -> ca2c82f9c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135803447 -> ca2c82f9c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106654042 -> aa5042783
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106654044 -> aa5042783
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106656839 -> aa5042783
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135813600 -> a1c0bef17
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106670369 -> a1c0bef17
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135817214 -> a1c0bef17
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106675367 -> a1c0bef17
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106670372 -> aa5042783
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#pullrequestreview-4135839024 -> 8ae5bcc45
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106702309 -> 8ae5bcc45
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106702311 -> 8ae5bcc45
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1475#discussion_r3106702313

## Summary by Sourcery

Introduce second-wave skill routing semantics with explainability metadata and research-connector policy exposure, while preserving coordinator-first orchestration lanes.

New Features:
- Expose stable `explanation` metadata and `research_connector_policy` in skill routing decisions and task bootstrap packets.
- Define ontology-style semantic groups and research connector rules to drive deterministic routing boosts and metadata surfaces.

Enhancements:
- Apply semantic-group-based boosts to skill selection in eligible research and orchestration lanes without overriding required skills.
- Preserve agent-coordinator as primary for coordinator-owned orchestration lanes when requested, honoring other requested agents as reviewers or secondary where appropriate.

Documentation:
- Extend message protocol, skill routing policy, and dev docs to describe the new explanation schema and research connector policy contracts, and add a PR fixed-in-commit mapping record.

Tests:
- Add and update deterministic tests for routing outputs, research connector matching, explanation schema exposure, and coordinator-first primary behavior in task bootstrap.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic routing explanation schema with per-skill evidence and semantic-group matches.
  * Introduced a research-only connector policy (approved/conditional/disallowed) surfaced in routing.

* **Bug Fixes**
  * Coordinator primary is preserved when explicitly requested; non-coordinator requests are honored as reviewer/secondary.

* **Documentation**
  * Protocol and policy docs updated with explanation and research connector policy fields and examples.

* **Tests**
  * Expanded tests for routing metadata, research-policy matching, lexeme matching, and coordinator routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



