### PR TITLE
feat(frontend,ios): consume next_best_action hints

### DIFF
--- a/docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md
+++ b/docs/orchestration/MONETIZATION_PLANNING_WAVE_PR_SERIES_RUNBOOK.md
@@ -149,6 +149,16 @@ Do not start these until PR-3 is merged and `main` is stable:
 6. `bug-hunter`
 7. `agent-coordinator`
 
+### PR-3 pre-open role order
+
+1. `agent-coordinator`
+2. `frontend-engineer`
+3. `creative-designer`
+4. `security-auditor`
+5. `qa-engineer-agent`
+6. `bug-hunter`
+7. `agent-coordinator`
+
 ### Mandatory post-open review lane
 
 - `qa-engineer-agent -> bug-hunter -> agent-coordinator`

--- a/docs/orchestration/MONETIZATION_PLANNING_WAVE_TASK_PACKET_2026-04-13.md
+++ b/docs/orchestration/MONETIZATION_PLANNING_WAVE_TASK_PACKET_2026-04-13.md
@@ -73,6 +73,16 @@ Deferred until after PR-3:
 6. `bug-hunter`
 7. `agent-coordinator`
 
+### PR-3 pre-open
+
+1. `agent-coordinator`
+2. `frontend-engineer`
+3. `creative-designer`
+4. `security-auditor`
+5. `qa-engineer-agent`
+6. `bug-hunter`
+7. `agent-coordinator`
+
 ### Mandatory post-open review lane
 
 - `qa-engineer-agent -> bug-hunter -> agent-coordinator`

--- a/docs/review/PR_1476_FIXED_MAPPING.md
+++ b/docs/review/PR_1476_FIXED_MAPPING.md
@@ -14,7 +14,60 @@ Record every new disposition here before resolving threads on GitHub.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1476#discussion_r3106665311 -> 5650dcdb3
+Disposition: FIXED
+Commit: 5650dcdb3
+Evidence: `frontend/src/pages/Pro/ProPaywallPage.tsx:40`, `frontend/src/pages/Pro/ProPaywallPage.tsx:44`, `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:88`, `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:194`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1476#discussion_r3106668204 -> 5650dcdb3
+Disposition: FIXED
+Commit: 5650dcdb3
+Evidence: `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:47`, `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:52`, `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:205`, `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:223`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1476#discussion_r3106670831 -> 5650dcdb3
+Disposition: FIXED
+Commit: 5650dcdb3
+Evidence: `frontend/src/pages/Pro/ProPaywallPage.tsx:40`, `frontend/src/pages/Pro/ProPaywallPage.tsx:44`, `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:88`, `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:194`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1476#pullrequestreview-4135809700
+Disposition: NOT-A-BUG
+Evidence: `frontend/src/pages/Pro/ProPaywallPage.tsx:40`, `ios/PulsePlate/Views/Components/SoftPaywallHookView.swift:9`, `ios/PulsePlate/Views/Components/SoftPaywallHookView.swift:12`, `ios/PulsePlate/Routing/PaywallRouter.swift:45`, `ios/PulsePlate/Routing/PaywallRouter.swift:53`
+Reason: This Sourcery review is an aggregate surface. Its inline `triggerReason` defect is fixed in `5650dcdb3`, the advisory-only `nextBestAction` prop is already documented in `SoftPaywallHookView`, and `PaywallTarget.resolve` now uses an explicit nil-guarded NBA-surface branch before the intentional fail-closed fallback to `.pro`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1476#pullrequestreview-4135811955 -> 5650dcdb3
+Disposition: FIXED
+Commit: 5650dcdb3
+Evidence: `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:47`, `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:52`, `frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx:205`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:68`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:80`, `frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx:232`, `frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx:248`, `ios/PulsePlate/Routing/PaywallRouter.swift:45`, `ios/PulsePlate/Routing/PaywallRouter.swift:53`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1476#pullrequestreview-4135813914
+Disposition: NOT-A-BUG
+Evidence: `frontend/src/pages/Pro/ProPaywallPage.tsx:40`, `frontend/src/pages/Pro/ProPaywallPage.tsx:44`
+Reason: This cubic review is an aggregate wrapper for inline thread `#discussion_r3106670831`, which is fixed in `5650dcdb3`; it does not add a separate unresolved defect beyond that thread-level finding.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1476#discussion_r3106684929
+Disposition: NOT-A-BUG
+Evidence: `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:68`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:80`, `frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx:232`, `frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx:248`
+Reason: cubic identified this on stale commit `7fae34e2`, but the current PR head already logs `triggerReason` into paywall analytics and asserts the derived advisory trigger in the focused web test. The current implementation is therefore already correct.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1476#pullrequestreview-4135824537
+Disposition: NOT-A-BUG
+Evidence: `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:68`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:80`, `frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx:232`, `frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx:248`
+Reason: This later cubic review is an aggregate wrapper for inline thread `#discussion_r3106684929`, which points at a stale pre-fix commit. On the current head the derived `triggerReason` already flows into analytics, so no separate unresolved defect remains.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1476#discussion_r3106687203
+Disposition: NOT-A-BUG
+Evidence: `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:68`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:80`, `frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx:232`, `frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx:248`
+Reason: The Codex connector comment also targets stale commit `7fae34e2`. On the current head the paywall analytics payload already uses the derived `triggerReason`, and the focused test asserts the propagated `targets_ready` advisory trigger.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1476#pullrequestreview-4135826334
+Disposition: NOT-A-BUG
+Evidence: `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:68`, `frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx:80`
+Reason: This Codex review is an aggregate shell for inline thread `#discussion_r3106687203`, which points at stale pre-fix code. The current head already carries the analytics fix, so the shell does not add a separate unresolved defect.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1476#issuecomment-4275677779
+Disposition: NOT-A-BUG
+Evidence: `AGENTS.md:5`, `AGENTS.md:8`, `AGENTS.md:42`, `AGENTS.md:45`, `AGENTS.md:51`, `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:43`, `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:52`
+Reason: The CodeRabbit docstring-coverage warning is advisory for this lane. The repo hard gates for merge readiness are `make verify`, current-head required checks, and dispositioned actionable review comments; docstring coverage is not a canonical merge-blocking contract here.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1476_FIXED_MAPPING.md
+++ b/docs/review/PR_1476_FIXED_MAPPING.md
@@ -1,0 +1,46 @@
+# PR #1476 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+This artifact is created immediately after PR open per repo governance.
+Record every new disposition here before resolving threads on GitHub.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Pre-commit green on latest pushed head
+- [ ] `make verify` green on latest pushed head
+
+## Validation Snapshot
+
+- [x] `python3 scripts/orchestration/check_preflight.py`
+- [x] `python3 scripts/orchestration/check_agent_consistency.py`
+- [x] `pre-commit run --all-files`
+- [x] `git diff --check`
+- [x] focused web tests for BMI / soft-paywall / pro-paywall hint consumption
+- [x] `cd frontend && npm run build`
+- [x] focused iOS `xcodebuild build-for-testing`
+- [ ] full `make verify`
+- [ ] full `make diff-cov`
+
+Note: this PR intentionally carries focused web+iOS validation evidence for the
+PR-3 slice. Full repo-wide coverage validation was not used as the gating
+signal for this lane.

--- a/frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx
+++ b/frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx
@@ -77,7 +77,7 @@ export default function SoftPaywallHook({
           exposure_id: ensureExposureId(),
           event_name: eventName,
           source_surface: BMI_SOFT_PAYWALL_SOURCE,
-          trigger_reason: BMI_SOFT_PAYWALL_TRIGGER_REASON,
+          trigger_reason: triggerReason,
           via: 'soft_paywall_hook',
           metadata: {
             hook_id: hook.id,

--- a/frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx
+++ b/frontend/src/components/SoftPaywallHook/SoftPaywallHook.tsx
@@ -9,8 +9,11 @@ import { createAnalyticsEventId, logPaywallExposure } from '../../lib/analytics'
 const BMI_SOFT_PAYWALL_SOURCE = 'bmi_soft_paywall';
 const BMI_SOFT_PAYWALL_TRIGGER_REASON = 'post_bmi';
 
+type NextBestAction = components['schemas']['NextBestAction'];
+
 interface SoftPaywallHookProps {
   hook?: components['schemas']['SoftPaywallHook'] | null;
+  nextBestAction?: NextBestAction | null;
   onCtaClick?: () => void;
 }
 
@@ -21,17 +24,24 @@ interface SoftPaywallHookProps {
  * - Uses default_* fields from backend (no i18n lookup)
  * - No hardcoded text
  * - No BMI value/category conditions
+ * - next_best_action is advisory route context only (no local entitlement logic)
  *
  * @param hook - Soft paywall hook data from backend (optional, null-safe)
+ * @param nextBestAction - Optional server-authored next step hint for CTA context
  * @param onCtaClick - Optional custom CTA handler (defaults to navigate to /pro)
  */
-export default function SoftPaywallHook({ hook, onCtaClick }: SoftPaywallHookProps): JSX.Element | null {
+export default function SoftPaywallHook({
+  hook,
+  nextBestAction,
+  onCtaClick,
+}: SoftPaywallHookProps): JSX.Element | null {
   const navigate = useNavigate();
   const exposureIdRef = useRef<string | null>(null);
   const hookIdRef = useRef<string | null>(null);
   const hasLoggedShownRef = useRef(false);
   const hookId = hook?.id ?? null;
   const isRenderable = Boolean(hook?.availability?.pro_available);
+  const triggerReason = nextBestAction?.trigger_reason ?? BMI_SOFT_PAYWALL_TRIGGER_REASON;
 
   useEffect(() => {
     if (!isRenderable || !hookId) {
@@ -73,6 +83,14 @@ export default function SoftPaywallHook({ hook, onCtaClick }: SoftPaywallHookPro
             hook_id: hook.id,
             position: hook.position,
             target: hook.target,
+            ...(nextBestAction
+              ? {
+                  next_best_action_type: nextBestAction.type,
+                  recommended_surface: nextBestAction.recommended_surface,
+                  recommended_tier: nextBestAction.recommended_tier,
+                  why_now: nextBestAction.why_now,
+                }
+              : {}),
           },
         });
       } catch {
@@ -80,7 +98,7 @@ export default function SoftPaywallHook({ hook, onCtaClick }: SoftPaywallHookPro
         // EN: Analytics failures must never break teaser/paywall UX.
       }
     },
-    [ensureExposureId, hook, isRenderable]
+    [ensureExposureId, hook, isRenderable, nextBestAction, triggerReason]
   );
 
   useEffect(() => {
@@ -112,8 +130,16 @@ export default function SoftPaywallHook({ hook, onCtaClick }: SoftPaywallHookPro
         state: {
           exposureId,
           source: BMI_SOFT_PAYWALL_SOURCE,
-          triggerReason: BMI_SOFT_PAYWALL_TRIGGER_REASON,
+          triggerReason,
           via: 'pro_page',
+          ...(nextBestAction
+            ? {
+                actionType: nextBestAction.type,
+                recommendedSurface: nextBestAction.recommended_surface,
+                recommendedTier: nextBestAction.recommended_tier,
+                whyNow: nextBestAction.why_now,
+              }
+            : {}),
         },
       });
     }

--- a/frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx
+++ b/frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx
@@ -43,6 +43,13 @@ describe("SoftPaywallHook", () => {
     },
     availability: { pro_available: true },
   };
+  const mockNextBestAction: components["schemas"]["NextBestAction"] = {
+    type: "unlock_targets",
+    recommended_surface: "pro_targets",
+    recommended_tier: "PRO",
+    trigger_reason: "post_bmi",
+    why_now: "post_bmi_baseline_body_metrics",
+  };
 
   beforeEach((): void => {
     vi.clearAllMocks();
@@ -211,5 +218,28 @@ describe("SoftPaywallHook", () => {
 
     expect(customHandler).toHaveBeenCalledTimes(1);
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("forwards next_best_action context through the existing paywall route state", (): void => {
+    render(
+      <MemoryRouter>
+        <SoftPaywallHook hook={mockHook} nextBestAction={mockNextBestAction} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByTestId("soft-paywall-cta"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/pro", {
+      state: {
+        exposureId: "analytics-id-1",
+        source: "bmi_soft_paywall",
+        triggerReason: "post_bmi",
+        via: "pro_page",
+        actionType: "unlock_targets",
+        recommendedSurface: "pro_targets",
+        recommendedTier: "PRO",
+        whyNow: "post_bmi_baseline_body_metrics",
+      },
+    });
   });
 });

--- a/frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx
+++ b/frontend/src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx
@@ -47,7 +47,7 @@ describe("SoftPaywallHook", () => {
     type: "unlock_targets",
     recommended_surface: "pro_targets",
     recommended_tier: "PRO",
-    trigger_reason: "post_bmi",
+    trigger_reason: "targets_ready",
     why_now: "post_bmi_baseline_body_metrics",
   };
 
@@ -233,7 +233,7 @@ describe("SoftPaywallHook", () => {
       state: {
         exposureId: "analytics-id-1",
         source: "bmi_soft_paywall",
-        triggerReason: "post_bmi",
+        triggerReason: "targets_ready",
         via: "pro_page",
         actionType: "unlock_targets",
         recommendedSurface: "pro_targets",
@@ -241,5 +241,10 @@ describe("SoftPaywallHook", () => {
         whyNow: "post_bmi_baseline_body_metrics",
       },
     });
+
+    const ctaPayload = logPaywallExposure.mock.calls.at(-1)?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(ctaPayload?.trigger_reason).toBe("targets_ready");
   });
 });

--- a/frontend/src/lib/__tests__/paywallPurchase.test.ts
+++ b/frontend/src/lib/__tests__/paywallPurchase.test.ts
@@ -26,4 +26,29 @@ describe("purchasePremium", () => {
       status: "web_checkout_unavailable",
     });
   });
+
+  it("records hint context when the paywall seam receives next_best_action metadata", async () => {
+    await expect(
+      purchasePremium({
+        source: "bmi_soft_paywall",
+        via: "pro_page",
+        triggerReason: "post_bmi",
+        actionType: "unlock_targets",
+        recommendedSurface: "pro_targets",
+        recommendedTier: "PRO",
+        whyNow: "post_bmi_baseline_body_metrics",
+      })
+    ).rejects.toThrow(WEB_CHECKOUT_UNAVAILABLE_MESSAGE);
+
+    expect(logMock).toHaveBeenCalledWith("purchase_failure", {
+      source: "bmi_soft_paywall",
+      via: "pro_page",
+      status: "web_checkout_unavailable",
+      triggerReason: "post_bmi",
+      actionType: "unlock_targets",
+      recommendedSurface: "pro_targets",
+      recommendedTier: "PRO",
+      whyNow: "post_bmi_baseline_body_metrics",
+    });
+  });
 });

--- a/frontend/src/lib/paywallPurchase.ts
+++ b/frontend/src/lib/paywallPurchase.ts
@@ -3,6 +3,11 @@ import { Events, log } from "./analytics";
 type PurchaseRequest = {
   source: string;
   via: string;
+  triggerReason?: string;
+  actionType?: string;
+  recommendedSurface?: string;
+  recommendedTier?: string;
+  whyNow?: string;
 };
 
 export const WEB_CHECKOUT_UNAVAILABLE_MESSAGE =
@@ -18,6 +23,11 @@ export async function purchasePremium(request: PurchaseRequest): Promise<never> 
       source: request.source,
       via: request.via,
       status: "web_checkout_unavailable",
+      ...(request.triggerReason ? { triggerReason: request.triggerReason } : {}),
+      ...(request.actionType ? { actionType: request.actionType } : {}),
+      ...(request.recommendedSurface ? { recommendedSurface: request.recommendedSurface } : {}),
+      ...(request.recommendedTier ? { recommendedTier: request.recommendedTier } : {}),
+      ...(request.whyNow ? { whyNow: request.whyNow } : {}),
     });
   } catch {
     // Ignore analytics transport failures in purchase flow.

--- a/frontend/src/pages/BMI/BMICalculatePage.tsx
+++ b/frontend/src/pages/BMI/BMICalculatePage.tsx
@@ -357,7 +357,12 @@ export default function BMICalculatePage(): JSX.Element {
           </div>
         </section>
 
-        {response?.soft_paywall ? <SoftPaywallHook hook={response.soft_paywall} /> : null}
+        {response?.soft_paywall ? (
+          <SoftPaywallHook
+            hook={response.soft_paywall}
+            nextBestAction={response.next_best_action}
+          />
+        ) : null}
 
         {response ? (
           <button

--- a/frontend/src/pages/BMI/__tests__/BMICalculatePage.test.tsx
+++ b/frontend/src/pages/BMI/__tests__/BMICalculatePage.test.tsx
@@ -3,12 +3,17 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import BMICalculatePage from '../BMICalculatePage';
 
+const softPaywallHookPropsSpy = vi.fn();
+
 vi.mock('../../../api/bmi', () => ({
   calculateBMI: vi.fn(),
 }));
 
 vi.mock('../../../components/SoftPaywallHook', () => ({
-  default: () => <div data-testid="soft-paywall-hook">soft paywall</div>,
+  default: (props: unknown) => {
+    softPaywallHookPropsSpy(props);
+    return <div data-testid="soft-paywall-hook">soft paywall</div>;
+  },
 }));
 
 vi.mock('react-i18next', () => ({
@@ -52,6 +57,7 @@ import { calculateBMI } from '../../../api/bmi';
 describe('BMICalculatePage', () => {
   beforeEach(() => {
     vi.mocked(calculateBMI).mockReset();
+    softPaywallHookPropsSpy.mockReset();
   });
 
   it('renders the redesigned BMI surface', () => {
@@ -86,6 +92,13 @@ describe('BMICalculatePage', () => {
       bmi: 22.4,
       category: 'Balanced zone',
       interpretation: 'Your body composition looks healthy.',
+      next_best_action: {
+        type: 'unlock_targets',
+        recommended_surface: 'pro_targets',
+        recommended_tier: 'PRO',
+        trigger_reason: 'post_bmi',
+        why_now: 'post_bmi_baseline_body_metrics',
+      },
       soft_paywall: null,
     } as Awaited<ReturnType<typeof calculateBMI>>);
 
@@ -101,5 +114,56 @@ describe('BMICalculatePage', () => {
     expect(await screen.findByText('22.4')).toBeInTheDocument();
     expect(screen.getByText('Your body composition looks healthy.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Calculate Again' })).toBeInTheDocument();
+  });
+
+  it('passes next_best_action through to the existing soft-paywall surface', async () => {
+    vi.mocked(calculateBMI).mockResolvedValue({
+      bmi: 22.4,
+      category: 'Balanced zone',
+      interpretation: 'Your body composition looks healthy.',
+      next_best_action: {
+        type: 'unlock_targets',
+        recommended_surface: 'pro_targets',
+        recommended_tier: 'PRO',
+        trigger_reason: 'post_bmi',
+        why_now: 'post_bmi_baseline_body_metrics',
+      },
+      soft_paywall: {
+        id: 'bmi.pro_interpretation_v1',
+        kind: 'cta',
+        position: 'post_result',
+        priority: 50,
+        target: 'pro_paywall',
+        message: {
+          lang: 'en',
+          title_key: 'soft_paywall.title',
+          body_key: 'soft_paywall.body',
+          cta_key: 'soft_paywall.cta',
+          default_title: 'More accurate interpretation',
+          default_body: 'Get PRO insights.',
+          default_cta: 'See PRO',
+        },
+        availability: { pro_available: true },
+      },
+    } as Awaited<ReturnType<typeof calculateBMI>>);
+
+    const user = userEvent.setup();
+    render(<BMICalculatePage />);
+
+    await user.type(screen.getByLabelText('Weight (kg)'), '70');
+    await user.type(screen.getByLabelText('Height (cm)'), '177');
+    await user.type(screen.getByLabelText('Age'), '31');
+    await user.click(screen.getByRole('button', { name: 'Calculate BMI' }));
+
+    expect(await screen.findByTestId('soft-paywall-hook')).toBeInTheDocument();
+    expect(softPaywallHookPropsSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        nextBestAction: expect.objectContaining({
+          type: 'unlock_targets',
+          recommended_surface: 'pro_targets',
+          trigger_reason: 'post_bmi',
+        }),
+      })
+    );
   });
 });

--- a/frontend/src/pages/Pro/ProPaywallPage.tsx
+++ b/frontend/src/pages/Pro/ProPaywallPage.tsx
@@ -13,6 +13,10 @@ type ProPaywallLocationState = {
   source?: string;
   triggerReason?: string;
   via?: string;
+  actionType?: string;
+  recommendedSurface?: string;
+  recommendedTier?: string;
+  whyNow?: string;
 };
 
 export default function ProPaywallPage(): JSX.Element {
@@ -22,13 +26,31 @@ export default function ProPaywallPage(): JSX.Element {
   const source = state?.source ?? DEFAULT_PRO_PAYWALL_SOURCE;
   const triggerReason = state?.triggerReason ?? DEFAULT_PRO_PAYWALL_TRIGGER_REASON;
   const via = state?.via ?? 'pro_page';
+  const hasNextBestActionContext = Boolean(
+    state?.actionType &&
+      state?.recommendedSurface &&
+      state?.recommendedTier &&
+      state?.whyNow
+  );
 
   const handleClose = (): void => {
     navigate(-1); // Go back to previous page
   };
 
   const handlePurchase = async (): Promise<void> => {
-    await purchasePremium({ source, via });
+    await purchasePremium({
+      source,
+      via,
+      ...(hasNextBestActionContext
+        ? {
+            triggerReason,
+            actionType: state?.actionType,
+            recommendedSurface: state?.recommendedSurface,
+            recommendedTier: state?.recommendedTier,
+            whyNow: state?.whyNow,
+          }
+        : {}),
+    });
     navigate(-1);
   };
 

--- a/frontend/src/pages/Pro/ProPaywallPage.tsx
+++ b/frontend/src/pages/Pro/ProPaywallPage.tsx
@@ -41,9 +41,9 @@ export default function ProPaywallPage(): JSX.Element {
     await purchasePremium({
       source,
       via,
+      triggerReason,
       ...(hasNextBestActionContext
         ? {
-            triggerReason,
             actionType: state?.actionType,
             recommendedSurface: state?.recommendedSurface,
             recommendedTier: state?.recommendedTier,

--- a/frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx
+++ b/frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx
@@ -191,4 +191,33 @@ describe("ProPaywallPage", () => {
       });
     });
   });
+
+  it("passes next_best_action context into the fail-closed purchase seam when provided", async () => {
+    purchasePremiumMock.mockResolvedValueOnce(undefined);
+
+    renderAtProRoute({
+      exposureId: "upstream-exposure-id",
+      source: "bmi_soft_paywall",
+      triggerReason: "post_bmi",
+      via: "pro_page",
+      actionType: "unlock_targets",
+      recommendedSurface: "pro_targets",
+      recommendedTier: "PRO",
+      whyNow: "post_bmi_baseline_body_metrics",
+    });
+
+    fireEvent.click(screen.getByTestId("paywall-cta"));
+
+    await waitFor(() => {
+      expect(purchasePremiumMock).toHaveBeenCalledWith({
+        source: "bmi_soft_paywall",
+        via: "pro_page",
+        triggerReason: "post_bmi",
+        actionType: "unlock_targets",
+        recommendedSurface: "pro_targets",
+        recommendedTier: "PRO",
+        whyNow: "post_bmi_baseline_body_metrics",
+      });
+    });
+  });
 });

--- a/frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx
+++ b/frontend/src/pages/Pro/__tests__/ProPaywallPage.test.tsx
@@ -49,6 +49,10 @@ function renderAtProRoute(state?: {
   source?: string;
   triggerReason?: string;
   via?: string;
+  actionType?: string;
+  recommendedSurface?: string;
+  recommendedTier?: string;
+  whyNow?: string;
 }) {
   return render(
     <MemoryRouter initialEntries={[{ pathname: "/pro", state }]}>
@@ -84,6 +88,7 @@ describe("ProPaywallPage", () => {
     expect(purchasePremiumMock).toHaveBeenCalledWith({
       source: "pro_page",
       via: "pro_page",
+      triggerReason: "unknown",
     });
     expect(logPaywallExposureMock).toHaveBeenCalledWith("paywall_view", {
       client_event_id: "event-pro-view",
@@ -119,6 +124,7 @@ describe("ProPaywallPage", () => {
       expect(purchasePremiumMock).toHaveBeenCalledWith({
         source: "pro_page",
         via: "pro_page",
+        triggerReason: "unknown",
       });
       expect(logPaywallExposureMock).toHaveBeenCalledTimes(2);
       expect(logPaywallExposureMock).toHaveBeenNthCalledWith(1, "paywall_view", {
@@ -188,6 +194,7 @@ describe("ProPaywallPage", () => {
       expect(purchasePremiumMock).toHaveBeenCalledWith({
         source: "bmi_soft_paywall",
         via: "pro_page",
+        triggerReason: "post_bmi",
       });
     });
   });

--- a/ios/PulsePlate/Models/BMI/BMICalculateResponseDTO.swift
+++ b/ios/PulsePlate/Models/BMI/BMICalculateResponseDTO.swift
@@ -25,6 +25,7 @@ public struct BMICalculateResponseDTO: Decodable, Sendable {
     public let visualization: BMIScaleV1DTO?
     public let interpretationV1: BMIInterpretationV1DTO?
     public let softPaywall: SoftPaywallHookDTO?
+    public let nextBestAction: NextBestActionDTO?
 
     enum CodingKeys: String, CodingKey {
         case bmi
@@ -39,5 +40,6 @@ public struct BMICalculateResponseDTO: Decodable, Sendable {
         case visualization
         case interpretationV1 = "interpretation_v1"
         case softPaywall = "soft_paywall"
+        case nextBestAction = "next_best_action"
     }
 }

--- a/ios/PulsePlate/Models/BMI/NextBestActionDTO.swift
+++ b/ios/PulsePlate/Models/BMI/NextBestActionDTO.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Server-authored advisory next-step hint.
+///
+/// Thin-client rule:
+/// - iOS only decodes and forwards this payload
+/// - no local tier inference or business logic beyond route-safe mapping
+public struct NextBestActionDTO: Decodable, Equatable, Sendable {
+    public let type: String
+    public let recommendedSurface: String
+    public let recommendedTier: String
+    public let triggerReason: String
+    public let whyNow: String
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case recommendedSurface = "recommended_surface"
+        case recommendedTier = "recommended_tier"
+        case triggerReason = "trigger_reason"
+        case whyNow = "why_now"
+    }
+}

--- a/ios/PulsePlate/Routing/PaywallRouter.swift
+++ b/ios/PulsePlate/Routing/PaywallRouter.swift
@@ -46,9 +46,11 @@ enum PaywallTarget: String, Equatable {
         softPaywallTarget: String,
         nextBestAction: NextBestActionDTO?
     ) -> PaywallTarget {
-        fromNextBestActionSurface(nextBestAction?.recommendedSurface ?? "")
-            ?? fromSoftPaywallHookTarget(softPaywallTarget)
-            ?? .pro
+        if let surface = nextBestAction?.recommendedSurface,
+           let mapped = fromNextBestActionSurface(surface) {
+            return mapped
+        }
+        return fromSoftPaywallHookTarget(softPaywallTarget) ?? .pro
     }
 
     /// Map backend soft-paywall `hook.target` strings to typed enum.

--- a/ios/PulsePlate/Routing/PaywallRouter.swift
+++ b/ios/PulsePlate/Routing/PaywallRouter.swift
@@ -11,10 +11,16 @@ final class PaywallRouter: ObservableObject {
     @Published var isPaywallPresented: Bool = false
     @Published var lastSource: PaywallSource? = nil
     @Published var lastTarget: PaywallTarget? = nil
+    @Published var lastNextBestAction: NextBestActionDTO? = nil
 
-    func presentPaywall(source: PaywallSource, target: PaywallTarget) {
+    func presentPaywall(
+        source: PaywallSource,
+        target: PaywallTarget,
+        nextBestAction: NextBestActionDTO? = nil
+    ) {
         lastSource = source
         lastTarget = target
+        lastNextBestAction = nextBestAction
         isPaywallPresented = true
     }
 
@@ -22,6 +28,7 @@ final class PaywallRouter: ObservableObject {
         isPaywallPresented = false
         lastSource = nil
         lastTarget = nil
+        lastNextBestAction = nil
     }
 }
 
@@ -33,6 +40,17 @@ enum PaywallTarget: String, Equatable {
     case pro
     case vip
 
+    /// RU: `next_best_action` остаётся advisory route context и не открывает экран сам.
+    /// EN: `next_best_action` stays advisory route context and never auto-opens a screen.
+    static func resolve(
+        softPaywallTarget: String,
+        nextBestAction: NextBestActionDTO?
+    ) -> PaywallTarget {
+        fromNextBestActionSurface(nextBestAction?.recommendedSurface ?? "")
+            ?? fromSoftPaywallHookTarget(softPaywallTarget)
+            ?? .pro
+    }
+
     /// Map backend soft-paywall `hook.target` strings to typed enum.
     ///
     /// Backend currently emits `pro_paywall` (see app.schemas.bmi.SoftPaywallHook).
@@ -43,6 +61,21 @@ enum PaywallTarget: String, Equatable {
         case "pro_paywall", "pro":
             return .pro
         case "vip_paywall", "vip":
+            return .vip
+        default:
+            return nil
+        }
+    }
+
+    /// Map backend next_best_action surfaces to the existing paywall targets.
+    ///
+    /// This is route-safe consumption only; it does not infer entitlement or checkout behavior.
+    static func fromNextBestActionSurface(_ surface: String) -> PaywallTarget? {
+        let normalized = surface.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch normalized {
+        case "pro_targets", "pro_daily_plate":
+            return .pro
+        case "vip_export":
             return .vip
         default:
             return nil

--- a/ios/PulsePlate/Screens/BMICalculatorScreen.swift
+++ b/ios/PulsePlate/Screens/BMICalculatorScreen.swift
@@ -74,10 +74,14 @@ struct BMICalculatorScreen: View {
                             }
 
                             if let hook = res.softPaywall {
-                                SoftPaywallHookView(hook: hook) {
+                                SoftPaywallHookView(hook: hook, nextBestAction: res.nextBestAction) {
                                     paywallRouter.presentPaywall(
                                         source: .bmiSoftPaywallCTA,
-                                        target: PaywallTarget.fromSoftPaywallHookTarget(hook.target) ?? .pro
+                                        target: PaywallTarget.resolve(
+                                            softPaywallTarget: hook.target,
+                                            nextBestAction: res.nextBestAction
+                                        ),
+                                        nextBestAction: res.nextBestAction
                                     )
                                 }
                             }

--- a/ios/PulsePlate/Views/Components/SoftPaywallHookView.swift
+++ b/ios/PulsePlate/Views/Components/SoftPaywallHookView.swift
@@ -2,12 +2,14 @@ import SwiftUI
 
 struct SoftPaywallHookView: View {
     let hook: SoftPaywallHookDTO
+    let nextBestAction: NextBestActionDTO?
     let onCtaTap: () -> Void
 
     var body: some View {
         // Thin-client rule:
         // - render only if hook exists
         // - NO BMI-dependent logic, NO language overrides, use default_* fields
+        // - nextBestAction is advisory route context only
         VStack(alignment: .leading, spacing: 8) {
             Text(hook.message.defaultTitle ?? "").font(.headline)
             Text(hook.message.defaultBody ?? "").font(.subheadline)

--- a/ios/PulsePlateTests/BMI/BMIFixtures.swift
+++ b/ios/PulsePlateTests/BMI/BMIFixtures.swift
@@ -41,7 +41,14 @@ enum BMIFixtures {
             "marker": {"value": 22.86}
           },
           "interpretation_v1": null,
-          "soft_paywall": null
+          "soft_paywall": null,
+          "next_best_action": {
+            "type": "unlock_targets",
+            "recommended_surface": "pro_targets",
+            "recommended_tier": "PRO",
+            "trigger_reason": "post_bmi",
+            "why_now": "post_bmi_baseline_body_metrics"
+          }
         }
         """.data(using: .utf8)!
     }
@@ -58,6 +65,7 @@ enum BMIFixtures {
           "waist_risk": null,
           "notes": [],
           "age_band": "adult",
+          "next_best_action": null,
           "visualization": null,
           "interpretation_v1": null,
           "soft_paywall": null

--- a/ios/PulsePlateTests/BMI/BMIResponseDecodingTests.swift
+++ b/ios/PulsePlateTests/BMI/BMIResponseDecodingTests.swift
@@ -10,11 +10,17 @@ final class BMIResponseDecodingTests: XCTestCase {
         XCTAssertEqual(dto.group, "general")
         XCTAssertEqual(dto.groupDisplay, "General")
         XCTAssertNotNil(dto.visualization)
+        XCTAssertEqual(dto.nextBestAction?.type, "unlock_targets")
+        XCTAssertEqual(dto.nextBestAction?.recommendedSurface, "pro_targets")
+        XCTAssertEqual(dto.nextBestAction?.recommendedTier, "PRO")
+        XCTAssertEqual(dto.nextBestAction?.triggerReason, "post_bmi")
+        XCTAssertEqual(dto.nextBestAction?.whyNow, "post_bmi_baseline_body_metrics")
     }
 
     func test_decodesPregnantNullables() throws {
         let dto = try JSONDecoder().decode(BMICalculateResponseDTO.self, from: BMIFixtures.pregnantJSON())
         XCTAssertNil(dto.category)
         XCTAssertNil(dto.visualization)
+        XCTAssertNil(dto.nextBestAction)
     }
 }

--- a/ios/PulsePlateTests/Services/BMIServiceThinAdapterTests.swift
+++ b/ios/PulsePlateTests/Services/BMIServiceThinAdapterTests.swift
@@ -40,6 +40,13 @@ final class BMIServiceThinAdapterTests: XCTestCase {
               "waist_risk": null,
               "notes": [],
               "age_band": "adult",
+              "next_best_action": {
+                "type": "unlock_targets",
+                "recommended_surface": "pro_targets",
+                "recommended_tier": "PRO",
+                "trigger_reason": "post_bmi",
+                "why_now": "post_bmi_baseline_body_metrics"
+              },
               "visualization": null,
               "interpretation_v1": null,
               "soft_paywall": null
@@ -74,6 +81,7 @@ final class BMIServiceThinAdapterTests: XCTestCase {
         XCTAssertEqual(response.bmi, 22.5)
         XCTAssertEqual(response.group, "general")
         XCTAssertEqual(response.category, "normal")
+        XCTAssertEqual(response.nextBestAction?.recommendedSurface, "pro_targets")
     }
 
     func test_calculate_returnsBMICalculateResponseDTO() async throws {
@@ -93,6 +101,13 @@ final class BMIServiceThinAdapterTests: XCTestCase {
           },
           "notes": [],
           "age_band": "adult",
+          "next_best_action": {
+            "type": "unlock_targets",
+            "recommended_surface": "pro_targets",
+            "recommended_tier": "PRO",
+            "trigger_reason": "post_bmi",
+            "why_now": "post_bmi_baseline_body_metrics"
+          },
           "visualization": {
             "ranges": [
               {"key": "bmi.underweight", "from": 0, "to": 18.5},
@@ -121,6 +136,8 @@ final class BMIServiceThinAdapterTests: XCTestCase {
         XCTAssertEqual(response.visualization?.ranges.first?.key, "bmi.underweight")
         XCTAssertEqual(response.visualization?.ranges.first?.from, 0)
         XCTAssertEqual(response.visualization?.ranges.first?.to, 18.5)
+        XCTAssertEqual(response.nextBestAction?.type, "unlock_targets")
+        XCTAssertEqual(response.nextBestAction?.triggerReason, "post_bmi")
     }
 
     func test_calculate_nullableCategory_decodesCorrectly() async throws {
@@ -136,6 +153,7 @@ final class BMIServiceThinAdapterTests: XCTestCase {
           "waist_risk": null,
           "notes": [],
           "age_band": "child",
+          "next_best_action": null,
           "visualization": null,
           "interpretation_v1": null,
           "soft_paywall": null

--- a/ios/PulsePlateTests/SoftPaywallCTARoutingTests.swift
+++ b/ios/PulsePlateTests/SoftPaywallCTARoutingTests.swift
@@ -5,12 +5,24 @@ final class SoftPaywallCTARoutingTests: XCTestCase {
     @MainActor
     func test_presentPaywall_setsPresented_andStoresContext() async {
         let router = PaywallRouter()
+        let nextBestAction = NextBestActionDTO(
+            type: "unlock_targets",
+            recommendedSurface: "pro_targets",
+            recommendedTier: "PRO",
+            triggerReason: "post_bmi",
+            whyNow: "post_bmi_baseline_body_metrics"
+        )
 
-        router.presentPaywall(source: .bmiSoftPaywallCTA, target: .pro)
+        router.presentPaywall(
+            source: .bmiSoftPaywallCTA,
+            target: .pro,
+            nextBestAction: nextBestAction
+        )
 
         XCTAssertTrue(router.isPaywallPresented)
         XCTAssertEqual(router.lastSource, .bmiSoftPaywallCTA)
         XCTAssertEqual(router.lastTarget, .pro)
+        XCTAssertEqual(router.lastNextBestAction, nextBestAction)
     }
 
     @MainActor
@@ -23,6 +35,7 @@ final class SoftPaywallCTARoutingTests: XCTestCase {
         XCTAssertFalse(router.isPaywallPresented)
         XCTAssertNil(router.lastSource)
         XCTAssertNil(router.lastTarget)
+        XCTAssertNil(router.lastNextBestAction)
     }
 
     func test_softPaywallTargetMapping_mapsVipPaywall() {
@@ -30,8 +43,40 @@ final class SoftPaywallCTARoutingTests: XCTestCase {
         XCTAssertEqual(PaywallTarget.fromSoftPaywallHookTarget("vip"), .vip)
     }
 
+    func test_nextBestActionSurfaceMapping_mapsProSurfaces() {
+        XCTAssertEqual(PaywallTarget.fromNextBestActionSurface("pro_targets"), .pro)
+        XCTAssertEqual(PaywallTarget.fromNextBestActionSurface("pro_daily_plate"), .pro)
+    }
+
+    func test_nextBestActionSurfaceMapping_mapsVipSurface() {
+        XCTAssertEqual(PaywallTarget.fromNextBestActionSurface("vip_export"), .vip)
+    }
+
+    func test_resolve_prefersNextBestActionSurface() {
+        let nextBestAction = NextBestActionDTO(
+            type: "upgrade_for_export",
+            recommendedSurface: "vip_export",
+            recommendedTier: "VIP",
+            triggerReason: "weekly_plan_ready",
+            whyNow: "weekly_plan_ready_export_and_share"
+        )
+
+        XCTAssertEqual(
+            PaywallTarget.resolve(
+                softPaywallTarget: "pro_paywall",
+                nextBestAction: nextBestAction
+            ),
+            .vip
+        )
+    }
+
     func test_softPaywallTargetMapping_fallsBackToNilForUnknown() {
         XCTAssertNil(PaywallTarget.fromSoftPaywallHookTarget("unknown"))
         XCTAssertNil(PaywallTarget.fromSoftPaywallHookTarget(""))
+    }
+
+    func test_nextBestActionSurfaceMapping_fallsBackToNilForUnknown() {
+        XCTAssertNil(PaywallTarget.fromNextBestActionSurface("unknown"))
+        XCTAssertNil(PaywallTarget.fromNextBestActionSurface(""))
     }
 }


### PR DESCRIPTION
## Summary
- consume backend `next_best_action` hints on existing web BMI/paywall CTA surfaces
- add iOS DTO and paywall-routing consumption for the matching monetization screens
- record the missing PR-3 coordinator role order in the monetization wave artifacts before coding

## Scope
- web BMI / soft-paywall / pro-paywall route chain only
- iOS BMI / soft-paywall / paywall routing surfaces only
- no auto-navigation, no new checkout entrypoints, no billing/provider spine reopen

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `pre-commit run --all-files`
- `git diff --check`
- `cd frontend && npm test -- --run src/components/SoftPaywallHook/__tests__/SoftPaywallHook.test.tsx src/pages/BMI/__tests__/BMICalculatePage.test.tsx src/pages/Pro/__tests__/ProPaywallPage.test.tsx src/lib/__tests__/paywallPurchase.test.ts`
- `cd frontend && npm run build`
- `cd ios && xcodebuild build-for-testing -project PulsePlate.xcodeproj -scheme PulsePlate -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO`

## Notes
- draft until PR governance artifacts and current-head CI are reconciled
- canonical review artifact: `docs/review/PR_1476_FIXED_MAPPING.md`
- no merge-ready claim in this body
- full `make verify` / `make diff-cov` was not used as the gating signal for this lane because the repo-wide coverage path is too large for this slice; this PR is intentionally carrying focused web+iOS validation evidence instead

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1476_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Current-head CI is green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green on latest pushed head
- [ ] `make verify` green on latest pushed head

## Summary by Sourcery

Проведен проброс подсказок `next_best_action`, предоставляемых бэкендом, через BMI и soft paywall-флоу в вебе и iOS, чтобы монетизационный контекст рекомендаций сохранялся в существующей маршрутизации paywall’ов и аналитике без изменения входных точек checkout’а.

New Features:
- Экспортировать бэкенд-пэйлоады `NextBestAction` в веб-флоу BMI soft-paywall и Pro paywall так, чтобы CTA передавали контекст рекомендованного апгрейда в маршрутизацию и логирование покупок.
- Ввести `NextBestActionDTO` на iOS и интегрировать его в декодирование BMI-ответа, маршрутизацию paywall’ов и обработку CTA soft paywall как неавтонавигационные подсказочные метаданные.

Enhancements:
- Расширить логирование покупок через paywall с возможностью опционально сохранять метаданные `next_best_action` вместе с существующими полями source и status.
- Добавить на iOS разрешение целевого paywall’а, которое предпочитает поверхности `next_best_action` целям soft-paywall с безопасными fallback’ами.
- Задокументировать порядок ролей координатора PR-3 и детали управления (governance) в runbook’е по монетизации и документах task packet.

Tests:
- Добавить прицельные тесты для веба и iOS, покрывающие декодирование, маппинг, приоритизацию маршрутизации и распространение `next_best_action` через BMI, soft paywall, Pro paywall и стыки с аналитикой покупок.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Wire backend-provided next_best_action hints through BMI and soft paywall flows on web and iOS, so advisory monetization context is carried into existing paywall routing and analytics without changing checkout entrypoints.

New Features:
- Expose backend NextBestAction payloads on web BMI soft-paywall and Pro paywall flows so CTAs carry advisory upgrade context into routing and purchase logging.
- Introduce an iOS NextBestActionDTO and integrate it into BMI response decoding, paywall routing, and soft paywall CTA handling as non-autonavigating hint metadata.

Enhancements:
- Extend paywall purchase logging to optionally persist next_best_action metadata alongside existing source and status fields.
- Add paywall target resolution on iOS that prefers next_best_action surfaces over soft-paywall targets with safe fallbacks.
- Record the PR-3 coordinator role order and governance details in monetization runbook and task packet docs.

Tests:
- Add focused web and iOS tests to cover next_best_action decoding, mapping, routing preference, and propagation through BMI, soft paywall, Pro paywall, and purchase analytics seams.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Paywalls now include contextual "next best action" recommendations that guide users to relevant subscription features or tiers based on their activity.
  * Enhanced analytics tracking captures recommendation context during paywall interactions.

* **Tests**
  * Added comprehensive test coverage for recommendation routing and context handling across web and mobile platforms.

* **Documentation**
  * Updated process documentation for review sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
