### PR TITLE
feat(docker): slim runtime and add image telemetry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,7 @@
 !scripts/
 !scripts/ci/
 !scripts/ci/check_python_startup_hooks.py
+!scripts/ci/emergency_python_wheels.json
 !scripts/ci/install_locked_python_requirements.py
 
 # Runtime application directories copied by Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,10 +65,15 @@ jobs:
       - name: Collect Docker image telemetry
         run: |
           set -euo pipefail
-          python3 scripts/ci/docker_image_telemetry.py \
+          if ! python3 scripts/ci/docker_image_telemetry.py \
             --image-ref pulseplate:test \
             --json-out docker-image-telemetry.json \
             --markdown-out docker-image-telemetry.md
+          then
+            echo "::warning::Docker image telemetry collection failed; reporting remains advisory-only."
+            printf '{"advisory_only": true, "warning": "telemetry collection failed"}\n' > docker-image-telemetry.json
+            printf '# Docker Image Telemetry\n\n- Warning: telemetry collection failed; workflow remains advisory-only.\n' > docker-image-telemetry.md
+          fi
 
       - name: Publish Docker telemetry to step summary
         run: |
@@ -82,7 +87,7 @@ jobs:
           path: |
             docker-image-telemetry.json
             docker-image-telemetry.md
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 14
 
       - name: Test Docker image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,29 @@ jobs:
           provenance: false
           target: production
 
+      - name: Collect Docker image telemetry
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/docker_image_telemetry.py \
+            --image-ref pulseplate:test \
+            --json-out docker-image-telemetry.json \
+            --markdown-out docker-image-telemetry.md
+
+      - name: Publish Docker telemetry to step summary
+        run: |
+          set -euo pipefail
+          cat docker-image-telemetry.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload Docker telemetry artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: docker-image-telemetry-build
+          path: |
+            docker-image-telemetry.json
+            docker-image-telemetry.md
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Test Docker image
         run: |
           # Set up cleanup trap to ensure container is always removed

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -53,10 +53,15 @@ jobs:
     - name: Collect Docker image telemetry
       run: |
         set -euo pipefail
-        python3 scripts/ci/docker_image_telemetry.py \
+        if ! python3 scripts/ci/docker_image_telemetry.py \
           --image-ref my-image-name:${{ github.run_id }}-${{ github.run_attempt }} \
           --json-out docker-image-telemetry.json \
           --markdown-out docker-image-telemetry.md
+        then
+          echo "::warning::Docker image telemetry collection failed; reporting remains advisory-only."
+          printf '{"advisory_only": true, "warning": "telemetry collection failed"}\n' > docker-image-telemetry.json
+          printf '# Docker Image Telemetry\n\n- Warning: telemetry collection failed; workflow remains advisory-only.\n' > docker-image-telemetry.md
+        fi
 
     - name: Publish Docker telemetry to step summary
       run: |
@@ -70,5 +75,5 @@ jobs:
         path: |
           docker-image-telemetry.json
           docker-image-telemetry.md
-        if-no-files-found: error
+        if-no-files-found: warn
         retention-days: 14

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,3 +49,26 @@ jobs:
         cache-to: type=gha,scope=docker-image-ci-${{ github.ref_name }},mode=min,ignore-error=true
         provenance: false
         target: production
+
+    - name: Collect Docker image telemetry
+      run: |
+        set -euo pipefail
+        python3 scripts/ci/docker_image_telemetry.py \
+          --image-ref my-image-name:${{ github.run_id }}-${{ github.run_attempt }} \
+          --json-out docker-image-telemetry.json \
+          --markdown-out docker-image-telemetry.md
+
+    - name: Publish Docker telemetry to step summary
+      run: |
+        set -euo pipefail
+        cat docker-image-telemetry.md >> "${GITHUB_STEP_SUMMARY}"
+
+    - name: Upload Docker telemetry artifact
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: docker-image-telemetry-docker-image
+        path: |
+          docker-image-telemetry.json
+          docker-image-telemetry.md
+        if-no-files-found: error
+        retention-days: 14

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -64,10 +64,15 @@ jobs:
       - name: Collect Docker image telemetry
         run: |
           set -euo pipefail
-          python3 scripts/ci/docker_image_telemetry.py \
+          if ! python3 scripts/ci/docker_image_telemetry.py \
             --image-ref pulseplate:trivy-scan-${{ github.sha }} \
             --json-out docker-image-telemetry.json \
             --markdown-out docker-image-telemetry.md
+          then
+            echo "::warning::Docker image telemetry collection failed; reporting remains advisory-only."
+            printf '{"advisory_only": true, "warning": "telemetry collection failed"}\n' > docker-image-telemetry.json
+            printf '# Docker Image Telemetry\n\n- Warning: telemetry collection failed; workflow remains advisory-only.\n' > docker-image-telemetry.md
+          fi
 
       - name: Publish Docker telemetry to step summary
         run: |
@@ -81,11 +86,12 @@ jobs:
           path: |
             docker-image-telemetry.json
             docker-image-telemetry.md
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 14
 
       - name: Install Trivy via apt
         run: |
+          set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y wget apt-transport-https gnupg lsb-release
           wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -61,6 +61,38 @@ jobs:
           provenance: false
           target: production
 
+      - name: Collect Docker image telemetry
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/docker_image_telemetry.py \
+            --image-ref pulseplate:trivy-scan-${{ github.sha }} \
+            --json-out docker-image-telemetry.json \
+            --markdown-out docker-image-telemetry.md
+
+      - name: Publish Docker telemetry to step summary
+        run: |
+          set -euo pipefail
+          cat docker-image-telemetry.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload Docker telemetry artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: docker-image-telemetry-trivy
+          path: |
+            docker-image-telemetry.json
+            docker-image-telemetry.md
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Install Trivy via apt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget apt-transport-https gnupg lsb-release
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update
+          sudo apt-get install -y trivy
+          trivy --version
       # PAT may be present but expired/revoked; anonymous pull still works for public trivy-db.
       - name: Log in to GHCR (Trivy DB)
         if: ${{ env.GHCR_READ_TOKEN_AVAILABLE == 'true' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -191,6 +191,10 @@ FROM runtime-base AS production
 
 # NOTE: On Debian-based images, `apt` depends on `gpgv` and removing either can break the base system.
 # We intentionally keep them in the production image and document the Trivy finding via `.trivyignore`.
+# RU: Временный возврат к root нужен только для удаления pip-скриптов из root-owned venv/system paths.
+# EN: Temporarily switch back to root only to remove pip binaries from root-owned venv/system paths.
+USER root
+
 # RU: Убираем pip из production-stage, но не трогаем runtime-base/development.
 # EN: Remove pip from the production stage only so shared runtime/dev topology stays intact.
 RUN /opt/venv/bin/python -m pip uninstall -y pip \
@@ -211,6 +215,10 @@ if importlib.util.find_spec("pip") is not None:
     sys.stderr.write("pip leaked into production system site-packages\n")
     sys.exit(1)
 PY
+
+# RU: Финальный runtime остаётся non-root как и в runtime-base.
+# EN: Final runtime stays non-root, matching the runtime-base contract.
+USER pulseplate
 
 # Stage 4: Staging stage
 # Extends production with staging-specific configurations

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     fi
 
 # Copy requirements and install Python dependencies
-COPY requirements.txt requirements-ci-lite.txt requirements-dev.txt constraints.txt ./
+COPY requirements.txt requirements-ci-lite.txt constraints.txt ./
 COPY scripts/ci/check_python_startup_hooks.py scripts/ci/install_locked_python_requirements.py scripts/ci/emergency_python_wheels.json /tmp/pulseplate-ci/
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ -z "${PULSEPLATE_PYTHON_INDEX_URL:-}" ]; then \
@@ -191,6 +191,26 @@ FROM runtime-base AS production
 
 # NOTE: On Debian-based images, `apt` depends on `gpgv` and removing either can break the base system.
 # We intentionally keep them in the production image and document the Trivy finding via `.trivyignore`.
+# RU: Убираем pip из production-stage, но не трогаем runtime-base/development.
+# EN: Remove pip from the production stage only so shared runtime/dev topology stays intact.
+RUN /opt/venv/bin/python -m pip uninstall -y pip \
+    && /usr/local/bin/python -m pip uninstall -y pip \
+    && /opt/venv/bin/python - <<'PY'
+import importlib.util
+import sys
+
+if importlib.util.find_spec("pip") is not None:
+    sys.stderr.write("pip leaked into production venv\n")
+    sys.exit(1)
+PY
+RUN /usr/local/bin/python - <<'PY'
+import importlib.util
+import sys
+
+if importlib.util.find_spec("pip") is not None:
+    sys.stderr.write("pip leaked into production system site-packages\n")
+    sys.exit(1)
+PY
 
 # Stage 4: Staging stage
 # Extends production with staging-specific configurations

--- a/docs/review/PR_1477_FIXED_MAPPING.md
+++ b/docs/review/PR_1477_FIXED_MAPPING.md
@@ -11,7 +11,7 @@ Bot and human review threads must be dispositioned below; resolve conversations 
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
-Commit: `019f002e02d9e6fab89574b89633de191b53b409`
+Commit: 019f002e02d9e6fab89574b89633de191b53b409
 Evidence: `scripts/ci/docker_image_telemetry.py:23-25`; `scripts/ci/docker_image_telemetry.py:77-93`; `scripts/ci/docker_image_telemetry.py:187-219`; `.github/workflows/build.yml:65-90`; `.github/workflows/docker-image.yml:53-78`; `.github/workflows/trivy.yml:64-94`; `tests/test_docker_image_telemetry.py:43-95`; `tests/test_python_supply_chain_controls.py:207-226`
 Reason: The remaining review delta is now fixed on-branch: docker CLI calls are timeout-bounded, JSON-array `COPY` inputs are included in telemetry evidence, shell-form `COPY` assumptions are documented in code, the Docker telemetry workflows now honor the backlog's warning/regression-only contract, and the Trivy apt install step now uses `set -euo pipefail`. This closes the concrete Sourcery and CodeRabbit follow-ups, and it closes the remaining workflow-contract issues originally identified by cubic.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#pullrequestreview-4135809211 -> 019f002e02d9e6fab89574b89633de191b53b409
@@ -24,21 +24,21 @@ Reason: The remaining review delta is now fixed on-branch: docker CLI calls are 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106669582 -> 019f002e02d9e6fab89574b89633de191b53b409
 
 Disposition: FIXED
-Commit: `d3fd45f4d1f09b144632fc1c81798fed9d4a0ba3`
+Commit: d3fd45f4d1f09b144632fc1c81798fed9d4a0ba3
 Evidence: `Dockerfile:194-221`; `tests/test_python_supply_chain_controls.py:194-203`
 Reason: The production-stage Dockerfile now temporarily switches back to `USER root` only for the pip-removal block and then returns to `USER pulseplate`, which resolves the real runtime-break risk identified by cubic and also removes the malformed heredoc/`RUN` layout that CodeRabbit flagged on the same block.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106666747 -> d3fd45f4d1f09b144632fc1c81798fed9d4a0ba3
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106669575 -> d3fd45f4d1f09b144632fc1c81798fed9d4a0ba3
 
 Disposition: FIXED
-Commit: `2805c4243e67716c3d25845542d017c67f916592`
+Commit: 2805c4243e67716c3d25845542d017c67f916592
 Evidence: `scripts/ci/docker_image_telemetry.py:96-119`; `tests/test_docker_image_telemetry.py:62-74`
 Reason: cubic found that Docker history sizes like `65.4kB`/`12MB` could be misparsed; the helper now normalizes Docker-style unit aliases before conversion and the new regression test locks that behavior.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106664334 -> 2805c4243e67716c3d25845542d017c67f916592
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106669572 -> 2805c4243e67716c3d25845542d017c67f916592
 
 Disposition: FIXED
-Commit: `6810462f73c5da6ffc769becca52d19eb0e6a561`
+Commit: 6810462f73c5da6ffc769becca52d19eb0e6a561
 Evidence: `scripts/ci/docker_image_telemetry.py:234-256`; `scripts/ci/docker_image_telemetry.py:368-394`; `tests/test_docker_image_telemetry.py:99-110`; `docs/review/PR_1477_FIXED_MAPPING.md:55-57`
 Reason: the remaining CodeRabbit follow-ups are now closed on-branch: baseline JSON payloads fail closed with the intended `RuntimeError` when the root object is not a mapping, `--top-layers` rejects zero/negative values at parse time, and the mapping artifact no longer makes an uncited SIGTERM truth claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106735234 -> 6810462f73c5da6ffc769becca52d19eb0e6a561
@@ -49,10 +49,10 @@ Reason: the remaining CodeRabbit follow-ups are now closed on-branch: baseline J
 
 ## Merge Readiness
 
-- [ ] Current-head CI green for PR branch head
-- [ ] Required checks complete (no pending jobs)
-- [ ] All review threads resolved on GitHub after disposition updates
-- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [x] Current-head CI green for PR branch head
+- [x] Required checks complete (no pending jobs)
+- [x] All review threads resolved on GitHub after disposition updates
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 
 ### Local validation evidence
 

--- a/docs/review/PR_1477_FIXED_MAPPING.md
+++ b/docs/review/PR_1477_FIXED_MAPPING.md
@@ -53,5 +53,6 @@ Reason: cubic found that Docker history sizes like `65.4kB`/`12MB` could be misp
 - [x] Targeted telemetry and supply-chain tests
 - [x] Accelerated full-suite coverage plus `diff-cover` equivalent completed
 - [ ] Canonical local `make verify`
-  Evidence: single-process `make diff-cov` still receives external `SIGTERM` in this environment during the full coverage run; do not mark merge-ready on that basis until current-head CI proves green.
+  Evidence: `AGENTS.md:8-20`; `AGENTS.md:492-500`
+  Reason: the canonical local gate remains unchecked in this artifact, so merge truth must still come from current-head CI rather than any partial local substitute.
 <!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1477_FIXED_MAPPING.md
+++ b/docs/review/PR_1477_FIXED_MAPPING.md
@@ -37,6 +37,16 @@ Reason: cubic found that Docker history sizes like `65.4kB`/`12MB` could be misp
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106664334 -> 2805c4243e67716c3d25845542d017c67f916592
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106669572 -> 2805c4243e67716c3d25845542d017c67f916592
 
+Disposition: FIXED
+Commit: `6810462f73c5da6ffc769becca52d19eb0e6a561`
+Evidence: `scripts/ci/docker_image_telemetry.py:234-256`; `scripts/ci/docker_image_telemetry.py:368-394`; `tests/test_docker_image_telemetry.py:99-110`; `docs/review/PR_1477_FIXED_MAPPING.md:55-57`
+Reason: the remaining CodeRabbit follow-ups are now closed on-branch: baseline JSON payloads fail closed with the intended `RuntimeError` when the root object is not a mapping, `--top-layers` rejects zero/negative values at parse time, and the mapping artifact no longer makes an uncited SIGTERM truth claim.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106735234 -> 6810462f73c5da6ffc769becca52d19eb0e6a561
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106735238 -> 6810462f73c5da6ffc769becca52d19eb0e6a561
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106735240 -> 6810462f73c5da6ffc769becca52d19eb0e6a561
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#pullrequestreview-4135871172 -> 6810462f73c5da6ffc769becca52d19eb0e6a561
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#pullrequestreview-4135872292 -> 6810462f73c5da6ffc769becca52d19eb0e6a561
+
 ## Merge Readiness
 
 - [ ] Current-head CI green for PR branch head

--- a/docs/review/PR_1477_FIXED_MAPPING.md
+++ b/docs/review/PR_1477_FIXED_MAPPING.md
@@ -1,0 +1,32 @@
+<!-- markdownlint-disable MD034 -->
+# PR 1477 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Bot and human review threads must be dispositioned below; resolve conversations on GitHub after mapping.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] Current-head CI green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+
+### Local validation evidence
+
+- [x] `pre-commit run --all-files`
+- [x] `make lint`
+- [x] `make typecheck`
+- [x] `make test-fast`
+- [x] Targeted telemetry and supply-chain tests
+- [x] Accelerated full-suite coverage plus `diff-cover` equivalent completed
+- [ ] Canonical local `make verify`
+  Evidence: single-process `make diff-cov` still receives external `SIGTERM` in this environment during the full coverage run; do not mark merge-ready on that basis until current-head CI proves green.
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1477_FIXED_MAPPING.md
+++ b/docs/review/PR_1477_FIXED_MAPPING.md
@@ -10,7 +10,30 @@ Bot and human review threads must be dispositioned below; resolve conversations 
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: `019f002e02d9e6fab89574b89633de191b53b409`
+Evidence: `scripts/ci/docker_image_telemetry.py:23-25`; `scripts/ci/docker_image_telemetry.py:77-93`; `scripts/ci/docker_image_telemetry.py:187-219`; `.github/workflows/build.yml:65-90`; `.github/workflows/docker-image.yml:53-78`; `.github/workflows/trivy.yml:64-94`; `tests/test_docker_image_telemetry.py:43-95`; `tests/test_python_supply_chain_controls.py:207-226`
+Reason: The remaining review delta is now fixed on-branch: docker CLI calls are timeout-bounded, JSON-array `COPY` inputs are included in telemetry evidence, shell-form `COPY` assumptions are documented in code, the Docker telemetry workflows now honor the backlog's warning/regression-only contract, and the Trivy apt install step now uses `set -euo pipefail`. This closes the concrete Sourcery and CodeRabbit follow-ups, and it closes the remaining workflow-contract issues originally identified by cubic.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#pullrequestreview-4135809211 -> 019f002e02d9e6fab89574b89633de191b53b409
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#pullrequestreview-4135810855 -> 019f002e02d9e6fab89574b89633de191b53b409
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#pullrequestreview-4135812976 -> 019f002e02d9e6fab89574b89633de191b53b409
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#pullrequestreview-4135818093 -> 019f002e02d9e6fab89574b89633de191b53b409
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106669576 -> 019f002e02d9e6fab89574b89633de191b53b409
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106669577 -> 019f002e02d9e6fab89574b89633de191b53b409
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106669582 -> 019f002e02d9e6fab89574b89633de191b53b409
+
+Disposition: FIXED
+Commit: `d3fd45f4d1f09b144632fc1c81798fed9d4a0ba3`
+Evidence: `Dockerfile:194-221`; `tests/test_python_supply_chain_controls.py:194-203`
+Reason: The production-stage Dockerfile now temporarily switches back to `USER root` only for the pip-removal block and then returns to `USER pulseplate`, which resolves the real runtime-break risk identified by cubic and also removes the malformed heredoc/`RUN` layout that CodeRabbit flagged on the same block.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106666747 -> d3fd45f4d1f09b144632fc1c81798fed9d4a0ba3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106669575 -> d3fd45f4d1f09b144632fc1c81798fed9d4a0ba3
+
+Disposition: FIXED
+Commit: `2805c4243e67716c3d25845542d017c67f916592`
+Evidence: `scripts/ci/docker_image_telemetry.py:96-119`; `tests/test_docker_image_telemetry.py:62-74`
+Reason: cubic found that Docker history sizes like `65.4kB`/`12MB` could be misparsed; the helper now normalizes Docker-style unit aliases before conversion and the new regression test locks that behavior.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106669572 -> 2805c4243e67716c3d25845542d017c67f916592
 
 ## Merge Readiness
 

--- a/docs/review/PR_1477_FIXED_MAPPING.md
+++ b/docs/review/PR_1477_FIXED_MAPPING.md
@@ -18,6 +18,7 @@ Reason: The remaining review delta is now fixed on-branch: docker CLI calls are 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#pullrequestreview-4135810855 -> 019f002e02d9e6fab89574b89633de191b53b409
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#pullrequestreview-4135812976 -> 019f002e02d9e6fab89574b89633de191b53b409
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#pullrequestreview-4135818093 -> 019f002e02d9e6fab89574b89633de191b53b409
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106664624 -> 019f002e02d9e6fab89574b89633de191b53b409
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106669576 -> 019f002e02d9e6fab89574b89633de191b53b409
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106669577 -> 019f002e02d9e6fab89574b89633de191b53b409
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106669582 -> 019f002e02d9e6fab89574b89633de191b53b409
@@ -33,6 +34,7 @@ Disposition: FIXED
 Commit: `2805c4243e67716c3d25845542d017c67f916592`
 Evidence: `scripts/ci/docker_image_telemetry.py:96-119`; `tests/test_docker_image_telemetry.py:62-74`
 Reason: cubic found that Docker history sizes like `65.4kB`/`12MB` could be misparsed; the helper now normalizes Docker-style unit aliases before conversion and the new regression test locks that behavior.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106664334 -> 2805c4243e67716c3d25845542d017c67f916592
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1477#discussion_r3106669572 -> 2805c4243e67716c3d25845542d017c67f916592
 
 ## Merge Readiness

--- a/scripts/ci/docker_image_telemetry.py
+++ b/scripts/ci/docker_image_telemetry.py
@@ -237,12 +237,23 @@ def _load_baseline_size_bytes(baseline_path: Path | None) -> int | None:
     if baseline_path is None or not baseline_path.exists():
         return None
     payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Unsupported baseline payload shape: {baseline_path}")
     if isinstance(payload.get("image_size_bytes"), int):
         return int(payload["image_size_bytes"])
     image_payload = payload.get("image")
     if isinstance(image_payload, dict) and isinstance(image_payload.get("size_bytes"), int):
         return int(image_payload["size_bytes"])
     raise RuntimeError(f"Unsupported baseline payload shape: {baseline_path}")
+
+
+def _positive_int(value: str) -> int:
+    """Parse a strictly positive integer for CLI arguments."""
+
+    parsed_value = int(value)
+    if parsed_value <= 0:
+        raise argparse.ArgumentTypeError("value must be greater than 0")
+    return parsed_value
 
 
 def collect_telemetry(
@@ -374,7 +385,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--top-layers",
-        type=int,
+        type=_positive_int,
         default=5,
         help="Number of largest layers to report",
     )

--- a/scripts/ci/docker_image_telemetry.py
+++ b/scripts/ci/docker_image_telemetry.py
@@ -13,6 +13,7 @@ import argparse
 from dataclasses import asdict, dataclass
 import json
 from pathlib import Path
+import re
 import shlex
 import shutil
 import subprocess  # nosec B404: bounded local Docker inspection is required for CI telemetry evidence (remove-by: 2026-09-30, ref: PR-docker-telemetry-baseline)
@@ -91,11 +92,24 @@ def _human_size_to_bytes(size_text: str) -> int:
     value = size_text.strip()
     if value in {"", "0", "0B"}:
         return 0
-    for unit, multiplier in SIZE_UNITS.items():
-        if value.upper().endswith(unit):
-            number_text = value[: -len(unit)].strip()
-            return int(float(number_text) * multiplier)
-    raise ValueError(f"Unsupported Docker size format: {size_text}")
+    match = re.fullmatch(r"(?P<number>\d+(?:\.\d+)?)\s*(?P<unit>[A-Za-z]+)", value)
+    if match is None:
+        raise ValueError(f"Unsupported Docker size format: {size_text}")
+    unit_aliases = {
+        "B": "B",
+        "K": "KB",
+        "KB": "KB",
+        "M": "MB",
+        "MB": "MB",
+        "G": "GB",
+        "GB": "GB",
+        "T": "TB",
+        "TB": "TB",
+    }
+    normalized_unit = unit_aliases.get(match.group("unit").upper())
+    if normalized_unit is None:
+        raise ValueError(f"Unsupported Docker size format: {size_text}")
+    return int(float(match.group("number")) * SIZE_UNITS[normalized_unit])
 
 
 def _bytes_to_human(size_bytes: int) -> str:

--- a/scripts/ci/docker_image_telemetry.py
+++ b/scripts/ci/docker_image_telemetry.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Collect deterministic Docker image telemetry for CI evidence.
+
+RU: Скрипт собирает advisory-only telemetry по размеру образа, крупнейшим слоям
+и build-context входам для PR-visible отчётов.
+EN: Collect advisory-only telemetry for image size, largest layers, and
+build-context inputs so Docker lanes emit deterministic evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+import shlex
+import shutil
+import subprocess  # nosec B404: bounded local Docker inspection is required for CI telemetry evidence (remove-by: 2026-09-30, ref: PR-docker-telemetry-baseline)
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKER_BINARY = shutil.which("docker")
+SIZE_UNITS = {
+    "B": 1,
+    "KB": 1_000,
+    "MB": 1_000_000,
+    "GB": 1_000_000_000,
+    "TB": 1_000_000_000_000,
+}
+
+
+@dataclass(frozen=True)
+class LayerTelemetry:
+    """Single Docker history row rendered as deterministic telemetry."""
+
+    created_by: str
+    size_bytes: int
+    size_human: str
+
+
+@dataclass(frozen=True)
+class BuildContextEvidence:
+    """Deterministic build-context evidence from repo-truth files."""
+
+    dockerfile_path: str
+    dockerignore_path: str
+    copy_inputs: tuple[str, ...]
+    dockerignore_allowlist: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BaselineComparison:
+    """Advisory baseline comparison; never fails the lane in this wave."""
+
+    baseline_path: str | None
+    baseline_size_bytes: int | None
+    size_delta_bytes: int | None
+    regression_warning: bool
+
+
+@dataclass(frozen=True)
+class ImageTelemetryReport:
+    """Top-level advisory telemetry payload."""
+
+    advisory_only: bool
+    image_ref: str
+    image_size_bytes: int
+    image_size_human: str
+    largest_layers: tuple[LayerTelemetry, ...]
+    build_context: BuildContextEvidence
+    baseline: BaselineComparison
+    warnings: tuple[str, ...]
+
+
+def _run_docker(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run Docker with a resolved binary path and fixed argv."""
+
+    if DOCKER_BINARY is None:
+        raise RuntimeError("docker binary is not available on PATH")
+    return subprocess.run(  # nosec B603: argv uses resolved docker path with fixed inspect/history subcommands only (remove-by: 2026-09-30, ref: PR-docker-telemetry-baseline)
+        [DOCKER_BINARY, *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _human_size_to_bytes(size_text: str) -> int:
+    """Parse Docker history size text into bytes."""
+
+    value = size_text.strip()
+    if value in {"", "0", "0B"}:
+        return 0
+    for unit, multiplier in SIZE_UNITS.items():
+        if value.upper().endswith(unit):
+            number_text = value[: -len(unit)].strip()
+            return int(float(number_text) * multiplier)
+    raise ValueError(f"Unsupported Docker size format: {size_text}")
+
+
+def _bytes_to_human(size_bytes: int) -> str:
+    """Render bytes using decimal Docker-style units."""
+
+    if size_bytes < SIZE_UNITS["KB"]:
+        return f"{size_bytes} B"
+    if size_bytes < SIZE_UNITS["MB"]:
+        return f"{size_bytes / SIZE_UNITS['KB']:.2f} KB"
+    if size_bytes < SIZE_UNITS["GB"]:
+        return f"{size_bytes / SIZE_UNITS['MB']:.2f} MB"
+    return f"{size_bytes / SIZE_UNITS['GB']:.2f} GB"
+
+
+def _read_image_size_bytes(image_ref: str) -> int:
+    """Read the total image size from docker image inspect."""
+
+    result = _run_docker(["image", "inspect", image_ref])
+    payload = json.loads(result.stdout)
+    if not payload:
+        raise RuntimeError(f"Docker inspect returned no payload for {image_ref}")
+    size_value = payload[0].get("Size")
+    if not isinstance(size_value, int):
+        raise RuntimeError(f"Docker inspect returned invalid Size for {image_ref}")
+    return size_value
+
+
+def _read_history_rows(image_ref: str) -> list[LayerTelemetry]:
+    """Read Docker history and normalize the largest layers."""
+
+    result = _run_docker(["history", "--no-trunc", "--format", "{{json .}}", image_ref])
+    rows: list[LayerTelemetry] = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        rows.append(
+            LayerTelemetry(
+                created_by=str(payload.get("CreatedBy", "")).strip() or "<unknown>",
+                size_bytes=_human_size_to_bytes(str(payload.get("Size", "0B"))),
+                size_human=str(payload.get("Size", "0B")).strip() or "0B",
+            )
+        )
+    return rows
+
+
+def _logical_lines(text: str) -> list[str]:
+    """Join Dockerfile continuation lines for simple COPY parsing."""
+
+    logical_lines: list[str] = []
+    current = ""
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if not current:
+            current = line
+        else:
+            current = f"{current} {line.lstrip()}"
+        if line.endswith("\\"):
+            current = current[:-1].rstrip()
+            continue
+        logical_lines.append(current)
+        current = ""
+    if current:
+        logical_lines.append(current)
+    return logical_lines
+
+
+def _parse_copy_inputs(dockerfile_path: Path) -> tuple[str, ...]:
+    """Extract local COPY inputs from the Dockerfile as concise evidence."""
+
+    inputs: list[str] = []
+    for line in _logical_lines(dockerfile_path.read_text(encoding="utf-8")):
+        stripped = line.strip()
+        if not stripped.startswith("COPY "):
+            continue
+        tokens = shlex.split(stripped[len("COPY ") :])
+        if any(token.startswith("--from=") for token in tokens):
+            continue
+        filtered_tokens = [token for token in tokens if not token.startswith("--")]
+        if len(filtered_tokens) < 2:
+            continue
+        for source in filtered_tokens[:-1]:
+            inputs.append(source)
+    return tuple(dict.fromkeys(inputs))
+
+
+def _parse_dockerignore_allowlist(dockerignore_path: Path) -> tuple[str, ...]:
+    """Collect explicit allowlist lines from .dockerignore."""
+
+    allowlist: list[str] = []
+    for raw_line in dockerignore_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or not line.startswith("!"):
+            continue
+        allowlist.append(line)
+    return tuple(allowlist)
+
+
+def _load_baseline_size_bytes(baseline_path: Path | None) -> int | None:
+    """Load a prior telemetry baseline if one is supplied."""
+
+    if baseline_path is None or not baseline_path.exists():
+        return None
+    payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+    if isinstance(payload.get("image_size_bytes"), int):
+        return int(payload["image_size_bytes"])
+    image_payload = payload.get("image")
+    if isinstance(image_payload, dict) and isinstance(image_payload.get("size_bytes"), int):
+        return int(image_payload["size_bytes"])
+    raise RuntimeError(f"Unsupported baseline payload shape: {baseline_path}")
+
+
+def collect_telemetry(
+    *,
+    image_ref: str,
+    dockerfile_path: Path,
+    dockerignore_path: Path,
+    top_layers: int,
+    baseline_path: Path | None,
+) -> ImageTelemetryReport:
+    """Collect advisory-only telemetry for the given local image reference."""
+
+    image_size_bytes = _read_image_size_bytes(image_ref)
+    history_rows = sorted(
+        _read_history_rows(image_ref),
+        key=lambda row: row.size_bytes,
+        reverse=True,
+    )[:top_layers]
+    copy_inputs = _parse_copy_inputs(dockerfile_path)
+    dockerignore_allowlist = _parse_dockerignore_allowlist(dockerignore_path)
+
+    warnings: list[str] = []
+    baseline_size_bytes = _load_baseline_size_bytes(baseline_path)
+    size_delta_bytes: int | None = None
+    regression_warning = False
+    if baseline_path is None:
+        warnings.append("No baseline JSON was provided; telemetry remains advisory-only.")
+    elif baseline_size_bytes is None:
+        warnings.append(
+            f"Baseline JSON is missing or absent at {baseline_path}; telemetry remains advisory-only."
+        )
+    else:
+        size_delta_bytes = image_size_bytes - baseline_size_bytes
+        if size_delta_bytes > 0:
+            regression_warning = True
+            warnings.append(
+                "Image size increased relative to the supplied baseline; "
+                "warning-only mode keeps the lane non-blocking."
+            )
+
+    return ImageTelemetryReport(
+        advisory_only=True,
+        image_ref=image_ref,
+        image_size_bytes=image_size_bytes,
+        image_size_human=_bytes_to_human(image_size_bytes),
+        largest_layers=tuple(history_rows),
+        build_context=BuildContextEvidence(
+            dockerfile_path=str(dockerfile_path),
+            dockerignore_path=str(dockerignore_path),
+            copy_inputs=copy_inputs,
+            dockerignore_allowlist=dockerignore_allowlist,
+        ),
+        baseline=BaselineComparison(
+            baseline_path=str(baseline_path) if baseline_path is not None else None,
+            baseline_size_bytes=baseline_size_bytes,
+            size_delta_bytes=size_delta_bytes,
+            regression_warning=regression_warning,
+        ),
+        warnings=tuple(warnings),
+    )
+
+
+def render_markdown(report: ImageTelemetryReport) -> str:
+    """Render a concise Markdown summary for PR-visible workflow evidence."""
+
+    lines = [
+        "# Docker Image Telemetry",
+        "",
+        f"- Image: `{report.image_ref}`",
+        f"- Advisory only: `{str(report.advisory_only).lower()}`",
+        f"- Size: `{report.image_size_human}` (`{report.image_size_bytes}` bytes)",
+    ]
+    if report.baseline.baseline_size_bytes is None:
+        lines.append("- Baseline: `not provided`")
+    else:
+        baseline_human = _bytes_to_human(report.baseline.baseline_size_bytes)
+        lines.append(
+            f"- Baseline: `{baseline_human}` (`{report.baseline.baseline_size_bytes}` bytes)"
+        )
+    if report.baseline.size_delta_bytes is not None:
+        delta = report.baseline.size_delta_bytes
+        sign = "+" if delta >= 0 else "-"
+        lines.append(
+            f"- Delta vs baseline: `{sign}{_bytes_to_human(abs(delta))}` (`{delta}` bytes)"
+        )
+    if report.warnings:
+        lines.extend(["", "## Warnings", ""])
+        lines.extend(f"- {warning}" for warning in report.warnings)
+
+    lines.extend(["", "## Largest Layers", "", "| Size | Command |", "| --- | --- |"])
+    for layer in report.largest_layers:
+        command = layer.created_by.replace("|", "\\|")
+        lines.append(f"| `{layer.size_human}` | `{command}` |")
+
+    lines.extend(
+        [
+            "",
+            "## Build Context Evidence",
+            "",
+            f"- Dockerfile: `{report.build_context.dockerfile_path}`",
+            f"- Dockerignore: `{report.build_context.dockerignore_path}`",
+            "- Local COPY inputs: "
+            + ", ".join(f"`{item}`" for item in report.build_context.copy_inputs),
+            "- Dockerignore allowlist: "
+            + ", ".join(f"`{item}`" for item in report.build_context.dockerignore_allowlist),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image-ref", required=True, help="Local Docker image reference")
+    parser.add_argument(
+        "--dockerfile",
+        default="Dockerfile",
+        help="Dockerfile path relative to repo root",
+    )
+    parser.add_argument(
+        "--dockerignore",
+        default=".dockerignore",
+        help=".dockerignore path relative to repo root",
+    )
+    parser.add_argument(
+        "--baseline-json",
+        default=None,
+        help="Optional prior telemetry JSON for advisory regression comparison",
+    )
+    parser.add_argument(
+        "--top-layers",
+        type=int,
+        default=5,
+        help="Number of largest layers to report",
+    )
+    parser.add_argument("--json-out", required=True, help="Output JSON report path")
+    parser.add_argument("--markdown-out", required=True, help="Output Markdown report path")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        report = collect_telemetry(
+            image_ref=args.image_ref,
+            dockerfile_path=REPO_ROOT / args.dockerfile,
+            dockerignore_path=REPO_ROOT / args.dockerignore,
+            top_layers=args.top_layers,
+            baseline_path=REPO_ROOT / args.baseline_json if args.baseline_json else None,
+        )
+    except (RuntimeError, ValueError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        print(f"docker_image_telemetry failed: {exc}", file=sys.stderr)
+        return 1
+
+    json_out = Path(args.json_out)
+    markdown_out = Path(args.markdown_out)
+    json_out.write_text(json.dumps(asdict(report), indent=2, sort_keys=True), encoding="utf-8")
+    markdown_out.write_text(render_markdown(report), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/docker_image_telemetry.py
+++ b/scripts/ci/docker_image_telemetry.py
@@ -21,6 +21,7 @@ import sys
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCKER_BINARY = shutil.which("docker")
+DOCKER_TIMEOUT_SECONDS = 60
 SIZE_UNITS = {
     "B": 1,
     "KB": 1_000,
@@ -78,12 +79,18 @@ def _run_docker(args: list[str]) -> subprocess.CompletedProcess[str]:
 
     if DOCKER_BINARY is None:
         raise RuntimeError("docker binary is not available on PATH")
-    return subprocess.run(  # nosec B603: argv uses resolved docker path with fixed inspect/history subcommands only (remove-by: 2026-09-30, ref: PR-docker-telemetry-baseline)
-        [DOCKER_BINARY, *args],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        return subprocess.run(  # nosec B603: argv uses resolved docker path with fixed inspect/history subcommands only (remove-by: 2026-09-30, ref: PR-docker-telemetry-baseline)
+            [DOCKER_BINARY, *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=DOCKER_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"docker command timed out after {DOCKER_TIMEOUT_SECONDS}s: {' '.join(args)}"
+        ) from exc
 
 
 def _human_size_to_bytes(size_text: str) -> int:
@@ -185,7 +192,23 @@ def _parse_copy_inputs(dockerfile_path: Path) -> tuple[str, ...]:
         stripped = line.strip()
         if not stripped.startswith("COPY "):
             continue
-        tokens = shlex.split(stripped[len("COPY ") :])
+        copy_args = stripped[len("COPY ") :].lstrip()
+        if copy_args.startswith("["):
+            try:
+                payload = json.loads(copy_args)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, list) or len(payload) < 2:
+                continue
+            for source in payload[:-1]:
+                if isinstance(source, str):
+                    inputs.append(source)
+            continue
+        # RU: shell-form COPY поддерживается ограниченной эвристикой; флаги
+        # `--from` остаются non-local inputs и intentionally исключаются.
+        # EN: shell-form COPY uses a bounded heuristic; `--from` inputs are
+        # treated as non-local and intentionally excluded from build-context evidence.
+        tokens = shlex.split(copy_args)
         if any(token.startswith("--from=") for token in tokens):
             continue
         filtered_tokens = [token for token in tokens if not token.startswith("--")]

--- a/tests/test_docker_image_telemetry.py
+++ b/tests/test_docker_image_telemetry.py
@@ -40,6 +40,21 @@ def _write_context_files(tmp_path: Path) -> tuple[Path, Path]:
     return dockerfile, dockerignore
 
 
+@pytest.mark.parametrize(
+    ("size_text", "expected_bytes"),
+    (
+        ("65.4kB", 65_400),
+        ("65.4k", 65_400),
+        ("12MB", 12_000_000),
+        ("512B", 512),
+    ),
+)
+def test_human_size_to_bytes_accepts_docker_style_units(
+    size_text: str, expected_bytes: int
+) -> None:
+    assert docker_image_telemetry._human_size_to_bytes(size_text) == expected_bytes
+
+
 def test_collect_telemetry_without_baseline_is_warning_only(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_docker_image_telemetry.py
+++ b/tests/test_docker_image_telemetry.py
@@ -40,6 +40,25 @@ def _write_context_files(tmp_path: Path) -> tuple[Path, Path]:
     return dockerfile, dockerignore
 
 
+def test_run_docker_uses_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(args=["docker"], returncode=0, stdout="[]", stderr="")
+
+    import subprocess
+
+    monkeypatch.setattr(docker_image_telemetry, "DOCKER_BINARY", "/usr/bin/docker")
+    monkeypatch.setattr(docker_image_telemetry.subprocess, "run", _fake_run)
+
+    docker_image_telemetry._run_docker(["image", "inspect", "pulseplate:test"])
+
+    assert captured["args"] == (["/usr/bin/docker", "image", "inspect", "pulseplate:test"],)
+    assert captured["kwargs"]["timeout"] == docker_image_telemetry.DOCKER_TIMEOUT_SECONDS
+
+
 @pytest.mark.parametrize(
     ("size_text", "expected_bytes"),
     (
@@ -53,6 +72,27 @@ def test_human_size_to_bytes_accepts_docker_style_units(
     size_text: str, expected_bytes: int
 ) -> None:
     assert docker_image_telemetry._human_size_to_bytes(size_text) == expected_bytes
+
+
+def test_parse_copy_inputs_supports_shell_and_json_forms(tmp_path: Path) -> None:
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "\n".join(
+            [
+                "FROM python:3.13-slim AS builder",
+                'COPY ["requirements.txt", "constraints.txt", "/tmp/deps/"]',
+                "COPY --chown=pulseplate:pulseplate app/ ./app/",
+                "COPY --from=builder /opt/venv /opt/venv",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert docker_image_telemetry._parse_copy_inputs(dockerfile) == (
+        "requirements.txt",
+        "constraints.txt",
+        "app/",
+    )
 
 
 def test_collect_telemetry_without_baseline_is_warning_only(

--- a/tests/test_docker_image_telemetry.py
+++ b/tests/test_docker_image_telemetry.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ci import docker_image_telemetry
+
+
+def _write_context_files(tmp_path: Path) -> tuple[Path, Path]:
+    dockerfile = tmp_path / "Dockerfile"
+    dockerignore = tmp_path / ".dockerignore"
+    dockerfile.write_text(
+        "\n".join(
+            [
+                "FROM python:3.13-slim AS builder",
+                "COPY requirements.txt requirements-ci-lite.txt constraints.txt ./",
+                "COPY --chown=pulseplate:pulseplate app/ ./app/",
+                "COPY --from=builder /opt/venv /opt/venv",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    dockerignore.write_text(
+        "\n".join(
+            [
+                "**",
+                "!Dockerfile",
+                "!requirements.txt",
+                "!requirements-ci-lite.txt",
+                "!constraints.txt",
+                "!scripts/",
+                "!scripts/ci/",
+                "!scripts/ci/emergency_python_wheels.json",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return dockerfile, dockerignore
+
+
+def test_collect_telemetry_without_baseline_is_warning_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dockerfile, dockerignore = _write_context_files(tmp_path)
+    history_rows = [
+        docker_image_telemetry.LayerTelemetry(
+            created_by="RUN apt-get update",
+            size_bytes=30_000_000,
+            size_human="30MB",
+        ),
+        docker_image_telemetry.LayerTelemetry(
+            created_by="COPY app/ ./app/",
+            size_bytes=5_000_000,
+            size_human="5MB",
+        ),
+    ]
+
+    monkeypatch.setattr(docker_image_telemetry, "_read_image_size_bytes", lambda _: 95_000_000)
+    monkeypatch.setattr(docker_image_telemetry, "_read_history_rows", lambda _: history_rows)
+
+    report = docker_image_telemetry.collect_telemetry(
+        image_ref="pulseplate:test",
+        dockerfile_path=dockerfile,
+        dockerignore_path=dockerignore,
+        top_layers=2,
+        baseline_path=None,
+    )
+
+    assert report.advisory_only is True
+    assert report.image_size_bytes == 95_000_000
+    assert report.largest_layers == tuple(history_rows)
+    assert report.build_context.copy_inputs == (
+        "requirements.txt",
+        "requirements-ci-lite.txt",
+        "constraints.txt",
+        "app/",
+    )
+    assert "!scripts/ci/emergency_python_wheels.json" in report.build_context.dockerignore_allowlist
+    assert report.baseline.baseline_size_bytes is None
+    assert report.baseline.regression_warning is False
+    assert "telemetry remains advisory-only" in report.warnings[0]
+
+
+def test_main_writes_warning_only_growth_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dockerfile, dockerignore = _write_context_files(tmp_path)
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps({"image_size_bytes": 80_000_000}), encoding="utf-8")
+
+    monkeypatch.setattr(docker_image_telemetry, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(docker_image_telemetry, "_read_image_size_bytes", lambda _: 95_000_000)
+    monkeypatch.setattr(
+        docker_image_telemetry,
+        "_read_history_rows",
+        lambda _: [
+            docker_image_telemetry.LayerTelemetry(
+                created_by="RUN python -m pip install -r requirements.txt",
+                size_bytes=12_500_000,
+                size_human="12.5MB",
+            )
+        ],
+    )
+
+    json_out = tmp_path / "telemetry.json"
+    markdown_out = tmp_path / "telemetry.md"
+    exit_code = docker_image_telemetry.main(
+        [
+            "--image-ref",
+            "pulseplate:test",
+            "--dockerfile",
+            dockerfile.name,
+            "--dockerignore",
+            dockerignore.name,
+            "--baseline-json",
+            baseline_path.name,
+            "--json-out",
+            str(json_out),
+            "--markdown-out",
+            str(markdown_out),
+        ]
+    )
+
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    markdown = markdown_out.read_text(encoding="utf-8")
+
+    assert exit_code == 0
+    assert payload["advisory_only"] is True
+    assert payload["image_size_bytes"] == 95_000_000
+    assert payload["baseline"]["baseline_size_bytes"] == 80_000_000
+    assert payload["baseline"]["size_delta_bytes"] == 15_000_000
+    assert payload["baseline"]["regression_warning"] is True
+    assert "warning-only mode keeps the lane non-blocking" in payload["warnings"][0]
+    assert "Docker Image Telemetry" in markdown
+    assert "Delta vs baseline" in markdown
+    assert "Build Context Evidence" in markdown

--- a/tests/test_docker_image_telemetry.py
+++ b/tests/test_docker_image_telemetry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import json
 from pathlib import Path
 
@@ -93,6 +94,20 @@ def test_parse_copy_inputs_supports_shell_and_json_forms(tmp_path: Path) -> None
         "constraints.txt",
         "app/",
     )
+
+
+def test_load_baseline_size_bytes_rejects_non_object_payload(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps(["unexpected", "payload"]), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="Unsupported baseline payload shape"):
+        docker_image_telemetry._load_baseline_size_bytes(baseline_path)
+
+
+@pytest.mark.parametrize("raw_value", ("0", "-1"))
+def test_positive_int_rejects_non_positive_values(raw_value: str) -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="greater than 0"):
+        docker_image_telemetry._positive_int(raw_value)
 
 
 def test_collect_telemetry_without_baseline_is_warning_only(

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -187,7 +187,10 @@ def test_canonical_ci_and_docker_use_supply_chain_guardrails() -> None:
     assert "!requirements-ci-lite.txt" in dockerignore_text
     assert "!constraints.txt" in dockerignore_text
     assert "!scripts/ci/check_python_startup_hooks.py" in dockerignore_text
+    assert "!scripts/ci/emergency_python_wheels.json" in dockerignore_text
     assert "!scripts/ci/install_locked_python_requirements.py" in dockerignore_text
+    assert "COPY requirements.txt requirements-ci-lite.txt constraints.txt ./" in docker_text
+    assert "COPY requirements.txt requirements-dev.txt constraints.txt ./" in docker_text
     assert "install_locked_python_requirements.py" in dependency_docs_text
     assert "PULSEPLATE_PYTHON_INDEX_URL" in dependency_docs_text
     assert "Run: make venv-sync" in init_test_db_text
@@ -363,3 +366,26 @@ def test_docker_ci_build_jobs_use_ci_lite_requirements_profile() -> None:
     assert "PULSEPLATE_REQUIREMENTS_FILE=requirements-ci-lite.txt" in docker_smoke_build_args
     assert "PULSEPLATE_REQUIREMENTS_FILE" not in local_build_args
     assert "PULSEPLATE_REQUIREMENTS_FILE" not in publish_build_args
+
+
+def test_docker_workflows_emit_image_telemetry_artifacts() -> None:
+    build_workflow_text = (REPO_ROOT / ".github" / "workflows" / "build.yml").read_text(
+        encoding="utf-8"
+    )
+    docker_image_workflow_text = (
+        REPO_ROOT / ".github" / "workflows" / "docker-image.yml"
+    ).read_text(encoding="utf-8")
+    trivy_workflow_text = (REPO_ROOT / ".github" / "workflows" / "trivy.yml").read_text(
+        encoding="utf-8"
+    )
+
+    for workflow_text in (
+        build_workflow_text,
+        docker_image_workflow_text,
+        trivy_workflow_text,
+    ):
+        assert "scripts/ci/docker_image_telemetry.py" in workflow_text
+        assert "docker-image-telemetry.json" in workflow_text
+        assert "docker-image-telemetry.md" in workflow_text
+        assert "GITHUB_STEP_SUMMARY" in workflow_text
+        assert "actions/upload-artifact@" in workflow_text

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -204,6 +204,26 @@ def test_canonical_ci_and_docker_use_supply_chain_guardrails() -> None:
     assert "install_locked_python_requirements.py" in dependency_docs_text
     assert "PULSEPLATE_PYTHON_INDEX_URL" in dependency_docs_text
     assert "Run: make venv-sync" in init_test_db_text
+    assert "Docker image telemetry collection failed; reporting remains advisory-only." in (
+        REPO_ROOT / ".github" / "workflows" / "build.yml"
+    ).read_text(encoding="utf-8")
+    assert "Docker image telemetry collection failed; reporting remains advisory-only." in (
+        REPO_ROOT / ".github" / "workflows" / "docker-image.yml"
+    ).read_text(encoding="utf-8")
+    assert "Docker image telemetry collection failed; reporting remains advisory-only." in (
+        REPO_ROOT / ".github" / "workflows" / "trivy.yml"
+    ).read_text(encoding="utf-8")
+    assert "if-no-files-found: warn" in (
+        REPO_ROOT / ".github" / "workflows" / "build.yml"
+    ).read_text(encoding="utf-8")
+    assert "if-no-files-found: warn" in (
+        REPO_ROOT / ".github" / "workflows" / "docker-image.yml"
+    ).read_text(encoding="utf-8")
+    trivy_workflow_text = (REPO_ROOT / ".github" / "workflows" / "trivy.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "if-no-files-found: warn" in trivy_workflow_text
+    assert "set -euo pipefail" in trivy_workflow_text.split("- name: Install Trivy via apt", 1)[1]
 
 
 @pytest.mark.parametrize("workflow_path", LOCKED_INSTALL_WORKFLOW_PATHS)

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -191,6 +191,16 @@ def test_canonical_ci_and_docker_use_supply_chain_guardrails() -> None:
     assert "!scripts/ci/install_locked_python_requirements.py" in dockerignore_text
     assert "COPY requirements.txt requirements-ci-lite.txt constraints.txt ./" in docker_text
     assert "COPY requirements.txt requirements-dev.txt constraints.txt ./" in docker_text
+    production_root_index = docker_text.index("FROM runtime-base AS production")
+    switch_to_root_index = docker_text.index("USER root", production_root_index)
+    uninstall_pip_index = docker_text.index("/opt/venv/bin/python -m pip uninstall -y pip")
+    return_to_non_root_index = docker_text.index("USER pulseplate", uninstall_pip_index)
+    assert (
+        production_root_index
+        < switch_to_root_index
+        < uninstall_pip_index
+        < return_to_non_root_index
+    )
     assert "install_locked_python_requirements.py" in dependency_docs_text
     assert "PULSEPLATE_PYTHON_INDEX_URL" in dependency_docs_text
     assert "Run: make venv-sync" in init_test_db_text


### PR DESCRIPTION
## Summary
- slim the backend production image without changing runtime topology or the `app.main:app` contract
- add deterministic Docker image telemetry under `scripts/ci/` and surface it in Docker-related workflows as warning-only evidence
- preserve current provenance contract and existing backend/frontend split

## What Changed
- remove unnecessary builder-stage `requirements-dev.txt` copy from the production build path
- strip `pip` only from the production runtime surface
- allowlist `scripts/ci/emergency_python_wheels.json` in `.dockerignore`
- add `scripts/ci/docker_image_telemetry.py` for image size, largest layers, and concise input/build-context evidence
- wire telemetry output into `.github/workflows/build.yml`, `.github/workflows/docker-image.yml`, and `.github/workflows/trivy.yml`
- extend supply-chain and telemetry tests

## Split Justification
This PR intentionally stays as one lane because the Docker runtime slimming change and the warning-only telemetry rollout share one verification contract.

- The telemetry helper, workflow wiring, and supply-chain tests must land together so the new evidence surface cannot drift from the Docker jobs it documents.
- Splitting the telemetry fallback/workflow changes from the runtime image slimming would create an intermediate state where review findings remain unresolved against current-head CI behavior.
- Remaining follow-up work stays out of scope for this PR: any future tightening from advisory telemetry to enforced gating must land in a separate PR after current warning-only evidence stabilizes.

## Validation
- `pre-commit run --all-files`
- `make validate-min`
- `.venv/bin/python -m pytest -q tests/test_docker_image_telemetry.py tests/test_python_supply_chain_controls.py tests/test_tooling_surface_guards.py`
- `make lint`
- `make typecheck`
- `make test-fast`
- `.venv/bin/python -m pytest -q -n auto --cov=app --cov=core --cov-report=xml:coverage.xml`
- `.venv/bin/python -m diff_cover.diff_cover_tool coverage.xml --compare-branch=origin/main --fail-under=97`

## Known Limitation
- local canonical `make verify` / single-process `make diff-cov` still receives external `SIGTERM` in this environment during the full coverage run
- this PR is not claimed merge-ready until current-head CI proves the canonical gate set on GitHub

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1477_FIXED_MAPPING.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now generates Docker image telemetry (JSON + Markdown), appends it to job summaries, and publishes artifacts with 14-day retention.

* **Security**
  * pip is removed from production images to reduce runtime attack surface.

* **Tests**
  * Added tests for image telemetry collection/reporting and CI workflow integration.

* **Documentation**
  * Added a review/validation note documenting PR disposition and validation checklist.

* **Chores**
  * .dockerignore updated to explicitly allow a CI emergency wheels file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
