### PR TITLE
fix(ci): redact Docker history CreatedBy to prevent secret leakage

### DIFF
--- a/docs/review/PR_1481_FIXED_MAPPING.md
+++ b/docs/review/PR_1481_FIXED_MAPPING.md
@@ -1,0 +1,8 @@
+# PR 1481 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments

--- a/scripts/ci/docker_image_telemetry.py
+++ b/scripts/ci/docker_image_telemetry.py
@@ -22,6 +22,7 @@ import sys
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCKER_BINARY = shutil.which("docker")
 DOCKER_TIMEOUT_SECONDS = 60
+REDACTED_CREATED_BY = "<redacted: docker history command hidden>"
 SIZE_UNITS = {
     "B": 1,
     "KB": 1_000,
@@ -155,7 +156,7 @@ def _read_history_rows(image_ref: str) -> list[LayerTelemetry]:
         payload = json.loads(line)
         rows.append(
             LayerTelemetry(
-                created_by=str(payload.get("CreatedBy", "")).strip() or "<unknown>",
+                created_by=REDACTED_CREATED_BY,
                 size_bytes=_human_size_to_bytes(str(payload.get("Size", "0B"))),
                 size_human=str(payload.get("Size", "0B")).strip() or "0B",
             )
@@ -343,7 +344,9 @@ def render_markdown(report: ImageTelemetryReport) -> str:
         lines.extend(["", "## Warnings", ""])
         lines.extend(f"- {warning}" for warning in report.warnings)
 
-    lines.extend(["", "## Largest Layers", "", "| Size | Command |", "| --- | --- |"])
+    lines.extend(
+        ["", "## Largest Layers", "", "| Size | Command (redacted) |", "| --- | --- |"]
+    )
     for layer in report.largest_layers:
         command = layer.created_by.replace("|", "\\|")
         lines.append(f"| `{layer.size_human}` | `{command}` |")

--- a/scripts/ci/docker_image_telemetry.py
+++ b/scripts/ci/docker_image_telemetry.py
@@ -344,9 +344,7 @@ def render_markdown(report: ImageTelemetryReport) -> str:
         lines.extend(["", "## Warnings", ""])
         lines.extend(f"- {warning}" for warning in report.warnings)
 
-    lines.extend(
-        ["", "## Largest Layers", "", "| Size | Command (redacted) |", "| --- | --- |"]
-    )
+    lines.extend(["", "## Largest Layers", "", "| Size | Command (redacted) |", "| --- | --- |"])
     for layer in report.largest_layers:
         command = layer.created_by.replace("|", "\\|")
         lines.append(f"| `{layer.size_human}` | `{command}` |")

--- a/tests/test_docker_image_telemetry.py
+++ b/tests/test_docker_image_telemetry.py
@@ -113,9 +113,9 @@ def test_positive_int_rejects_non_positive_values(raw_value: str) -> None:
 def test_read_history_rows_redacts_created_by(monkeypatch: pytest.MonkeyPatch) -> None:
     import subprocess
 
-    stdout = '\n'.join(
+    stdout = "\n".join(
         [
-            '{"CreatedBy":"RUN pip install --index-url https://user:pass@example.com/simple","Size":"10MB"}',
+            '{"CreatedBy":"RUN --mount=type=secret,id=pip_index_url sh -c \\"pip install --index-url ${PULSEPLATE_PRIVATE_INDEX_URL}\\"","Size":"10MB"}',
             '{"CreatedBy":"RUN echo SAFE","Size":"5MB"}',
         ]
     )
@@ -134,9 +134,7 @@ def test_read_history_rows_redacts_created_by(monkeypatch: pytest.MonkeyPatch) -
     rows = docker_image_telemetry._read_history_rows("pulseplate:test")
 
     assert len(rows) == 2
-    assert all(
-        row.created_by == docker_image_telemetry.REDACTED_CREATED_BY for row in rows
-    )
+    assert all(row.created_by == docker_image_telemetry.REDACTED_CREATED_BY for row in rows)
     assert rows[0].size_bytes == 10_000_000
     assert rows[1].size_bytes == 5_000_000
 

--- a/tests/test_docker_image_telemetry.py
+++ b/tests/test_docker_image_telemetry.py
@@ -110,6 +110,37 @@ def test_positive_int_rejects_non_positive_values(raw_value: str) -> None:
         docker_image_telemetry._positive_int(raw_value)
 
 
+def test_read_history_rows_redacts_created_by(monkeypatch: pytest.MonkeyPatch) -> None:
+    import subprocess
+
+    stdout = '\n'.join(
+        [
+            '{"CreatedBy":"RUN pip install --index-url https://user:pass@example.com/simple","Size":"10MB"}',
+            '{"CreatedBy":"RUN echo SAFE","Size":"5MB"}',
+        ]
+    )
+
+    monkeypatch.setattr(
+        docker_image_telemetry,
+        "_run_docker",
+        lambda _args: subprocess.CompletedProcess(
+            args=["docker", "history"],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        ),
+    )
+
+    rows = docker_image_telemetry._read_history_rows("pulseplate:test")
+
+    assert len(rows) == 2
+    assert all(
+        row.created_by == docker_image_telemetry.REDACTED_CREATED_BY for row in rows
+    )
+    assert rows[0].size_bytes == 10_000_000
+    assert rows[1].size_bytes == 5_000_000
+
+
 def test_collect_telemetry_without_baseline_is_warning_only(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Scope
- redact Docker `history --no-trunc` command strings in telemetry without changing layer-size reporting
- remove credential-shaped fixture content that was tripping `detect-secrets` on PR `#1481`
- restore canonical review-governance artifacts for the existing PR lane

## Files
- `scripts/ci/docker_image_telemetry.py`
- `tests/test_docker_image_telemetry.py`
- `docs/review/PR_1481_FIXED_MAPPING.md`

## DoD
- `CreatedBy` telemetry remains fully redacted via `REDACTED_CREATED_BY`
- regression test still proves redaction and size parsing without embedding credential-shaped literals
- canonical review mapping artifact exists for PR `#1481`
- PR body mirrors the Phase2 artifact contract for the current branch head

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1481`
- `. .venv/bin/activate && pytest -q tests/test_docker_image_telemetry.py`
- `. .venv/bin/activate && pre-commit run --all-files`
- `make verify` reached the `diff-cov` coverage phase locally; merge-ready is not claimed until the canonical local gate and current-head GitHub checks both complete on the updated branch

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1481_FIXED_MAPPING.md`

## Merge Readiness
- Not claimed yet
- Current work is intended to clear the existing GitHub failures on `lint`, `PR Body Phase2 gates`, and `Merge readiness gate`
- Final merge-ready decision stays blocked on updated current-head CI plus the canonical local `make verify` outcome

## Deferred / Follow-ups
- none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Docker image telemetry reports now redact sensitive command information in the "Largest Layers" output. The command column label has been updated to "Command (redacted)" to reflect this change.

* **Tests**
  * Added comprehensive unit test coverage for the command redaction functionality in docker image telemetry reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->