### PR TITLE
feat(ai): add validated knowledge promotion seam

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -461,13 +461,13 @@
         "is_verified": false,
         "line_number": 104
       },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "d09f8c85f8e347671e7b4f4bc76b3341fa0727b9",
-        "is_verified": false,
-        "line_number": 111
-      },
+        {
+          "type": "Hex High Entropy String",
+          "filename": "scripts/ci/emergency_python_wheels.json",
+          "hashed_secret": "8dd39e27e184590c790cbecd95f65e0ceaf61b46",
+          "is_verified": false,
+          "line_number": 111
+        },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,16 @@ If adding rate-limit to endpoints, use thin **route wrappers**; do not change ca
 
 **Rationale:** WebSocket transport is long-lived and stateful; strict baseline rules prevent auth bypass and uncontrolled scope creep.
 
+**Knowledge promotion invariant (hard rule):**
+
+- RAG chunks are evidence artifacts, not canonical facts.
+- Knowledge promotion is allowed only from validated RAG evidence.
+- `prepare_insight_runtime(...)` is the canonical seam for runtime knowledge policy.
+- Route layer and `legacy_app.py` must never write or mutate knowledge records.
+- Request-local recursive caches are optimization helpers only and must never be treated as persistent knowledge.
+- Promotion must fail closed on degraded retrieval/orchestration reasons.
+- Semantic cache must not be widened or implied by knowledge-promotion work unless the dedicated semantic-cache gate explicitly opens.
+
 ---
 
 ## REQUIRED READING (before any change)

--- a/app/services/insight_application_service.py
+++ b/app/services/insight_application_service.py
@@ -6,6 +6,8 @@ EN: Application service for the /insight execution path.
 
 from __future__ import annotations
 
+import inspect
+import logging
 import os
 from collections.abc import Callable
 from typing import Any
@@ -22,10 +24,12 @@ from app.utils.feature_flags import (
     is_recursive_rag_enabled,
 )
 from core.ai.insight_runtime import InsightTransparencyNotice
+from core.knowledge.store import KnowledgeStore
 from core.insight.llm_provider_loader import LLMProvider
 from core.ai import prepare_insight_runtime
 
 INSIGHT_TEXT_MAX_LENGTH = 2000
+logger = logging.getLogger(__name__)
 
 
 def _ensure_insight_text_length(prompt_text: str) -> str:
@@ -56,6 +60,27 @@ def _resolve_effective_provider_name(
     return runtime_provider_name
 
 
+async def _maybe_promote_knowledge_candidates(
+    *,
+    knowledge_store: KnowledgeStore | None,
+    candidates: list[Any],
+) -> None:
+    """Best-effort promotion must never break the user response path."""
+
+    if knowledge_store is None or not candidates:
+        return
+
+    try:
+        promote_result = knowledge_store.promote(candidates)
+        if inspect.isawaitable(promote_result):
+            await promote_result
+    except Exception:
+        logger.warning(
+            "Knowledge promotion failed; response path continues without persistence",
+            exc_info=True,
+        )
+
+
 async def execute_insight_request(
     req: Any,
     *,
@@ -66,6 +91,7 @@ async def execute_insight_request(
     provider_loader: Callable[[], LLMProvider | None],
     transparency_loader: Callable[[], tuple[str, str] | InsightTransparencyNotice],
     direct_provider_factory: Callable[[], LLMProvider] | None = None,
+    knowledge_store: KnowledgeStore | None = None,
     response_factory: Callable[..., Any],
     source_item_factory: Callable[..., Any],
 ) -> Any:
@@ -100,9 +126,14 @@ async def execute_insight_request(
         philosophy_phase12_enabled=is_philosophy_phase12_enabled(),
         philosophy_linguistic_enabled=philosophy_linguistic_enabled,
         philosophy_pragmatic_enabled=is_philosophy_pragmatic_enabled(),
+        knowledge_policy=prepared_runtime.knowledge_policy,
         route_path=route_path,
         route_type=prepared_runtime.decision.route_type.value,
         user_tier=user_tier,
+    )
+    await _maybe_promote_knowledge_candidates(
+        knowledge_store=knowledge_store,
+        candidates=list(runtime_result.knowledge_candidates),
     )
     insight_text = runtime_result.insight[:INSIGHT_TEXT_MAX_LENGTH]
     source_items = [source_item_factory(**item) for item in runtime_result.source_dicts]

--- a/app/services/insight_application_service.py
+++ b/app/services/insight_application_service.py
@@ -25,6 +25,7 @@ from app.utils.feature_flags import (
     is_recursive_rag_enabled,
 )
 from core.ai.insight_runtime import InsightTransparencyNotice
+from core.knowledge.contracts import KnowledgeFactCandidate
 from core.knowledge.store import KnowledgeStore
 from core.insight.llm_provider_loader import LLMProvider
 from core.ai import prepare_insight_runtime
@@ -65,7 +66,7 @@ def _resolve_effective_provider_name(
 async def _maybe_promote_knowledge_candidates(
     *,
     knowledge_store: KnowledgeStore | None,
-    candidates: list[Any],
+    candidates: list[KnowledgeFactCandidate],
 ) -> None:
     """Best-effort promotion must never break the user response path."""
 
@@ -73,7 +74,12 @@ async def _maybe_promote_knowledge_candidates(
         return
 
     try:
-        promote_result = knowledge_store.promote(candidates)
+        # RU: Даже синхронный store должен идти вне response path и под тем же timeout.
+        # EN: Even sync stores must run off the response path and under the same timeout.
+        promote_result = await asyncio.wait_for(
+            asyncio.to_thread(knowledge_store.promote, candidates),
+            timeout=KNOWLEDGE_PROMOTION_TIMEOUT_SECONDS,
+        )
         if inspect.isawaitable(promote_result):
             await asyncio.wait_for(
                 promote_result,

--- a/app/services/insight_application_service.py
+++ b/app/services/insight_application_service.py
@@ -6,6 +6,7 @@ EN: Application service for the /insight execution path.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 import os
@@ -29,6 +30,7 @@ from core.insight.llm_provider_loader import LLMProvider
 from core.ai import prepare_insight_runtime
 
 INSIGHT_TEXT_MAX_LENGTH = 2000
+KNOWLEDGE_PROMOTION_TIMEOUT_SECONDS = 0.25
 logger = logging.getLogger(__name__)
 
 
@@ -73,7 +75,15 @@ async def _maybe_promote_knowledge_candidates(
     try:
         promote_result = knowledge_store.promote(candidates)
         if inspect.isawaitable(promote_result):
-            await promote_result
+            await asyncio.wait_for(
+                promote_result,
+                timeout=KNOWLEDGE_PROMOTION_TIMEOUT_SECONDS,
+            )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Knowledge promotion timed out; response path continues without persistence",
+            exc_info=True,
+        )
     except Exception:
         logger.warning(
             "Knowledge promotion failed; response path continues without persistence",

--- a/app/services/insight_runtime.py
+++ b/app/services/insight_runtime.py
@@ -93,6 +93,7 @@ async def _traced_retrieve_and_validate_rag(
     philo_validation_enabled: bool,
     recursive_rag_enabled: bool,
     subject_id: int | None,
+    knowledge_policy: Any,
     user_tier: str,
     route_path: str,
 ) -> Any:
@@ -112,6 +113,7 @@ async def _traced_retrieve_and_validate_rag(
             recursive_rag_enabled=recursive_rag_enabled,
             optimization_enabled=optimization_enabled,
             subject_id=subject_id,
+            knowledge_policy=knowledge_policy,
         )
         set_attributes(span, **{"pulseplate.rag.hops": rag_result.hops})
         return rag_result
@@ -131,6 +133,7 @@ async def generate_traced_insight(
     philosophy_phase12_enabled: bool,
     philosophy_linguistic_enabled: bool,
     philosophy_pragmatic_enabled: bool,
+    knowledge_policy: Any,
     route_path: str,
     route_type: str,
     user_tier: str,
@@ -150,6 +153,7 @@ async def generate_traced_insight(
         philo_validation_enabled: bool,
         recursive_rag_enabled: bool,
         subject_id: int | None,
+        knowledge_policy: Any = None,
     ) -> Any:
         return await _traced_retrieve_and_validate_rag(
             prompt_input,
@@ -157,6 +161,7 @@ async def generate_traced_insight(
             philo_validation_enabled=philo_validation_enabled,
             recursive_rag_enabled=recursive_rag_enabled,
             subject_id=subject_id,
+            knowledge_policy=knowledge_policy,
             user_tier=user_tier,
             route_path=route_path,
         )
@@ -180,6 +185,7 @@ async def generate_traced_insight(
             philosophy_phase12_enabled=philosophy_phase12_enabled,
             philosophy_linguistic_enabled=philosophy_linguistic_enabled,
             philosophy_pragmatic_enabled=philosophy_pragmatic_enabled,
+            knowledge_policy=knowledge_policy,
             rag_retriever=_rag_retriever,
         )
 

--- a/core/ai/__init__.py
+++ b/core/ai/__init__.py
@@ -7,6 +7,7 @@ EN: Canonical facade for the AI bounded context.
 from core.ai.insight_runtime import (
     DirectInsightProviderStub,
     InsightProviderLoadError,
+    KnowledgePolicy,
     InsightTransparencyNotice,
     InsightTransparencyUnavailableError,
     PreparedInsightRuntime,
@@ -18,6 +19,7 @@ from core.ai.insight_runtime import (
 __all__ = [
     "DirectInsightProviderStub",
     "InsightProviderLoadError",
+    "KnowledgePolicy",
     "InsightTransparencyNotice",
     "InsightTransparencyUnavailableError",
     "PreparedInsightRuntime",

--- a/core/ai/insight_runtime.py
+++ b/core/ai/insight_runtime.py
@@ -12,12 +12,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Mapping
 
+from core.knowledge.policy import KnowledgePolicy
 from core.insight.llm_provider_loader import (
     LLMProvider,
     LLMProviderFactory,
     load_llm_get_provider,
 )
-from core.insight.philosophical_runtime import PhilosophicalRuntime, RouteDecision
+from core.insight.philosophical_runtime import PhilosophicalRuntime, RouteDecision, RouteType
+from core.rag.contracts import RAGDegradedReason
 
 
 class InsightProviderLoadError(RuntimeError):
@@ -44,6 +46,7 @@ class PreparedInsightRuntime:
     decision: RouteDecision
     provider: LLMProvider
     transparency_notice: InsightTransparencyNotice
+    knowledge_policy: KnowledgePolicy
 
 
 class DirectInsightProviderStub:
@@ -177,9 +180,29 @@ def prepare_insight_runtime(
         provider_factory = direct_provider_factory or DirectInsightProviderStub
         provider = provider_factory()
 
+    knowledge_policy = _build_default_knowledge_policy(decision=decision)
+
     return PreparedInsightRuntime(
         runtime=runtime,
         decision=decision,
         provider=provider,
         transparency_notice=transparency_notice,
+        knowledge_policy=knowledge_policy,
+    )
+
+
+def _build_default_knowledge_policy(*, decision: RouteDecision) -> KnowledgePolicy:
+    """Build the canonical runtime knowledge policy from the route decision."""
+
+    route_type_value = getattr(decision.route_type, "value", decision.route_type)
+    allow_knowledge = route_type_value == RouteType.RAG_FACTUAL.value
+    return KnowledgePolicy(
+        enabled=allow_knowledge,
+        allow_reads=allow_knowledge,
+        allow_promotion=allow_knowledge,
+        min_confidence=0.7,
+        require_rag_factual_route=True,
+        deny_degraded_reasons=tuple(reason.value for reason in RAGDegradedReason),
+        subject_scope_required=True,
+        rail="product_ai_runtime",
     )

--- a/core/insight/philosophical_runtime.py
+++ b/core/insight/philosophical_runtime.py
@@ -11,7 +11,6 @@ import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from functools import lru_cache
 from typing import Protocol, cast
 
 from core.knowledge.contracts import KnowledgeFactCandidate
@@ -83,9 +82,8 @@ _SAFE_WELLNESS_DISCLAIMER = {
 }
 
 
-@lru_cache(maxsize=None)
 def _retriever_accepts_knowledge_policy(retrieve_rag: Callable[..., object]) -> bool:
-    """Cache whether the retriever accepts the canonical knowledge-policy kwarg."""
+    """Return whether the retriever accepts the canonical knowledge-policy kwarg."""
 
     try:
         parameters = inspect.signature(retrieve_rag).parameters.values()

--- a/core/insight/philosophical_runtime.py
+++ b/core/insight/philosophical_runtime.py
@@ -11,6 +11,7 @@ import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
+from functools import lru_cache
 from typing import Protocol, cast
 
 from core.knowledge.contracts import KnowledgeFactCandidate
@@ -80,6 +81,22 @@ _SAFE_WELLNESS_DISCLAIMER = {
         "Si tienes síntomas o preocupación por alguna condición, consulta con un profesional sanitario autorizado."
     ),
 }
+
+
+@lru_cache(maxsize=None)
+def _retriever_accepts_knowledge_policy(retrieve_rag: Callable[..., object]) -> bool:
+    """Cache whether the retriever accepts the canonical knowledge-policy kwarg."""
+
+    try:
+        parameters = inspect.signature(retrieve_rag).parameters.values()
+    except (TypeError, ValueError):
+        return True
+
+    return any(
+        parameter.name == "knowledge_policy" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
+
 
 _CONSERVATIVE_FALLBACK_MESSAGES = {
     "en": (
@@ -558,7 +575,7 @@ class PhilosophicalRuntime:
             "recursive_rag_enabled": recursive_rag_enabled,
             "subject_id": subject_id,
         }
-        if "knowledge_policy" in inspect.signature(retrieve_rag).parameters:
+        if _retriever_accepts_knowledge_policy(retrieve_rag):
             kwargs["knowledge_policy"] = knowledge_policy
         return await retrieve_rag(prompt_input, **kwargs)
 
@@ -572,11 +589,14 @@ class PhilosophicalRuntime:
     ) -> list[KnowledgeFactCandidate]:
         """Trust promotion candidates only from the canonical validated RAG path."""
 
-        if decision.route_type != RouteType.RAG_FACTUAL:
-            return []
         if not philo_validation_enabled:
             return []
         if knowledge_policy is None or not knowledge_policy.enabled:
+            return []
+        if (
+            knowledge_policy.require_rag_factual_route
+            and decision.route_type != RouteType.RAG_FACTUAL
+        ):
             return []
         if not knowledge_policy.allow_promotion:
             return []

--- a/core/insight/philosophical_runtime.py
+++ b/core/insight/philosophical_runtime.py
@@ -6,12 +6,15 @@ EN: Runtime chooses a cheaper/faster/more reliable answer path before LLM calls.
 
 from __future__ import annotations
 
+import inspect
 import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Protocol, cast
 
+from core.knowledge.contracts import KnowledgeFactCandidate
+from core.knowledge.policy import KnowledgePolicy
 from core.bmi.query import extract_bmi_inputs, render_bmi_query_answer
 from core.insight.analytical import (
     AnalyticalSyntheticClassifier,
@@ -165,6 +168,7 @@ class RuntimeResult:
     hops: int = 0
     latency_ms: int = 0
     metadata: RuntimeMetadata = field(default_factory=RuntimeMetadata)
+    knowledge_candidates: list[KnowledgeFactCandidate] = field(default_factory=list)
 
 
 class PhilosophicalQueryRouter:
@@ -346,6 +350,7 @@ class PhilosophicalRuntime:
         philosophy_phase12_enabled: bool,
         philosophy_linguistic_enabled: bool,
         philosophy_pragmatic_enabled: bool,
+        knowledge_policy: KnowledgePolicy | None = None,
         rag_retriever: _RagRetriever | None = None,
     ) -> RuntimeResult:
         """Generate an insight with deterministic routing and validation."""
@@ -401,12 +406,13 @@ class PhilosophicalRuntime:
 
         if use_rag and decision.needs_rag:
             retrieve_rag = rag_retriever or rag_orchestration.retrieve_and_validate_rag
-            rag_result = await retrieve_rag(
-                prompt_input,
-                max_chunks=3,
+            rag_result = await self._retrieve_rag_result(
+                retrieve_rag=retrieve_rag,
+                prompt_input=prompt_input,
                 philo_validation_enabled=philo_validation_enabled,
                 recursive_rag_enabled=recursive_rag_enabled,
                 subject_id=subject_id,
+                knowledge_policy=knowledge_policy,
             )
             prompt_input = rag_result.formatted_prompt
             confidence = rag_result.confidence
@@ -522,7 +528,66 @@ class PhilosophicalRuntime:
                 if public_metadata_enabled
                 else RuntimeMetadata()
             ),
+            knowledge_candidates=(
+                self._resolve_runtime_knowledge_candidates(
+                    decision=decision,
+                    rag_result=rag_result,
+                    philo_validation_enabled=philo_validation_enabled,
+                    knowledge_policy=knowledge_policy,
+                )
+                if use_rag and decision.needs_rag
+                else []
+            ),
         )
+
+    async def _retrieve_rag_result(
+        self,
+        *,
+        retrieve_rag: _RagRetriever,
+        prompt_input: str,
+        philo_validation_enabled: bool,
+        recursive_rag_enabled: bool,
+        subject_id: int | None,
+        knowledge_policy: KnowledgePolicy | None,
+    ) -> RAGOrchestrationResult:
+        """Call the retriever while keeping backward compatibility for test seams."""
+
+        kwargs: dict[str, object] = {
+            "max_chunks": 3,
+            "philo_validation_enabled": philo_validation_enabled,
+            "recursive_rag_enabled": recursive_rag_enabled,
+            "subject_id": subject_id,
+        }
+        if "knowledge_policy" in inspect.signature(retrieve_rag).parameters:
+            kwargs["knowledge_policy"] = knowledge_policy
+        return await retrieve_rag(prompt_input, **kwargs)
+
+    def _resolve_runtime_knowledge_candidates(
+        self,
+        *,
+        decision: RouteDecision,
+        rag_result: RAGOrchestrationResult,
+        philo_validation_enabled: bool,
+        knowledge_policy: KnowledgePolicy | None,
+    ) -> list[KnowledgeFactCandidate]:
+        """Trust promotion candidates only from the canonical validated RAG path."""
+
+        if decision.route_type != RouteType.RAG_FACTUAL:
+            return []
+        if not philo_validation_enabled:
+            return []
+        if knowledge_policy is None or not knowledge_policy.enabled:
+            return []
+        if not knowledge_policy.allow_promotion:
+            return []
+        if not getattr(rag_result, "rag_actually_used", False):
+            return []
+        if getattr(rag_result, "degraded_reason", None) is not None:
+            return []
+        if not getattr(rag_result, "knowledge_candidates_canonical", False):
+            return []
+
+        return list(getattr(rag_result, "knowledge_candidates", []))
 
     def _build_prompt(
         self,

--- a/core/knowledge/__init__.py
+++ b/core/knowledge/__init__.py
@@ -1,0 +1,24 @@
+"""Knowledge bounded-context exports.
+
+RU: Экспорт внутреннего bounded-context для knowledge promotion.
+EN: Internal bounded-context exports for knowledge promotion.
+"""
+
+from core.knowledge.contracts import (
+    KnowledgeEvidenceRef,
+    KnowledgeFactCandidate,
+    KnowledgeRecord,
+)
+from core.knowledge.policy import KnowledgePolicy
+from core.knowledge.promotion import build_knowledge_promotion_candidates
+from core.knowledge.store import KnowledgeStore, NoOpKnowledgeStore
+
+__all__ = [
+    "KnowledgeEvidenceRef",
+    "KnowledgeFactCandidate",
+    "KnowledgePolicy",
+    "KnowledgeRecord",
+    "KnowledgeStore",
+    "NoOpKnowledgeStore",
+    "build_knowledge_promotion_candidates",
+]

--- a/core/knowledge/contracts.py
+++ b/core/knowledge/contracts.py
@@ -1,0 +1,55 @@
+"""Canonical internal contracts for knowledge promotion.
+
+RU: Канонические внутренние контракты для knowledge promotion.
+EN: Canonical internal contracts for knowledge promotion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+@dataclass(frozen=True)
+class KnowledgeEvidenceRef:
+    """Reference to validated retrieval evidence used for promotion."""
+
+    chunk_id: str
+    file: str
+    score: float
+    hop: int
+
+
+@dataclass(frozen=True)
+class KnowledgeFactCandidate:
+    """Internal fact candidate derived from validated RAG evidence only."""
+
+    fact_key: str
+    subject: str
+    predicate: str
+    value: str
+    observed_at: datetime
+    confidence: float
+    access_scope: str
+    rail: str
+    provenance: tuple[KnowledgeEvidenceRef, ...]
+    supersedes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class KnowledgeRecord:
+    """Persistable internal record produced by the knowledge store seam."""
+
+    fact_key: str
+    subject: str
+    predicate: str
+    value: str
+    status: str
+    confidence: float
+    access_scope: str
+    rail: str
+    provenance: tuple[KnowledgeEvidenceRef, ...]
+    observed_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc),
+    )
+    superseded_by: str | None = None

--- a/core/knowledge/policy.py
+++ b/core/knowledge/policy.py
@@ -1,0 +1,23 @@
+"""Knowledge promotion policy types.
+
+RU: Типы policy для bounded knowledge promotion.
+EN: Policy types for bounded knowledge promotion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class KnowledgePolicy:
+    """Deterministic runtime policy for internal knowledge access/promotion."""
+
+    enabled: bool
+    allow_reads: bool
+    allow_promotion: bool
+    min_confidence: float
+    require_rag_factual_route: bool
+    deny_degraded_reasons: tuple[str, ...]
+    subject_scope_required: bool
+    rail: str

--- a/core/knowledge/promotion.py
+++ b/core/knowledge/promotion.py
@@ -1,0 +1,174 @@
+"""Promotion helpers for validated RAG evidence.
+
+RU: Хелперы promotion только из validated RAG evidence.
+EN: Promotion helpers only from validated RAG evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+import hashlib
+
+from core.knowledge.contracts import (
+    KnowledgeEvidenceRef,
+    KnowledgeFactCandidate,
+    KnowledgeRecord,
+)
+from core.knowledge.policy import KnowledgePolicy
+from core.rag.contracts import RAGChunk
+
+
+def build_knowledge_promotion_candidates(
+    *,
+    chunks: list[RAGChunk],
+    confidence: float | None,
+    degraded_reason: str | None,
+    subject_id: int | None,
+    knowledge_policy: KnowledgePolicy,
+) -> list[KnowledgeFactCandidate]:
+    """Return deterministic candidates from validated chunks or fail closed."""
+
+    if not knowledge_policy.enabled or not knowledge_policy.allow_promotion:
+        return []
+    if not chunks:
+        return []
+    if degraded_reason is not None and degraded_reason in knowledge_policy.deny_degraded_reasons:
+        return []
+    if confidence is None or confidence < knowledge_policy.min_confidence:
+        return []
+    if knowledge_policy.subject_scope_required and subject_id is None:
+        return []
+
+    access_scope = _resolve_access_scope(subject_id=subject_id)
+    observed_at = datetime.now(timezone.utc)
+    candidates: list[KnowledgeFactCandidate] = []
+    for chunk in chunks:
+        if not chunk.content.strip():
+            continue
+        source = chunk.file.strip() or "unknown_source"
+        evidence_ref = KnowledgeEvidenceRef(
+            chunk_id=chunk.chunk_id,
+            file=source,
+            score=chunk.score,
+            hop=chunk.hop,
+        )
+        # RU: canonical candidate stores an evidence envelope, not raw chunk text.
+        # EN: canonical candidate stores an evidence envelope, not raw chunk text.
+        subject = access_scope
+        predicate = f"validated_rag_evidence:{source}:{chunk.chunk_id}"
+        value = _build_evidence_value(chunk=chunk, source=source)
+        fact_key = _build_fact_key(
+            subject=subject,
+            predicate=predicate,
+            value=value,
+            access_scope=access_scope,
+            rail=knowledge_policy.rail,
+        )
+        candidates.append(
+            KnowledgeFactCandidate(
+                fact_key=fact_key,
+                subject=subject,
+                predicate=predicate,
+                value=value,
+                observed_at=observed_at,
+                confidence=confidence,
+                access_scope=access_scope,
+                rail=knowledge_policy.rail,
+                provenance=(evidence_ref,),
+            )
+        )
+    return candidates
+
+
+def candidate_should_supersede(
+    *,
+    existing: KnowledgeRecord,
+    candidate: KnowledgeFactCandidate,
+) -> bool:
+    """Return whether a candidate should supersede an existing active record."""
+
+    if not _shares_supersession_scope(existing=existing, candidate=candidate):
+        return False
+    if existing.fact_key not in candidate.supersedes:
+        return False
+    if candidate.confidence > existing.confidence:
+        return True
+    if (
+        candidate.confidence == existing.confidence
+        and candidate.observed_at > existing.observed_at
+        and bool(candidate.supersedes)
+    ):
+        return True
+    return False
+
+
+def candidate_to_record(candidate: KnowledgeFactCandidate) -> KnowledgeRecord:
+    """Convert a candidate into an active knowledge record."""
+
+    return KnowledgeRecord(
+        fact_key=candidate.fact_key,
+        subject=candidate.subject,
+        predicate=candidate.predicate,
+        value=candidate.value,
+        status="active",
+        confidence=candidate.confidence,
+        access_scope=candidate.access_scope,
+        rail=candidate.rail,
+        provenance=candidate.provenance,
+        observed_at=candidate.observed_at,
+    )
+
+
+def mark_record_superseded(
+    *,
+    record: KnowledgeRecord,
+    superseded_by: str,
+) -> KnowledgeRecord:
+    """Return a superseded copy of an existing record."""
+
+    return replace(record, status="superseded", superseded_by=superseded_by)
+
+
+def _build_fact_key(
+    *,
+    subject: str,
+    predicate: str,
+    value: str,
+    access_scope: str,
+    rail: str,
+) -> str:
+    """Build a deterministic fact key from the canonical promotion scope."""
+
+    digest = hashlib.sha256(
+        f"{subject}|{predicate}|{value}|{access_scope}|{rail}".encode("utf-8")
+    ).hexdigest()
+    return digest[:24]
+
+
+def _resolve_access_scope(*, subject_id: int | None) -> str:
+    """Resolve deterministic access scope for the candidate."""
+
+    return "subject:none" if subject_id is None else f"subject:{subject_id}"
+
+
+def _shares_supersession_scope(
+    *,
+    existing: KnowledgeRecord,
+    candidate: KnowledgeFactCandidate,
+) -> bool:
+    """Return whether record and candidate belong to the same logical fact scope."""
+
+    return (
+        existing.subject == candidate.subject
+        and existing.predicate == candidate.predicate
+        and existing.access_scope == candidate.access_scope
+        and existing.rail == candidate.rail
+    )
+
+
+def _build_evidence_value(*, chunk: RAGChunk, source: str) -> str:
+    """Build deterministic evidence envelope value without storing raw chunk text."""
+
+    digest = hashlib.sha256(chunk.content.strip().encode("utf-8")).hexdigest()[:16]
+    return f"chunk={chunk.chunk_id};source={source};digest={digest};hop={chunk.hop}"

--- a/core/knowledge/store.py
+++ b/core/knowledge/store.py
@@ -1,0 +1,143 @@
+"""Store seam for bounded internal knowledge records.
+
+RU: Store seam для bounded knowledge records без DB rollout.
+EN: Store seam for bounded knowledge records without DB rollout.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from collections.abc import Iterable
+from typing import Protocol
+
+from core.knowledge.contracts import KnowledgeFactCandidate, KnowledgeRecord
+from core.knowledge.promotion import (
+    candidate_should_supersede,
+    candidate_to_record,
+    mark_record_superseded,
+)
+
+KnowledgePromoteResult = list[KnowledgeRecord] | Awaitable[list[KnowledgeRecord]]
+
+
+class KnowledgeStore(Protocol):
+    """Protocol for internal knowledge promotion and lookup."""
+
+    def promote(self, candidates: list[KnowledgeFactCandidate]) -> KnowledgePromoteResult:
+        """Promote candidates into active records."""
+
+    def read(
+        self,
+        *,
+        subject: str,
+        predicate: str,
+        access_scope: str,
+        rail: str,
+    ) -> list[KnowledgeRecord]:
+        """Return matching active records for the logical fact scope."""
+
+
+class NoOpKnowledgeStore:
+    """Store implementation that refuses persistence and returns no records."""
+
+    def promote(self, candidates: list[KnowledgeFactCandidate]) -> list[KnowledgeRecord]:
+        del candidates
+        return []
+
+    def read(
+        self,
+        *,
+        subject: str,
+        predicate: str,
+        access_scope: str,
+        rail: str,
+    ) -> list[KnowledgeRecord]:
+        del subject, predicate, access_scope, rail
+        return []
+
+
+class InMemoryKnowledgeStore:
+    """Deterministic in-memory store for bounded tests and local seams."""
+
+    def __init__(self) -> None:
+        self._records: list[KnowledgeRecord] = []
+
+    def promote(self, candidates: list[KnowledgeFactCandidate]) -> list[KnowledgeRecord]:
+        promoted: list[KnowledgeRecord] = []
+        for candidate in candidates:
+            active_records = self.read(
+                subject=candidate.subject,
+                predicate=candidate.predicate,
+                access_scope=candidate.access_scope,
+                rail=candidate.rail,
+            )
+            if _candidate_replays_existing(active_records=active_records, candidate=candidate):
+                continue
+            if not active_records:
+                record = candidate_to_record(candidate)
+                self._records.append(record)
+                promoted.append(record)
+                continue
+
+            if not _candidate_beats_all_active(active_records=active_records, candidate=candidate):
+                continue
+
+            updated_records: list[KnowledgeRecord] = []
+            for record in self._records:
+                if record in active_records:
+                    updated_records.append(
+                        mark_record_superseded(record=record, superseded_by=candidate.fact_key)
+                    )
+                else:
+                    updated_records.append(record)
+            record = candidate_to_record(candidate)
+            updated_records.append(record)
+            self._records = updated_records
+            promoted.append(record)
+        return promoted
+
+    def read(
+        self,
+        *,
+        subject: str,
+        predicate: str,
+        access_scope: str,
+        rail: str,
+    ) -> list[KnowledgeRecord]:
+        return [
+            record
+            for record in self._records
+            if record.status == "active"
+            and record.subject == subject
+            and record.predicate == predicate
+            and record.access_scope == access_scope
+            and record.rail == rail
+        ]
+
+
+def _candidate_beats_all_active(
+    *,
+    active_records: Iterable[KnowledgeRecord],
+    candidate: KnowledgeFactCandidate,
+) -> bool:
+    """Return whether the candidate supersedes every active record in scope."""
+
+    return all(
+        candidate_should_supersede(existing=record, candidate=candidate)
+        for record in active_records
+    )
+
+
+def _candidate_replays_existing(
+    *,
+    active_records: Iterable[KnowledgeRecord],
+    candidate: KnowledgeFactCandidate,
+) -> bool:
+    """Return whether candidate is an idempotent replay of active evidence."""
+
+    return any(
+        record.fact_key == candidate.fact_key
+        and record.value == candidate.value
+        and record.provenance == candidate.provenance
+        for record in active_records
+    )

--- a/core/knowledge/store.py
+++ b/core/knowledge/store.py
@@ -96,6 +96,11 @@ class InMemoryKnowledgeStore:
             promoted.append(record)
         return promoted
 
+    def all_records(self) -> list[KnowledgeRecord]:
+        """Return a snapshot for tests without exposing the live internal list."""
+
+        return list(self._records)
+
     def read(
         self,
         *,

--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -446,10 +446,11 @@ def _build_knowledge_candidates(
 
     from core.knowledge.promotion import build_knowledge_promotion_candidates
 
-    return build_knowledge_promotion_candidates(
+    candidates: list["KnowledgeFactCandidate"] = build_knowledge_promotion_candidates(
         chunks=chunks_to_use,
         confidence=confidence,
         degraded_reason=None if degraded_reason is None else degraded_reason.value,
         subject_id=subject_id,
         knowledge_policy=knowledge_policy,
     )
+    return candidates

--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional, SupportsFloat, cast
 
 if TYPE_CHECKING:
+    from core.knowledge.contracts import KnowledgeFactCandidate
+    from core.knowledge.policy import KnowledgePolicy
     from core.rag.contracts import RAGChunk
 
 from core.rag.contracts import RAGContext, RAGDegradedReason
@@ -60,6 +62,12 @@ class RAGOrchestrationResult:
 
     degraded_reason: RAGDegradedReason | None = None
     """Deterministic internal degraded-path reason (not part of public API)."""
+
+    knowledge_candidates: list["KnowledgeFactCandidate"] = field(default_factory=list)
+    """Internal-only promotion candidates derived from validated evidence."""
+
+    knowledge_candidates_canonical: bool = False
+    """True only when candidates come from the canonical validated orchestration path."""
 
 
 def _empty_result(
@@ -167,6 +175,7 @@ async def retrieve_and_validate_rag(
     recursive_rag_enabled: bool = False,
     optimization_enabled: bool = False,
     subject_id: int | None = None,
+    knowledge_policy: "KnowledgePolicy | None" = None,
 ) -> RAGOrchestrationResult:
     """Orchestrate RAG retrieval + philosophy validation.
 
@@ -211,6 +220,7 @@ async def retrieve_and_validate_rag(
         recursive_rag_enabled,
         optimization_enabled,
         subject_id,
+        knowledge_policy,
     )
 
 
@@ -221,6 +231,7 @@ async def _run_orchestration(
     recursive_enabled: bool,
     optimization_enabled: bool,
     subject_id: int | None,
+    knowledge_policy: "KnowledgePolicy | None",
 ) -> RAGOrchestrationResult:
     """Execute RAG retrieval + validation pipeline."""
     recursive_executed = False
@@ -278,6 +289,8 @@ async def _run_orchestration(
             )
 
         chunks_to_use = rag_ctx.chunks
+        knowledge_candidates: list["KnowledgeFactCandidate"] = []
+        knowledge_candidates_canonical = False
 
         if philo_enabled:
             from core.rag.philosophy_pipeline import run_pipeline
@@ -286,6 +299,7 @@ async def _run_orchestration(
             chunks_to_use = pipeline_result.filtered_chunks
             chunks_filtered = len(rag_ctx.chunks) - len(pipeline_result.filtered_chunks)
             warnings = pipeline_result.warnings
+            knowledge_candidates_canonical = True
 
             for w in warnings:
                 logger.debug("rag_pipeline: %s", w)
@@ -306,6 +320,14 @@ async def _run_orchestration(
         confidence = _resolve_confidence(
             chunks_to_use=chunks_to_use,
         )
+        if knowledge_candidates_canonical:
+            knowledge_candidates = _build_knowledge_candidates(
+                chunks_to_use=chunks_to_use,
+                confidence=confidence,
+                degraded_reason=getattr(rag_ctx, "degraded_reason", None),
+                subject_id=subject_id,
+                knowledge_policy=knowledge_policy,
+            )
 
         # Build formatted prompt with RAG context
         from core.insight.safety import redact_rag_context_for_insight
@@ -370,6 +392,8 @@ async def _run_orchestration(
             chunks_filtered=chunks_filtered,
             recursive_executed=recursive_executed,
             degraded_reason=getattr(rag_ctx, "degraded_reason", None),
+            knowledge_candidates=knowledge_candidates,
+            knowledge_candidates_canonical=knowledge_candidates_canonical,
         )
     except Exception:
         logger.warning(
@@ -403,3 +427,27 @@ def _build_prompt_with_context(text: str, context: Optional[str]) -> str:
     if not context:
         return text
     return f"Context:\n{context}\n\nQuestion: {text}\nAnswer:"
+
+
+def _build_knowledge_candidates(
+    *,
+    chunks_to_use: list["RAGChunk"],
+    confidence: float | None,
+    degraded_reason: RAGDegradedReason | None,
+    subject_id: int | None,
+    knowledge_policy: "KnowledgePolicy | None",
+) -> list["KnowledgeFactCandidate"]:
+    """Build internal knowledge candidates from validated evidence or fail closed."""
+
+    if knowledge_policy is None:
+        return []
+
+    from core.knowledge.promotion import build_knowledge_promotion_candidates
+
+    return build_knowledge_promotion_candidates(
+        chunks=chunks_to_use,
+        confidence=confidence,
+        degraded_reason=None if degraded_reason is None else degraded_reason.value,
+        subject_id=subject_id,
+        knowledge_policy=knowledge_policy,
+    )

--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -299,7 +299,9 @@ async def _run_orchestration(
             chunks_to_use = pipeline_result.filtered_chunks
             chunks_filtered = len(rag_ctx.chunks) - len(pipeline_result.filtered_chunks)
             warnings = pipeline_result.warnings
-            knowledge_candidates_canonical = True
+            knowledge_candidates_canonical = (
+                not recursive_executed and getattr(rag_ctx, "degraded_reason", None) is None
+            )
 
             for w in warnings:
                 logger.debug("rag_pipeline: %s", w)

--- a/core/rag/vector_rag.py
+++ b/core/rag/vector_rag.py
@@ -166,6 +166,34 @@ def _normalize_similarity(value: object) -> float | None:
     return numeric
 
 
+def _build_sqlalchemy_vector_type(dimensions: int) -> Any:
+    """Return pgvector SQLAlchemy type or a SQL-rendering fallback.
+
+    RU: В verify/test-окружении Python-пакет `pgvector` может отсутствовать,
+    но Postgres SQL path всё равно должен быть построим и проверяем.
+    EN: In verify/test environments the `pgvector` Python package may be absent,
+    but the Postgres SQL path must still be constructible and testable.
+    """
+
+    try:
+        from pgvector.sqlalchemy import VECTOR
+
+        return VECTOR(dimensions)
+    except ModuleNotFoundError:
+        from sqlalchemy.types import UserDefinedType
+
+        class _FallbackVector(UserDefinedType):
+            cache_ok = True
+
+            def __init__(self, size: int | None = None) -> None:
+                self._size = dimensions if size is None else size
+
+            def get_col_spec(self, **_kwargs: Any) -> str:
+                return f"VECTOR({self._size})"
+
+        return _FallbackVector(dimensions)
+
+
 # ---------------------------------------------------------------------------
 # Vector retrieval (dialect-aware)
 # ---------------------------------------------------------------------------
@@ -183,12 +211,11 @@ def _retrieve_vector_postgres(
     If corpus_prefixes is provided, filters results to rows where source
     starts with one of the given prefixes (agent-specific corpus filtering).
     """
-    from pgvector.sqlalchemy import VECTOR
     from sqlalchemy import BigInteger, Integer, String, bindparam, cast, or_, select
 
     user_knowledge = _user_knowledge_table()
 
-    vector_type = VECTOR(EMBEDDING_DIMENSIONS)
+    vector_type = _build_sqlalchemy_vector_type(EMBEDDING_DIMENSIONS)
     qvec_param = bindparam("qvec", type_=vector_type)
     qvec_vector = cast(qvec_param, vector_type)
     limit_param = bindparam("lim", type_=Integer())

--- a/docs/orchestration/WAVE6_K1_DOD_2026-04-19.md
+++ b/docs/orchestration/WAVE6_K1_DOD_2026-04-19.md
@@ -1,0 +1,44 @@
+# WAVE6 K1 Definition of Done
+
+## Definition of Done
+
+**PR:** `PR-K1`
+
+**Task:** Post-A5 bounded runtime slice for knowledge contracts and promotion from validated RAG evidence.
+
+### Scope
+
+- [x] Scope respected as internal runtime/core work only
+- [x] No route/public schema/DB/semantic-cache creep
+
+### Code Quality
+
+See canonical Quality Gates: `RUNBOOK_AGENT.md` (Quality Gates section)
+
+- [ ] Quality gates pass (pending final validation run)
+- [x] No dead code added intentionally
+
+### Documentation
+
+- [x] `AGENTS.md` updated
+- [ ] `RUNBOOK_AGENT.md` updated (not needed for this slice)
+- [x] Module-specific packet/orchestration docs updated
+- [x] `BACKLOG_LEDGER.md` updated
+
+### Process
+
+- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
+- [ ] CI green (if applicable)
+- [ ] PR description complete (outside local worktree scope for now)
+
+### Security & Architecture
+
+- [ ] No architectural violations (final check pending)
+- [ ] No security issues (final check pending)
+- [x] Layer boundaries respected
+- [x] Invariants maintained
+
+---
+
+**Verified by:** agent-coordinator
+**Date:** 2026-04-19

--- a/docs/orchestration/WAVE6_K1_KNOWLEDGE_PROMOTION_PACKET_2026-04-19.md
+++ b/docs/orchestration/WAVE6_K1_KNOWLEDGE_PROMOTION_PACKET_2026-04-19.md
@@ -1,0 +1,130 @@
+# Wave 6 K1 Knowledge Promotion Packet
+
+**Date:** 19 April 2026
+**Scope:** bounded post-A5 runtime follow-up for internal knowledge contracts
+**Mode:** implementation packet
+
+## Purpose
+
+Freeze one narrow post-A5 runtime slice that introduces first-class internal
+knowledge contracts and promotion rules **without** widening into semantic
+cache, persistent storage, or HTTP/public-contract work.
+
+This packet exists to:
+
+- add a bounded `core/knowledge/*` subdomain;
+- treat RAG chunks as evidence artifacts, not canonical facts;
+- allow promotion only from validated RAG evidence that survives orchestration;
+- keep route/service layers thin and keep semantic cache deferred.
+
+## Current-head truth
+
+- `core/ai/insight_runtime.py` already owns the canonical non-HTTP runtime
+  preparation seam.
+- `core/rag/orchestration.py` already computes deterministic retrieval
+  diagnostics and degraded reasons.
+- `core/insight/philosophical_runtime.py` already receives raw
+  `RAGOrchestrationResult` and turns it into internal runtime metadata without
+  public DTO drift.
+- `app/services/insight_application_service.py` is already a thin handoff layer
+  and must stay that way.
+
+## Hard boundaries
+
+- No `legacy_app.py` edits
+- No `app/routers/*` edits
+- No OpenAPI or public response contract changes
+- No DB migrations or Postgres table rollout
+- No Redis / GPTCache / semantic-cache implementation
+- No route-layer or raw-provider promotion logic
+- No widening into advisory/wiki/plugin control-plane rails
+
+## Canonical implementation surfaces
+
+### New internal subdomain
+
+- `core/knowledge/__init__.py`
+- `core/knowledge/contracts.py`
+- `core/knowledge/policy.py`
+- `core/knowledge/promotion.py`
+- `core/knowledge/store.py`
+
+### Existing seams allowed to change
+
+- `core/ai/insight_runtime.py`
+- `core/rag/orchestration.py`
+- `core/insight/philosophical_runtime.py`
+- `app/services/insight_runtime.py`
+- `app/services/insight_application_service.py`
+
+Reason:
+
+- `app/services/insight_runtime.py` remains an allowed thin tracing seam only,
+  used to thread `knowledge_policy` into the existing traced runtime handoff
+  without moving promotion logic into routes or `legacy_app.py`.
+
+## Required invariants
+
+- RAG chunks remain evidence artifacts only.
+- Knowledge promotion is allowed only from validated RAG evidence.
+- Promotion must fail closed on degraded retrieval/orchestration reasons.
+- `prepare_insight_runtime(...)` is the canonical seam for runtime knowledge
+  policy.
+- Request-local recursive caches are optimization helpers only and must never be
+  treated as persistent knowledge.
+- `DEEP_REASONING` is promotion-denied by default.
+- Access scope must be at least as strict as the current tenant/subject
+  isolation model.
+
+## Required role-agent order for this lane
+
+1. `agent-coordinator`
+2. `architecture-specialist`
+3. `data-scientist-agent`
+4. `backend-engineer`
+5. `security-auditor`
+6. `qa-engineer-agent`
+7. `bug-hunter`
+
+Rules:
+
+- every assigned role agent must be used in this order;
+- no assigned role agent may be skipped without an explicit packet update;
+- the canonical post-open `qa-engineer-agent -> bug-hunter` pass remains
+  mandatory.
+
+## Execution evidence
+
+- `docs/orchestration/WAVE6_K1_TASK_ANALYSIS_2026-04-19.md`
+- `docs/orchestration/WAVE6_K1_WORK_REVIEW_2026-04-19.md`
+- `docs/orchestration/WAVE6_K1_SYNTHESIS_2026-04-19.md`
+- `docs/orchestration/WAVE6_K1_DOD_2026-04-19.md`
+
+## Deliverables
+
+- bounded `core/knowledge/*` contracts/policy/promotion/store seam
+- `PreparedInsightRuntime.knowledge_policy`
+- internal-only runtime handoff for promotion candidates
+- deterministic tests for promotion allow/deny and supersession behavior
+- root invariant wording updated without redefining semantic-cache gate
+
+## Validation
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- targeted pytest for knowledge/runtime/orchestration paths
+- `pre-commit run --all-files`
+- `make verify`
+
+## Explicit semantic-cache boundary
+
+K1 is **not** semantic cache.
+
+Semantic cache remains governed by:
+
+- `docs/roadmap/PulsePlate_Semantic_Cache_Gate_and_Plan.md`
+
+Hard rule:
+
+- do not widen K1 into semantic-cache records, cache hit logic, Redis/GPTCache,
+  or observability for semantic-cache precision/false-hit tracking.

--- a/docs/orchestration/WAVE6_K1_SYNTHESIS_2026-04-19.md
+++ b/docs/orchestration/WAVE6_K1_SYNTHESIS_2026-04-19.md
@@ -1,0 +1,30 @@
+# WAVE6 K1 Synthesis
+
+## Synthesis
+
+**Task:** Implement `PR-K1` as a bounded post-A5 runtime slice for knowledge contracts and promotion from validated RAG evidence.
+
+**Final Decision:**
+K1 proceeds as a bounded internal runtime seam: `core/knowledge/*`, `core/ai/insight_runtime.py`, `core/rag/orchestration.py`, `core/insight/philosophical_runtime.py`, `app/services/insight_runtime.py`, and `app/services/insight_application_service.py`.
+
+**Rationale:**
+This preserves the plan’s core intent: policy is decided in `prepare_insight_runtime(...)`, candidates are built only from validated RAG evidence before prompt formatting becomes the output path, and the service layer remains thin. The only additional seam is the existing traced adapter, which is required to pass the policy through the current app-layer telemetry handoff without reopening routes or `legacy_app.py`.
+
+**Alternatives Considered:**
+1. Remove `app/services/insight_runtime.py` changes entirely.
+   Reason not chosen: `knowledge_policy` would then bypass the existing traced handoff and force worse drift elsewhere.
+2. Store raw chunk content as canonical fact values.
+   Reason not chosen: violates the invariant that retrieval artifacts are evidence, not canonical facts.
+
+**Follow-ups:**
+- [ ] semantic cache remains deferred to its own gated lane → `BACKLOG_LEDGER.md`
+- [ ] persistent knowledge storage remains deferred to a dedicated storage/migration lane → `BACKLOG_LEDGER.md`
+
+**Postponed Items:**
+- Semantic-cache admission/hit logic - Reason: explicitly out of K1 scope → recorded as deferred in roadmap packeting.
+- DB-backed knowledge store - Reason: storage/migration lane is intentionally closed for K1 → keep deferred.
+
+---
+
+**Synthesis by:** agent-coordinator
+**Date:** 2026-04-19

--- a/docs/orchestration/WAVE6_K1_TASK_ANALYSIS_2026-04-19.md
+++ b/docs/orchestration/WAVE6_K1_TASK_ANALYSIS_2026-04-19.md
@@ -1,0 +1,54 @@
+# WAVE6 K1 Task Analysis
+
+## Task Analysis
+
+**Task:** Implement `PR-K1` as a bounded post-A5 runtime slice for knowledge contracts and promotion from validated RAG evidence only.
+
+**Domain(s):** AI/ML | Architecture | Security | Multiple
+
+**Complexity:** Complex
+
+**Priority:** P1
+
+- **Priority track (P0-A / P0-B / P1):** P1
+
+**Expected Outcome:** Internal knowledge promotion contracts land without route/public schema drift, DB/storage rollout, or semantic-cache expansion.
+
+**Invariants Affected:**
+- [ ] One BMI Engine
+- [x] Thin HTTP Adapter Policy
+- [x] Layer Separation
+- [x] Contract-First
+- [x] Other: bounded post-A5 product-AI runtime rail
+
+**Risks:**
+1. Promotion drift could canonicalize raw retrieval artifacts; mitigate by fail-closed policy and evidence-envelope candidates only.
+2. Scope drift could leak into route or storage lanes; mitigate by restricting edits to declared runtime seams and updating packet if one thin tracing seam is required.
+3. Degraded retrieval could poison knowledge; mitigate by denying promotion on every degraded reason and sub-threshold confidence path.
+
+**Proposed Approach:**
+1. Add `core/knowledge/*` contracts/policy/promotion/store with no FastAPI imports.
+2. Thread `KnowledgePolicy` through the existing runtime/orchestration seams.
+3. Keep application service thin and allow only protocol-based store handoff.
+4. Add narrow deterministic tests for policy, promotion, and non-persistent recursive behavior.
+5. Record coordinator-first governance artifacts for the lane.
+
+**Agent Assignment:**
+- **Primary:** `agent-coordinator` - owns scope, role order, synthesis, and DoD.
+- **Secondary:** `architecture-specialist` - enforces bounded seam and anti-drift review.
+- **Secondary:** `data-scientist-agent` - validates promotion semantics and evidence grade.
+- **Secondary:** `backend-engineer` - implements the runtime/core changes.
+- **Secondary:** `security-auditor` - verifies fail-closed and scope isolation.
+- **Secondary:** `qa-engineer-agent` - adds deterministic tests.
+- **Secondary:** `bug-hunter` - mandatory final defect pass.
+- **Dependencies:** preflight and agent consistency must pass before edits.
+
+**Constraints:**
+- No `legacy_app.py`, `app/routers/*`, OpenAPI, DB migration, or semantic-cache rollout.
+- Promotion source of truth is validated RAG evidence only.
+- `DEEP_REASONING` stays promotion-denied by default.
+
+---
+
+**Analysis by:** agent-coordinator
+**Date:** 2026-04-19

--- a/docs/orchestration/WAVE6_K1_WORK_REVIEW_2026-04-19.md
+++ b/docs/orchestration/WAVE6_K1_WORK_REVIEW_2026-04-19.md
@@ -1,0 +1,111 @@
+# WAVE6 K1 Work Review
+
+## Work Review
+
+**Task:** Implement `PR-K1` as a bounded post-A5 runtime slice for internal knowledge contracts and promotion from validated RAG evidence.
+
+**Agent(s) Involved:**
+- `agent-coordinator`
+- `architecture-specialist`
+- `data-scientist-agent`
+- `backend-engineer`
+- `security-auditor`
+- `qa-engineer-agent`
+- `bug-hunter`
+
+### Agent Outputs
+
+#### `agent-coordinator`
+- **Work Completed:** framed the lane as post-A5 runtime-only, added backlog/packet/governance anchors, and enforced semantic-cache deferral.
+- **Key Deliverables:**
+  - `docs/roadmap/BACKLOG_LEDGER.md` K1 anchor
+  - `docs/orchestration/WAVE6_K1_KNOWLEDGE_PROMOTION_PACKET_2026-04-19.md`
+  - root `AGENTS.md` invariant update
+- **✅ Strengths:** scope is explicit, storage/cache drift is blocked, public API drift remains forbidden.
+- **⚠️ Issues:** execution evidence had to be added explicitly in `docs/orchestration/`.
+- **📝 Notes:** coordinator-first is now documented as repo-tracked evidence for the lane.
+
+#### `architecture-specialist`
+- **Work Completed:** reviewed live diff against packet boundaries.
+- **Key Deliverables:**
+  - flagged undeclared `app/services/insight_runtime.py` seam
+  - flagged missing coordinator-first tracked artifacts
+- **✅ Strengths:** confirmed no drift into `legacy_app.py`, routers, OpenAPI, DB migrations, or semantic cache.
+- **⚠️ Issues:** thin tracing seam had to be declared explicitly; malformed indentation in the tracing adapter required a code fix.
+- **📝 Notes:** K1 remains acceptable only if app-layer tracing seam stays thin and policy-only.
+
+#### `data-scientist-agent`
+- **Work Completed:** reviewed candidate identity and evidence-version semantics.
+- **Key Deliverables:**
+  - flagged same-source evidence collapse risk in `fact_key`
+  - required explicit supersession semantics instead of timestamp churn
+- **✅ Strengths:** kept K1 evidence-envelope shape deterministic and replay-safe.
+- **⚠️ Issues:** version identity needed to include evidence value, not only scope coordinates.
+- **📝 Notes:** supersession is valid only for declared replacement of prior evidence, never for implicit same-scope overwrite.
+
+#### `backend-engineer`
+- **Work Completed:** reviewed store seam and request-path handoff.
+- **Key Deliverables:**
+  - flagged missing `rail` isolation in store reads
+  - flagged synchronous inline promotion as a response-path fragility
+- **✅ Strengths:** confirmed the seam can stay bounded if storage remains protocol-only and fail-safe.
+- **⚠️ Issues:** `KnowledgeStore.read(...)` had to become `rail`-aware and promotion had to become best-effort.
+- **📝 Notes:** K1 must not turn request success into storage success coupling.
+
+#### `security-auditor`
+- **Work Completed:** reviewed validated-only promotion invariants.
+- **Key Deliverables:**
+  - flagged synthetic/custom retriever candidate injection risk
+  - flagged non-validated (`philo_validation_enabled=false`) promotion leakage
+- **✅ Strengths:** canonical orchestration already denied degraded empty/all-filtered paths.
+- **⚠️ Issues:** runtime trust had to be narrowed to canonical validated RAG only; noncanonical candidate seams must fail closed.
+- **📝 Notes:** promotion remains acceptable only when route=`RAG_FACTUAL`, validation is on, and candidates are marked canonical by orchestration.
+
+#### `qa-engineer-agent`
+- **Work Completed:** reviewed seam coverage and regression gaps.
+- **Key Deliverables:**
+  - requested runtime seam tests for `knowledge_policy` compatibility
+  - requested negative service handoff and deny-by-policy coverage
+- **✅ Strengths:** test additions stay narrow and deterministic.
+- **⚠️ Issues:** prior recursive non-persistence assertion was too weak and needed replacement with seam-level promotion denial.
+- **📝 Notes:** K1 coverage must prove fail-closed behavior, not only happy-path promotion.
+
+#### `bug-hunter`
+- **Work Completed:** validated cross-rail and response-path edge cases.
+- **Key Deliverables:**
+  - confirmed cross-rail store leakage risk
+  - confirmed promotion exceptions could break an otherwise valid response
+- **✅ Strengths:** findings aligned with backend/security review and sharpened edge-case coverage.
+- **⚠️ Issues:** service handoff needed exception swallowing and store lookups needed strict `rail` scoping.
+- **📝 Notes:** bug sweep did not justify widening scope beyond the K1 bounded seam.
+
+### Synthesis
+
+The lane is acceptable when treated as `core/knowledge/* + runtime/orchestration seam + thin traced handoff`. The app-layer tracing adapter is allowed only because it threads already-decided policy through an existing non-route seam. Final synthesis from the role-agent pass is:
+
+- promotion is canonical only from validated `RAG_FACTUAL` evidence
+- store lookup scope is `subject + predicate + access_scope + rail`
+- request success must not depend on storage success
+- K1 remains bounded and does not reopen semantic-cache or DB rollout scope
+
+### Quality Check
+
+See canonical Quality Gates: `RUNBOOK_AGENT.md` (Quality Gates section)
+
+- ❌ Quality gates: pending until targeted pytest, `pre-commit`, and `make verify` complete on the final diff
+
+### Requirements Met
+
+- ✅ Original requirements: mostly implemented in bounded form
+- ✅ Project conventions: boundary rules documented and updated
+- ✅ Documentation updated: packet, ledger, epic anchor, AGENTS invariant, and coordinator artifacts added
+
+### Conflicts / Inconsistencies
+
+- Initial scope drift for `app/services/insight_runtime.py` was resolved by explicitly declaring it as a thin tracing seam in the packet.
+- Initial “chunk-as-fact” promotion semantics were corrected toward an evidence-envelope value.
+
+---
+
+**Review by:** agent-coordinator
+**Date:** 2026-04-19

--- a/docs/review/PR_1483_FIXED_MAPPING.md
+++ b/docs/review/PR_1483_FIXED_MAPPING.md
@@ -1,0 +1,38 @@
+<!-- markdownlint-disable MD034 -->
+# PR #1483 - Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:47-57`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`.
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+PR #1483 opened without actionable review comments. This artifact is the
+canonical source of truth for future thread disposition and merge-readiness
+tracking as review activity lands on the branch head.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:38-45`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+  Evidence: GitHub checks for PR #1483 current head.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: GitHub checks for PR #1483 current head.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: No review threads yet; re-check before merge.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: No actionable review comments yet; re-check before merge.
+- [ ] Pre-commit green on latest pushed head
+  Evidence: local pre-push hooks passed before `origin/codex/pr-k1-knowledge-promotion` push.
+- [ ] `make verify` green on latest pushed head
+  Evidence: local `make verify` / `make diff-cov` did not complete in this environment because repeated runs were terminated externally with `make: *** [diff-cov] Terminated: 15`; GitHub current-head CI remains the heavy gate for this draft PR.
+<!-- markdownlint-enable MD034 -->

--- a/docs/review/PR_1483_FIXED_MAPPING.md
+++ b/docs/review/PR_1483_FIXED_MAPPING.md
@@ -73,6 +73,42 @@ Evidence: `core/rag/orchestration.py:295-304`, `core/insight/philosophical_runti
 Reason: The Cubic wrapper review only aggregates the two inline findings already dispositioned above; on current head the promotion-canonical guard and `**kwargs` retriever forwarding are already correct, so the wrapper itself does not represent a separate unresolved defect.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#pullrequestreview-4139263200
 
+Disposition: FIXED
+Commit: 7eec5d903
+Evidence: `app/services/insight_application_service.py:76-97`, `tests/test_remaining_modules.py:655-690`
+Reason: Sync knowledge-store promotion is now offloaded via `asyncio.to_thread(...)` and bounded by the same timeout contract as awaitable stores, so slow synchronous persistence can no longer stall the response path.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#discussion_r3110157635 -> 7eec5d903
+
+Disposition: FIXED
+Commit: 7eec5d903
+Evidence: `core/insight/philosophical_runtime.py:85-96`, `tests/test_philosophical_runtime.py:628-637`
+Reason: `_retriever_accepts_knowledge_policy(...)` no longer uses `@lru_cache`, so callable retriever instances do not need to be hashable and the helper cannot accumulate an unbounded per-callable cache.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#discussion_r3110157643 -> 7eec5d903
+
+Disposition: FIXED
+Commit: 7eec5d903
+Evidence: `app/services/insight_application_service.py:76-97`, `core/insight/philosophical_runtime.py:85-96`, `tests/test_remaining_modules.py:655-690`, `tests/test_philosophical_runtime.py:628-637`
+Reason: The latest CodeRabbit wrapper is fully covered by the current-head fixes for sync promotion timeout handling and removal of the unsafe retriever-signature cache.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#pullrequestreview-4139390601 -> 7eec5d903
+
+Disposition: FIXED
+Commit: 7eec5d903
+Evidence: `core/insight/philosophical_runtime.py:85-96`, `tests/test_philosophical_runtime.py:628-637`
+Reason: The cubic inline request is satisfied by removing the cache decorator entirely, which resolves both the unhashable-callable failure mode and the unbounded-cache-growth concern.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#discussion_r3110174850 -> 7eec5d903
+
+Disposition: FIXED
+Commit: 7eec5d903
+Evidence: `core/insight/philosophical_runtime.py:85-96`, `tests/test_philosophical_runtime.py:628-637`
+Reason: The helper no longer maintains any cache state, so there is no remaining unbounded `lru_cache(maxsize=None)` growth path on current head.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#discussion_r3110174851 -> 7eec5d903
+
+Disposition: FIXED
+Commit: 7eec5d903
+Evidence: `core/insight/philosophical_runtime.py:85-96`, `tests/test_philosophical_runtime.py:628-637`
+Reason: The latest cubic wrapper is fully covered by the same current-head cache-removal fix mapped above; no separate unresolved defect remains beyond those inline comments.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#pullrequestreview-4139408489 -> 7eec5d903
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/review/PR_1483_FIXED_MAPPING.md
+++ b/docs/review/PR_1483_FIXED_MAPPING.md
@@ -109,6 +109,11 @@ Evidence: `core/insight/philosophical_runtime.py:85-96`, `tests/test_philosophic
 Reason: The latest cubic wrapper is fully covered by the same current-head cache-removal fix mapped above; no separate unresolved defect remains beyond those inline comments.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#pullrequestreview-4139408489 -> 7eec5d903
 
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-knowledge-promotion-from-validated-rag`
+Reason: The latest CodeRabbit wrapper only asks for explicit return annotations on two test helper methods in `tests/test_remaining_modules.py`. That change is low-risk and test-only, but landing it in PR-K1 would widen this merge lane into a whole-file `black` reformat of an already-touched test module, so it is intentionally deferred to the documented PR-K1 closeout follow-up after merge.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#pullrequestreview-4139572722
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/review/PR_1483_FIXED_MAPPING.md
+++ b/docs/review/PR_1483_FIXED_MAPPING.md
@@ -9,13 +9,36 @@ Canonical review-governance artifact and PR-body mirror requirements:
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-PR #1483 opened without actionable review comments. This artifact is the
-canonical source of truth for future thread disposition and merge-readiness
-tracking as review activity lands on the branch head.
-
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: e8a689710
+Evidence: `app/services/insight_application_service.py:32-33`, `app/services/insight_application_service.py:65-91`, `tests/test_remaining_modules.py`
+Reason: Best-effort promotion is now bounded by an explicit async timeout so slow or stalled awaitable stores degrade to logging instead of request-path latency.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#discussion_r3109939655 -> e8a689710
+
+Disposition: FIXED
+Commit: e8a689710
+Evidence: `core/insight/philosophical_runtime.py:86-98`, `core/insight/philosophical_runtime.py:560-580`, `tests/test_philosophical_runtime.py`
+Reason: The retriever seam now caches signature support, forwards `knowledge_policy` to `**kwargs`-compatible retrievers, and fails closed toward forward-compatible passing when signature introspection is opaque.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#discussion_r3109959617 -> e8a689710
+
+Disposition: FIXED
+Commit: e8a689710
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:1639-1643`
+Reason: The PR-K1 ledger entry now reflects active implementation status instead of staying in planned state while this slice is in flight.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#discussion_r3109959623 -> e8a689710
+
+Disposition: FIXED
+Commit: e8a689710
+Evidence: `core/insight/philosophical_runtime.py:86-98`, `core/insight/philosophical_runtime.py:592-600`, `core/knowledge/store.py:99-102`, `tests/test_knowledge_contracts.py`
+Reason: The Sourcery review surfaced three real high-level issues and the current head now addresses all of them: the route-factual policy flag is enforced, retriever signature introspection is cached, and `InMemoryKnowledgeStore` exposes a stable `all_records()` seam for tests.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#pullrequestreview-4139123418 -> e8a689710
+
+Disposition: NOT-A-BUG
+Evidence: `core/knowledge/store.py:20-27` already allows awaitable `promote(...)` returns, while the remaining actionable inline findings from the wrapper are fixed above as `#discussion_r3109959617` and `#discussion_r3109959623`.
+Reason: The CodeRabbit wrapper review does not introduce a separate standalone defect once the stale protocol nitpick is checked against current code and the concrete inline issues are dispositioned.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#pullrequestreview-4139178116
 
 ## Merge Readiness
 
@@ -28,9 +51,9 @@ Merge-readiness contract:
 - [ ] Required checks complete (no pending jobs)
   Evidence: GitHub checks for PR #1483 current head.
 - [ ] All review threads resolved on GitHub after disposition updates
-  Evidence: No review threads yet; re-check before merge.
+  Evidence: Current known review-thread URLs are dispositioned above; re-check GitHub thread state on current head before merge.
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: No actionable review comments yet; re-check before merge.
+  Evidence: Current known bot review URLs are mapped above; re-check current head before merge for any new activity.
 - [ ] Pre-commit green on latest pushed head
   Evidence: local pre-push hooks passed before `origin/codex/pr-k1-knowledge-promotion` push.
 - [ ] `make verify` green on latest pushed head

--- a/docs/review/PR_1483_FIXED_MAPPING.md
+++ b/docs/review/PR_1483_FIXED_MAPPING.md
@@ -40,6 +40,28 @@ Evidence: `core/knowledge/store.py:20-27` already allows awaitable `promote(...)
 Reason: The CodeRabbit wrapper review does not introduce a separate standalone defect once the stale protocol nitpick is checked against current code and the concrete inline issues are dispositioned.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#pullrequestreview-4139178116
 
+Disposition: FIXED
+Commit: a7acaff6d
+Evidence: `tests/test_remaining_modules.py:303-341`, `tests/test_remaining_modules.py:459-479`
+Reason: The fast-lane helper seams now carry explicit return annotations and a typed `supersedes` parameter, matching repo typing requirements for modified Python helpers.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#discussion_r3110020760 -> a7acaff6d
+
+Disposition: FIXED
+Commit: a7acaff6d
+Evidence: `tests/test_remaining_modules.py:769-780`
+Reason: The pgvector-missing smoke test no longer patches `builtins.__import__`; it now simulates the missing module through `monkeypatch` + `sys.modules`, which stays within repo test policy.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#discussion_r3110020770 -> a7acaff6d
+
+Disposition: NOT-A-BUG
+Evidence: `core/rag/orchestration.py:295-304`
+Reason: Current head no longer marks knowledge candidates canonical unconditionally; promotion is allowed only when the philosophy path ran without recursion and without a degraded retrieval reason, so the bot comment is stale relative to current code.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#discussion_r3110038251
+
+Disposition: NOT-A-BUG
+Evidence: `core/insight/philosophical_runtime.py:86-98`, `core/insight/philosophical_runtime.py:572-580`
+Reason: Current head already supports retrievers that accept `**kwargs` and falls back safely when signature introspection is opaque, so the strict-forwarding concern is stale on this head.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#discussion_r3110038254
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/review/PR_1483_FIXED_MAPPING.md
+++ b/docs/review/PR_1483_FIXED_MAPPING.md
@@ -62,6 +62,17 @@ Evidence: `core/insight/philosophical_runtime.py:86-98`, `core/insight/philosoph
 Reason: Current head already supports retrievers that accept `**kwargs` and falls back safely when signature introspection is opaque, so the strict-forwarding concern is stale on this head.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#discussion_r3110038254
 
+Disposition: FIXED
+Commit: a7acaff6d
+Evidence: `tests/test_remaining_modules.py:303-341`, `tests/test_remaining_modules.py:459-479`, `tests/test_remaining_modules.py:769-780`
+Reason: The current CodeRabbit review wrapper is fully covered by the two actionable current-head findings fixed in `a7acaff6d`: helper type hints were tightened and the forbidden `builtins.__import__` patch was replaced with a `monkeypatch`-based module-missing simulation.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#pullrequestreview-4139245059 -> a7acaff6d
+
+Disposition: NOT-A-BUG
+Evidence: `core/rag/orchestration.py:295-304`, `core/insight/philosophical_runtime.py:86-98`, `core/insight/philosophical_runtime.py:572-580`
+Reason: The Cubic wrapper review only aggregates the two inline findings already dispositioned above; on current head the promotion-canonical guard and `**kwargs` retriever forwarding are already correct, so the wrapper itself does not represent a separate unresolved defect.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1483#pullrequestreview-4139263200
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1640,7 +1640,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR-K1
-  - Status: 📋 Planned (post-A5 runtime follow-up only)
+  - Status: 🟡 In progress in PR `#1483` (PR-K1 runtime seam); close via docs-only follow-up after merge per ledger policy.
   - Area: AI runtime / knowledge / retrieval orchestration
   - Finding Type: bounded knowledge-promotion contract gap
   - Reason (EN): The current AI runtime already has deterministic retrieval diagnostics, bounded `core/ai/*` ownership, and request-local recursive optimization caches, but it does not yet expose a first-class internal fact-promotion contract separated from retrieval artifacts. Without that seam, later runtime work risks promoting raw provider output, route-layer behavior, or request-local caches into canonical knowledge. `PR-K1` closes that gap as a bounded post-A5 follow-up without widening into semantic cache or DB/storage rollout.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1635,6 +1635,34 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - LLM outputs used for product copy/coaching pass `philosophy_validator` (BLOCKER = rewrite)
     - AI runtime/runbook docs link to the same gate source instead of ad-hoc evaluation notes
 
+<a id="ledger-p1-knowledge-promotion-from-validated-rag"></a>
+- [ ] P1: Knowledge contracts and promotion from validated RAG evidence
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-K1
+  - Status: 📋 Planned (post-A5 runtime follow-up only)
+  - Area: AI runtime / knowledge / retrieval orchestration
+  - Finding Type: bounded knowledge-promotion contract gap
+  - Reason (EN): The current AI runtime already has deterministic retrieval diagnostics, bounded `core/ai/*` ownership, and request-local recursive optimization caches, but it does not yet expose a first-class internal fact-promotion contract separated from retrieval artifacts. Without that seam, later runtime work risks promoting raw provider output, route-layer behavior, or request-local caches into canonical knowledge. `PR-K1` closes that gap as a bounded post-A5 follow-up without widening into semantic cache or DB/storage rollout.
+  - Links:
+    - `docs/orchestration/WAVE6_K1_KNOWLEDGE_PROMOTION_PACKET_2026-04-19.md`
+    - `docs/orchestration/contracts/AI_RUNTIME_GATE_CONTRACT.md`
+    - `docs/roadmap/PulsePlate_Semantic_Cache_Gate_and_Plan.md`
+    - `docs/roadmap/PulsePlate_RAG_LLM_Karpathy_Epic_Pipeline.md`
+    - `core/ai/insight_runtime.py`
+    - `core/rag/orchestration.py`
+    - `core/insight/philosophical_runtime.py`
+    - `app/services/insight_application_service.py`
+    - `docs/memory/kpp_knowledge_promotion_pipeline.md`
+    - `AGENTS.md`
+  - DoD:
+    - A bounded `core/knowledge/*` internal subdomain exists for knowledge contracts, policy, promotion, and store protocol only
+    - `prepare_insight_runtime(...)` owns the canonical knowledge-policy seam for runtime execution
+    - Promotion candidates are derived only from validated RAG evidence that survives orchestration and fail closed on degraded paths or insufficient confidence
+    - `legacy_app.py`, `app/routers/*`, OpenAPI, and public response DTOs remain unchanged
+    - No DB migration, Redis/GPTCache, or semantic-cache rollout is introduced in this slice
+    - Deterministic tests cover promotion allow/deny behavior, supersession rules, and the invariant that request-local recursive caches never become persistent knowledge
+
 <a id="ledger-p1-apple-server-api-migration"></a>
 - [ ] P1: Apple receipt verification migration to App Store Server API
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1644,6 +1644,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Area: AI runtime / knowledge / retrieval orchestration
   - Finding Type: bounded knowledge-promotion contract gap
   - Reason (EN): The current AI runtime already has deterministic retrieval diagnostics, bounded `core/ai/*` ownership, and request-local recursive optimization caches, but it does not yet expose a first-class internal fact-promotion contract separated from retrieval artifacts. Without that seam, later runtime work risks promoting raw provider output, route-layer behavior, or request-local caches into canonical knowledge. `PR-K1` closes that gap as a bounded post-A5 follow-up without widening into semantic cache or DB/storage rollout.
+  - Deferred follow-up (PR #1483 merge closeout): add explicit return annotations to `TestPhilosophicalRuntimeFastLane._runtime_policy` and `_runtime_candidate` in `tests/test_remaining_modules.py`; keep it out of PR-K1 because touching that file here would pull a full-file `black` reformat into the merge lane for a low-risk test-only nitpick.
   - Links:
     - `docs/orchestration/WAVE6_K1_KNOWLEDGE_PROMOTION_PACKET_2026-04-19.md`
     - `docs/orchestration/contracts/AI_RUNTIME_GATE_CONTRACT.md`

--- a/docs/roadmap/PulsePlate_RAG_LLM_Karpathy_Epic_Pipeline.md
+++ b/docs/roadmap/PulsePlate_RAG_LLM_Karpathy_Epic_Pipeline.md
@@ -15,7 +15,7 @@ Implement it as a **separate advisory compiled-memory workforce rail**, while th
 | Rail B1 | `P2: Karpathy-style advisory wiki umbrella` | Advisory workforce compiled memory | local operator memory, advisory wiki/compiler/query-lint/reference-corpus controls | product RAG replacement, DB/runtime/API source of truth, public response-contract logic |
 | Rail B2 | `P2: Plugin/control-plane families umbrella` | Advisory plugin/control-plane families | GitHub governance/CI review truth, Cloudflare preview/deploy control-plane, Figma design execution/review evidence, Hugging Face research/model-eval tooling | product runtime truth, public response-contract logic, semantic cache, bounded-context ownership |
 
-For the continuous bootstrap lane `PR-S0 -> PR-A5`, `docs/orchestration/WAVE6_AI_RUNTIME_AND_ADVISORY_SERIES_PACKET_2026-04-13.md` is the canonical series SoT. This roadmap epic defers to that packet whenever sequencing, rail-boundary, or semantic-cache-gating wording diverges.
+For the continuous bootstrap lane `PR-S0 -> PR-A5`, `docs/orchestration/WAVE6_AI_RUNTIME_AND_ADVISORY_SERIES_PACKET_2026-04-13.md` is the canonical series SoT. This roadmap epic defers to that packet whenever sequencing, rail-boundary, or semantic-cache-gating wording diverges. The first bounded post-A5 runtime follow-up is `PR-K1`, governed by `docs/orchestration/WAVE6_K1_KNOWLEDGE_PROMOTION_PACKET_2026-04-19.md`.
 
 ### Temporary `security-floor` seam (canonical wording)
 
@@ -96,6 +96,7 @@ Use it as:
 - architecture/packet preparation now
 - implementation rail after the emergency fixes are stabilized
 - strict one-PR-at-a-time runtime sequence through `A5`
+- treat `K1` as the first bounded post-A5 follow-up, not as semantic-cache rollout
 
 ### Governance rule for the prep PR
 
@@ -356,6 +357,38 @@ Make AI quality drift detectable before merge/release.
 - explicit evaluation package exists
 - gates are deterministic
 - runtime docs point to one gate source
+
+---
+
+## PR-K1 — knowledge promotion from validated RAG evidence
+#### Title
+`feat(knowledge): add knowledge contracts and promotion from validated RAG evidence`
+
+#### Backlog target
+`ledger-p1-knowledge-promotion-from-validated-rag`
+
+#### Goal
+Add a bounded internal knowledge seam after `A5` so that later runtime work can
+promote validated RAG evidence without treating retrieval artifacts, raw model
+output, or request-local recursive caches as canonical facts.
+
+#### In scope
+- `core/knowledge/*` contracts, policy, promotion, and store protocol
+- runtime knowledge policy via `prepare_insight_runtime(...)`
+- internal-only promotion candidates threaded through runtime seams
+- deterministic promotion allow/deny and supersession tests
+
+#### Out of scope
+- semantic cache implementation
+- DB migrations or persistent knowledge storage rollout
+- route / OpenAPI / public response shape changes
+- promotion from `DEEP_REASONING` or from raw provider output
+
+#### DoD
+- promotion is derived only from validated RAG evidence that survives orchestration
+- degraded paths fail closed
+- route layer remains thin and unchanged
+- semantic cache stays deferred and out of scope
 
 ---
 

--- a/scripts/ci/emergency_python_wheels.json
+++ b/scripts/ci/emergency_python_wheels.json
@@ -105,10 +105,10 @@
     },
     {
       "package": "ruff",
-      "version": "0.15.10",
-      "filename": "ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-      "url": "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-      "sha256": "51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609"
+      "version": "0.15.11",
+      "filename": "ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+      "sha256": "1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431"
     },
     {
       "package": "types-pyyaml",

--- a/tests/test_core_ai_insight_runtime.py
+++ b/tests/test_core_ai_insight_runtime.py
@@ -11,12 +11,14 @@ import pytest
 from core.ai.insight_runtime import (
     DirectInsightProviderStub,
     InsightProviderLoadError,
+    KnowledgePolicy,
     InsightTransparencyNotice,
     InsightTransparencyUnavailableError,
     load_insight_provider,
     prepare_insight_runtime,
     require_ai_generated_insight_notice,
 )
+from core.rag.contracts import RAGDegradedReason
 
 
 class _FakeProvider:
@@ -156,6 +158,8 @@ def test_prepare_insight_runtime_uses_direct_stub_for_local_answer(
 
     assert isinstance(prepared.provider, DirectInsightProviderStub)
     assert prepared.transparency_notice.surface_id == "ai_generated_insight"
+    assert prepared.knowledge_policy.allow_promotion is False
+    assert prepared.knowledge_policy.allow_reads is False
 
 
 def test_prepare_insight_runtime_uses_provider_loader_for_generation(
@@ -196,6 +200,52 @@ def test_prepare_insight_runtime_uses_provider_loader_for_generation(
     assert prepared.provider is provider
     assert prepared.decision.route_type.value == "deep_reasoning"
     assert prepared.transparency_notice.wellness_boundary == "Wellness only."
+    assert prepared.knowledge_policy == KnowledgePolicy(
+        enabled=False,
+        allow_reads=False,
+        allow_promotion=False,
+        min_confidence=0.7,
+        require_rag_factual_route=True,
+        deny_degraded_reasons=tuple(reason.value for reason in RAGDegradedReason),
+        subject_scope_required=True,
+        rail="product_ai_runtime",
+    )
+
+
+def test_prepare_insight_runtime_enables_knowledge_promotion_for_rag_factual_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RAG factual route must enable bounded knowledge reads and promotion."""
+
+    @dataclass
+    class _FakeDecision:
+        needs_generation: bool
+        route_type: object
+
+    class _FakeRuntime:
+        def preview_route(
+            self, *, text: str, lang: str | None, router_enabled: bool, use_rag: bool
+        ) -> _FakeDecision:
+            del text, lang, router_enabled, use_rag
+            return _FakeDecision(
+                needs_generation=True,
+                route_type=SimpleNamespace(value="RAG_FACTUAL"),
+            )
+
+    monkeypatch.setattr("core.ai.insight_runtime.PhilosophicalRuntime", _FakeRuntime, raising=True)
+
+    prepared = prepare_insight_runtime(
+        text="hello",
+        use_rag=True,
+        philosophy_router_enabled=True,
+        philosophy_linguistic_enabled=False,
+        provider_loader=lambda: _FakeProvider(),
+        transparency_loader=lambda: ("ai_generated_insight", "Wellness only."),
+    )
+
+    assert prepared.knowledge_policy.enabled is True
+    assert prepared.knowledge_policy.allow_reads is True
+    assert prepared.knowledge_policy.allow_promotion is True
 
 
 def test_prepare_insight_runtime_uses_direct_transparency_notice(

--- a/tests/test_insight_application_service.py
+++ b/tests/test_insight_application_service.py
@@ -15,6 +15,7 @@ from app.services.insight_application_service import (
     execute_insight_request,
 )
 from core.ai.insight_runtime import InsightTransparencyNotice
+from core.knowledge.policy import KnowledgePolicy
 from core.insight.llm_provider_loader import LLMProvider
 
 
@@ -29,6 +30,19 @@ class _FakeProvider:
 
     def generate(self, prompt: str) -> Awaitable[str]:
         raise RuntimeError(f"Unexpected provider.generate call for prompt={prompt!r}")
+
+
+def _knowledge_policy() -> KnowledgePolicy:
+    return KnowledgePolicy(
+        enabled=True,
+        allow_reads=True,
+        allow_promotion=False,
+        min_confidence=0.7,
+        require_rag_factual_route=True,
+        deny_degraded_reasons=("retrieval_empty",),
+        subject_scope_required=True,
+        rail="product_ai_runtime",
+    )
 
 
 @pytest.mark.asyncio
@@ -73,6 +87,7 @@ async def test_execute_insight_request_uses_injected_dependencies(
             surface_id="ai_generated_insight",
             wellness_boundary="Wellness only.",
         ),
+        knowledge_policy=_knowledge_policy(),
     )
 
     async def _fake_generate_traced_insight(**kwargs: object) -> object:
@@ -85,6 +100,7 @@ async def test_execute_insight_request_uses_injected_dependencies(
             rag_used=True,
             hops=1,
             latency_ms=12,
+            knowledge_candidates=[],
             metadata=SimpleNamespace(
                 route_type="deep_reasoning",
                 depth_used=2,
@@ -136,6 +152,7 @@ async def test_execute_insight_request_uses_injected_dependencies(
     }
     assert observed["generate_kwargs"]["subject_id"] == 123
     assert observed["generate_kwargs"]["route_path"] == "/api/v1/insight"
+    assert observed["generate_kwargs"]["knowledge_policy"] == prepared_runtime.knowledge_policy
     assert response["provider"] == "fake-provider"
     assert response["transparency_notice_id"] == "ai_generated_insight"
     assert response["sources"][0]["chunk_id"] == "c1"
@@ -210,6 +227,7 @@ async def test_execute_insight_request_prefers_active_fallback_provider_name(
             surface_id="ai_generated_insight",
             wellness_boundary="Wellness only.",
         ),
+        knowledge_policy=_knowledge_policy(),
     )
 
     async def _fake_generate_traced_insight(**kwargs: object) -> object:
@@ -221,6 +239,7 @@ async def test_execute_insight_request_prefers_active_fallback_provider_name(
             rag_used=False,
             hops=0,
             latency_ms=5,
+            knowledge_candidates=[],
             metadata=SimpleNamespace(
                 route_type="deep_reasoning",
                 depth_used=1,
@@ -250,6 +269,256 @@ async def test_execute_insight_request_prefers_active_fallback_provider_name(
         input_guard=lambda text: None,
         provider_loader=lambda: _FakeProvider(),
         transparency_loader=lambda: ("ai_generated_insight", "Wellness only."),
+        response_factory=lambda **payload: dict(payload),
+        source_item_factory=lambda **payload: dict(payload),
+    )
+
+    assert response["provider"] == "stub"
+
+
+@pytest.mark.asyncio
+async def test_execute_insight_request_hands_internal_candidates_to_store_without_payload_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Thin service may promote internal candidates without changing public payload."""
+
+    observed: dict[str, Any] = {}
+
+    @dataclass
+    class _Request:
+        text: str
+
+    candidate = SimpleNamespace(fact_key="fact-1")
+    prepared_runtime = SimpleNamespace(
+        runtime=object(),
+        provider=SimpleNamespace(active_provider_name="stub"),
+        decision=SimpleNamespace(route_type=SimpleNamespace(value="rag_factual")),
+        transparency_notice=InsightTransparencyNotice(
+            surface_id="ai_generated_insight",
+            wellness_boundary="Wellness only.",
+        ),
+        knowledge_policy=_knowledge_policy(),
+    )
+
+    async def _fake_generate_traced_insight(**kwargs: object) -> object:
+        observed["generate_kwargs"] = kwargs
+        return SimpleNamespace(
+            insight="generated insight",
+            provider_name="stub",
+            source_dicts=[],
+            confidence=0.92,
+            rag_used=True,
+            hops=1,
+            latency_ms=8,
+            knowledge_candidates=[candidate],
+            metadata=SimpleNamespace(
+                route_type="rag_factual",
+                depth_used=1,
+                verification_rate=1.0,
+                falsifiability_rate=1.0,
+                contradiction_count=0,
+                reason_codes=["rag_factual"],
+                optimization_applied=False,
+            ),
+        )
+
+    class _Store:
+        def promote(self, candidates: list[object]) -> list[object]:
+            observed["promoted"] = candidates
+            return candidates
+
+        def read(
+            self, *, subject: str, predicate: str, access_scope: str, rail: str
+        ) -> list[object]:
+            del subject, predicate, access_scope, rail
+            return []
+
+    monkeypatch.setattr(
+        "app.services.insight_application_service.prepare_insight_runtime",
+        lambda **kwargs: prepared_runtime,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "app.services.insight_application_service.generate_traced_insight",
+        _fake_generate_traced_insight,
+        raising=True,
+    )
+
+    response = await execute_insight_request(
+        _Request(text="hello"),
+        route_path="/api/v1/insight",
+        user_tier="VIP",
+        subject_id=42,
+        input_guard=lambda text: None,
+        provider_loader=lambda: _FakeProvider(),
+        transparency_loader=lambda: ("ai_generated_insight", "Wellness only."),
+        knowledge_store=_Store(),
+        response_factory=lambda **payload: dict(payload),
+        source_item_factory=lambda **payload: dict(payload),
+    )
+
+    assert observed["promoted"] == [candidate]
+    assert response["provider"] == "stub"
+    assert "knowledge_candidates" not in response
+
+
+@pytest.mark.asyncio
+async def test_execute_insight_request_skips_store_when_no_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty candidate handoff must not touch the store seam."""
+
+    observed: dict[str, Any] = {"promote_called": False}
+
+    @dataclass
+    class _Request:
+        text: str
+
+    prepared_runtime = SimpleNamespace(
+        runtime=object(),
+        provider=SimpleNamespace(active_provider_name="stub"),
+        decision=SimpleNamespace(route_type=SimpleNamespace(value="rag_factual")),
+        transparency_notice=InsightTransparencyNotice(
+            surface_id="ai_generated_insight",
+            wellness_boundary="Wellness only.",
+        ),
+        knowledge_policy=_knowledge_policy(),
+    )
+
+    async def _fake_generate_traced_insight(**kwargs: object) -> object:
+        return SimpleNamespace(
+            insight="generated insight",
+            provider_name="stub",
+            source_dicts=[],
+            confidence=0.92,
+            rag_used=True,
+            hops=1,
+            latency_ms=8,
+            knowledge_candidates=[],
+            metadata=SimpleNamespace(
+                route_type="rag_factual",
+                depth_used=1,
+                verification_rate=1.0,
+                falsifiability_rate=1.0,
+                contradiction_count=0,
+                reason_codes=["rag_factual"],
+                optimization_applied=False,
+            ),
+        )
+
+    class _Store:
+        def promote(self, candidates: list[object]) -> list[object]:
+            observed["promote_called"] = True
+            return candidates
+
+        def read(
+            self, *, subject: str, predicate: str, access_scope: str, rail: str
+        ) -> list[object]:
+            del subject, predicate, access_scope, rail
+            return []
+
+    monkeypatch.setattr(
+        "app.services.insight_application_service.prepare_insight_runtime",
+        lambda **kwargs: prepared_runtime,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "app.services.insight_application_service.generate_traced_insight",
+        _fake_generate_traced_insight,
+        raising=True,
+    )
+
+    response = await execute_insight_request(
+        _Request(text="hello"),
+        route_path="/api/v1/insight",
+        user_tier="VIP",
+        subject_id=42,
+        input_guard=lambda text: None,
+        provider_loader=lambda: _FakeProvider(),
+        transparency_loader=lambda: ("ai_generated_insight", "Wellness only."),
+        knowledge_store=_Store(),
+        response_factory=lambda **payload: dict(payload),
+        source_item_factory=lambda **payload: dict(payload),
+    )
+
+    assert observed["promote_called"] is False
+    assert response["provider"] == "stub"
+
+
+@pytest.mark.asyncio
+async def test_execute_insight_request_survives_store_promotion_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Knowledge promotion errors must not fail an otherwise valid response."""
+
+    @dataclass
+    class _Request:
+        text: str
+
+    candidate = SimpleNamespace(fact_key="fact-1")
+    prepared_runtime = SimpleNamespace(
+        runtime=object(),
+        provider=SimpleNamespace(active_provider_name="stub"),
+        decision=SimpleNamespace(route_type=SimpleNamespace(value="rag_factual")),
+        transparency_notice=InsightTransparencyNotice(
+            surface_id="ai_generated_insight",
+            wellness_boundary="Wellness only.",
+        ),
+        knowledge_policy=_knowledge_policy(),
+    )
+
+    async def _fake_generate_traced_insight(**kwargs: object) -> object:
+        return SimpleNamespace(
+            insight="generated insight",
+            provider_name="stub",
+            source_dicts=[],
+            confidence=0.92,
+            rag_used=True,
+            hops=1,
+            latency_ms=8,
+            knowledge_candidates=[candidate],
+            metadata=SimpleNamespace(
+                route_type="rag_factual",
+                depth_used=1,
+                verification_rate=1.0,
+                falsifiability_rate=1.0,
+                contradiction_count=0,
+                reason_codes=["rag_factual"],
+                optimization_applied=False,
+            ),
+        )
+
+    class _AsyncFailingStore:
+        async def promote(self, candidates: list[object]) -> list[object]:
+            del candidates
+            raise RuntimeError("store unavailable")
+
+        def read(
+            self, *, subject: str, predicate: str, access_scope: str, rail: str
+        ) -> list[object]:
+            del subject, predicate, access_scope, rail
+            return []
+
+    monkeypatch.setattr(
+        "app.services.insight_application_service.prepare_insight_runtime",
+        lambda **kwargs: prepared_runtime,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "app.services.insight_application_service.generate_traced_insight",
+        _fake_generate_traced_insight,
+        raising=True,
+    )
+
+    response = await execute_insight_request(
+        _Request(text="hello"),
+        route_path="/api/v1/insight",
+        user_tier="VIP",
+        subject_id=42,
+        input_guard=lambda text: None,
+        provider_loader=lambda: _FakeProvider(),
+        transparency_loader=lambda: ("ai_generated_insight", "Wellness only."),
+        knowledge_store=_AsyncFailingStore(),
         response_factory=lambda **payload: dict(payload),
         source_item_factory=lambda **payload: dict(payload),
     )

--- a/tests/test_knowledge_contracts.py
+++ b/tests/test_knowledge_contracts.py
@@ -1,0 +1,181 @@
+"""Tests for bounded knowledge contracts and store seam."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from core.knowledge.contracts import (
+    KnowledgeEvidenceRef,
+    KnowledgeFactCandidate,
+    KnowledgeRecord,
+)
+from core.knowledge.store import InMemoryKnowledgeStore
+
+
+def test_knowledge_contracts_preserve_provenance_and_scope() -> None:
+    """Contracts must keep provenance, access scope, and observed timestamp intact."""
+
+    observed_at = datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc)
+    evidence = KnowledgeEvidenceRef(
+        chunk_id="chunk-1",
+        file="docs/test.md",
+        score=0.91,
+        hop=2,
+    )
+    candidate = KnowledgeFactCandidate(
+        fact_key="fact-1",
+        subject="subject:42",
+        predicate="validated_rag_evidence:docs/test.md:chunk-1",
+        value="chunk=chunk-1;source=docs/test.md;digest=abc123;hop=2",
+        observed_at=observed_at,
+        confidence=0.91,
+        access_scope="subject:42",
+        rail="product_ai_runtime",
+        provenance=(evidence,),
+    )
+    record = KnowledgeRecord(
+        fact_key=candidate.fact_key,
+        subject=candidate.subject,
+        predicate=candidate.predicate,
+        value=candidate.value,
+        status="active",
+        confidence=candidate.confidence,
+        access_scope=candidate.access_scope,
+        rail=candidate.rail,
+        provenance=candidate.provenance,
+        observed_at=observed_at,
+    )
+
+    assert candidate.provenance[0].chunk_id == "chunk-1"
+    assert candidate.access_scope == "subject:42"
+    assert candidate.observed_at == observed_at
+    assert record.provenance == candidate.provenance
+    assert record.observed_at == observed_at
+
+
+def test_in_memory_store_replays_identical_evidence_idempotently() -> None:
+    """In-memory store must not duplicate or self-supersede identical evidence."""
+
+    observed_at = datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc)
+    store = InMemoryKnowledgeStore()
+    first = KnowledgeFactCandidate(
+        fact_key="fact-1",
+        subject="subject:42",
+        predicate="validated_rag_evidence:docs/test.md:chunk-1",
+        value="v1",
+        observed_at=observed_at,
+        confidence=0.7,
+        access_scope="subject:42",
+        rail="product_ai_runtime",
+        provenance=(KnowledgeEvidenceRef("chunk-1", "docs/test.md", 0.7, 1),),
+    )
+
+    first_records = store.promote([first])
+    second_records = store.promote([first])
+    active = store.read(
+        subject="subject:42",
+        predicate="validated_rag_evidence:docs/test.md:chunk-1",
+        access_scope="subject:42",
+        rail="product_ai_runtime",
+    )
+
+    assert len(first_records) == 1
+    assert second_records == []
+    assert len(active) == 1
+    assert active[0].fact_key == "fact-1"
+    assert active[0].value == "v1"
+
+
+def test_in_memory_store_only_supersedes_when_explicitly_declared() -> None:
+    """Distinct evidence stays active unless the candidate explicitly supersedes it."""
+
+    observed_at = datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc)
+    store = InMemoryKnowledgeStore()
+    first = KnowledgeFactCandidate(
+        fact_key="fact-1",
+        subject="subject:42",
+        predicate="validated_rag_evidence:docs/test.md:chunk-1",
+        value="v1",
+        observed_at=observed_at,
+        confidence=0.7,
+        access_scope="subject:42",
+        rail="product_ai_runtime",
+        provenance=(KnowledgeEvidenceRef("chunk-1", "docs/test.md", 0.7, 1),),
+    )
+    superseding = KnowledgeFactCandidate(
+        fact_key="fact-2",
+        subject="subject:42",
+        predicate="validated_rag_evidence:docs/test.md:chunk-1",
+        value="v2",
+        observed_at=observed_at.replace(minute=1),
+        confidence=0.9,
+        access_scope="subject:42",
+        rail="product_ai_runtime",
+        provenance=(KnowledgeEvidenceRef("chunk-1", "docs/test.md", 0.9, 1),),
+        supersedes=("fact-1",),
+    )
+
+    store.promote([first])
+    promoted = store.promote([superseding])
+    active = store.read(
+        subject="subject:42",
+        predicate="validated_rag_evidence:docs/test.md:chunk-1",
+        access_scope="subject:42",
+        rail="product_ai_runtime",
+    )
+
+    assert len(promoted) == 1
+    assert len(active) == 1
+    assert active[0].fact_key == "fact-2"
+    assert len(store._records) == 2
+    superseded = [record for record in store._records if record.status == "superseded"]
+    assert len(superseded) == 1
+    assert superseded[0].fact_key == "fact-1"
+    assert superseded[0].superseded_by == "fact-2"
+
+
+def test_in_memory_store_keeps_identical_scope_isolated_by_rail() -> None:
+    """Same logical fact may coexist across rails without cross-reading leakage."""
+
+    observed_at = datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc)
+    store = InMemoryKnowledgeStore()
+    runtime_candidate = KnowledgeFactCandidate(
+        fact_key="fact-runtime",
+        subject="subject:42",
+        predicate="validated_rag_evidence:docs/test.md:chunk-1",
+        value="v1",
+        observed_at=observed_at,
+        confidence=0.7,
+        access_scope="subject:42",
+        rail="product_ai_runtime",
+        provenance=(KnowledgeEvidenceRef("chunk-1", "docs/test.md", 0.7, 1),),
+    )
+    shadow_candidate = KnowledgeFactCandidate(
+        fact_key="fact-shadow",
+        subject="subject:42",
+        predicate="validated_rag_evidence:docs/test.md:chunk-1",
+        value="v1",
+        observed_at=observed_at,
+        confidence=0.7,
+        access_scope="subject:42",
+        rail="shadow_runtime",
+        provenance=(KnowledgeEvidenceRef("chunk-1", "docs/test.md", 0.7, 1),),
+    )
+
+    store.promote([runtime_candidate, shadow_candidate])
+
+    runtime_records = store.read(
+        subject="subject:42",
+        predicate="validated_rag_evidence:docs/test.md:chunk-1",
+        access_scope="subject:42",
+        rail="product_ai_runtime",
+    )
+    shadow_records = store.read(
+        subject="subject:42",
+        predicate="validated_rag_evidence:docs/test.md:chunk-1",
+        access_scope="subject:42",
+        rail="shadow_runtime",
+    )
+
+    assert [record.fact_key for record in runtime_records] == ["fact-runtime"]
+    assert [record.fact_key for record in shadow_records] == ["fact-shadow"]

--- a/tests/test_knowledge_contracts.py
+++ b/tests/test_knowledge_contracts.py
@@ -127,8 +127,8 @@ def test_in_memory_store_only_supersedes_when_explicitly_declared() -> None:
     assert len(promoted) == 1
     assert len(active) == 1
     assert active[0].fact_key == "fact-2"
-    assert len(store._records) == 2
-    superseded = [record for record in store._records if record.status == "superseded"]
+    assert len(store.all_records()) == 2
+    superseded = [record for record in store.all_records() if record.status == "superseded"]
     assert len(superseded) == 1
     assert superseded[0].fact_key == "fact-1"
     assert superseded[0].superseded_by == "fact-2"

--- a/tests/test_knowledge_promotion.py
+++ b/tests/test_knowledge_promotion.py
@@ -1,0 +1,254 @@
+"""Tests for knowledge promotion fail-closed behavior."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from core.knowledge.contracts import KnowledgeRecord
+from core.knowledge.policy import KnowledgePolicy
+from core.knowledge.promotion import (
+    build_knowledge_promotion_candidates,
+    candidate_should_supersede,
+)
+from core.rag.contracts import RAGChunk
+
+
+def _policy() -> KnowledgePolicy:
+    return KnowledgePolicy(
+        enabled=True,
+        allow_reads=True,
+        allow_promotion=True,
+        min_confidence=0.7,
+        require_rag_factual_route=True,
+        deny_degraded_reasons=("retrieval_empty", "all_chunks_filtered"),
+        subject_scope_required=True,
+        rail="product_ai_runtime",
+    )
+
+
+def test_build_knowledge_promotion_candidates_uses_validated_chunks_only() -> None:
+    """Promotion must derive candidates from the surviving validated chunks only."""
+
+    chunks = [
+        RAGChunk(
+            chunk_id="chunk-1",
+            file="docs/one.md",
+            content=" First validated chunk. ",
+            score=0.88,
+            hop=1,
+        ),
+        RAGChunk(
+            chunk_id="chunk-2",
+            file="docs/two.md",
+            content="Second validated chunk.",
+            score=0.84,
+            hop=2,
+        ),
+    ]
+
+    candidates = build_knowledge_promotion_candidates(
+        chunks=chunks,
+        confidence=0.82,
+        degraded_reason=None,
+        subject_id=42,
+        knowledge_policy=_policy(),
+    )
+
+    assert [candidate.predicate for candidate in candidates] == [
+        "validated_rag_evidence:docs/one.md:chunk-1",
+        "validated_rag_evidence:docs/two.md:chunk-2",
+    ]
+    assert candidates[0].subject == "subject:42"
+    assert candidates[0].access_scope == "subject:42"
+    assert candidates[0].provenance[0].file == "docs/one.md"
+    assert "First validated chunk." not in candidates[0].value
+
+
+def test_build_knowledge_promotion_candidates_fails_closed_on_degraded_confidence_and_scope() -> (
+    None
+):
+    """Promotion must deny degraded, low-confidence, and missing-scope paths."""
+
+    chunks = [
+        RAGChunk(
+            chunk_id="chunk-1",
+            file="docs/one.md",
+            content="Validated chunk.",
+            score=0.88,
+            hop=1,
+        )
+    ]
+
+    degraded = build_knowledge_promotion_candidates(
+        chunks=chunks,
+        confidence=0.82,
+        degraded_reason="retrieval_empty",
+        subject_id=42,
+        knowledge_policy=_policy(),
+    )
+    low_confidence = build_knowledge_promotion_candidates(
+        chunks=chunks,
+        confidence=0.69,
+        degraded_reason=None,
+        subject_id=42,
+        knowledge_policy=_policy(),
+    )
+    missing_scope = build_knowledge_promotion_candidates(
+        chunks=chunks,
+        confidence=0.82,
+        degraded_reason=None,
+        subject_id=None,
+        knowledge_policy=_policy(),
+    )
+    disabled_policy = build_knowledge_promotion_candidates(
+        chunks=chunks,
+        confidence=0.82,
+        degraded_reason=None,
+        subject_id=42,
+        knowledge_policy=KnowledgePolicy(
+            enabled=False,
+            allow_reads=True,
+            allow_promotion=True,
+            min_confidence=0.7,
+            require_rag_factual_route=True,
+            deny_degraded_reasons=("retrieval_empty", "all_chunks_filtered"),
+            subject_scope_required=True,
+            rail="product_ai_runtime",
+        ),
+    )
+    denied_policy = build_knowledge_promotion_candidates(
+        chunks=chunks,
+        confidence=0.82,
+        degraded_reason=None,
+        subject_id=42,
+        knowledge_policy=KnowledgePolicy(
+            enabled=True,
+            allow_reads=True,
+            allow_promotion=False,
+            min_confidence=0.7,
+            require_rag_factual_route=True,
+            deny_degraded_reasons=("retrieval_empty", "all_chunks_filtered"),
+            subject_scope_required=True,
+            rail="product_ai_runtime",
+        ),
+    )
+
+    assert degraded == []
+    assert low_confidence == []
+    assert missing_scope == []
+    assert disabled_policy == []
+    assert denied_policy == []
+
+
+def test_candidate_should_supersede_only_when_scope_matches_and_evidence_is_stronger() -> None:
+    """Supersession must stay bounded to the logical fact scope and stronger evidence."""
+
+    observed_at = datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc)
+    existing = KnowledgeRecord(
+        fact_key="fact-1",
+        subject="subject:42",
+        predicate="validated_rag_evidence:docs/one.md:chunk-1",
+        value="v1",
+        status="active",
+        confidence=0.75,
+        access_scope="subject:42",
+        rail="product_ai_runtime",
+        provenance=(),
+        observed_at=observed_at,
+    )
+    stronger = build_knowledge_promotion_candidates(
+        chunks=[
+            RAGChunk(
+                chunk_id="chunk-1",
+                file="docs/one.md",
+                content="v2",
+                score=0.91,
+                hop=1,
+            )
+        ],
+        confidence=0.91,
+        degraded_reason=None,
+        subject_id=42,
+        knowledge_policy=_policy(),
+    )[0]
+    stronger = KnowledgeRecord(
+        fact_key=stronger.fact_key,
+        subject=stronger.subject,
+        predicate=stronger.predicate,
+        value=stronger.value,
+        status="active",
+        confidence=stronger.confidence,
+        access_scope=stronger.access_scope,
+        rail=stronger.rail,
+        provenance=stronger.provenance,
+        observed_at=stronger.observed_at,
+    )
+    explicit_superseding_candidate = build_knowledge_promotion_candidates(
+        chunks=[
+            RAGChunk(
+                chunk_id="chunk-1",
+                file="docs/one.md",
+                content="v4",
+                score=0.95,
+                hop=1,
+            )
+        ],
+        confidence=0.95,
+        degraded_reason=None,
+        subject_id=42,
+        knowledge_policy=_policy(),
+    )[0]
+    explicit_superseding_candidate = explicit_superseding_candidate.__class__(
+        fact_key=explicit_superseding_candidate.fact_key,
+        subject=explicit_superseding_candidate.subject,
+        predicate=explicit_superseding_candidate.predicate,
+        value=explicit_superseding_candidate.value,
+        observed_at=explicit_superseding_candidate.observed_at,
+        confidence=explicit_superseding_candidate.confidence,
+        access_scope=explicit_superseding_candidate.access_scope,
+        rail=explicit_superseding_candidate.rail,
+        provenance=explicit_superseding_candidate.provenance,
+        supersedes=("fact-1",),
+    )
+    other_scope = build_knowledge_promotion_candidates(
+        chunks=[
+            RAGChunk(
+                chunk_id="chunk-1",
+                file="docs/one.md",
+                content="v3",
+                score=0.8,
+                hop=1,
+            )
+        ],
+        confidence=0.8,
+        degraded_reason=None,
+        subject_id=99,
+        knowledge_policy=_policy(),
+    )[0]
+
+    assert (
+        candidate_should_supersede(
+            existing=existing,
+            candidate=build_knowledge_promotion_candidates(
+                chunks=[
+                    RAGChunk(
+                        chunk_id="chunk-1",
+                        file="docs/one.md",
+                        content="v2",
+                        score=0.91,
+                        hop=1,
+                    )
+                ],
+                confidence=0.91,
+                degraded_reason=None,
+                subject_id=42,
+                knowledge_policy=_policy(),
+            )[0],
+        )
+        is False
+    )
+    assert (
+        candidate_should_supersede(existing=existing, candidate=explicit_superseding_candidate)
+        is True
+    )
+    assert candidate_should_supersede(existing=existing, candidate=other_scope) is False

--- a/tests/test_philosophical_runtime.py
+++ b/tests/test_philosophical_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from dataclasses import dataclass
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -479,6 +480,154 @@ class TestPhilosophicalRuntime:
         assert result.knowledge_candidates == []
         assert result.metadata.falsifiability_rate is None
         assert result.metadata.contradiction_count == 0
+
+    async def test_runtime_forwards_knowledge_policy_to_kwargs_retriever(self) -> None:
+        """Forward-compatible retrievers using **kwargs must still receive policy."""
+
+        runtime = PhilosophicalRuntime()
+        provider = _StaticProvider(response="kwargs answer")
+        observed: dict[str, object] = {}
+        candidate = KnowledgeFactCandidate(
+            fact_key="fact-kwargs",
+            subject="subject:42",
+            predicate="validated_rag_evidence:docs/keep.md:keep",
+            value="chunk=keep;source=docs/keep.md;digest=kwargs;hop=1",
+            observed_at=datetime(2026, 4, 20, 12, 10, tzinfo=timezone.utc),
+            confidence=0.9,
+            access_scope="subject:42",
+            rail="product_ai_runtime",
+            provenance=(KnowledgeEvidenceRef("keep", "docs/keep.md", 0.9, 1),),
+        )
+        policy = KnowledgePolicy(
+            enabled=True,
+            allow_reads=True,
+            allow_promotion=True,
+            min_confidence=0.7,
+            require_rag_factual_route=True,
+            deny_degraded_reasons=("retrieval_empty", "all_chunks_filtered"),
+            subject_scope_required=True,
+            rail="product_ai_runtime",
+        )
+
+        async def _kwargs_retriever(
+            prompt_input: str,
+            *,
+            max_chunks: int,
+            philo_validation_enabled: bool,
+            recursive_rag_enabled: bool,
+            subject_id: int | None,
+            **kwargs: object,
+        ) -> RAGOrchestrationResult:
+            del max_chunks, philo_validation_enabled, recursive_rag_enabled, subject_id
+            observed["prompt_input"] = prompt_input
+            observed["knowledge_policy"] = kwargs["knowledge_policy"]
+            return RAGOrchestrationResult(
+                chunks=[],
+                formatted_prompt=prompt_input,
+                rag_actually_used=True,
+                confidence=0.9,
+                hops=1,
+                latency_ms=5,
+                knowledge_candidates=[candidate],
+                knowledge_candidates_canonical=True,
+            )
+
+        result = await runtime.generate_insight(
+            text="How much protein should I eat for recovery?",
+            lang="en",
+            provider=provider,
+            use_rag=True,
+            philo_validation_enabled=True,
+            recursive_rag_enabled=False,
+            subject_id=42,
+            philosophy_router_enabled=True,
+            philosophy_phase12_enabled=False,
+            philosophy_linguistic_enabled=True,
+            philosophy_pragmatic_enabled=False,
+            knowledge_policy=policy,
+            rag_retriever=_kwargs_retriever,
+        )
+
+        assert observed["knowledge_policy"] == policy
+        assert result.knowledge_candidates == [candidate]
+
+    async def test_runtime_forwards_policy_when_signature_introspection_fails(self) -> None:
+        """Opaque retrievers must fail closed toward forward-compatible policy passing."""
+
+        runtime = PhilosophicalRuntime()
+        provider = _StaticProvider(response="opaque answer")
+        observed: dict[str, object] = {}
+        candidate = KnowledgeFactCandidate(
+            fact_key="fact-opaque",
+            subject="subject:42",
+            predicate="validated_rag_evidence:docs/keep.md:keep",
+            value="chunk=keep;source=docs/keep.md;digest=opaque;hop=1",
+            observed_at=datetime(2026, 4, 20, 12, 15, tzinfo=timezone.utc),
+            confidence=0.9,
+            access_scope="subject:42",
+            rail="product_ai_runtime",
+            provenance=(KnowledgeEvidenceRef("keep", "docs/keep.md", 0.9, 1),),
+        )
+        policy = KnowledgePolicy(
+            enabled=True,
+            allow_reads=True,
+            allow_promotion=True,
+            min_confidence=0.7,
+            require_rag_factual_route=True,
+            deny_degraded_reasons=("retrieval_empty", "all_chunks_filtered"),
+            subject_scope_required=True,
+            rail="product_ai_runtime",
+        )
+
+        class _OpaqueRetriever:
+            async def __call__(
+                self,
+                prompt_input: str,
+                *,
+                max_chunks: int,
+                philo_validation_enabled: bool,
+                recursive_rag_enabled: bool,
+                subject_id: int | None,
+                **kwargs: object,
+            ) -> RAGOrchestrationResult:
+                del max_chunks, philo_validation_enabled, recursive_rag_enabled, subject_id
+                observed["prompt_input"] = prompt_input
+                observed["knowledge_policy"] = kwargs["knowledge_policy"]
+                return RAGOrchestrationResult(
+                    chunks=[],
+                    formatted_prompt=prompt_input,
+                    rag_actually_used=True,
+                    confidence=0.9,
+                    hops=1,
+                    latency_ms=5,
+                    knowledge_candidates=[candidate],
+                    knowledge_candidates_canonical=True,
+                )
+
+        opaque_retriever = _OpaqueRetriever()
+        runtime_mod._retriever_accepts_knowledge_policy.cache_clear()
+        try:
+            with patch.object(runtime_mod.inspect, "signature", side_effect=ValueError("opaque")):
+                result = await runtime.generate_insight(
+                    text="How much protein should I eat for recovery?",
+                    lang="en",
+                    provider=provider,
+                    use_rag=True,
+                    philo_validation_enabled=True,
+                    recursive_rag_enabled=False,
+                    subject_id=42,
+                    philosophy_router_enabled=True,
+                    philosophy_phase12_enabled=False,
+                    philosophy_linguistic_enabled=True,
+                    philosophy_pragmatic_enabled=False,
+                    knowledge_policy=policy,
+                    rag_retriever=opaque_retriever,
+                )
+        finally:
+            runtime_mod._retriever_accepts_knowledge_policy.cache_clear()
+
+        assert observed["knowledge_policy"] == policy
+        assert result.knowledge_candidates == [candidate]
 
     async def test_metadata_hidden_when_new_flags_are_off(self) -> None:
         runtime = PhilosophicalRuntime()

--- a/tests/test_philosophical_runtime.py
+++ b/tests/test_philosophical_runtime.py
@@ -605,29 +605,36 @@ class TestPhilosophicalRuntime:
                 )
 
         opaque_retriever = _OpaqueRetriever()
-        runtime_mod._retriever_accepts_knowledge_policy.cache_clear()
-        try:
-            with patch.object(runtime_mod.inspect, "signature", side_effect=ValueError("opaque")):
-                result = await runtime.generate_insight(
-                    text="How much protein should I eat for recovery?",
-                    lang="en",
-                    provider=provider,
-                    use_rag=True,
-                    philo_validation_enabled=True,
-                    recursive_rag_enabled=False,
-                    subject_id=42,
-                    philosophy_router_enabled=True,
-                    philosophy_phase12_enabled=False,
-                    philosophy_linguistic_enabled=True,
-                    philosophy_pragmatic_enabled=False,
-                    knowledge_policy=policy,
-                    rag_retriever=opaque_retriever,
-                )
-        finally:
-            runtime_mod._retriever_accepts_knowledge_policy.cache_clear()
+        with patch.object(runtime_mod.inspect, "signature", side_effect=ValueError("opaque")):
+            result = await runtime.generate_insight(
+                text="How much protein should I eat for recovery?",
+                lang="en",
+                provider=provider,
+                use_rag=True,
+                philo_validation_enabled=True,
+                recursive_rag_enabled=False,
+                subject_id=42,
+                philosophy_router_enabled=True,
+                philosophy_phase12_enabled=False,
+                philosophy_linguistic_enabled=True,
+                philosophy_pragmatic_enabled=False,
+                knowledge_policy=policy,
+                rag_retriever=opaque_retriever,
+            )
 
         assert observed["knowledge_policy"] == policy
         assert result.knowledge_candidates == [candidate]
+
+    async def test_retriever_accepts_knowledge_policy_handles_unhashable_callable_instance(
+        self,
+    ) -> None:
+        @dataclass(eq=True)
+        class _UnhashableRetriever:
+            async def __call__(self, prompt_input: str, **kwargs: object) -> object:
+                del prompt_input, kwargs
+                return None
+
+        assert runtime_mod._retriever_accepts_knowledge_policy(_UnhashableRetriever()) is True
 
     async def test_metadata_hidden_when_new_flags_are_off(self) -> None:
         runtime = PhilosophicalRuntime()

--- a/tests/test_philosophical_runtime.py
+++ b/tests/test_philosophical_runtime.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from dataclasses import dataclass
 from types import SimpleNamespace
 
 import pytest
 
+from core.knowledge.contracts import KnowledgeEvidenceRef, KnowledgeFactCandidate
+from core.knowledge.policy import KnowledgePolicy
 from core.insight.analytical import (
     AnalyticalSyntheticClassifier,
     FalsificationChecker,
@@ -29,6 +32,7 @@ from core.insight.philosophical_runtime import (
 from core.insight import philosophical_runtime as runtime_mod
 from core.insight.analytical import FalsificationReport, VerificationReport
 from core.bmi import extract_bmi_inputs
+from core.rag.orchestration import RAGOrchestrationResult
 
 
 @dataclass
@@ -338,6 +342,141 @@ class TestPhilosophicalRuntime:
         assert result.metadata.route_type == RouteType.RAG_FACTUAL.value
         assert result.provider_name == "philosophical_runtime"
         assert result.metadata.verification_rate is None
+
+    async def test_runtime_preserves_canonical_candidates_from_validated_retriever(self) -> None:
+        """Canonical validated retriever candidates may flow through the runtime."""
+
+        runtime = PhilosophicalRuntime()
+        provider = _StaticProvider(response="validated answer")
+        policy = KnowledgePolicy(
+            enabled=True,
+            allow_reads=True,
+            allow_promotion=True,
+            min_confidence=0.7,
+            require_rag_factual_route=True,
+            deny_degraded_reasons=("retrieval_empty", "all_chunks_filtered"),
+            subject_scope_required=True,
+            rail="product_ai_runtime",
+        )
+        candidate = KnowledgeFactCandidate(
+            fact_key="fact-1",
+            subject="subject:42",
+            predicate="validated_rag_evidence:docs/keep.md:keep",
+            value="chunk=keep;source=docs/keep.md;digest=abc123;hop=1",
+            observed_at=datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc),
+            confidence=0.9,
+            access_scope="subject:42",
+            rail="product_ai_runtime",
+            provenance=(KnowledgeEvidenceRef("keep", "docs/keep.md", 0.9, 1),),
+        )
+        observed: dict[str, object] = {}
+
+        async def _canonical_retriever(
+            prompt_input: str,
+            *,
+            max_chunks: int,
+            philo_validation_enabled: bool,
+            recursive_rag_enabled: bool,
+            subject_id: int | None,
+            knowledge_policy: KnowledgePolicy | None,
+        ) -> RAGOrchestrationResult:
+            observed["prompt_input"] = prompt_input
+            observed["knowledge_policy"] = knowledge_policy
+            del max_chunks, philo_validation_enabled, recursive_rag_enabled, subject_id
+            return RAGOrchestrationResult(
+                chunks=[],
+                formatted_prompt=prompt_input,
+                rag_actually_used=True,
+                confidence=0.9,
+                hops=1,
+                latency_ms=5,
+                knowledge_candidates=[candidate],
+                knowledge_candidates_canonical=True,
+            )
+
+        result = await runtime.generate_insight(
+            text="How much protein should I eat for recovery?",
+            lang="en",
+            provider=provider,
+            use_rag=True,
+            philo_validation_enabled=True,
+            recursive_rag_enabled=False,
+            subject_id=42,
+            philosophy_router_enabled=True,
+            philosophy_phase12_enabled=False,
+            philosophy_linguistic_enabled=True,
+            philosophy_pragmatic_enabled=False,
+            knowledge_policy=policy,
+            rag_retriever=_canonical_retriever,
+        )
+
+        assert observed["knowledge_policy"] == policy
+        assert result.knowledge_candidates == [candidate]
+
+    async def test_runtime_keeps_legacy_retriever_compatible_without_candidate_trust(self) -> None:
+        """Legacy retrievers without knowledge_policy kwarg must stay compatible and fail closed."""
+
+        runtime = PhilosophicalRuntime()
+        provider = _StaticProvider(response="legacy answer")
+        candidate = KnowledgeFactCandidate(
+            fact_key="fact-legacy",
+            subject="subject:42",
+            predicate="validated_rag_evidence:docs/keep.md:keep",
+            value="chunk=keep;source=docs/keep.md;digest=abc123;hop=1",
+            observed_at=datetime(2026, 4, 20, 12, 5, tzinfo=timezone.utc),
+            confidence=0.9,
+            access_scope="subject:42",
+            rail="product_ai_runtime",
+            provenance=(KnowledgeEvidenceRef("keep", "docs/keep.md", 0.9, 1),),
+        )
+
+        async def _legacy_retriever(
+            prompt_input: str,
+            *,
+            max_chunks: int,
+            philo_validation_enabled: bool,
+            recursive_rag_enabled: bool,
+            subject_id: int | None,
+        ) -> RAGOrchestrationResult:
+            del max_chunks, philo_validation_enabled, recursive_rag_enabled, subject_id
+            return RAGOrchestrationResult(
+                chunks=[],
+                formatted_prompt=prompt_input,
+                rag_actually_used=True,
+                confidence=0.9,
+                hops=1,
+                latency_ms=5,
+                knowledge_candidates=[candidate],
+                knowledge_candidates_canonical=False,
+            )
+
+        result = await runtime.generate_insight(
+            text="How much protein should I eat for recovery?",
+            lang="en",
+            provider=provider,
+            use_rag=True,
+            philo_validation_enabled=True,
+            recursive_rag_enabled=False,
+            subject_id=42,
+            philosophy_router_enabled=True,
+            philosophy_phase12_enabled=False,
+            philosophy_linguistic_enabled=True,
+            philosophy_pragmatic_enabled=False,
+            knowledge_policy=KnowledgePolicy(
+                enabled=True,
+                allow_reads=True,
+                allow_promotion=True,
+                min_confidence=0.7,
+                require_rag_factual_route=True,
+                deny_degraded_reasons=("retrieval_empty", "all_chunks_filtered"),
+                subject_scope_required=True,
+                rail="product_ai_runtime",
+            ),
+            rag_retriever=_legacy_retriever,
+        )
+
+        assert provider.calls == 1
+        assert result.knowledge_candidates == []
         assert result.metadata.falsifiability_rate is None
         assert result.metadata.contradiction_count == 0
 

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -1428,6 +1428,38 @@ async def test_rag_orchestration_denies_candidates_on_degraded_and_empty_context
 
 
 @pytest.mark.asyncio
+async def test_rag_orchestration_denies_canonical_candidates_when_retrieval_is_degraded() -> None:
+    """Validated pipelines must not mark degraded retrieval as canonical evidence."""
+
+    chunk = _make_chunk(chunk_id="keep", file="docs/keep.md", score=0.9)
+    rag_ctx = _make_rag_context(chunks=[chunk], confidence=0.9)
+    rag_ctx.degraded_reason = RAGDegradedReason.RETRIEVAL_EMPTY
+    pipeline_result = PipelineResult(
+        filtered_chunks=[chunk],
+        stage_results=[],
+        warnings=[],
+        total_latency_ms=1.0,
+    )
+
+    with (
+        patch("asyncio.to_thread", new_callable=AsyncMock, return_value=rag_ctx),
+        patch("core.rag.vector_rag.retrieve_context_structured"),
+        patch("core.rag.philosophy_pipeline.run_pipeline", return_value=pipeline_result),
+        patch("core.rag.formatting.format_rag_chunks_for_prompt", return_value="Keep chunk"),
+        patch("core.insight.safety.redact_rag_context_for_insight", return_value="Keep chunk"),
+    ):
+        result = await retrieve_and_validate_rag(
+            "test prompt",
+            philo_validation_enabled=True,
+            subject_id=42,
+            knowledge_policy=_knowledge_policy(),
+        )
+
+    assert result.knowledge_candidates == []
+    assert result.knowledge_candidates_canonical is False
+
+
+@pytest.mark.asyncio
 async def test_rag_orchestration_confidence_threshold_gates_candidates() -> None:
     """Sub-threshold confidence must keep usable RAG output but deny promotion."""
 

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from core.knowledge.policy import KnowledgePolicy
 from core.rag.contracts import RAGChunk, RAGContext, RAGDegradedReason
 from core.insight.safety import redact_rag_context_for_insight
 from core.rag.formatting import build_rag_source_dicts, format_rag_chunks_for_prompt
@@ -30,6 +31,19 @@ from core.rag.orchestration import (
 )
 from core.rag.philosophy_pipeline import PipelineResult, StageResult
 from core.rag.validation import ValidationResult
+
+
+def _knowledge_policy() -> KnowledgePolicy:
+    return KnowledgePolicy(
+        enabled=True,
+        allow_reads=True,
+        allow_promotion=True,
+        min_confidence=0.7,
+        require_rag_factual_route=True,
+        deny_degraded_reasons=tuple(reason.value for reason in RAGDegradedReason),
+        subject_scope_required=True,
+        rail="product_ai_runtime",
+    )
 
 
 def _make_chunk(
@@ -1314,3 +1328,154 @@ def test_simple_rag_skips_chunks_that_become_empty_after_redaction(
 
     assert len(result.chunks) == 1
     assert result.chunks[0].content == "safe chunk"
+
+
+@pytest.mark.asyncio
+async def test_rag_orchestration_builds_candidates_only_from_validated_chunks() -> None:
+    """Knowledge candidates must derive from surviving validated chunks only."""
+
+    chunks = [
+        _make_chunk(chunk_id="keep", file="docs/keep.md", score=0.9),
+        _make_chunk(chunk_id="drop", file="docs/drop.md", score=0.2),
+    ]
+    rag_ctx = _make_rag_context(chunks=chunks, confidence=0.5)
+    pipeline_result = PipelineResult(
+        filtered_chunks=[chunks[0]],
+        stage_results=[],
+        warnings=[],
+        total_latency_ms=1.0,
+    )
+
+    with (
+        patch("asyncio.to_thread", new_callable=AsyncMock, return_value=rag_ctx),
+        patch("core.rag.vector_rag.retrieve_context_structured"),
+        patch("core.rag.philosophy_pipeline.run_pipeline", return_value=pipeline_result),
+        patch("core.rag.formatting.format_rag_chunks_for_prompt", return_value="Keep chunk"),
+        patch("core.insight.safety.redact_rag_context_for_insight", return_value="Keep chunk"),
+    ):
+        result = await retrieve_and_validate_rag(
+            "test prompt",
+            philo_validation_enabled=True,
+            subject_id=42,
+            knowledge_policy=_knowledge_policy(),
+        )
+
+    assert [chunk.chunk_id for chunk in result.chunks] == ["keep"]
+    assert len(result.knowledge_candidates) == 1
+    assert result.knowledge_candidates_canonical is True
+    assert result.knowledge_candidates[0].predicate == "validated_rag_evidence:docs/keep.md:keep"
+
+
+@pytest.mark.asyncio
+async def test_rag_orchestration_denies_candidates_on_degraded_and_empty_context_paths() -> None:
+    """Fail-closed paths must never emit knowledge candidates."""
+
+    chunk = _make_chunk(chunk_id="keep", file="docs/keep.md", score=0.9)
+    rag_ctx = _make_rag_context(chunks=[chunk], confidence=0.9)
+    rag_ctx.degraded_reason = RAGDegradedReason.RETRIEVAL_EMPTY
+
+    with (
+        patch("asyncio.to_thread", new_callable=AsyncMock, return_value=rag_ctx),
+        patch("core.rag.vector_rag.retrieve_context_structured"),
+    ):
+        degraded_result = await retrieve_and_validate_rag(
+            "test prompt",
+            subject_id=42,
+            knowledge_policy=_knowledge_policy(),
+        )
+
+    filtered_pipeline = PipelineResult(
+        filtered_chunks=[],
+        stage_results=[],
+        warnings=[],
+        total_latency_ms=1.0,
+    )
+    with (
+        patch(
+            "asyncio.to_thread",
+            new_callable=AsyncMock,
+            return_value=_make_rag_context(chunks=[chunk], confidence=0.9),
+        ),
+        patch("core.rag.vector_rag.retrieve_context_structured"),
+        patch("core.rag.philosophy_pipeline.run_pipeline", return_value=filtered_pipeline),
+    ):
+        filtered_result = await retrieve_and_validate_rag(
+            "test prompt",
+            philo_validation_enabled=True,
+            subject_id=42,
+            knowledge_policy=_knowledge_policy(),
+        )
+
+    with (
+        patch(
+            "asyncio.to_thread",
+            new_callable=AsyncMock,
+            return_value=_make_rag_context(chunks=[chunk], confidence=0.9),
+        ),
+        patch("core.rag.vector_rag.retrieve_context_structured"),
+        patch("core.rag.formatting.format_rag_chunks_for_prompt", return_value="usable"),
+        patch("core.insight.safety.redact_rag_context_for_insight", return_value="   "),
+    ):
+        redacted_empty_result = await retrieve_and_validate_rag(
+            "test prompt",
+            subject_id=42,
+            knowledge_policy=_knowledge_policy(),
+        )
+
+    assert degraded_result.knowledge_candidates == []
+    assert filtered_result.knowledge_candidates == []
+    assert redacted_empty_result.knowledge_candidates == []
+
+
+@pytest.mark.asyncio
+async def test_rag_orchestration_confidence_threshold_gates_candidates() -> None:
+    """Sub-threshold confidence must keep usable RAG output but deny promotion."""
+
+    chunk = _make_chunk(chunk_id="keep", file="docs/keep.md", score=0.65)
+    with (
+        patch(
+            "asyncio.to_thread",
+            new_callable=AsyncMock,
+            return_value=_make_rag_context(chunks=[chunk], confidence=0.2),
+        ),
+        patch("core.rag.vector_rag.retrieve_context_structured"),
+        patch("core.rag.formatting.format_rag_chunks_for_prompt", return_value="Keep chunk"),
+        patch("core.insight.safety.redact_rag_context_for_insight", return_value="Keep chunk"),
+    ):
+        result = await retrieve_and_validate_rag(
+            "test prompt",
+            subject_id=42,
+            knowledge_policy=_knowledge_policy(),
+        )
+
+    assert result.rag_actually_used is True
+    assert result.confidence == 0.65
+    assert result.knowledge_candidates == []
+    assert result.knowledge_candidates_canonical is False
+
+
+@pytest.mark.asyncio
+async def test_rag_orchestration_denies_candidates_when_validation_is_disabled() -> None:
+    """Promotion candidates are canonical only on the validated orchestration path."""
+
+    chunk = _make_chunk(chunk_id="keep", file="docs/keep.md", score=0.9)
+    with (
+        patch(
+            "asyncio.to_thread",
+            new_callable=AsyncMock,
+            return_value=_make_rag_context(chunks=[chunk], confidence=0.9),
+        ),
+        patch("core.rag.vector_rag.retrieve_context_structured"),
+        patch("core.rag.formatting.format_rag_chunks_for_prompt", return_value="Keep chunk"),
+        patch("core.insight.safety.redact_rag_context_for_insight", return_value="Keep chunk"),
+    ):
+        result = await retrieve_and_validate_rag(
+            "test prompt",
+            philo_validation_enabled=False,
+            subject_id=42,
+            knowledge_policy=_knowledge_policy(),
+        )
+
+    assert result.rag_actually_used is True
+    assert result.knowledge_candidates == []
+    assert result.knowledge_candidates_canonical is False

--- a/tests/test_recursive_rag.py
+++ b/tests/test_recursive_rag.py
@@ -6,7 +6,9 @@ from typing import Any
 
 import pytest
 
+from core.knowledge.policy import KnowledgePolicy
 from core.rag.contracts import OptimizationStopReason, RAGChunk, RAGContext
+from core.rag.orchestration import retrieve_and_validate_rag
 from core.rag.philosophy_pipeline import PipelineResult
 from core.rag.recursive_retrieval import retrieve_recursive_context_structured
 from core.rag.validation import ValidationResult
@@ -1000,3 +1002,60 @@ def test_hop_vector_cache_disabled_when_optimization_flag_off(
 
     assert result.optimization_stats is None
     assert calls["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_recursive_nonvalidated_path_never_emits_knowledge_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recursive request-local memoization must remain optimization-only."""
+    import core.rag.recursive_retrieval as recursive
+
+    monkeypatch.setattr(recursive, "MAX_RAG_HOPS", 3)
+    monkeypatch.setattr(recursive, "MAX_REFINEMENT_PASSES", 5)
+    monkeypatch.setattr(recursive, "MAX_VERIFICATION_QUERIES", 0)
+    monkeypatch.setattr(recursive, "MIN_CONFIDENCE_GAIN_PER_HOP", -1.0)
+
+    calls = {"n": 0}
+
+    def _fake_retrieve(query: str, **_: Any) -> RAGContext:
+        calls["n"] += 1
+        return _ctx(
+            query,
+            [
+                RAGChunk(
+                    chunk_id=f"doc-{len(query)}",
+                    file="doc.md",
+                    content=f"fiber vegetables nutrition guidance token{len(query)}",
+                    score=0.7,
+                )
+            ],
+            confidence=0.7,
+        )
+
+    monkeypatch.setattr("core.rag.vector_rag.retrieve_context_structured", _fake_retrieve)
+    monkeypatch.setattr(recursive, "_refine_query", lambda current, *_args, **_kwargs: current)
+
+    result = await retrieve_and_validate_rag(
+        "first",
+        philo_validation_enabled=False,
+        recursive_rag_enabled=True,
+        optimization_enabled=True,
+        subject_id=42,
+        knowledge_policy=KnowledgePolicy(
+            enabled=True,
+            allow_reads=True,
+            allow_promotion=True,
+            min_confidence=0.7,
+            require_rag_factual_route=True,
+            deny_degraded_reasons=("retrieval_empty", "all_chunks_filtered"),
+            subject_scope_required=True,
+            rail="product_ai_runtime",
+        ),
+    )
+
+    assert calls["n"] >= 1
+    assert result.recursive_executed is True
+    assert result.rag_actually_used is True
+    assert result.knowledge_candidates == []
+    assert result.knowledge_candidates_canonical is False

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -11,6 +11,8 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import asyncio
+
 import pytest
 
 from tests.test_root_npm_dependency_guards import _load_json
@@ -528,7 +530,7 @@ class TestKnowledgeStoreFastLane:
 
         assert [record.fact_key for record in active] == ["fact-3"]
         assert wrong_scope == []
-        assert len([record for record in store._records if record.status == "superseded"]) == 1
+        assert len([record for record in store.all_records() if record.status == "superseded"]) == 1
 
 
 class TestInsightApplicationServiceFastLane:
@@ -584,6 +586,46 @@ class TestInsightApplicationServiceFastLane:
 
         assert warnings
         assert "Knowledge promotion failed" in str(warnings[0][0][0])
+        assert warnings[0][1]["exc_info"] is True
+
+    @pytest.mark.asyncio
+    async def test_maybe_promote_knowledge_candidates_times_out_async_store(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Timed-out promotion must degrade to logging instead of request latency."""
+
+        from app.services.insight_application_service import _maybe_promote_knowledge_candidates
+
+        warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+        class _SlowStore:
+            def promote(self, candidates: list[object]) -> object:
+                del candidates
+
+                async def _stall() -> list[object]:
+                    await asyncio.Future()
+
+                return _stall()
+
+        monkeypatch.setattr(
+            "app.services.insight_application_service.KNOWLEDGE_PROMOTION_TIMEOUT_SECONDS",
+            0.01,
+            raising=True,
+        )
+        monkeypatch.setattr(
+            "app.services.insight_application_service.logger.warning",
+            lambda *args, **kwargs: warnings.append((args, kwargs)),
+            raising=True,
+        )
+
+        await _maybe_promote_knowledge_candidates(
+            knowledge_store=_SlowStore(),
+            candidates=[SimpleNamespace(fact_key="fact-1")],
+        )
+
+        assert warnings
+        assert "Knowledge promotion timed out" in str(warnings[0][0][0])
         assert warnings[0][1]["exc_info"] is True
 
 

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -7,11 +7,12 @@ EN: Tests for remaining modules with low coverage
 """
 
 import sys
+import time
 from collections.abc import Sequence
 from pathlib import Path
 from datetime import datetime, timezone
 from types import ModuleType, SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
 import asyncio
@@ -561,9 +562,10 @@ class TestInsightApplicationServiceFastLane:
         """Async stores must be awaited before the response path continues."""
 
         from app.services.insight_application_service import _maybe_promote_knowledge_candidates
+        from core.knowledge.contracts import KnowledgeFactCandidate
 
         observed: dict[str, object] = {}
-        candidate = SimpleNamespace(fact_key="fact-1")
+        candidate = cast(KnowledgeFactCandidate, SimpleNamespace(fact_key="fact-1"))
 
         class _AsyncStore:
             async def promote(self, candidates: list[object]) -> list[object]:
@@ -585,6 +587,7 @@ class TestInsightApplicationServiceFastLane:
         """Store failures must not break the user response path."""
 
         from app.services.insight_application_service import _maybe_promote_knowledge_candidates
+        from core.knowledge.contracts import KnowledgeFactCandidate
 
         warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
@@ -601,7 +604,7 @@ class TestInsightApplicationServiceFastLane:
 
         await _maybe_promote_knowledge_candidates(
             knowledge_store=_BrokenStore(),
-            candidates=[SimpleNamespace(fact_key="fact-1")],
+            candidates=[cast(KnowledgeFactCandidate, SimpleNamespace(fact_key="fact-1"))],
         )
 
         assert warnings
@@ -616,6 +619,7 @@ class TestInsightApplicationServiceFastLane:
         """Timed-out promotion must degrade to logging instead of request latency."""
 
         from app.services.insight_application_service import _maybe_promote_knowledge_candidates
+        from core.knowledge.contracts import KnowledgeFactCandidate
 
         warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
@@ -641,7 +645,45 @@ class TestInsightApplicationServiceFastLane:
 
         await _maybe_promote_knowledge_candidates(
             knowledge_store=_SlowStore(),
-            candidates=[SimpleNamespace(fact_key="fact-1")],
+            candidates=[cast(KnowledgeFactCandidate, SimpleNamespace(fact_key="fact-1"))],
+        )
+
+        assert warnings
+        assert "Knowledge promotion timed out" in str(warnings[0][0][0])
+        assert warnings[0][1]["exc_info"] is True
+
+    @pytest.mark.asyncio
+    async def test_maybe_promote_knowledge_candidates_times_out_sync_store(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sync promotion must also respect the bounded timeout via thread offload."""
+
+        from app.services.insight_application_service import _maybe_promote_knowledge_candidates
+        from core.knowledge.contracts import KnowledgeFactCandidate
+
+        warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+        class _SlowSyncStore:
+            def promote(self, candidates: list[object]) -> list[object]:
+                del candidates
+                time.sleep(0.05)
+                return []
+
+        monkeypatch.setattr(
+            "app.services.insight_application_service.KNOWLEDGE_PROMOTION_TIMEOUT_SECONDS",
+            0.01,
+            raising=True,
+        )
+        monkeypatch.setattr(
+            "app.services.insight_application_service.logger.warning",
+            lambda *args, **kwargs: warnings.append((args, kwargs)),
+            raising=True,
+        )
+
+        await _maybe_promote_knowledge_candidates(
+            knowledge_store=_SlowSyncStore(),
+            candidates=[cast(KnowledgeFactCandidate, SimpleNamespace(fact_key="fact-1"))],
         )
 
         assert warnings

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -7,6 +7,8 @@ EN: Tests for remaining modules with low coverage
 """
 
 from pathlib import Path
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -259,7 +261,6 @@ class TestTimeUtilsModule:
         # Test datetime parsing
         result = parse_datetime("2024-01-01T00:00:00")
         assert result is not None
-
         result = parse_datetime("2024-01-01")
         assert result is not None
 
@@ -283,6 +284,448 @@ class TestTimeUtilsModule:
         # Test date validation
         assert is_valid_date("2024-01-01") is True
         assert is_valid_date("invalid") is False
+
+
+class TestKnowledgePromotionFastLane:
+    """Keep knowledge promotion fail-closed branches in the deterministic fast lane."""
+
+    @staticmethod
+    def _knowledge_policy(
+        *,
+        enabled: bool = True,
+        allow_promotion: bool = True,
+        subject_scope_required: bool = True,
+    ):
+        from core.knowledge.policy import KnowledgePolicy
+
+        return KnowledgePolicy(
+            enabled=enabled,
+            allow_reads=True,
+            allow_promotion=allow_promotion,
+            min_confidence=0.7,
+            require_rag_factual_route=True,
+            deny_degraded_reasons=("retrieval_empty", "all_chunks_filtered"),
+            subject_scope_required=subject_scope_required,
+            rail="product_ai_runtime",
+        )
+
+    @staticmethod
+    def _chunk(*, content: str = "Validated chunk."):
+        from core.rag.contracts import RAGChunk
+
+        return RAGChunk(
+            chunk_id="chunk-1",
+            file="docs/one.md",
+            content=content,
+            score=0.88,
+            hop=1,
+        )
+
+    @staticmethod
+    def _candidate(*, fact_key: str, confidence: float, observed_at: datetime, supersedes=()):
+        from core.knowledge.contracts import KnowledgeEvidenceRef, KnowledgeFactCandidate
+
+        return KnowledgeFactCandidate(
+            fact_key=fact_key,
+            subject="subject:42",
+            predicate="validated_rag_evidence:docs/one.md:chunk-1",
+            value=f"chunk=chunk-1;source=docs/one.md;digest={fact_key};hop=1",
+            observed_at=observed_at,
+            confidence=confidence,
+            access_scope="subject:42",
+            rail="product_ai_runtime",
+            provenance=(KnowledgeEvidenceRef("chunk-1", "docs/one.md", confidence, 1),),
+            supersedes=tuple(supersedes),
+        )
+
+    def test_build_knowledge_promotion_candidates_covers_fail_closed_branches(self) -> None:
+        """Promotion must reject missing inputs and empty validated content deterministically."""
+
+        from core.knowledge.promotion import build_knowledge_promotion_candidates
+
+        policy = self._knowledge_policy()
+
+        assert (
+            build_knowledge_promotion_candidates(
+                chunks=[],
+                confidence=0.9,
+                degraded_reason=None,
+                subject_id=42,
+                knowledge_policy=policy,
+            )
+            == []
+        )
+        assert (
+            build_knowledge_promotion_candidates(
+                chunks=[self._chunk()],
+                confidence=0.9,
+                degraded_reason="retrieval_empty",
+                subject_id=42,
+                knowledge_policy=policy,
+            )
+            == []
+        )
+        assert (
+            build_knowledge_promotion_candidates(
+                chunks=[self._chunk()],
+                confidence=None,
+                degraded_reason=None,
+                subject_id=42,
+                knowledge_policy=policy,
+            )
+            == []
+        )
+        assert (
+            build_knowledge_promotion_candidates(
+                chunks=[self._chunk()],
+                confidence=0.9,
+                degraded_reason=None,
+                subject_id=None,
+                knowledge_policy=policy,
+            )
+            == []
+        )
+        assert (
+            build_knowledge_promotion_candidates(
+                chunks=[self._chunk(content="   ")],
+                confidence=0.9,
+                degraded_reason=None,
+                subject_id=42,
+                knowledge_policy=policy,
+            )
+            == []
+        )
+
+    def test_knowledge_promotion_record_helpers_cover_supersession_paths(self) -> None:
+        """Same-confidence newer evidence may supersede only when explicitly declared."""
+
+        from core.knowledge.contracts import KnowledgeRecord
+        from core.knowledge.promotion import (
+            candidate_should_supersede,
+            candidate_to_record,
+            mark_record_superseded,
+        )
+
+        observed_at = datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc)
+        existing = KnowledgeRecord(
+            fact_key="fact-1",
+            subject="subject:42",
+            predicate="validated_rag_evidence:docs/one.md:chunk-1",
+            value="chunk=chunk-1;source=docs/one.md;digest=fact-1;hop=1",
+            status="active",
+            confidence=0.9,
+            access_scope="subject:42",
+            rail="product_ai_runtime",
+            provenance=(),
+            observed_at=observed_at,
+        )
+        candidate = self._candidate(
+            fact_key="fact-2",
+            confidence=0.9,
+            observed_at=observed_at.replace(minute=1),
+            supersedes=("fact-1",),
+        )
+
+        assert candidate_should_supersede(existing=existing, candidate=candidate) is True
+
+        active_record = candidate_to_record(candidate)
+        assert active_record.status == "active"
+        assert active_record.fact_key == "fact-2"
+
+        superseded = mark_record_superseded(record=existing, superseded_by="fact-2")
+        assert superseded.status == "superseded"
+        assert superseded.superseded_by == "fact-2"
+
+
+class TestKnowledgeStoreFastLane:
+    """Keep bounded knowledge store seams covered by test-fast."""
+
+    @staticmethod
+    def _candidate(*, fact_key: str, confidence: float, observed_at: datetime, supersedes=()):
+        from core.knowledge.contracts import KnowledgeEvidenceRef, KnowledgeFactCandidate
+
+        return KnowledgeFactCandidate(
+            fact_key=fact_key,
+            subject="subject:42",
+            predicate="validated_rag_evidence:docs/test.md:chunk-1",
+            value=f"value:{fact_key}",
+            observed_at=observed_at,
+            confidence=confidence,
+            access_scope="subject:42",
+            rail="product_ai_runtime",
+            provenance=(KnowledgeEvidenceRef("chunk-1", "docs/test.md", confidence, 1),),
+            supersedes=tuple(supersedes),
+        )
+
+    def test_noop_knowledge_store_discards_promotions_and_reads(self) -> None:
+        """No-op store must fail closed without persisting or leaking records."""
+
+        from core.knowledge.store import NoOpKnowledgeStore
+
+        store = NoOpKnowledgeStore()
+        candidate = self._candidate(
+            fact_key="fact-1",
+            confidence=0.8,
+            observed_at=datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc),
+        )
+
+        assert store.promote([candidate]) == []
+        assert (
+            store.read(
+                subject="subject:42",
+                predicate="validated_rag_evidence:docs/test.md:chunk-1",
+                access_scope="subject:42",
+                rail="product_ai_runtime",
+            )
+            == []
+        )
+
+    def test_in_memory_knowledge_store_replays_reads_and_supersedes_only_when_eligible(
+        self,
+    ) -> None:
+        """Store must support idempotent replay, scoped reads, and explicit supersession only."""
+
+        from core.knowledge.store import InMemoryKnowledgeStore
+
+        observed_at = datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc)
+        store = InMemoryKnowledgeStore()
+        first = self._candidate(fact_key="fact-1", confidence=0.8, observed_at=observed_at)
+        weaker = self._candidate(
+            fact_key="fact-2",
+            confidence=0.7,
+            observed_at=observed_at.replace(minute=1),
+            supersedes=("fact-1",),
+        )
+        stronger = self._candidate(
+            fact_key="fact-3",
+            confidence=0.95,
+            observed_at=observed_at.replace(minute=2),
+            supersedes=("fact-1",),
+        )
+
+        first_promoted = store.promote([first])
+        replay_promoted = store.promote([first])
+        weaker_promoted = store.promote([weaker])
+        stronger_promoted = store.promote([stronger])
+
+        assert [record.fact_key for record in first_promoted] == ["fact-1"]
+        assert replay_promoted == []
+        assert weaker_promoted == []
+        assert [record.fact_key for record in stronger_promoted] == ["fact-3"]
+
+        active = store.read(
+            subject="subject:42",
+            predicate="validated_rag_evidence:docs/test.md:chunk-1",
+            access_scope="subject:42",
+            rail="product_ai_runtime",
+        )
+        wrong_scope = store.read(
+            subject="subject:42",
+            predicate="validated_rag_evidence:docs/test.md:chunk-1",
+            access_scope="subject:99",
+            rail="product_ai_runtime",
+        )
+
+        assert [record.fact_key for record in active] == ["fact-3"]
+        assert wrong_scope == []
+        assert len([record for record in store._records if record.status == "superseded"]) == 1
+
+
+class TestInsightApplicationServiceFastLane:
+    """Keep async knowledge-promotion seam covered by test-fast."""
+
+    @pytest.mark.asyncio
+    async def test_maybe_promote_knowledge_candidates_awaits_async_store(self) -> None:
+        """Async stores must be awaited before the response path continues."""
+
+        from app.services.insight_application_service import _maybe_promote_knowledge_candidates
+
+        observed: dict[str, object] = {}
+        candidate = SimpleNamespace(fact_key="fact-1")
+
+        class _AsyncStore:
+            async def promote(self, candidates: list[object]) -> list[object]:
+                observed["candidates"] = candidates
+                return []
+
+        await _maybe_promote_knowledge_candidates(
+            knowledge_store=_AsyncStore(),
+            candidates=[candidate],
+        )
+
+        assert observed["candidates"] == [candidate]
+
+    @pytest.mark.asyncio
+    async def test_maybe_promote_knowledge_candidates_logs_and_swallows_store_errors(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Store failures must not break the user response path."""
+
+        from app.services.insight_application_service import _maybe_promote_knowledge_candidates
+
+        warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+        class _BrokenStore:
+            def promote(self, candidates: list[object]) -> list[object]:
+                del candidates
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(
+            "app.services.insight_application_service.logger.warning",
+            lambda *args, **kwargs: warnings.append((args, kwargs)),
+            raising=True,
+        )
+
+        await _maybe_promote_knowledge_candidates(
+            knowledge_store=_BrokenStore(),
+            candidates=[SimpleNamespace(fact_key="fact-1")],
+        )
+
+        assert warnings
+        assert "Knowledge promotion failed" in str(warnings[0][0][0])
+        assert warnings[0][1]["exc_info"] is True
+
+
+class TestPhilosophicalRuntimeFastLane:
+    """Keep runtime knowledge-candidate gating covered by the fast lane."""
+
+    @staticmethod
+    def _runtime_policy(*, enabled: bool = True, allow_promotion: bool = True):
+        from core.knowledge.policy import KnowledgePolicy
+
+        return KnowledgePolicy(
+            enabled=enabled,
+            allow_reads=True,
+            allow_promotion=allow_promotion,
+            min_confidence=0.7,
+            require_rag_factual_route=True,
+            deny_degraded_reasons=("retrieval_empty", "all_chunks_filtered"),
+            subject_scope_required=True,
+            rail="product_ai_runtime",
+        )
+
+    @staticmethod
+    def _runtime_candidate():
+        from core.knowledge.contracts import KnowledgeEvidenceRef, KnowledgeFactCandidate
+
+        return KnowledgeFactCandidate(
+            fact_key="fact-1",
+            subject="subject:42",
+            predicate="validated_rag_evidence:docs/test.md:chunk-1",
+            value="chunk=chunk-1;source=docs/test.md;digest=abc123;hop=1",
+            observed_at=datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc),
+            confidence=0.9,
+            access_scope="subject:42",
+            rail="product_ai_runtime",
+            provenance=(KnowledgeEvidenceRef("chunk-1", "docs/test.md", 0.9, 1),),
+        )
+
+    @pytest.mark.parametrize(
+        (
+            "route_type",
+            "philo_validation_enabled",
+            "policy",
+            "rag_actually_used",
+            "degraded_reason",
+            "canonical",
+            "expected_count",
+        ),
+        [
+            ("DEEP_REASONING", True, "enabled", True, None, True, 0),
+            ("RAG_FACTUAL", False, "enabled", True, None, True, 0),
+            ("RAG_FACTUAL", True, "none", True, None, True, 0),
+            ("RAG_FACTUAL", True, "disabled", True, None, True, 0),
+            ("RAG_FACTUAL", True, "deny", True, None, True, 0),
+            ("RAG_FACTUAL", True, "enabled", False, None, True, 0),
+            ("RAG_FACTUAL", True, "enabled", True, "retrieval_empty", True, 0),
+            ("RAG_FACTUAL", True, "enabled", True, None, False, 0),
+            ("RAG_FACTUAL", True, "enabled", True, None, True, 1),
+        ],
+    )
+    def test_resolve_runtime_knowledge_candidates_honors_all_guards(
+        self,
+        route_type: str,
+        philo_validation_enabled: bool,
+        policy: str,
+        rag_actually_used: bool,
+        degraded_reason: str | None,
+        canonical: bool,
+        expected_count: int,
+    ) -> None:
+        """Runtime may promote only canonical candidates from validated factual RAG paths."""
+
+        from core.insight.philosophical_runtime import (
+            PhilosophicalRuntime,
+            RiskLevel,
+            RouteDecision,
+            RouteType,
+        )
+        from core.rag.orchestration import RAGOrchestrationResult
+
+        runtime = PhilosophicalRuntime()
+        candidate = self._runtime_candidate()
+        decision = RouteDecision(
+            route_type=RouteType(route_type),
+            target_depth=1,
+            needs_rag=True,
+            needs_generation=True,
+            risk_level=RiskLevel.LOW,
+        )
+        if policy == "none":
+            knowledge_policy = None
+        elif policy == "disabled":
+            knowledge_policy = self._runtime_policy(enabled=False)
+        elif policy == "deny":
+            knowledge_policy = self._runtime_policy(allow_promotion=False)
+        else:
+            knowledge_policy = self._runtime_policy()
+
+        result = runtime._resolve_runtime_knowledge_candidates(
+            decision=decision,
+            rag_result=RAGOrchestrationResult(
+                chunks=[],
+                formatted_prompt="prompt",
+                rag_actually_used=rag_actually_used,
+                confidence=0.9,
+                hops=1,
+                latency_ms=1,
+                degraded_reason=degraded_reason,
+                knowledge_candidates=[candidate],
+                knowledge_candidates_canonical=canonical,
+            ),
+            philo_validation_enabled=philo_validation_enabled,
+            knowledge_policy=knowledge_policy,
+        )
+
+        assert len(result) == expected_count
+
+
+class TestVectorTypeFastLane:
+    """Keep pgvector SQLAlchemy fallback covered inside test-fast."""
+
+    def test_build_sqlalchemy_vector_type_falls_back_when_pgvector_is_missing(self) -> None:
+        """Fallback vector type must still render valid SQL when pgvector is absent."""
+
+        from core.rag import vector_rag
+
+        original_import = __import__
+
+        def _fake_import(
+            name: str,
+            globals=None,
+            locals=None,
+            fromlist=(),
+            level: int = 0,
+        ):
+            if name == "pgvector.sqlalchemy":
+                raise ModuleNotFoundError("pgvector not installed")
+            return original_import(name, globals, locals, fromlist, level)
+
+        with patch("builtins.__import__", side_effect=_fake_import):
+            vector_type = vector_rag._build_sqlalchemy_vector_type(7)
+
+        assert vector_type.get_col_spec() == "VECTOR(7)"
 
 
 class TestDbGuardAndFallbackSmokeCoverage:

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -6,9 +6,12 @@ RU: Тесты для оставшихся модулей с низким пок
 EN: Tests for remaining modules with low coverage
 """
 
+import sys
+from collections.abc import Sequence
 from pathlib import Path
 from datetime import datetime, timezone
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import asyncio
@@ -16,6 +19,11 @@ import asyncio
 import pytest
 
 from tests.test_root_npm_dependency_guards import _load_json
+
+if TYPE_CHECKING:
+    from core.knowledge.contracts import KnowledgeFactCandidate
+    from core.knowledge.policy import KnowledgePolicy
+    from core.rag.contracts import RAGChunk
 
 
 def test_root_npm_security_override_smoke() -> None:
@@ -297,7 +305,7 @@ class TestKnowledgePromotionFastLane:
         enabled: bool = True,
         allow_promotion: bool = True,
         subject_scope_required: bool = True,
-    ):
+    ) -> "KnowledgePolicy":
         from core.knowledge.policy import KnowledgePolicy
 
         return KnowledgePolicy(
@@ -312,7 +320,7 @@ class TestKnowledgePromotionFastLane:
         )
 
     @staticmethod
-    def _chunk(*, content: str = "Validated chunk."):
+    def _chunk(*, content: str = "Validated chunk.") -> "RAGChunk":
         from core.rag.contracts import RAGChunk
 
         return RAGChunk(
@@ -324,7 +332,13 @@ class TestKnowledgePromotionFastLane:
         )
 
     @staticmethod
-    def _candidate(*, fact_key: str, confidence: float, observed_at: datetime, supersedes=()):
+    def _candidate(
+        *,
+        fact_key: str,
+        confidence: float,
+        observed_at: datetime,
+        supersedes: Sequence[str] = (),
+    ) -> "KnowledgeFactCandidate":
         from core.knowledge.contracts import KnowledgeEvidenceRef, KnowledgeFactCandidate
 
         return KnowledgeFactCandidate(
@@ -443,7 +457,13 @@ class TestKnowledgeStoreFastLane:
     """Keep bounded knowledge store seams covered by test-fast."""
 
     @staticmethod
-    def _candidate(*, fact_key: str, confidence: float, observed_at: datetime, supersedes=()):
+    def _candidate(
+        *,
+        fact_key: str,
+        confidence: float,
+        observed_at: datetime,
+        supersedes: Sequence[str] = (),
+    ) -> "KnowledgeFactCandidate":
         from core.knowledge.contracts import KnowledgeEvidenceRef, KnowledgeFactCandidate
 
         return KnowledgeFactCandidate(
@@ -746,26 +766,18 @@ class TestPhilosophicalRuntimeFastLane:
 class TestVectorTypeFastLane:
     """Keep pgvector SQLAlchemy fallback covered inside test-fast."""
 
-    def test_build_sqlalchemy_vector_type_falls_back_when_pgvector_is_missing(self) -> None:
+    def test_build_sqlalchemy_vector_type_falls_back_when_pgvector_is_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Fallback vector type must still render valid SQL when pgvector is absent."""
 
         from core.rag import vector_rag
 
-        original_import = __import__
-
-        def _fake_import(
-            name: str,
-            globals=None,
-            locals=None,
-            fromlist=(),
-            level: int = 0,
-        ):
-            if name == "pgvector.sqlalchemy":
-                raise ModuleNotFoundError("pgvector not installed")
-            return original_import(name, globals, locals, fromlist, level)
-
-        with patch("builtins.__import__", side_effect=_fake_import):
-            vector_type = vector_rag._build_sqlalchemy_vector_type(7)
+        # RU: Имитируем отсутствие установленного pgvector без моков import hook.
+        # EN: Simulate a missing pgvector install without patching Python's import hook.
+        monkeypatch.setitem(sys.modules, "pgvector", ModuleType("pgvector"))
+        monkeypatch.delitem(sys.modules, "pgvector.sqlalchemy", raising=False)
+        vector_type = vector_rag._build_sqlalchemy_vector_type(7)
 
         assert vector_type.get_col_spec() == "VECTOR(7)"
 


### PR DESCRIPTION
## Summary
- add the bounded `core/knowledge/*` contract, policy, promotion, and store seam for PR-K1
- thread canonical knowledge policy through insight runtime and RAG orchestration so promotion is allowed only from validated `RAG_FACTUAL` evidence and fails closed on degraded or non-canonical paths
- add deterministic tests and K1 coordination artifacts, plus a `pgvector`-free SQLAlchemy fallback for vector-RAG tests when the optional package is absent

## Why
PR-K1 is the first bounded post-A5 runtime follow-up. It closes the gap between retrieval artifacts and canonical knowledge promotion without widening scope into semantic cache, DB rollout, or public route/OpenAPI changes.

## How to validate
- `pre-commit run --all-files`
- `.venv/bin/python scripts/ci/check_local_verify_environment.py`
- `.venv/bin/python -m flake8 .`
- `.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null app core`
- `.venv/bin/python -m pytest -q tests/edges tests/test_remaining_modules.py --maxfail=3`
- `.venv/bin/python -m pytest -q tests/test_knowledge_promotion.py tests/test_knowledge_contracts.py tests/test_rag_orchestration.py tests/test_recursive_rag.py tests/test_insight_application_service.py tests/test_philosophical_runtime.py tests/test_vector_rag.py::TestRetrieveVectorPostgres::test_postgres_query_and_format tests/test_vector_rag.py::TestCorpusFilteringVectorRag::test_postgres_corpus_filtering_builds_where_clause`

## Risk / rollout notes
- internal-only runtime seam; route layer, OpenAPI, and public response DTOs stay unchanged
- semantic cache and persistent DB rollout remain explicitly out of scope
- local `make diff-cov` was attempted multiple times but was terminated externally with `make: *** [diff-cov] Terminated: 15` before completion in this environment, so branch-scoped local validation is attached here and the remaining heavy merge signal must come from current-head GitHub checks

## Summary by Sourcery

Ввести ограниченный внутренний «шов» для продвижения знаний, который формирует канонических кандидатов только из валидированных RAG‑доказательств и прокладывает политику работы с знаниями через AI‑инсайт, RAG‑оркестрацию и философский runtime, не изменяя публичные API.

Новые возможности:
- Добавить базовые контракты для работы со знаниями, политику, вспомогательные функции для продвижения и протокол хранилища с no-op и in‑memory реализациями для управления внутренними фактами.
- Экспортировать `KnowledgePolicy` из `prepare_insight_runtime` и прокинуть её через уровни runtime, оркестрации и сервисов для контроля чтения и продвижения внутренних знаний.
- Поддержать необязательное best-effort‑продвижение знаний в сервисе приложения инсайтов через внедряемый `KnowledgeStore`, сохраняя пользовательские ответы без изменений.

Улучшения:
- Ужесточить RAG‑оркестрацию так, чтобы кандидаты знаний формировались только из валидированных, не деградировавших и достаточно уверенных чанков, и помечать канонических кандидатов на валидированном пути.
- Гарантировать обратную совместимость философского runtime и рекурсивного RAG, при этом доверяя кандидатам на продвижение только по каноническому валидированному маршруту `RAG_FACTUAL`.
- Добавить резервный тип векторов SQLAlchemy без `pgvector`, чтобы запросы vector‑RAG в Postgres продолжали конструироваться при отсутствии пакета `pgvector`.

Документация:
- Добавить пакет оркестрации K1 для продвижения знаний и связанные документы по анализу задач, ревью работы, синтезу и DoD, а также обновить roadmap/backlog и рекомендации для агентов, чтобы задокументировать ограниченный коридор продвижения знаний и его инварианты.

Тесты:
- Добавить комплексные тесты, покрывающие контракты знаний, политику продвижения и правила супрессии, фильтрацию кандидатов в RAG‑оркестрации, передачу управления в философском runtime, неперсистентность рекурсивного RAG, поведение продвижения на уровне сервисов и резервный механизм vector‑RAG для Postgres.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a bounded internal knowledge promotion seam that derives canonical candidates only from validated RAG evidence and threads a runtime knowledge policy through AI insight, RAG orchestration, and philosophical runtime without changing public APIs.

New Features:
- Add core knowledge contracts, policy, promotion helpers, and a store protocol with no-op and in-memory implementations for internal fact management.
- Expose a KnowledgePolicy from prepare_insight_runtime and propagate it through runtime, orchestration, and service layers to control internal knowledge reads and promotion.
- Support optional best-effort knowledge promotion in the insight application service via an injectable KnowledgeStore while keeping user-visible responses unchanged.

Enhancements:
- Tighten RAG orchestration to build knowledge candidates only from validated, non-degraded, sufficiently confident chunks and mark canonical candidates on the validated path.
- Ensure philosophical runtime and recursive RAG remain backward compatible while trusting promotion candidates only on the canonical validated RAG_FACTUAL route.
- Add a pgvector-free SQLAlchemy vector type fallback so Postgres vector-RAG queries remain constructible when the pgvector package is absent.

Documentation:
- Add a K1 knowledge promotion orchestration packet and related task analysis, work review, synthesis, and DoD documents, and update roadmap/backlog and agent guidelines to document the bounded knowledge promotion corridor and invariants.

Tests:
- Add comprehensive tests covering knowledge contracts, promotion policy and supersession rules, RAG orchestration candidate gating, philosophical runtime handoff, recursive RAG non-persistence, service-level promotion behavior, and the Postgres vector-RAG fallback.

</details>

Новые возможности:
- Добавить базовые контракты знаний, политику, вспомогательные средства продвижения и протокол хранилища (включая in-memory и no-op хранилище) для внутреннего управления фактами.
- Экспортировать runtime‑политику знаний из `prepare_insight_runtime` и пропускать её через философский runtime, RAG‑оркестрацию и сервисные слои для контроля чтения и продвижения знаний.
- Поддержать необязательное внутреннее продвижение знаний во время выполнения insight’ов через подключаемый `KnowledgeStore`, не влияя на пользовательские ответы.
- Расширить результаты RAG‑оркестрации и выходы философского runtime, чтобы они несли внутренние кандидаты знаний, выводимые только из валидированных RAG‑доказательств.

Улучшения:
- Ужесточить RAG‑оркестрацию так, чтобы генерировать кандидатов на продвижение только из валидированных, не деградировавших и достаточно уверенных чанков, и «fail closed» при деградировавших или невалидированных ветках.
- Обеспечить совместимость рекурсивного RAG и устаревших/не знающих о политике ретриверов, при этом никогда не выдавая канонических кандидатов на продвижение.
- Обновить векторный RAG‑ретривер для Postgres так, чтобы он использовал резервный тип SQLAlchemy без `pgvector`, когда пакет `pgvector` недоступен.
- Прояснить и расширить внутренний roadmap, оркестрационные пакеты и документацию по агентам/процессам относительно объёма и инвариантов продвижения знаний.

Документация:
- Добавить отдельные документы по оркестрационному пакету K1 knowledge promotion, анализу задач, ревью работы, синтезу и DoD, а также обновить roadmap/backlog и гайды для агентов, чтобы задокументировать ограниченный «коридор» продвижения знаний и его инварианты.

Тесты:
- Добавить комплексные тесты для контрактов знаний, политики продвижения, правил генерации кандидатов и замещения, поведения оркестрационных «ворот», handoff’а в философском runtime, отсутствия персистентности в рекурсивном RAG и поведения продвижения на уровне сервисов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ввести ограниченный внутренний «шов» для продвижения знаний, который формирует канонических кандидатов только из валидированных RAG‑доказательств и прокладывает политику работы с знаниями через AI‑инсайт, RAG‑оркестрацию и философский runtime, не изменяя публичные API.

Новые возможности:
- Добавить базовые контракты для работы со знаниями, политику, вспомогательные функции для продвижения и протокол хранилища с no-op и in‑memory реализациями для управления внутренними фактами.
- Экспортировать `KnowledgePolicy` из `prepare_insight_runtime` и прокинуть её через уровни runtime, оркестрации и сервисов для контроля чтения и продвижения внутренних знаний.
- Поддержать необязательное best-effort‑продвижение знаний в сервисе приложения инсайтов через внедряемый `KnowledgeStore`, сохраняя пользовательские ответы без изменений.

Улучшения:
- Ужесточить RAG‑оркестрацию так, чтобы кандидаты знаний формировались только из валидированных, не деградировавших и достаточно уверенных чанков, и помечать канонических кандидатов на валидированном пути.
- Гарантировать обратную совместимость философского runtime и рекурсивного RAG, при этом доверяя кандидатам на продвижение только по каноническому валидированному маршруту `RAG_FACTUAL`.
- Добавить резервный тип векторов SQLAlchemy без `pgvector`, чтобы запросы vector‑RAG в Postgres продолжали конструироваться при отсутствии пакета `pgvector`.

Документация:
- Добавить пакет оркестрации K1 для продвижения знаний и связанные документы по анализу задач, ревью работы, синтезу и DoD, а также обновить roadmap/backlog и рекомендации для агентов, чтобы задокументировать ограниченный коридор продвижения знаний и его инварианты.

Тесты:
- Добавить комплексные тесты, покрывающие контракты знаний, политику продвижения и правила супрессии, фильтрацию кандидатов в RAG‑оркестрации, передачу управления в философском runtime, неперсистентность рекурсивного RAG, поведение продвижения на уровне сервисов и резервный механизм vector‑RAG для Postgres.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a bounded internal knowledge promotion seam that derives canonical candidates only from validated RAG evidence and threads a runtime knowledge policy through AI insight, RAG orchestration, and philosophical runtime without changing public APIs.

New Features:
- Add core knowledge contracts, policy, promotion helpers, and a store protocol with no-op and in-memory implementations for internal fact management.
- Expose a KnowledgePolicy from prepare_insight_runtime and propagate it through runtime, orchestration, and service layers to control internal knowledge reads and promotion.
- Support optional best-effort knowledge promotion in the insight application service via an injectable KnowledgeStore while keeping user-visible responses unchanged.

Enhancements:
- Tighten RAG orchestration to build knowledge candidates only from validated, non-degraded, sufficiently confident chunks and mark canonical candidates on the validated path.
- Ensure philosophical runtime and recursive RAG remain backward compatible while trusting promotion candidates only on the canonical validated RAG_FACTUAL route.
- Add a pgvector-free SQLAlchemy vector type fallback so Postgres vector-RAG queries remain constructible when the pgvector package is absent.

Documentation:
- Add a K1 knowledge promotion orchestration packet and related task analysis, work review, synthesis, and DoD documents, and update roadmap/backlog and agent guidelines to document the bounded knowledge promotion corridor and invariants.

Tests:
- Add comprehensive tests covering knowledge contracts, promotion policy and supersession rules, RAG orchestration candidate gating, philosophical runtime handoff, recursive RAG non-persistence, service-level promotion behavior, and the Postgres vector-RAG fallback.

</details>

</details>

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1483_FIXED_MAPPING.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded internal knowledge promotion seam that only derives candidates from validated RAG evidence and threads a runtime `KnowledgePolicy` through insight and RAG paths. Public APIs stay the same; promotion is best‑effort, time‑bounded, and fails closed on degraded or non‑canonical paths (aligns with PR‑K1).

- **New Features**
  - Added `core/knowledge/*`: contracts, `KnowledgePolicy`, promotion helpers, and a `KnowledgeStore` seam with `NoOp` and in‑memory stores; `KnowledgePolicy` re‑exported via `core.ai`.
  - `prepare_insight_runtime(...)` now returns `knowledge_policy`; only validated `RAG_FACTUAL` routes emit candidates; orchestration marks canonical candidates and forwards internally.
  - Insight app service can optionally promote via an injected `KnowledgeStore`; promotion uses a 250ms timeout, supports awaitable stores, and never blocks responses.
  - Vector RAG adds a SQLAlchemy fallback when `pgvector` is absent; governance/docs updated with the K1 packet and a Fixed‑in‑Commit mapping artifact.

- **Bug Fixes**
  - Hardened retriever seam by introspecting function signatures and passing `knowledge_policy` only when accepted; preserved legacy retriever and recursive RAG compatibility.
  - Enforced fail‑closed promotion on deny‑listed degraded reasons and missing subject scope; non‑validated paths never emit candidates.
  - Stabilized orchestration typing and candidate plumbing; improved promotion timeout logging; refreshed `.secrets.baseline` after a `ruff` wheel update.

<sup>Written for commit 7b93a8cd6f7b16919b0ec1e79da9afe0fee69a57. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Split Justification
This PR cannot be split safely without breaking the K1 runtime invariant because the bounded `core/knowledge/*` contract, the runtime/orchestration seam, the deterministic policy tests, and the governance packet/docs all describe the same post-A5 slice and would fail policy or test expectations if promoted independently.

A partial split would leave one of these invalid intermediate states on the branch head: runtime wiring without the contract/store layer, contract files without the fail-closed orchestration path, or governance/docs claiming a K1 slice that is not actually executable. Follow-up PRs still remain after this large change: current-head CI remediation, review-thread disposition once comments land, and any later semantic-cache/storage work, which stays explicitly out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a bounded, fail‑closed runtime lane for deterministic knowledge promotion from validated retrievals, plus policy, contract, promotion, and store abstractions and non‑blocking service integration to optionally persist candidates without blocking responses.
* **Documentation**
  * Added orchestration, roadmap, and governance docs specifying knowledge‑promotion invariants, boundaries, and implementation constraints.
* **Tests**
  * Extensive new and updated tests covering policy, promotion candidate building, store behavior, orchestration gates, canonicality, supersession, and fail‑closed semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Deferred / Follow-ups
- CodeRabbit review `#pullrequestreview-4139572722`: add explicit return annotations to `TestPhilosophicalRuntimeFastLane._runtime_policy` and `_runtime_candidate` in `tests/test_remaining_modules.py` after PR-K1 merges. Tracked in `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-knowledge-promotion-from-validated-rag`; kept out of this lane to avoid whole-file `black` churn in an otherwise merge-ready PR.

