### PR TITLE
fix(ci): pin actions SHAs in rag-release-gates workflow

### DIFF
--- a/.github/workflows/rag-release-gates.yml
+++ b/.github/workflows/rag-release-gates.yml
@@ -43,10 +43,10 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -64,7 +64,7 @@ jobs:
             --generator-mode extractive_stub
 
       - name: Upload gate artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: rag-release-gates-smoke
           path: |
@@ -82,10 +82,10 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -109,7 +109,7 @@ jobs:
             --disallow-runtime-fallbacks
 
       - name: Upload weekly gate artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: rag-release-gates-weekly
           path: |

--- a/docs/review/PR_1486_FIXED_MAPPING.md
+++ b/docs/review/PR_1486_FIXED_MAPPING.md
@@ -1,0 +1,22 @@
+# PR #1486 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:58-60`.
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+Record every actionable human or bot review item here before resolving threads or
+claiming merge readiness.
+
+## Fixed in Commit Mapping
+
+_No review threads yet. Add dispositions (FIXED / NOT-A-BUG / DEFERRED) with
+evidence as comments arrive._
+
+## Merge Readiness
+
+- Pending: required CI green on current head; complete checklist above after review.

--- a/docs/review/PR_1486_FIXED_MAPPING.md
+++ b/docs/review/PR_1486_FIXED_MAPPING.md
@@ -6,17 +6,16 @@ Canonical review-governance artifact and PR-body mirror requirements:
 `AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
 `docs/orchestration/AGENTS.md:58-60`.
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
-Record every actionable human or bot review item here before resolving threads or
-claiming merge readiness.
+Bots (CodeRabbit, Sourcery, Cubic) left no actionable code changes; CodeRabbit noted PR body template gaps (metadata). Mapping uses N/A path for zero thread URLs.
 
 ## Fixed in Commit Mapping
 
-_No review threads yet. Add dispositions (FIXED / NOT-A-BUG / DEFERRED) with
-evidence as comments arrive._
+- No actionable review comments
 
 ## Merge Readiness
 
-- Pending: required CI green on current head; complete checklist above after review.
+- CI: required jobs green on current PR head after push; re-check `PR Body Phase2 gates`.
+- Local: run `make verify` on this branch before merge when feasible (operator evidence).


### PR DESCRIPTION
## Summary

Post-merge CI fix: `test-main` failed `guard_actions_pin` after PR #1484 because `rag-release-gates.yml` used tag refs for `actions/checkout`, `actions/setup-python`, and `actions/upload-artifact`.

## Change

- Pin all `uses:` to full 40-char SHAs matching canonical `ci.yml` (same SHAs + version comments).

## Risk & Impact

- **Risk:** Low for runtime; aligns CI with supply-chain pin policy (`guard_actions_pin`).
- **Impact:** Workflow-only; no API, DB, or client behavior.

## Tests / verification

- `python3 scripts/ci/guard_actions_pin.py --root .` → OK
- `make verify-env lint typecheck test-fast` → OK (run full `make verify` including `diff-cov` before merge when possible)

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

Canonical artifact: `docs/review/PR_1486_FIXED_MAPPING.md` (N/A: no actionable review threads requiring code changes).

## Merge Readiness

- [ ] Required CI green on latest head (including PR Body Phase2 gates)
- [ ] Local `make verify` evidence (recommended)

## Deferred / Follow-ups

- None.

Refs: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24670663472


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI workflows updated to pin specific action versions for more consistent and reliable runs.
* **Documentation**
  * Added a review and merge-readiness checklist documenting fixed-in-commit mapping, discussion-thread verification, and local verification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->