### PR TITLE
docs(deploy): reconcile split backend and frontend docker contract

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -463,7 +463,12 @@ jobs:
           bundle_dir="$(mktemp -d)"
           bundle_name="pulseplate-shell-bundle-${{ github.run_id }}-${{ github.run_attempt }}"
           archive_path="$bundle_dir/${bundle_name}.tgz"
-          tar -czf "$archive_path" frontend deploy/Caddyfile.production scripts/diagnose_web.sh
+          tar -czf "$archive_path" \
+            frontend \
+            deploy/Caddyfile.production \
+            deploy/docker-compose.production.yaml \
+            scripts/diagnose_web.sh \
+            scripts/redeploy_caddy.sh
 
           scp -i "$key_path" \
             "$archive_path" \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -540,6 +540,7 @@ jobs:
           set -euo pipefail
           export DEPLOY_DIR='${{ vars.DEPLOY_DIR }}'
           export PRODUCTION_DOMAIN='${{ secrets.PRODUCTION_DOMAIN }}'
+          export SHELL_BUNDLE_DIR="${GITHUB_WORKSPACE}"
           bash scripts/deploy_production.sh --preflight-only
 
       - name: Deploy on self-hosted runner (pinned digest)

--- a/deploy/PRODUCTION.md
+++ b/deploy/PRODUCTION.md
@@ -201,6 +201,8 @@ It now also terminates `www.<domain>` and permanently redirects it to the apex p
    git switch --detach origin/main
    scp deploy/Caddyfile.production ubuntu@your-host:/srv/pulseplate-production/
    scp deploy/docker-compose.production.yaml ubuntu@your-host:/srv/pulseplate-production/
+   scp scripts/diagnose_web.sh ubuntu@your-host:/srv/pulseplate-production/scripts/diagnose_web.sh
+   scp scripts/redeploy_caddy.sh ubuntu@your-host:/srv/pulseplate-production/scripts/redeploy_caddy.sh
    rsync -az --delete frontend/ ubuntu@your-host:/srv/frontend/
    ```
 

--- a/deploy/PRODUCTION.md
+++ b/deploy/PRODUCTION.md
@@ -201,6 +201,7 @@ It now also terminates `www.<domain>` and permanently redirects it to the apex p
    git switch --detach origin/main
    scp deploy/Caddyfile.production ubuntu@your-host:/srv/pulseplate-production/
    scp deploy/docker-compose.production.yaml ubuntu@your-host:/srv/pulseplate-production/
+   ssh ubuntu@your-host 'mkdir -p /srv/pulseplate-production/scripts'
    scp scripts/diagnose_web.sh ubuntu@your-host:/srv/pulseplate-production/scripts/diagnose_web.sh
    scp scripts/redeploy_caddy.sh ubuntu@your-host:/srv/pulseplate-production/scripts/redeploy_caddy.sh
    rsync -az --delete frontend/ ubuntu@your-host:/srv/frontend/

--- a/deploy/PRODUCTION.md
+++ b/deploy/PRODUCTION.md
@@ -123,10 +123,14 @@ On the production server:
       missing `.env` (default path: `$DEPLOY_DIR/.env`, typically
       `/srv/pulseplate-production/.env`).
   - `Caddyfile.production` (Caddy reverse proxy config; see Caddyfile Configuration below)
-- A managed PostgreSQL instance reachable from the production host via `DATABASE_URL`
-- Managed database backup / PITR handled by the provider; the production deploy script no longer runs local `pg_dump`
-- Compose must reference `IMAGE_REF` (recommended) or `TAG` (backwards-compatible):
-- **Firewall configured**: Ports 80 (HTTP) and 443 (HTTPS) must be open (see Firewall Setup below)
+  - a sibling `frontend/` shell bundle adjacent to the deploy directory (typically
+    `/srv/frontend`) so the `caddy` image can be rebuilt from
+    `frontend/Dockerfile.caddy-spa`
+  - A managed PostgreSQL instance reachable from the production host via `DATABASE_URL`
+  - Managed database backup / PITR handled by the provider; the production deploy script no longer runs local `pg_dump`
+  - The canonical production compose contract pins `app` via `IMAGE_REF`; `TAG`
+    remains deploy-helper compatibility input, not the primary compose contract
+  - **Firewall configured**: Ports 80 (HTTP) and 443 (HTTPS) must be open (see Firewall Setup below)
 
 Example `docker-compose.production.yaml`:
 
@@ -157,7 +161,11 @@ services:
       --forwarded-allow-ips="172.30.100.0/24"
 
   caddy:
-    image: caddy:2.10.2
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile.caddy-spa
+      args:
+        VITE_API_BASE: ${VITE_API_BASE:-/api/v1}
     restart: unless-stopped
     networks: [web]
     ports:
@@ -183,17 +191,24 @@ It already contains a complete and secure reverse proxy setup using the `{$PRODU
 It also contains a staging TLS fallback vhost for `STAGING_FALLBACK_DOMAIN` (default: `pulseplate-staging.duckdns.org`) used during build-only phases.
 It now also terminates `www.<domain>` and permanently redirects it to the apex production host so Cloudflare can issue/validate TLS consistently for both names.
 
-**To use it on the production server:**
+**To stage it manually from merged release truth:**
 
-1. Copy the file to your deploy directory:
+1. On a local merged checkout or from an unpacked CI-produced release bundle,
+   sync the release shell bundle to the production host:
 
    ```bash
-   cp deploy/Caddyfile.production /srv/pulseplate-production/
-   # or
-   cp deploy/Caddyfile.production /opt/pulseplate/
+   git fetch origin main
+   git switch --detach origin/main
+   scp deploy/Caddyfile.production ubuntu@your-host:/srv/pulseplate-production/
+   scp deploy/docker-compose.production.yaml ubuntu@your-host:/srv/pulseplate-production/
+   rsync -az --delete frontend/ ubuntu@your-host:/srv/frontend/
    ```
 
-2. Ensure the file is readable by Docker (mode 644 or similar):
+   GitHub Actions production deploy already stages this bundle before
+   `scripts/deploy_production.sh` runs. Manual copy is for bootstrap or
+   emergency recovery from merged release truth.
+
+2. On the production server, ensure the file is readable by Docker (mode 644 or similar):
 
    ```bash
    chmod 644 ./Caddyfile.production
@@ -481,11 +496,19 @@ High-level steps (run on the production server):
      - This file is a server-local bootstrap artifact. GitHub Actions does not
        provision it for you.
    - `Caddyfile.production` (copied from `deploy/Caddyfile.production`)
+   - sibling `frontend/` shell bundle (typically `/srv/frontend`)
    - managed PostgreSQL credentials in `DATABASE_URL`
-3. Ensure the compose file uses `IMAGE_REF` (preferred) or `TAG` (backwards-compatible).
-   - Production CD now also stages the current `frontend/`, `deploy/Caddyfile.production`,
-     and `scripts/diagnose_web.sh` bundle before `scripts/deploy_production.sh` runs so the
-     public shell can be rebuilt from the same release tree as the backend image.
+3. Ensure the compose file keeps `app` on `IMAGE_REF` and `caddy` on the
+   separate `frontend/Dockerfile.caddy-spa` shell build.
+   - Production CD stages the current `frontend/`, `deploy/Caddyfile.production`,
+     `deploy/docker-compose.production.yaml`, `scripts/diagnose_web.sh`, and
+     `scripts/redeploy_caddy.sh` bundle before `scripts/deploy_production.sh`
+     runs so the public shell can be rebuilt from the same release tree as the
+     backend image.
+   - Do not rebuild `caddy` from `/srv/frontend` unless that shell bundle came
+     from the same production CD run, a CI-produced release bundle, or a merged
+     detached checkout like the one above. If shell provenance is unclear, stop
+     and re-stage it first.
 4. Wait for a successful Nightly run on `main`, then set `PRODUCTION_ENV_READY=true`
    only after the host bootstrap is complete.
 5. Create and push a new semver tag (e.g. `v0.2.2`).

--- a/deploy/WORKFLOW.md
+++ b/deploy/WORKFLOW.md
@@ -92,19 +92,23 @@ git push origin main
 ssh root@pulseplate.app
 cd /srv/pulseplate-production
 
-# 1. Подтянуть новый образ
-docker compose -f docker-compose.production.yaml pull
+# 1. Подтянуть backend image
+docker compose -f docker-compose.production.yaml pull app
 
 # 2. Прогнать миграции через release image
 docker compose --env-file .env -f docker-compose.production.yaml run --rm --no-deps app alembic upgrade head
 
-# 3. Перезапустить сервисы
+# 3. Убедиться, что `/srv/frontend` и deploy inputs пришли из того же production CD run,
+#    CI-produced release bundle или merged detached checkout. Если provenance неясен,
+#    сначала пересинхронизировать shell bundle из merged truth и только потом rebuild.
+# 4. Пересобрать edge shell из уже синхронизированного release shell bundle и перезапустить стек
+docker compose -f docker-compose.production.yaml build caddy
 docker compose -f docker-compose.production.yaml up -d --force-recreate
 
-# 4. Проверить статус
+# 5. Проверить статус
 docker compose -f docker-compose.production.yaml ps
 
-# 5. Проверить health
+# 6. Проверить health
 curl -fsS https://pulseplate.app/health | jq .
 ```
 
@@ -161,6 +165,8 @@ ssh root@pulseplate.app
 cd /srv/pulseplate-production
 
 # Canonical production contract: managed PostgreSQL lives outside compose and is reached via DATABASE_URL
+# Normal production deploy assumes the release shell bundle was already staged
+# from CI or another merged release artifact. Do not rsync from a dirty local checkout.
 
 # Обновить образ app из registry (IMAGE_REF)
 docker compose -f docker-compose.production.yaml pull app
@@ -191,8 +197,9 @@ curl -fsS https://pulseplate.app/health | jq .
 ### Emergency apex shell recovery (DigitalOcean + Cloudflare drift)
 
 Если production apex внезапно уходит в белый экран, JSON probe или пустой shell,
-не чини это руками только в Cloudflare. Сначала восстанови repo-owned shell
-bundle на origin.
+не чини это руками только в Cloudflare. Нормальный deploy path уже должен идти
+через CI-staged release shell bundle; этот раздел только про emergency recovery,
+когда edge drift уже произошёл и bundle надо пересинхронизировать из merged truth.
 
 **Жёсткое правило:** emergency shell sync разрешён только из **merged canonical
 tree** (`origin/main` / release commit) или из CI-produced release bundle.
@@ -208,6 +215,7 @@ scp deploy/Caddyfile.production ubuntu@64.226.117.163:/srv/pulseplate-production
 scp deploy/docker-compose.production.yaml ubuntu@64.226.117.163:/srv/pulseplate-production/docker-compose.production.yaml
 rsync -az --delete frontend/ ubuntu@64.226.117.163:/srv/frontend/
 scp scripts/diagnose_web.sh ubuntu@64.226.117.163:/srv/pulseplate-production/scripts/diagnose_web.sh
+scp scripts/redeploy_caddy.sh ubuntu@64.226.117.163:/srv/pulseplate-production/scripts/redeploy_caddy.sh
 
 # На сервере: rebuild/restart только edge shell
 ssh ubuntu@64.226.117.163 '
@@ -308,12 +316,15 @@ bash scripts/diagnose_web.sh
    docker compose up -d --force-recreate app
    ```
 
-3. **Изменить `Caddyfile.production` на сервере (это конфиг):**
+3. **Изменить `Caddyfile.production` в merged truth и пересинхронизировать shell bundle:**
    ```bash
    # ✅ ПРАВИЛЬНО
-   cd /srv/pulseplate-production
-   nano Caddyfile.production
-   docker compose up -d --force-recreate caddy
+   git fetch origin main
+   git switch --detach origin/main
+   $EDITOR deploy/Caddyfile.production
+   scp deploy/Caddyfile.production ubuntu@64.226.117.163:/srv/pulseplate-production/Caddyfile.production
+   scp scripts/redeploy_caddy.sh ubuntu@64.226.117.163:/srv/pulseplate-production/scripts/redeploy_caddy.sh
+   ssh ubuntu@64.226.117.163 'cd /srv/pulseplate-production && bash scripts/redeploy_caddy.sh'
    ```
 
 ---

--- a/deploy/WORKFLOW.md
+++ b/deploy/WORKFLOW.md
@@ -214,6 +214,7 @@ git switch --detach origin/main
 scp deploy/Caddyfile.production ubuntu@64.226.117.163:/srv/pulseplate-production/Caddyfile.production
 scp deploy/docker-compose.production.yaml ubuntu@64.226.117.163:/srv/pulseplate-production/docker-compose.production.yaml
 rsync -az --delete frontend/ ubuntu@64.226.117.163:/srv/frontend/
+ssh ubuntu@64.226.117.163 'mkdir -p /srv/pulseplate-production/scripts'
 scp scripts/diagnose_web.sh ubuntu@64.226.117.163:/srv/pulseplate-production/scripts/diagnose_web.sh
 scp scripts/redeploy_caddy.sh ubuntu@64.226.117.163:/srv/pulseplate-production/scripts/redeploy_caddy.sh
 
@@ -322,6 +323,7 @@ bash scripts/diagnose_web.sh
    # Сначала: merge PR с нужным изменением в deploy/Caddyfile.production
    git fetch origin main
    git switch --detach origin/main
+   ssh ubuntu@64.226.117.163 'mkdir -p /srv/pulseplate-production/scripts'
    scp deploy/Caddyfile.production ubuntu@64.226.117.163:/srv/pulseplate-production/Caddyfile.production
    scp deploy/docker-compose.production.yaml ubuntu@64.226.117.163:/srv/pulseplate-production/docker-compose.production.yaml
    rsync -az --delete frontend/ ubuntu@64.226.117.163:/srv/frontend/

--- a/deploy/WORKFLOW.md
+++ b/deploy/WORKFLOW.md
@@ -375,7 +375,9 @@ curl -fsS https://pulseplate.app/health | jq .
 ### Release shell parity
 
 - Tag-based production deploy must ship the public shell inputs together:
-  `frontend/`, `deploy/Caddyfile.production`, and `scripts/diagnose_web.sh`.
+  `frontend/`, `deploy/Caddyfile.production`,
+  `deploy/docker-compose.production.yaml`, `scripts/diagnose_web.sh`, and
+  `scripts/redeploy_caddy.sh`.
 - `scripts/deploy_production.sh` now rebuilds `caddy` during production deploy, so the
   public SPA shell stays aligned with the same release tree as the backend `IMAGE_REF`.
 - SSH production deploys use run-scoped `/tmp` bundle paths and the production deploy

--- a/deploy/WORKFLOW.md
+++ b/deploy/WORKFLOW.md
@@ -316,13 +316,16 @@ bash scripts/diagnose_web.sh
    docker compose up -d --force-recreate app
    ```
 
-3. **Изменить `Caddyfile.production` в merged truth и пересинхронизировать shell bundle:**
+3. **Изменить `Caddyfile.production` через PR, затем пересинхронизировать весь shell bundle из merged truth:**
    ```bash
    # ✅ ПРАВИЛЬНО
+   # Сначала: merge PR с нужным изменением в deploy/Caddyfile.production
    git fetch origin main
    git switch --detach origin/main
-   $EDITOR deploy/Caddyfile.production
    scp deploy/Caddyfile.production ubuntu@64.226.117.163:/srv/pulseplate-production/Caddyfile.production
+   scp deploy/docker-compose.production.yaml ubuntu@64.226.117.163:/srv/pulseplate-production/docker-compose.production.yaml
+   rsync -az --delete frontend/ ubuntu@64.226.117.163:/srv/frontend/
+   scp scripts/diagnose_web.sh ubuntu@64.226.117.163:/srv/pulseplate-production/scripts/diagnose_web.sh
    scp scripts/redeploy_caddy.sh ubuntu@64.226.117.163:/srv/pulseplate-production/scripts/redeploy_caddy.sh
    ssh ubuntu@64.226.117.163 'cd /srv/pulseplate-production && bash scripts/redeploy_caddy.sh'
    ```

--- a/deploy/docker-compose.staging.yaml
+++ b/deploy/docker-compose.staging.yaml
@@ -1,3 +1,10 @@
+# Optional staging runtime only. The canonical split deploy contract lives in
+# `deploy/docker-compose.production.yaml` and
+# `deploy/docker-compose.production.selfhosted.yaml`.
+# This file remains a temporary staging seam while the fallback-vhost / staging
+# deploy-enablement work tracked in
+# `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-staging-tls-fallback-seam-after-full-staging-readiness`
+# is still open.
 version: "3.9"
 
 networks:

--- a/docs/review/PR_1488_FIXED_MAPPING.md
+++ b/docs/review/PR_1488_FIXED_MAPPING.md
@@ -17,37 +17,29 @@ Record every actionable human/bot disposition here before resolving threads on G
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4148229640
 Disposition: FIXED
 Commit: see mapping entries below
-Evidence: review covered by `#discussion_r3117952073` and the split-contract test hardening in [tests/test_cd_workflow_production_deploy_gate.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_cd_workflow_production_deploy_gate.py:64).
+Evidence: [tests/test_deploy_contract_scripts.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_deploy_contract_scripts.py:20), [tests/test_cd_workflow_production_deploy_gate.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_cd_workflow_production_deploy_gate.py:64)
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3117952073
-Disposition: FIXED
-Commit: 02b06b8d5
-Evidence: [scripts/deploy_production.sh](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/scripts/deploy_production.sh:294), [tests/test_deploy_contract_scripts.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_deploy_contract_scripts.py:29)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4148229640 -> 02b06b8d5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3117952073 -> 02b06b8d5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3117952077 -> 02b06b8d5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3117952082 -> 02b06b8d5
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4148251408
 Disposition: FIXED
 Commit: see mapping entries below
-Evidence: review covered by `#discussion_r3117970414` and `#discussion_r3117970442`, both fixed and mapped below.
+Evidence: [deploy/PRODUCTION.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/deploy/PRODUCTION.md:204), [deploy/WORKFLOW.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/deploy/WORKFLOW.md:217), [docs/review/PR_1488_FIXED_MAPPING.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/docs/review/PR_1488_FIXED_MAPPING.md:1)
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3117970414
-Disposition: FIXED
-Commit: 02b06b8d5
-Evidence: [deploy/PRODUCTION.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/deploy/PRODUCTION.md:204), [deploy/WORKFLOW.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/deploy/WORKFLOW.md:217), [deploy/WORKFLOW.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/deploy/WORKFLOW.md:325)
-
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3117970442
-Disposition: FIXED
-Commit: 6943052e6
-Evidence: [docs/review/PR_1488_FIXED_MAPPING.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/docs/review/PR_1488_FIXED_MAPPING.md:17)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4148251408 -> 6943052e6
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3117970414 -> 02b06b8d5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3117970442 -> 6943052e6
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4149616401
 Disposition: FIXED
 Commit: see mapping entries below
-Evidence: review covered by `#discussion_r3119216490` and the `app.env_file` contract assertion in [tests/test_deploy_contract_scripts.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_deploy_contract_scripts.py:27).
+Evidence: [scripts/deploy_production.sh](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/scripts/deploy_production.sh:369), [tests/test_deploy_contract_scripts.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_deploy_contract_scripts.py:25)
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3119216490
-Disposition: FIXED
-Commit: ebed66e71
-Evidence: [scripts/deploy_production.sh](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/scripts/deploy_production.sh:369), [tests/test_deploy_contract_scripts.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_deploy_contract_scripts.py:27)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4149616401 -> ebed66e71
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3119216490 -> ebed66e71
 
 ## Merge Readiness
 

--- a/docs/review/PR_1488_FIXED_MAPPING.md
+++ b/docs/review/PR_1488_FIXED_MAPPING.md
@@ -14,10 +14,20 @@ Record every actionable human/bot disposition here before resolving threads on G
 
 ## Fixed in Commit Mapping
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4148229640
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: review covered by `#discussion_r3117952073` and the split-contract test hardening in [tests/test_cd_workflow_production_deploy_gate.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_cd_workflow_production_deploy_gate.py:64).
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3117952073
 Disposition: FIXED
 Commit: 02b06b8d5
 Evidence: [scripts/deploy_production.sh](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/scripts/deploy_production.sh:294), [tests/test_deploy_contract_scripts.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_deploy_contract_scripts.py:29)
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4148251408
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: review covered by `#discussion_r3117970414` and `#discussion_r3117970442`, both fixed and mapped below.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3117970414
 Disposition: FIXED
@@ -29,7 +39,15 @@ Disposition: FIXED
 Commit: 6943052e6
 Evidence: [docs/review/PR_1488_FIXED_MAPPING.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/docs/review/PR_1488_FIXED_MAPPING.md:17)
 
-- Ready-state bot review pass completed on `2026-04-21`; no unmapped actionable review comments should remain after the remediation rerun on the latest head.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4149616401
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: review covered by `#discussion_r3119216490` and the `app.env_file` contract assertion in [tests/test_deploy_contract_scripts.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_deploy_contract_scripts.py:27).
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3119216490
+Disposition: FIXED
+Commit: ebed66e71
+Evidence: [scripts/deploy_production.sh](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/scripts/deploy_production.sh:369), [tests/test_deploy_contract_scripts.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_deploy_contract_scripts.py:27)
 
 ## Merge Readiness
 

--- a/docs/review/PR_1488_FIXED_MAPPING.md
+++ b/docs/review/PR_1488_FIXED_MAPPING.md
@@ -14,12 +14,21 @@ Record every actionable human/bot disposition here before resolving threads on G
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4148229640 -> 02b06b8d5
-  Disposition: FIXED
-  Evidence: [scripts/deploy_production.sh](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/scripts/deploy_production.sh:294), [tests/test_deploy_contract_scripts.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_deploy_contract_scripts.py:15), [tests/test_cd_workflow_production_deploy_gate.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_cd_workflow_production_deploy_gate.py:64)
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4148251408 -> 02b06b8d5
-  Disposition: FIXED
-  Evidence: [deploy/PRODUCTION.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/deploy/PRODUCTION.md:204), [deploy/WORKFLOW.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/deploy/WORKFLOW.md:217), [deploy/WORKFLOW.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/deploy/WORKFLOW.md:325), [scripts/deploy_production.sh](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/scripts/deploy_production.sh:294)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3117952073
+Disposition: FIXED
+Commit: 02b06b8d5
+Evidence: [scripts/deploy_production.sh](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/scripts/deploy_production.sh:294), [tests/test_deploy_contract_scripts.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_deploy_contract_scripts.py:29)
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3117970414
+Disposition: FIXED
+Commit: 02b06b8d5
+Evidence: [deploy/PRODUCTION.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/deploy/PRODUCTION.md:204), [deploy/WORKFLOW.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/deploy/WORKFLOW.md:217), [deploy/WORKFLOW.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/deploy/WORKFLOW.md:325)
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3117970442
+Disposition: FIXED
+Commit: 6943052e6
+Evidence: [docs/review/PR_1488_FIXED_MAPPING.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/docs/review/PR_1488_FIXED_MAPPING.md:17)
+
 - Ready-state bot review pass completed on `2026-04-21`; no unmapped actionable review comments should remain after the remediation rerun on the latest head.
 
 ## Merge Readiness

--- a/docs/review/PR_1488_FIXED_MAPPING.md
+++ b/docs/review/PR_1488_FIXED_MAPPING.md
@@ -14,7 +14,13 @@ Record every actionable human/bot disposition here before resolving threads on G
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4148229640 -> 02b06b8d5
+  Disposition: FIXED
+  Evidence: [scripts/deploy_production.sh](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/scripts/deploy_production.sh:294), [tests/test_deploy_contract_scripts.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_deploy_contract_scripts.py:15), [tests/test_cd_workflow_production_deploy_gate.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_cd_workflow_production_deploy_gate.py:64)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4148251408 -> 02b06b8d5
+  Disposition: FIXED
+  Evidence: [deploy/PRODUCTION.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/deploy/PRODUCTION.md:204), [deploy/WORKFLOW.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/deploy/WORKFLOW.md:217), [deploy/WORKFLOW.md](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/deploy/WORKFLOW.md:325), [scripts/deploy_production.sh](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/scripts/deploy_production.sh:294)
+- Ready-state bot review pass completed on `2026-04-21`; no unmapped actionable review comments should remain after the remediation rerun on the latest head.
 
 ## Merge Readiness
 
@@ -23,17 +29,17 @@ Merge-readiness contract:
 `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
 
 - [ ] Current-head CI is green for PR branch head
-  Evidence: pending current-head PR checks for branch `fix/docker-deploy-contract-reconciliation`.
+  Evidence: rerun required after ready-state remediation commits.
 - [ ] Required checks complete (no pending jobs)
-  Evidence: pending current-head PR checks for branch `fix/docker-deploy-contract-reconciliation`.
+  Evidence: rerun required after ready-state remediation commits.
 - [ ] All review threads resolved on GitHub after disposition updates
-  Evidence: no post-open review pass completed yet.
+  Evidence: `check_review_threads_disposition.py --pr-number 1488 --require-auth` reported no resolved review threads before the ready-state remediation rerun.
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: post-open bot review lane not finished yet.
+  Evidence: this artifact now records the ready-state Sourcery and CodeRabbit review URLs; latest-head bot rerun still pending.
 - [ ] Pre-commit green on latest pushed head
-  Evidence: local rerun passed before adding this artifact; re-run on final pushed head pending.
+  Evidence: local rerun passed before this artifact update; re-run on final pushed head pending.
 - [ ] `make verify` green on latest pushed head
-  Evidence: final local `make verify` rerun still in progress at artifact creation time.
+  Evidence: final rerun required after ready-state remediation commits.
 
 ## Deferred / Follow-ups
 

--- a/docs/review/PR_1488_FIXED_MAPPING.md
+++ b/docs/review/PR_1488_FIXED_MAPPING.md
@@ -1,0 +1,41 @@
+# PR #1488 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+- [x] Discussion-thread pass initialized
+- [x] Fixed in commit mapping initialized
+
+This artifact is created immediately after the PR is opened per repo governance.
+Record every actionable human/bot disposition here before resolving threads on GitHub.
+
+## Fixed in Commit Mapping
+
+No actionable review threads yet.
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+  Evidence: pending current-head PR checks for branch `fix/docker-deploy-contract-reconciliation`.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: pending current-head PR checks for branch `fix/docker-deploy-contract-reconciliation`.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: no post-open review pass completed yet.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: post-open bot review lane not finished yet.
+- [ ] Pre-commit green on latest pushed head
+  Evidence: local rerun passed before adding this artifact; re-run on final pushed head pending.
+- [ ] `make verify` green on latest pushed head
+  Evidence: final local `make verify` rerun still in progress at artifact creation time.
+
+## Deferred / Follow-ups
+
+- staging fallback-vhost removal and full staging runtime readiness remain tracked under `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-staging-tls-fallback-seam-after-full-staging-readiness`
+- runtime slimming, image-budget telemetry, signed provenance, SBOM/VEX, Dagger, and Cloudflare changes remain out of scope for PR #1488

--- a/docs/review/PR_1488_FIXED_MAPPING.md
+++ b/docs/review/PR_1488_FIXED_MAPPING.md
@@ -41,6 +41,11 @@ Evidence: [scripts/deploy_production.sh](/Users/katsiaryna_kavaleuskaya/Develope
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4149616401 -> ebed66e71
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#discussion_r3119216490 -> ebed66e71
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4150072953
+Disposition: NOT-A-BUG
+Evidence: [scripts/deploy_production.sh](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/scripts/deploy_production.sh:232), [scripts/deploy_production.sh](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/scripts/deploy_production.sh:369), [tests/test_deploy_contract_scripts.py](/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/worktrees/fix-docker-deploy-contract-reconciliation/tests/test_deploy_contract_scripts.py:104)
+Reason: The duplicated compose-path normalization is confined to two fail-closed call sites with identical guarded behavior and test coverage; widening this docs/deploy lane into a refactor would increase scope without changing the deploy contract or fixing a correctness bug.
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/review/PR_1488_FIXED_MAPPING.md
+++ b/docs/review/PR_1488_FIXED_MAPPING.md
@@ -6,15 +6,15 @@ Canonical review-governance artifact and PR-body mirror requirements:
 `AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
 `docs/orchestration/AGENTS.md:79-82`.
 
-- [x] Discussion-thread pass initialized
-- [x] Fixed in commit mapping initialized
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 This artifact is created immediately after the PR is opened per repo governance.
 Record every actionable human/bot disposition here before resolving threads on GitHub.
 
 ## Fixed in Commit Mapping
 
-No actionable review threads yet.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/roadmap/DEPLOY_WEB_DIAGNOSIS_AND_FIX.md
+++ b/docs/roadmap/DEPLOY_WEB_DIAGNOSIS_AND_FIX.md
@@ -65,6 +65,12 @@ The earlier diagnosis packet mixed three different concerns:
 After PR-1, item 3 is already resolved in its own lane and must not be re-opened
 in PR-2.
 
+Staging runtime posture also remains a separate seam. Production keeps staging
+HTTPS alive via the fallback vhost while full staging readiness is tracked in
+`docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-staging-tls-fallback-seam-after-full-staging-readiness`.
+PR-2 may acknowledge that seam, but must not broaden into staging release-policy
+work.
+
 For PR-2, the remaining deploy-shell problem is best framed as **contract drift**:
 
 - runtime config already encodes the correct SPA and API split
@@ -82,6 +88,9 @@ PR-2 must do the following:
 3. Add/formalize `scripts/diagnose_web.sh`
 4. Update deploy/operator docs so they point to the real baked-shell model
 5. Add deterministic repo-side verification for the diagnosis and redeploy flow
+6. Keep production/self-hosted split-contract docs aligned while treating staging
+   runtime enablement as a documented temporary seam, not as the canonical
+   production contract
 
 ## Explicitly Out Of Scope For PR-2
 

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -239,9 +239,11 @@ sync_shell_bundle() {
   local source_caddyfile="$SHELL_BUNDLE_DIR/deploy/Caddyfile.production"
   local source_compose=""
   local source_diagnose="$SHELL_BUNDLE_DIR/scripts/diagnose_web.sh"
+  local source_redeploy="$SHELL_BUNDLE_DIR/scripts/redeploy_caddy.sh"
   local target_compose=""
   local compose_relative_path=""
   local shell_root
+  local target_scripts_dir="$DEPLOY_DIR/scripts"
   shell_root="$(cd "$DEPLOY_DIR/.." && pwd)"
 
   if [ -z "$RESOLVED_COMPOSE_FILE" ]; then
@@ -294,16 +296,21 @@ sync_shell_bundle() {
 
   echo "Syncing production shell bundle from: $SHELL_BUNDLE_DIR"
   rm -rf "$shell_root/frontend"
-  mkdir -p "$shell_root/frontend" "$shell_root/scripts"
+  mkdir -p "$shell_root/frontend" "$target_scripts_dir"
   mkdir -p "$(dirname "$target_compose")"
   cp -R "$source_frontend/." "$shell_root/frontend/"
   cp "$source_caddyfile" "$DEPLOY_DIR/Caddyfile.production"
   cp "$source_compose" "$target_compose"
-  rm -f "$shell_root/scripts/diagnose_web.sh"
+  rm -f "$target_scripts_dir/diagnose_web.sh" "$target_scripts_dir/redeploy_caddy.sh"
 
   if [ -f "$source_diagnose" ]; then
-    cp "$source_diagnose" "$shell_root/scripts/diagnose_web.sh"
-    chmod +x "$shell_root/scripts/diagnose_web.sh"
+    cp "$source_diagnose" "$target_scripts_dir/diagnose_web.sh"
+    chmod +x "$target_scripts_dir/diagnose_web.sh"
+  fi
+
+  if [ -f "$source_redeploy" ]; then
+    cp "$source_redeploy" "$target_scripts_dir/redeploy_caddy.sh"
+    chmod +x "$target_scripts_dir/redeploy_caddy.sh"
   fi
 }
 

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -367,10 +367,68 @@ validate_managed_postgres_contract() {
 }
 
 validate_shell_bundle_contract() {
+  local source_frontend=""
+  local source_caddyfile=""
+  local source_compose=""
+  local compose_relative_path=""
   local required_redeploy=""
 
   if [ -z "$SHELL_BUNDLE_DIR" ]; then
     return 0
+  fi
+
+  if [ -z "$DEPLOY_DIR" ]; then
+    echo "❌ DEPLOY_DIR is required when SHELL_BUNDLE_DIR is set" >&2
+    exit 1
+  fi
+
+  if [ -z "$RESOLVED_COMPOSE_FILE" ]; then
+    echo "❌ Could not resolve a compose filename for shell bundle validation" >&2
+    exit 1
+  fi
+
+  source_frontend="$SHELL_BUNDLE_DIR/frontend"
+  source_caddyfile="$SHELL_BUNDLE_DIR/deploy/Caddyfile.production"
+
+  if [[ "$RESOLVED_COMPOSE_FILE" = /* ]]; then
+    case "$RESOLVED_COMPOSE_FILE" in
+      "$DEPLOY_DIR"/*)
+        compose_relative_path="${RESOLVED_COMPOSE_FILE#"$DEPLOY_DIR"/}"
+        ;;
+      *)
+        echo "❌ COMPOSE_FILE must stay within DEPLOY_DIR: $RESOLVED_COMPOSE_FILE" >&2
+        exit 1
+        ;;
+    esac
+  else
+    compose_relative_path="${RESOLVED_COMPOSE_FILE#./}"
+    case "$compose_relative_path" in
+      ""|"."|..|../*|*/../*|*/..)
+        echo "❌ COMPOSE_FILE must stay within DEPLOY_DIR: $RESOLVED_COMPOSE_FILE" >&2
+        exit 1
+        ;;
+    esac
+  fi
+
+  if [[ "$compose_relative_path" = deploy/* ]]; then
+    source_compose="$SHELL_BUNDLE_DIR/$compose_relative_path"
+  else
+    source_compose="$SHELL_BUNDLE_DIR/deploy/$compose_relative_path"
+  fi
+
+  if [ ! -d "$source_frontend" ]; then
+    echo "❌ SHELL_BUNDLE_DIR is missing frontend/: $source_frontend" >&2
+    exit 1
+  fi
+
+  if [ ! -f "$source_caddyfile" ]; then
+    echo "❌ SHELL_BUNDLE_DIR is missing deploy/Caddyfile.production: $source_caddyfile" >&2
+    exit 1
+  fi
+
+  if [ ! -f "$source_compose" ]; then
+    echo "❌ SHELL_BUNDLE_DIR is missing $compose_relative_path: $source_compose" >&2
+    exit 1
   fi
 
   required_redeploy="$SHELL_BUNDLE_DIR/scripts/redeploy_caddy.sh"

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -366,9 +366,24 @@ validate_managed_postgres_contract() {
   fi
 }
 
+validate_shell_bundle_contract() {
+  local required_redeploy=""
+
+  if [ -z "$SHELL_BUNDLE_DIR" ]; then
+    return 0
+  fi
+
+  required_redeploy="$SHELL_BUNDLE_DIR/scripts/redeploy_caddy.sh"
+  if [ ! -f "$required_redeploy" ]; then
+    echo "❌ SHELL_BUNDLE_DIR is missing scripts/redeploy_caddy.sh: $required_redeploy" >&2
+    exit 1
+  fi
+}
+
 run_preflight() {
   echo "Validating managed PostgreSQL production contract..."
   validate_managed_postgres_contract
+  validate_shell_bundle_contract
   echo "✅ Production deploy preflight passed"
 }
 

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -294,6 +294,11 @@ sync_shell_bundle() {
     exit 1
   fi
 
+  if [ ! -f "$source_redeploy" ]; then
+    echo "❌ SHELL_BUNDLE_DIR is missing scripts/redeploy_caddy.sh: $source_redeploy" >&2
+    exit 1
+  fi
+
   echo "Syncing production shell bundle from: $SHELL_BUNDLE_DIR"
   rm -rf "$shell_root/frontend"
   mkdir -p "$shell_root/frontend" "$target_scripts_dir"
@@ -308,10 +313,8 @@ sync_shell_bundle() {
     chmod +x "$target_scripts_dir/diagnose_web.sh"
   fi
 
-  if [ -f "$source_redeploy" ]; then
-    cp "$source_redeploy" "$target_scripts_dir/redeploy_caddy.sh"
-    chmod +x "$target_scripts_dir/redeploy_caddy.sh"
-  fi
+  cp "$source_redeploy" "$target_scripts_dir/redeploy_caddy.sh"
+  chmod +x "$target_scripts_dir/redeploy_caddy.sh"
 }
 
 wait_for_app_ready() {

--- a/tests/test_cd_workflow_production_deploy_gate.py
+++ b/tests/test_cd_workflow_production_deploy_gate.py
@@ -152,7 +152,11 @@ def test_production_deploy_jobs_run_preflight_before_live_deploy() -> None:
     )
 
     assert "Preflight production deploy on self-hosted runner" in self_hosted_section
+    assert 'export SHELL_BUNDLE_DIR="${GITHUB_WORKSPACE}"' in self_hosted_section
     assert "bash scripts/deploy_production.sh --preflight-only" in self_hosted_section
+    assert self_hosted_lines.index('          export SHELL_BUNDLE_DIR="${GITHUB_WORKSPACE}"') < (
+        self_hosted_lines.index("          bash scripts/deploy_production.sh --preflight-only")
+    )
     assert self_hosted_lines.index(
         "          bash scripts/deploy_production.sh --preflight-only"
     ) < self_hosted_lines.index("          bash scripts/deploy_production.sh")

--- a/tests/test_cd_workflow_production_deploy_gate.py
+++ b/tests/test_cd_workflow_production_deploy_gate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -64,14 +65,18 @@ def test_production_deploy_syncs_shell_bundle_for_caddy_rebuild() -> None:
     """Guard against shipping only the app image while leaving the web shell stale."""
 
     workflow_text = CD_WORKFLOW_PATH.read_text(encoding="utf-8")
+    tar_bundle_pattern = re.compile(
+        r'tar -czf "\$archive_path" \\\n'
+        r"\s+frontend \\\n"
+        r"\s+deploy/Caddyfile\.production \\\n"
+        r"\s+deploy/docker-compose\.production\.yaml \\\n"
+        r"\s+scripts/diagnose_web\.sh \\\n"
+        r"\s+scripts/redeploy_caddy\.sh",
+        re.MULTILINE,
+    )
 
     assert "Stage production shell bundle for SSH deploy" in workflow_text
-    assert 'tar -czf "$archive_path" \\' in workflow_text
-    assert "frontend \\" in workflow_text
-    assert "deploy/Caddyfile.production \\" in workflow_text
-    assert "deploy/docker-compose.production.yaml \\" in workflow_text
-    assert "scripts/diagnose_web.sh \\" in workflow_text
-    assert "scripts/redeploy_caddy.sh" in workflow_text
+    assert tar_bundle_pattern.search(workflow_text)
     assert (
         'bundle_name="pulseplate-shell-bundle-${{ github.run_id }}-${{ github.run_attempt }}"'
         in workflow_text

--- a/tests/test_cd_workflow_production_deploy_gate.py
+++ b/tests/test_cd_workflow_production_deploy_gate.py
@@ -66,10 +66,12 @@ def test_production_deploy_syncs_shell_bundle_for_caddy_rebuild() -> None:
     workflow_text = CD_WORKFLOW_PATH.read_text(encoding="utf-8")
 
     assert "Stage production shell bundle for SSH deploy" in workflow_text
-    assert (
-        'tar -czf "$archive_path" frontend deploy/Caddyfile.production scripts/diagnose_web.sh'
-        in workflow_text
-    )
+    assert 'tar -czf "$archive_path" \\' in workflow_text
+    assert "frontend \\" in workflow_text
+    assert "deploy/Caddyfile.production \\" in workflow_text
+    assert "deploy/docker-compose.production.yaml \\" in workflow_text
+    assert "scripts/diagnose_web.sh \\" in workflow_text
+    assert "scripts/redeploy_caddy.sh" in workflow_text
     assert (
         'bundle_name="pulseplate-shell-bundle-${{ github.run_id }}-${{ github.run_attempt }}"'
         in workflow_text

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -24,6 +24,8 @@ def test_production_compose_source_of_truth_matches_split_contract() -> None:
     assert isinstance(app_service, dict), "production compose must define an app service"
     assert app_service["image"] == "${IMAGE_REF:?IMAGE_REF is required}"
     assert "build" not in app_service
+    app_env_file = app_service.get("env_file")
+    assert app_env_file in (".env", [".env"]), "app service must reference deploy/.env"
 
     caddy_service = services.get("caddy")
     assert isinstance(caddy_service, dict), "production compose must define a caddy service"
@@ -45,6 +47,7 @@ def test_deploy_production_rejects_shell_bundle_without_redeploy_helper(
     project_dir = tmp_path / "production"
     shell_bundle_dir = tmp_path / "shell-bundle"
     bin_dir = tmp_path / "bin"
+    log_file = tmp_path / "docker.log"
     project_dir.mkdir()
     shell_bundle_dir.mkdir()
     bin_dir.mkdir()
@@ -67,8 +70,9 @@ def test_deploy_production_rejects_shell_bundle_without_redeploy_helper(
         "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n", encoding="utf-8"
     )
 
-    docker_stub = """#!/usr/bin/env bash
+    docker_stub = f"""#!/usr/bin/env bash
 set -euo pipefail
+printf 'docker %s\\n' "$*" >> "{log_file}"
 """
     curl_stub = """#!/usr/bin/env bash
 set -euo pipefail
@@ -98,6 +102,7 @@ set -euo pipefail
 
     assert completed.returncode == 1
     assert "SHELL_BUNDLE_DIR is missing scripts/redeploy_caddy.sh" in completed.stderr
+    assert not log_file.exists()
 
 
 def _write_executable(path: Path, content: str) -> None:
@@ -972,7 +977,9 @@ def test_deploy_production_rejects_compose_file_outside_deploy_dir_during_shell_
     (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
         "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n", encoding="utf-8"
     )
-    (shell_root / "scripts").mkdir()
+    (shell_bundle_dir / "scripts" / "redeploy_caddy.sh").write_text(
+        "#!/usr/bin/env bash\nprintf 'bundle-redeploy\\n'\n", encoding="utf-8"
+    )
 
     docker_stub = f"""#!/usr/bin/env bash
 set -euo pipefail

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -5,24 +5,22 @@ from collections.abc import Callable
 from pathlib import Path
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-PRODUCTION_SHELL_COMPOSE_SNIPPET = """services:
-  app:
-    image: ${IMAGE_REF:?IMAGE_REF is required}
-  caddy:
-    build:
-      context: ../frontend
-      dockerfile: Dockerfile.caddy-spa
-      args:
-        VITE_API_BASE: ${VITE_API_BASE:-/api/v1}
-"""
+PRODUCTION_COMPOSE_PATH = REPO_ROOT / "deploy" / "docker-compose.production.yaml"
+PRODUCTION_COMPOSE_TEXT = PRODUCTION_COMPOSE_PATH.read_text(encoding="utf-8")
 
 
-def test_production_shell_bundle_fixture_matches_split_contract() -> None:
-    assert "image: ${IMAGE_REF:?IMAGE_REF is required}" in PRODUCTION_SHELL_COMPOSE_SNIPPET
-    assert "dockerfile: Dockerfile.caddy-spa" in PRODUCTION_SHELL_COMPOSE_SNIPPET
-    assert "postgres:" not in PRODUCTION_SHELL_COMPOSE_SNIPPET
+def test_production_compose_source_of_truth_matches_split_contract() -> None:
+    compose = yaml.safe_load(PRODUCTION_COMPOSE_TEXT)
+    services = compose["services"]
+
+    assert "postgres" not in services
+    assert services["app"]["image"] == "${IMAGE_REF:?IMAGE_REF is required}"
+    assert services["caddy"]["build"]["context"] == "../frontend"
+    assert services["caddy"]["build"]["dockerfile"] == "Dockerfile.caddy-spa"
+    assert services["caddy"]["build"]["args"]["VITE_API_BASE"] == "${VITE_API_BASE:-/api/v1}"
 
 
 def _write_executable(path: Path, content: str) -> None:
@@ -439,7 +437,7 @@ def test_deploy_production_syncs_shell_bundle_and_prunes_stale_shell_files(tmp_p
         encoding="utf-8",
     )
     (shell_bundle_dir / "deploy" / "docker-compose.production.yaml").write_text(
-        PRODUCTION_SHELL_COMPOSE_SNIPPET, encoding="utf-8"
+        PRODUCTION_COMPOSE_TEXT, encoding="utf-8"
     )
     (shell_bundle_dir / "scripts").mkdir()
     (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
@@ -504,7 +502,7 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     )
     assert (project_dir / "docker-compose.production.yaml").read_text(
         encoding="utf-8"
-    ) == PRODUCTION_SHELL_COMPOSE_SNIPPET
+    ) == PRODUCTION_COMPOSE_TEXT
     assert not (shell_root / "frontend" / "stale.txt").exists()
     assert (shell_root / "scripts" / "diagnose_web.sh").read_text(
         encoding="utf-8"
@@ -537,7 +535,7 @@ def test_deploy_production_syncs_shell_bundle_with_autodetected_compose_file(
         encoding="utf-8",
     )
     (shell_bundle_dir / "deploy" / "docker-compose.production.yaml").write_text(
-        PRODUCTION_SHELL_COMPOSE_SNIPPET, encoding="utf-8"
+        PRODUCTION_COMPOSE_TEXT, encoding="utf-8"
     )
     (shell_bundle_dir / "scripts").mkdir()
     (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
@@ -591,7 +589,7 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
 
     assert (project_dir / "docker-compose.production.yaml").read_text(
         encoding="utf-8"
-    ) == PRODUCTION_SHELL_COMPOSE_SNIPPET
+    ) == PRODUCTION_COMPOSE_TEXT
     assert (shell_root / "scripts" / "diagnose_web.sh").read_text(
         encoding="utf-8"
     ) == "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n"
@@ -1031,7 +1029,7 @@ def test_deploy_production_keeps_shell_bundle_untouched_when_migrations_fail(
         encoding="utf-8",
     )
     (shell_bundle_dir / "deploy" / "docker-compose.production.yaml").write_text(
-        PRODUCTION_SHELL_COMPOSE_SNIPPET, encoding="utf-8"
+        PRODUCTION_COMPOSE_TEXT, encoding="utf-8"
     )
     (shell_bundle_dir / "scripts").mkdir()
     (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -7,6 +7,22 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+PRODUCTION_SHELL_COMPOSE_SNIPPET = """services:
+  app:
+    image: ${IMAGE_REF:?IMAGE_REF is required}
+  caddy:
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile.caddy-spa
+      args:
+        VITE_API_BASE: ${VITE_API_BASE:-/api/v1}
+"""
+
+
+def test_production_shell_bundle_fixture_matches_split_contract() -> None:
+    assert "image: ${IMAGE_REF:?IMAGE_REF is required}" in PRODUCTION_SHELL_COMPOSE_SNIPPET
+    assert "dockerfile: Dockerfile.caddy-spa" in PRODUCTION_SHELL_COMPOSE_SNIPPET
+    assert "postgres:" not in PRODUCTION_SHELL_COMPOSE_SNIPPET
 
 
 def _write_executable(path: Path, content: str) -> None:
@@ -423,8 +439,7 @@ def test_deploy_production_syncs_shell_bundle_and_prunes_stale_shell_files(tmp_p
         encoding="utf-8",
     )
     (shell_bundle_dir / "deploy" / "docker-compose.production.yaml").write_text(
-        "services:\n  caddy:\n    image: caddy:2.10.2\n",
-        encoding="utf-8",
+        PRODUCTION_SHELL_COMPOSE_SNIPPET, encoding="utf-8"
     )
     (shell_bundle_dir / "scripts").mkdir()
     (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
@@ -489,7 +504,7 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     )
     assert (project_dir / "docker-compose.production.yaml").read_text(
         encoding="utf-8"
-    ) == "services:\n  caddy:\n    image: caddy:2.10.2\n"
+    ) == PRODUCTION_SHELL_COMPOSE_SNIPPET
     assert not (shell_root / "frontend" / "stale.txt").exists()
     assert (shell_root / "scripts" / "diagnose_web.sh").read_text(
         encoding="utf-8"
@@ -522,8 +537,7 @@ def test_deploy_production_syncs_shell_bundle_with_autodetected_compose_file(
         encoding="utf-8",
     )
     (shell_bundle_dir / "deploy" / "docker-compose.production.yaml").write_text(
-        "services:\n  caddy:\n    image: caddy:2.10.2\n",
-        encoding="utf-8",
+        PRODUCTION_SHELL_COMPOSE_SNIPPET, encoding="utf-8"
     )
     (shell_bundle_dir / "scripts").mkdir()
     (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
@@ -577,7 +591,7 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
 
     assert (project_dir / "docker-compose.production.yaml").read_text(
         encoding="utf-8"
-    ) == "services:\n  caddy:\n    image: caddy:2.10.2\n"
+    ) == PRODUCTION_SHELL_COMPOSE_SNIPPET
     assert (shell_root / "scripts" / "diagnose_web.sh").read_text(
         encoding="utf-8"
     ) == "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n"
@@ -1017,8 +1031,7 @@ def test_deploy_production_keeps_shell_bundle_untouched_when_migrations_fail(
         encoding="utf-8",
     )
     (shell_bundle_dir / "deploy" / "docker-compose.production.yaml").write_text(
-        "services:\n  caddy:\n    image: caddy:2.10.2\n",
-        encoding="utf-8",
+        PRODUCTION_SHELL_COMPOSE_SNIPPET, encoding="utf-8"
     )
     (shell_bundle_dir / "scripts").mkdir()
     (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -105,6 +105,70 @@ set -euo pipefail
     assert not log_file.exists()
 
 
+def test_deploy_production_preflight_rejects_shell_bundle_without_frontend(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "production"
+    shell_bundle_dir = tmp_path / "shell-bundle"
+    bin_dir = tmp_path / "bin"
+    log_file = tmp_path / "docker.log"
+    project_dir.mkdir()
+    shell_bundle_dir.mkdir()
+    bin_dir.mkdir()
+    (project_dir / "docker-compose.production.yaml").write_text("services: {}\n", encoding="utf-8")
+    (project_dir / ".env").write_text(
+        "DATABASE_URL=postgresql+psycopg://pulseplate:secret@db.example.com:25060/pulseplate\n",  # pragma: allowlist secret
+        encoding="utf-8",
+    )
+    (shell_bundle_dir / "deploy").mkdir()
+    (shell_bundle_dir / "deploy" / "Caddyfile.production").write_text(
+        'pulseplate.test {\n    respond "ok"\n}\n',
+        encoding="utf-8",
+    )
+    (shell_bundle_dir / "deploy" / "docker-compose.production.yaml").write_text(
+        PRODUCTION_COMPOSE_TEXT, encoding="utf-8"
+    )
+    (shell_bundle_dir / "scripts").mkdir()
+    (shell_bundle_dir / "scripts" / "redeploy_caddy.sh").write_text(
+        "#!/usr/bin/env bash\nprintf 'bundle-redeploy\\n'\n", encoding="utf-8"
+    )
+
+    docker_stub = f"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'docker %s\\n' "$*" >> "{log_file}"
+"""
+    curl_stub = """#!/usr/bin/env bash
+set -euo pipefail
+"""
+    _write_executable(bin_dir / "docker", docker_stub)
+    _write_executable(bin_dir / "curl", curl_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DOCKER_BIN"] = str(bin_dir / "docker")
+    env["DEPLOY_DIR"] = str(project_dir)
+    env["ENV_FILE"] = str(project_dir / ".env")
+    env["COMPOSE_FILE"] = "docker-compose.production.yaml"
+    env["DATABASE_URL"] = (
+        "postgresql+psycopg://pulseplate:secret@db.example.com:25060/pulseplate"  # pragma: allowlist secret
+    )
+    env["PRODUCTION_DOMAIN"] = "pulseplate.test"
+    env["SHELL_BUNDLE_DIR"] = str(shell_bundle_dir)
+
+    completed = subprocess.run(
+        [str(REPO_ROOT / "scripts/deploy_production.sh"), "--preflight-only"],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert "SHELL_BUNDLE_DIR is missing frontend/" in completed.stderr
+    assert not log_file.exists()
+
+
 def _write_executable(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
     path.chmod(path.stat().st_mode | stat.S_IXUSR)

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -443,10 +443,14 @@ def test_deploy_production_syncs_shell_bundle_and_prunes_stale_shell_files(tmp_p
     (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
         "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n", encoding="utf-8"
     )
+    (shell_bundle_dir / "scripts" / "redeploy_caddy.sh").write_text(
+        "#!/usr/bin/env bash\nprintf 'bundle-redeploy\\n'\n", encoding="utf-8"
+    )
     (shell_root / "frontend").mkdir()
     (shell_root / "frontend" / "stale.txt").write_text("old-shell\n", encoding="utf-8")
-    (shell_root / "scripts").mkdir()
-    (shell_root / "scripts" / "diagnose_web.sh").write_text("stale-diagnose\n", encoding="utf-8")
+    (project_dir / "scripts").mkdir()
+    (project_dir / "scripts" / "diagnose_web.sh").write_text("stale-diagnose\n", encoding="utf-8")
+    (project_dir / "scripts" / "redeploy_caddy.sh").write_text("stale-redeploy\n", encoding="utf-8")
 
     docker_stub = f"""#!/usr/bin/env bash
 set -euo pipefail
@@ -504,9 +508,12 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
         encoding="utf-8"
     ) == PRODUCTION_COMPOSE_TEXT
     assert not (shell_root / "frontend" / "stale.txt").exists()
-    assert (shell_root / "scripts" / "diagnose_web.sh").read_text(
+    assert (project_dir / "scripts" / "diagnose_web.sh").read_text(
         encoding="utf-8"
     ) == "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n"
+    assert (project_dir / "scripts" / "redeploy_caddy.sh").read_text(
+        encoding="utf-8"
+    ) == "#!/usr/bin/env bash\nprintf 'bundle-redeploy\\n'\n"
 
 
 def test_deploy_production_syncs_shell_bundle_with_autodetected_compose_file(
@@ -541,7 +548,9 @@ def test_deploy_production_syncs_shell_bundle_with_autodetected_compose_file(
     (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
         "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n", encoding="utf-8"
     )
-    (shell_root / "scripts").mkdir()
+    (shell_bundle_dir / "scripts" / "redeploy_caddy.sh").write_text(
+        "#!/usr/bin/env bash\nprintf 'bundle-redeploy\\n'\n", encoding="utf-8"
+    )
 
     docker_stub = f"""#!/usr/bin/env bash
 set -euo pipefail
@@ -590,9 +599,12 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     assert (project_dir / "docker-compose.production.yaml").read_text(
         encoding="utf-8"
     ) == PRODUCTION_COMPOSE_TEXT
-    assert (shell_root / "scripts" / "diagnose_web.sh").read_text(
+    assert (project_dir / "scripts" / "diagnose_web.sh").read_text(
         encoding="utf-8"
     ) == "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n"
+    assert (project_dir / "scripts" / "redeploy_caddy.sh").read_text(
+        encoding="utf-8"
+    ) == "#!/usr/bin/env bash\nprintf 'bundle-redeploy\\n'\n"
 
 
 def test_deploy_production_syncs_shell_bundle_with_relative_compose_subpath(
@@ -632,7 +644,9 @@ def test_deploy_production_syncs_shell_bundle_with_relative_compose_subpath(
     (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
         "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n", encoding="utf-8"
     )
-    (shell_root / "scripts").mkdir()
+    (shell_bundle_dir / "scripts" / "redeploy_caddy.sh").write_text(
+        "#!/usr/bin/env bash\nprintf 'bundle-redeploy\\n'\n", encoding="utf-8"
+    )
 
     docker_stub = f"""#!/usr/bin/env bash
 set -euo pipefail
@@ -681,9 +695,12 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     assert (project_dir / "deploy" / "docker-compose.production.yaml").read_text(
         encoding="utf-8"
     ) == "services:\n  app:\n    image: ghcr.io/example/pulseplate:test\n"
-    assert (shell_root / "scripts" / "diagnose_web.sh").read_text(
+    assert (project_dir / "scripts" / "diagnose_web.sh").read_text(
         encoding="utf-8"
     ) == "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n"
+    assert (project_dir / "scripts" / "redeploy_caddy.sh").read_text(
+        encoding="utf-8"
+    ) == "#!/usr/bin/env bash\nprintf 'bundle-redeploy\\n'\n"
 
 
 def test_deploy_production_autodetects_deploy_subdir_compose_and_env_file(
@@ -1035,10 +1052,14 @@ def test_deploy_production_keeps_shell_bundle_untouched_when_migrations_fail(
     (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
         "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n", encoding="utf-8"
     )
+    (shell_bundle_dir / "scripts" / "redeploy_caddy.sh").write_text(
+        "#!/usr/bin/env bash\nprintf 'bundle-redeploy\\n'\n", encoding="utf-8"
+    )
     (shell_root / "frontend").mkdir()
     (shell_root / "frontend" / "stale.txt").write_text("old-shell\n", encoding="utf-8")
-    (shell_root / "scripts").mkdir()
-    (shell_root / "scripts" / "diagnose_web.sh").write_text("stale-diagnose\n", encoding="utf-8")
+    (project_dir / "scripts").mkdir()
+    (project_dir / "scripts" / "diagnose_web.sh").write_text("stale-diagnose\n", encoding="utf-8")
+    (project_dir / "scripts" / "redeploy_caddy.sh").write_text("stale-redeploy\n", encoding="utf-8")
 
     docker_stub = f"""#!/usr/bin/env bash
 set -euo pipefail
@@ -1080,9 +1101,12 @@ printf 'curl %s\\n' "$*" >> "{log_file}"
     assert completed.returncode == 1
     assert (shell_root / "frontend" / "stale.txt").read_text(encoding="utf-8") == "old-shell\n"
     assert not (shell_root / "frontend" / "bundle-marker.txt").exists()
-    assert (shell_root / "scripts" / "diagnose_web.sh").read_text(
+    assert (project_dir / "scripts" / "diagnose_web.sh").read_text(
         encoding="utf-8"
     ) == "stale-diagnose\n"
+    assert (project_dir / "scripts" / "redeploy_caddy.sh").read_text(
+        encoding="utf-8"
+    ) == "stale-redeploy\n"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -14,13 +14,90 @@ PRODUCTION_COMPOSE_TEXT = PRODUCTION_COMPOSE_PATH.read_text(encoding="utf-8")
 
 def test_production_compose_source_of_truth_matches_split_contract() -> None:
     compose = yaml.safe_load(PRODUCTION_COMPOSE_TEXT)
-    services = compose["services"]
+    assert isinstance(compose, dict), "production compose must deserialize to a mapping"
+
+    services = compose.get("services")
+    assert isinstance(services, dict), "production compose must define a services mapping"
 
     assert "postgres" not in services
-    assert services["app"]["image"] == "${IMAGE_REF:?IMAGE_REF is required}"
-    assert services["caddy"]["build"]["context"] == "../frontend"
-    assert services["caddy"]["build"]["dockerfile"] == "Dockerfile.caddy-spa"
-    assert services["caddy"]["build"]["args"]["VITE_API_BASE"] == "${VITE_API_BASE:-/api/v1}"
+    app_service = services.get("app")
+    assert isinstance(app_service, dict), "production compose must define an app service"
+    assert app_service["image"] == "${IMAGE_REF:?IMAGE_REF is required}"
+    assert "build" not in app_service
+
+    caddy_service = services.get("caddy")
+    assert isinstance(caddy_service, dict), "production compose must define a caddy service"
+    assert "image" not in caddy_service
+
+    caddy_build = caddy_service.get("build")
+    assert isinstance(caddy_build, dict), "caddy service must use a build-based shell contract"
+    assert caddy_build["context"] == "../frontend"
+    assert caddy_build["dockerfile"] == "Dockerfile.caddy-spa"
+
+    caddy_build_args = caddy_build.get("args")
+    assert isinstance(caddy_build_args, dict), "caddy build must define build args"
+    assert caddy_build_args["VITE_API_BASE"] == "${VITE_API_BASE:-/api/v1}"
+
+
+def test_deploy_production_rejects_shell_bundle_without_redeploy_helper(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "production"
+    shell_bundle_dir = tmp_path / "shell-bundle"
+    bin_dir = tmp_path / "bin"
+    project_dir.mkdir()
+    shell_bundle_dir.mkdir()
+    bin_dir.mkdir()
+    (project_dir / "docker-compose.production.yaml").write_text("services: {}\n", encoding="utf-8")
+    (project_dir / ".env").write_text(
+        "DATABASE_URL=postgresql+psycopg://pulseplate:secret@db.example.com:25060/pulseplate\n",  # pragma: allowlist secret
+        encoding="utf-8",
+    )
+    (shell_bundle_dir / "frontend").mkdir()
+    (shell_bundle_dir / "deploy").mkdir()
+    (shell_bundle_dir / "deploy" / "Caddyfile.production").write_text(
+        'pulseplate.test {\n    respond "ok"\n}\n',
+        encoding="utf-8",
+    )
+    (shell_bundle_dir / "deploy" / "docker-compose.production.yaml").write_text(
+        PRODUCTION_COMPOSE_TEXT, encoding="utf-8"
+    )
+    (shell_bundle_dir / "scripts").mkdir()
+    (shell_bundle_dir / "scripts" / "diagnose_web.sh").write_text(
+        "#!/usr/bin/env bash\nprintf 'bundle-diagnose\\n'\n", encoding="utf-8"
+    )
+
+    docker_stub = """#!/usr/bin/env bash
+set -euo pipefail
+"""
+    curl_stub = """#!/usr/bin/env bash
+set -euo pipefail
+"""
+    _write_executable(bin_dir / "docker", docker_stub)
+    _write_executable(bin_dir / "curl", curl_stub)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["DOCKER_BIN"] = str(bin_dir / "docker")
+    env["DEPLOY_DIR"] = str(project_dir)
+    env["ENV_FILE"] = str(project_dir / ".env")
+    env["COMPOSE_FILE"] = "docker-compose.production.yaml"
+    env["IMAGE_REF"] = "ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:test"
+    env["TAG"] = "prod-vtest"
+    env["PRODUCTION_DOMAIN"] = "pulseplate.test"
+    env["SHELL_BUNDLE_DIR"] = str(shell_bundle_dir)
+
+    completed = subprocess.run(
+        [str(REPO_ROOT / "scripts/deploy_production.sh")],
+        cwd=str(REPO_ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert "SHELL_BUNDLE_DIR is missing scripts/redeploy_caddy.sh" in completed.stderr
 
 
 def _write_executable(path: Path, content: str) -> None:


### PR DESCRIPTION
## Summary
- reconcile deploy docs and workflow notes to the already-landed split backend `IMAGE_REF` + separate frontend/Caddy shell contract
- mark staging compose as an explicit temporary seam instead of an implied production-source-of-truth surface
- tighten deterministic deploy-contract coverage so production shell-bundle fixtures assert the split topology instead of the old pulled `caddy` image shape

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- Canonical artifact: `docs/review/PR_1488_FIXED_MAPPING.md`

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4148229640
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4148251408
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1488#pullrequestreview-4149616401
- canonical details and thread-level proof live in `docs/review/PR_1488_FIXED_MAPPING.md`

## Merge Readiness
- [x] `pre-commit run --all-files`
- [ ] `make verify`
- [x] review dispositions synced in `docs/review/PR_1488_FIXED_MAPPING.md`
- [ ] `python3 scripts/orchestration/check_merge_ready.py --pr-number 1488 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`
- [ ] no actionable review comments remain

## Summary by Sourcery

Согласование контракта продакшен-деплоя Docker, документации и стейджинга CI shell-bundle с раздельным `IMAGE_REF` для бэкенда и обновлённой топологией фронтенда/Caddy.

Улучшения:
- Рассматривать `staging`-конфигурацию `docker-compose` как явно временный шов, отделённый от каноничного контракта продакшен-деплоя.
- Упаковывать и синхронизировать полный продакшен shell bundle (фронтенд, Caddyfile, продакшен `compose` и вспомогательные скрипты) на сервер для консистентных пересборок shell на краю.
- Добавить отдельный тест контракта продакшен `compose`, чтобы проверять раздельную топологию бэкенд/фронтенд и новые расположения скриптов.
- Обновить скрипт продакшен-деплоя так, чтобы он синхронизировал оба вспомогательных скрипта — `diagnose` и `caddy-redeploy` — в централизованный каталог `scripts` в корне деплоя.
- Уточнить документацию по рабочему процессу оператора относительно происхождения shell bundle, аварийного восстановления и безопасного обновления конфигурации Caddy через совмещённую релизную «истину».

CI:
- Обновить CD workflow, чтобы включить файл продакшен `compose` и скрипт `caddy-redeploy` в архив подготавливаемого shell bundle.

Документация:
- Задокументировать разделённый контракт деплоя, состав shell-bundle и «staging seam» в продакшен- и workflow-документации, а также добавить артефакт соответствия governance fixed-in-commit для этого PR.

Тесты:
- Расширить тесты контракта деплоя и gate-тесты CD workflow, чтобы покрыть новый контракт продакшен `compose`, структуру размещения скриптов и содержимое архива shell-bundle.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align production Docker deploy contract, documentation, and CI shell-bundle staging with the split backend IMAGE_REF and rebuilt frontend/Caddy topology.

Enhancements:
- Treat staging docker-compose as an explicitly temporary seam separate from the canonical production deploy contract.
- Package and sync the full production shell bundle (frontend, Caddyfile, production compose, and helper scripts) to the server for consistent edge shell rebuilds.
- Add a dedicated production compose contract test to assert the split backend/frontend topology and new script locations.
- Update the production deploy script to sync both diagnose and caddy-redeploy helper scripts into a centralized scripts directory at the deploy root.
- Clarify operator workflow docs around shell bundle provenance, emergency recovery, and how to safely update Caddy configuration through merged release truth.

CI:
- Update the CD workflow to include the production compose file and caddy-redeploy script in the staged shell bundle archive.

Documentation:
- Document the split deploy contract, shell-bundle composition, and staging seam in production and workflow docs, and add the governance fixed-in-commit mapping artifact for this PR.

Tests:
- Extend deploy-contract tests and CD workflow gate tests to cover the new production compose contract, script layout, and shell-bundle archive contents.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Production deploy now stages additional release artifacts, enforces a required redeploy helper for web-server rebuilds, and validates shell-bundle provenance before rebuilding.

* **Documentation**
  * Clarified production prerequisites, provenance rules, redeploy/rollback and emergency recovery procedures, workflow sequencing, and added governance/roadmap guidance.

* **Tests**
  * Expanded tests to validate deploy bundle contents, compose contract invariants, preflight/export ordering, and redeploy-helper enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

