### PR TITLE
feat(ci): add docker image telemetry baseline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      actions: write
+      actions: read
       contents: read
 
     steps:
@@ -70,11 +70,25 @@ jobs:
             --image pulseplate:test \
             --output-json docker-runtime-dependency-surface.json
 
+      - name: Resolve Docker image telemetry baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/fetch_docker_image_baseline.py \
+            --repo "${{ github.repository }}" \
+            --workflow build.yml \
+            --artifact-name docker-image-telemetry-build \
+            --fallback-json docs/telemetry/docker_image_baseline.production.json \
+            --output docker-image-baseline.json
+
       - name: Collect Docker image telemetry
         run: |
           set -euo pipefail
           if ! python3 scripts/ci/docker_image_telemetry.py \
             --image-ref pulseplate:test \
+            --baseline-json docker-image-baseline.json \
             --json-out docker-image-telemetry.json \
             --markdown-out docker-image-telemetry.md
           then

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,7 +5,7 @@ env:
   PULSEPLATE_PYTHON_TRUSTED_HOST: ${{ secrets.PULSEPLATE_PYTHON_TRUSTED_HOST || vars.PULSEPLATE_PYTHON_TRUSTED_HOST }}
 
 permissions:
-  actions: write
+  actions: read
   contents: read
 
 on:
@@ -57,11 +57,25 @@ jobs:
           --image my-image-name:${{ github.run_id }}-${{ github.run_attempt }} \
           --output-json docker-runtime-dependency-surface.json
 
+    - name: Resolve Docker image telemetry baseline
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        python3 scripts/ci/fetch_docker_image_baseline.py \
+          --repo "${{ github.repository }}" \
+          --workflow build.yml \
+          --artifact-name docker-image-telemetry-build \
+          --fallback-json docs/telemetry/docker_image_baseline.production.json \
+          --output docker-image-baseline.json
+
     - name: Collect Docker image telemetry
       run: |
         set -euo pipefail
         if ! python3 scripts/ci/docker_image_telemetry.py \
           --image-ref my-image-name:${{ github.run_id }}-${{ github.run_attempt }} \
+          --baseline-json docker-image-baseline.json \
           --json-out docker-image-telemetry.json \
           --markdown-out docker-image-telemetry.md
         then

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     permissions:
-      actions: write
+      actions: read
       contents: read # for actions/checkout to fetch code
       packages: read # for ghcr.io/aquasecurity/trivy-db pulls (AGENTS.md GHCR policy)
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
@@ -69,11 +69,25 @@ jobs:
             --image pulseplate:trivy-scan-${{ github.sha }} \
             --output-json docker-runtime-dependency-surface.json
 
+      - name: Resolve Docker image telemetry baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/fetch_docker_image_baseline.py \
+            --repo "${{ github.repository }}" \
+            --workflow build.yml \
+            --artifact-name docker-image-telemetry-build \
+            --fallback-json docs/telemetry/docker_image_baseline.production.json \
+            --output docker-image-baseline.json
+
       - name: Collect Docker image telemetry
         run: |
           set -euo pipefail
           if ! python3 scripts/ci/docker_image_telemetry.py \
             --image-ref pulseplate:trivy-scan-${{ github.sha }} \
+            --baseline-json docker-image-baseline.json \
             --json-out docker-image-telemetry.json \
             --markdown-out docker-image-telemetry.md
           then

--- a/docs/deploy/DOCKER.md
+++ b/docs/deploy/DOCKER.md
@@ -139,6 +139,22 @@ frontend/Caddy changes.
 Explicitly deferred after this PR:
 
 - hard image-budget cap / failure threshold
+  Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-docker-image-hard-budget-gate`
+  Remove-by: 2026-05-31
+  Rollback: keep telemetry advisory-only and remove any premature hard-stop threshold from Docker lanes.
+  Exit criteria: a dedicated follow-up PR lands a deterministic hard-fail threshold for the production backend image after the warning-only baseline stabilizes on `main`.
 - `P1: Shared Safety audit script after install-profile split`
+  Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-safety-audit-shared-script-after-pr1479`
+  Remove-by: 2026-06-15
+  Rollback: keep Safety invocation duplicated in the existing workflows until the shared extraction lands.
+  Exit criteria: a follow-up PR extracts the shared Safety invocation/reporting path without reopening install-profile split scope.
 - provenance / attestation recovery
+  Backlog: `docs/roadmap/BACKLOG_LEDGER.md#backlog-restore-signed-build-provenance`
+  Remove-by: 2026-06-30
+  Rollback: keep signed provenance disabled on the known cache/buildx seam and preserve the documented workaround.
+  Exit criteria: signed provenance and downstream verification return to the canonical image workflow without destabilizing the release path.
 - Dagger or any alternate control-plane work
+  Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-dagger-pilot-after-docker-baseline`
+  Remove-by: 2026-07-15
+  Rollback: keep the current GitHub Actions-based Docker control plane as the only supported path.
+  Exit criteria: telemetry baseline and provenance follow-ups are closed and a separate evaluation packet re-approves any Dagger pilot.

--- a/docs/deploy/DOCKER.md
+++ b/docs/deploy/DOCKER.md
@@ -1,4 +1,4 @@
-# Docker Runtime Contract
+# Docker Runtime And Telemetry Contract
 
 This document is the operator-facing source of truth for the PulsePlate backend
 Docker runtime contract.
@@ -10,22 +10,9 @@ Docker runtime contract.
 - Optional vector / ML dependencies stay in `requirements-rag-vector.txt`.
 - Production target remains the split backend image that serves `app.main:app`.
 - Frontend / Caddy topology remains separate and out of scope for this slice.
-
-## Why this slice exists
-
-The install-profile split removed heavy ML / GPU packages from the generic CI
-surface, but some production-target Docker workflows were still building the
-backend image with `requirements-ci-lite.txt`.
-
-That left CI-only tooling inside the runtime image:
-
-- `pre-commit`
-- `bandit`
-- `diff-cover`
-- `pytest`
-
-This PR standardizes production-target Docker builds on a dedicated runtime
-manifest so the backend image does not carry CI-only tooling.
+- Runtime slimming merged via `PR #1490` on April 22, 2026.
+- The current Docker/CI slice establishes the first canonical backend-image
+  telemetry baseline for warning-only regression reporting.
 
 ## Runtime manifest policy
 
@@ -46,6 +33,50 @@ Blocked package classes for the default backend runtime:
 - optional vector / ML stack: `sentence-transformers`, `transformers`, `torch`,
   `pgvector`
 - GPU / CUDA packages: `nvidia-*`, `cuda-*`, `triton`
+
+## Why the telemetry slice exists
+
+Runtime slimming removed CI-only tooling from the production backend image, but
+the project still needs one canonical baseline so PR authors can see image-size
+drift, largest layers, and build-context evidence before merge.
+
+This wave keeps that signal warning-only:
+
+- no absolute image-size cap
+- no hard failure threshold for positive delta vs baseline
+- no provenance / Dagger reopening until the baseline exists
+
+## Baseline source rule
+
+All three Docker telemetry lanes use one canonical backend baseline:
+
+1. latest successful `main` artifact from `build.yml`
+2. checked-in seed fallback at `docs/telemetry/docker_image_baseline.production.json`
+
+`scripts/ci/fetch_docker_image_baseline.py` resolves the baseline before
+telemetry collection. If GitHub lookup/download fails, the workflow falls back
+to the checked-in seed and still publishes advisory evidence.
+
+## Telemetry evidence contract
+
+`scripts/ci/docker_image_telemetry.py` remains local-image-only. It does not
+talk to GitHub; it only renders PR-visible evidence from the built image and
+the resolved baseline JSON.
+
+Each Docker lane publishes:
+
+- `docker-image-telemetry.json`
+- `docker-image-telemetry.md`
+- `GITHUB_STEP_SUMMARY` entry
+
+Evidence must include:
+
+- image size
+- baseline source: `main-artifact` or `repo-seed-fallback`
+- baseline reference metadata when available
+- delta vs baseline in warning-only mode
+- largest layers
+- build-context evidence
 
 ## Validation commands
 
@@ -75,6 +106,21 @@ docker run --rm pulseplate:runtime-slim \
   python -c "import app.main; print('app.main import ok')"
 ```
 
+Resolve the canonical baseline and generate advisory telemetry:
+
+```bash
+python3 scripts/ci/fetch_docker_image_baseline.py \
+  --repo Katsiarynakavaleuskaya/PulsePlate \
+  --fallback-json docs/telemetry/docker_image_baseline.production.json \
+  --output artifacts/docker/docker-image-baseline.json
+
+python3 scripts/ci/docker_image_telemetry.py \
+  --image-ref pulseplate:runtime-slim \
+  --baseline-json artifacts/docker/docker-image-baseline.json \
+  --json-out artifacts/docker/docker-image-telemetry.json \
+  --markdown-out artifacts/docker/docker-image-telemetry.md
+```
+
 ## Rollback
 
 If the runtime image fails to build or boot after this slice:
@@ -85,14 +131,14 @@ If the runtime image fails to build or boot after this slice:
 3. keep the runtime-surface findings as evidence in the PR and record the
    follow-up in `docs/roadmap/BACKLOG_LEDGER.md`
 
-Do not widen this rollback into image-budget telemetry, provenance, or
+Do not widen this rollback into hard image-budget enforcement, provenance, or
 frontend/Caddy changes.
 
 ## Deferred follow-ups
 
-Explicitly deferred from this PR:
+Explicitly deferred after this PR:
 
-- `P1: Docker image budget and telemetry baseline`
+- hard image-budget cap / failure threshold
 - `P1: Shared Safety audit script after install-profile split`
 - provenance / attestation recovery
 - Dagger or any alternate control-plane work

--- a/docs/orchestration/DOCKER_IMAGE_BUDGET_TELEMETRY_TASK_PACKET_2026-04-22.md
+++ b/docs/orchestration/DOCKER_IMAGE_BUDGET_TELEMETRY_TASK_PACKET_2026-04-22.md
@@ -1,0 +1,53 @@
+# Docker Image Budget And Telemetry Task Packet — 2026-04-22
+
+Status: Active PR-5 slice in the Docker / CI discipline series
+
+## Summary
+
+After runtime slimming merged via `PR #1490` on April 22, 2026, this slice
+establishes the first canonical backend-image telemetry baseline for Docker
+lanes. The baseline stays warning-only in this wave: CI must surface image size,
+largest layers, build-context evidence, and delta vs baseline without turning
+that signal into a hard budget gate yet.
+
+## Branch / worktree
+
+- Branch: `codex/docker-image-budget-telemetry-baseline`
+- Worktree: `worktrees/docker-image-budget-telemetry-pr5`
+
+## Mandatory role order
+
+1. `agent-coordinator`
+2. `architecture-specialist`
+3. `security-auditor`
+4. `backend-engineer`
+5. `dev-operator`
+6. post-open `qa-engineer-agent`
+7. post-open `bug-hunter`
+
+No ad hoc role stack may replace this order.
+
+## Scope
+
+- add a checked-in backend-image seed baseline
+- fetch the latest successful `main` Docker telemetry artifact when available
+- normalize baseline-source metadata into PR-visible telemetry evidence
+- wire baseline comparison into `build.yml`, `docker-image.yml`, and `trivy.yml`
+- update docs and backlog for the telemetry-baseline slice
+
+## Non-goals
+
+- no hard image-size budget cap
+- no Shared Safety audit script extraction
+- no provenance / attestation recovery
+- no Dagger or alternate control plane
+- no frontend/Caddy topology changes
+- no runtime dependency-contract widening
+
+## Acceptance criteria
+
+- Docker workflows resolve one canonical backend baseline before telemetry collection
+- telemetry reports baseline source as `main-artifact` or `repo-seed-fallback`
+- delta vs baseline remains warning-only and PR-visible
+- largest-layer and build-context evidence stay in the same JSON/Markdown payload
+- docs and backlog explicitly keep Shared Safety and provenance/Dagger follow-ups deferred

--- a/docs/review/PR_1492_FIXED_MAPPING.md
+++ b/docs/review/PR_1492_FIXED_MAPPING.md
@@ -22,16 +22,16 @@ Merge-readiness contract:
 `AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
 `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
 
-- [ ] Current-head CI is green for PR branch head
-  Evidence: pending after current head `418ec17c8`.
-- [ ] Required checks complete (no pending jobs)
-  Evidence: pending after current head `418ec17c8`.
-- [ ] All review threads resolved on GitHub after disposition updates
-  Evidence: pending; no review threads at bootstrap.
+- [x] Current-head CI is green for PR branch head
+  Evidence: current head `15ededfbf`; GitHub `CI` run `24774044773` completed `success`.
+- [x] Required checks complete (no pending jobs)
+  Evidence: `gh pr checks 1492` shows current-head required checks complete on `15ededfbf`.
+- [x] All review threads resolved on GitHub after disposition updates
+  Evidence: GraphQL review-thread query returned no review threads on PR `#1492`.
 - [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: `CodeRabbit` is a draft-skip shell and the `Sourcery` comment is a reviewer guide shell with no inline actionable findings on current head.
+  Evidence: `CodeRabbit` is a draft-skip shell, `Sourcery` is a reviewer-guide shell, and `Codecov` is advisory coverage reporting only.
 - [x] Pre-commit green on latest pushed head
-  Evidence: `pre-commit run --all-files` passed locally on the current head before and after `418ec17c8`.
+  Evidence: `pre-commit run --all-files` passed locally on current head `15ededfbf`.
 - [ ] `make verify` green on latest pushed head
   Evidence: not run for this lane; GitHub current-head checks remain the heavy signal.
 

--- a/docs/review/PR_1492_FIXED_MAPPING.md
+++ b/docs/review/PR_1492_FIXED_MAPPING.md
@@ -23,9 +23,9 @@ Disposition: FIXED
 Commit: 8f0e04ff4a47625e33b06e43cc1672718927ab96
 Evidence: `scripts/ci/fetch_docker_image_baseline.py:19`, `scripts/ci/fetch_docker_image_baseline.py:47`, `scripts/ci/fetch_docker_image_baseline.py:153`, `scripts/ci/fetch_docker_image_baseline.py:229`, `scripts/ci/docker_image_telemetry.py:258`, `tests/test_fetch_docker_image_baseline.py:169`, `docs/deploy/DOCKER.md:141`, `docs/roadmap/BACKLOG_LEDGER.md:645`.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123483705 -> 2b9b969b9d885f38393fdcb82e4463dd61ba3aa5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123483705 -> 2b9b969b95dcfb3a3ffce692ac29f37ba2247a51
 Disposition: FIXED
-Commit: 2b9b969b9d885f38393fdcb82e4463dd61ba3aa5
+Commit: 2b9b969b95dcfb3a3ffce692ac29f37ba2247a51
 Evidence: `docs/review/PR_1492_FIXED_MAPPING.md:23`.
 
 ## Merge Readiness

--- a/docs/review/PR_1492_FIXED_MAPPING.md
+++ b/docs/review/PR_1492_FIXED_MAPPING.md
@@ -14,7 +14,19 @@ Record every actionable human/bot disposition here before resolving threads on G
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123468456 -> 8f0e04ff4a47625e33b06e43cc1672718927ab96
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123470365 -> 8f0e04ff4a47625e33b06e43cc1672718927ab96
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123483703 -> 8f0e04ff4a47625e33b06e43cc1672718927ab96
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123483729 -> 8f0e04ff4a47625e33b06e43cc1672718927ab96
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123483739 -> 8f0e04ff4a47625e33b06e43cc1672718927ab96
+Disposition: FIXED
+Commit: 8f0e04ff4a47625e33b06e43cc1672718927ab96
+Evidence: `scripts/ci/fetch_docker_image_baseline.py:19`, `scripts/ci/fetch_docker_image_baseline.py:47`, `scripts/ci/fetch_docker_image_baseline.py:153`, `scripts/ci/fetch_docker_image_baseline.py:229`, `scripts/ci/docker_image_telemetry.py:258`, `tests/test_fetch_docker_image_baseline.py:169`, `docs/deploy/DOCKER.md:141`, `docs/roadmap/BACKLOG_LEDGER.md:645`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123483705 -> 2b9b969b9d885f38393fdcb82e4463dd61ba3aa5
+Disposition: FIXED
+Commit: 2b9b969b9d885f38393fdcb82e4463dd61ba3aa5
+Evidence: `docs/review/PR_1492_FIXED_MAPPING.md:23`.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1492_FIXED_MAPPING.md
+++ b/docs/review/PR_1492_FIXED_MAPPING.md
@@ -1,0 +1,44 @@
+# PR #1492 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+This artifact is created immediately after the PR is opened per repo governance.
+Record every actionable human/bot disposition here before resolving threads on GitHub.
+
+## Fixed in Commit Mapping
+
+No actionable review threads are mapped yet. Add entries here before resolving
+any human or bot thread on GitHub.
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+  Evidence: pending after draft PR open on `66bb095ec`.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: pending after draft PR open on `66bb095ec`.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: pending; no review threads at bootstrap.
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: none yet; draft PR opened and no review comments exist at bootstrap.
+- [x] Pre-commit green on latest pushed head
+  Evidence: `pre-commit run --all-files` passed locally before the `66bb095ec` push.
+- [ ] `make verify` green on latest pushed head
+  Evidence: not run for this lane; GitHub current-head checks remain the heavy signal.
+
+## Deferred / Follow-ups
+
+- hard image-size budget cap / failure threshold
+- `docs/roadmap/BACKLOG_LEDGER.md` line 540 (`P1: Shared Safety audit script after install-profile split`)
+- provenance / attestation recovery
+- Dagger or alternate control-plane work

--- a/docs/review/PR_1492_FIXED_MAPPING.md
+++ b/docs/review/PR_1492_FIXED_MAPPING.md
@@ -22,16 +22,16 @@ Merge-readiness contract:
 `AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
 `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
 
-- [x] Current-head CI is green for PR branch head
-  Evidence: current head `15ededfbf`; GitHub `CI` run `24774044773` completed `success`.
-- [x] Required checks complete (no pending jobs)
-  Evidence: `gh pr checks 1492` shows current-head required checks complete on `15ededfbf`.
-- [x] All review threads resolved on GitHub after disposition updates
-  Evidence: GraphQL review-thread query returned no review threads on PR `#1492`.
-- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: `CodeRabbit` is a draft-skip shell, `Sourcery` is a reviewer-guide shell, and `Codecov` is advisory coverage reporting only.
-- [x] Pre-commit green on latest pushed head
-  Evidence: `pre-commit run --all-files` passed locally on current head `15ededfbf`.
+- [ ] Current-head CI is green for PR branch head
+  Evidence: pending after remediation head and current review-cycle reruns.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: pending after remediation head and current review-cycle reruns.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: pending current remediation for open review threads.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: pending current remediation for open CodeRabbit/Sourcery/Codex findings.
+- [ ] Pre-commit green on latest pushed head
+  Evidence: pending after remediation head is committed.
 - [ ] `make verify` green on latest pushed head
   Evidence: not run for this lane; GitHub current-head checks remain the heavy signal.
 

--- a/docs/review/PR_1492_FIXED_MAPPING.md
+++ b/docs/review/PR_1492_FIXED_MAPPING.md
@@ -30,10 +30,14 @@ Evidence: `docs/review/PR_1492_FIXED_MAPPING.md:23`.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123568932 -> 4bab743e4c3cab9ad57ebcb3ea7f747db6fda24c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123568939 -> 4bab743e4c3cab9ad57ebcb3ea7f747db6fda24c
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123568960 -> 4bab743e4c3cab9ad57ebcb3ea7f747db6fda24c
 Disposition: FIXED
 Commit: 4bab743e4c3cab9ad57ebcb3ea7f747db6fda24c
-Evidence: `docs/roadmap/BACKLOG_LEDGER.md:645`, `scripts/ci/docker_image_telemetry.py:265`, `scripts/ci/fetch_docker_image_baseline.py:281`, `tests/test_docker_image_telemetry.py:109`.
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:645`, `scripts/ci/docker_image_telemetry.py:265`, `tests/test_docker_image_telemetry.py:109`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123568960 -> 9517af233c8b560619b0871182266993bd35311d
+Disposition: FIXED
+Commit: 9517af233c8b560619b0871182266993bd35311d
+Evidence: `scripts/ci/fetch_docker_image_baseline.py:281`, `tests/test_fetch_docker_image_baseline.py:1`.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1492_FIXED_MAPPING.md
+++ b/docs/review/PR_1492_FIXED_MAPPING.md
@@ -28,16 +28,22 @@ Disposition: FIXED
 Commit: 2b9b969b95dcfb3a3ffce692ac29f37ba2247a51
 Evidence: `docs/review/PR_1492_FIXED_MAPPING.md:23`.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123568932 -> 4bab743e4c3cab9ad57ebcb3ea7f747db6fda24c
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123568939 -> 4bab743e4c3cab9ad57ebcb3ea7f747db6fda24c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123568932 -> 4bab743e47fbe4c925c47a9ba659751d48ca06dd
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123568939 -> 4bab743e47fbe4c925c47a9ba659751d48ca06dd
 Disposition: FIXED
-Commit: 4bab743e4c3cab9ad57ebcb3ea7f747db6fda24c
+Commit: 4bab743e47fbe4c925c47a9ba659751d48ca06dd
 Evidence: `docs/roadmap/BACKLOG_LEDGER.md:645`, `scripts/ci/docker_image_telemetry.py:265`, `tests/test_docker_image_telemetry.py:109`.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123568960 -> 9517af233c8b560619b0871182266993bd35311d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123568960 -> 9517af233299d1dc415e2f01a62236331042ff57
 Disposition: FIXED
-Commit: 9517af233c8b560619b0871182266993bd35311d
+Commit: 9517af233299d1dc415e2f01a62236331042ff57
 Evidence: `scripts/ci/fetch_docker_image_baseline.py:281`, `tests/test_fetch_docker_image_baseline.py:1`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123671377 -> 43b7d1e204abbbe40734eba3fbf203445bfea0e4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123671380 -> 43b7d1e204abbbe40734eba3fbf203445bfea0e4
+Disposition: FIXED
+Commit: 43b7d1e204abbbe40734eba3fbf203445bfea0e4
+Evidence: `scripts/ci/docker_image_telemetry.py:249`, `scripts/ci/fetch_docker_image_baseline.py:136`, `tests/test_docker_image_telemetry.py:108`, `tests/test_fetch_docker_image_baseline.py:31`.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1492_FIXED_MAPPING.md
+++ b/docs/review/PR_1492_FIXED_MAPPING.md
@@ -6,16 +6,15 @@ Canonical review-governance artifact and PR-body mirror requirements:
 `AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
 `docs/orchestration/AGENTS.md:79-82`.
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 This artifact is created immediately after the PR is opened per repo governance.
 Record every actionable human/bot disposition here before resolving threads on GitHub.
 
 ## Fixed in Commit Mapping
 
-No actionable review threads are mapped yet. Add entries here before resolving
-any human or bot thread on GitHub.
+- No actionable review comments
 
 ## Merge Readiness
 
@@ -24,15 +23,15 @@ Merge-readiness contract:
 `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
 
 - [ ] Current-head CI is green for PR branch head
-  Evidence: pending after draft PR open on `66bb095ec`.
+  Evidence: pending after current head `418ec17c8`.
 - [ ] Required checks complete (no pending jobs)
-  Evidence: pending after draft PR open on `66bb095ec`.
+  Evidence: pending after current head `418ec17c8`.
 - [ ] All review threads resolved on GitHub after disposition updates
   Evidence: pending; no review threads at bootstrap.
 - [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: none yet; draft PR opened and no review comments exist at bootstrap.
+  Evidence: `CodeRabbit` is a draft-skip shell and the `Sourcery` comment is a reviewer guide shell with no inline actionable findings on current head.
 - [x] Pre-commit green on latest pushed head
-  Evidence: `pre-commit run --all-files` passed locally before the `66bb095ec` push.
+  Evidence: `pre-commit run --all-files` passed locally on the current head before and after `418ec17c8`.
 - [ ] `make verify` green on latest pushed head
   Evidence: not run for this lane; GitHub current-head checks remain the heavy signal.
 

--- a/docs/review/PR_1492_FIXED_MAPPING.md
+++ b/docs/review/PR_1492_FIXED_MAPPING.md
@@ -45,6 +45,26 @@ Disposition: FIXED
 Commit: 43b7d1e204abbbe40734eba3fbf203445bfea0e4
 Evidence: `scripts/ci/docker_image_telemetry.py:249`, `scripts/ci/fetch_docker_image_baseline.py:136`, `tests/test_docker_image_telemetry.py:108`, `tests/test_fetch_docker_image_baseline.py:31`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#pullrequestreview-4154124724 -> 8f0e04ff4a47625e33b06e43cc1672718927ab96
+Disposition: FIXED
+Commit: 8f0e04ff4a47625e33b06e43cc1672718927ab96
+Evidence: `scripts/ci/fetch_docker_image_baseline.py:238`, `scripts/ci/docker_image_telemetry.py:258`, `tests/test_fetch_docker_image_baseline.py:169`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#pullrequestreview-4154138455 -> 1d2d93607b831678352a2215d68797a84b4f5d27
+Disposition: FIXED
+Commit: 1d2d93607b831678352a2215d68797a84b4f5d27
+Evidence: `docs/review/PR_1492_FIXED_MAPPING.md:23`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#pullrequestreview-4154226985 -> 9517af233299d1dc415e2f01a62236331042ff57
+Disposition: FIXED
+Commit: 9517af233299d1dc415e2f01a62236331042ff57
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:645`, `scripts/ci/docker_image_telemetry.py:265`, `scripts/ci/fetch_docker_image_baseline.py:289`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#pullrequestreview-4154348135 -> 43b7d1e204abbbe40734eba3fbf203445bfea0e4
+Disposition: FIXED
+Commit: 43b7d1e204abbbe40734eba3fbf203445bfea0e4
+Evidence: `scripts/ci/docker_image_telemetry.py:249`, `scripts/ci/fetch_docker_image_baseline.py:136`, `tests/test_docker_image_telemetry.py:108`, `tests/test_fetch_docker_image_baseline.py:31`.
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/review/PR_1492_FIXED_MAPPING.md
+++ b/docs/review/PR_1492_FIXED_MAPPING.md
@@ -28,6 +28,13 @@ Disposition: FIXED
 Commit: 2b9b969b95dcfb3a3ffce692ac29f37ba2247a51
 Evidence: `docs/review/PR_1492_FIXED_MAPPING.md:23`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123568932 -> 4bab743e4c3cab9ad57ebcb3ea7f747db6fda24c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123568939 -> 4bab743e4c3cab9ad57ebcb3ea7f747db6fda24c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1492#discussion_r3123568960 -> 4bab743e4c3cab9ad57ebcb3ea7f747db6fda24c
+Disposition: FIXED
+Commit: 4bab743e4c3cab9ad57ebcb3ea7f747db6fda24c
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md:645`, `scripts/ci/docker_image_telemetry.py:265`, `scripts/ci/fetch_docker_image_baseline.py:281`, `tests/test_docker_image_telemetry.py:109`.
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -653,6 +653,15 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/DOCKER_IMAGE_BUDGET_TELEMETRY_TASK_PACKET_2026-04-22.md`
     - `.github/workflows/build.yml`
     - `.github/workflows/docker-image.yml`
+    - `.github/workflows/trivy.yml`
+    - `docs/telemetry/docker_image_baseline.production.json`
+    - `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md`
+  - DoD:
+    - CI emits deterministic image-size evidence for touched Docker lanes
+    - Largest-layer and build-context summaries are visible to PR authors before merge
+    - Baseline source is explicit (`main-artifact` or `repo-seed-fallback`)
+    - The first gate is warning/regression-only, not an absolute size cap
+    - Follow-up provenance or Dagger decisions can cite this baseline explicitly
 
 <a id="ledger-p1-docker-image-hard-budget-gate"></a>
 - [ ] P1: Docker image hard budget gate after telemetry baseline
@@ -671,15 +680,6 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - A canonical hard-fail threshold exists for the production backend image
     - Docker lanes fail deterministically when the threshold regresses beyond policy
     - The gate uses the same canonical telemetry artifact contract introduced by PR `#1492`
-    - `.github/workflows/trivy.yml`
-    - `docs/telemetry/docker_image_baseline.production.json`
-    - `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md`
-  - DoD:
-    - CI emits deterministic image-size evidence for touched Docker lanes
-    - Largest-layer and build-context summaries are visible to PR authors before merge
-    - Baseline source is explicit (`main-artifact` or `repo-seed-fallback`)
-    - The first gate is warning/regression-only, not an absolute size cap
-    - Follow-up provenance or Dagger decisions can cite this baseline explicitly
 
 <a id="ledger-p1-business-wave-runtime-follow-through"></a>
 - [ ] P1: Business wave runtime follow-through after governance/docs foundation

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -612,12 +612,12 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Deterministic tests cover the hook fix and the promoted validation contract
 
 <a id="ledger-p1-docker-runtime-slimming-after-profile-split"></a>
-- [ ] P1: Docker runtime slimming after CI install-profile split
+- [x] P1: Docker runtime slimming after CI install-profile split
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-DOCKER-RUNTIME-SLIMMING
+  - Target PR: PR #1490 (`fix(docker): slim runtime after profile split`)
   - Area: docker / runtime / supply-chain
-  - Status note: Active after `PR #1488` merged on April 21, 2026 and reconciled the split deploy contract. This slice now standardizes production-target Docker builds on a dedicated runtime manifest and keeps image-budget telemetry plus shared Safety audit extraction deferred to later PRs.
+  - Status note: Merged on April 22, 2026 via `PR #1490`. Production-target Docker builds now use `requirements-docker-runtime.txt`; the next main Docker/CI slice is the warning-only image-budget and telemetry baseline, while Shared Safety audit extraction remains deferred.
   - Depends on:
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-ci-install-profile-split-after-disk-unblock`
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-docker-deploy-contract-reconciliation`
@@ -641,21 +641,25 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Docker image budget and telemetry baseline
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-DOCKER-IMAGE-BUDGET
+  - Target PR: PR-TBD-DOCKER-IMAGE-BUDGET-TELEMETRY
   - Area: CI / docker / telemetry
+  - Status note: Active PR-5 slice after `PR #1490` merged on April 22, 2026. This lane establishes one canonical backend-image baseline, prefers the latest successful `main` artifact, falls back to a checked-in seed baseline, and keeps delta reporting warning-only.
   - Depends on:
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-ci-install-profile-split-after-disk-unblock`
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-docker-deploy-contract-reconciliation`
-  - Reason: The project needs deterministic PR-facing evidence for image size regressions, largest layers, and build-context drift before discussing provenance recovery sequencing or any Dagger pilot. Start with warning/regression-only reporting, not an absolute hard stop.
+  - Reason: The project needs deterministic PR-facing evidence for image size regressions, largest layers, build-context drift, and baseline provenance before discussing provenance recovery sequencing or any Dagger pilot. Start with warning/regression-only reporting, not an absolute hard stop.
   - Links:
     - `docs/orchestration/DOCKER_CI_DISCIPLINE_PR_SERIES_PACKET_2026-04-16.md`
+    - `docs/orchestration/DOCKER_IMAGE_BUDGET_TELEMETRY_TASK_PACKET_2026-04-22.md`
     - `.github/workflows/build.yml`
     - `.github/workflows/docker-image.yml`
     - `.github/workflows/trivy.yml`
+    - `docs/telemetry/docker_image_baseline.production.json`
     - `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md`
   - DoD:
     - CI emits deterministic image-size evidence for touched Docker lanes
     - Largest-layer and build-context summaries are visible to PR authors before merge
+    - Baseline source is explicit (`main-artifact` or `repo-seed-fallback`)
     - The first gate is warning/regression-only, not an absolute size cap
     - Follow-up provenance or Dagger decisions can cite this baseline explicitly
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -641,7 +641,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Docker image budget and telemetry baseline
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-DOCKER-IMAGE-BUDGET-TELEMETRY
+  - Target PR: PR #1492
   - Area: CI / docker / telemetry
   - Status note: Active PR-5 slice after `PR #1490` merged on April 22, 2026. This lane establishes one canonical backend-image baseline, prefers the latest successful `main` artifact, falls back to a checked-in seed baseline, and keeps delta reporting warning-only.
   - Depends on:
@@ -653,6 +653,24 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/DOCKER_IMAGE_BUDGET_TELEMETRY_TASK_PACKET_2026-04-22.md`
     - `.github/workflows/build.yml`
     - `.github/workflows/docker-image.yml`
+
+<a id="ledger-p1-docker-image-hard-budget-gate"></a>
+- [ ] P1: Docker image hard budget gate after telemetry baseline
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD-DOCKER-HARD-BUDGET-GATE
+  - Area: CI / docker / telemetry
+  - Depends on:
+    - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-docker-image-budget-telemetry`
+  - Reason: The repo should not enforce a hard image-size failure threshold until the warning-only baseline has stabilized on `main` and the canonical telemetry evidence is trustworthy enough to gate merges deterministically.
+  - Links:
+    - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-docker-image-budget-telemetry`
+    - `.github/workflows/build.yml`
+    - `.github/workflows/docker-image.yml`
+  - DoD:
+    - A canonical hard-fail threshold exists for the production backend image
+    - Docker lanes fail deterministically when the threshold regresses beyond policy
+    - The gate uses the same canonical telemetry artifact contract introduced by PR `#1492`
     - `.github/workflows/trivy.yml`
     - `docs/telemetry/docker_image_baseline.production.json`
     - `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md`

--- a/docs/telemetry/docker_image_baseline.production.json
+++ b/docs/telemetry/docker_image_baseline.production.json
@@ -1,0 +1,18 @@
+{
+  "baseline_reference": {
+    "artifact_id": 6575089628,
+    "artifact_name": "docker-image-telemetry-build",
+    "branch": "main",
+    "repo": "Katsiarynakavaleuskaya/PulsePlate",
+    "seed_note": "Checked-in fallback seeded from the latest successful main Docker Build and Push artifact at PR-5 branch start.",
+    "seeded_at": "2026-04-22T09:46:43Z",
+    "seeded_from_run_attempt": 1,
+    "seeded_from_run_id": 24771474567,
+    "seeded_from_run_number": 6987,
+    "seeded_from_run_url": "https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24771474567",
+    "workflow": "build.yml"
+  },
+  "baseline_source": "repo-seed-fallback",
+  "image_size_bytes": 445565354,
+  "image_size_human": "445.57 MB"
+}

--- a/scripts/ci/docker_image_telemetry.py
+++ b/scripts/ci/docker_image_telemetry.py
@@ -315,7 +315,7 @@ def collect_telemetry(
             f"Baseline JSON is missing or absent at {baseline_path}; telemetry remains advisory-only."
         )
     else:
-        size_delta_bytes = image_size_bytes - baseline_size_bytes
+        size_delta_bytes = image_size_bytes - loaded_baseline.size_bytes
         if baseline_source == "repo-seed-fallback":
             warnings.append(
                 "Using the checked-in repo seed fallback baseline; refresh against the latest "

--- a/scripts/ci/docker_image_telemetry.py
+++ b/scripts/ci/docker_image_telemetry.py
@@ -257,16 +257,21 @@ def _load_baseline(baseline_path: Path | None) -> LoadedBaseline | None:
     baseline_reference = payload.get("baseline_reference")
     if baseline_reference is not None and not isinstance(baseline_reference, dict):
         raise RuntimeError(f"Unsupported baseline payload shape: {baseline_path}")
+    normalized_source = None
+    if baseline_source is not None:
+        stripped_source = baseline_source.strip()
+        if stripped_source:
+            normalized_source = stripped_source
     if isinstance(payload.get("image_size_bytes"), int):
         return LoadedBaseline(
-            source=baseline_source.strip() if isinstance(baseline_source, str) else None,
+            source=normalized_source,
             reference=baseline_reference,
             size_bytes=int(payload["image_size_bytes"]),
         )
     image_payload = payload.get("image")
     if isinstance(image_payload, dict) and isinstance(image_payload.get("size_bytes"), int):
         return LoadedBaseline(
-            source=baseline_source.strip() if isinstance(baseline_source, str) else None,
+            source=normalized_source,
             reference=baseline_reference,
             size_bytes=int(image_payload["size_bytes"]),
         )

--- a/scripts/ci/docker_image_telemetry.py
+++ b/scripts/ci/docker_image_telemetry.py
@@ -56,6 +56,8 @@ class BaselineComparison:
     """Advisory baseline comparison; never fails the lane in this wave."""
 
     baseline_path: str | None
+    baseline_source: str | None
+    baseline_reference: dict[str, object] | None
     baseline_size_bytes: int | None
     size_delta_bytes: int | None
     regression_warning: bool
@@ -232,7 +234,16 @@ def _parse_dockerignore_allowlist(dockerignore_path: Path) -> tuple[str, ...]:
     return tuple(allowlist)
 
 
-def _load_baseline_size_bytes(baseline_path: Path | None) -> int | None:
+@dataclass(frozen=True)
+class LoadedBaseline:
+    """Normalized baseline metadata extracted from a prior telemetry payload."""
+
+    source: str | None
+    reference: dict[str, object] | None
+    size_bytes: int
+
+
+def _load_baseline(baseline_path: Path | None) -> LoadedBaseline | None:
     """Load a prior telemetry baseline if one is supplied."""
 
     if baseline_path is None or not baseline_path.exists():
@@ -240,11 +251,25 @@ def _load_baseline_size_bytes(baseline_path: Path | None) -> int | None:
     payload = json.loads(baseline_path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise RuntimeError(f"Unsupported baseline payload shape: {baseline_path}")
+    baseline_source = payload.get("baseline_source")
+    if baseline_source is not None and not isinstance(baseline_source, str):
+        raise RuntimeError(f"Unsupported baseline payload shape: {baseline_path}")
+    baseline_reference = payload.get("baseline_reference")
+    if baseline_reference is not None and not isinstance(baseline_reference, dict):
+        raise RuntimeError(f"Unsupported baseline payload shape: {baseline_path}")
     if isinstance(payload.get("image_size_bytes"), int):
-        return int(payload["image_size_bytes"])
+        return LoadedBaseline(
+            source=baseline_source.strip() if isinstance(baseline_source, str) else None,
+            reference=baseline_reference,
+            size_bytes=int(payload["image_size_bytes"]),
+        )
     image_payload = payload.get("image")
     if isinstance(image_payload, dict) and isinstance(image_payload.get("size_bytes"), int):
-        return int(image_payload["size_bytes"])
+        return LoadedBaseline(
+            source=baseline_source.strip() if isinstance(baseline_source, str) else None,
+            reference=baseline_reference,
+            size_bytes=int(image_payload["size_bytes"]),
+        )
     raise RuntimeError(f"Unsupported baseline payload shape: {baseline_path}")
 
 
@@ -277,17 +302,25 @@ def collect_telemetry(
     dockerignore_allowlist = _parse_dockerignore_allowlist(dockerignore_path)
 
     warnings: list[str] = []
-    baseline_size_bytes = _load_baseline_size_bytes(baseline_path)
+    loaded_baseline = _load_baseline(baseline_path)
+    baseline_size_bytes = loaded_baseline.size_bytes if loaded_baseline is not None else None
+    baseline_source = loaded_baseline.source if loaded_baseline is not None else None
+    baseline_reference = loaded_baseline.reference if loaded_baseline is not None else None
     size_delta_bytes: int | None = None
     regression_warning = False
     if baseline_path is None:
         warnings.append("No baseline JSON was provided; telemetry remains advisory-only.")
-    elif baseline_size_bytes is None:
+    elif loaded_baseline is None:
         warnings.append(
             f"Baseline JSON is missing or absent at {baseline_path}; telemetry remains advisory-only."
         )
     else:
         size_delta_bytes = image_size_bytes - baseline_size_bytes
+        if baseline_source == "repo-seed-fallback":
+            warnings.append(
+                "Using the checked-in repo seed fallback baseline; refresh against the latest "
+                "successful main artifact when GitHub artifact lookup recovers."
+            )
         if size_delta_bytes > 0:
             regression_warning = True
             warnings.append(
@@ -309,6 +342,8 @@ def collect_telemetry(
         ),
         baseline=BaselineComparison(
             baseline_path=str(baseline_path) if baseline_path is not None else None,
+            baseline_source=baseline_source,
+            baseline_reference=baseline_reference,
             baseline_size_bytes=baseline_size_bytes,
             size_delta_bytes=size_delta_bytes,
             regression_warning=regression_warning,
@@ -333,6 +368,14 @@ def render_markdown(report: ImageTelemetryReport) -> str:
         baseline_human = _bytes_to_human(report.baseline.baseline_size_bytes)
         lines.append(
             f"- Baseline: `{baseline_human}` (`{report.baseline.baseline_size_bytes}` bytes)"
+        )
+    if report.baseline.baseline_source is not None:
+        lines.append(f"- Baseline source: `{report.baseline.baseline_source}`")
+    if report.baseline.baseline_reference:
+        lines.append(
+            "- Baseline reference: `"
+            + _format_baseline_reference(report.baseline.baseline_reference)
+            + "`"
         )
     if report.baseline.size_delta_bytes is not None:
         delta = report.baseline.size_delta_bytes
@@ -364,6 +407,33 @@ def render_markdown(report: ImageTelemetryReport) -> str:
         ]
     )
     return "\n".join(lines)
+
+
+def _format_baseline_reference(reference: dict[str, object]) -> str:
+    """Render compact baseline reference metadata for Markdown summaries."""
+
+    if {"workflow", "run_number", "artifact_name"} <= reference.keys():
+        parts = [
+            f"workflow={reference['workflow']}",
+            f"branch={reference.get('branch', 'unknown')}",
+            f"run={reference['run_number']}",
+        ]
+        if reference.get("run_attempt") is not None:
+            parts.append(f"attempt={reference['run_attempt']}")
+        parts.append(f"artifact={reference['artifact_name']}")
+        if reference.get("artifact_id") is not None:
+            parts.append(f"artifact_id={reference['artifact_id']}")
+        return ", ".join(parts)
+    if {"workflow", "seeded_from_run_number", "artifact_name"} <= reference.keys():
+        parts = [
+            f"workflow={reference['workflow']}",
+            f"seeded_from_run={reference['seeded_from_run_number']}",
+            f"artifact={reference['artifact_name']}",
+        ]
+        if reference.get("seeded_at") is not None:
+            parts.append(f"seeded_at={reference['seeded_at']}")
+        return ", ".join(parts)
+    return json.dumps(reference, sort_keys=True)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/scripts/ci/docker_image_telemetry.py
+++ b/scripts/ci/docker_image_telemetry.py
@@ -262,18 +262,29 @@ def _load_baseline(baseline_path: Path | None) -> LoadedBaseline | None:
         stripped_source = baseline_source.strip()
         if stripped_source:
             normalized_source = stripped_source
-    if isinstance(payload.get("image_size_bytes"), int):
+    image_size_bytes = payload.get("image_size_bytes")
+    if (
+        isinstance(image_size_bytes, int)
+        and not isinstance(image_size_bytes, bool)
+        and image_size_bytes >= 0
+    ):
         return LoadedBaseline(
             source=normalized_source,
             reference=baseline_reference,
-            size_bytes=int(payload["image_size_bytes"]),
+            size_bytes=image_size_bytes,
         )
     image_payload = payload.get("image")
-    if isinstance(image_payload, dict) and isinstance(image_payload.get("size_bytes"), int):
+    nested_size_bytes = image_payload.get("size_bytes") if isinstance(image_payload, dict) else None
+    if (
+        isinstance(image_payload, dict)
+        and isinstance(nested_size_bytes, int)
+        and not isinstance(nested_size_bytes, bool)
+        and nested_size_bytes >= 0
+    ):
         return LoadedBaseline(
             source=normalized_source,
             reference=baseline_reference,
-            size_bytes=int(image_payload["size_bytes"]),
+            size_bytes=nested_size_bytes,
         )
     raise RuntimeError(f"Unsupported baseline payload shape: {baseline_path}")
 

--- a/scripts/ci/docker_image_telemetry.py
+++ b/scripts/ci/docker_image_telemetry.py
@@ -248,7 +248,12 @@ def _load_baseline(baseline_path: Path | None) -> LoadedBaseline | None:
 
     if baseline_path is None or not baseline_path.exists():
         return None
-    payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+    if not baseline_path.is_file():
+        raise RuntimeError(f"Unsupported baseline payload shape: {baseline_path}")
+    try:
+        payload = json.loads(baseline_path.read_text(encoding="utf-8"))
+    except (OSError, PermissionError) as exc:
+        raise RuntimeError(f"Unable to read baseline payload: {baseline_path}") from exc
     if not isinstance(payload, dict):
         raise RuntimeError(f"Unsupported baseline payload shape: {baseline_path}")
     baseline_source = payload.get("baseline_source")

--- a/scripts/ci/fetch_docker_image_baseline.py
+++ b/scripts/ci/fetch_docker_image_baseline.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Resolve a Docker image telemetry baseline for CI jobs.
+
+The helper prefers the latest successful `main` artifact from the canonical
+Docker build workflow and falls back to a checked-in seed baseline when GitHub
+lookup or download is unavailable. Remote lookup remains advisory-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess  # nosec B404: bounded gh CLI calls are required to fetch workflow artifacts for CI telemetry (remove-by: 2026-09-30, ref: PR-docker-image-budget-telemetry)
+import sys
+import tempfile
+import zipfile
+
+DEFAULT_ARTIFACT_NAME = "docker-image-telemetry-build"
+DEFAULT_ARTIFACT_PAYLOAD_NAME = "docker-image-telemetry.json"
+DEFAULT_BRANCH = "main"
+DEFAULT_WORKFLOW = "build.yml"
+MAIN_ARTIFACT_SOURCE = "main-artifact"
+
+
+def _gh_path() -> str:
+    """Return the absolute gh binary path or fail closed."""
+
+    gh_path = shutil.which("gh")
+    if gh_path is None:
+        raise RuntimeError("gh binary is not available on PATH")
+    return gh_path
+
+
+def _auth_env() -> dict[str, str]:
+    """Return a subprocess env that exposes a GitHub token to gh."""
+
+    token = os.getenv("GH_TOKEN", "").strip() or os.getenv("GITHUB_TOKEN", "").strip()
+    if not token:
+        raise RuntimeError("GH_TOKEN or GITHUB_TOKEN is required for Docker baseline fetch.")
+    env = os.environ.copy()
+    env["GH_TOKEN"] = token
+    env.setdefault("GITHUB_TOKEN", token)
+    return env
+
+
+def _run_gh(args: list[str], *, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Run gh with a resolved binary path and fixed argv."""
+
+    return subprocess.run(  # nosec B603: argv uses a resolved gh path with fixed GitHub API/auth subcommands only (remove-by: 2026-09-30, ref: PR-docker-image-budget-telemetry)
+        [_gh_path(), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _ensure_gh_auth(env: dict[str, str]) -> None:
+    """Verify the provided token is usable before API calls."""
+
+    _run_gh(["auth", "status"], env=env)
+
+
+def _github_api_json(endpoint: str, *, env: dict[str, str]) -> object:
+    """Fetch JSON from the GitHub REST API through gh."""
+
+    completed = _run_gh(["api", endpoint], env=env)
+    return json.loads(completed.stdout)
+
+
+def _find_run_and_artifact(
+    *,
+    repo: str,
+    workflow: str,
+    branch: str,
+    artifact_name: str,
+    env: dict[str, str],
+    per_page: int,
+) -> tuple[dict[str, object], dict[str, object]]:
+    """Return the first successful workflow run that published the target artifact."""
+
+    runs_payload = _github_api_json(
+        (
+            f"repos/{repo}/actions/workflows/{workflow}/runs"
+            f"?branch={branch}&status=success&event=push&per_page={per_page}"
+        ),
+        env=env,
+    )
+    if not isinstance(runs_payload, dict):
+        raise RuntimeError("GitHub workflow-runs response is not an object.")
+    workflow_runs = runs_payload.get("workflow_runs")
+    if not isinstance(workflow_runs, list):
+        raise RuntimeError("GitHub workflow-runs response is missing workflow_runs.")
+
+    for run in workflow_runs:
+        if not isinstance(run, dict):
+            continue
+        run_id = run.get("id")
+        if not isinstance(run_id, int):
+            continue
+        artifacts_payload = _github_api_json(
+            f"repos/{repo}/actions/runs/{run_id}/artifacts",
+            env=env,
+        )
+        if not isinstance(artifacts_payload, dict):
+            continue
+        artifacts = artifacts_payload.get("artifacts")
+        if not isinstance(artifacts, list):
+            continue
+        for artifact in artifacts:
+            if not isinstance(artifact, dict):
+                continue
+            if artifact.get("name") == artifact_name:
+                return run, artifact
+
+    raise RuntimeError(
+        f"No successful {workflow} run on {branch} published artifact {artifact_name}."
+    )
+
+
+def _extract_image_size_bytes(payload: object) -> int:
+    """Extract a canonical image_size_bytes value from telemetry payloads."""
+
+    if not isinstance(payload, dict):
+        raise RuntimeError("Docker telemetry payload must be a JSON object.")
+    if isinstance(payload.get("image_size_bytes"), int):
+        return int(payload["image_size_bytes"])
+    image_payload = payload.get("image")
+    if isinstance(image_payload, dict) and isinstance(image_payload.get("size_bytes"), int):
+        return int(image_payload["size_bytes"])
+    raise RuntimeError("Docker telemetry payload is missing image_size_bytes.")
+
+
+def _extract_artifact_payload(archive_path: Path) -> dict[str, object]:
+    """Read docker-image-telemetry.json from an artifact archive."""
+
+    with zipfile.ZipFile(archive_path) as archive:
+        members = [
+            name for name in archive.namelist() if Path(name).name == DEFAULT_ARTIFACT_PAYLOAD_NAME
+        ]
+        if len(members) != 1:
+            raise RuntimeError(
+                f"Expected exactly one {DEFAULT_ARTIFACT_PAYLOAD_NAME} in artifact archive; "
+                f"found {len(members)}."
+            )
+        payload = json.loads(archive.read(members[0]).decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("Extracted Docker telemetry payload is not an object.")
+    return payload
+
+
+def _download_artifact_payload(
+    *,
+    repo: str,
+    artifact_id: int,
+    env: dict[str, str],
+) -> dict[str, object]:
+    """Download and parse the telemetry artifact payload."""
+
+    with tempfile.TemporaryDirectory(prefix="docker-image-baseline-") as temp_dir:
+        archive_path = Path(temp_dir) / "artifact.zip"
+        completed = subprocess.run(  # nosec B603: argv uses resolved gh path with fixed artifact-download subcommand only (remove-by: 2026-09-30, ref: PR-docker-image-budget-telemetry)
+            [
+                _gh_path(),
+                "api",
+                f"repos/{repo}/actions/artifacts/{artifact_id}/zip",
+            ],
+            check=True,
+            capture_output=True,
+            env=env,
+        )
+        archive_path.write_bytes(completed.stdout)
+        return _extract_artifact_payload(archive_path)
+
+
+def _normalize_main_artifact_baseline(
+    *,
+    repo: str,
+    workflow: str,
+    branch: str,
+    run: dict[str, object],
+    artifact: dict[str, object],
+    raw_payload: dict[str, object],
+) -> dict[str, object]:
+    """Normalize the remote artifact into the repo baseline schema."""
+
+    image_size_bytes = _extract_image_size_bytes(raw_payload)
+    image_size_human = raw_payload.get("image_size_human")
+    normalized: dict[str, object] = {
+        "baseline_source": MAIN_ARTIFACT_SOURCE,
+        "baseline_reference": {
+            "artifact_id": artifact["id"],
+            "artifact_name": artifact["name"],
+            "branch": branch,
+            "repo": repo,
+            "run_attempt": run.get("run_attempt"),
+            "run_id": run["id"],
+            "run_number": run.get("run_number"),
+            "run_url": run.get("html_url"),
+            "workflow": workflow,
+        },
+        "image_size_bytes": image_size_bytes,
+    }
+    if isinstance(image_size_human, str) and image_size_human.strip():
+        normalized["image_size_human"] = image_size_human.strip()
+    return normalized
+
+
+def fetch_main_artifact_baseline(
+    *,
+    repo: str,
+    workflow: str,
+    branch: str,
+    artifact_name: str,
+    per_page: int,
+) -> dict[str, object]:
+    """Fetch and normalize the latest successful main-artifact baseline."""
+
+    env = _auth_env()
+    _ensure_gh_auth(env)
+    run, artifact = _find_run_and_artifact(
+        repo=repo,
+        workflow=workflow,
+        branch=branch,
+        artifact_name=artifact_name,
+        env=env,
+        per_page=per_page,
+    )
+    artifact_id = artifact.get("id")
+    if not isinstance(artifact_id, int):
+        raise RuntimeError("Artifact payload is missing an integer id.")
+    raw_payload = _download_artifact_payload(repo=repo, artifact_id=artifact_id, env=env)
+    return _normalize_main_artifact_baseline(
+        repo=repo,
+        workflow=workflow,
+        branch=branch,
+        run=run,
+        artifact=artifact,
+        raw_payload=raw_payload,
+    )
+
+
+def _write_payload(output_path: Path, payload: dict[str, object]) -> None:
+    """Write a normalized JSON payload to disk."""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/repo GitHub identifier")
+    parser.add_argument("--output", required=True, help="Resolved baseline JSON output path")
+    parser.add_argument(
+        "--fallback-json",
+        required=True,
+        help="Checked-in repo fallback baseline JSON path",
+    )
+    parser.add_argument(
+        "--workflow",
+        default=DEFAULT_WORKFLOW,
+        help="Workflow file used for the canonical main baseline",
+    )
+    parser.add_argument(
+        "--branch",
+        default=DEFAULT_BRANCH,
+        help="Branch used for the canonical main baseline",
+    )
+    parser.add_argument(
+        "--artifact-name",
+        default=DEFAULT_ARTIFACT_NAME,
+        help="Artifact name expected from the canonical workflow run",
+    )
+    parser.add_argument(
+        "--per-page",
+        type=int,
+        default=20,
+        help="Number of successful runs to search before falling back",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    output_path = Path(args.output)
+    fallback_path = Path(args.fallback_json)
+
+    try:
+        payload = fetch_main_artifact_baseline(
+            repo=args.repo,
+            workflow=args.workflow,
+            branch=args.branch,
+            artifact_name=args.artifact_name,
+            per_page=args.per_page,
+        )
+    except (
+        RuntimeError,
+        subprocess.CalledProcessError,
+        json.JSONDecodeError,
+        zipfile.BadZipFile,
+    ) as exc:
+        if not fallback_path.exists():
+            print(
+                "docker baseline fetch failed and fallback baseline is missing: "
+                f"{fallback_path} ({exc})",
+                file=sys.stderr,
+            )
+            return 1
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(fallback_path, output_path)
+        print(
+            "Advisory: using repo-seed-fallback baseline because latest successful "
+            f"main artifact fetch failed: {exc}",
+            file=sys.stderr,
+        )
+        return 0
+
+    _write_payload(output_path, payload)
+    print(
+        "Resolved Docker image baseline from latest successful main artifact: " f"{output_path}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/fetch_docker_image_baseline.py
+++ b/scripts/ci/fetch_docker_image_baseline.py
@@ -279,10 +279,6 @@ def fetch_main_artifact_baseline(
             f"{workflow} runs on {branch}: {last_error}"
         ) from last_error
 
-    raise RuntimeError(
-        f"No successful {workflow} run on {branch} published artifact {artifact_name}."
-    )
-
 
 def _write_payload(output_path: Path, payload: dict[str, object]) -> None:
     """Write a normalized JSON payload to disk."""

--- a/scripts/ci/fetch_docker_image_baseline.py
+++ b/scripts/ci/fetch_docker_image_baseline.py
@@ -278,6 +278,7 @@ def fetch_main_artifact_baseline(
             "No valid Docker telemetry payload was found in the latest successful "
             f"{workflow} runs on {branch}: {last_error}"
         ) from last_error
+    raise AssertionError("Unreachable: candidate loop invariant violated.")
 
 
 def _write_payload(output_path: Path, payload: dict[str, object]) -> None:

--- a/scripts/ci/fetch_docker_image_baseline.py
+++ b/scripts/ci/fetch_docker_image_baseline.py
@@ -22,6 +22,7 @@ DEFAULT_ARTIFACT_NAME = "docker-image-telemetry-build"
 DEFAULT_ARTIFACT_PAYLOAD_NAME = "docker-image-telemetry.json"
 DEFAULT_BRANCH = "main"
 DEFAULT_WORKFLOW = "build.yml"
+GH_TIMEOUT_SECONDS = 30
 MAIN_ARTIFACT_SOURCE = "main-artifact"
 
 
@@ -49,13 +50,19 @@ def _auth_env() -> dict[str, str]:
 def _run_gh(args: list[str], *, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
     """Run gh with a resolved binary path and fixed argv."""
 
-    return subprocess.run(  # nosec B603: argv uses a resolved gh path with fixed GitHub API/auth subcommands only (remove-by: 2026-09-30, ref: PR-docker-image-budget-telemetry)
-        [_gh_path(), *args],
-        check=True,
-        capture_output=True,
-        text=True,
-        env=env,
-    )
+    try:
+        return subprocess.run(  # nosec B603: argv uses a resolved gh path with fixed GitHub API/auth subcommands only (remove-by: 2026-09-30, ref: PR-docker-image-budget-telemetry)
+            [_gh_path(), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"gh command timed out after {GH_TIMEOUT_SECONDS}s: {' '.join(args)}"
+        ) from exc
 
 
 def _ensure_gh_auth(env: dict[str, str]) -> None:
@@ -161,16 +168,23 @@ def _download_artifact_payload(
 
     with tempfile.TemporaryDirectory(prefix="docker-image-baseline-") as temp_dir:
         archive_path = Path(temp_dir) / "artifact.zip"
-        completed = subprocess.run(  # nosec B603: argv uses resolved gh path with fixed artifact-download subcommand only (remove-by: 2026-09-30, ref: PR-docker-image-budget-telemetry)
-            [
-                _gh_path(),
-                "api",
-                f"repos/{repo}/actions/artifacts/{artifact_id}/zip",
-            ],
-            check=True,
-            capture_output=True,
-            env=env,
-        )
+        try:
+            completed = subprocess.run(  # nosec B603: argv uses resolved gh path with fixed artifact-download subcommand only (remove-by: 2026-09-30, ref: PR-docker-image-budget-telemetry)
+                [
+                    _gh_path(),
+                    "api",
+                    f"repos/{repo}/actions/artifacts/{artifact_id}/zip",
+                ],
+                check=True,
+                capture_output=True,
+                env=env,
+                timeout=GH_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                "gh artifact download timed out after "
+                f"{GH_TIMEOUT_SECONDS}s for artifact {artifact_id}"
+            ) from exc
         archive_path.write_bytes(completed.stdout)
         return _extract_artifact_payload(archive_path)
 
@@ -249,8 +263,15 @@ def fetch_main_artifact_baseline(
                 artifact=artifact,
                 raw_payload=raw_payload,
             )
-        except RuntimeError as exc:
-            last_error = exc
+        except (
+            RuntimeError,
+            subprocess.CalledProcessError,
+            json.JSONDecodeError,
+            zipfile.BadZipFile,
+        ) as exc:
+            last_error = RuntimeError(
+                f"Artifact {artifact_id} from run {run.get('id')} is unusable: {exc}"
+            )
 
     if last_error is not None:
         raise RuntimeError(

--- a/scripts/ci/fetch_docker_image_baseline.py
+++ b/scripts/ci/fetch_docker_image_baseline.py
@@ -71,7 +71,7 @@ def _github_api_json(endpoint: str, *, env: dict[str, str]) -> object:
     return json.loads(completed.stdout)
 
 
-def _find_run_and_artifact(
+def _iter_run_artifact_candidates(
     *,
     repo: str,
     workflow: str,
@@ -79,8 +79,8 @@ def _find_run_and_artifact(
     artifact_name: str,
     env: dict[str, str],
     per_page: int,
-) -> tuple[dict[str, object], dict[str, object]]:
-    """Return the first successful workflow run that published the target artifact."""
+) -> list[tuple[dict[str, object], dict[str, object]]]:
+    """Return successful workflow runs that published the target artifact."""
 
     runs_payload = _github_api_json(
         (
@@ -95,6 +95,7 @@ def _find_run_and_artifact(
     if not isinstance(workflow_runs, list):
         raise RuntimeError("GitHub workflow-runs response is missing workflow_runs.")
 
+    candidates: list[tuple[dict[str, object], dict[str, object]]] = []
     for run in workflow_runs:
         if not isinstance(run, dict):
             continue
@@ -114,11 +115,9 @@ def _find_run_and_artifact(
             if not isinstance(artifact, dict):
                 continue
             if artifact.get("name") == artifact_name:
-                return run, artifact
+                candidates.append((run, artifact))
 
-    raise RuntimeError(
-        f"No successful {workflow} run on {branch} published artifact {artifact_name}."
-    )
+    return candidates
 
 
 def _extract_image_size_bytes(payload: object) -> int:
@@ -221,7 +220,7 @@ def fetch_main_artifact_baseline(
 
     env = _auth_env()
     _ensure_gh_auth(env)
-    run, artifact = _find_run_and_artifact(
+    candidates = _iter_run_artifact_candidates(
         repo=repo,
         workflow=workflow,
         branch=branch,
@@ -229,17 +228,38 @@ def fetch_main_artifact_baseline(
         env=env,
         per_page=per_page,
     )
-    artifact_id = artifact.get("id")
-    if not isinstance(artifact_id, int):
-        raise RuntimeError("Artifact payload is missing an integer id.")
-    raw_payload = _download_artifact_payload(repo=repo, artifact_id=artifact_id, env=env)
-    return _normalize_main_artifact_baseline(
-        repo=repo,
-        workflow=workflow,
-        branch=branch,
-        run=run,
-        artifact=artifact,
-        raw_payload=raw_payload,
+    if not candidates:
+        raise RuntimeError(
+            f"No successful {workflow} run on {branch} published artifact {artifact_name}."
+        )
+
+    last_error: RuntimeError | None = None
+    for run, artifact in candidates:
+        artifact_id = artifact.get("id")
+        if not isinstance(artifact_id, int):
+            last_error = RuntimeError("Artifact payload is missing an integer id.")
+            continue
+        try:
+            raw_payload = _download_artifact_payload(repo=repo, artifact_id=artifact_id, env=env)
+            return _normalize_main_artifact_baseline(
+                repo=repo,
+                workflow=workflow,
+                branch=branch,
+                run=run,
+                artifact=artifact,
+                raw_payload=raw_payload,
+            )
+        except RuntimeError as exc:
+            last_error = exc
+
+    if last_error is not None:
+        raise RuntimeError(
+            "No valid Docker telemetry payload was found in the latest successful "
+            f"{workflow} runs on {branch}: {last_error}"
+        ) from last_error
+
+    raise RuntimeError(
+        f"No successful {workflow} run on {branch} published artifact {artifact_name}."
     )
 
 

--- a/scripts/ci/fetch_docker_image_baseline.py
+++ b/scripts/ci/fetch_docker_image_baseline.py
@@ -132,11 +132,22 @@ def _extract_image_size_bytes(payload: object) -> int:
 
     if not isinstance(payload, dict):
         raise RuntimeError("Docker telemetry payload must be a JSON object.")
-    if isinstance(payload.get("image_size_bytes"), int):
-        return int(payload["image_size_bytes"])
+    image_size_bytes = payload.get("image_size_bytes")
+    if (
+        isinstance(image_size_bytes, int)
+        and not isinstance(image_size_bytes, bool)
+        and image_size_bytes >= 0
+    ):
+        return image_size_bytes
     image_payload = payload.get("image")
-    if isinstance(image_payload, dict) and isinstance(image_payload.get("size_bytes"), int):
-        return int(image_payload["size_bytes"])
+    nested_size_bytes = image_payload.get("size_bytes") if isinstance(image_payload, dict) else None
+    if (
+        isinstance(image_payload, dict)
+        and isinstance(nested_size_bytes, int)
+        and not isinstance(nested_size_bytes, bool)
+        and nested_size_bytes >= 0
+    ):
+        return nested_size_bytes
     raise RuntimeError("Docker telemetry payload is missing image_size_bytes.")
 
 

--- a/tests/test_docker_image_telemetry.py
+++ b/tests/test_docker_image_telemetry.py
@@ -105,6 +105,25 @@ def test_load_baseline_size_bytes_rejects_non_object_payload(tmp_path: Path) -> 
         docker_image_telemetry._load_baseline(baseline_path)
 
 
+@pytest.mark.parametrize(
+    ("payload",),
+    (
+        ({"image_size_bytes": True},),
+        ({"image_size_bytes": -1},),
+        ({"image": {"size_bytes": False}},),
+        ({"image": {"size_bytes": -5}},),
+    ),
+)
+def test_load_baseline_rejects_bool_and_negative_size_values(
+    tmp_path: Path, payload: dict[str, object]
+) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="Unsupported baseline payload shape"):
+        docker_image_telemetry._load_baseline(baseline_path)
+
+
 @pytest.mark.parametrize("raw_value", ("0", "-1"))
 def test_positive_int_rejects_non_positive_values(raw_value: str) -> None:
     with pytest.raises(argparse.ArgumentTypeError, match="greater than 0"):

--- a/tests/test_docker_image_telemetry.py
+++ b/tests/test_docker_image_telemetry.py
@@ -105,6 +105,14 @@ def test_load_baseline_size_bytes_rejects_non_object_payload(tmp_path: Path) -> 
         docker_image_telemetry._load_baseline(baseline_path)
 
 
+def test_load_baseline_rejects_directory_path(tmp_path: Path) -> None:
+    baseline_path = tmp_path / "baseline-dir"
+    baseline_path.mkdir()
+
+    with pytest.raises(RuntimeError, match="Unsupported baseline payload shape"):
+        docker_image_telemetry._load_baseline(baseline_path)
+
+
 @pytest.mark.parametrize(
     ("payload",),
     (

--- a/tests/test_docker_image_telemetry.py
+++ b/tests/test_docker_image_telemetry.py
@@ -102,7 +102,7 @@ def test_load_baseline_size_bytes_rejects_non_object_payload(tmp_path: Path) -> 
     baseline_path.write_text(json.dumps(["unexpected", "payload"]), encoding="utf-8")
 
     with pytest.raises(RuntimeError, match="Unsupported baseline payload shape"):
-        docker_image_telemetry._load_baseline_size_bytes(baseline_path)
+        docker_image_telemetry._load_baseline(baseline_path)
 
 
 @pytest.mark.parametrize("raw_value", ("0", "-1"))
@@ -180,8 +180,52 @@ def test_collect_telemetry_without_baseline_is_warning_only(
     )
     assert "!scripts/ci/emergency_python_wheels.json" in report.build_context.dockerignore_allowlist
     assert report.baseline.baseline_size_bytes is None
+    assert report.baseline.baseline_source is None
     assert report.baseline.regression_warning is False
     assert "telemetry remains advisory-only" in report.warnings[0]
+
+
+def test_collect_telemetry_reports_repo_seed_fallback_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dockerfile, dockerignore = _write_context_files(tmp_path)
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "baseline_source": "repo-seed-fallback",
+                "baseline_reference": {
+                    "workflow": "build.yml",
+                    "seeded_from_run_number": 6987,
+                    "artifact_name": "docker-image-telemetry-build",
+                    "seeded_at": "2026-04-22T09:46:43Z",
+                },
+                "image_size_bytes": 80_000_000,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(docker_image_telemetry, "_read_image_size_bytes", lambda _: 75_000_000)
+    monkeypatch.setattr(docker_image_telemetry, "_read_history_rows", lambda _: [])
+
+    report = docker_image_telemetry.collect_telemetry(
+        image_ref="pulseplate:test",
+        dockerfile_path=dockerfile,
+        dockerignore_path=dockerignore,
+        top_layers=5,
+        baseline_path=baseline_path,
+    )
+
+    assert report.baseline.baseline_source == "repo-seed-fallback"
+    assert report.baseline.baseline_reference == {
+        "workflow": "build.yml",
+        "seeded_from_run_number": 6987,
+        "artifact_name": "docker-image-telemetry-build",
+        "seeded_at": "2026-04-22T09:46:43Z",
+    }
+    assert report.baseline.regression_warning is False
+    assert "repo seed fallback baseline" in report.warnings[0]
 
 
 def test_main_writes_warning_only_growth_report(
@@ -189,7 +233,23 @@ def test_main_writes_warning_only_growth_report(
 ) -> None:
     dockerfile, dockerignore = _write_context_files(tmp_path)
     baseline_path = tmp_path / "baseline.json"
-    baseline_path.write_text(json.dumps({"image_size_bytes": 80_000_000}), encoding="utf-8")
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "baseline_source": "main-artifact",
+                "baseline_reference": {
+                    "workflow": "build.yml",
+                    "branch": "main",
+                    "run_number": 6987,
+                    "run_attempt": 1,
+                    "artifact_name": "docker-image-telemetry-build",
+                    "artifact_id": 6575089628,
+                },
+                "image_size_bytes": 80_000_000,
+            }
+        ),
+        encoding="utf-8",
+    )
 
     monkeypatch.setattr(docker_image_telemetry, "REPO_ROOT", tmp_path)
     monkeypatch.setattr(docker_image_telemetry, "_read_image_size_bytes", lambda _: 95_000_000)
@@ -230,10 +290,13 @@ def test_main_writes_warning_only_growth_report(
     assert exit_code == 0
     assert payload["advisory_only"] is True
     assert payload["image_size_bytes"] == 95_000_000
+    assert payload["baseline"]["baseline_source"] == "main-artifact"
     assert payload["baseline"]["baseline_size_bytes"] == 80_000_000
     assert payload["baseline"]["size_delta_bytes"] == 15_000_000
     assert payload["baseline"]["regression_warning"] is True
     assert "warning-only mode keeps the lane non-blocking" in payload["warnings"][0]
     assert "Docker Image Telemetry" in markdown
+    assert "Baseline source" in markdown
+    assert "Baseline reference" in markdown
     assert "Delta vs baseline" in markdown
     assert "Build Context Evidence" in markdown

--- a/tests/test_fetch_docker_image_baseline.py
+++ b/tests/test_fetch_docker_image_baseline.py
@@ -195,3 +195,78 @@ def test_run_gh_uses_resolved_absolute_binary(monkeypatch: pytest.MonkeyPatch) -
 
     assert captured["args"] == (["/usr/bin/gh", "api", "repos/owner/repo"],)
     assert captured["kwargs"]["env"] == {"GH_TOKEN": "token"}
+    assert captured["kwargs"]["timeout"] == fetch_docker_image_baseline.GH_TIMEOUT_SECONDS
+
+
+def test_run_gh_wraps_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fetch_docker_image_baseline.shutil, "which", lambda _: "/usr/bin/gh")
+
+    def _raise_timeout(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=30)
+
+    monkeypatch.setattr(fetch_docker_image_baseline.subprocess, "run", _raise_timeout)
+
+    with pytest.raises(RuntimeError, match="gh command timed out"):
+        fetch_docker_image_baseline._run_gh(["api", "repos/owner/repo"], env={"GH_TOKEN": "t"})
+
+
+def test_fetch_main_artifact_baseline_skips_called_process_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fetch_docker_image_baseline, "_auth_env", lambda: {"GH_TOKEN": "token"})
+    monkeypatch.setattr(fetch_docker_image_baseline, "_ensure_gh_auth", lambda env: None)
+    monkeypatch.setattr(
+        fetch_docker_image_baseline,
+        "_iter_run_artifact_candidates",
+        lambda **_kwargs: [
+            (
+                {
+                    "id": 31,
+                    "run_attempt": 1,
+                    "run_number": 601,
+                    "html_url": "https://github.com/example/repo/actions/runs/31",
+                },
+                {
+                    "id": 201,
+                    "name": "docker-image-telemetry-build",
+                },
+            ),
+            (
+                {
+                    "id": 30,
+                    "run_attempt": 1,
+                    "run_number": 600,
+                    "html_url": "https://github.com/example/repo/actions/runs/30",
+                },
+                {
+                    "id": 200,
+                    "name": "docker-image-telemetry-build",
+                },
+            ),
+        ],
+    )
+
+    def _fake_download_artifact_payload(**kwargs: object) -> dict[str, object]:
+        artifact_id = kwargs["artifact_id"]
+        if artifact_id == 201:
+            raise subprocess.CalledProcessError(returncode=1, cmd=["gh", "api"])
+        if artifact_id == 200:
+            return {"image_size_bytes": 777777, "image_size_human": "777.78 KB"}
+        raise AssertionError(f"unexpected artifact_id={artifact_id}")
+
+    monkeypatch.setattr(
+        fetch_docker_image_baseline,
+        "_download_artifact_payload",
+        _fake_download_artifact_payload,
+    )
+
+    payload = fetch_docker_image_baseline.fetch_main_artifact_baseline(
+        repo="owner/repo",
+        workflow="build.yml",
+        branch="main",
+        artifact_name="docker-image-telemetry-build",
+        per_page=10,
+    )
+
+    assert payload["image_size_bytes"] == 777777
+    assert payload["baseline_reference"]["artifact_id"] == 200

--- a/tests/test_fetch_docker_image_baseline.py
+++ b/tests/test_fetch_docker_image_baseline.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import zipfile
+
+import pytest
+
+from scripts.ci import fetch_docker_image_baseline
+
+
+def test_gh_path_uses_absolute_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fetch_docker_image_baseline.shutil, "which", lambda _: "/usr/bin/gh")
+
+    assert fetch_docker_image_baseline._gh_path() == "/usr/bin/gh"
+
+
+def test_auth_env_accepts_github_token_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token")
+
+    env = fetch_docker_image_baseline._auth_env()
+
+    assert env["GH_TOKEN"] == "github-token"
+    assert env["GITHUB_TOKEN"] == "github-token"
+
+
+def test_extract_artifact_payload_requires_single_telemetry_json(tmp_path: Path) -> None:
+    archive_path = tmp_path / "artifact.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("first/docker-image-telemetry.json", "{}")
+        archive.writestr("second/docker-image-telemetry.json", "{}")
+
+    with pytest.raises(RuntimeError, match="Expected exactly one"):
+        fetch_docker_image_baseline._extract_artifact_payload(archive_path)
+
+
+def test_fetch_main_artifact_baseline_normalizes_remote_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fetch_docker_image_baseline, "_auth_env", lambda: {"GH_TOKEN": "token"})
+    monkeypatch.setattr(fetch_docker_image_baseline, "_ensure_gh_auth", lambda env: None)
+    monkeypatch.setattr(
+        fetch_docker_image_baseline,
+        "_find_run_and_artifact",
+        lambda **_kwargs: (
+            {
+                "id": 11,
+                "run_attempt": 2,
+                "run_number": 345,
+                "html_url": "https://github.com/example/repo/actions/runs/11",
+            },
+            {
+                "id": 99,
+                "name": "docker-image-telemetry-build",
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        fetch_docker_image_baseline,
+        "_download_artifact_payload",
+        lambda **_kwargs: {
+            "image_size_bytes": 123456,
+            "image_size_human": "123.46 KB",
+        },
+    )
+
+    payload = fetch_docker_image_baseline.fetch_main_artifact_baseline(
+        repo="owner/repo",
+        workflow="build.yml",
+        branch="main",
+        artifact_name="docker-image-telemetry-build",
+        per_page=10,
+    )
+
+    assert payload["baseline_source"] == "main-artifact"
+    assert payload["image_size_bytes"] == 123456
+    assert payload["baseline_reference"]["artifact_id"] == 99
+    assert payload["baseline_reference"]["run_number"] == 345
+
+
+def test_main_falls_back_to_repo_seed_when_remote_lookup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fallback_path = tmp_path / "fallback.json"
+    output_path = tmp_path / "resolved.json"
+    fallback_payload = {
+        "baseline_source": "repo-seed-fallback",
+        "image_size_bytes": 222,
+    }
+    fallback_path.write_text(json.dumps(fallback_payload), encoding="utf-8")
+    monkeypatch.setattr(
+        fetch_docker_image_baseline,
+        "fetch_main_artifact_baseline",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("gh auth failed")),
+    )
+
+    exit_code = fetch_docker_image_baseline.main(
+        [
+            "--repo",
+            "owner/repo",
+            "--fallback-json",
+            str(fallback_path),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(output_path.read_text(encoding="utf-8")) == fallback_payload
+    assert "using repo-seed-fallback baseline" in capsys.readouterr().err
+
+
+def test_run_gh_uses_resolved_absolute_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(args=["gh"], returncode=0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(fetch_docker_image_baseline.shutil, "which", lambda _: "/usr/bin/gh")
+    monkeypatch.setattr(fetch_docker_image_baseline.subprocess, "run", _fake_run)
+
+    fetch_docker_image_baseline._run_gh(["api", "repos/owner/repo"], env={"GH_TOKEN": "token"})
+
+    assert captured["args"] == (["/usr/bin/gh", "api", "repos/owner/repo"],)
+    assert captured["kwargs"]["env"] == {"GH_TOKEN": "token"}

--- a/tests/test_fetch_docker_image_baseline.py
+++ b/tests/test_fetch_docker_image_baseline.py
@@ -36,6 +36,22 @@ def test_extract_artifact_payload_requires_single_telemetry_json(tmp_path: Path)
         fetch_docker_image_baseline._extract_artifact_payload(archive_path)
 
 
+@pytest.mark.parametrize(
+    ("payload",),
+    (
+        ({"image_size_bytes": True},),
+        ({"image_size_bytes": -1},),
+        ({"image": {"size_bytes": False}},),
+        ({"image": {"size_bytes": -5}},),
+    ),
+)
+def test_extract_image_size_bytes_rejects_bool_and_negative_values(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(RuntimeError, match="missing image_size_bytes"):
+        fetch_docker_image_baseline._extract_image_size_bytes(payload)
+
+
 def test_fetch_main_artifact_baseline_normalizes_remote_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_fetch_docker_image_baseline.py
+++ b/tests/test_fetch_docker_image_baseline.py
@@ -43,19 +43,21 @@ def test_fetch_main_artifact_baseline_normalizes_remote_payload(
     monkeypatch.setattr(fetch_docker_image_baseline, "_ensure_gh_auth", lambda env: None)
     monkeypatch.setattr(
         fetch_docker_image_baseline,
-        "_find_run_and_artifact",
-        lambda **_kwargs: (
-            {
-                "id": 11,
-                "run_attempt": 2,
-                "run_number": 345,
-                "html_url": "https://github.com/example/repo/actions/runs/11",
-            },
-            {
-                "id": 99,
-                "name": "docker-image-telemetry-build",
-            },
-        ),
+        "_iter_run_artifact_candidates",
+        lambda **_kwargs: [
+            (
+                {
+                    "id": 11,
+                    "run_attempt": 2,
+                    "run_number": 345,
+                    "html_url": "https://github.com/example/repo/actions/runs/11",
+                },
+                {
+                    "id": 99,
+                    "name": "docker-image-telemetry-build",
+                },
+            )
+        ],
     )
     monkeypatch.setattr(
         fetch_docker_image_baseline,
@@ -78,6 +80,70 @@ def test_fetch_main_artifact_baseline_normalizes_remote_payload(
     assert payload["image_size_bytes"] == 123456
     assert payload["baseline_reference"]["artifact_id"] == 99
     assert payload["baseline_reference"]["run_number"] == 345
+
+
+def test_fetch_main_artifact_baseline_skips_invalid_latest_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fetch_docker_image_baseline, "_auth_env", lambda: {"GH_TOKEN": "token"})
+    monkeypatch.setattr(fetch_docker_image_baseline, "_ensure_gh_auth", lambda env: None)
+    monkeypatch.setattr(
+        fetch_docker_image_baseline,
+        "_iter_run_artifact_candidates",
+        lambda **_kwargs: [
+            (
+                {
+                    "id": 21,
+                    "run_attempt": 1,
+                    "run_number": 500,
+                    "html_url": "https://github.com/example/repo/actions/runs/21",
+                },
+                {
+                    "id": 101,
+                    "name": "docker-image-telemetry-build",
+                },
+            ),
+            (
+                {
+                    "id": 20,
+                    "run_attempt": 1,
+                    "run_number": 499,
+                    "html_url": "https://github.com/example/repo/actions/runs/20",
+                },
+                {
+                    "id": 100,
+                    "name": "docker-image-telemetry-build",
+                },
+            ),
+        ],
+    )
+
+    def _fake_download_artifact_payload(**kwargs: object) -> dict[str, object]:
+        artifact_id = kwargs["artifact_id"]
+        if artifact_id == 101:
+            return {"advisory_only": True, "warning": "telemetry collection failed"}
+        if artifact_id == 100:
+            return {"image_size_bytes": 654321, "image_size_human": "654.32 KB"}
+        raise AssertionError(f"unexpected artifact_id={artifact_id}")
+
+    monkeypatch.setattr(
+        fetch_docker_image_baseline,
+        "_download_artifact_payload",
+        _fake_download_artifact_payload,
+    )
+
+    payload = fetch_docker_image_baseline.fetch_main_artifact_baseline(
+        repo="owner/repo",
+        workflow="build.yml",
+        branch="main",
+        artifact_name="docker-image-telemetry-build",
+        per_page=10,
+    )
+
+    assert payload["baseline_source"] == "main-artifact"
+    assert payload["image_size_bytes"] == 654321
+    assert payload["baseline_reference"]["artifact_id"] == 100
+    assert payload["baseline_reference"]["run_number"] == 499
 
 
 def test_main_falls_back_to_repo_seed_when_remote_lookup_fails(

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -63,6 +63,15 @@ def _python_setup_step(path: str, job_name: str) -> dict[str, object]:
     raise AssertionError(f"Missing python-setup step for {path}:{job_name}")
 
 
+def _workflow_step_by_name(path: str, job_name: str, step_name: str) -> dict[str, object]:
+    """Return a workflow step by its display name."""
+
+    for step in _workflow_steps(path, job_name):
+        if step.get("name") == step_name:
+            return step
+    raise AssertionError(f"Missing step {step_name!r} for {path}:{job_name}")
+
+
 def test_dependency_security_schema_blocks_known_bad_litellm_versions() -> None:
     schema = json.loads(
         (REPO_ROOT / "tests" / "fixtures" / "dependency_security_schema.json").read_text(
@@ -589,8 +598,74 @@ def test_docker_workflows_emit_image_telemetry_artifacts() -> None:
         trivy_workflow_text,
     ):
         assert "docker-runtime-dependency-surface.json" in workflow_text
+        assert "scripts/ci/fetch_docker_image_baseline.py" in workflow_text
         assert "scripts/ci/docker_image_telemetry.py" in workflow_text
+        assert "docs/telemetry/docker_image_baseline.production.json" in workflow_text
+        assert "--baseline-json docker-image-baseline.json" in workflow_text
         assert "docker-image-telemetry.json" in workflow_text
         assert "docker-image-telemetry.md" in workflow_text
         assert "GITHUB_STEP_SUMMARY" in workflow_text
         assert "actions/upload-artifact@" in workflow_text
+
+    build_workflow = _load_workflow(".github/workflows/build.yml")
+    docker_image_workflow = _load_workflow(".github/workflows/docker-image.yml")
+    trivy_workflow = _load_workflow(".github/workflows/trivy.yml")
+
+    build_job_permissions = build_workflow["jobs"]["build"]["permissions"]
+    docker_image_permissions = docker_image_workflow["permissions"]
+    trivy_job_permissions = trivy_workflow["jobs"]["build"]["permissions"]
+    producer_artifact_name = _workflow_step_by_name(
+        ".github/workflows/build.yml",
+        "build",
+        "Upload Docker telemetry artifact",
+    )["with"]["name"]
+    build_resolve_step = _workflow_step_by_name(
+        ".github/workflows/build.yml",
+        "build",
+        "Resolve Docker image telemetry baseline",
+    )["run"]
+    docker_image_resolve_step = _workflow_step_by_name(
+        ".github/workflows/docker-image.yml",
+        "build",
+        "Resolve Docker image telemetry baseline",
+    )["run"]
+    trivy_resolve_step = _workflow_step_by_name(
+        ".github/workflows/trivy.yml",
+        "build",
+        "Resolve Docker image telemetry baseline",
+    )["run"]
+
+    assert build_job_permissions["actions"] == "read"
+    assert build_job_permissions["contents"] == "read"
+    assert docker_image_permissions["actions"] == "read"
+    assert docker_image_permissions["contents"] == "read"
+    assert trivy_job_permissions["actions"] == "read"
+    assert trivy_job_permissions["contents"] == "read"
+    assert "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in build_workflow_text
+    assert "GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in build_workflow_text
+    assert "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in docker_image_workflow_text
+    assert "GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in docker_image_workflow_text
+    assert "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in trivy_workflow_text
+    assert "GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in trivy_workflow_text
+    assert producer_artifact_name == "docker-image-telemetry-build"
+    assert f"--artifact-name {producer_artifact_name}" in build_resolve_step
+    assert f"--artifact-name {producer_artifact_name}" in docker_image_resolve_step
+    assert f"--artifact-name {producer_artifact_name}" in trivy_resolve_step
+    assert "--workflow build.yml" in build_resolve_step
+    assert "--workflow build.yml" in docker_image_resolve_step
+    assert "--workflow build.yml" in trivy_resolve_step
+
+
+def test_checked_in_docker_image_baseline_seed_has_expected_schema() -> None:
+    baseline_payload = json.loads(
+        (REPO_ROOT / "docs" / "telemetry" / "docker_image_baseline.production.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert baseline_payload["baseline_source"] == "repo-seed-fallback"
+    assert baseline_payload["image_size_bytes"] > 0
+    assert baseline_payload["image_size_human"].endswith("MB")
+    assert baseline_payload["baseline_reference"]["artifact_name"] == "docker-image-telemetry-build"
+    assert baseline_payload["baseline_reference"]["workflow"] == "build.yml"
+    assert baseline_payload["baseline_reference"]["seeded_from_run_id"] == 24771474567

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -619,6 +619,13 @@ def test_docker_workflows_emit_image_telemetry_artifacts() -> None:
         "build",
         "Upload Docker telemetry artifact",
     )["with"]["name"]
+    producer_artifact_paths = str(
+        _workflow_step_by_name(
+            ".github/workflows/build.yml",
+            "build",
+            "Upload Docker telemetry artifact",
+        )["with"]["path"]
+    )
     build_resolve_step = _workflow_step_by_name(
         ".github/workflows/build.yml",
         "build",
@@ -648,6 +655,7 @@ def test_docker_workflows_emit_image_telemetry_artifacts() -> None:
     assert "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in trivy_workflow_text
     assert "GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" in trivy_workflow_text
     assert producer_artifact_name == "docker-image-telemetry-build"
+    assert producer_artifact_paths.splitlines().count("docker-image-telemetry.json") == 1
     assert f"--artifact-name {producer_artifact_name}" in build_resolve_step
     assert f"--artifact-name {producer_artifact_name}" in docker_image_resolve_step
     assert f"--artifact-name {producer_artifact_name}" in trivy_resolve_step


### PR DESCRIPTION
## Summary

Add the first canonical Docker image telemetry baseline for the production backend image.

This PR keeps Docker image regression reporting advisory-only in this wave. Docker lanes now resolve a baseline from the latest successful `main` Docker telemetry artifact when available, fall back to a checked-in seed baseline when GitHub artifact lookup fails, and publish baseline-source evidence in PR-visible telemetry output.

## Scope

- add `scripts/ci/fetch_docker_image_baseline.py`
- add checked-in seed baseline `docs/telemetry/docker_image_baseline.production.json`
- extend `scripts/ci/docker_image_telemetry.py` with baseline source/reference metadata
- wire baseline resolution into `build.yml`, `docker-image.yml`, and `trivy.yml`
- add focused tests for baseline fetch, telemetry rendering, and workflow contract drift
- update Docker docs, task packet, and backlog status for PR-5

## Non-goals

- no hard image-size budget cap
- no Shared Safety audit script extraction
- no provenance / attestation recovery
- no Dagger or alternate control plane
- no frontend/Caddy topology changes

## Split Justification

This PR is above the normal size threshold because the Docker image budget and telemetry baseline contract is inherently cross-surface and would become inconsistent if split mid-flight.

The change has to land as one slice to keep the producer/consumer contract aligned across the baseline fetch helper, telemetry renderer, three Docker workflows, the checked-in fallback baseline, workflow-contract tests, and the operator docs/backlog packet that define the same baseline source rule.

If these pieces were split across separate PRs, the repo would temporarily carry one of the broken intermediate states this slice is explicitly preventing: workflows calling a helper that does not exist yet, telemetry output claiming baseline metadata the renderer cannot emit, a checked-in fallback baseline with no consumer, or workflow tests that assert a contract not yet wired into CI.

Follow-up PRs remain intentionally separate after this lands:
- hard image-size budget cap / failure threshold
- `Shared Safety audit script after install-profile split`
- provenance / attestation recovery
- Dagger or alternate control-plane work

## Validation

- [x] `python3 scripts/orchestration/check_preflight.py`
- [x] `python3 scripts/orchestration/check_agent_consistency.py`
- [x] `python3 -m pytest -q tests/test_fetch_docker_image_baseline.py tests/test_docker_image_telemetry.py tests/test_python_supply_chain_controls.py`
- [x] `python3 scripts/ci/fetch_docker_image_baseline.py --repo Katsiarynakavaleuskaya/PulsePlate --fallback-json docs/telemetry/docker_image_baseline.production.json --output /tmp/docker-image-budget-baseline-check.json`
- [x] `GH_TOKEN="$(gh auth token)" python3 scripts/ci/fetch_docker_image_baseline.py --repo Katsiarynakavaleuskaya/PulsePlate --fallback-json docs/telemetry/docker_image_baseline.production.json --output /tmp/docker-image-budget-baseline-live.json`
- [x] `pre-commit run --all-files`
- [x] pre-push hooks including `mypy`, backend tests, Bandit, and Docker build test on the current head

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_1492_FIXED_MAPPING.md`

## Merge Readiness

- [x] Current-head CI is green for PR branch head
- [x] Required checks complete (no pending jobs)
- [x] All review threads resolved on GitHub after disposition updates
- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] `pre-commit run --all-files` passed on the latest pushed head
- [ ] `make verify` green on the latest pushed head

## Deferred / Follow-ups

- hard image-size budget cap / failure threshold
- `Shared Safety audit script after install-profile split`
- provenance / attestation recovery
- Dagger or alternate control-plane work

## Summary by Sourcery

Вводится каноническая базовая линия телеметрии Docker-образа и её интеграция в CI‑воркфлоу для консультативной (advisory‑only) отчётности по регрессии размера образа.

Новые возможности:
- Добавлен вспомогательный скрипт CI для получения базовых линий телеметрии Docker‑образов из артефакта последнего успешно выполненного workflow ветки main или из зафиксированной (checked‑in) исходной базовой линии.
- Добавлена зафиксированная JSON‑базовая линия production backend Docker‑образа, используемая как исходный резервный вариант (seed fallback) репозитория.

Улучшения:
- Расширена отчётность телеметрии Docker‑образов: в JSON‑ и Markdown‑вывод добавлены данные об источнике и ссылке (reference) базовой линии.
- Обновлены Docker‑воркфлоу: перед сбором телеметрии они разрешают (resolve) каноническую базовую линию, при этом права для actions и contents ужесточены до read‑only.
- Задокументирован контракт телеметрии Docker‑образов, правила определения источника базовой линии и поток валидации, а также добавлены пакет задач (task packet) и управляющий артефакт (governance artifact) для этого среза телеметрии.
- Обновлены элементы бэклога roadmap, чтобы отразить завершение оптимизации runtime и появление нового среза telemetry‑baseline.

Тесты:
- Добавлены тесты для вспомогателя получения базовой линии, включая разрешение через `gh` CLI, извлечение полезной нагрузки артефакта, поведение резервного перехода при сбое и нормализацию схемы.
- Расширены тесты телеметрии, чтобы покрыть обработку источника/ссылки базовой линии, поведение резервного использования seed из репозитория и Markdown‑рендеринг метаданных базовой линии.
- Расширены контрактные тесты CI‑воркфлоу, чтобы проверять проводку (wiring) разрешения базовой линии, права доступа, экспонирование токенов, именование артефактов и схему исходной базовой линии (seed baseline).

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a canonical Docker image telemetry baseline and wire it into CI workflows for advisory-only image-size regression reporting.

New Features:
- Add a CI helper script to resolve Docker image telemetry baselines from the latest successful main workflow artifact or a checked-in seed baseline.
- Add a checked-in production backend Docker image baseline JSON used as the repository seed fallback.

Enhancements:
- Extend Docker image telemetry reporting to carry baseline source and reference metadata into JSON and Markdown outputs.
- Update Docker workflows to resolve the canonical baseline before telemetry collection while tightening permissions to read-only for actions and contents.
- Document the Docker image telemetry contract, baseline source rules, and validation flow, and add a task packet plus governance artifact for this telemetry slice.
- Update the roadmap backlog entries to reflect completion of runtime slimming and the new telemetry-baseline slice details.

Tests:
- Add tests for the baseline fetch helper, including gh CLI resolution, artifact payload extraction, failure fallback behavior, and schema normalization.
- Expand telemetry tests to cover baseline source/reference handling, repo seed fallback behavior, and Markdown rendering of baseline metadata.
- Extend CI workflow contract tests to assert baseline resolution wiring, permissions, token exposure, artifact naming, and seed baseline schema.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now resolves a canonical Docker-image baseline (with a checked-in fallback), passes it into telemetry collection, and keeps baseline deltas warning-only.
  * Workflow job permissions for image-telemetry jobs tightened from write to read.

* **Documentation**
  * Expanded runtime/telemetry contract, baseline-source rules, validation commands, task packet, and roadmap/backlog updates.

* **Tests**
  * Broadened tests for baseline resolution, fallback behavior, telemetry payload/markdown, and workflow assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->