### PR TITLE
feat(evals): add canonical threshold reporting and companion artifact bridge for RAG release gates

### DIFF
--- a/docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md
+++ b/docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md
@@ -5,6 +5,7 @@
 **Canonical notebook:** [`notebooks/pulseplate_rag_release_gates.ipynb`](../../notebooks/pulseplate_rag_release_gates.ipynb)
 **Canonical runner:** [`scripts/evals/run_rag_release_gates.py`](../../scripts/evals/run_rag_release_gates.py)
 **Lane packet:** [`docs/orchestration/PULSEPLATE_RAG_RELEASE_GATES_TASK_PACKET_2026-04-20.md`](../orchestration/PULSEPLATE_RAG_RELEASE_GATES_TASK_PACKET_2026-04-20.md)
+**Follow-up packet:** [`docs/orchestration/PULSEPLATE_RAG_RELEASE_GATES_THRESHOLD_REPORTING_TASK_PACKET_2026-04-22.md`](../orchestration/PULSEPLATE_RAG_RELEASE_GATES_THRESHOLD_REPORTING_TASK_PACKET_2026-04-22.md)
 **Ledger anchor:** [`ledger-p1-rag-release-gates-lane`](../roadmap/BACKLOG_LEDGER.md#ledger-p1-rag-release-gates-lane)
 
 ## Purpose
@@ -157,7 +158,7 @@ Initial thresholds:
 GATE_THRESHOLDS = {
     "evidence_exact_match_rate": 0.70,
     "mean_nli_entailment": 0.85,
-    "support_precision": 0.70,
+    "support_precision": 0.80,
     "ece": 0.08,
     "escalation_min": 0.10,
     "escalation_max": 0.25,
@@ -187,8 +188,10 @@ Canonical fields:
 - `generator_mode`
 - `sample_size`
 - `thresholds`
+- `threshold_results`
 - `gate_checks`
 - `release_decision`
+- optional `companion_metrics`
 
 ### Trace-level schema
 
@@ -218,6 +221,24 @@ This schema contract is the intended bridge between:
 
 The goal is to avoid a future dashboard migration that re-implements evaluation logic.
 
+## Companion Artifact Bridge
+
+The release-gates lane remains the canonical owner of threshold vocabulary,
+gate checks, and `PASS` / `NO-GO` release decisions.
+
+Optional companion RAGAS artifacts are informational only and must not change:
+
+- `thresholds`
+- `threshold_results`
+- `gate_checks`
+- `release_decision`
+- `--require-pass`
+
+When provided, the companion artifact must already exist as a local JSON artifact
+under the gitignored `artifacts/rag_eval/<experiment_id>/...` family. The
+canonical runner may ingest it for reporting, but it does not execute `ragas`
+itself and it does not become a second eval source of truth.
+
 ## Storage Model
 
 ### v1 source of truth
@@ -233,6 +254,8 @@ PR / CI visibility:
   - `metrics_summary.json`
   - `latest_executed.ipynb`
 - write a compact markdown summary to the CI check summary / PR check output
+- surface deterministic threshold rows in both the markdown report and the CI summary
+- include companion RAGAS metrics only as an informational block when explicitly provided
 
 ### v2 persistence
 
@@ -261,6 +284,16 @@ python3 scripts/evals/run_rag_release_gates.py \
   --input-path data/evals/pulseplate_rag_eval_sample.jsonl \
   --retriever-mode local_tfidf \
   --generator-mode extractive_stub
+```
+
+Optional local composition with a precomputed companion RAGAS artifact:
+
+```bash
+python3 scripts/evals/run_rag_release_gates.py \
+  --input-path data/evals/pulseplate_rag_eval_sample.jsonl \
+  --retriever-mode local_tfidf \
+  --generator-mode extractive_stub \
+  --companion-metrics-json artifacts/rag_eval/ragas_bootstrap_manual/metrics_summary.json
 ```
 
 Stricter local lane:
@@ -307,8 +340,13 @@ The sample smoke proves:
 - runner completes
 - artifact pack is emitted
 - no paid provider path is required
+- threshold reporting is surfaced deterministically
 
 It does **not** claim release readiness by itself.
+
+The PR smoke lane remains advisory/reporting-only. The weekly/manual lane remains
+the canonical strict execution path and is the only GitHub path that should pair
+this runner with `--require-pass`.
 
 ## Security Notes
 

--- a/docs/evals/RAGAS_SETUP.md
+++ b/docs/evals/RAGAS_SETUP.md
@@ -17,6 +17,9 @@
 - This companion lane does not own threshold vocabulary such as `PASS`, `NO-GO`,
   or canonical gate semantics.
 - If you need canonical runtime-grounded release evidence, use the release-gates lane instead.
+- The companion runner may feed a precomputed JSON artifact into the canonical
+  release-gates runner for informational reporting, but it does not replace the
+  canonical runner or artifact contract.
 
 ## Scope
 - Dataset inspiration surface: `/api/v1/pro/cbt/insight`
@@ -79,6 +82,22 @@ Default output is stdout only. Optional file outputs may reuse the existing
 gitignored `artifacts/rag_eval/<experiment_id>/...` family, but this companion
 lane does not redefine that artifact contract.
 
+Optional local composition with the canonical release-gates runner:
+
+```bash
+python3 scripts/evals/run_rag_release_gates.py \
+  --input-path data/evals/pulseplate_rag_eval_sample.jsonl \
+  --retriever-mode local_tfidf \
+  --generator-mode extractive_stub \
+  --companion-metrics-json artifacts/rag_eval/ragas_bootstrap_manual/metrics_summary.json
+```
+
+This bridge is local and informational only:
+
+- it does not install or execute `ragas` in GitHub CI
+- it does not change canonical gate outcomes
+- it does not create a second canonical evaluation rail
+
 ## Output Contract
 Stdout prints a deterministic Markdown summary:
 
@@ -111,3 +130,9 @@ pytest -q tests/evals/test_ragas_dataset_contract.py
 pytest -q tests/evals/test_ragas_metrics_config.py
 pytest -q tests/evals/test_ragas_runner_contract.py
 ```
+
+## Deferred GraphRAG Note
+
+Selective GraphRAG evaluation remains deferred to a separate docs/ADR lane.
+This companion bootstrap does not introduce GraphRAG runtime behavior,
+graph-specific thresholds, or graph artifact schema.

--- a/docs/orchestration/PULSEPLATE_RAG_RELEASE_GATES_THRESHOLD_REPORTING_TASK_PACKET_2026-04-22.md
+++ b/docs/orchestration/PULSEPLATE_RAG_RELEASE_GATES_THRESHOLD_REPORTING_TASK_PACKET_2026-04-22.md
@@ -1,0 +1,176 @@
+# PulsePlate RAG Release Gates Threshold Reporting Task Packet
+
+**Date:** 2026-04-22 (`America/New_York`)
+**Mode:** coordinator-first, worktree-isolated, canonical-release-gates follow-up
+**Worktree:** `worktrees/rag-release-gates-threshold-reporting`
+**Branch:** `feat/rag-release-gates-threshold-reporting`
+**Ledger:** [`ledger-p1-rag-release-gates-lane`](../roadmap/BACKLOG_LEDGER.md#ledger-p1-rag-release-gates-lane)
+
+## Decision Question
+
+How should PulsePlate improve canonical threshold/result reporting for the
+release-gates lane and optionally surface companion RAGAS metrics without
+creating a second evaluation rail or widening into runtime/GraphRAG work?
+
+## Summary
+
+This lane is a narrow follow-up on the canonical release-gates runner.
+It adds richer threshold reporting and an optional informational companion
+artifact adapter for precomputed RAGAS JSON. Canonical gate ownership stays
+inside `scripts/evals/run_rag_release_gates.py`.
+
+## Success Criteria
+
+1. The canonical runner emits deterministic `threshold_results`.
+2. `gate_report.md` and `GITHUB_STEP_SUMMARY` show threshold rows clearly.
+3. A precomputed companion RAGAS JSON artifact can be ingested for
+   informational reporting only.
+4. Companion metrics do not change `gate_checks`, `release_decision`, or
+   `--require-pass`.
+5. PR smoke remains advisory/reporting-only.
+6. Weekly/manual execution remains the only canonical strict GitHub lane.
+
+## Role Order (mandatory)
+
+Execute in this order for the lane:
+
+1. `agent-coordinator`
+2. `architecture-specialist`
+3. `data-scientist-agent`
+4. `ai-innovation-specialist`
+5. `backend-engineer`
+
+Post-open mandatory review lane:
+
+1. `qa-engineer-agent`
+2. `bug-hunter`
+
+Conditional reviewer:
+
+- `security-auditor` only if scope drifts into privileged surfaces beyond the
+  approved eval/docs/workflow seam
+
+## Skill / Plugin Routing
+
+Required skills:
+
+- `pulseplate-workflow`
+- `pulseplate-gates`
+- `docs-sync`
+
+Recommended skills:
+
+- `agents-md`
+- `code-review-expert`
+- `bug-triage`
+
+Required plugin surfaces:
+
+- `GitHub` for live PR/check/review truth
+- `CodeRabbit` for post-open review truth
+
+Explicitly out of scope for this lane:
+
+- `Computer Use`
+- `Linear`
+- `Hugging Face`
+- `Life Science Research`
+- `Netlify`
+- `Cloudflare`
+- `Sentry`
+- `build-ios-apps`
+- `build-macos-apps`
+- `build-web-apps`
+- `Expo`
+
+## Scope
+
+### In scope
+
+- `scripts/evals/run_rag_release_gates.py`
+- `tests/test_rag_release_gates_runner.py`
+- `docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md`
+- `docs/evals/RAGAS_SETUP.md`
+- this packet
+- `.github/workflows/rag-release-gates.yml` only if required to surface improved
+  reporting without changing PR-smoke strictness
+
+### Out of scope
+
+- `app/**`
+- `core/**`
+- `llm.py`
+- `evals/ragas/**`
+- runtime requirements / CI install surface for `ragas`
+- public DTO/OpenAPI/runtime schema changes
+- GraphRAG runtime behavior
+- graph-specific thresholds or artifact schema
+
+## Architecture Decision
+
+### Canonical ownership
+
+- `scripts/evals/run_rag_release_gates.py` remains the only canonical owner of:
+  - `thresholds`
+  - `threshold_results`
+  - `gate_checks`
+  - `release_decision`
+  - `--require-pass`
+
+### Companion bridge
+
+- Optional input: precomputed companion JSON artifact
+- Source family: `artifacts/rag_eval/<experiment_id>/...`
+- Reporting role: informational only
+- Companion metrics must never affect:
+  - `threshold_results`
+  - `gate_checks`
+  - `release_decision`
+  - weekly/manual strict semantics
+
+## Risks
+
+- accidental second eval rail through companion metrics influencing gate logic
+- accidental CI widening by installing or invoking `ragas`
+- doc drift between threshold values in code and canonical docs
+- accidental forward-binding of future selective GraphRAG evaluation semantics
+
+## Mitigations
+
+- fail closed on malformed companion JSON
+- keep companion metrics report-only
+- keep PR smoke advisory
+- keep weekly/manual strict lane unchanged
+- update docs to state that GraphRAG stays deferred to a separate docs/ADR lane
+
+## Validation
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+pytest -q tests/test_rag_release_gates_runner.py
+pre-commit run --all-files
+make verify
+```
+
+Manual local composition smoke:
+
+```bash
+python -m evals.ragas.run_ragas_eval \
+  --dataset evals/ragas/testset.jsonl \
+  --output-json artifacts/rag_eval/ragas_bootstrap_manual/metrics_summary.json
+
+python3 scripts/evals/run_rag_release_gates.py \
+  --input-path data/evals/pulseplate_rag_eval_sample.jsonl \
+  --retriever-mode local_tfidf \
+  --generator-mode extractive_stub \
+  --companion-metrics-json artifacts/rag_eval/ragas_bootstrap_manual/metrics_summary.json
+```
+
+## DoD
+
+- canonical runner emits deterministic threshold rows
+- canonical docs describe threshold reporting and companion artifact bridge
+- companion JSON ingestion is fail-closed and informational only
+- no runtime/request-path/GraphRAG widening is introduced
+- post-open `qa-engineer-agent -> bug-hunter` lane is executed after PR open

--- a/docs/review/PR_1493_FIXED_MAPPING.md
+++ b/docs/review/PR_1493_FIXED_MAPPING.md
@@ -15,6 +15,21 @@ claiming merge readiness.
 
 ## Fixed in Commit Mapping
 
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1493_FIXED_MAPPING.md`
+Reason: The Sourcery review shell only aggregates the inline CLI/env-precedence suggestion that is fixed and mapped below; after that inline URL is dispositioned, the review shell adds no separate unresolved obligation.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1493#pullrequestreview-4154419522
+
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1493_FIXED_MAPPING.md`
+Reason: This CodeRabbit review shell summarizes the two inline runner findings mapped below for stable companion-path emission and canonical metric ordering; it does not add a separate unresolved action once those inline URLs are dispositioned.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1493#pullrequestreview-4154460774
+
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1493_FIXED_MAPPING.md`
+Reason: This follow-up CodeRabbit review shell only contains the already-mapped fail-fast companion validation finding plus the already-mapped repo-relative path/ordering follow-up, so the shell itself is advisory once those inline comments are covered.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1493#pullrequestreview-4154990039
+
 Disposition: FIXED
 Commit: 2aca6ef76
 Evidence: `tests/test_rag_release_gates_runner.py:493-579`

--- a/docs/review/PR_1493_FIXED_MAPPING.md
+++ b/docs/review/PR_1493_FIXED_MAPPING.md
@@ -34,5 +34,7 @@ Merge-readiness contract:
 
 - This PR is a canonical release-gates follow-up, not a second eval rail.
 - Companion RAGAS metrics remain informational only in this lane.
+- Post-open reviewer lane completed on head `f9c9de14c`:
+  `qa-engineer-agent` and `bug-hunter` reported no remaining delta findings.
 - Continuity remains under
   `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-rag-release-gates-lane`.

--- a/docs/review/PR_1493_FIXED_MAPPING.md
+++ b/docs/review/PR_1493_FIXED_MAPPING.md
@@ -1,0 +1,38 @@
+# PR #1493 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+This artifact is the source of truth for review dispositions on PR #1493.
+Record every actionable human or bot review item here before resolving threads or
+claiming merge readiness.
+
+## Fixed in Commit Mapping
+
+No actionable review items recorded yet.
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] Pre-commit green on latest pushed head
+- [ ] `make verify` green on latest pushed head
+
+## Notes
+
+- This PR is a canonical release-gates follow-up, not a second eval rail.
+- Companion RAGAS metrics remain informational only in this lane.
+- Continuity remains under
+  `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-rag-release-gates-lane`.

--- a/docs/review/PR_1493_FIXED_MAPPING.md
+++ b/docs/review/PR_1493_FIXED_MAPPING.md
@@ -6,8 +6,8 @@ Canonical review-governance artifact and PR-body mirror requirements:
 `AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
 `docs/orchestration/AGENTS.md:79-82`.
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 This artifact is the source of truth for review dispositions on PR #1493.
 Record every actionable human or bot review item here before resolving threads or
@@ -15,7 +15,7 @@ claiming merge readiness.
 
 ## Fixed in Commit Mapping
 
-No actionable review items recorded yet.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1493_FIXED_MAPPING.md
+++ b/docs/review/PR_1493_FIXED_MAPPING.md
@@ -15,7 +15,29 @@ claiming merge readiness.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 2aca6ef76
+Evidence: `tests/test_rag_release_gates_runner.py:493-579`
+Reason: The runner contract now covers explicit CLI wiring for `--companion-metrics-json` and locks the precedence rule so an explicit CLI path wins over the env fallback.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1493#discussion_r3123728964 -> 2aca6ef76
+
+Disposition: FIXED
+Commit: 2aca6ef76
+Evidence: `scripts/evals/run_rag_release_gates.py:2424-2442`; `tests/test_rag_release_gates_runner.py:1211-1244`
+Reason: Companion artifact validation now happens before `run_evaluation(...)`, and the runner test proves malformed companion JSON aborts before the expensive evaluation loop starts.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1493#discussion_r3123731846 -> 2aca6ef76
+
+Disposition: FIXED
+Commit: 2aca6ef76
+Evidence: `scripts/evals/run_rag_release_gates.py:381-446`; `tests/test_rag_release_gates_runner.py:1125-1137`
+Reason: Emitted companion metadata now uses a stable repo-relative artifact path instead of leaking checkout-specific absolute filesystem paths.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1493#discussion_r3123763539 -> 2aca6ef76
+
+Disposition: FIXED
+Commit: 2aca6ef76
+Evidence: `scripts/evals/run_rag_release_gates.py:434-450`; `tests/test_rag_release_gates_runner.py:1187-1208`
+Reason: Companion metrics are normalized in canonical `faithfulness -> answer_relevancy -> context_precision` order, and the dedicated test now protects against noisy diffs from arbitrary JSON key order.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1493#discussion_r3123763553 -> 2aca6ef76
 
 ## Merge Readiness
 

--- a/scripts/evals/run_rag_release_gates.py
+++ b/scripts/evals/run_rag_release_gates.py
@@ -2323,7 +2323,7 @@ def build_config(args: argparse.Namespace) -> EvalConfig:
     if companion_metrics_json is not None:
         _ensure_within(
             companion_metrics_json,
-            project_root / "artifacts",
+            project_root / "artifacts" / "rag_eval",
             label="companion_metrics_json",
         )
     sample_size = _require_positive_int(

--- a/scripts/evals/run_rag_release_gates.py
+++ b/scripts/evals/run_rag_release_gates.py
@@ -229,6 +229,7 @@ class EvalConfig:
     nli_model_name: str
     notebook_path: Path
     require_pass: bool
+    companion_metrics_json: Path | None = None
     allow_dataset_fallback: bool = True
     allow_runtime_fallbacks: bool = True
 
@@ -357,6 +358,191 @@ def _record_strict_violation(state: EvalRuntimeState, message: str) -> None:
     state.warnings.append(message)
     if not state.config.allow_runtime_fallbacks and message not in state.strict_violations:
         state.strict_violations.append(message)
+
+
+def _json_safe_float(value: float) -> float | None:
+    """Return a JSON-safe float, preserving NaN as null."""
+
+    return None if math.isnan(value) else float(value)
+
+
+def _require_finite_metric(value: Any, *, label: str) -> float:
+    """Parse a metric value and fail closed when it is not finite."""
+
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"{label} must be numeric") from exc
+    if not math.isfinite(numeric):
+        raise RuntimeError(f"{label} must be finite")
+    return numeric
+
+
+def _load_companion_metrics(path: Path | None) -> dict[str, Any] | None:
+    """Load an optional companion RAGAS artifact for informational reporting."""
+
+    if path is None:
+        return None
+    if not path.exists():
+        raise FileNotFoundError(f"Companion metrics JSON not found: {path}")
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Companion metrics JSON is invalid: {path}") from exc
+
+    if not isinstance(payload, dict):
+        raise RuntimeError("Companion metrics JSON root must be an object")
+    expected_payload_keys = {"dataset_path", "sample_count", "report_only", "metrics"}
+    if set(payload) != expected_payload_keys:
+        raise RuntimeError(
+            "Companion metrics JSON must contain exactly: "
+            "dataset_path, sample_count, report_only, metrics"
+        )
+
+    dataset_path = str(payload.get("dataset_path") or "").strip()
+    if not dataset_path:
+        raise RuntimeError("Companion metrics JSON must contain a non-empty dataset_path")
+
+    sample_count = _safe_int(payload.get("sample_count"), default=-1)
+    if sample_count <= 0:
+        raise RuntimeError("Companion metrics JSON must contain a positive sample_count")
+
+    report_only = payload.get("report_only")
+    if report_only is not True:
+        raise RuntimeError("Companion metrics JSON must declare report_only=true")
+
+    metrics = payload.get("metrics")
+    if not isinstance(metrics, dict) or not metrics:
+        raise RuntimeError("Companion metrics JSON must contain a non-empty metrics object")
+    expected_metric_keys = {"faithfulness", "answer_relevancy", "context_precision"}
+    if set(metrics) != expected_metric_keys:
+        raise RuntimeError(
+            "Companion metrics JSON must contain exactly: "
+            "faithfulness, answer_relevancy, context_precision"
+        )
+
+    normalized_metrics: dict[str, float] = {}
+    for raw_name, raw_value in metrics.items():
+        metric_name = str(raw_name).strip()
+        if not metric_name:
+            raise RuntimeError("Companion metrics JSON metric names must be non-empty")
+        metric_value = _require_finite_metric(
+            raw_value,
+            label=f"companion metric '{metric_name}'",
+        )
+        if not 0.0 <= metric_value <= 1.0:
+            raise RuntimeError(f"companion metric '{metric_name}' must stay within [0, 1]")
+        normalized_metrics[metric_name] = metric_value
+
+    return {
+        "ragas": {
+            "source_path": str(path.resolve()),
+            "dataset_path": dataset_path,
+            "sample_count": sample_count,
+            "report_only": True,
+            "metrics": normalized_metrics,
+        }
+    }
+
+
+def _build_threshold_results(
+    retrieval_summary: dict[str, float],
+    faithfulness_summary: dict[str, float],
+    calibration_metrics: dict[str, float],
+    routing_summary: dict[str, float],
+    gate_checks: dict[str, bool],
+    *,
+    strict_violation_count: int,
+) -> list[dict[str, Any]]:
+    """Return deterministic threshold rows for reports and artifact summaries."""
+
+    return [
+        {
+            "gate_id": "gate_a_recall_at_effective_k",
+            "metric_key": "recall_at_effective_k",
+            "threshold_key": "recall_at_50",
+            "value": _json_safe_float(retrieval_summary["recall_at_effective_k"]),
+            "target": GATE_THRESHOLDS["recall_at_50"],
+            "comparison": "gte",
+            "passed": gate_checks["gate_a_recall_at_effective_k"],
+        },
+        {
+            "gate_id": "gate_b1_evidence_exact_match",
+            "metric_key": "evidence_exact_match_rate",
+            "threshold_key": "evidence_exact_match_rate",
+            "value": _json_safe_float(faithfulness_summary["evidence_exact_match_rate"]),
+            "target": GATE_THRESHOLDS["evidence_exact_match_rate"],
+            "comparison": "gte",
+            "passed": gate_checks["gate_b1_evidence_exact_match"],
+        },
+        {
+            "gate_id": "gate_b2_mean_nli_entailment",
+            "metric_key": "mean_nli_entailment",
+            "threshold_key": "mean_nli_entailment",
+            "value": _json_safe_float(faithfulness_summary["mean_nli_entailment"]),
+            "target": GATE_THRESHOLDS["mean_nli_entailment"],
+            "comparison": "gte",
+            "passed": gate_checks["gate_b2_mean_nli_entailment"],
+        },
+        {
+            "gate_id": "gate_b3_support_precision",
+            "metric_key": "support_precision",
+            "threshold_key": "support_precision",
+            "value": _json_safe_float(faithfulness_summary["support_precision"]),
+            "target": GATE_THRESHOLDS["support_precision"],
+            "comparison": "gte",
+            "passed": gate_checks["gate_b3_support_precision"],
+        },
+        {
+            "gate_id": "gate_c1_ece",
+            "metric_key": "ece",
+            "threshold_key": "ece",
+            "value": _json_safe_float(calibration_metrics["ece"]),
+            "target": GATE_THRESHOLDS["ece"],
+            "comparison": "lte",
+            "passed": gate_checks["gate_c1_ece"],
+        },
+        {
+            "gate_id": "gate_c2_escalation_corridor",
+            "metric_key": "escalation_rate",
+            "threshold_key": "escalation_corridor",
+            "value": _json_safe_float(routing_summary["escalation_rate"]),
+            "target": {
+                "min": GATE_THRESHOLDS["escalation_min"],
+                "max": GATE_THRESHOLDS["escalation_max"],
+            },
+            "comparison": "between_inclusive",
+            "passed": gate_checks["gate_c2_escalation_corridor"],
+        },
+        {
+            "gate_id": "gate_d1_no_runtime_mode_fallbacks",
+            "metric_key": "strict_violation_count",
+            "threshold_key": "strict_violation_count",
+            "value": strict_violation_count,
+            "target": 0,
+            "comparison": "eq",
+            "passed": gate_checks["gate_d1_no_runtime_mode_fallbacks"],
+        },
+    ]
+
+
+def _format_threshold_target(target: Any) -> str:
+    """Render threshold targets for Markdown tables."""
+
+    if isinstance(target, dict):
+        lower = target.get("min")
+        upper = target.get("max")
+        return f"{lower}..{upper}"
+    return str(target)
+
+
+def _format_threshold_value(value: Any) -> str:
+    """Render threshold values for Markdown tables."""
+
+    if value is None:
+        return "null"
+    return str(value)
 
 
 def _record_runtime_fallback(state: EvalRuntimeState, warning: str) -> None:
@@ -1534,6 +1720,7 @@ def build_metrics_summary(
     *,
     dataset_fallback_used: bool,
     dataset_path_used: str,
+    companion_metrics: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], dict[str, bool], str]:
     """Build summary metrics, gate checks, and the release decision."""
 
@@ -1643,6 +1830,14 @@ def build_metrics_summary(
             not state.strict_violations if not state.config.allow_runtime_fallbacks else True
         ),
     }
+    threshold_results = _build_threshold_results(
+        retrieval_summary,
+        faithfulness_summary,
+        calibration_metrics,
+        routing_summary,
+        gate_checks,
+        strict_violation_count=len(state.strict_violations),
+    )
     release_decision = "PASS" if all(gate_checks.values()) else "NO-GO"
     metrics_summary = {
         "experiment_id": state.config.experiment_id,
@@ -1662,9 +1857,12 @@ def build_metrics_summary(
         "calibration": calibration_metrics,
         "routing": routing_summary,
         "thresholds": GATE_THRESHOLDS,
+        "threshold_results": threshold_results,
         "gate_checks": gate_checks,
         "release_decision": release_decision,
     }
+    if companion_metrics is not None:
+        metrics_summary["companion_metrics"] = companion_metrics
     return metrics_summary, gate_checks, release_decision
 
 
@@ -1676,6 +1874,7 @@ def build_gate_report_markdown(metrics_summary: dict[str, Any]) -> str:
     calibration = metrics_summary["calibration"]
     routing = metrics_summary["routing"]
     gate_checks = metrics_summary["gate_checks"]
+    threshold_results = metrics_summary.get("threshold_results", [])
     lines = [
         f"# PulsePlate RAG Release Gate Report — {metrics_summary['experiment_id']}",
         "",
@@ -1693,6 +1892,26 @@ def build_gate_report_markdown(metrics_summary: dict[str, Any]) -> str:
     lines.extend(
         f"- [{'x' if passed else ' '}] `{gate_name}`" for gate_name, passed in gate_checks.items()
     )
+    if threshold_results:
+        lines.extend(
+            [
+                "",
+                "## Threshold results",
+                "",
+                "Gate | Metric | Value | Target | Comparison | Passed",
+                "--- | --- | --- | --- | --- | ---",
+                *[
+                    (
+                        f"`{row['gate_id']}` | `{row['metric_key']}` | "
+                        f"`{_format_threshold_value(row['value'])}` | "
+                        f"`{_format_threshold_target(row['target'])}` | "
+                        f"`{row['comparison']}` | "
+                        f"`{row['passed']}`"
+                    )
+                    for row in threshold_results
+                ],
+            ],
+        )
     lines.extend(
         [
             "",
@@ -1709,6 +1928,26 @@ def build_gate_report_markdown(metrics_summary: dict[str, Any]) -> str:
             *[f"- `{key}`: `{value}`" for key, value in routing.items()],
         ],
     )
+    companion_metrics = metrics_summary.get("companion_metrics", {})
+    ragas_metrics = companion_metrics.get("ragas") if isinstance(companion_metrics, dict) else None
+    if isinstance(ragas_metrics, dict):
+        lines.extend(
+            [
+                "",
+                "## Companion RAGAS metrics",
+                f"- Source path: `{ragas_metrics['source_path']}`",
+                f"- Dataset path: `{ragas_metrics['dataset_path']}`",
+                f"- Sample count: `{ragas_metrics['sample_count']}`",
+                f"- Report only: `{ragas_metrics['report_only']}`",
+                "",
+                "Metric | Score",
+                "--- | ---:",
+                *[
+                    f"`{metric_name}` | `{metric_value}`"
+                    for metric_name, metric_value in ragas_metrics["metrics"].items()
+                ],
+            ],
+        )
     if metrics_summary["runtime_warnings"]:
         lines.extend(
             [
@@ -1929,21 +2168,46 @@ def _write_github_step_summary(metrics_summary: dict[str, Any], artifacts: dict[
         f"- Retriever mode: `{metrics_summary['retriever_mode']}`",
         f"- Generator mode: `{metrics_summary['generator_mode']}`",
         "",
-        "### Metrics",
-        f"- `recall_at_50`: `{metrics_summary['retrieval']['recall_at_50']}`",
-        (
-            "- `evidence_exact_match_rate`: "
-            f"`{metrics_summary['faithfulness']['evidence_exact_match_rate']}`"
-        ),
-        ("- `mean_nli_entailment`: " f"`{metrics_summary['faithfulness']['mean_nli_entailment']}`"),
-        ("- `support_precision`: " f"`{metrics_summary['faithfulness']['support_precision']}`"),
-        f"- `ece`: `{metrics_summary['calibration']['ece']}`",
-        "",
         "### Artifacts",
         f"- Gate report: `{artifacts['gate_report']}`",
         f"- Metrics summary: `{artifacts['metrics_summary']}`",
         f"- Traces: `{artifacts['traces_jsonl']}`",
     ]
+    threshold_results = metrics_summary.get("threshold_results", [])
+    if threshold_results:
+        summary_lines[6:6] = [
+            "### Threshold results",
+            "",
+            "Gate | Value | Target | Comparison | Passed",
+            "--- | --- | --- | --- | ---",
+            *[
+                (
+                    f"`{row['gate_id']}` | "
+                    f"`{_format_threshold_value(row['value'])}` | "
+                    f"`{_format_threshold_target(row['target'])}` | "
+                    f"`{row['comparison']}` | "
+                    f"`{row['passed']}`"
+                )
+                for row in threshold_results
+            ],
+            "",
+        ]
+    companion_metrics = metrics_summary.get("companion_metrics", {})
+    ragas_metrics = companion_metrics.get("ragas") if isinstance(companion_metrics, dict) else None
+    if isinstance(ragas_metrics, dict):
+        summary_lines.extend(
+            [
+                "",
+                "### Companion RAGAS metrics",
+                f"- Source path: `{ragas_metrics['source_path']}`",
+                f"- Sample count: `{ragas_metrics['sample_count']}`",
+                f"- Report only: `{ragas_metrics['report_only']}`",
+                *[
+                    f"- `{metric_name}`: `{metric_value}`"
+                    for metric_name, metric_value in ragas_metrics["metrics"].items()
+                ],
+            ],
+        )
     with Path(summary_path).open("a", encoding="utf-8") as handle:
         handle.write("\n".join(summary_lines) + "\n")
 
@@ -2041,6 +2305,12 @@ def build_config(args: argparse.Namespace) -> EvalConfig:
         args.artifact_root or os.getenv("PULSEPLATE_RAG_EVAL_ARTIFACT_ROOT", DEFAULT_ARTIFACT_ROOT),
     )
     notebook_path = _resolve_path(args.notebook_path or DEFAULT_NOTEBOOK_PATH)
+    companion_metrics_json_raw = getattr(args, "companion_metrics_json", None) or os.getenv(
+        "PULSEPLATE_RAG_COMPANION_METRICS_JSON"
+    )
+    companion_metrics_json = (
+        _resolve_path(companion_metrics_json_raw) if companion_metrics_json_raw else None
+    )
     experiment_id = sanitize_experiment_id(
         args.experiment_id
         or os.getenv(
@@ -2050,6 +2320,12 @@ def build_config(args: argparse.Namespace) -> EvalConfig:
     )
     _ensure_within(input_path, project_root, label="input_path")
     _ensure_within(artifact_root, project_root / "artifacts", label="artifact_root")
+    if companion_metrics_json is not None:
+        _ensure_within(
+            companion_metrics_json,
+            project_root / "artifacts",
+            label="companion_metrics_json",
+        )
     sample_size = _require_positive_int(
         _safe_int(
             args.sample_size or os.getenv("PULSEPLATE_RAG_EVAL_SAMPLE_SIZE", "500"),
@@ -2086,6 +2362,7 @@ def build_config(args: argparse.Namespace) -> EvalConfig:
             args.nli_model_name or os.getenv("NLI_MODEL_NAME", "roberta-large-mnli")
         ).strip(),
         notebook_path=notebook_path,
+        companion_metrics_json=companion_metrics_json,
         require_pass=bool(args.require_pass),
         allow_dataset_fallback=not bool(args.disallow_dataset_fallback),
         allow_runtime_fallbacks=not bool(args.disallow_runtime_fallbacks),
@@ -2116,6 +2393,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--enable-nli-model", action="store_true")
     parser.add_argument("--nli-model-name")
     parser.add_argument("--notebook-path")
+    parser.add_argument(
+        "--companion-metrics-json",
+        help="Optional informational companion metrics JSON emitted by evals/ragas.",
+    )
     parser.add_argument(
         "--require-pass",
         action="store_true",
@@ -2148,12 +2429,14 @@ async def async_main(args: argparse.Namespace) -> int:
     )
     traces = await run_evaluation(state, rows)
     calibration_metrics = apply_calibration(traces)
+    companion_metrics = _load_companion_metrics(config.companion_metrics_json)
     metrics_summary, _, release_decision = build_metrics_summary(
         state,
         traces,
         calibration_metrics,
         dataset_fallback_used=dataset_fallback_used,
         dataset_path_used=dataset_path_used,
+        companion_metrics=companion_metrics,
     )
     run_dir = config.artifact_root / config.experiment_id
     artifacts = write_artifacts(

--- a/scripts/evals/run_rag_release_gates.py
+++ b/scripts/evals/run_rag_release_gates.py
@@ -378,7 +378,16 @@ def _require_finite_metric(value: Any, *, label: str) -> float:
     return numeric
 
 
-def _load_companion_metrics(path: Path | None) -> dict[str, Any] | None:
+def _repo_relative_display_path(path: Path, *, project_root: Path) -> str:
+    """Return a stable repo-relative artifact path for emitted metadata."""
+
+    try:
+        return path.resolve().relative_to(project_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _load_companion_metrics(path: Path | None, *, project_root: Path) -> dict[str, Any] | None:
     """Load an optional companion RAGAS artifact for informational reporting."""
 
     if path is None:
@@ -423,12 +432,9 @@ def _load_companion_metrics(path: Path | None) -> dict[str, Any] | None:
         )
 
     normalized_metrics: dict[str, float] = {}
-    for raw_name, raw_value in metrics.items():
-        metric_name = str(raw_name).strip()
-        if not metric_name:
-            raise RuntimeError("Companion metrics JSON metric names must be non-empty")
+    for metric_name in ("faithfulness", "answer_relevancy", "context_precision"):
         metric_value = _require_finite_metric(
-            raw_value,
+            metrics[metric_name],
             label=f"companion metric '{metric_name}'",
         )
         if not 0.0 <= metric_value <= 1.0:
@@ -437,7 +443,7 @@ def _load_companion_metrics(path: Path | None) -> dict[str, Any] | None:
 
     return {
         "ragas": {
-            "source_path": str(path.resolve()),
+            "source_path": _repo_relative_display_path(path, project_root=project_root),
             "dataset_path": dataset_path,
             "sample_count": sample_count,
             "report_only": True,
@@ -2419,6 +2425,10 @@ async def async_main(args: argparse.Namespace) -> int:
     """Execute the release-gates run."""
 
     config = build_config(args)
+    companion_metrics = _load_companion_metrics(
+        config.companion_metrics_json,
+        project_root=config.project_root,
+    )
     imports = load_pulseplate_imports()
     state = EvalRuntimeState(config=config, pulseplate_imports=imports)
     rows, dataset_fallback_used, dataset_path_used = load_eval_input(
@@ -2429,7 +2439,6 @@ async def async_main(args: argparse.Namespace) -> int:
     )
     traces = await run_evaluation(state, rows)
     calibration_metrics = apply_calibration(traces)
-    companion_metrics = _load_companion_metrics(config.companion_metrics_json)
     metrics_summary, _, release_decision = build_metrics_summary(
         state,
         traces,

--- a/tests/test_rag_release_gates_runner.py
+++ b/tests/test_rag_release_gates_runner.py
@@ -490,6 +490,95 @@ def test_build_config_uses_companion_metrics_env_fallback(
     assert config.companion_metrics_json == companion_path.resolve()
 
 
+def test_build_config_accepts_companion_metrics_cli_path(tmp_path: Path) -> None:
+    """CLI wiring must propagate an explicit companion metrics artifact path."""
+
+    project_root = tmp_path / "repo"
+    artifact_root = project_root / "artifacts" / "rag_eval"
+    notebook_path = project_root / "notebooks" / "pulseplate_rag_release_gates.ipynb"
+    input_path = project_root / "input.jsonl"
+    companion_path = artifact_root / "manual" / "metrics_summary.json"
+
+    artifact_root.mkdir(parents=True)
+    notebook_path.parent.mkdir(parents=True)
+    input_path.write_text("", encoding="utf-8")
+    companion_path.parent.mkdir(parents=True, exist_ok=True)
+    companion_path.write_text("{}", encoding="utf-8")
+
+    args = argparse.Namespace(
+        project_root=str(project_root),
+        input_path=str(input_path),
+        artifact_root=str(artifact_root),
+        experiment_id="safe_run",
+        sample_size="5",
+        top_k="5",
+        random_seed="42",
+        retriever_mode="local_tfidf",
+        generator_mode="extractive_stub",
+        enable_nli_model=False,
+        nli_model_name="roberta-large-mnli",
+        notebook_path=str(notebook_path),
+        require_pass=False,
+        disallow_dataset_fallback=False,
+        disallow_runtime_fallbacks=False,
+        companion_metrics_json=str(companion_path),
+    )
+
+    config = build_config(args)
+
+    assert config.companion_metrics_json == companion_path.resolve()
+
+
+def test_build_config_prefers_cli_companion_metrics_over_env_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit CLI companion metrics input must win over the env fallback."""
+
+    project_root = tmp_path / "repo"
+    artifact_root = project_root / "artifacts" / "rag_eval"
+    notebook_path = project_root / "notebooks" / "pulseplate_rag_release_gates.ipynb"
+    input_path = project_root / "input.jsonl"
+    env_companion_path = artifact_root / "env" / "metrics_summary.json"
+    cli_companion_path = artifact_root / "cli" / "metrics_summary.json"
+
+    artifact_root.mkdir(parents=True)
+    notebook_path.parent.mkdir(parents=True)
+    input_path.write_text("", encoding="utf-8")
+    env_companion_path.parent.mkdir(parents=True, exist_ok=True)
+    cli_companion_path.parent.mkdir(parents=True, exist_ok=True)
+    env_companion_path.write_text("{}", encoding="utf-8")
+    cli_companion_path.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setenv(
+        "PULSEPLATE_RAG_COMPANION_METRICS_JSON",
+        str(env_companion_path),
+    )
+
+    args = argparse.Namespace(
+        project_root=str(project_root),
+        input_path=str(input_path),
+        artifact_root=str(artifact_root),
+        experiment_id="safe_run",
+        sample_size="5",
+        top_k="5",
+        random_seed="42",
+        retriever_mode="local_tfidf",
+        generator_mode="extractive_stub",
+        enable_nli_model=False,
+        nli_model_name="roberta-large-mnli",
+        notebook_path=str(notebook_path),
+        require_pass=False,
+        disallow_dataset_fallback=False,
+        disallow_runtime_fallbacks=False,
+        companion_metrics_json=str(cli_companion_path),
+    )
+
+    config = build_config(args)
+
+    assert config.companion_metrics_json == cli_companion_path.resolve()
+
+
 def test_build_config_rejects_off_family_companion_metrics_path(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1018,7 +1107,7 @@ def test_valid_companion_json_adds_informational_metrics_without_affecting_relea
         dataset_path_used=dataset_path,
     )
     companion_path = _write_companion_metrics(tmp_path)
-    companion_metrics = runner._load_companion_metrics(companion_path)
+    companion_metrics = runner._load_companion_metrics(companion_path, project_root=tmp_path)
 
     metrics_summary, gate_checks, release_decision = runner.build_metrics_summary(
         state,
@@ -1035,7 +1124,7 @@ def test_valid_companion_json_adds_informational_metrics_without_affecting_relea
     assert gate_checks == baseline_summary["gate_checks"]
     assert metrics_summary["companion_metrics"] == {
         "ragas": {
-            "source_path": str(companion_path.resolve()),
+            "source_path": "artifacts/rag_eval/manual/metrics_summary.json",
             "dataset_path": "evals/ragas/testset.jsonl",
             "sample_count": 16,
             "report_only": True,
@@ -1092,7 +1181,67 @@ def test_malformed_companion_metrics_fail_closed(
         companion_path.write_text(json.dumps(payload), encoding="utf-8")
 
     with pytest.raises((FileNotFoundError, RuntimeError), match=error_pattern):
-        runner._load_companion_metrics(companion_path)
+        runner._load_companion_metrics(companion_path, project_root=tmp_path)
+
+
+def test_companion_metrics_are_emitted_with_canonical_metric_order(tmp_path: Path) -> None:
+    """Companion metrics output must keep canonical metric ordering."""
+
+    payload = {
+        "dataset_path": "evals/ragas/testset.jsonl",
+        "sample_count": 16,
+        "report_only": True,
+        "metrics": {
+            "context_precision": 0.88,
+            "faithfulness": 0.84,
+            "answer_relevancy": 0.79,
+        },
+    }
+    companion_path = _write_companion_metrics(tmp_path, payload=payload)
+
+    companion_metrics = runner._load_companion_metrics(companion_path, project_root=tmp_path)
+
+    assert list(companion_metrics["ragas"]["metrics"]) == [
+        "faithfulness",
+        "answer_relevancy",
+        "context_precision",
+    ]
+
+
+def test_async_main_fails_fast_on_malformed_companion_metrics_before_evaluation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Broken companion artifacts must abort before the expensive evaluation loop starts."""
+
+    project_root = tmp_path / "repo"
+    artifact_root = project_root / "artifacts" / "rag_eval"
+    companion_path = artifact_root / "manual" / "metrics_summary.json"
+    project_root.mkdir()
+    artifact_root.mkdir(parents=True)
+    companion_path.parent.mkdir(parents=True, exist_ok=True)
+    companion_path.write_text("{not-json", encoding="utf-8")
+
+    run_evaluation_mock = AsyncMock()
+    monkeypatch.setattr(runner, "run_evaluation", run_evaluation_mock)
+
+    with pytest.raises(RuntimeError, match="Companion metrics JSON is invalid"):
+        runner.main(
+            [
+                "--project-root",
+                str(project_root),
+                "--input-path",
+                str(project_root / "input.jsonl"),
+                "--artifact-root",
+                str(artifact_root),
+                "--experiment-id",
+                "invalid_companion",
+                "--companion-metrics-json",
+                str(companion_path),
+            ]
+        )
+
+    run_evaluation_mock.assert_not_awaited()
 
 
 def test_threshold_results_ordering_and_escalation_corridor_are_deterministic(
@@ -1142,7 +1291,10 @@ def test_step_summary_includes_threshold_results_and_optional_companion_metrics(
     summary_path = tmp_path / "github_step_summary.md"
     monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
     state = _make_release_gate_state(tmp_path, experiment_id="step_summary")
-    companion_metrics = runner._load_companion_metrics(_write_companion_metrics(tmp_path))
+    companion_metrics = runner._load_companion_metrics(
+        _write_companion_metrics(tmp_path),
+        project_root=tmp_path,
+    )
     metrics_summary, _, _ = runner.build_metrics_summary(
         state,
         _passing_release_gate_traces(),

--- a/tests/test_rag_release_gates_runner.py
+++ b/tests/test_rag_release_gates_runner.py
@@ -490,6 +490,52 @@ def test_build_config_uses_companion_metrics_env_fallback(
     assert config.companion_metrics_json == companion_path.resolve()
 
 
+def test_build_config_rejects_off_family_companion_metrics_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Companion artifact paths must stay inside the canonical rag_eval family."""
+
+    project_root = tmp_path / "repo"
+    artifact_root = project_root / "artifacts" / "rag_eval"
+    notebook_path = project_root / "notebooks" / "pulseplate_rag_release_gates.ipynb"
+    input_path = project_root / "input.jsonl"
+    companion_path = project_root / "artifacts" / "tmp" / "metrics_summary.json"
+
+    artifact_root.mkdir(parents=True)
+    notebook_path.parent.mkdir(parents=True)
+    input_path.write_text("", encoding="utf-8")
+    companion_path.parent.mkdir(parents=True, exist_ok=True)
+    companion_path.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setenv(
+        "PULSEPLATE_RAG_COMPANION_METRICS_JSON",
+        str(companion_path),
+    )
+
+    args = argparse.Namespace(
+        project_root=str(project_root),
+        input_path=str(input_path),
+        artifact_root=str(artifact_root),
+        experiment_id="safe_run",
+        sample_size="5",
+        top_k="5",
+        random_seed="42",
+        retriever_mode="local_tfidf",
+        generator_mode="extractive_stub",
+        enable_nli_model=False,
+        nli_model_name="roberta-large-mnli",
+        notebook_path=str(notebook_path),
+        require_pass=False,
+        disallow_dataset_fallback=False,
+        disallow_runtime_fallbacks=False,
+        companion_metrics_json=None,
+    )
+
+    with pytest.raises(ValueError, match="companion_metrics_json"):
+        build_config(args)
+
+
 @pytest.mark.parametrize(
     ("field_name", "field_value"),
     [

--- a/tests/test_rag_release_gates_runner.py
+++ b/tests/test_rag_release_gates_runner.py
@@ -63,6 +63,108 @@ def _config(tmp_path: Path, *, enable_nli_model: bool = False) -> EvalConfig:
     )
 
 
+def _make_release_gate_state(
+    tmp_path: Path,
+    *,
+    experiment_id: str = "test_run",
+    allow_runtime_fallbacks: bool = True,
+) -> EvalRuntimeState:
+    """Build a minimal runtime state for release-gate summary tests."""
+
+    config = _config(tmp_path)
+    config = EvalConfig(
+        **{
+            **config.__dict__,
+            "experiment_id": experiment_id,
+            "allow_runtime_fallbacks": allow_runtime_fallbacks,
+        }
+    )
+    return EvalRuntimeState(config=config, pulseplate_imports=PulsePlateImports())
+
+
+def _make_trace(
+    query_id: str,
+    *,
+    routing_decision: str = "ship_candidate",
+    recall_at_effective_k: float = 0.9,
+    evidence_exact_match: bool = True,
+    mean_nli_entailment: float = 0.9,
+    support_precision: float = 0.9,
+) -> dict[str, object]:
+    """Build a deterministic trace row for summary-only tests."""
+
+    return {
+        "trace_id": f"trace-{query_id}",
+        "timestamp": "2026-04-22T00:00:00+00:00",
+        "experiment_id": "test_run",
+        "query_id": query_id,
+        "query_text": f"Query {query_id}",
+        "top_k_retrieved": [{"doc_id": "docs/tiers.md", "source_url": "docs/tiers.md"}],
+        "retrieval_metrics": {
+            "recall_at_3": recall_at_effective_k,
+            "recall_at_10": recall_at_effective_k,
+            "recall_at_50": recall_at_effective_k,
+            "recall_at_effective_k": recall_at_effective_k,
+            "mrr_at_10": recall_at_effective_k,
+            "ndcg_at_10": recall_at_effective_k,
+        },
+        "faithfulness_metrics": {
+            "evidence_exact_match": evidence_exact_match,
+            "mean_nli_entailment": mean_nli_entailment,
+            "support_precision": support_precision,
+        },
+        "confidence": 0.9,
+        "post_hoc_calibrated_confidence": 0.9,
+        "routing_decision": routing_decision,
+        "latency": 1,
+        "human_label_if_any": 1,
+        "philosophy_output_validation": {"ok": True},
+    }
+
+
+def _passing_release_gate_traces() -> list[dict[str, object]]:
+    """Return traces that satisfy the current canonical gates."""
+
+    return [
+        _make_trace("q1", routing_decision="ship_candidate"),
+        _make_trace("q2", routing_decision="ship_candidate"),
+        _make_trace("q3", routing_decision="ship_candidate"),
+        _make_trace("q4", routing_decision="escalate"),
+    ]
+
+
+def _companion_metrics_payload() -> dict[str, object]:
+    """Return a valid companion RAGAS metrics payload."""
+
+    return {
+        "dataset_path": "evals/ragas/testset.jsonl",
+        "sample_count": 16,
+        "report_only": True,
+        "metrics": {
+            "faithfulness": 0.84,
+            "answer_relevancy": 0.79,
+            "context_precision": 0.88,
+        },
+    }
+
+
+def _write_companion_metrics(
+    tmp_path: Path,
+    payload: dict[str, object] | None = None,
+    *,
+    relative_path: str = "artifacts/rag_eval/manual/metrics_summary.json",
+) -> Path:
+    """Write a companion metrics JSON artifact under the canonical artifact root."""
+
+    companion_path = tmp_path / relative_path
+    companion_path.parent.mkdir(parents=True, exist_ok=True)
+    companion_path.write_text(
+        json.dumps(payload or _companion_metrics_payload()),
+        encoding="utf-8",
+    )
+    return companion_path
+
+
 def test_runner_contract_imports_are_available() -> None:
     """The runner must point at the real repo hooks, not ad-hoc shims."""
 
@@ -784,3 +886,196 @@ def test_notebook_parity_uses_emitted_artifact_from_template(tmp_path: Path) -> 
     assert "::chunk_" not in emitted_text
     assert "recall@50" not in emitted_text
     assert "mean_entailment" not in emitted_text
+
+
+def test_no_companion_json_keeps_legacy_release_decision_behavior(tmp_path: Path) -> None:
+    """Missing companion input must preserve legacy release-gate behavior."""
+
+    state = _make_release_gate_state(tmp_path, experiment_id="legacy_no_companion")
+    traces = _passing_release_gate_traces()
+
+    baseline_summary, gate_checks, release_decision = runner.build_metrics_summary(
+        state,
+        traces,
+        {"ece": 0.05},
+        dataset_fallback_used=False,
+        dataset_path_used="data/evals/pulseplate_rag_eval_sample.jsonl",
+    )
+
+    assert release_decision == "PASS"
+    assert all(gate_checks.values()) is True
+    assert "companion_metrics" not in baseline_summary
+
+
+def test_valid_companion_json_adds_informational_metrics_without_affecting_release_decision(
+    tmp_path: Path,
+) -> None:
+    """Valid companion metrics must stay informational and keep gate outcomes unchanged."""
+
+    state = _make_release_gate_state(tmp_path, experiment_id="with_companion")
+    traces = _passing_release_gate_traces()
+    dataset_path = "data/evals/pulseplate_rag_eval_sample.jsonl"
+    calibration_metrics = {"ece": 0.05}
+
+    baseline_summary, _, baseline_release_decision = runner.build_metrics_summary(
+        state,
+        traces,
+        calibration_metrics,
+        dataset_fallback_used=False,
+        dataset_path_used=dataset_path,
+    )
+    companion_path = _write_companion_metrics(tmp_path)
+    companion_metrics = runner._load_companion_metrics(companion_path)
+
+    metrics_summary, gate_checks, release_decision = runner.build_metrics_summary(
+        state,
+        traces,
+        calibration_metrics,
+        dataset_fallback_used=False,
+        dataset_path_used=dataset_path,
+        companion_metrics=companion_metrics,
+    )
+    gate_report = runner.build_gate_report_markdown(metrics_summary)
+
+    assert baseline_release_decision == "PASS"
+    assert release_decision == baseline_release_decision
+    assert gate_checks == baseline_summary["gate_checks"]
+    assert metrics_summary["companion_metrics"] == {
+        "ragas": {
+            "source_path": str(companion_path.resolve()),
+            "dataset_path": "evals/ragas/testset.jsonl",
+            "sample_count": 16,
+            "report_only": True,
+            "metrics": {
+                "faithfulness": 0.84,
+                "answer_relevancy": 0.79,
+                "context_precision": 0.88,
+            },
+        }
+    }
+    assert "## Companion RAGAS metrics" in gate_report
+    assert "`faithfulness` | `0.84`" in gate_report
+    assert "`answer_relevancy` | `0.79`" in gate_report
+    assert "`context_precision` | `0.88`" in gate_report
+
+
+@pytest.mark.parametrize(
+    ("payload", "error_pattern"),
+    [
+        (None, "Companion metrics JSON not found"),
+        (
+            {
+                "dataset_path": "evals/ragas/testset.jsonl",
+                "sample_count": 16,
+                "report_only": True,
+            },
+            "must contain exactly: dataset_path, sample_count, report_only, metrics",
+        ),
+        (
+            {
+                "dataset_path": "evals/ragas/testset.jsonl",
+                "sample_count": 16,
+                "report_only": True,
+                "metrics": {
+                    "faithfulness": 0.84,
+                    "answer_relevancy": float("nan"),
+                    "context_precision": 0.88,
+                },
+            },
+            "must be finite",
+        ),
+    ],
+)
+def test_malformed_companion_metrics_fail_closed(
+    tmp_path: Path,
+    payload: dict[str, object] | None,
+    error_pattern: str,
+) -> None:
+    """Malformed companion artifacts must fail closed at the runner boundary."""
+
+    companion_path = tmp_path / "artifacts" / "rag_eval" / "manual" / "metrics_summary.json"
+    if payload is not None:
+        companion_path.parent.mkdir(parents=True, exist_ok=True)
+        companion_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises((FileNotFoundError, RuntimeError), match=error_pattern):
+        runner._load_companion_metrics(companion_path)
+
+
+def test_threshold_results_ordering_and_escalation_corridor_are_deterministic(
+    tmp_path: Path,
+) -> None:
+    """Threshold rows must keep canonical order and stable corridor serialization."""
+
+    state = _make_release_gate_state(tmp_path, experiment_id="threshold_ordering")
+    metrics_summary, _, release_decision = runner.build_metrics_summary(
+        state,
+        _passing_release_gate_traces(),
+        {"ece": 0.05},
+        dataset_fallback_used=False,
+        dataset_path_used="data/evals/pulseplate_rag_eval_sample.jsonl",
+    )
+    threshold_results = metrics_summary["threshold_results"]
+    gate_report = runner.build_gate_report_markdown(metrics_summary)
+
+    assert release_decision == "PASS"
+    assert [row["gate_id"] for row in threshold_results] == [
+        "gate_a_recall_at_effective_k",
+        "gate_b1_evidence_exact_match",
+        "gate_b2_mean_nli_entailment",
+        "gate_b3_support_precision",
+        "gate_c1_ece",
+        "gate_c2_escalation_corridor",
+        "gate_d1_no_runtime_mode_fallbacks",
+    ]
+    assert threshold_results[5] == {
+        "gate_id": "gate_c2_escalation_corridor",
+        "metric_key": "escalation_rate",
+        "threshold_key": "escalation_corridor",
+        "value": 0.25,
+        "target": {"min": 0.1, "max": 0.25},
+        "comparison": "between_inclusive",
+        "passed": True,
+    }
+    assert "`gate_c2_escalation_corridor` | `escalation_rate` | `0.25` | `0.1..0.25`" in gate_report
+
+
+def test_step_summary_includes_threshold_results_and_optional_companion_metrics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GitHub step summary must include threshold rows and optional companion metrics."""
+
+    summary_path = tmp_path / "github_step_summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
+    state = _make_release_gate_state(tmp_path, experiment_id="step_summary")
+    companion_metrics = runner._load_companion_metrics(_write_companion_metrics(tmp_path))
+    metrics_summary, _, _ = runner.build_metrics_summary(
+        state,
+        _passing_release_gate_traces(),
+        {"ece": 0.05},
+        dataset_fallback_used=False,
+        dataset_path_used="data/evals/pulseplate_rag_eval_sample.jsonl",
+        companion_metrics=companion_metrics,
+    )
+
+    runner._write_github_step_summary(
+        metrics_summary,
+        {
+            "gate_report": "artifacts/rag_eval/step_summary/gate_report.md",
+            "metrics_summary": "artifacts/rag_eval/step_summary/metrics_summary.json",
+            "traces_jsonl": "artifacts/rag_eval/step_summary/traces.jsonl",
+        },
+    )
+    summary_text = summary_path.read_text(encoding="utf-8")
+
+    assert "## PulsePlate RAG Release Gates" in summary_text
+    assert "### Threshold results" in summary_text
+    assert (
+        "`gate_c2_escalation_corridor` | `0.25` | `0.1..0.25` | `between_inclusive` | `True`"
+        in summary_text
+    )
+    assert "### Companion RAGAS metrics" in summary_text
+    assert "- `faithfulness`: `0.84`" in summary_text
+    assert "- `answer_relevancy`: `0.79`" in summary_text
+    assert "- `context_precision`: `0.88`" in summary_text

--- a/tests/test_rag_release_gates_runner.py
+++ b/tests/test_rag_release_gates_runner.py
@@ -443,6 +443,53 @@ def test_build_config_rejects_paths_outside_project_root(tmp_path: Path) -> None
         build_config(args)
 
 
+def test_build_config_uses_companion_metrics_env_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Companion artifact path may come from the canonical env fallback."""
+
+    project_root = tmp_path / "repo"
+    artifact_root = project_root / "artifacts" / "rag_eval"
+    notebook_path = project_root / "notebooks" / "pulseplate_rag_release_gates.ipynb"
+    input_path = project_root / "input.jsonl"
+    companion_path = artifact_root / "manual" / "metrics_summary.json"
+
+    artifact_root.mkdir(parents=True)
+    notebook_path.parent.mkdir(parents=True)
+    input_path.write_text("", encoding="utf-8")
+    companion_path.parent.mkdir(parents=True, exist_ok=True)
+    companion_path.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setenv(
+        "PULSEPLATE_RAG_COMPANION_METRICS_JSON",
+        str(companion_path),
+    )
+
+    args = argparse.Namespace(
+        project_root=str(project_root),
+        input_path=str(input_path),
+        artifact_root=str(artifact_root),
+        experiment_id="safe_run",
+        sample_size="5",
+        top_k="5",
+        random_seed="42",
+        retriever_mode="local_tfidf",
+        generator_mode="extractive_stub",
+        enable_nli_model=False,
+        nli_model_name="roberta-large-mnli",
+        notebook_path=str(notebook_path),
+        require_pass=False,
+        disallow_dataset_fallback=False,
+        disallow_runtime_fallbacks=False,
+        companion_metrics_json=None,
+    )
+
+    config = build_config(args)
+
+    assert config.companion_metrics_json == companion_path.resolve()
+
+
 @pytest.mark.parametrize(
     ("field_name", "field_value"),
     [


### PR DESCRIPTION
## Summary

Add a narrow follow-up for the canonical PulsePlate RAG release-gates lane.

This PR improves canonical threshold/result reporting in `scripts/evals/run_rag_release_gates.py` and adds an optional companion RAGAS artifact adapter for informational reporting only.

It does not create a second evaluation rail and does not change runtime request-path behavior.

## Why

The canonical internal evaluation lane already lives in `docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md` with threshold vocabulary, artifact ownership, and weekly/manual strict gate semantics.

The companion `evals/ragas/*` lane from `PR #1489` is intentionally report-only and local-first. What was missing is a safe bridge that lets the canonical release-gates runner surface companion RAGAS metrics informationally while preserving existing threshold ownership and release decision semantics.

## Coordinator Start

This lane was started coordinator-first from a clean synced `main` with the required preflight:

- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- isolated worktree: `worktrees/rag-release-gates-threshold-reporting`
- coordinator packet: `artifacts/orchestration/task_packets/rag-release-gates-threshold-reporting-preopen.json`
- committed lane packet: `docs/orchestration/PULSEPLATE_RAG_RELEASE_GATES_THRESHOLD_REPORTING_TASK_PACKET_2026-04-22.md`

## Role Order

Pre-open coordinator-owned role order:
- `agent-coordinator`
- `architecture-specialist`
- `data-scientist-agent`
- `ai-innovation-specialist`
- `backend-engineer`

Mandatory post-open review lane:
- `qa-engineer-agent`
- `bug-hunter`

`security-auditor` stays out of this PR unless scope drifts into privileged surfaces.

## Skills And Plugins

Required skill routing for this lane:
- `pulseplate-workflow`
- `docs-sync`
- `pulseplate-gates`

Recommended support skills:
- `agents-md`
- `bug-triage`
- `code-review-expert`

Plugin use for this PR:
- `GitHub` for live PR/check/review truth
- `CodeRabbit` for post-open review truth

Explicitly out of scope for this lane: `Computer Use`, `Linear`, `Hugging Face`, `Life Science Research`, `Netlify`, `Cloudflare`, `Sentry`, `build-ios-apps`, `build-macos-apps`, `build-web-apps`, `Expo`.

## Scope

### In scope
- `scripts/evals/run_rag_release_gates.py`
- `tests/test_rag_release_gates_runner.py`
- `docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md`
- `docs/evals/RAGAS_SETUP.md`
- `docs/orchestration/PULSEPLATE_RAG_RELEASE_GATES_THRESHOLD_REPORTING_TASK_PACKET_2026-04-22.md`

### Out of scope
- `app/**`
- `core/**`
- `llm.py`
- runtime requirements
- CI `ragas` execution
- GraphRAG runtime changes
- semantic cache widening
- provider behavior changes
- request-path DTO/OpenAPI changes

## What Changed

- added deterministic `threshold_results` rows to canonical release-gates summaries
- added optional `--companion-metrics-json` / `PULSEPLATE_RAG_COMPANION_METRICS_JSON`
- fail-closed companion JSON validation for malformed, missing, or non-finite metrics
- surfaced threshold tables in `gate_report.md` and `GITHUB_STEP_SUMMARY`
- surfaced companion RAGAS metrics as informational only when a valid artifact is provided
- documented that release-gates remains the canonical threshold owner and the companion lane remains subordinate/report-only

## Validation

Local validation on this lane:
- `pytest -q tests/test_rag_release_gates_runner.py`
- `pre-commit run --all-files`
- `make verify`

Manual composition smoke:
- validated canonical runner with a synthetic companion artifact under `artifacts/rag_eval/ragas_bootstrap_manual/metrics_summary.json`
- confirmed companion metrics appear in report outputs without changing canonical gate ownership or release decision

## Risks

- malformed companion artifacts widening failure surface at the canonical runner boundary
- accidental wording drift that could imply a second canonical eval rail
- accidental future coupling between companion metrics and canonical PASS/NO-GO semantics

## Deferred / Follow-ups

Continuity stays under `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-rag-release-gates-lane`.

Deferred after this PR:
- selective GraphRAG docs/ADR lane only
- no runtime GraphRAG implementation in this PR
- no CI-side direct `ragas` execution in this PR

## Split Justification

This lane is intentionally narrow but cannot be split safely below the current diff size because the code, docs, packet, tests, PR-body mirror, and mapping artifact all express one governed contract change:
- the canonical release-gates runner gains deterministic threshold reporting
- the runner accepts an optional companion RAGAS artifact adapter
- the adapter must remain informational only and fail closed
- the canonical docs and review-governance artifacts must stay synchronized with that exact contract

Splitting these pieces across multiple PRs would create temporary drift between runner behavior, tests, docs, and phase2 governance for the same lane.

Follow-up PRs after this lane remain separate:
- selective GraphRAG docs/ADR lane only
- no runtime GraphRAG implementation here
- no CI-side direct `ragas` execution here

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed


### Fixed in Commit Mapping

- Canonical artifact: `docs/review/PR_<N>_FIXED_MAPPING.md`
- Dispositions will be recorded there before any thread resolution or merge-ready claim

## Merge Readiness

- [ ] `pre-commit run --all-files`
- [ ] `make verify`
- [ ] required current-head checks are PASS
- [ ] no pending required jobs remain
- [ ] mandatory wait-window completed

## Summary by Sourcery

Улучшен канонический раннер `PulsePlate RAG` для release-gates за счёт детерминированной отчётности по порогам и необязательного, только-информационного моста к сопутствующим метрикам RAGAS, без изменения семантики гейтов или поведения во время выполнения.

Новые возможности:
- Экспорт детерминированных строк с результатами по порогам в сводки метрик, markdown-отчёты гейтов и GitHub step summaries для lane `release-gates`.
- Поддержка необязательного JSON-артефакта с сопутствующими метриками RAGAS через флаг CLI или переменную окружения для информационной отчётности в отчётах гейтов и CI-сводках.

Улучшения:
- Строгая валидация артефактов сопутствующих метрик (схема, семейство путей, конечные значения оценок в диапазоне 0–1) и fail-closed поведение при некорректном вводе при сохранении неизменной канонической логики гейтов.
- Расширение конфигурации `release-gates` для отслеживания необязательного пути к артефакту сопутствующих метрик, разрешаемого в рамках канонического семейства артефактов `rag_eval`.
- Добавление оркестрационных и review-governance пакетов, документирующих follow-up lane по отчётности порогов и контракт для сопутствующих метрик.

Документация:
- Обновление документации по настройке `release-gates` и RAGAS с описанием детерминированной отчётности по порогам, моста к сопутствующему артефакту и сохранения канонического владения порогами и решениями о релизе, включая примечание о том, что работа по GraphRAG остаётся отложенной.

Тесты:
- Расширение тестов раннера `release-gates` для покрытия конфигурации сопутствующих метрик через env/CLI, применения семейства путей, fail-closed поведения для некорректных артефактов, детерминированного порядка и сериализации порогов, а также включения секций о порогах и сопутствующих метриках в markdown и GitHub step summaries.

Прочее:
- Добавление документа с сопоставлением `fixed-in-commit` для PR #1493 для отслеживания решений по review и проверок готовности к слиянию для follow-up по отчётности порогов в `release-gates`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the canonical PulsePlate RAG release-gates runner with deterministic threshold reporting and an optional, informational-only bridge to companion RAGAS metrics, without changing gate semantics or runtime behavior.

New Features:
- Expose deterministic threshold result rows in metrics summaries, markdown gate reports, and GitHub step summaries for the release-gates lane.
- Accept an optional companion RAGAS metrics JSON artifact via CLI flag or environment variable for informational reporting in gate reports and CI summaries.

Enhancements:
- Validate companion metrics artifacts strictly (schema, path family, finite 0–1 scores) and fail closed on malformed input while keeping canonical gate logic unchanged.
- Extend the release-gates configuration to track an optional companion metrics artifact path resolved under the canonical rag_eval artifact family.
- Add orchestration and review-governance packets documenting the threshold reporting follow-up lane and companion metrics contract.

Documentation:
- Update release-gates and RAGAS setup docs to describe deterministic threshold reporting, the companion artifact bridge, and the continued canonical ownership of thresholds and release decisions, including a note that GraphRAG work remains deferred.

Tests:
- Expand release-gates runner tests to cover companion metrics env/CLI config, path-family enforcement, fail-closed behavior for malformed artifacts, deterministic threshold ordering and serialization, and inclusion of threshold and companion sections in markdown and GitHub step summaries.

Chores:
- Add a fixed-in-commit mapping document for PR #1493 to track review dispositions and merge-readiness checks for the release-gates threshold reporting follow-up.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Улучшен канонический раннер `PulsePlate RAG` для release-gates за счёт детерминированной отчётности по порогам и необязательного, только-информационного моста к сопутствующим метрикам RAGAS, без изменения семантики гейтов или поведения во время выполнения.

Новые возможности:
- Экспорт детерминированных строк с результатами по порогам в сводки метрик, markdown-отчёты гейтов и GitHub step summaries для lane `release-gates`.
- Поддержка необязательного JSON-артефакта с сопутствующими метриками RAGAS через флаг CLI или переменную окружения для информационной отчётности в отчётах гейтов и CI-сводках.

Улучшения:
- Строгая валидация артефактов сопутствующих метрик (схема, семейство путей, конечные значения оценок в диапазоне 0–1) и fail-closed поведение при некорректном вводе при сохранении неизменной канонической логики гейтов.
- Расширение конфигурации `release-gates` для отслеживания необязательного пути к артефакту сопутствующих метрик, разрешаемого в рамках канонического семейства артефактов `rag_eval`.
- Добавление оркестрационных и review-governance пакетов, документирующих follow-up lane по отчётности порогов и контракт для сопутствующих метрик.

Документация:
- Обновление документации по настройке `release-gates` и RAGAS с описанием детерминированной отчётности по порогам, моста к сопутствующему артефакту и сохранения канонического владения порогами и решениями о релизе, включая примечание о том, что работа по GraphRAG остаётся отложенной.

Тесты:
- Расширение тестов раннера `release-gates` для покрытия конфигурации сопутствующих метрик через env/CLI, применения семейства путей, fail-closed поведения для некорректных артефактов, детерминированного порядка и сериализации порогов, а также включения секций о порогах и сопутствующих метриках в markdown и GitHub step summaries.

Прочее:
- Добавление документа с сопоставлением `fixed-in-commit` для PR #1493 для отслеживания решений по review и проверок готовности к слиянию для follow-up по отчётности порогов в `release-gates`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the canonical PulsePlate RAG release-gates runner with deterministic threshold reporting and an optional, informational-only bridge to companion RAGAS metrics, without changing gate semantics or runtime behavior.

New Features:
- Expose deterministic threshold result rows in metrics summaries, markdown gate reports, and GitHub step summaries for the release-gates lane.
- Accept an optional companion RAGAS metrics JSON artifact via CLI flag or environment variable for informational reporting in gate reports and CI summaries.

Enhancements:
- Validate companion metrics artifacts strictly (schema, path family, finite 0–1 scores) and fail closed on malformed input while keeping canonical gate logic unchanged.
- Extend the release-gates configuration to track an optional companion metrics artifact path resolved under the canonical rag_eval artifact family.
- Add orchestration and review-governance packets documenting the threshold reporting follow-up lane and companion metrics contract.

Documentation:
- Update release-gates and RAGAS setup docs to describe deterministic threshold reporting, the companion artifact bridge, and the continued canonical ownership of thresholds and release decisions, including a note that GraphRAG work remains deferred.

Tests:
- Expand release-gates runner tests to cover companion metrics env/CLI config, path-family enforcement, fail-closed behavior for malformed artifacts, deterministic threshold ordering and serialization, and inclusion of threshold and companion sections in markdown and GitHub step summaries.

Chores:
- Add a fixed-in-commit mapping document for PR #1493 to track review dispositions and merge-readiness checks for the release-gates threshold reporting follow-up.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deterministic threshold reporting to the canonical RAG release‑gates runner and an optional, report‑only bridge to companion RAGAS metrics. Gate semantics and runtime behavior are unchanged.

- **New Features**
  - Emit `threshold_results` in the metrics summary and render them in `gate_report.md` and the GitHub step summary with deterministic ordering.
  - Accept an optional companion metrics JSON via `--companion-metrics-json` or `PULSEPLATE_RAG_COMPANION_METRICS_JSON`; enforce exact schema and finite 0–1 scores, restrict paths to `artifacts/rag_eval/**`, fail fast before evaluation, prefer CLI over env, and render as informational only with repo‑relative paths and canonical metric order.

- **Docs & Tests**
  - Document the companion bridge and local-only composition; clarify weekly/manual strict lane with `--require-pass`; tighten `support_precision` to 0.80; add the follow‑up packet; add `docs/review/PR_1493_FIXED_MAPPING.md` recording Sourcery/CodeRabbit review‑shell dispositions and fixed mappings.
  - Add tests for legacy behavior without companion input; CLI precedence over env; off‑family path rejection; fail‑fast on invalid JSON and non‑finite values; deterministic threshold ordering and corridor formatting; GitHub step summary threshold rows and the optional companion block; repo‑relative source path and canonical metric order.

<sup>Written for commit 30f8b3aee2deeae5182a6318371baa2c9edd1b44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  - Added orchestration/task-packet, review-governance doc, and expanded RAG setup and release-gates guidance clarifying companion-metrics are informational, CI lane semantics, and validation/verification steps.

* **New Features**
  - Optional companion-metrics JSON input for informational reporting only (does not change gate outcomes).
  - CI/markdown now include deterministic threshold_results.
  - Increased support precision threshold from 0.70 to 0.80.

* **Tests**
  - Added tests for companion-metrics handling, fail-closed validation, and stable threshold-reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->