### PR TITLE
fix(ci): stabilize main 3.12 xdist worker pressure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1089,14 +1089,18 @@ jobs:
           # IMPORTANT: main branch must maintain 97% coverage per project standards
           # See .cursorrules and AGENTS.md
           #
-          # CI stability: Python 3.13 has seen intermittent segfaults under xdist+coverage.
-          # Run sequentially on 3.13; keep parallelism for older versions.
+          # CI stability: Python 3.12 has shown repeated xdist worker termination on the
+          # full main-branch suite, while Python 3.13 has seen intermittent segfaults under
+          # xdist+coverage. Keep the fallback scoped to unstable main-only interpreters.
           # Intentionally removed `--cov-context=test` due to flaky coverage DB corruption under xdist
           # on Python 3.13 ("no such table: context"). Revisit after pytest/hypothesis upgrades.
           PYVER="${MATRIX_PYTHON_VERSION}"
           if [[ "$PYVER" == 3.13* ]]; then
             # Fully disable xdist plugin on 3.13 (more stable than `-n 0`)
             PYTEST_XDIST_ARGS=(-p no:xdist)
+          elif [[ "$PYVER" == 3.12* ]]; then
+            # Keep xdist for 3.12, but reduce worker pressure on the full main-branch suite.
+            PYTEST_XDIST_ARGS=(-n 2 --dist=loadscope)
           else
             PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)
           fi

--- a/docs/orchestration/MAINLINE_CI_XDIST_WORKER_STABILITY_PACKET_2026-04-22.md
+++ b/docs/orchestration/MAINLINE_CI_XDIST_WORKER_STABILITY_PACKET_2026-04-22.md
@@ -1,0 +1,133 @@
+# Mainline CI Xdist Worker Stability Packet
+
+## Goal
+
+Bring a new remediation PR to current-head draft readiness under
+coordinator-owned orchestration by narrowing the repeated
+`[gw1] node down: Not properly terminated` instability on the full
+`main`-branch `CI` matrix without reopening unrelated nightly or Node 22
+surfaces.
+
+## Current Truth
+
+- Base branch: `main`
+- Synced lane start:
+  - `git status --short --branch` -> clean
+  - `git rev-list --left-right --count HEAD...origin/main` -> `0 0`
+- Active remediation branch: `codex/fix-ci-xdist-worker-stability`
+- User-reported stable failure signature:
+  - `"[gw1] node down: Not properly terminated"`
+  - observed around `54%`-`57%` during the full pytest progress stream
+- Live `main` evidence gathered on `22 April 2026`:
+  - `CI` run `24771474555`
+    - `test-main (3.11, 60)` job `72483386535` succeeded in `7m29s`
+    - `test-main (3.12, 60)` job `72483372336` remained inside
+      `Run tests with coverage` from `10:14:43Z` until run cancellation at
+      `10:38:21Z`
+    - `test-main (3.13, 90)` job `72483372298` remained inside the same step
+      until the run cancellation; that path is already sequential by policy
+  - `Nightly Full Tests` run `24760590280` completed `success`, so nightly is
+    not the default target for this lane
+- Current-head nuance:
+  - exact historical GitHub run URL carrying the retained `gw1 node down`
+    string was not recoverable from available run history at lane start
+  - the lane therefore treats the user-reported signature plus the stalled
+    `main` 3.12 job as the narrow live repro anchor until branch/current-head
+    evidence supersedes it
+
+## Mandatory Role Order
+
+1. `agent-coordinator`
+2. `dev-operator`
+3. `architecture-specialist`
+4. `backend-engineer`
+5. `security-auditor`
+6. `qa-engineer-agent`
+7. `bug-hunter`
+8. `agent-coordinator`
+
+Rules:
+
+- This role order is mandatory for the lane.
+- The canonical post-open review pass remains
+  `qa-engineer-agent -> bug-hunter`.
+- No ad hoc parallel role stack may replace this order.
+- `dev-operator` gathers GitHub Actions and local parity evidence; it does not
+  replace reviewers.
+
+## Scope Lock
+
+### In Scope
+
+- `test-main` interpreter-specific execution policy inside
+  `.github/workflows/ci.yml`
+- A narrow workflow contract test that freezes the scoped fallback
+- Coordinator packet / review artifact / backlog alignment for this lane
+- Branch/current-head evidence proving the former unstable `3.12` full-suite
+  path no longer stalls or crashes
+
+### Out of Scope
+
+- `Nightly Full Tests`, Node 22 parity, or release-gate selector work
+- `test-pr`, `test-feature`, `coverage-*`, job IDs, or required-check topology
+- Product runtime behavior, public APIs, iOS, frontend, Docker, Cloudflare,
+  Hugging Face, or Life Science Research surfaces
+- Broad repo-wide test cleanup beyond what is needed to stabilize the affected
+  `test-main` interpreter path
+
+## Expected Touched Surfaces
+
+- `.github/workflows/ci.yml`
+- `tests/test_ci_workflow_pr_size_governance_contract.py`
+- `docs/orchestration/MAINLINE_CI_XDIST_WORKER_STABILITY_PACKET_2026-04-22.md`
+- `docs/roadmap/BACKLOG_LEDGER.md`
+- `docs/review/PR_<NEW_PR_NUMBER>_FIXED_MAPPING.md`
+
+## Coordinator Decision
+
+- Start with the smallest fallback boundary: keep `3.11` unchanged, keep `3.13`
+  on its existing sequential contract, and reduce `3.12` from `-n 4` to
+  `-n 2` while preserving `--dist=loadscope`.
+- Full `3.12` sequential mode is an allowed second-step escalation only if the
+  new branch/current-head evidence still reproduces the worker instability after
+  the narrowed `-n 2` fallback.
+- The old nightly/node22 backlog item must not be reused as substitute proof
+  for this lane.
+
+## Acceptance Criteria
+
+- `test-main` keeps its existing job identity and required-check topology
+- `.github/workflows/ci.yml` scopes the new fallback to `test-main` `3.12`
+  only, while preserving the existing `3.13` sequential branch
+- A regression test freezes the `3.12 -> -n 2` / `3.13 -> no xdist` contract
+- Targeted local workflow contract tests pass
+- `pre-commit run --all-files` passes before push
+- `make validate-changed` passes before push
+- Branch/current-head `CI` completes without `gw1 node down` or a stalled
+  `3.12` full-suite worker path
+- Post-open `qa-engineer-agent -> bug-hunter` review pass is completed
+
+## Validation Baseline
+
+```bash
+python3 scripts/orchestration/check_preflight.py \
+  --path .github/workflows/ci.yml \
+  --path tests/test_ci_workflow_pr_size_governance_contract.py \
+  --path docs/orchestration \
+  --path docs/roadmap/BACKLOG_LEDGER.md
+python3 scripts/orchestration/check_agent_consistency.py
+./.venv/bin/pytest -q \
+  tests/test_ci_workflow_pr_size_governance_contract.py \
+  tests/test_python_supply_chain_controls.py \
+  tests/test_current_head_pr_checks.py
+pre-commit run --all-files
+make validate-changed
+```
+
+## Stop Conditions
+
+- `3.12 -> -n 2` still leaves the branch/current-head `test-main` path unstable
+- Any proposed change widens beyond `test-main` interpreter-specific execution
+  policy without fresh evidence
+- Required check names or PR routing contracts drift
+- New actionable review/bot comments remain unresolved or unmapped

--- a/docs/orchestration/MAINLINE_CI_XDIST_WORKER_STABILITY_PACKET_2026-04-22.md
+++ b/docs/orchestration/MAINLINE_CI_XDIST_WORKER_STABILITY_PACKET_2026-04-22.md
@@ -26,7 +26,7 @@ surfaces.
       `10:38:21Z`
     - `test-main (3.13, 90)` job `72483372298` remained inside the same step
       until the run cancellation; that path is already sequential by policy
-  - `Nightly Full Tests` run `24760590280` completed `success`, so nightly is
+  - `Nightly Full Tests` run `24760590280` completed with status `success`, so nightly is
     not the default target for this lane
 - Current-head nuance:
   - exact historical GitHub run URL carrying the retained `gw1 node down`

--- a/docs/review/PR_1494_FIXED_MAPPING.md
+++ b/docs/review/PR_1494_FIXED_MAPPING.md
@@ -14,7 +14,22 @@ every new human or bot disposition here before resolving threads on GitHub.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 4ac7cc218
+Evidence: `tests/test_ci_workflow_pr_size_governance_contract.py:51-63`, `tests/test_ci_workflow_pr_size_governance_contract.py:222-248`
+Reason: The workflow contract test now extracts each `if/elif/else` shell branch and proves the interpreter-specific xdist mapping directly instead of only checking for string presence anywhere in the job.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1494#discussion_r3123721053 -> 4ac7cc218
+
+Disposition: FIXED
+Commit: 4ac7cc218
+Evidence: `docs/orchestration/MAINLINE_CI_XDIST_WORKER_STABILITY_PACKET_2026-04-22.md:29`
+Reason: The packet wording now states that the nightly run completed with status `success`, removing the awkward phrasing without widening lane scope.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1494#discussion_r3123721058 -> 4ac7cc218
+
+Disposition: NOT-A-BUG
+Evidence: `AGENTS.md:371-382`; `docs/orchestration/MAINLINE_CI_XDIST_WORKER_STABILITY_PACKET_2026-04-22.md:38-56`
+Reason: Coordinator-owned lane packets define the mandatory executable role order for that lane. This packet intentionally preserves the user-approved `dev-operator` evidence pass before the architecture/backend/security sequence, and the canonical post-open `qa-engineer-agent -> bug-hunter` review pass remains intact.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1494#discussion_r3123721937
 
 ## Merge Readiness
 

--- a/docs/review/PR_1494_FIXED_MAPPING.md
+++ b/docs/review/PR_1494_FIXED_MAPPING.md
@@ -6,25 +6,15 @@ Canonical review-governance artifact and PR-body mirror requirements:
 `AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
 `docs/orchestration/AGENTS.md:58-60`.
 
-- [x] Discussion-thread pass artifact created
-- [x] Fixed in commit mapping artifact created
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 This artifact is created immediately after PR open per repo governance. Record
 every new human or bot disposition here before resolving threads on GitHub.
 
 ## Fixed in Commit Mapping
 
-No actionable review or bot comments are mapped yet.
-
-Add each new GitHub review thread or bot comment here before resolving it:
-
-```
-- <thread-or-review-url>
-Disposition: FIXED | NOT-A-BUG | DEFERRED
-Commit: <sha-if-fixed>
-Evidence: <file:line | command | test>
-Reason: <short rationale>
-```
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1494_FIXED_MAPPING.md
+++ b/docs/review/PR_1494_FIXED_MAPPING.md
@@ -1,0 +1,67 @@
+# PR #1494 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:58-60`.
+
+- [x] Discussion-thread pass artifact created
+- [x] Fixed in commit mapping artifact created
+
+This artifact is created immediately after PR open per repo governance. Record
+every new human or bot disposition here before resolving threads on GitHub.
+
+## Fixed in Commit Mapping
+
+No actionable review or bot comments are mapped yet.
+
+Add each new GitHub review thread or bot comment here before resolving it:
+
+```
+- <thread-or-review-url>
+Disposition: FIXED | NOT-A-BUG | DEFERRED
+Commit: <sha-if-fixed>
+Evidence: <file:line | command | test>
+Reason: <short rationale>
+```
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+  Evidence: pending first branch-head `CI` cycle for PR `#1494`.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: pending first branch-head `CI` cycle for PR `#1494`.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: no review threads yet; re-evaluate after first review/bot cycle.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: no actionable bot comments are mapped yet.
+- [x] Pre-commit green on validated remediation head
+  Evidence: `pre-commit run --all-files` passed before opening PR `#1494`.
+- [ ] `make verify` green on validated remediation head
+  Evidence: not run yet on this draft remediation head.
+
+## Notes
+
+- Narrow remediation scope:
+  - keep `test-main` job identity unchanged
+  - reduce Python `3.12` from `-n 4` to `-n 2` with `--dist=loadscope`
+  - keep Python `3.13` on its existing `-p no:xdist` fallback
+- Live evidence anchors:
+  - user-reported signature: `[gw1] node down: Not properly terminated`
+  - `main` run `24771474555`
+  - `test-main (3.12, 60)` job `72483372336`
+  - `test-main (3.11, 60)` job `72483386535`
+  - green nightly reference `24760590280`
+- Local validation already collected:
+  - `python3 scripts/orchestration/check_preflight.py --path ...` passed
+  - `python3 scripts/orchestration/check_agent_consistency.py` passed
+  - `./.venv/bin/pytest -q tests/test_ci_workflow_pr_size_governance_contract.py tests/test_python_supply_chain_controls.py tests/test_current_head_pr_checks.py` passed
+  - `make validate-changed` passed
+  - `pre-commit run --all-files` passed
+- Canonical lane packet:
+  `docs/orchestration/MAINLINE_CI_XDIST_WORKER_STABILITY_PACKET_2026-04-22.md`

--- a/docs/review/PR_1494_FIXED_MAPPING.md
+++ b/docs/review/PR_1494_FIXED_MAPPING.md
@@ -31,6 +31,12 @@ Evidence: `AGENTS.md:371-382`; `docs/orchestration/MAINLINE_CI_XDIST_WORKER_STAB
 Reason: Coordinator-owned lane packets define the mandatory executable role order for that lane. This packet intentionally preserves the user-approved `dev-operator` evidence pass before the architecture/backend/security sequence, and the canonical post-open `qa-engineer-agent -> bug-hunter` review pass remains intact.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1494#discussion_r3123721937
 
+Disposition: FIXED
+Commit: b2b8c90c7
+Evidence: `docs/review/PR_1494_FIXED_MAPPING.md:34-49`
+Reason: The merge-readiness section now carries an explicit mandatory wait-window checkbox plus auditable evidence text, matching the repo governance contract and closing the remaining actionable CodeRabbit nitpick.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1494#pullrequestreview-4154411428 -> b2b8c90c7
+
 ## Merge Readiness
 
 Merge-readiness contract:
@@ -45,12 +51,12 @@ Merge-readiness contract:
   Evidence: pending first branch-head `CI` cycle for PR `#1494`.
 - [x] All review threads resolved on GitHub after disposition updates
   Evidence: `discussion_r3123721053`, `discussion_r3123721058`, and `discussion_r3123721937` are resolved on GitHub.
-- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: CodeRabbit review body `pullrequestreview-4154411428` still needs an explicit disposition entry after the wait-window checklist fix is committed.
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: CodeRabbit review body `pullrequestreview-4154411428` is mapped above to `b2b8c90c7`, and Sourcery actionables are already mapped to `4ac7cc218`.
 - [x] Pre-commit green on validated remediation head
   Evidence: `pre-commit run --all-files` passed before opening PR `#1494`.
 - [ ] `make verify` green on validated remediation head
-  Evidence: not run yet on this draft remediation head.
+  Evidence: pending final rerun after the wait-window governance sync commits.
 
 ## Notes
 

--- a/docs/review/PR_1494_FIXED_MAPPING.md
+++ b/docs/review/PR_1494_FIXED_MAPPING.md
@@ -26,6 +26,12 @@ Evidence: `docs/orchestration/MAINLINE_CI_XDIST_WORKER_STABILITY_PACKET_2026-04-
 Reason: The packet wording now states that the nightly run completed with status `success`, removing the awkward phrasing without widening lane scope.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1494#discussion_r3123721058 -> 4ac7cc218
 
+Disposition: FIXED
+Commit: 4ac7cc218
+Evidence: `tests/test_ci_workflow_pr_size_governance_contract.py:51-63`, `tests/test_ci_workflow_pr_size_governance_contract.py:222-248`; `docs/orchestration/MAINLINE_CI_XDIST_WORKER_STABILITY_PACKET_2026-04-22.md:29`
+Reason: The Sourcery review body's actionable items were the same workflow-contract and packet-wording issues already fixed in `4ac7cc218`, so the review-body summary must be mapped alongside the resolved inline threads.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1494#pullrequestreview-4154410486 -> 4ac7cc218
+
 Disposition: NOT-A-BUG
 Evidence: `AGENTS.md:371-382`; `docs/orchestration/MAINLINE_CI_XDIST_WORKER_STABILITY_PACKET_2026-04-22.md:38-56`
 Reason: Coordinator-owned lane packets define the mandatory executable role order for that lane. This packet intentionally preserves the user-approved `dev-operator` evidence pass before the architecture/backend/security sequence, and the canonical post-open `qa-engineer-agent -> bug-hunter` review pass remains intact.
@@ -52,7 +58,7 @@ Merge-readiness contract:
 - [x] All review threads resolved on GitHub after disposition updates
   Evidence: `discussion_r3123721053`, `discussion_r3123721058`, and `discussion_r3123721937` are resolved on GitHub.
 - [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: CodeRabbit review body `pullrequestreview-4154411428` is mapped above to `b2b8c90c7`, and Sourcery actionables are already mapped to `4ac7cc218`.
+  Evidence: Sourcery review body `pullrequestreview-4154410486` is mapped above to `4ac7cc218`, and CodeRabbit review body `pullrequestreview-4154411428` is mapped above to `b2b8c90c7`.
 - [x] Pre-commit green on validated remediation head
   Evidence: `pre-commit run --all-files` passed before opening PR `#1494`.
 - [ ] `make verify` green on validated remediation head

--- a/docs/review/PR_1494_FIXED_MAPPING.md
+++ b/docs/review/PR_1494_FIXED_MAPPING.md
@@ -37,14 +37,16 @@ Merge-readiness contract:
 `AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
 `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
 
+- [ ] Mandatory wait-window satisfied (final check pass completed, then waited >=1 review cycle after latest bot/review activity)
+  Evidence: pending final review/bot activity timestamp and post-wait verification.
 - [ ] Current-head CI is green for PR branch head
   Evidence: pending first branch-head `CI` cycle for PR `#1494`.
 - [ ] Required checks complete (no pending jobs)
   Evidence: pending first branch-head `CI` cycle for PR `#1494`.
-- [ ] All review threads resolved on GitHub after disposition updates
-  Evidence: no review threads yet; re-evaluate after first review/bot cycle.
+- [x] All review threads resolved on GitHub after disposition updates
+  Evidence: `discussion_r3123721053`, `discussion_r3123721058`, and `discussion_r3123721937` are resolved on GitHub.
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: no actionable bot comments are mapped yet.
+  Evidence: CodeRabbit review body `pullrequestreview-4154411428` still needs an explicit disposition entry after the wait-window checklist fix is committed.
 - [x] Pre-commit green on validated remediation head
   Evidence: `pre-commit run --all-files` passed before opening PR `#1494`.
 - [ ] `make verify` green on validated remediation head

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -9499,7 +9499,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Main CI xdist worker stability on Python 3.12 full suite
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (CI stability / merge-signal integrity)
-  - Target PR: PR TBD (`codex/fix-ci-xdist-worker-stability`)
+  - Target PR: PR #1494 (`codex/fix-ci-xdist-worker-stability`)
   - Status: In progress as of April 22, 2026
   - Reason: the `main`-branch `CI` full-suite lane continues to surface
     user-reported `"[gw1] node down: Not properly terminated"` instability in

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -9495,6 +9495,38 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
       composite action so `ci.yml` and `nightly-tests.yml` do not drift again.
 
 
+<a id="ledger-p1-main-ci-xdist-worker-stability"></a>
+- [ ] P1: Main CI xdist worker stability on Python 3.12 full suite
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (CI stability / merge-signal integrity)
+  - Target PR: PR TBD (`codex/fix-ci-xdist-worker-stability`)
+  - Status: In progress as of April 22, 2026
+  - Reason: the `main`-branch `CI` full-suite lane continues to surface
+    user-reported `"[gw1] node down: Not properly terminated"` instability in
+    the xdist-backed `test-main` path. Current lane evidence shows
+    `test-main (3.11, 60)` finishing normally while `test-main (3.12, 60)`
+    lingers in `Run tests with coverage` far beyond the healthy 3.11 runtime,
+    making the interpreter-specific xdist policy the narrowest remediation
+    surface. This item is distinct from the older nightly/node22 parity work.
+  - Links:
+    - `docs/orchestration/MAINLINE_CI_XDIST_WORKER_STABILITY_PACKET_2026-04-22.md`
+    - `.github/workflows/ci.yml`
+    - `tests/test_ci_workflow_pr_size_governance_contract.py`
+    - User-reported signature: `[gw1] node down: Not properly terminated`
+    - Current main run: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24771474555>
+    - `test-main (3.12, 60)` job: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24771474555/job/72483372336>
+    - Healthy comparator `test-main (3.11, 60)` job: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24771474555/job/72483386535>
+    - Green nightly reference: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24760590280>
+  - DoD:
+    - `test-main` keeps the same job identity and required-check topology
+    - `3.12` fallback is scoped to the narrowest effective execution policy in
+      `.github/workflows/ci.yml`
+    - A regression test freezes the workflow contract
+    - `pre-commit run --all-files`, `make validate-changed`, and branch/current-head
+      `CI` pass on the remediation branch
+    - Post-open `qa-engineer-agent -> bug-hunter` review pass is complete
+
+
 <a id="ledger-p1-remove-pygments-pip-audit-ignore"></a>
 - [ ] P1: Remove temporary Pygments pip-audit ignore when patched release exists
   - Owner: @katsiaryna_kavaleuskaya

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -186,3 +186,26 @@ def test_ios_unit_tests_stay_in_blocking_ios_job() -> None:
     assert "no test targets were found" in ios_tests_section
     assert '"xcodebuild", "test-without-building"' in ios_tests_section
     assert 'ONLY_TESTING="$(../scripts/ios_test_targets.sh)"' not in ios_ui_smoke_section
+
+
+def test_main_branch_xdist_fallback_stays_scoped_to_unstable_interpreters() -> None:
+    workflow = _load_ci_workflow()
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+
+    test_main = jobs["test-main"]
+    assert isinstance(test_main, dict)
+    matrix = test_main["strategy"]["matrix"]["include"]
+    assert isinstance(matrix, list)
+
+    timeouts = {entry["python-version"]: entry["timeout-minutes"] for entry in matrix}
+    assert timeouts == {"3.11": 60, "3.12": 60, "3.13": 90}
+
+    workflow_text = CI_WORKFLOW_PATH.read_text(encoding="utf-8")
+    test_main_section = _extract_job_section(workflow_text, "  test-main:")
+
+    assert 'if [[ "$PYVER" == 3.13* ]]; then' in test_main_section
+    assert 'elif [[ "$PYVER" == 3.12* ]]; then' in test_main_section
+    assert "PYTEST_XDIST_ARGS=(-p no:xdist)" in test_main_section
+    assert "PYTEST_XDIST_ARGS=(-n 2 --dist=loadscope)" in test_main_section
+    assert "PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)" in test_main_section

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -48,6 +48,21 @@ def _assert_contains_all_tokens(expression: str, expected_tokens: tuple[str, ...
         assert token in expression
 
 
+def _extract_shell_conditional_block(
+    script_text: str,
+    branch_marker: str,
+    next_marker: str,
+) -> str:
+    """Return the shell branch body between two explicit workflow markers."""
+
+    start_anchor = f"{branch_marker}\n"
+    end_anchor = f"\n{next_marker}"
+    assert start_anchor in script_text, f"Missing shell branch marker: {branch_marker}"
+    branch_tail = script_text.split(start_anchor, maxsplit=1)[1]
+    assert end_anchor in branch_tail, f"Missing shell branch boundary after {branch_marker}"
+    return branch_tail.split(end_anchor, maxsplit=1)[0]
+
+
 def test_pr_size_governance_uses_pull_request_head_sha() -> None:
     """Guard against merge-SHA inflation in PR-size governance diff calculation."""
 
@@ -204,8 +219,30 @@ def test_main_branch_xdist_fallback_stays_scoped_to_unstable_interpreters() -> N
     workflow_text = CI_WORKFLOW_PATH.read_text(encoding="utf-8")
     test_main_section = _extract_job_section(workflow_text, "  test-main:")
 
-    assert 'if [[ "$PYVER" == 3.13* ]]; then' in test_main_section
-    assert 'elif [[ "$PYVER" == 3.12* ]]; then' in test_main_section
-    assert "PYTEST_XDIST_ARGS=(-p no:xdist)" in test_main_section
-    assert "PYTEST_XDIST_ARGS=(-n 2 --dist=loadscope)" in test_main_section
-    assert "PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)" in test_main_section
+    py313_block = _extract_shell_conditional_block(
+        test_main_section,
+        'if [[ "$PYVER" == 3.13* ]]; then',
+        '          elif [[ "$PYVER" == 3.12* ]]; then',
+    )
+    py312_block = _extract_shell_conditional_block(
+        test_main_section,
+        '          elif [[ "$PYVER" == 3.12* ]]; then',
+        "          else",
+    )
+    default_block = _extract_shell_conditional_block(
+        test_main_section,
+        "          else",
+        "          fi",
+    )
+
+    assert "PYTEST_XDIST_ARGS=(-p no:xdist)" in py313_block
+    assert "PYTEST_XDIST_ARGS=(-n 2 --dist=loadscope)" not in py313_block
+    assert "PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)" not in py313_block
+
+    assert "PYTEST_XDIST_ARGS=(-n 2 --dist=loadscope)" in py312_block
+    assert "PYTEST_XDIST_ARGS=(-p no:xdist)" not in py312_block
+    assert "PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)" not in py312_block
+
+    assert "PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)" in default_block
+    assert "PYTEST_XDIST_ARGS=(-p no:xdist)" not in default_block
+    assert "PYTEST_XDIST_ARGS=(-n 2 --dist=loadscope)" not in default_block


### PR DESCRIPTION
## Summary
- reduce `test-main` Python 3.12 worker pressure from `-n 4` to `-n 2` while keeping `--dist=loadscope`
- keep the existing Python 3.13 sequential fallback unchanged
- add a CI workflow contract test and record the new mainline xdist stability lane in packet/ledger artifacts

## Testing
- `./.venv/bin/pytest -q tests/test_ci_workflow_pr_size_governance_contract.py tests/test_python_supply_chain_controls.py tests/test_current_head_pr_checks.py`
- `make validate-changed`
- `pre-commit run --all-files`
- `make verify` pending final rerun after the wait-window governance sync commits

## Context
- Packet: `docs/orchestration/MAINLINE_CI_XDIST_WORKER_STABILITY_PACKET_2026-04-22.md`
- Ledger: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-main-ci-xdist-worker-stability`
- Canonical review artifact: `docs/review/PR_1494_FIXED_MAPPING.md`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1494_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Mandatory wait-window satisfied (final check pass completed, then waited >=1 review cycle after latest bot/review activity)
- [ ] Current-head CI is green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [x] All review threads resolved on GitHub after disposition updates
- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Pre-commit green on validated remediation head
- [ ] `make verify` green on validated remediation head

## Deferred / Follow-ups
- Escalate `test-main` Python 3.12 to full sequential mode only if current-head branch evidence still reproduces worker instability after the narrower `-n 2` fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted CI workflow configuration to improve test execution stability for Python 3.12 and 3.13 environments.

* **Tests**
  * Added regression test to ensure CI workflow stability settings remain properly scoped and prevent future degradation.

* **Documentation**
  * Added internal CI governance documentation and backlog tracking for remediation efforts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->