### PR TITLE
feat(ai): reconcile philosophical rollout policy

### DIFF
--- a/app/services/insight_application_service.py
+++ b/app/services/insight_application_service.py
@@ -125,12 +125,16 @@ async def execute_insight_request(
     use_rag = str(os.getenv("FEATURE_RAG", "")).strip().lower() in {"1", "true", "on", "yes"}
 
     philosophy_router_enabled = is_philosophy_router_enabled()
+    philosophy_phase12_enabled = is_philosophy_phase12_enabled()
     philosophy_linguistic_enabled = is_philosophy_linguistic_enabled()
+    philosophy_pragmatic_enabled = is_philosophy_pragmatic_enabled()
     prepared_runtime = prepare_insight_runtime(
         text=prompt_input,
         use_rag=use_rag,
         philosophy_router_enabled=philosophy_router_enabled,
+        philosophy_phase12_enabled=philosophy_phase12_enabled,
         philosophy_linguistic_enabled=philosophy_linguistic_enabled,
+        philosophy_pragmatic_enabled=philosophy_pragmatic_enabled,
         provider_loader=provider_loader,
         transparency_loader=transparency_loader,
         direct_provider_factory=direct_provider_factory,
@@ -145,10 +149,7 @@ async def execute_insight_request(
         philo_validation_enabled=is_philosophy_validation_enabled(),
         recursive_rag_enabled=is_recursive_rag_enabled(),
         subject_id=subject_id,
-        philosophy_router_enabled=philosophy_router_enabled,
-        philosophy_phase12_enabled=is_philosophy_phase12_enabled(),
-        philosophy_linguistic_enabled=philosophy_linguistic_enabled,
-        philosophy_pragmatic_enabled=is_philosophy_pragmatic_enabled(),
+        rollout_policy=prepared_runtime.rollout_policy,
         knowledge_policy=prepared_runtime.knowledge_policy,
         route_path=route_path,
         route_type=prepared_runtime.decision.route_type.value,

--- a/app/services/insight_runtime.py
+++ b/app/services/insight_runtime.py
@@ -29,6 +29,7 @@ from app.utils.feature_flags import (
     is_recursive_rag_enabled,
     is_recursive_rag_optimization_enabled,
 )
+from core.insight.philosophical_runtime import PhilosophyRolloutPolicy
 
 
 class TracedInsightProvider:
@@ -129,14 +130,15 @@ async def generate_traced_insight(
     philo_validation_enabled: bool,
     recursive_rag_enabled: bool,
     subject_id: int | None,
-    philosophy_router_enabled: bool,
-    philosophy_phase12_enabled: bool,
-    philosophy_linguistic_enabled: bool,
-    philosophy_pragmatic_enabled: bool,
     knowledge_policy: Any,
     route_path: str,
     route_type: str,
     user_tier: str,
+    rollout_policy: PhilosophyRolloutPolicy | None = None,
+    philosophy_router_enabled: bool = False,
+    philosophy_phase12_enabled: bool = False,
+    philosophy_linguistic_enabled: bool = False,
+    philosophy_pragmatic_enabled: bool = False,
 ) -> Any:
     """Run philosophical insight generation with app-layer tracing only."""
 
@@ -181,6 +183,7 @@ async def generate_traced_insight(
             philo_validation_enabled=philo_validation_enabled,
             recursive_rag_enabled=recursive_rag_enabled,
             subject_id=subject_id,
+            rollout_policy=rollout_policy,
             philosophy_router_enabled=philosophy_router_enabled,
             philosophy_phase12_enabled=philosophy_phase12_enabled,
             philosophy_linguistic_enabled=philosophy_linguistic_enabled,

--- a/core/ai/__init__.py
+++ b/core/ai/__init__.py
@@ -15,11 +15,13 @@ from core.ai.insight_runtime import (
     prepare_insight_runtime,
     require_ai_generated_insight_notice,
 )
+from core.insight.philosophical_runtime import PhilosophyRolloutPolicy
 
 __all__ = [
     "DirectInsightProviderStub",
     "InsightProviderLoadError",
     "KnowledgePolicy",
+    "PhilosophyRolloutPolicy",
     "InsightTransparencyNotice",
     "InsightTransparencyUnavailableError",
     "PreparedInsightRuntime",

--- a/core/ai/insight_runtime.py
+++ b/core/ai/insight_runtime.py
@@ -18,7 +18,12 @@ from core.insight.llm_provider_loader import (
     LLMProviderFactory,
     load_llm_get_provider,
 )
-from core.insight.philosophical_runtime import PhilosophicalRuntime, RouteDecision, RouteType
+from core.insight.philosophical_runtime import (
+    PhilosophicalRuntime,
+    PhilosophyRolloutPolicy,
+    RouteDecision,
+    RouteType,
+)
 from core.rag.contracts import RAGDegradedReason
 
 
@@ -44,6 +49,7 @@ class PreparedInsightRuntime:
 
     runtime: PhilosophicalRuntime
     decision: RouteDecision
+    rollout_policy: PhilosophyRolloutPolicy
     provider: LLMProvider
     transparency_notice: InsightTransparencyNotice
     knowledge_policy: KnowledgePolicy
@@ -148,6 +154,8 @@ def prepare_insight_runtime(
     use_rag: bool,
     philosophy_router_enabled: bool,
     philosophy_linguistic_enabled: bool,
+    philosophy_phase12_enabled: bool = False,
+    philosophy_pragmatic_enabled: bool = False,
     provider_loader: Callable[[], LLMProvider | None] | None = None,
     transparency_loader: Callable[[], tuple[str, str] | InsightTransparencyNotice] | None = None,
     direct_provider_factory: Callable[[], LLMProvider] | None = None,
@@ -159,11 +167,16 @@ def prepare_insight_runtime(
     """
 
     runtime = PhilosophicalRuntime()
-    router_enabled = philosophy_router_enabled or philosophy_linguistic_enabled
+    rollout_policy = PhilosophyRolloutPolicy(
+        router_enabled=philosophy_router_enabled,
+        phase12_enabled=philosophy_phase12_enabled,
+        linguistic_enabled=philosophy_linguistic_enabled,
+        pragmatic_enabled=philosophy_pragmatic_enabled,
+    )
     decision = runtime.preview_route(
         text=text,
         lang=None,
-        router_enabled=router_enabled,
+        router_enabled=rollout_policy.preview_router_enabled,
         use_rag=use_rag,
     )
 
@@ -185,6 +198,7 @@ def prepare_insight_runtime(
     return PreparedInsightRuntime(
         runtime=runtime,
         decision=decision,
+        rollout_policy=rollout_policy,
         provider=provider,
         transparency_notice=transparency_notice,
         knowledge_policy=knowledge_policy,

--- a/core/insight/philosophical_runtime.py
+++ b/core/insight/philosophical_runtime.py
@@ -420,6 +420,7 @@ class PhilosophicalRuntime:
                 answer=_SAFE_WELLNESS_DISCLAIMER[_normalize_runtime_lang(lang)],
                 provider_name="philosophical_runtime",
                 decision=decision,
+                public_metadata_enabled=policy.public_metadata_enabled,
                 verification_report=None,
                 falsification_report=None,
                 contradiction_count=0,
@@ -433,6 +434,7 @@ class PhilosophicalRuntime:
                 answer=local_direct,
                 provider_name="philosophical_runtime",
                 decision=decision,
+                public_metadata_enabled=policy.public_metadata_enabled,
                 verification_report=None,
                 falsification_report=None,
                 contradiction_count=0,
@@ -825,6 +827,7 @@ class PhilosophicalRuntime:
         answer: str,
         provider_name: str,
         decision: RouteDecision,
+        public_metadata_enabled: bool,
         verification_report: VerificationReport | None,
         falsification_report: FalsificationReport | None,
         contradiction_count: int,
@@ -838,6 +841,8 @@ class PhilosophicalRuntime:
         `public_metadata_enabled`, so direct answers do not bypass metadata
         exposure policy.
         """
+        if not public_metadata_enabled:
+            raise ValueError("direct-result metadata requires public metadata access")
         tokens_saved_estimate = _estimate_tokens_saved(
             prompt_text=decision.simplified_query,
             target_depth=decision.target_depth,

--- a/core/insight/philosophical_runtime.py
+++ b/core/insight/philosophical_runtime.py
@@ -831,7 +831,13 @@ class PhilosophicalRuntime:
         fallback_reason: str,
         rewrite_count: int,
     ) -> RuntimeResult:
-        """Build a result for fully local/direct answers."""
+        """Build a result for fully local/direct answers.
+
+        Direct results are reachable only from preview-router paths. The rollout
+        contract guarantees `preview_router_enabled` implies
+        `public_metadata_enabled`, so direct answers do not bypass metadata
+        exposure policy.
+        """
         tokens_saved_estimate = _estimate_tokens_saved(
             prompt_text=decision.simplified_query,
             target_depth=decision.target_depth,

--- a/core/insight/philosophical_runtime.py
+++ b/core/insight/philosophical_runtime.py
@@ -892,6 +892,7 @@ def _normalize_runtime_lang(lang: str | None) -> str:
 __all__ = [
     "PhilosophicalQueryRouter",
     "PhilosophicalRuntime",
+    "PhilosophyRolloutPolicy",
     "RiskLevel",
     "RouteDecision",
     "RouteType",

--- a/core/insight/philosophical_runtime.py
+++ b/core/insight/philosophical_runtime.py
@@ -161,6 +161,35 @@ class RouteDecision:
 
 
 @dataclass(frozen=True)
+class PhilosophyRolloutPolicy:
+    """Canonical internal rollout truth for philosophical runtime behavior."""
+
+    router_enabled: bool = False
+    phase12_enabled: bool = False
+    linguistic_enabled: bool = False
+    pragmatic_enabled: bool = False
+
+    @property
+    def preview_router_enabled(self) -> bool:
+        """Return the preview-routing authority for router-backed paths."""
+
+        return self.router_enabled or self.linguistic_enabled
+
+    @property
+    def public_metadata_enabled(self) -> bool:
+        """Return whether runtime metadata may be exposed publicly."""
+
+        return any(
+            (
+                self.router_enabled,
+                self.phase12_enabled,
+                self.linguistic_enabled,
+                self.pragmatic_enabled,
+            )
+        )
+
+
+@dataclass(frozen=True)
 class RuntimeMetadata:
     """Public runtime metadata exposed via InsightResponse."""
 
@@ -364,27 +393,25 @@ class PhilosophicalRuntime:
         philo_validation_enabled: bool,
         recursive_rag_enabled: bool,
         subject_id: int | None = None,
-        philosophy_router_enabled: bool,
-        philosophy_phase12_enabled: bool,
-        philosophy_linguistic_enabled: bool,
-        philosophy_pragmatic_enabled: bool,
+        philosophy_router_enabled: bool = False,
+        philosophy_phase12_enabled: bool = False,
+        philosophy_linguistic_enabled: bool = False,
+        philosophy_pragmatic_enabled: bool = False,
+        rollout_policy: PhilosophyRolloutPolicy | None = None,
         knowledge_policy: KnowledgePolicy | None = None,
         rag_retriever: _RagRetriever | None = None,
     ) -> RuntimeResult:
         """Generate an insight with deterministic routing and validation."""
-        public_metadata_enabled = any(
-            (
-                philosophy_router_enabled,
-                philosophy_phase12_enabled,
-                philosophy_linguistic_enabled,
-                philosophy_pragmatic_enabled,
-            )
+        policy = rollout_policy or PhilosophyRolloutPolicy(
+            router_enabled=philosophy_router_enabled,
+            phase12_enabled=philosophy_phase12_enabled,
+            linguistic_enabled=philosophy_linguistic_enabled,
+            pragmatic_enabled=philosophy_pragmatic_enabled,
         )
-        router_enabled = philosophy_router_enabled or philosophy_linguistic_enabled
         decision = self.preview_route(
             text=text,
             lang=lang,
-            router_enabled=router_enabled,
+            router_enabled=policy.preview_router_enabled,
             use_rag=use_rag,
         )
 
@@ -445,7 +472,7 @@ class PhilosophicalRuntime:
         prompt_text = self._build_prompt(
             base_prompt=prompt_input,
             decision=decision,
-            phase12_enabled=philosophy_phase12_enabled,
+            phase12_enabled=policy.phase12_enabled,
         )
         prompt_text = _trim_prompt(prompt_text)
 
@@ -457,7 +484,7 @@ class PhilosophicalRuntime:
         contradiction_count = 0
         runtime_reason_codes = list(decision.reason_codes)
 
-        if philosophy_phase12_enabled:
+        if policy.phase12_enabled:
             citations = [item["file"] for item in rag_source_dicts]
             verification_report = self._verification.validate(answer, citations=citations)
             falsification_report = self._falsification.validate(answer)
@@ -469,7 +496,7 @@ class PhilosophicalRuntime:
                 contradiction_count=contradiction_count,
                 answer=answer,
                 query=text,
-                pragmatic_enabled=philosophy_pragmatic_enabled,
+                pragmatic_enabled=policy.pragmatic_enabled,
                 rag_used=rag_used,
             ):
                 rewrite_count = 1
@@ -516,7 +543,7 @@ class PhilosophicalRuntime:
                 decision=decision,
                 rag_used=rag_used,
             ),
-            runtime_verification_enabled=philosophy_phase12_enabled,
+            runtime_verification_enabled=policy.phase12_enabled,
         )
 
         tokens_saved_estimate = _estimate_tokens_saved(
@@ -557,7 +584,7 @@ class PhilosophicalRuntime:
                     reason_codes=runtime_reason_codes,
                     optimization_applied=decision.optimization_applied,
                 )
-                if public_metadata_enabled
+                if policy.public_metadata_enabled
                 else RuntimeMetadata()
             ),
             knowledge_candidates=(

--- a/docs/orchestration/WAVE6_A6_PHILOSOPHICAL_ROLLOUT_W1_PACKET_2026-04-22.md
+++ b/docs/orchestration/WAVE6_A6_PHILOSOPHICAL_ROLLOUT_W1_PACKET_2026-04-22.md
@@ -1,0 +1,180 @@
+# Wave 6 A6 Philosophical Rollout W1 Packet
+
+**Date:** 22 April 2026
+**Scope:** bounded Wave 6 product-AI runtime follow-up for philosophical phase rollout
+**Mode:** planning packet
+
+## Purpose
+
+Freeze one narrow Wave 6 follow-up slice after `PR-V1` that rolls out the
+existing philosophical runtime foundation on bounded product-AI surfaces
+without reopening foundation work or widening into semantic cache.
+
+This packet exists to:
+
+- keep `PR-A6` phase-ordered and `phase12-first reconciliation`;
+- reconcile router/validation/rewrite/fallback behavior against the current
+  bounded runtime seam;
+- preserve `VerificationBundle` / verify-before-write semantics already landed
+  in `PR-V1`;
+- keep app/service layers thin and public transport contracts unchanged;
+- defer any measured quality or latency claims to replay/benchmark evidence.
+
+## Current-head truth
+
+- `core/insight/philosophical_runtime.py` already contains the philosophical
+  runtime foundation: router preview, local-direct paths, verification,
+  falsification, contradiction counting, rewrite/fallback logic, and knowledge
+  candidate handoff.
+- `core/ai/insight_runtime.py` already owns the canonical non-HTTP bounded seam
+  via `prepare_insight_runtime(...)`.
+- `app/services/insight_application_service.py` and
+  `app/services/insight_runtime.py` are already the thin application handoff and
+  tracing seams and must stay that way.
+- `PR-V1` already landed the verification registry and canonical
+  verify-before-write admission contract through the runtime/RAG path.
+- Semantic cache remains deferred and must not be widened by this lane.
+
+## Hard boundaries
+
+- No `legacy_app.py` edits
+- No `app/routers/*` edits
+- No OpenAPI or public response shape changes
+- No new route-layer DTOs
+- No semantic cache, Redis, GPTCache, GraphRAG, or ContextManifest work
+- No philosophy foundation rewrite or second runtime stack
+- No reopening verification-registry architecture from `PR-V1`
+- No widening into advisory/wiki/plugin control-plane rails
+
+## Canonical implementation surfaces
+
+### Primary runtime seams
+
+- `core/insight/philosophical_runtime.py`
+- `core/ai/insight_runtime.py`
+- `app/services/insight_application_service.py`
+- `app/services/insight_runtime.py`
+
+### Support surfaces only if needed
+
+- `app/utils/feature_flags.py`
+- `core/rag/orchestration.py`
+
+### Canonical planning evidence
+
+- `docs/orchestration/WAVE6_A6_TASK_ANALYSIS_2026-04-22.md`
+- `docs/roadmap/PulsePlate_RAG_LLM_Karpathy_Epic_Pipeline.md`
+- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-philosophical-logic`
+
+## Required invariants
+
+- `PR-A6` is a bounded rollout/reconciliation lane, not a foundation rewrite.
+- W1 treats `Aristotelian + Analytical` as the primary execution target because
+  live code already exposes this through `FEATURE_PHILOSOPHY_PHASE12`.
+- `prepare_insight_runtime(...)` remains the canonical ownership seam for
+  bounded runtime preparation.
+- App/service layers stay thin and must not author philosophy truth outside the
+  bounded runtime seam.
+- `VerificationBundle` / verify-before-write semantics from `PR-V1` remain in
+  force.
+- Existing metadata fields only: `route_type`, `depth_used`,
+  `verification_rate`, `falsifiability_rate`, `contradiction_count`,
+  `reason_codes`, `optimization_applied`.
+- Replay/eval evidence remains the source of truth for any comparative efficacy
+  or latency-uplift claim.
+- Semantic cache remains deferred under
+  `docs/roadmap/PulsePlate_Semantic_Cache_Gate_and_Plan.md`.
+
+## Required role-agent order for this lane
+
+1. `agent-coordinator`
+2. `architecture-specialist`
+3. `data-scientist-agent`
+4. `backend-engineer`
+5. `security-auditor`
+6. `qa-engineer-agent`
+7. `bug-hunter`
+
+Rules:
+
+- every assigned role agent must be used in this order;
+- no assigned role agent may be skipped without an explicit packet update;
+- the canonical post-open `qa-engineer-agent -> bug-hunter` pass remains
+  mandatory.
+
+## W1 scope
+
+### In scope
+
+- introduce one bounded internal phase-rollout contract for the existing
+  philosophy flags on the runtime path;
+- surface stable additive runtime evidence for active philosophy phases using
+  existing metadata fields;
+- keep router/validation/rewrite/fallback behavior coherent across `core/ai`,
+  runtime, and app handoff seams;
+- add deterministic tests for bounded rollout behavior and no payload drift.
+
+### Out of scope
+
+- broad rollout of every philosophy family in one PR
+- replay/eval corpus promotion unless the implementation directly changes that
+  contract
+- recursive speed optimization lane (`PR-A7`)
+- semantic cache and persistence work
+- any scientific, comparative, or latency-uplift claim not backed by the
+  replay/eval contract
+
+## First-Cut Defect Guardrails
+
+The first implementation cut must preserve these exact guardrails:
+
+- `router_enabled = philosophy_router_enabled || philosophy_linguistic_enabled`
+  remains the truth table for route preview and direct-answer paths
+- `generate_insight(...)` keeps legacy bool compatibility in the first cut while
+  normalizing into the internal rollout policy
+- tracing stays observational only and must not become a competing rollout
+  authority
+- app/service layers must not keep a second rollout-truth source after
+  `prepare_insight_runtime(...)` returns the prepared policy
+- rollout policy must not subsume `philo_validation_enabled` or
+  `verification_bundle` admission semantics
+- existing direct medical/local-answer no-provider behavior and verify-before-
+  write fail-closed behavior must remain bit-for-bit intact
+
+## Primary tests
+
+- `tests/test_philosophical_runtime.py`
+- `tests/test_core_ai_insight_runtime.py`
+- `tests/test_insight_application_service.py`
+- one narrow metadata path in `tests/test_philosophy_validation_integration.py`
+
+Fallback only if needed:
+
+- `tests/test_rag_orchestration.py`
+- `tests/test_remaining_modules.py`
+- `tests/test_logic_philosophy_replay_eval.py`
+
+## Validation
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- targeted `pytest -q` on the primary test surfaces above
+- `pre-commit run --all-files`
+- `make verify`
+
+## Plugin / Skill Recommendation
+
+Planning stage:
+
+- no plugin family is required now
+- no extra skill activation is required beyond coordinator-first repo workflow
+
+Useful later, but not needed for planning:
+
+- `GitHub` for current-head PR/check truth once implementation starts
+- `CodeRabbit` for the post-open review cycle
+
+Keep unused at planning stage:
+
+- `Computer Use`, `Hugging Face`, `Cloudflare`, `Figma`, `Jam`, `Expo`,
+  `build-*`, `Life Science Research`

--- a/docs/orchestration/WAVE6_A6_TASK_ANALYSIS_2026-04-22.md
+++ b/docs/orchestration/WAVE6_A6_TASK_ANALYSIS_2026-04-22.md
@@ -13,8 +13,8 @@ philosophical phase rollout on the existing product-AI insight surfaces.
 
 - **Priority track (P0-A / P0-B / P1):** P1
 
-**Expected Outcome:** A narrow `phase12-first reconciliation` lane lands on the
-existing bounded runtime seams without foundation rewrite, semantic-cache
+**Expected Outcome:** A narrow `phase12-first reconciliation` lane targets the
+existing bounded runtime seams without foundation rewrites, semantic-cache
 expansion, public/API contract drift, or unproven quality-uplift claims.
 
 **Invariants Affected:**

--- a/docs/orchestration/WAVE6_A6_TASK_ANALYSIS_2026-04-22.md
+++ b/docs/orchestration/WAVE6_A6_TASK_ANALYSIS_2026-04-22.md
@@ -1,0 +1,78 @@
+# WAVE6 A6 Task Analysis
+
+## Task Analysis
+
+**Task:** Implement `PR-A6` as a bounded Wave 6 runtime slice for
+philosophical phase rollout on the existing product-AI insight surfaces.
+
+**Domain(s):** AI/ML | Architecture | Security | Multiple
+
+**Complexity:** Complex
+
+**Priority:** P1
+
+- **Priority track (P0-A / P0-B / P1):** P1
+
+**Expected Outcome:** A narrow `phase12-first reconciliation` lane lands on the
+existing bounded runtime seams without foundation rewrite, semantic-cache
+expansion, public/API contract drift, or unproven quality-uplift claims.
+
+**Invariants Affected:**
+- [ ] One BMI Engine
+- [x] Thin HTTP Adapter Policy
+- [x] Layer Separation
+- [x] Contract-First
+- [x] Other: bounded Wave 6 product-AI runtime rail
+
+**Risks:**
+1. Scope drift could reopen philosophical foundation work instead of rolling out
+   bounded phases; mitigate by treating `Aristotelian + Analytical` as the W1
+   target and keeping every change behind existing runtime seams.
+2. Phase rollout truth could drift across app/core layers; mitigate by
+   centralizing the runtime phase contract and keeping
+   `prepare_insight_runtime(...)` as the canonical ownership seam.
+3. Verification semantics from `PR-V1` could be weakened during rollout;
+   mitigate by preserving `VerificationBundle` handoff and denying any widening
+   into semantic-cache or public trust claims.
+4. Scientific-overclaim risk could present rollout behavior as measured uplift;
+   mitigate by keeping quality/latency hypotheses benchmark-gated and deferred
+   to the replay/eval lane.
+
+**Proposed Approach:**
+1. Create a dedicated A6 lane packet and reconcile live repo truth against the
+   current philosophical runtime foundation.
+2. Introduce one bounded internal phase-rollout seam for the existing
+   philosophy flags and thread it through `core/ai`, runtime, and app handoff
+   surfaces only.
+3. Surface stable additive runtime evidence for the active philosophy phases
+   without changing the public response shape.
+4. Add deterministic tests for bounded rollout behavior and no payload drift.
+5. Keep semantic cache, replay promotion, and wider advisory/plugin rails out of
+   scope.
+
+**Agent Assignment:**
+- **Primary:** `agent-coordinator` - owns scope, role order, synthesis, and DoD.
+- **Secondary:** `architecture-specialist` - enforces bounded seam and anti-drift review.
+- **Secondary:** `data-scientist-agent` - validates phase-order logic and reliability framing.
+- **Secondary:** `backend-engineer` - implements the internal rollout seam and runtime changes.
+- **Secondary:** `security-auditor` - verifies fail-closed boundaries and no contract widening.
+- **Secondary:** `qa-engineer-agent` - adds deterministic bounded-rollout tests.
+- **Secondary:** `bug-hunter` - mandatory final defect pass.
+- **Dependencies:** preflight and agent consistency must pass before edits; the
+  canonical post-open `qa-engineer-agent -> bug-hunter` pass remains mandatory.
+
+**Constraints:**
+- No `legacy_app.py`, `app/routers/*`, OpenAPI, DTO, or response-shape changes.
+- No semantic cache, Redis, GPTCache, GraphRAG, ContextManifest, or second
+  runtime stack.
+- No reopening `PR-V1`; verification registry and verify-before-write remain in
+  force and must be preserved.
+- W1 stays phase-ordered and narrow; do not claim full philosophy-family rollout
+  in one PR.
+- Any quality/latency uplift claims stay deferred until replay/benchmark
+  evidence explicitly promotes them.
+
+---
+
+**Analysis by:** agent-coordinator
+**Date:** 2026-04-22

--- a/docs/review/PR_1495_FIXED_MAPPING.md
+++ b/docs/review/PR_1495_FIXED_MAPPING.md
@@ -37,15 +37,15 @@ Merge-readiness contract:
 `AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
 `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
 
-- [ ] Current-head CI is green for PR branch head
-  Evidence: current-head CI is still in progress / needs the post-governance rerun on the latest branch head.
-- [ ] Required checks complete (no pending jobs)
-  Evidence: latest current-head required jobs are not complete yet.
-- [ ] All review threads resolved on GitHub after disposition updates
-  Evidence: Sourcery review shell and inline thread are dispositioned here; GitHub thread resolution still needs to be performed after this artifact is pushed.
-- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: current actionable Sourcery URLs are mapped above; re-check after any new bot activity remains mandatory.
-- [ ] Pre-commit green on latest pushed head
-  Evidence: `pre-commit run --all-files` passed on the latest local branch head before governance update.
-- [ ] `make verify` green on latest pushed head
-  Evidence: this lane follows the user-approved narrow local gate bundle plus GitHub current-head CI as the heavyweight signal; no fresh full `make verify` claim is made here.
+- [x] Current-head CI is green for PR branch head
+  Evidence: `gh pr checks 1495` is fully green on head `99710dfd035f7cc182ba62ffde15f92e83ab89cb`, including `Merge readiness gate`, `coverage-pr`, `diff-coverage`, `lint`, `security`, and `test-pr (3.13)`.
+- [x] Required checks complete (no pending jobs)
+  Evidence: current-head required jobs are complete; the remaining entries are non-blocking `skipping` lanes only.
+- [x] All review threads resolved on GitHub after disposition updates
+  Evidence: `gh api graphql ... reviewThreads` returns only resolved threads for `PR #1495`, including the Sourcery inline thread `#discussion_r3123746307`.
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: the actionable Sourcery and CodeRabbit review shells are mapped above, and `gh pr view 1495 --json latestReviews` shows no newer unmapped review after `#pullrequestreview-4154609821`.
+- [x] Pre-commit green on latest pushed head
+  Evidence: `pre-commit run --all-files` passed on the merge-ready branch state before this artifact refresh commit.
+- [x] `make verify` green on latest pushed head
+  Evidence: `make verify` passed on the merge-ready branch state before this artifact refresh commit.

--- a/docs/review/PR_1495_FIXED_MAPPING.md
+++ b/docs/review/PR_1495_FIXED_MAPPING.md
@@ -26,6 +26,11 @@ Reason: `PR-A6 W1` intentionally preserves legacy `philosophy_*` bool compatibil
 Evidence: `docs/orchestration/WAVE6_A6_PHILOSOPHICAL_ROLLOUT_W1_PACKET_2026-04-22.md:133-139`; `app/services/insight_application_service.py:143-157`; `app/services/insight_runtime.py:123-142`; `core/insight/philosophical_runtime.py:386-415`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#pullrequestreview-4154591459
 
+Disposition: FIXED
+Commit: dd1035347
+Evidence: `tests/test_insight_application_service.py` now pins the philosophy feature-flag readers in the prepare-kwargs assertion path, `core/insight/philosophical_runtime.py` exports `PhilosophyRolloutPolicy` via `__all__`, and `docs/orchestration/WAVE6_A6_TASK_ANALYSIS_2026-04-22.md` applies the requested wording cleanup without changing scope.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#pullrequestreview-4154609821
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/review/PR_1495_FIXED_MAPPING.md
+++ b/docs/review/PR_1495_FIXED_MAPPING.md
@@ -1,0 +1,40 @@
+# PR #1495 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+This artifact is created immediately after the PR is opened per repo governance.
+Record every actionable human/bot disposition here before resolving threads on GitHub.
+
+## Fixed in Commit Mapping
+
+Disposition: NOT-A-BUG
+Evidence: `app/services/insight_runtime.py:123-191` declares `generate_traced_insight(...)` with a leading `*`, so all arguments are keyword-only and positional-call drift is impossible. The added `rollout_policy` parameter does not change positional compatibility because there is no positional call surface to preserve. The broader suggestion to hard-fail mixed `rollout_policy` plus legacy bool inputs is advisory future tightening, not a correctness blocker for this first-cut compatibility slice.
+Reason: The reported “parameter reordering” breakage cannot occur on the live function signature, and the remaining high-level guidance does not identify a current behavioral regression in this bounded PR.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#discussion_r3123746307
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#pullrequestreview-4154439968
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+  Evidence: current-head CI is still in progress / needs the post-governance rerun on the latest branch head.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: latest current-head required jobs are not complete yet.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: Sourcery review shell and inline thread are dispositioned here; GitHub thread resolution still needs to be performed after this artifact is pushed.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: current actionable Sourcery URLs are mapped above; re-check after any new bot activity remains mandatory.
+- [ ] Pre-commit green on latest pushed head
+  Evidence: `pre-commit run --all-files` passed on the latest local branch head before governance update.
+- [ ] `make verify` green on latest pushed head
+  Evidence: this lane follows the user-approved narrow local gate bundle plus GitHub current-head CI as the heavyweight signal; no fresh full `make verify` claim is made here.

--- a/docs/review/PR_1495_FIXED_MAPPING.md
+++ b/docs/review/PR_1495_FIXED_MAPPING.md
@@ -31,6 +31,11 @@ Commit: dd1035347
 Evidence: `tests/test_insight_application_service.py` now pins the philosophy feature-flag readers in the prepare-kwargs assertion path, `core/insight/philosophical_runtime.py` exports `PhilosophyRolloutPolicy` via `__all__`, and `docs/orchestration/WAVE6_A6_TASK_ANALYSIS_2026-04-22.md` applies the requested wording cleanup without changing scope.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#pullrequestreview-4154609821
 
+Disposition: NOT-A-BUG
+Evidence: `PhilosophyRolloutPolicy.preview_router_enabled` is `router_enabled || linguistic_enabled`, while `public_metadata_enabled` is `any(router_enabled, phase12_enabled, linguistic_enabled, pragmatic_enabled)`, so every live path that can reach `_build_direct_result(...)` already implies public metadata is enabled. When metadata is disabled, `preview_route(...)` falls back to `DEEP_REASONING` and never reaches the direct SAFE_WELLNESS_DISCLAIMER / local direct-answer helper path. The helper docstring now states this invariant explicitly.
+Reason: The reported metadata-bypass scenario is unreachable on the live W1 contract; direct-result paths do not bypass rollout metadata policy because they require preview-router activation first.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#pullrequestreview-4155227251
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/review/PR_1495_FIXED_MAPPING.md
+++ b/docs/review/PR_1495_FIXED_MAPPING.md
@@ -36,6 +36,11 @@ Evidence: `PhilosophyRolloutPolicy.preview_router_enabled` is `router_enabled ||
 Reason: The reported metadata-bypass scenario is unreachable on the live W1 contract; direct-result paths do not bypass rollout metadata policy because they require preview-router activation first.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#pullrequestreview-4155227251
 
+Disposition: FIXED
+Commit: 92c0b8075
+Evidence: `core/insight/philosophical_runtime.py` now threads `public_metadata_enabled` into `_build_direct_result(...)` and raises a loud `ValueError` if a future caller tries to reach the direct-result helper without public metadata access, while `tests/test_philosophical_runtime.py` adds a regression anchor for that invariant.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#pullrequestreview-4155379644
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/review/PR_1495_FIXED_MAPPING.md
+++ b/docs/review/PR_1495_FIXED_MAPPING.md
@@ -20,6 +20,12 @@ Reason: The reported “parameter reordering” breakage cannot occur on the liv
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#discussion_r3123746307
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#pullrequestreview-4154439968
 
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-philosophical-logic`
+Reason: `PR-A6 W1` intentionally preserves legacy `philosophy_*` bool compatibility while making `PhilosophyRolloutPolicy` the prepared-runtime authority. The canonical in-repo app path passes only `rollout_policy`, so there is no live dual-authority bug on the shipped W1 path. A correct mixed-input conflict guard or deprecation wrapper requires a follow-up compatibility slice that can distinguish omitted legacy bools from explicitly conflicting values without widening W1.
+Evidence: `docs/orchestration/WAVE6_A6_PHILOSOPHICAL_ROLLOUT_W1_PACKET_2026-04-22.md:133-139`; `app/services/insight_application_service.py:143-157`; `app/services/insight_runtime.py:123-142`; `core/insight/philosophical_runtime.py:386-415`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#pullrequestreview-4154591459
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2011,8 +2011,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Philosophical logic principles for LLM reliability (Aristotelian, Analytical, Post-Analytical, Linguistic)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (high impact on reliability)
-  - Target PR: PR #1024 (`feat: add philosophical runtime foundation for insight`) -> PR-TBD-LLM-PHILOSOPHY-ROLLOUT
-  - Status: 🟡 In progress (foundation merged in PR #1024; rollout follow-ups remain)
+  - Target PR: PR #1024 (`feat: add philosophical runtime foundation for insight`) -> PR-A6 (`feat(ai-quality): rollout philosophical validation phases on bounded surfaces`)
+  - Status: 🟡 In progress (foundation merged in PR #1024; bounded W1 rollout lane active on `codex/ai-philosophical-rollout-w1`)
   - Dependencies:
     - [P0 Master checklist phase-fit triage](#ledger-p0-master-checklist-triage)
     - [P0 Payment rails RU/BY + iOS baseline](#ledger-p0-payments-ruby-ios)

--- a/scripts/evals/run_rag_release_gates.py
+++ b/scripts/evals/run_rag_release_gates.py
@@ -817,6 +817,12 @@ async def pulseplate_runtime_generate(
         philosophy_linguistic_enabled=_truthy_env(
             os.getenv("FEATURE_PHILOSOPHY_LINGUISTIC"),
         ),
+        philosophy_phase12_enabled=_truthy_env(
+            os.getenv("FEATURE_PHILOSOPHY_PHASE12"),
+        ),
+        philosophy_pragmatic_enabled=_truthy_env(
+            os.getenv("FEATURE_PHILOSOPHY_PRAGMATIC"),
+        ),
         provider_loader=lambda: provider,
         transparency_loader=lambda: (
             "ai_generated_insight",
@@ -833,13 +839,11 @@ async def pulseplate_runtime_generate(
         philo_validation_enabled=True,
         recursive_rag_enabled=False,
         subject_id=subject_id,
-        philosophy_router_enabled=False,
-        philosophy_phase12_enabled=False,
-        philosophy_linguistic_enabled=False,
-        philosophy_pragmatic_enabled=False,
+        knowledge_policy=prepared.knowledge_policy,
         route_path="/api/v1/insight",
         route_type=prepared.decision.route_type.value,
         user_tier=user_tier,
+        rollout_policy=prepared.rollout_policy,
     )
     answer = str(getattr(result, "insight", ""))
     confidence = _safe_float(

--- a/tests/test_core_ai_insight_runtime.py
+++ b/tests/test_core_ai_insight_runtime.py
@@ -18,6 +18,7 @@ from core.ai.insight_runtime import (
     prepare_insight_runtime,
     require_ai_generated_insight_notice,
 )
+from core.insight.philosophical_runtime import PhilosophyRolloutPolicy
 from core.rag.contracts import RAGDegradedReason
 
 
@@ -160,6 +161,7 @@ def test_prepare_insight_runtime_uses_direct_stub_for_local_answer(
     assert prepared.transparency_notice.surface_id == "ai_generated_insight"
     assert prepared.knowledge_policy.allow_promotion is False
     assert prepared.knowledge_policy.allow_reads is False
+    assert prepared.rollout_policy == PhilosophyRolloutPolicy()
 
 
 def test_prepare_insight_runtime_uses_provider_loader_for_generation(
@@ -200,6 +202,12 @@ def test_prepare_insight_runtime_uses_provider_loader_for_generation(
     assert prepared.provider is provider
     assert prepared.decision.route_type.value == "deep_reasoning"
     assert prepared.transparency_notice.wellness_boundary == "Wellness only."
+    assert prepared.rollout_policy == PhilosophyRolloutPolicy(
+        router_enabled=True,
+        phase12_enabled=False,
+        linguistic_enabled=False,
+        pragmatic_enabled=False,
+    )
     assert prepared.knowledge_policy == KnowledgePolicy(
         enabled=False,
         allow_reads=False,
@@ -246,6 +254,50 @@ def test_prepare_insight_runtime_enables_knowledge_promotion_for_rag_factual_rou
     assert prepared.knowledge_policy.enabled is True
     assert prepared.knowledge_policy.allow_reads is True
     assert prepared.knowledge_policy.allow_promotion is True
+
+
+def test_prepare_insight_runtime_returns_rollout_policy_and_preserves_router_linguistic_parity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prepared runtime must own rollout truth and preserve router-or-linguistic preview routing."""
+
+    @dataclass
+    class _FakeDecision:
+        needs_generation: bool
+        route_type: object
+
+    class _FakeRuntime:
+        def preview_route(
+            self, *, text: str, lang: str | None, router_enabled: bool, use_rag: bool
+        ) -> _FakeDecision:
+            assert text == "hello"
+            assert lang is None
+            assert router_enabled is True
+            assert use_rag is False
+            return _FakeDecision(
+                needs_generation=True,
+                route_type=SimpleNamespace(value="deep_reasoning"),
+            )
+
+    monkeypatch.setattr("core.ai.insight_runtime.PhilosophicalRuntime", _FakeRuntime, raising=True)
+
+    prepared = prepare_insight_runtime(
+        text="hello",
+        use_rag=False,
+        philosophy_router_enabled=False,
+        philosophy_linguistic_enabled=True,
+        philosophy_phase12_enabled=True,
+        philosophy_pragmatic_enabled=True,
+        provider_loader=lambda: _FakeProvider(),
+        transparency_loader=lambda: ("ai_generated_insight", "Wellness only."),
+    )
+
+    assert prepared.rollout_policy == PhilosophyRolloutPolicy(
+        router_enabled=False,
+        phase12_enabled=True,
+        linguistic_enabled=True,
+        pragmatic_enabled=True,
+    )
 
 
 def test_prepare_insight_runtime_uses_direct_transparency_notice(

--- a/tests/test_insight_application_service.py
+++ b/tests/test_insight_application_service.py
@@ -15,6 +15,7 @@ from app.services.insight_application_service import (
     execute_insight_request,
 )
 from core.ai.insight_runtime import InsightTransparencyNotice
+from core.insight.philosophical_runtime import PhilosophyRolloutPolicy
 from core.knowledge.policy import KnowledgePolicy
 from core.insight.llm_provider_loader import LLMProvider
 from core.verification.contracts import VerificationArtifact, VerificationBundle
@@ -43,6 +44,21 @@ def _knowledge_policy() -> KnowledgePolicy:
         deny_degraded_reasons=("retrieval_empty",),
         subject_scope_required=True,
         rail="product_ai_runtime",
+    )
+
+
+def _rollout_policy(
+    *,
+    router_enabled: bool = False,
+    phase12_enabled: bool = False,
+    linguistic_enabled: bool = False,
+    pragmatic_enabled: bool = False,
+) -> PhilosophyRolloutPolicy:
+    return PhilosophyRolloutPolicy(
+        router_enabled=router_enabled,
+        phase12_enabled=phase12_enabled,
+        linguistic_enabled=linguistic_enabled,
+        pragmatic_enabled=pragmatic_enabled,
     )
 
 
@@ -105,6 +121,10 @@ async def test_execute_insight_request_uses_injected_dependencies(
         runtime=object(),
         provider=object(),
         decision=SimpleNamespace(route_type=SimpleNamespace(value="deep_reasoning")),
+        rollout_policy=_rollout_policy(
+            phase12_enabled=True,
+            linguistic_enabled=True,
+        ),
         transparency_notice=InsightTransparencyNotice(
             surface_id="ai_generated_insight",
             wellness_boundary="Wellness only.",
@@ -167,7 +187,9 @@ async def test_execute_insight_request_uses_injected_dependencies(
         "text": "hello",
         "use_rag": False,
         "philosophy_router_enabled": False,
+        "philosophy_phase12_enabled": False,
         "philosophy_linguistic_enabled": False,
+        "philosophy_pragmatic_enabled": False,
         "provider_loader": _provider_loader,
         "transparency_loader": _transparency_loader,
         "direct_provider_factory": _direct_provider_factory,
@@ -175,9 +197,11 @@ async def test_execute_insight_request_uses_injected_dependencies(
     assert observed["generate_kwargs"]["subject_id"] == 123
     assert observed["generate_kwargs"]["route_path"] == "/api/v1/insight"
     assert observed["generate_kwargs"]["knowledge_policy"] == prepared_runtime.knowledge_policy
+    assert observed["generate_kwargs"]["rollout_policy"] is prepared_runtime.rollout_policy
     assert response["provider"] == "fake-provider"
     assert response["transparency_notice_id"] == "ai_generated_insight"
     assert response["sources"][0]["chunk_id"] == "c1"
+    assert "rollout_policy" not in response
 
 
 @pytest.mark.asyncio
@@ -232,6 +256,104 @@ async def test_execute_insight_request_rejects_oversized_prompt(
 
 
 @pytest.mark.asyncio
+async def test_execute_insight_request_uses_prepared_rollout_policy_as_execution_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prepared rollout truth must flow downstream even if env-backed rollout readers disagree."""
+
+    observed: dict[str, Any] = {}
+
+    @dataclass
+    class _Request:
+        text: str
+
+    prepared_runtime = SimpleNamespace(
+        runtime=object(),
+        provider=object(),
+        decision=SimpleNamespace(route_type=SimpleNamespace(value="deep_reasoning")),
+        rollout_policy=_rollout_policy(
+            router_enabled=True,
+            phase12_enabled=True,
+            linguistic_enabled=False,
+            pragmatic_enabled=True,
+        ),
+        transparency_notice=InsightTransparencyNotice(
+            surface_id="ai_generated_insight",
+            wellness_boundary="Wellness only.",
+        ),
+        knowledge_policy=_knowledge_policy(),
+    )
+
+    async def _fake_generate_traced_insight(**kwargs: object) -> object:
+        observed["generate_kwargs"] = kwargs
+        return SimpleNamespace(
+            insight="generated insight",
+            provider_name="fake-provider",
+            source_dicts=[],
+            confidence=0.9,
+            rag_used=False,
+            hops=0,
+            latency_ms=12,
+            knowledge_candidates=[],
+            metadata=SimpleNamespace(
+                route_type="deep_reasoning",
+                depth_used=2,
+                verification_rate=0.8,
+                falsifiability_rate=0.7,
+                contradiction_count=0,
+                reason_codes=["legacy_path"],
+                optimization_applied=False,
+            ),
+        )
+
+    monkeypatch.setattr(
+        "app.services.insight_application_service.is_philosophy_router_enabled",
+        lambda: False,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "app.services.insight_application_service.is_philosophy_phase12_enabled",
+        lambda: False,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "app.services.insight_application_service.is_philosophy_linguistic_enabled",
+        lambda: False,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "app.services.insight_application_service.is_philosophy_pragmatic_enabled",
+        lambda: False,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "app.services.insight_application_service.prepare_insight_runtime",
+        lambda **kwargs: prepared_runtime,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "app.services.insight_application_service.generate_traced_insight",
+        _fake_generate_traced_insight,
+        raising=True,
+    )
+
+    response = await execute_insight_request(
+        _Request(text="hello"),
+        route_path="/api/v1/insight",
+        user_tier="VIP",
+        input_guard=lambda text: None,
+        provider_loader=lambda: _FakeProvider(),
+        transparency_loader=lambda: ("ai_generated_insight", "Wellness only."),
+        response_factory=lambda **payload: dict(payload),
+        source_item_factory=lambda **payload: dict(payload),
+    )
+
+    assert observed["generate_kwargs"]["rollout_policy"] is prepared_runtime.rollout_policy
+    assert response["route_type"] == "deep_reasoning"
+    assert "rollout_policy" not in response
+
+
+@pytest.mark.asyncio
 async def test_execute_insight_request_prefers_active_fallback_provider_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -245,6 +367,7 @@ async def test_execute_insight_request_prefers_active_fallback_provider_name(
         runtime=object(),
         provider=SimpleNamespace(active_provider_name="stub"),
         decision=SimpleNamespace(route_type=SimpleNamespace(value="deep_reasoning")),
+        rollout_policy=_rollout_policy(),
         transparency_notice=InsightTransparencyNotice(
             surface_id="ai_generated_insight",
             wellness_boundary="Wellness only.",
@@ -315,6 +438,11 @@ async def test_execute_insight_request_hands_internal_candidates_to_store_withou
         runtime=object(),
         provider=SimpleNamespace(active_provider_name="stub"),
         decision=SimpleNamespace(route_type=SimpleNamespace(value="rag_factual")),
+        rollout_policy=_rollout_policy(
+            router_enabled=True,
+            phase12_enabled=True,
+            linguistic_enabled=True,
+        ),
         transparency_notice=InsightTransparencyNotice(
             surface_id="ai_generated_insight",
             wellness_boundary="Wellness only.",
@@ -401,6 +529,11 @@ async def test_execute_insight_request_skips_store_when_no_candidates(
         runtime=object(),
         provider=SimpleNamespace(active_provider_name="stub"),
         decision=SimpleNamespace(route_type=SimpleNamespace(value="rag_factual")),
+        rollout_policy=_rollout_policy(
+            router_enabled=True,
+            phase12_enabled=True,
+            linguistic_enabled=True,
+        ),
         transparency_notice=InsightTransparencyNotice(
             surface_id="ai_generated_insight",
             wellness_boundary="Wellness only.",
@@ -483,6 +616,11 @@ async def test_execute_insight_request_survives_store_promotion_failure(
         runtime=object(),
         provider=SimpleNamespace(active_provider_name="stub"),
         decision=SimpleNamespace(route_type=SimpleNamespace(value="rag_factual")),
+        rollout_policy=_rollout_policy(
+            router_enabled=True,
+            phase12_enabled=True,
+            linguistic_enabled=True,
+        ),
         transparency_notice=InsightTransparencyNotice(
             surface_id="ai_generated_insight",
             wellness_boundary="Wellness only.",
@@ -567,6 +705,11 @@ async def test_execute_insight_request_skips_store_when_bundle_denies_admission(
         runtime=object(),
         provider=SimpleNamespace(active_provider_name="stub"),
         decision=SimpleNamespace(route_type=SimpleNamespace(value="rag_factual")),
+        rollout_policy=_rollout_policy(
+            router_enabled=True,
+            phase12_enabled=True,
+            linguistic_enabled=True,
+        ),
         transparency_notice=InsightTransparencyNotice(
             surface_id="ai_generated_insight",
             wellness_boundary="Wellness only.",
@@ -652,6 +795,11 @@ async def test_execute_insight_request_skips_store_when_bundle_is_missing(
         runtime=object(),
         provider=SimpleNamespace(active_provider_name="stub"),
         decision=SimpleNamespace(route_type=SimpleNamespace(value="rag_factual")),
+        rollout_policy=_rollout_policy(
+            router_enabled=True,
+            phase12_enabled=True,
+            linguistic_enabled=True,
+        ),
         transparency_notice=InsightTransparencyNotice(
             surface_id="ai_generated_insight",
             wellness_boundary="Wellness only.",

--- a/tests/test_insight_application_service.py
+++ b/tests/test_insight_application_service.py
@@ -168,6 +168,26 @@ async def test_execute_insight_request_uses_injected_dependencies(
         _fake_generate_traced_insight,
         raising=True,
     )
+    monkeypatch.setattr(
+        "app.services.insight_application_service.is_philosophy_router_enabled",
+        lambda: False,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "app.services.insight_application_service.is_philosophy_phase12_enabled",
+        lambda: False,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "app.services.insight_application_service.is_philosophy_linguistic_enabled",
+        lambda: False,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "app.services.insight_application_service.is_philosophy_pragmatic_enabled",
+        lambda: False,
+        raising=True,
+    )
 
     response = await execute_insight_request(
         _Request(text="hello"),

--- a/tests/test_philosophical_runtime.py
+++ b/tests/test_philosophical_runtime.py
@@ -794,6 +794,31 @@ class TestPhilosophicalRuntime:
         assert result.metadata.depth_used == 0
         assert result.metadata.reason_codes == []
 
+    async def test_build_direct_result_requires_public_metadata_access(self) -> None:
+        runtime = PhilosophicalRuntime()
+
+        with pytest.raises(
+            ValueError, match="direct-result metadata requires public metadata access"
+        ):
+            runtime._build_direct_result(
+                answer="BMI stands for body mass index.",
+                provider_name="philosophical_runtime",
+                decision=RouteDecision(
+                    route_type=RouteType.DIRECT_DEFINITION,
+                    target_depth=1,
+                    needs_rag=False,
+                    needs_generation=False,
+                    risk_level=RiskLevel.LOW,
+                    reason_codes=["cached_definition"],
+                ),
+                public_metadata_enabled=False,
+                verification_report=None,
+                falsification_report=None,
+                contradiction_count=0,
+                fallback_reason="",
+                rewrite_count=0,
+            )
+
     async def test_build_prompt_covers_all_route_variants(self) -> None:
         runtime = PhilosophicalRuntime()
 

--- a/tests/test_philosophical_runtime.py
+++ b/tests/test_philosophical_runtime.py
@@ -26,6 +26,7 @@ from core.insight.linguistic import LanguageGameType, SpeechActType
 from core.insight.philosophical_runtime import (
     PhilosophicalQueryRouter,
     PhilosophicalRuntime,
+    PhilosophyRolloutPolicy,
     RiskLevel,
     RouteDecision,
     RouteType,
@@ -365,6 +366,47 @@ class TestPhilosophicalRuntime:
         assert result.metadata.route_type == RouteType.RAG_FACTUAL.value
         assert result.provider_name == "philosophical_runtime"
         assert result.metadata.verification_rate is None
+
+    async def test_rollout_policy_matches_legacy_bool_path_for_deterministic_input(self) -> None:
+        """Prepared rollout policy must preserve legacy behavior for the same deterministic call."""
+
+        legacy_runtime = PhilosophicalRuntime()
+        policy_runtime = PhilosophicalRuntime()
+        legacy_provider = _StaticProvider(response="Balanced nutrition supports steady energy.")
+        policy_provider = _StaticProvider(response="Balanced nutrition supports steady energy.")
+
+        legacy_result = await legacy_runtime.generate_insight(
+            text="Tell me about balanced nutrition.",
+            lang="en",
+            provider=legacy_provider,
+            use_rag=False,
+            philo_validation_enabled=False,
+            recursive_rag_enabled=False,
+            philosophy_router_enabled=True,
+            philosophy_phase12_enabled=False,
+            philosophy_linguistic_enabled=True,
+            philosophy_pragmatic_enabled=False,
+        )
+        policy_result = await policy_runtime.generate_insight(
+            text="Tell me about balanced nutrition.",
+            lang="en",
+            provider=policy_provider,
+            use_rag=False,
+            philo_validation_enabled=False,
+            recursive_rag_enabled=False,
+            rollout_policy=PhilosophyRolloutPolicy(
+                router_enabled=True,
+                phase12_enabled=False,
+                linguistic_enabled=True,
+                pragmatic_enabled=False,
+            ),
+        )
+
+        assert legacy_result.insight == policy_result.insight
+        assert legacy_result.provider_name == policy_result.provider_name
+        assert legacy_result.metadata.route_type == policy_result.metadata.route_type
+        assert legacy_result.metadata.depth_used == policy_result.metadata.depth_used
+        assert legacy_result.metadata.reason_codes == policy_result.metadata.reason_codes
 
     async def test_runtime_preserves_canonical_candidates_from_validated_retriever(self) -> None:
         """Canonical validated retriever candidates may flow through the runtime."""

--- a/tests/test_philosophy_validation_integration.py
+++ b/tests/test_philosophy_validation_integration.py
@@ -466,6 +466,7 @@ class TestPhilosophicalRuntimeIntegration:
         assert data["falsifiability_rate"] is not None
         assert data["contradiction_count"] == 0
         assert isinstance(data["reason_codes"], list)
+        assert "rollout_policy" not in data
 
 
 class TestPhilosophicalRuntimeFlagUnit:

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -1409,6 +1409,42 @@ class TestPhilosophicalRuntimeFastLane:
 
         assert result == []
 
+    def test_build_direct_result_requires_public_metadata_access(self) -> None:
+        """Direct-result helper must fail closed when metadata exposure is disabled."""
+
+        from core.insight.philosophical_runtime import (
+            PhilosophicalRuntime,
+            RiskLevel,
+            RouteDecision,
+            RouteType,
+        )
+
+        runtime = PhilosophicalRuntime()
+        decision = RouteDecision(
+            route_type=RouteType.DIRECT_DEFINITION,
+            target_depth=0,
+            needs_rag=False,
+            needs_generation=False,
+            risk_level=RiskLevel.LOW,
+            simplified_query="simple query",
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="direct-result metadata requires public metadata access",
+        ):
+            runtime._build_direct_result(
+                answer="local answer",
+                provider_name="local",
+                decision=decision,
+                public_metadata_enabled=False,
+                verification_report=None,
+                falsification_report=None,
+                contradiction_count=0,
+                fallback_reason="",
+                rewrite_count=0,
+            )
+
 
 class TestVectorTypeFastLane:
     """Keep pgvector SQLAlchemy fallback covered inside test-fast."""


### PR DESCRIPTION
## Summary
- implement PR-A6 W1 as a narrow phase12-first philosophical rollout reconciliation slice
- add `PhilosophyRolloutPolicy` as the canonical internal rollout source of truth
- make `prepare_insight_runtime(...)` the sole owner of rollout truth for the execution path
- preserve public response/OpenAPI contracts and verify-before-write semantics

## Key Changes
- `core/ai/insight_runtime.py`
  - `PreparedInsightRuntime` now carries `rollout_policy`
  - `prepare_insight_runtime(...)` builds canonical rollout policy from router/phase12/linguistic/pragmatic inputs
- `core/insight/philosophical_runtime.py`
  - runtime normalizes legacy bools into `PhilosophyRolloutPolicy`
  - when a prepared policy is supplied, execution uses it as authority
- `app/services/insight_application_service.py`
  - snapshots rollout flags once
  - passes `prepared_runtime.rollout_policy` downstream
- `app/services/insight_runtime.py`
  - forwards `rollout_policy` through tracing adapter while keeping tracing observational only
- `scripts/evals/run_rag_release_gates.py`
  - eval surface now follows the same prepared-policy contract
- tests updated for rollout parity, prepared-once handoff, and no public payload drift

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#discussion_r3123746307
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#pullrequestreview-4154439968
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#pullrequestreview-4154591459
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#pullrequestreview-4154609821
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#pullrequestreview-4155227251
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1495#pullrequestreview-4155379644

## Merge Readiness
- [ ] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Anchors
- packet: `docs/orchestration/WAVE6_A6_PHILOSOPHICAL_ROLLOUT_W1_PACKET_2026-04-22.md`
- task analysis: `docs/orchestration/WAVE6_A6_TASK_ANALYSIS_2026-04-22.md`
- backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-philosophical-logic`

## Summary by Sourcery

Ввести каноническую философскую политику раскатки (rollout) и протянуть её через стек выполнения insight-runtime, сохранив существующие публичные контракты и поведение.

Новые возможности:
- Добавить `PhilosophyRolloutPolicy` как каноническое внутреннее представление состояния философской раскатки и сделать его доступным через `PreparedInsightRuntime`.
- Позволить генерации философского рантайма принимать подготовленную политику раскатки в дополнение к унаследованным булевым флагам.

Улучшения:
- Централизовать «истину» о раскатке в `prepare_insight_runtime` и распространять подготовленную политику раскатки через сервисы приложения и трассировку до философского рантайма.
- Привести скрипт RAG eval в соответствие с контрактом подготовленной политики раскатки, чтобы оценки использовали тот же путь конфигурации рантайма.
- Гарантировать, что раскрытие метаданных рантайма управляется унифицированной политикой раскатки, а не разрозненными проверками флагов.

Документация:
- Добавить документы по планированию философской раскатки Wave 6 A6, пакеты анализа задач и документ с маппингом fixed-in-commit, а также обновить элемент бэклога roadmap для работы по философской логике.

Тесты:
- Расширить тесты insight-runtime, сервисов приложения и философского рантайма, чтобы покрыть паритет политики раскатки с унаследованными флагами, одноразовую подготовку и передачу (prepared-once handoff), а также убедиться, что нет дрейфа публичного полезного ответа, включая сокрытие `rollout_policy` во внешних ответах.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a canonical philosophical rollout policy and thread it through the insight runtime stack while preserving existing public contracts and behavior.

New Features:
- Add PhilosophyRolloutPolicy as the canonical internal representation of philosophical rollout state and expose it via PreparedInsightRuntime.
- Allow philosophical runtime generation to accept a prepared rollout policy in addition to legacy boolean flags.

Enhancements:
- Centralize rollout truth in prepare_insight_runtime and propagate the prepared rollout policy through app services and tracing to the philosophical runtime.
- Align RAG eval script with the prepared rollout policy contract so evals use the same runtime configuration path.
- Ensure runtime metadata exposure is governed by the unified rollout policy rather than scattered flag checks.

Documentation:
- Add Wave 6 A6 philosophical rollout planning and task analysis packets and a fixed-in-commit mapping doc, and update the roadmap backlog entry for the philosophical logic work.

Tests:
- Extend insight runtime, application service, and philosophical runtime tests to cover rollout policy parity with legacy flags, prepared-once handoff, and ensure no public response payload drift, including hiding rollout_policy from external responses.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized philosophical feature toggles into a single rollout policy that now drives runtime behavior, routing previews, and metadata exposure; rollout policy is produced during runtime preparation and consumed at execution time.

* **Tests**
  * Expanded coverage to assert rollout-policy wiring, parity with legacy boolean flags, enforcement of metadata gating, and that the policy is used internally but not exposed in responses.

* **Documentation**
  * Added planning, task-analysis, review, and roadmap docs for the phased, bounded rollout and verification guardrails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->