### PR TITLE
ci(docker): enforce hard image budget gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,23 +86,22 @@ jobs:
       - name: Collect Docker image telemetry
         run: |
           set -euo pipefail
-          if ! python3 scripts/ci/docker_image_telemetry.py \
+          python3 scripts/ci/docker_image_telemetry.py \
             --image-ref pulseplate:test \
             --baseline-json docker-image-baseline.json \
             --json-out docker-image-telemetry.json \
             --markdown-out docker-image-telemetry.md
-          then
-            echo "::warning::Docker image telemetry collection failed; reporting remains advisory-only."
-            printf '{"advisory_only": true, "warning": "telemetry collection failed"}\n' > docker-image-telemetry.json
-            printf '# Docker Image Telemetry\n\n- Warning: telemetry collection failed; workflow remains advisory-only.\n' > docker-image-telemetry.md
-          fi
 
       - name: Publish Docker telemetry to step summary
+        if: ${{ always() }}
         run: |
           set -euo pipefail
-          cat docker-image-telemetry.md >> "${GITHUB_STEP_SUMMARY}"
+          if [ -f docker-image-telemetry.md ]; then
+            cat docker-image-telemetry.md >> "${GITHUB_STEP_SUMMARY}"
+          fi
 
       - name: Upload Docker telemetry artifact
+        if: ${{ always() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: docker-image-telemetry-build
@@ -110,6 +109,34 @@ jobs:
             docker-runtime-dependency-surface.json
             docker-image-telemetry.json
             docker-image-telemetry.md
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Enforce Docker image budget
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check_docker_image_budget.py \
+            --telemetry-json docker-image-telemetry.json \
+            --budget-json docs/telemetry/docker_image_budget.production.json \
+            --json-out docker-image-budget-check.json \
+            --markdown-out docker-image-budget-check.md
+
+      - name: Publish Docker budget check to step summary
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          if [ -f docker-image-budget-check.md ]; then
+            cat docker-image-budget-check.md >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload Docker budget check artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: docker-image-budget-check-build
+          path: |
+            docker-image-budget-check.json
+            docker-image-budget-check.md
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,8 @@ jobs:
           retention-days: 14
 
       - name: Enforce Docker image budget
+        id: docker_image_budget
+        continue-on-error: true
         run: |
           set -euo pipefail
           python3 scripts/ci/check_docker_image_budget.py \
@@ -188,6 +190,12 @@ jobs:
           curl -f http://localhost:8000/health || exit 1
 
           echo "✅ Docker image test completed successfully"
+
+      - name: Fail build job when Docker budget check failed
+        if: ${{ steps.docker_image_budget.outcome == 'failure' }}
+        run: |
+          echo "::error::Docker image hard budget gate failed."
+          exit 1
 
   # Security scan
   security-scan:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -73,23 +73,22 @@ jobs:
     - name: Collect Docker image telemetry
       run: |
         set -euo pipefail
-        if ! python3 scripts/ci/docker_image_telemetry.py \
+        python3 scripts/ci/docker_image_telemetry.py \
           --image-ref my-image-name:${{ github.run_id }}-${{ github.run_attempt }} \
           --baseline-json docker-image-baseline.json \
           --json-out docker-image-telemetry.json \
           --markdown-out docker-image-telemetry.md
-        then
-          echo "::warning::Docker image telemetry collection failed; reporting remains advisory-only."
-          printf '{"advisory_only": true, "warning": "telemetry collection failed"}\n' > docker-image-telemetry.json
-          printf '# Docker Image Telemetry\n\n- Warning: telemetry collection failed; workflow remains advisory-only.\n' > docker-image-telemetry.md
-        fi
 
     - name: Publish Docker telemetry to step summary
+      if: ${{ always() }}
       run: |
         set -euo pipefail
-        cat docker-image-telemetry.md >> "${GITHUB_STEP_SUMMARY}"
+        if [ -f docker-image-telemetry.md ]; then
+          cat docker-image-telemetry.md >> "${GITHUB_STEP_SUMMARY}"
+        fi
 
     - name: Upload Docker telemetry artifact
+      if: ${{ always() }}
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: docker-image-telemetry-docker-image
@@ -97,5 +96,33 @@ jobs:
           docker-runtime-dependency-surface.json
           docker-image-telemetry.json
           docker-image-telemetry.md
+        if-no-files-found: warn
+        retention-days: 14
+
+    - name: Enforce Docker image budget
+      run: |
+        set -euo pipefail
+        python3 scripts/ci/check_docker_image_budget.py \
+          --telemetry-json docker-image-telemetry.json \
+          --budget-json docs/telemetry/docker_image_budget.production.json \
+          --json-out docker-image-budget-check.json \
+          --markdown-out docker-image-budget-check.md
+
+    - name: Publish Docker budget check to step summary
+      if: ${{ always() }}
+      run: |
+        set -euo pipefail
+        if [ -f docker-image-budget-check.md ]; then
+          cat docker-image-budget-check.md >> "${GITHUB_STEP_SUMMARY}"
+        fi
+
+    - name: Upload Docker budget check artifact
+      if: ${{ always() }}
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: docker-image-budget-check-docker-image
+        path: |
+          docker-image-budget-check.json
+          docker-image-budget-check.md
         if-no-files-found: warn
         retention-days: 14

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -100,6 +100,8 @@ jobs:
         retention-days: 14
 
     - name: Enforce Docker image budget
+      id: docker_image_budget
+      continue-on-error: true
       run: |
         set -euo pipefail
         python3 scripts/ci/check_docker_image_budget.py \
@@ -126,3 +128,9 @@ jobs:
           docker-image-budget-check.md
         if-no-files-found: warn
         retention-days: 14
+
+    - name: Fail docker-image job when Docker budget check failed
+      if: ${{ steps.docker_image_budget.outcome == 'failure' }}
+      run: |
+        echo "::error::Docker image hard budget gate failed."
+        exit 1

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -85,23 +85,22 @@ jobs:
       - name: Collect Docker image telemetry
         run: |
           set -euo pipefail
-          if ! python3 scripts/ci/docker_image_telemetry.py \
+          python3 scripts/ci/docker_image_telemetry.py \
             --image-ref pulseplate:trivy-scan-${{ github.sha }} \
             --baseline-json docker-image-baseline.json \
             --json-out docker-image-telemetry.json \
             --markdown-out docker-image-telemetry.md
-          then
-            echo "::warning::Docker image telemetry collection failed; reporting remains advisory-only."
-            printf '{"advisory_only": true, "warning": "telemetry collection failed"}\n' > docker-image-telemetry.json
-            printf '# Docker Image Telemetry\n\n- Warning: telemetry collection failed; workflow remains advisory-only.\n' > docker-image-telemetry.md
-          fi
 
       - name: Publish Docker telemetry to step summary
+        if: ${{ always() }}
         run: |
           set -euo pipefail
-          cat docker-image-telemetry.md >> "${GITHUB_STEP_SUMMARY}"
+          if [ -f docker-image-telemetry.md ]; then
+            cat docker-image-telemetry.md >> "${GITHUB_STEP_SUMMARY}"
+          fi
 
       - name: Upload Docker telemetry artifact
+        if: ${{ always() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: docker-image-telemetry-trivy
@@ -109,6 +108,34 @@ jobs:
             docker-runtime-dependency-surface.json
             docker-image-telemetry.json
             docker-image-telemetry.md
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Enforce Docker image budget
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check_docker_image_budget.py \
+            --telemetry-json docker-image-telemetry.json \
+            --budget-json docs/telemetry/docker_image_budget.production.json \
+            --json-out docker-image-budget-check.json \
+            --markdown-out docker-image-budget-check.md
+
+      - name: Publish Docker budget check to step summary
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          if [ -f docker-image-budget-check.md ]; then
+            cat docker-image-budget-check.md >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload Docker budget check artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: docker-image-budget-check-trivy
+          path: |
+            docker-image-budget-check.json
+            docker-image-budget-check.md
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -112,6 +112,8 @@ jobs:
           retention-days: 14
 
       - name: Enforce Docker image budget
+        id: docker_image_budget
+        continue-on-error: true
         run: |
           set -euo pipefail
           python3 scripts/ci/check_docker_image_budget.py \
@@ -201,3 +203,9 @@ jobs:
         if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}
         with:
           sarif_file: 'trivy-results.sarif'
+
+      - name: Fail trivy job when Docker budget check failed
+        if: ${{ steps.docker_image_budget.outcome == 'failure' }}
+        run: |
+          echo "::error::Docker image hard budget gate failed."
+          exit 1

--- a/docs/deploy/DOCKER.md
+++ b/docs/deploy/DOCKER.md
@@ -81,7 +81,7 @@ Evidence must include:
 - image size
 - baseline source: `main-artifact` or `repo-seed-fallback`
 - baseline reference metadata when available
-- delta vs baseline in warning-only mode
+- delta vs baseline against the blocking hard-budget policy
 - largest layers
 - build-context evidence
 
@@ -118,7 +118,7 @@ docker run --rm pulseplate:runtime-slim \
   python -c "import app.main; print('app.main import ok')"
 ```
 
-Resolve the canonical baseline and generate advisory telemetry:
+Resolve the canonical baseline and generate telemetry evidence:
 
 ```bash
 python3 scripts/ci/fetch_docker_image_baseline.py \

--- a/docs/deploy/DOCKER.md
+++ b/docs/deploy/DOCKER.md
@@ -11,8 +11,9 @@ Docker runtime contract.
 - Production target remains the split backend image that serves `app.main:app`.
 - Frontend / Caddy topology remains separate and out of scope for this slice.
 - Runtime slimming merged via `PR #1490` on April 22, 2026.
-- The current Docker/CI slice establishes the first canonical backend-image
-  telemetry baseline for warning-only regression reporting.
+- Telemetry baseline landed via `PR #1492` on April 22, 2026.
+- The current Docker/CI slice promotes that telemetry baseline into a
+  deterministic hard budget gate for the production backend image.
 
 ## Runtime manifest policy
 
@@ -34,17 +35,21 @@ Blocked package classes for the default backend runtime:
   `pgvector`
 - GPU / CUDA packages: `nvidia-*`, `cuda-*`, `triton`
 
-## Why the telemetry slice exists
+## Why the hard-budget slice exists
 
 Runtime slimming removed CI-only tooling from the production backend image, but
 the project still needs one canonical baseline so PR authors can see image-size
 drift, largest layers, and build-context evidence before merge.
 
-This wave keeps that signal warning-only:
+Telemetry baseline established deterministic image-size evidence, but PR authors
+still need merge-blocking enforcement once the baseline is stable on `main`.
 
-- no absolute image-size cap
-- no hard failure threshold for positive delta vs baseline
-- no provenance / Dagger reopening until the baseline exists
+This wave promotes the production backend image to a hard gate:
+
+- absolute image-size cap: `470000000` bytes
+- max positive delta vs baseline: `20000000` bytes
+- same canonical baseline source rule as the telemetry wave
+- provenance / Dagger and Shared Safety remain deferred
 
 ## Baseline source rule
 
@@ -67,6 +72,8 @@ Each Docker lane publishes:
 
 - `docker-image-telemetry.json`
 - `docker-image-telemetry.md`
+- `docker-image-budget-check.json`
+- `docker-image-budget-check.md`
 - `GITHUB_STEP_SUMMARY` entry
 
 Evidence must include:
@@ -77,6 +84,11 @@ Evidence must include:
 - delta vs baseline in warning-only mode
 - largest layers
 - build-context evidence
+
+Hard budget enforcement must fail when either of these are true:
+
+- `image_size_bytes > 470000000`
+- `baseline.size_delta_bytes > 20000000`
 
 ## Validation commands
 
@@ -119,6 +131,12 @@ python3 scripts/ci/docker_image_telemetry.py \
   --baseline-json artifacts/docker/docker-image-baseline.json \
   --json-out artifacts/docker/docker-image-telemetry.json \
   --markdown-out artifacts/docker/docker-image-telemetry.md
+
+python3 scripts/ci/check_docker_image_budget.py \
+  --telemetry-json artifacts/docker/docker-image-telemetry.json \
+  --budget-json docs/telemetry/docker_image_budget.production.json \
+  --json-out artifacts/docker/docker-image-budget-check.json \
+  --markdown-out artifacts/docker/docker-image-budget-check.md
 ```
 
 ## Rollback
@@ -131,18 +149,12 @@ If the runtime image fails to build or boot after this slice:
 3. keep the runtime-surface findings as evidence in the PR and record the
    follow-up in `docs/roadmap/BACKLOG_LEDGER.md`
 
-Do not widen this rollback into hard image-budget enforcement, provenance, or
-frontend/Caddy changes.
+Do not widen this rollback into provenance or frontend/Caddy changes.
 
 ## Deferred follow-ups
 
 Explicitly deferred after this PR:
 
-- hard image-budget cap / failure threshold
-  Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-docker-image-hard-budget-gate`
-  Remove-by: 2026-05-31
-  Rollback: keep telemetry advisory-only and remove any premature hard-stop threshold from Docker lanes.
-  Exit criteria: a dedicated follow-up PR lands a deterministic hard-fail threshold for the production backend image after the warning-only baseline stabilizes on `main`.
 - `P1: Shared Safety audit script after install-profile split`
   Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-safety-audit-shared-script-after-pr1479`
   Remove-by: 2026-06-15

--- a/docs/orchestration/DOCKER_IMAGE_HARD_BUDGET_GATE_TASK_PACKET_2026-04-22.md
+++ b/docs/orchestration/DOCKER_IMAGE_HARD_BUDGET_GATE_TASK_PACKET_2026-04-22.md
@@ -1,0 +1,50 @@
+# Docker Image Hard Budget Gate Task Packet — 2026-04-22
+
+Status: Active PR-6 slice in the Docker / CI discipline series
+
+## Summary
+
+After telemetry baseline merged via `PR #1492`, this slice promotes the
+production backend image from warning-only regression reporting to a
+deterministic hard budget gate.
+
+## Branch / worktree
+
+- Branch: `codex/docker-image-hard-budget-gate`
+- Worktree: `worktrees/docker-image-hard-budget-gate-pr6`
+
+## Mandatory role order
+
+1. `agent-coordinator`
+2. `architecture-specialist`
+3. `security-auditor`
+4. `backend-engineer`
+5. `dev-operator`
+6. post-open `qa-engineer-agent`
+7. post-open `bug-hunter`
+
+No ad hoc role stack may replace this order.
+
+## Scope
+
+- add one checked-in hard-budget policy for the production backend image
+- add a dedicated budget-check helper under `scripts/ci/`
+- wire the hard gate into `build.yml`, `docker-image.yml`, and `trivy.yml`
+- keep baseline fetch and telemetry generation as separate seams
+- update docs and backlog for the hard-budget slice
+
+## Non-goals
+
+- no Shared Safety extraction
+- no provenance / attestation recovery
+- no Dagger or alternate control plane
+- no frontend/Caddy topology change
+- no runtime dependency-contract widening
+
+## Acceptance criteria
+
+- all three Docker lanes use the same checked-in budget policy
+- image-size cap and positive-delta cap fail the lane deterministically
+- telemetry artifacts and budget-check artifacts stay PR-visible even on failure
+- telemetry/budget reporting stays scoped to the production backend image
+- docs and backlog keep Shared Safety and provenance/Dagger explicitly deferred

--- a/docs/review/PR_1498_FIXED_MAPPING.md
+++ b/docs/review/PR_1498_FIXED_MAPPING.md
@@ -1,0 +1,41 @@
+# PR #1498 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+This artifact is created immediately after the PR is opened per repo governance.
+Record every actionable human/bot disposition here before resolving threads on GitHub.
+
+## Fixed in Commit Mapping
+
+Pending initial review threads.
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Current-head CI is green for PR branch head
+  Evidence: pending current-head GitHub checks after PR open.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: pending current-head GitHub checks after PR open.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: pending initial review cycle.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: pending initial review cycle.
+- [x] Pre-commit green on latest pushed head
+  Evidence: `pre-commit run --all-files` passed before commit `89ef1466c`.
+- [ ] `make verify` green on latest pushed head
+  Evidence: not run for this lane; current-head GitHub checks remain the heavy signal by operator choice.
+
+## Deferred / Follow-ups
+
+- `docs/roadmap/BACKLOG_LEDGER.md` line 540 (`P1: Shared Safety audit script after install-profile split`)
+- provenance / Dagger follow-up after the hard budget gate stabilizes

--- a/docs/review/PR_1498_FIXED_MAPPING.md
+++ b/docs/review/PR_1498_FIXED_MAPPING.md
@@ -26,6 +26,11 @@ Evidence: `docs/orchestration/DOCKER_IMAGE_HARD_BUDGET_GATE_TASK_PACKET_2026-04-
 Reason: The suggestion to extract the three Docker hard-budget lanes into a shared composite action is maintainability advice, not a correctness bug. This slice intentionally keeps the enforcement blocks explicit inside the three canonical workflows named in the task packet so each lane preserves its own artifact naming, summary publication, and terminal fail-step semantics without widening scope into a reusable-actions refactor.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1498#pullrequestreview-4157673112
 
+Disposition: NOT-A-BUG
+Evidence: `tests/test_python_supply_chain_controls.py:75-78`; `tests/test_python_supply_chain_controls.py:690-748`; `.github/workflows/build.yml:15-198`; `.github/workflows/docker-image.yml:17-136`; `.github/workflows/trivy.yml:22-195`
+Reason: `_workflow_step_names(...)` is a scoped contract helper used only for the three Docker workflow jobs that this test audits, and every step in those jobs is intentionally named. Keeping direct `step["name"]` access fail-closed is desirable here because an unnamed step would represent workflow-contract drift that should surface as a hard test failure instead of being silently normalized behind a fallback label.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1498#pullrequestreview-4157794544
+
 ## Merge Readiness
 
 Merge-readiness contract:
@@ -41,7 +46,7 @@ Merge-readiness contract:
 - [ ] All review threads resolved on GitHub after disposition updates
   Evidence: pending initial review cycle.
 - [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: `docs/review/PR_1498_FIXED_MAPPING.md:17-28`
+  Evidence: `docs/review/PR_1498_FIXED_MAPPING.md:17-33`
 - [x] Pre-commit green on latest pushed head
   Evidence: `pre-commit run --all-files` passed before commit `99157f43a`.
 - [ ] `make verify` green on latest pushed head

--- a/docs/review/PR_1498_FIXED_MAPPING.md
+++ b/docs/review/PR_1498_FIXED_MAPPING.md
@@ -40,4 +40,7 @@ Merge-readiness contract:
 ## Deferred / Follow-ups
 
 - `docs/roadmap/BACKLOG_LEDGER.md` line 540 (`P1: Shared Safety audit script after install-profile split`)
-- provenance / Dagger follow-up after the hard budget gate stabilizes
+- provenance recovery follow-up
+  Backlog: `docs/roadmap/BACKLOG_LEDGER.md#backlog-restore-signed-build-provenance`
+- Dagger follow-up after the hard budget gate stabilizes
+  Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-dagger-pilot-after-docker-baseline`

--- a/docs/review/PR_1498_FIXED_MAPPING.md
+++ b/docs/review/PR_1498_FIXED_MAPPING.md
@@ -14,7 +14,17 @@ Record every actionable human/bot disposition here before resolving threads on G
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 99157f43a
+Evidence: `tests/test_python_supply_chain_controls.py:75-78`; `tests/test_python_supply_chain_controls.py:690-748`; `docs/review/PR_1498_FIXED_MAPPING.md:42-46`
+Reason: The workflow-contract test now caches step-name lists once, asserts the docker-image hard-budget ordering explicitly, and the deferred provenance/Dagger follow-ups now point to concrete backlog anchors instead of an untracked umbrella note.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1498#pullrequestreview-4157683913 -> 99157f43a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1498#discussion_r3126676236 -> 99157f43a
+
+Disposition: NOT-A-BUG
+Evidence: `docs/orchestration/DOCKER_IMAGE_HARD_BUDGET_GATE_TASK_PACKET_2026-04-22.md:28-35`; `docs/orchestration/DOCKER_IMAGE_HARD_BUDGET_GATE_TASK_PACKET_2026-04-22.md:36-42`; `.github/workflows/build.yml:103-198`; `.github/workflows/docker-image.yml:90-136`; `.github/workflows/trivy.yml:102-163`
+Reason: The suggestion to extract the three Docker hard-budget lanes into a shared composite action is maintainability advice, not a correctness bug. This slice intentionally keeps the enforcement blocks explicit inside the three canonical workflows named in the task packet so each lane preserves its own artifact naming, summary publication, and terminal fail-step semantics without widening scope into a reusable-actions refactor.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1498#pullrequestreview-4157673112
 
 ## Merge Readiness
 
@@ -30,10 +40,10 @@ Merge-readiness contract:
   Evidence: pending current-head GitHub checks after PR open.
 - [ ] All review threads resolved on GitHub after disposition updates
   Evidence: pending initial review cycle.
-- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: pending initial review cycle.
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: `docs/review/PR_1498_FIXED_MAPPING.md:17-28`
 - [x] Pre-commit green on latest pushed head
-  Evidence: `pre-commit run --all-files` passed before commit `89ef1466c`.
+  Evidence: `pre-commit run --all-files` passed before commit `99157f43a`.
 - [ ] `make verify` green on latest pushed head
   Evidence: not run for this lane; current-head GitHub checks remain the heavy signal by operator choice.
 

--- a/docs/review/PR_1498_FIXED_MAPPING.md
+++ b/docs/review/PR_1498_FIXED_MAPPING.md
@@ -6,15 +6,15 @@ Canonical review-governance artifact and PR-body mirror requirements:
 `AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
 `docs/orchestration/AGENTS.md:79-82`.
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 This artifact is created immediately after the PR is opened per repo governance.
 Record every actionable human/bot disposition here before resolving threads on GitHub.
 
 ## Fixed in Commit Mapping
 
-Pending initial review threads.
+- No actionable review comments
 
 ## Merge Readiness
 
@@ -22,6 +22,8 @@ Merge-readiness contract:
 `AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
 `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
 
+- [ ] Mandatory wait-window satisfied (final check pass completed, then waited >=1 review cycle after latest bot/review activity)
+  Evidence: pending initial review and current-head CI cycle.
 - [ ] Current-head CI is green for PR branch head
   Evidence: pending current-head GitHub checks after PR open.
 - [ ] Required checks complete (no pending jobs)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -669,13 +669,17 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Priority: P1
   - Target PR: PR-TBD-DOCKER-HARD-BUDGET-GATE
   - Area: CI / docker / telemetry
+  - Status note: Active PR-6 slice after `PR #1492` merged on April 22, 2026. This lane promotes the production backend image from warning-only telemetry to a deterministic hybrid hard gate with an absolute cap and a maximum positive delta vs baseline.
   - Depends on:
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-docker-image-budget-telemetry`
   - Reason: The repo should not enforce a hard image-size failure threshold until the warning-only baseline has stabilized on `main` and the canonical telemetry evidence is trustworthy enough to gate merges deterministically.
   - Links:
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-docker-image-budget-telemetry`
+    - `docs/orchestration/DOCKER_IMAGE_HARD_BUDGET_GATE_TASK_PACKET_2026-04-22.md`
     - `.github/workflows/build.yml`
     - `.github/workflows/docker-image.yml`
+    - `.github/workflows/trivy.yml`
+    - `docs/telemetry/docker_image_budget.production.json`
   - DoD:
     - A canonical hard-fail threshold exists for the production backend image
     - Docker lanes fail deterministically when the threshold regresses beyond policy

--- a/docs/telemetry/docker_image_budget.production.json
+++ b/docs/telemetry/docker_image_budget.production.json
@@ -1,0 +1,15 @@
+{
+  "budget_name": "production-backend-image",
+  "budget_version": 1,
+  "budget_scope": "production-backend-image",
+  "max_image_size_bytes": 470000000,
+  "max_positive_delta_bytes": 20000000,
+  "baseline_reference": {
+    "baseline_file": "docs/telemetry/docker_image_baseline.production.json",
+    "baseline_source": "repo-seed-fallback",
+    "seeded_from_run_id": 24771474567,
+    "seeded_from_run_number": 6987,
+    "workflow": "build.yml"
+  },
+  "policy_note": "Hybrid hard gate: enforce an absolute cap and a max positive delta against the canonical telemetry baseline for the production backend image."
+}

--- a/scripts/ci/check_docker_image_budget.py
+++ b/scripts/ci/check_docker_image_budget.py
@@ -138,10 +138,16 @@ def evaluate_budget(
     baseline_size_bytes_raw = baseline_payload.get("baseline_size_bytes")
     if baseline_size_bytes_raw is None:
         baseline_size_bytes = None
-    elif isinstance(baseline_size_bytes_raw, int) and not isinstance(baseline_size_bytes_raw, bool):
+    elif (
+        isinstance(baseline_size_bytes_raw, int)
+        and not isinstance(baseline_size_bytes_raw, bool)
+        and baseline_size_bytes_raw >= 0
+    ):
         baseline_size_bytes = baseline_size_bytes_raw
     else:
-        raise RuntimeError("Docker image telemetry baseline_size_bytes must be null or an integer.")
+        raise RuntimeError(
+            "Docker image telemetry baseline_size_bytes must be null or a non-negative integer."
+        )
 
     baseline_source = baseline_payload.get("baseline_source")
     if baseline_source is not None and not isinstance(baseline_source, str):

--- a/scripts/ci/check_docker_image_budget.py
+++ b/scripts/ci/check_docker_image_budget.py
@@ -150,8 +150,12 @@ def evaluate_budget(
         )
 
     baseline_source = baseline_payload.get("baseline_source")
-    if baseline_source is not None and not isinstance(baseline_source, str):
-        raise RuntimeError("Docker image telemetry baseline_source must be null or a string.")
+    if baseline_source is not None and (
+        not isinstance(baseline_source, str) or not baseline_source.strip()
+    ):
+        raise RuntimeError(
+            "Docker image telemetry baseline_source must be null or a non-empty string."
+        )
 
     size_delta_raw = baseline_payload.get("size_delta_bytes")
     if size_delta_raw is None:

--- a/scripts/ci/check_docker_image_budget.py
+++ b/scripts/ci/check_docker_image_budget.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Enforce the production Docker image hard-budget policy.
+
+RU: Скрипт проверяет telemetry report против фиксированного hard-budget policy
+и пишет PR-visible evidence в JSON/Markdown.
+EN: Validate the Docker telemetry report against the checked-in hard-budget
+policy and emit PR-visible JSON/Markdown evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+import sys
+
+
+@dataclass(frozen=True)
+class DockerImageBudgetPolicy:
+    """Checked-in hard-budget policy for the production backend image."""
+
+    budget_name: str
+    budget_version: int
+    budget_scope: str
+    max_image_size_bytes: int
+    max_positive_delta_bytes: int
+    baseline_reference: dict[str, object]
+    policy_note: str
+
+
+@dataclass(frozen=True)
+class BudgetCheckResult:
+    """Deterministic budget-check result used by CI and PR summaries."""
+
+    passed: bool
+    image_ref: str
+    image_size_bytes: int
+    baseline_size_bytes: int | None
+    baseline_source: str | None
+    size_delta_bytes: int | None
+    max_image_size_bytes: int
+    max_positive_delta_bytes: int
+    violations: tuple[str, ...]
+    policy: DockerImageBudgetPolicy
+
+
+def _load_json_object(path: Path, *, description: str) -> dict[str, object]:
+    """Load a JSON object and fail closed on malformed payloads."""
+
+    if not path.exists() or not path.is_file():
+        raise RuntimeError(f"{description} is missing: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, PermissionError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Unable to read {description}: {path}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{description} must be a JSON object: {path}")
+    return payload
+
+
+def _read_non_negative_int(payload: dict[str, object], key: str, *, description: str) -> int:
+    """Return a non-negative integer field from a payload."""
+
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise RuntimeError(f"{description} field {key!r} must be a non-negative integer.")
+    return value
+
+
+def load_budget_policy(path: Path) -> DockerImageBudgetPolicy:
+    """Parse the checked-in Docker budget policy."""
+
+    payload = _load_json_object(path, description="Docker image budget policy")
+    budget_name = payload.get("budget_name")
+    budget_scope = payload.get("budget_scope")
+    policy_note = payload.get("policy_note")
+    baseline_reference = payload.get("baseline_reference")
+    budget_version = payload.get("budget_version")
+
+    if not isinstance(budget_name, str) or not budget_name.strip():
+        raise RuntimeError("Docker image budget policy requires a non-empty budget_name.")
+    if not isinstance(budget_scope, str) or not budget_scope.strip():
+        raise RuntimeError("Docker image budget policy requires a non-empty budget_scope.")
+    if not isinstance(policy_note, str) or not policy_note.strip():
+        raise RuntimeError("Docker image budget policy requires a non-empty policy_note.")
+    if (
+        not isinstance(budget_version, int)
+        or isinstance(budget_version, bool)
+        or budget_version <= 0
+    ):
+        raise RuntimeError("Docker image budget policy requires a positive integer budget_version.")
+    if not isinstance(baseline_reference, dict) or not baseline_reference:
+        raise RuntimeError("Docker image budget policy requires a baseline_reference object.")
+
+    return DockerImageBudgetPolicy(
+        budget_name=budget_name.strip(),
+        budget_version=budget_version,
+        budget_scope=budget_scope.strip(),
+        max_image_size_bytes=_read_non_negative_int(
+            payload,
+            "max_image_size_bytes",
+            description="Docker image budget policy",
+        ),
+        max_positive_delta_bytes=_read_non_negative_int(
+            payload,
+            "max_positive_delta_bytes",
+            description="Docker image budget policy",
+        ),
+        baseline_reference=baseline_reference,
+        policy_note=policy_note.strip(),
+    )
+
+
+def evaluate_budget(
+    *,
+    telemetry_path: Path,
+    budget_path: Path,
+) -> BudgetCheckResult:
+    """Evaluate the Docker telemetry report against the hard-budget policy."""
+
+    telemetry_payload = _load_json_object(telemetry_path, description="Docker image telemetry")
+    image_ref = telemetry_payload.get("image_ref")
+    if not isinstance(image_ref, str) or not image_ref.strip():
+        raise RuntimeError("Docker image telemetry requires a non-empty image_ref.")
+
+    baseline_payload = telemetry_payload.get("baseline")
+    if not isinstance(baseline_payload, dict):
+        raise RuntimeError("Docker image telemetry requires a baseline object.")
+
+    policy = load_budget_policy(budget_path)
+    image_size_bytes = _read_non_negative_int(
+        telemetry_payload,
+        "image_size_bytes",
+        description="Docker image telemetry",
+    )
+
+    baseline_size_bytes_raw = baseline_payload.get("baseline_size_bytes")
+    if baseline_size_bytes_raw is None:
+        baseline_size_bytes = None
+    elif isinstance(baseline_size_bytes_raw, int) and not isinstance(baseline_size_bytes_raw, bool):
+        baseline_size_bytes = baseline_size_bytes_raw
+    else:
+        raise RuntimeError("Docker image telemetry baseline_size_bytes must be null or an integer.")
+
+    baseline_source = baseline_payload.get("baseline_source")
+    if baseline_source is not None and not isinstance(baseline_source, str):
+        raise RuntimeError("Docker image telemetry baseline_source must be null or a string.")
+
+    size_delta_raw = baseline_payload.get("size_delta_bytes")
+    if size_delta_raw is None:
+        size_delta_bytes = None
+    elif isinstance(size_delta_raw, int) and not isinstance(size_delta_raw, bool):
+        size_delta_bytes = size_delta_raw
+    else:
+        raise RuntimeError("Docker image telemetry size_delta_bytes must be null or an integer.")
+
+    violations: list[str] = []
+    if image_size_bytes > policy.max_image_size_bytes:
+        violations.append(
+            "Image size exceeds the absolute hard-budget cap "
+            f"({image_size_bytes} > {policy.max_image_size_bytes})."
+        )
+    if size_delta_bytes is not None and size_delta_bytes > policy.max_positive_delta_bytes:
+        violations.append(
+            "Image size delta exceeds the allowed positive regression budget "
+            f"({size_delta_bytes} > {policy.max_positive_delta_bytes})."
+        )
+
+    return BudgetCheckResult(
+        passed=not violations,
+        image_ref=image_ref.strip(),
+        image_size_bytes=image_size_bytes,
+        baseline_size_bytes=baseline_size_bytes,
+        baseline_source=baseline_source.strip() if isinstance(baseline_source, str) else None,
+        size_delta_bytes=size_delta_bytes,
+        max_image_size_bytes=policy.max_image_size_bytes,
+        max_positive_delta_bytes=policy.max_positive_delta_bytes,
+        violations=tuple(violations),
+        policy=policy,
+    )
+
+
+def render_markdown(result: BudgetCheckResult) -> str:
+    """Render a concise Markdown summary for the hard-budget result."""
+
+    lines = [
+        "# Docker Image Budget Check",
+        "",
+        f"- Passed: `{str(result.passed).lower()}`",
+        f"- Image: `{result.image_ref}`",
+        f"- Image size bytes: `{result.image_size_bytes}`",
+        f"- Absolute cap bytes: `{result.max_image_size_bytes}`",
+        f"- Positive delta cap bytes: `{result.max_positive_delta_bytes}`",
+    ]
+    if result.baseline_size_bytes is not None:
+        lines.append(f"- Baseline size bytes: `{result.baseline_size_bytes}`")
+    if result.baseline_source is not None:
+        lines.append(f"- Baseline source: `{result.baseline_source}`")
+    if result.size_delta_bytes is not None:
+        lines.append(f"- Delta vs baseline bytes: `{result.size_delta_bytes}`")
+
+    lines.extend(
+        [
+            f"- Policy: `{result.policy.budget_name}` v`{result.policy.budget_version}`",
+            f"- Scope: `{result.policy.budget_scope}`",
+            "",
+        ]
+    )
+    if result.violations:
+        lines.extend(["## Violations", ""])
+        lines.extend(f"- {violation}" for violation in result.violations)
+    else:
+        lines.extend(["## Result", "", "- Budget check passed within policy."])
+    return "\n".join(lines)
+
+
+def render_failure_markdown(*, error: str, telemetry_path: Path, budget_path: Path) -> str:
+    """Render fail-closed Markdown evidence for malformed inputs."""
+
+    return "\n".join(
+        [
+            "# Docker Image Budget Check",
+            "",
+            "- Passed: `false`",
+            f"- Telemetry input: `{telemetry_path}`",
+            f"- Budget policy input: `{budget_path}`",
+            "",
+            "## Fail-Closed Error",
+            "",
+            f"- {error}",
+        ]
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--telemetry-json", required=True, help="Path to docker-image-telemetry.json"
+    )
+    parser.add_argument(
+        "--budget-json", required=True, help="Path to checked-in budget policy JSON"
+    )
+    parser.add_argument("--json-out", required=True, help="Path to JSON output artifact")
+    parser.add_argument("--markdown-out", required=True, help="Path to Markdown output artifact")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    telemetry_path = Path(args.telemetry_json)
+    budget_path = Path(args.budget_json)
+    json_out = Path(args.json_out)
+    markdown_out = Path(args.markdown_out)
+    try:
+        result = evaluate_budget(
+            telemetry_path=telemetry_path,
+            budget_path=budget_path,
+        )
+    except RuntimeError as exc:
+        failure_payload = {
+            "passed": False,
+            "error": str(exc),
+            "telemetry_json": str(telemetry_path),
+            "budget_json": str(budget_path),
+        }
+        json_out.write_text(json.dumps(failure_payload, indent=2, sort_keys=True), encoding="utf-8")
+        markdown_out.write_text(
+            render_failure_markdown(
+                error=str(exc),
+                telemetry_path=telemetry_path,
+                budget_path=budget_path,
+            ),
+            encoding="utf-8",
+        )
+        print(f"check_docker_image_budget failed: {exc}", file=sys.stderr)
+        return 1
+
+    json_out.write_text(json.dumps(asdict(result), indent=2, sort_keys=True), encoding="utf-8")
+    markdown_out.write_text(render_markdown(result), encoding="utf-8")
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_docker_image_budget.py
+++ b/tests/test_check_docker_image_budget.py
@@ -140,6 +140,24 @@ def test_evaluate_budget_rejects_negative_baseline_size_bytes(tmp_path: Path) ->
         )
 
 
+def test_evaluate_budget_rejects_blank_baseline_source(tmp_path: Path) -> None:
+    telemetry_path = _write_telemetry_payload(
+        tmp_path,
+        image_size_bytes=430000000,
+        size_delta_bytes=-12000000,
+    )
+    payload = json.loads(telemetry_path.read_text(encoding="utf-8"))
+    payload["baseline"]["baseline_source"] = ""
+    telemetry_path.write_text(json.dumps(payload), encoding="utf-8")
+    budget_path = _write_budget_policy(tmp_path)
+
+    with pytest.raises(RuntimeError, match="baseline_source"):
+        check_docker_image_budget.evaluate_budget(
+            telemetry_path=telemetry_path,
+            budget_path=budget_path,
+        )
+
+
 def test_main_writes_artifacts_on_budget_breach(tmp_path: Path) -> None:
     telemetry_path = _write_telemetry_payload(
         tmp_path,

--- a/tests/test_check_docker_image_budget.py
+++ b/tests/test_check_docker_image_budget.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ci import check_docker_image_budget
+
+
+def _write_budget_policy(tmp_path: Path) -> Path:
+    budget_path = tmp_path / "budget.json"
+    budget_path.write_text(
+        json.dumps(
+            {
+                "budget_name": "production-backend-image",
+                "budget_version": 1,
+                "budget_scope": "production-backend-image",
+                "max_image_size_bytes": 470000000,
+                "max_positive_delta_bytes": 20000000,
+                "baseline_reference": {
+                    "baseline_file": "docs/telemetry/docker_image_baseline.production.json",
+                    "workflow": "build.yml",
+                },
+                "policy_note": "Hard gate for the production backend image.",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return budget_path
+
+
+def _write_telemetry_payload(
+    tmp_path: Path,
+    *,
+    image_size_bytes: int,
+    size_delta_bytes: int | None,
+    baseline_size_bytes: int | None = 445565354,
+) -> Path:
+    telemetry_path = tmp_path / "telemetry.json"
+    telemetry_path.write_text(
+        json.dumps(
+            {
+                "advisory_only": True,
+                "image_ref": "pulseplate:test",
+                "image_size_bytes": image_size_bytes,
+                "baseline": {
+                    "baseline_source": "main-artifact",
+                    "baseline_size_bytes": baseline_size_bytes,
+                    "size_delta_bytes": size_delta_bytes,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return telemetry_path
+
+
+def test_evaluate_budget_passes_within_policy(tmp_path: Path) -> None:
+    telemetry_path = _write_telemetry_payload(
+        tmp_path,
+        image_size_bytes=460000000,
+        size_delta_bytes=15000000,
+    )
+    budget_path = _write_budget_policy(tmp_path)
+
+    result = check_docker_image_budget.evaluate_budget(
+        telemetry_path=telemetry_path,
+        budget_path=budget_path,
+    )
+
+    assert result.passed is True
+    assert result.violations == ()
+
+
+def test_evaluate_budget_fails_on_absolute_cap_breach(tmp_path: Path) -> None:
+    telemetry_path = _write_telemetry_payload(
+        tmp_path,
+        image_size_bytes=470000001,
+        size_delta_bytes=1000000,
+    )
+    budget_path = _write_budget_policy(tmp_path)
+
+    result = check_docker_image_budget.evaluate_budget(
+        telemetry_path=telemetry_path,
+        budget_path=budget_path,
+    )
+
+    assert result.passed is False
+    assert "absolute hard-budget cap" in result.violations[0]
+
+
+def test_evaluate_budget_fails_on_positive_delta_breach(tmp_path: Path) -> None:
+    telemetry_path = _write_telemetry_payload(
+        tmp_path,
+        image_size_bytes=460000000,
+        size_delta_bytes=20000001,
+    )
+    budget_path = _write_budget_policy(tmp_path)
+
+    result = check_docker_image_budget.evaluate_budget(
+        telemetry_path=telemetry_path,
+        budget_path=budget_path,
+    )
+
+    assert result.passed is False
+    assert "positive regression budget" in result.violations[0]
+
+
+def test_evaluate_budget_allows_negative_delta_within_cap(tmp_path: Path) -> None:
+    telemetry_path = _write_telemetry_payload(
+        tmp_path,
+        image_size_bytes=430000000,
+        size_delta_bytes=-12000000,
+    )
+    budget_path = _write_budget_policy(tmp_path)
+
+    result = check_docker_image_budget.evaluate_budget(
+        telemetry_path=telemetry_path,
+        budget_path=budget_path,
+    )
+
+    assert result.passed is True
+    assert result.size_delta_bytes == -12000000
+
+
+def test_main_fails_closed_on_malformed_telemetry_and_writes_evidence(tmp_path: Path) -> None:
+    telemetry_path = tmp_path / "telemetry.json"
+    telemetry_path.write_text(
+        json.dumps({"image_ref": "pulseplate:test", "baseline": {}}),
+        encoding="utf-8",
+    )
+    budget_path = _write_budget_policy(tmp_path)
+    json_out = tmp_path / "budget-check.json"
+    markdown_out = tmp_path / "budget-check.md"
+
+    exit_code = check_docker_image_budget.main(
+        [
+            "--telemetry-json",
+            str(telemetry_path),
+            "--budget-json",
+            str(budget_path),
+            "--json-out",
+            str(json_out),
+            "--markdown-out",
+            str(markdown_out),
+        ]
+    )
+
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    markdown = markdown_out.read_text(encoding="utf-8")
+
+    assert exit_code == 1
+    assert payload["passed"] is False
+    assert "image_size_bytes" in payload["error"]
+    assert "Fail-Closed Error" in markdown
+
+
+def test_main_fails_closed_on_malformed_policy_and_writes_evidence(tmp_path: Path) -> None:
+    telemetry_path = _write_telemetry_payload(
+        tmp_path,
+        image_size_bytes=460000000,
+        size_delta_bytes=1000000,
+    )
+    budget_path = tmp_path / "budget.json"
+    budget_path.write_text(json.dumps({"budget_name": ""}), encoding="utf-8")
+    json_out = tmp_path / "budget-check.json"
+    markdown_out = tmp_path / "budget-check.md"
+
+    exit_code = check_docker_image_budget.main(
+        [
+            "--telemetry-json",
+            str(telemetry_path),
+            "--budget-json",
+            str(budget_path),
+            "--json-out",
+            str(json_out),
+            "--markdown-out",
+            str(markdown_out),
+        ]
+    )
+
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    markdown = markdown_out.read_text(encoding="utf-8")
+
+    assert exit_code == 1
+    assert payload["passed"] is False
+    assert "budget_name" in payload["error"]
+    assert "Docker image budget policy" in markdown

--- a/tests/test_check_docker_image_budget.py
+++ b/tests/test_check_docker_image_budget.py
@@ -124,6 +124,56 @@ def test_evaluate_budget_allows_negative_delta_within_cap(tmp_path: Path) -> Non
     assert result.size_delta_bytes == -12000000
 
 
+def test_evaluate_budget_rejects_negative_baseline_size_bytes(tmp_path: Path) -> None:
+    telemetry_path = _write_telemetry_payload(
+        tmp_path,
+        image_size_bytes=430000000,
+        size_delta_bytes=-12000000,
+        baseline_size_bytes=-1,
+    )
+    budget_path = _write_budget_policy(tmp_path)
+
+    with pytest.raises(RuntimeError, match="baseline_size_bytes"):
+        check_docker_image_budget.evaluate_budget(
+            telemetry_path=telemetry_path,
+            budget_path=budget_path,
+        )
+
+
+def test_main_writes_artifacts_on_budget_breach(tmp_path: Path) -> None:
+    telemetry_path = _write_telemetry_payload(
+        tmp_path,
+        image_size_bytes=470000001,
+        size_delta_bytes=1000000,
+    )
+    budget_path = _write_budget_policy(tmp_path)
+    json_out = tmp_path / "budget-check.json"
+    markdown_out = tmp_path / "budget-check.md"
+
+    exit_code = check_docker_image_budget.main(
+        [
+            "--telemetry-json",
+            str(telemetry_path),
+            "--budget-json",
+            str(budget_path),
+            "--json-out",
+            str(json_out),
+            "--markdown-out",
+            str(markdown_out),
+        ]
+    )
+
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    markdown = markdown_out.read_text(encoding="utf-8")
+
+    assert exit_code == 1
+    assert payload["passed"] is False
+    assert payload["violations"]
+    assert "absolute hard-budget cap" in payload["violations"][0]
+    assert "## Violations" in markdown
+    assert "Passed: `false`" in markdown
+
+
 def test_main_fails_closed_on_malformed_telemetry_and_writes_evidence(tmp_path: Path) -> None:
     telemetry_path = tmp_path / "telemetry.json"
     telemetry_path.write_text(

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -655,17 +655,34 @@ def test_docker_workflows_emit_image_telemetry_artifacts() -> None:
         ".github/workflows/build.yml",
         "build",
         "Enforce Docker image budget",
-    )["run"]
+    )
     docker_image_budget_step = _workflow_step_by_name(
         ".github/workflows/docker-image.yml",
         "build",
         "Enforce Docker image budget",
-    )["run"]
+    )
     trivy_budget_step = _workflow_step_by_name(
         ".github/workflows/trivy.yml",
         "build",
         "Enforce Docker image budget",
-    )["run"]
+    )
+    build_fail_budget_step = _workflow_step_by_name(
+        ".github/workflows/build.yml",
+        "build",
+        "Fail build job when Docker budget check failed",
+    )
+    docker_image_fail_budget_step = _workflow_step_by_name(
+        ".github/workflows/docker-image.yml",
+        "build",
+        "Fail docker-image job when Docker budget check failed",
+    )
+    trivy_fail_budget_step = _workflow_step_by_name(
+        ".github/workflows/trivy.yml",
+        "build",
+        "Fail trivy job when Docker budget check failed",
+    )
+    build_steps = build_workflow["jobs"]["build"]["steps"]
+    trivy_steps = trivy_workflow["jobs"]["build"]["steps"]
 
     assert build_job_permissions["actions"] == "read"
     assert build_job_permissions["contents"] == "read"
@@ -687,12 +704,39 @@ def test_docker_workflows_emit_image_telemetry_artifacts() -> None:
     assert "--workflow build.yml" in build_resolve_step
     assert "--workflow build.yml" in docker_image_resolve_step
     assert "--workflow build.yml" in trivy_resolve_step
-    assert "--budget-json docs/telemetry/docker_image_budget.production.json" in build_budget_step
     assert (
         "--budget-json docs/telemetry/docker_image_budget.production.json"
-        in docker_image_budget_step
+        in build_budget_step["run"]
     )
-    assert "--budget-json docs/telemetry/docker_image_budget.production.json" in trivy_budget_step
+    assert (
+        "--budget-json docs/telemetry/docker_image_budget.production.json"
+        in docker_image_budget_step["run"]
+    )
+    assert (
+        "--budget-json docs/telemetry/docker_image_budget.production.json"
+        in trivy_budget_step["run"]
+    )
+    assert build_budget_step["continue-on-error"] is True
+    assert docker_image_budget_step["continue-on-error"] is True
+    assert trivy_budget_step["continue-on-error"] is True
+    assert build_fail_budget_step["if"] == "${{ steps.docker_image_budget.outcome == 'failure' }}"
+    assert (
+        docker_image_fail_budget_step["if"]
+        == "${{ steps.docker_image_budget.outcome == 'failure' }}"
+    )
+    assert trivy_fail_budget_step["if"] == "${{ steps.docker_image_budget.outcome == 'failure' }}"
+    assert [step["name"] for step in build_steps].index("Enforce Docker image budget") < [
+        step["name"] for step in build_steps
+    ].index("Test Docker image")
+    assert [step["name"] for step in build_steps].index("Test Docker image") < [
+        step["name"] for step in build_steps
+    ].index("Fail build job when Docker budget check failed")
+    assert [step["name"] for step in trivy_steps].index("Enforce Docker image budget") < [
+        step["name"] for step in trivy_steps
+    ].index("Run Trivy vulnerability scanner")
+    assert [step["name"] for step in trivy_steps].index("Run Trivy vulnerability scanner") < [
+        step["name"] for step in trivy_steps
+    ].index("Fail trivy job when Docker budget check failed")
 
 
 def test_checked_in_docker_image_baseline_seed_has_expected_schema() -> None:

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -72,6 +72,12 @@ def _workflow_step_by_name(path: str, job_name: str, step_name: str) -> dict[str
     raise AssertionError(f"Missing step {step_name!r} for {path}:{job_name}")
 
 
+def _workflow_step_names(path: str, job_name: str) -> list[str]:
+    """Return display names for a workflow job's steps."""
+
+    return [str(step["name"]) for step in _workflow_steps(path, job_name)]
+
+
 def test_dependency_security_schema_blocks_known_bad_litellm_versions() -> None:
     schema = json.loads(
         (REPO_ROOT / "tests" / "fixtures" / "dependency_security_schema.json").read_text(
@@ -681,8 +687,9 @@ def test_docker_workflows_emit_image_telemetry_artifacts() -> None:
         "build",
         "Fail trivy job when Docker budget check failed",
     )
-    build_steps = build_workflow["jobs"]["build"]["steps"]
-    trivy_steps = trivy_workflow["jobs"]["build"]["steps"]
+    build_step_names = _workflow_step_names(".github/workflows/build.yml", "build")
+    docker_image_step_names = _workflow_step_names(".github/workflows/docker-image.yml", "build")
+    trivy_step_names = _workflow_step_names(".github/workflows/trivy.yml", "build")
 
     assert build_job_permissions["actions"] == "read"
     assert build_job_permissions["contents"] == "read"
@@ -725,18 +732,21 @@ def test_docker_workflows_emit_image_telemetry_artifacts() -> None:
         == "${{ steps.docker_image_budget.outcome == 'failure' }}"
     )
     assert trivy_fail_budget_step["if"] == "${{ steps.docker_image_budget.outcome == 'failure' }}"
-    assert [step["name"] for step in build_steps].index("Enforce Docker image budget") < [
-        step["name"] for step in build_steps
-    ].index("Test Docker image")
-    assert [step["name"] for step in build_steps].index("Test Docker image") < [
-        step["name"] for step in build_steps
-    ].index("Fail build job when Docker budget check failed")
-    assert [step["name"] for step in trivy_steps].index("Enforce Docker image budget") < [
-        step["name"] for step in trivy_steps
-    ].index("Run Trivy vulnerability scanner")
-    assert [step["name"] for step in trivy_steps].index("Run Trivy vulnerability scanner") < [
-        step["name"] for step in trivy_steps
-    ].index("Fail trivy job when Docker budget check failed")
+    assert build_step_names.index("Enforce Docker image budget") < build_step_names.index(
+        "Test Docker image"
+    )
+    assert build_step_names.index("Test Docker image") < build_step_names.index(
+        "Fail build job when Docker budget check failed"
+    )
+    assert docker_image_step_names.index("Enforce Docker image budget") < (
+        docker_image_step_names.index("Fail docker-image job when Docker budget check failed")
+    )
+    assert trivy_step_names.index("Enforce Docker image budget") < trivy_step_names.index(
+        "Run Trivy vulnerability scanner"
+    )
+    assert trivy_step_names.index("Run Trivy vulnerability scanner") < trivy_step_names.index(
+        "Fail trivy job when Docker budget check failed"
+    )
 
 
 def test_checked_in_docker_image_baseline_seed_has_expected_schema() -> None:

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -239,24 +239,29 @@ def test_canonical_ci_and_docker_use_supply_chain_guardrails() -> None:
     assert "install_locked_python_requirements.py" in dependency_docs_text
     assert "PULSEPLATE_PYTHON_INDEX_URL" in dependency_docs_text
     assert "Run: make venv-sync" in init_test_db_text
-    assert "Docker image telemetry collection failed; reporting remains advisory-only." in (
-        REPO_ROOT / ".github" / "workflows" / "build.yml"
-    ).read_text(encoding="utf-8")
-    assert "Docker image telemetry collection failed; reporting remains advisory-only." in (
-        REPO_ROOT / ".github" / "workflows" / "docker-image.yml"
-    ).read_text(encoding="utf-8")
-    assert "Docker image telemetry collection failed; reporting remains advisory-only." in (
-        REPO_ROOT / ".github" / "workflows" / "trivy.yml"
-    ).read_text(encoding="utf-8")
-    assert "if-no-files-found: warn" in (
-        REPO_ROOT / ".github" / "workflows" / "build.yml"
-    ).read_text(encoding="utf-8")
-    assert "if-no-files-found: warn" in (
+    build_workflow_text = (REPO_ROOT / ".github" / "workflows" / "build.yml").read_text(
+        encoding="utf-8"
+    )
+    docker_image_workflow_text = (
         REPO_ROOT / ".github" / "workflows" / "docker-image.yml"
     ).read_text(encoding="utf-8")
     trivy_workflow_text = (REPO_ROOT / ".github" / "workflows" / "trivy.yml").read_text(
         encoding="utf-8"
     )
+    for workflow_text in (
+        build_workflow_text,
+        docker_image_workflow_text,
+        trivy_workflow_text,
+    ):
+        assert "Docker image telemetry collection failed; reporting remains advisory-only." not in (
+            workflow_text
+        )
+        assert "scripts/ci/check_docker_image_budget.py" in workflow_text
+        assert "docs/telemetry/docker_image_budget.production.json" in workflow_text
+        assert "docker-image-budget-check.json" in workflow_text
+        assert "docker-image-budget-check.md" in workflow_text
+        assert "if-no-files-found: warn" in workflow_text
+
     assert "if-no-files-found: warn" in trivy_workflow_text
     assert "set -euo pipefail" in trivy_workflow_text.split("- name: Install Trivy via apt", 1)[1]
 
@@ -600,12 +605,17 @@ def test_docker_workflows_emit_image_telemetry_artifacts() -> None:
         assert "docker-runtime-dependency-surface.json" in workflow_text
         assert "scripts/ci/fetch_docker_image_baseline.py" in workflow_text
         assert "scripts/ci/docker_image_telemetry.py" in workflow_text
+        assert "scripts/ci/check_docker_image_budget.py" in workflow_text
         assert "docs/telemetry/docker_image_baseline.production.json" in workflow_text
+        assert "docs/telemetry/docker_image_budget.production.json" in workflow_text
         assert "--baseline-json docker-image-baseline.json" in workflow_text
         assert "docker-image-telemetry.json" in workflow_text
         assert "docker-image-telemetry.md" in workflow_text
+        assert "docker-image-budget-check.json" in workflow_text
+        assert "docker-image-budget-check.md" in workflow_text
         assert "GITHUB_STEP_SUMMARY" in workflow_text
         assert "actions/upload-artifact@" in workflow_text
+        assert "workflow remains advisory-only" not in workflow_text
 
     build_workflow = _load_workflow(".github/workflows/build.yml")
     docker_image_workflow = _load_workflow(".github/workflows/docker-image.yml")
@@ -641,6 +651,21 @@ def test_docker_workflows_emit_image_telemetry_artifacts() -> None:
         "build",
         "Resolve Docker image telemetry baseline",
     )["run"]
+    build_budget_step = _workflow_step_by_name(
+        ".github/workflows/build.yml",
+        "build",
+        "Enforce Docker image budget",
+    )["run"]
+    docker_image_budget_step = _workflow_step_by_name(
+        ".github/workflows/docker-image.yml",
+        "build",
+        "Enforce Docker image budget",
+    )["run"]
+    trivy_budget_step = _workflow_step_by_name(
+        ".github/workflows/trivy.yml",
+        "build",
+        "Enforce Docker image budget",
+    )["run"]
 
     assert build_job_permissions["actions"] == "read"
     assert build_job_permissions["contents"] == "read"
@@ -662,6 +687,12 @@ def test_docker_workflows_emit_image_telemetry_artifacts() -> None:
     assert "--workflow build.yml" in build_resolve_step
     assert "--workflow build.yml" in docker_image_resolve_step
     assert "--workflow build.yml" in trivy_resolve_step
+    assert "--budget-json docs/telemetry/docker_image_budget.production.json" in build_budget_step
+    assert (
+        "--budget-json docs/telemetry/docker_image_budget.production.json"
+        in docker_image_budget_step
+    )
+    assert "--budget-json docs/telemetry/docker_image_budget.production.json" in trivy_budget_step
 
 
 def test_checked_in_docker_image_baseline_seed_has_expected_schema() -> None:
@@ -677,3 +708,22 @@ def test_checked_in_docker_image_baseline_seed_has_expected_schema() -> None:
     assert baseline_payload["baseline_reference"]["artifact_name"] == "docker-image-telemetry-build"
     assert baseline_payload["baseline_reference"]["workflow"] == "build.yml"
     assert baseline_payload["baseline_reference"]["seeded_from_run_id"] == 24771474567
+
+
+def test_checked_in_docker_image_budget_policy_has_expected_schema() -> None:
+    budget_payload = json.loads(
+        (REPO_ROOT / "docs" / "telemetry" / "docker_image_budget.production.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert budget_payload["budget_name"] == "production-backend-image"
+    assert budget_payload["budget_version"] == 1
+    assert budget_payload["budget_scope"] == "production-backend-image"
+    assert budget_payload["max_image_size_bytes"] == 470000000
+    assert budget_payload["max_positive_delta_bytes"] == 20000000
+    assert (
+        budget_payload["baseline_reference"]["baseline_file"]
+        == "docs/telemetry/docker_image_baseline.production.json"
+    )
+    assert budget_payload["baseline_reference"]["workflow"] == "build.yml"


### PR DESCRIPTION
## Summary

Promote the production backend Docker image from warning-only telemetry to a deterministic hard budget gate after the telemetry baseline landed in PR #1492.

This PR adds a checked-in budget policy, a dedicated hard-budget checker, and blocking enforcement in the three Docker telemetry lanes while preserving baseline resolution and telemetry collection as separate seams.

## Scope

- add `docs/telemetry/docker_image_budget.production.json`
- add `scripts/ci/check_docker_image_budget.py`
- make Docker telemetry generation blocking in `build.yml`, `docker-image.yml`, and `trivy.yml`
- publish and upload budget-check JSON/Markdown artifacts even when the budget step fails
- update Docker docs, backlog state, and the PR-6 task packet
- sync canonical review mapping in `docs/review/PR_1498_FIXED_MAPPING.md`
- extend focused tests for the budget helper and workflow contracts

## Split Justification

This lane intentionally keeps the full hard-budget slice together because the policy file, checker helper, workflow enforcement, docs, and contract tests are one atomic CI contract. Splitting the budget checker away from workflow wiring or from the checked-in policy would leave a half-wired gate that either cannot enforce or cannot document the canonical production budget surface.

## Non-goals

- no Shared Safety audit script work
- no provenance or Dagger work
- no frontend/Caddy changes
- no application runtime feature changes

## Validation

- [x] `python3 scripts/orchestration/check_preflight.py`
- [x] `python3 scripts/orchestration/check_agent_consistency.py`
- [x] `python3 -m pytest -q tests/test_check_docker_image_budget.py tests/test_python_supply_chain_controls.py`
- [x] `python3 -m pytest -q tests/test_docker_image_telemetry.py`
- [x] `pre-commit run --all-files`
- [x] pre-push hooks (`mypy`, backend tests, Bandit, docker build test)
- [ ] current-head GitHub checks
- [ ] `python3 scripts/orchestration/check_merge_ready.py --pr-number 1498 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`

## Deferred / Follow-ups

- `docs/roadmap/BACKLOG_LEDGER.md` line 540 (`P1: Shared Safety audit script after install-profile split`)
- provenance recovery follow-up
  Backlog: `docs/roadmap/BACKLOG_LEDGER.md#backlog-restore-signed-build-provenance`
- Dagger follow-up after the hard budget gate stabilizes
  Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-dagger-pilot-after-docker-baseline`

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] CodeRabbit: no unresolved actionable items
- [x] Sourcery: no unresolved actionable items
- [x] Cubic: no unresolved actionable items
- [x] Human review threads dispositioned

### Fixed in Commit Mapping

See `docs/review/PR_1498_FIXED_MAPPING.md`.

## Merge Readiness

- [ ] Mandatory wait window completed
- [ ] Required current-head checks pass
- [ ] No pending required jobs
- [ ] `check_merge_ready.py --require-auth` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced Docker image budget gate: CI fails when the production image exceeds configured size or delta limits.

* **Behavior Changes**
  * Telemetry and budget-check reports are now always published and uploaded as CI artifacts/step summaries, even if earlier steps fail.

* **Documentation**
  * Added policy docs and deployment guidance describing the hard budget gate and evidence artifacts.

* **Tests**
  * Added tests validating budget checks, telemetry wiring, and CI enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- ci-refresh 2026-04-23 -->
