### PR TITLE
feat(ci): restore signed docker provenance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -341,6 +341,7 @@ jobs:
           # PR #1448: re-enable SLSA provenance attestations for GHCR publish.
           # Keep scoped cache + mode=min + ignore-error=true to reduce export flakes.
           provenance: mode=max
+          sbom: true
           target: production
 
       - name: Set image ref for SBOM and image scan

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -132,6 +132,7 @@ jobs:
           push-to-registry: true
 
       - name: Verify staged image attestations
+        if: ${{ always() && steps.build.outcome == 'success' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -386,6 +387,7 @@ jobs:
           push-to-registry: true
 
       - name: Verify production image attestations
+        if: ${{ always() && steps.build.outcome == 'success' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,6 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      attestations: write
       contents: read
       packages: write
       id-token: write
@@ -107,6 +108,28 @@ jobs:
           # Use dedicated staging target which extends production but allows
           # staging-specific customizations (e.g., debug logging, extended health checks)
           target: staging
+
+      - name: Attest staged image provenance
+        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate staged image SBOM
+        uses: anchore/sbom-action@da167eac915b4e86f08b264dbdbc867b61be6f0c # v0.20.5
+        with:
+          image: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: docker-image-sbom.spdx.json
+
+      - name: Attest staged image SBOM
+        uses: actions/attest@281a49d4cbb0a72c9575a50d18f6deb515a11deb # v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: docker-image-sbom.spdx.json
+          push-to-registry: true
 
       - name: Verify staged image attestations
         env:
@@ -283,6 +306,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      attestations: write
       contents: read
       packages: write
       id-token: write
@@ -338,6 +362,28 @@ jobs:
           provenance: mode=max
           sbom: true
           target: production
+
+      - name: Attest production image provenance
+        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate production image SBOM
+        uses: anchore/sbom-action@da167eac915b4e86f08b264dbdbc867b61be6f0c # v0.20.5
+        with:
+          image: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: docker-image-sbom.spdx.json
+
+      - name: Attest production image SBOM
+        uses: actions/attest@281a49d4cbb0a72c9575a50d18f6deb515a11deb # v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: docker-image-sbom.spdx.json
+          push-to-registry: true
 
       - name: Verify production image attestations
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -85,6 +85,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push image (staging)
+        id: build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
@@ -99,14 +100,47 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}:staging-latest
           cache-from: type=gha,scope=cd-staging-${{ github.ref_name }}
           cache-to: type=gha,scope=cd-staging-${{ github.ref_name }},mode=min,ignore-error=true
-          # Disable provenance to avoid buildx/GHA cache export failures
-          # ("cache entry no longer exists" / BlobNotFound). Trade-off: SLSA
-          # attestations are disabled, so cosign verify-attestation will fail
-          # for this image until the cache/provenance stack is stable.
-          provenance: false
+          # Keep the scoped cache workaround, but restore registry-backed
+          # provenance/SBOM attestations for push-to-registry lanes.
+          provenance: mode=max
+          sbom: true
           # Use dedicated staging target which extends production but allows
           # staging-specific customizations (e.g., debug logging, extended health checks)
           target: staging
+
+      - name: Verify staged image attestations
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check_docker_provenance_attestation.py \
+            --image-name "${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}" \
+            --digest "${{ steps.build.outputs.digest }}" \
+            --repo "${{ github.repository }}" \
+            --signer-workflow "${{ github.repository }}/.github/workflows/cd.yml" \
+            --source-ref "${{ github.ref }}" \
+            --json-out docker-provenance-attestation-check.json \
+            --markdown-out docker-provenance-attestation-check.md
+
+      - name: Publish staging attestation verification to step summary
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          if [ -f docker-provenance-attestation-check.md ]; then
+            cat docker-provenance-attestation-check.md >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload staging attestation verification artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: docker-provenance-attestation-check-cd-staging
+          path: |
+            docker-provenance-attestation-check.json
+            docker-provenance-attestation-check.md
+          if-no-files-found: warn
+          retention-days: 14
 
       # When STAGING_DEPLOY_ENABLED=true but SSH_KEY (or host) is not set, skip deploy to avoid "ssh: no key found" / fingerprint mismatch.
       # Use env so multi-line SSH_KEY is not inlined in run (avoids breaking when key was set and working).
@@ -299,12 +333,45 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}:prod-${{ github.ref_name }}
           cache-from: type=gha,scope=cd-production-${{ github.ref_name }}
           cache-to: type=gha,scope=cd-production-${{ github.ref_name }},mode=min,ignore-error=true
-          # Disable provenance to avoid buildx/GHA cache export failures
-          # ("cache entry no longer exists" / BlobNotFound). Trade-off: SLSA
-          # attestations are disabled, so cosign verify-attestation will fail
-          # for this image until the cache/provenance stack is stable.
-          provenance: false
+          # Keep the scoped cache workaround, but restore registry-backed
+          # provenance/SBOM attestations for push-to-registry lanes.
+          provenance: mode=max
+          sbom: true
           target: production
+
+      - name: Verify production image attestations
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check_docker_provenance_attestation.py \
+            --image-name "${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}" \
+            --digest "${{ steps.build.outputs.digest }}" \
+            --repo "${{ github.repository }}" \
+            --signer-workflow "${{ github.repository }}/.github/workflows/cd.yml" \
+            --source-ref "${{ github.ref }}" \
+            --json-out docker-provenance-attestation-check.json \
+            --markdown-out docker-provenance-attestation-check.md
+
+      - name: Publish production attestation verification to step summary
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          if [ -f docker-provenance-attestation-check.md ]; then
+            cat docker-provenance-attestation-check.md >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload production attestation verification artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: docker-provenance-attestation-check-cd-production
+          path: |
+            docker-provenance-attestation-check.json
+            docker-provenance-attestation-check.md
+          if-no-files-found: warn
+          retention-days: 14
 
   production-deploy-config:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md
+++ b/docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md
@@ -7,7 +7,7 @@ Superseded in part by the 2026-04-23 pushed-image provenance restore lane
 Docker image push to GHCR was failing with `failed to push ... cache entry no longer exists` when using `cache-from: type=gha` and default provenance. This is a known class of issues with buildx + GHA cache backend where cache blobs can become unavailable during export/push.
 
 To unblock main and stabilize CI/CD, we keep one workaround profile across
-workflows. The **steps below follow the same order as** [Evidence Anchors](#evidence-anchors-fileline) (top → bottom) so operators can walk the YAML and the ADR in lockstep.
+workflows. The **steps below follow the same order as** [Evidence Anchors](#evidence-anchors) (top → bottom) so operators can walk the YAML and the ADR in lockstep.
 
 1. **`build.yml` — local test image (`load: true`)** — `push: false`, scoped `cache-from` / `cache-to` (`build-production-${{ github.ref_name }}`, `mode=min`, `ignore-error=true`), **`provenance: false`**. Uses the docker exporter; **SLSA attestations are not supported for `load: true`** (registry push is required for attestations). Do not enable `provenance` on this step without a separate push-based job.
 2. **`build.yml` — publish to GHCR (`push: true`)** — **`platforms: linux/amd64`** only (reduces cache/export surface; restore `linux/arm64` when stable), same scoped cache pattern as (1), **`provenance: mode=max`** (PR #1448) while keeping `cache-to: ... mode=min,ignore-error=true` to reduce export flakes.
@@ -18,7 +18,7 @@ workflows. The **steps below follow the same order as** [Evidence Anchors](#evid
 Cross-cutting themes: **scoped GHA cache keys** (per ref / job family) replace an older “omit `cache-from` on CD” iteration that avoided `BlobNotFound` but hurt hit rate; **`ignore-error=true` on `cache-to`** remains the export fail-safe everywhere.
 
 ## Decision
-Aligned with **Context steps (1)–(5)** above (same order as [Evidence Anchors](#evidence-anchors-fileline)):
+Aligned with **Context steps (1)–(5)** above (same order as [Evidence Anchors](#evidence-anchors)):
 
 - Keep **`provenance: false`** on `load: true` paths listed in those anchors; for pushed-image lanes in `build.yml` and `cd.yml`, use **`provenance: mode=max`** plus **`sbom: true`**.
 - Keep **`linux/amd64` only** on all publish/CD image builds; restore multi-arch when cache/provenance is stable.
@@ -38,19 +38,28 @@ Aligned with **Context steps (1)–(5)** above (same order as [Evidence Anchors]
 - Smoke and other `load: true` CI jobs cannot serve as a provenance pilot without changing architecture (e.g. build+push to a scratch tag, then pull/run).
 
 ## Evidence Anchors
-- `.github/workflows/build.yml` local build job: `load: true`, scoped `cache-from` / `cache-to`, `provenance: false`.
-- `.github/workflows/build.yml` publish job: `linux/amd64`, `push: true`, scoped `cache-from` / `cache-to`, `provenance: mode=max`, `sbom: true`.
-- `.github/workflows/cd.yml` staging image: scoped `cache-from` / `cache-to`, `provenance: mode=max`, `sbom: true`, exact-digest attestation verification before deploy.
-- `.github/workflows/cd.yml` production image: scoped `cache-from` / `cache-to`, `provenance: mode=max`, `sbom: true`, exact-digest attestation verification before deploy.
-- `.github/workflows/docker-openapi-smoke.yml` smoke build: `load: true`, `provenance: false` (attestations incompatible with `load`; see Context).
+- `.github/workflows/build.yml:49-64` local build job: `load: true`,
+  scoped `cache-from` / `cache-to`, `provenance: false`.
+- `.github/workflows/build.yml:327-345` publish job: `linux/amd64`,
+  `push: true`, scoped `cache-from` / `cache-to`,
+  `provenance: mode=max`, `sbom: true`.
+- `.github/workflows/cd.yml:88-148` staging image: scoped
+  `cache-from` / `cache-to`, `provenance: mode=max`, `sbom: true`,
+  exact-digest attestation verification before deploy.
+- `.github/workflows/cd.yml:343-402` production image: scoped
+  `cache-from` / `cache-to`, `provenance: mode=max`, `sbom: true`,
+  exact-digest attestation verification before deploy.
+- `.github/workflows/docker-openapi-smoke.yml:61-80` smoke build:
+  `load: true`, `provenance: false` (attestations incompatible with
+  `load`; see Context).
 
 ## Exit Criteria / Definition of Done
 - [ ] Upstream fix or documented stable approach: buildx and/or GHA cache backend no longer produces "cache entry no longer exists" (or equivalent) when using `cache-from: type=gha` and provenance enabled.
 - [x] Remove `provenance: false` and restore `provenance: mode=max`
   for `build.yml` publish (`push: true`) path (PR #1448).
 - [x] Remove `provenance: false` and restore `provenance: mode=max`
-  for `cd.yml` pushed-image paths while keeping scoped cache + `mode=min`
-  + `ignore-error=true`.
+  for `cd.yml` pushed-image paths while keeping scoped cache, `mode=min`,
+  and `ignore-error=true`.
 - [x] Verify pushed-image provenance and SPDX SBOM attestations by exact digest before deploy.
 - [ ] Re-evaluate cache scopes and `mode=min` vs `mode=max` once provenance is re-enabled on GHCR pushes.
 - [ ] Optionally restore `platforms: linux/amd64,linux/arm64` when
@@ -60,6 +69,8 @@ Aligned with **Context steps (1)–(5)** above (same order as [Evidence Anchors]
 ## Links
 - Workflow: `.github/workflows/build.yml`.
 - Workflow: `.github/workflows/cd.yml`.
-- PR #1448 (publish provenance re-enable): https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1448
-- Docker CI attestations overview: https://docs.docker.com/build/ci/github-actions/attestations/
+- PR `#1448` (publish provenance re-enable):
+  [GitHub PR `#1448`](https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1448)
+- Docker CI attestations overview:
+  [Docker CI attestations docs](https://docs.docker.com/build/ci/github-actions/attestations/)
 - Backlog Ledger: `docs/roadmap/BACKLOG_LEDGER.md` (`#backlog-restore-signed-build-provenance` — restore signed build provenance; DoD and blockers tracked in the ledger).

--- a/docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md
+++ b/docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md
@@ -1,7 +1,7 @@
 # ADR: Docker build provenance: false workaround (2026-03-01)
 
 ## Status
-Accepted (temporary seam, partial rollout via PR #1448)
+Superseded in part by the 2026-04-23 pushed-image provenance restore lane
 
 ## Context
 Docker image push to GHCR was failing with `failed to push ... cache entry no longer exists` when using `cache-from: type=gha` and default provenance. This is a known class of issues with buildx + GHA cache backend where cache blobs can become unavailable during export/push.
@@ -11,8 +11,8 @@ workflows. The **steps below follow the same order as** [Evidence Anchors](#evid
 
 1. **`build.yml` — local test image (`load: true`)** — `push: false`, scoped `cache-from` / `cache-to` (`build-production-${{ github.ref_name }}`, `mode=min`, `ignore-error=true`), **`provenance: false`**. Uses the docker exporter; **SLSA attestations are not supported for `load: true`** (registry push is required for attestations). Do not enable `provenance` on this step without a separate push-based job.
 2. **`build.yml` — publish to GHCR (`push: true`)** — **`platforms: linux/amd64`** only (reduces cache/export surface; restore `linux/arm64` when stable), same scoped cache pattern as (1), **`provenance: mode=max`** (PR #1448) while keeping `cache-to: ... mode=min,ignore-error=true` to reduce export flakes.
-3. **`cd.yml` — staging image** — **`cache-from` / `cache-to`** with scope `cd-staging-${{ github.ref_name }}` (`mode=min`, `ignore-error=true`), **`provenance: false`**, `target: staging`, **`linux/amd64`**.
-4. **`cd.yml` — production image** — same cache policy with scope **`cd-production-${{ github.ref_name }}`**, **`provenance: false`**, **`linux/amd64`**.
+3. **`cd.yml` — staging image** — keep **`cache-from` / `cache-to`** with scope `cd-staging-${{ github.ref_name }}` (`mode=min`, `ignore-error=true`), restore **`provenance: mode=max`** and **`sbom: true`**, then verify both attestations by exact digest before any deploy step.
+4. **`cd.yml` — production image** — same cache policy with scope **`cd-production-${{ github.ref_name }}`**, restore **`provenance: mode=max`** and **`sbom: true`**, then verify both attestations by exact digest before any deploy step.
 5. **`docker-openapi-smoke.yml` — smoke build** — same pattern as (1): `load: true`, scoped cache (`docker-openapi-smoke-v2-${{ github.ref_name }}`), **`provenance: false`** (attestations incompatible with `load`; see (1)).
 
 Cross-cutting themes: **scoped GHA cache keys** (per ref / job family) replace an older “omit `cache-from` on CD” iteration that avoided `BlobNotFound` but hurt hit rate; **`ignore-error=true` on `cache-to`** remains the export fail-safe everywhere.
@@ -20,38 +20,42 @@ Cross-cutting themes: **scoped GHA cache keys** (per ref / job family) replace a
 ## Decision
 Aligned with **Context steps (1)–(5)** above (same order as [Evidence Anchors](#evidence-anchors-fileline)):
 
-- Keep **`provenance: false`** on `load: true` and non-publish paths listed in those anchors; for `build.yml` publish (`push: true`) use **`provenance: mode=max`** (PR #1448).
+- Keep **`provenance: false`** on `load: true` paths listed in those anchors; for pushed-image lanes in `build.yml` and `cd.yml`, use **`provenance: mode=max`** plus **`sbom: true`**.
 - Keep **`linux/amd64` only** on all publish/CD image builds; restore multi-arch when cache/provenance is stable.
 - Keep **scoped** `cache-from: type=gha` + `cache-to: type=gha,mode=min,ignore-error=true` on each of those steps (scopes differ per job; see anchors).
-- Keep **inline comments** in workflows stating the trade-off (SLSA off; `cosign verify-attestation` fails for these images) and intent to re-enable.
+- Keep **inline comments** in workflows stating the narrowed workaround boundary: `load: true` jobs remain excluded, pushed-image lanes verify OCI-backed provenance/SBOM before deploy.
 - Treat this ADR as the temporary seam SoT until **Exit Criteria** are met.
 
 ## Rationale
 - Restores green CI/CD and reliable image pushes to GHCR.
-- Trade-off remains scoped: publish attestations are restored, but non-publish paths (`load: true` / CD seams) keep temporary constraints.
+- Trade-off remains scoped: pushed-image attestations are restored, but `load: true` paths keep temporary constraints.
 - Single-arch reduces variables while cache/provenance tooling is unstable.
 - Scoped `cache-from` on CD improves cache reuse while `ignore-error=true` on `cache-to` limits export-time flakes.
 
 ## Consequences
-- Image consumers can verify SLSA provenance for GHCR images produced by `build.yml` publish (`push: true`) after PR #1448.
+- Image consumers can verify SLSA provenance for GHCR images produced by pushed-image lanes in `build.yml` and `cd.yml`.
 - Arm64 image builds are deferred until we re-enable multi-platform.
 - Smoke and other `load: true` CI jobs cannot serve as a provenance pilot without changing architecture (e.g. build+push to a scratch tag, then pull/run).
 
-## Evidence Anchors (file:line)
-- `.github/workflows/build.yml:42`-`.github/workflows/build.yml:56` local build job: `load: true`, scoped `cache-from` / `cache-to`, `provenance: false`.
-- `.github/workflows/build.yml:266`-`.github/workflows/build.yml:285` publish: `linux/amd64`, `push: true`, scoped `cache-from` / `cache-to`, `provenance: mode=max`.
-- `.github/workflows/cd.yml:87`-`.github/workflows/cd.yml:108` staging image: `cache-from` / `cache-to`, `provenance: false`, `target: staging`.
-- `.github/workflows/cd.yml:284`-`.github/workflows/cd.yml:305` production image: `cache-from` / `cache-to`, `provenance: false`.
-- `.github/workflows/docker-openapi-smoke.yml:61`-`.github/workflows/docker-openapi-smoke.yml:79` smoke build: `load: true`, `provenance: false` (attestations incompatible with `load`; see Context).
+## Evidence Anchors
+- `.github/workflows/build.yml` local build job: `load: true`, scoped `cache-from` / `cache-to`, `provenance: false`.
+- `.github/workflows/build.yml` publish job: `linux/amd64`, `push: true`, scoped `cache-from` / `cache-to`, `provenance: mode=max`, `sbom: true`.
+- `.github/workflows/cd.yml` staging image: scoped `cache-from` / `cache-to`, `provenance: mode=max`, `sbom: true`, exact-digest attestation verification before deploy.
+- `.github/workflows/cd.yml` production image: scoped `cache-from` / `cache-to`, `provenance: mode=max`, `sbom: true`, exact-digest attestation verification before deploy.
+- `.github/workflows/docker-openapi-smoke.yml` smoke build: `load: true`, `provenance: false` (attestations incompatible with `load`; see Context).
 
 ## Exit Criteria / Definition of Done
 - [ ] Upstream fix or documented stable approach: buildx and/or GHA cache backend no longer produces "cache entry no longer exists" (or equivalent) when using `cache-from: type=gha` and provenance enabled.
 - [x] Remove `provenance: false` and restore `provenance: mode=max`
   for `build.yml` publish (`push: true`) path (PR #1448).
+- [x] Remove `provenance: false` and restore `provenance: mode=max`
+  for `cd.yml` pushed-image paths while keeping scoped cache + `mode=min`
+  + `ignore-error=true`.
+- [x] Verify pushed-image provenance and SPDX SBOM attestations by exact digest before deploy.
 - [ ] Re-evaluate cache scopes and `mode=min` vs `mode=max` once provenance is re-enabled on GHCR pushes.
 - [ ] Optionally restore `platforms: linux/amd64,linux/arm64` when
   cache/provenance is stable.
-- [ ] Update this ADR status to Superseded with a pointer to the final removal PR when workaround is fully removed.
+- [ ] Update this ADR status again when the remaining `load: true` exceptions are fully removed.
 
 ## Links
 - Workflow: `.github/workflows/build.yml`.

--- a/docs/deploy/DOCKER.md
+++ b/docs/deploy/DOCKER.md
@@ -12,8 +12,9 @@ Docker runtime contract.
 - Frontend / Caddy topology remains separate and out of scope for this slice.
 - Runtime slimming merged via `PR #1490` on April 22, 2026.
 - Telemetry baseline landed via `PR #1492` on April 22, 2026.
-- The current Docker/CI slice promotes that telemetry baseline into a
-  deterministic hard budget gate for the production backend image.
+- Hard-budget enforcement landed via `PR #1498` on April 22, 2026.
+- The current Docker/CI slice restores signed provenance and SPDX SBOM
+  attestations on pushed-image lanes and verifies both before deploy.
 
 ## Runtime manifest policy
 
@@ -41,15 +42,17 @@ Runtime slimming removed CI-only tooling from the production backend image, but
 the project still needs one canonical baseline so PR authors can see image-size
 drift, largest layers, and build-context evidence before merge.
 
-Telemetry baseline established deterministic image-size evidence, but PR authors
-still need merge-blocking enforcement once the baseline is stable on `main`.
+Telemetry and the hard-budget gate established deterministic image-size
+evidence, but deployable image trust still depended on the temporary CD
+workaround that kept pushed-image attestations disabled.
 
-This wave promotes the production backend image to a hard gate:
+This wave restores signed provenance on pushed-image lanes only:
 
-- absolute image-size cap: `470000000` bytes
-- max positive delta vs baseline: `20000000` bytes
-- same canonical baseline source rule as the telemetry wave
-- provenance / Dagger and Shared Safety remain deferred
+- keep the current hard-budget contract unchanged
+- restore `provenance: mode=max` on pushed-image lanes in `build.yml` and `cd.yml`
+- emit SPDX SBOM attestations on the same pushed-image lanes
+- verify both provenance and SBOM by exact digest before staging or production deploy
+- Dagger and Shared Safety remain deferred
 
 ## Baseline source rule
 
@@ -89,6 +92,34 @@ Hard budget enforcement must fail when either of these are true:
 
 - `image_size_bytes > 470000000`
 - `baseline.size_delta_bytes > 20000000`
+
+## Attestation verification contract
+
+Staging and production deploy flow must verify the exact pushed digest with
+GitHub-native attestation verification before any deploy step continues.
+
+Helper:
+
+- `scripts/ci/check_docker_provenance_attestation.py`
+
+Inputs:
+
+- registry image name without a tag
+- exact pushed digest from `docker/build-push-action`
+- GitHub repo identity
+- signer workflow path
+- source ref for the current run
+
+Outputs:
+
+- `docker-provenance-attestation-check.json`
+- `docker-provenance-attestation-check.md`
+- `GITHUB_STEP_SUMMARY` entry in `cd.yml`
+
+The verifier must fail closed unless both checks pass:
+
+- provenance predicate: `https://slsa.dev/provenance/v1`
+- SBOM predicate: `https://spdx.dev/Document/v2.3`
 
 ## Validation commands
 
@@ -137,19 +168,27 @@ python3 scripts/ci/check_docker_image_budget.py \
   --budget-json docs/telemetry/docker_image_budget.production.json \
   --json-out artifacts/docker/docker-image-budget-check.json \
   --markdown-out artifacts/docker/docker-image-budget-check.md
+
+python3 scripts/ci/check_docker_provenance_attestation.py \
+  --image-name ghcr.io/katsiarynakavaleuskaya/pulseplate \
+  --digest sha256:example \
+  --repo Katsiarynakavaleuskaya/PulsePlate \
+  --signer-workflow Katsiarynakavaleuskaya/PulsePlate/.github/workflows/cd.yml \
+  --source-ref refs/heads/main \
+  --json-out artifacts/docker/docker-provenance-attestation-check.json \
+  --markdown-out artifacts/docker/docker-provenance-attestation-check.md
 ```
 
 ## Rollback
 
-If the runtime image fails to build or boot after this slice:
+If pushed-image provenance verification fails after this slice:
 
-1. restore the previous Docker build arg usage in production-target workflows
-2. switch `PULSEPLATE_REQUIREMENTS_FILE` back to the prior manifest for the
-   affected workflow
-3. keep the runtime-surface findings as evidence in the PR and record the
-   follow-up in `docs/roadmap/BACKLOG_LEDGER.md`
+1. keep `load: true` jobs unchanged on `provenance: false`
+2. revert pushed-image provenance/SBOM restoration only on the failing lane
+3. keep attestation evidence artifacts in the PR and record the follow-up in
+   `docs/roadmap/BACKLOG_LEDGER.md`
 
-Do not widen this rollback into provenance or frontend/Caddy changes.
+Do not widen this rollback into Shared Safety, Dagger, or frontend/Caddy changes.
 
 ## Deferred follow-ups
 
@@ -160,13 +199,8 @@ Explicitly deferred after this PR:
   Remove-by: 2026-06-15
   Rollback: keep Safety invocation duplicated in the existing workflows until the shared extraction lands.
   Exit criteria: a follow-up PR extracts the shared Safety invocation/reporting path without reopening install-profile split scope.
-- provenance / attestation recovery
-  Backlog: `docs/roadmap/BACKLOG_LEDGER.md#backlog-restore-signed-build-provenance`
-  Remove-by: 2026-06-30
-  Rollback: keep signed provenance disabled on the known cache/buildx seam and preserve the documented workaround.
-  Exit criteria: signed provenance and downstream verification return to the canonical image workflow without destabilizing the release path.
 - Dagger or any alternate control-plane work
   Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-dagger-pilot-after-docker-baseline`
   Remove-by: 2026-07-15
   Rollback: keep the current GitHub Actions-based Docker control plane as the only supported path.
-  Exit criteria: telemetry baseline and provenance follow-ups are closed and a separate evaluation packet re-approves any Dagger pilot.
+  Exit criteria: telemetry baseline, hard-budget, and provenance slices are closed and a separate evaluation packet re-approves any Dagger pilot.

--- a/docs/deploy/DOCKER.md
+++ b/docs/deploy/DOCKER.md
@@ -116,10 +116,16 @@ Outputs:
 - `docker-provenance-attestation-check.md`
 - `GITHUB_STEP_SUMMARY` entry in `cd.yml`
 
+CD generates GitHub-signed attestations before verification:
+
+- provenance: `actions/attest-build-provenance`
+- SBOM: `actions/attest` with `sbom-path`
+- registry publication: `push-to-registry: true`
+
 The verifier must fail closed unless both checks pass:
 
 - provenance predicate: `https://slsa.dev/provenance/v1`
-- SBOM predicate: `https://spdx.dev/Document/v2.3`
+- SBOM predicate: `https://spdx.dev/Document`
 
 ## Validation commands
 

--- a/docs/orchestration/AGENTS.md
+++ b/docs/orchestration/AGENTS.md
@@ -62,8 +62,8 @@ Scope: `docs/orchestration/**`
   - invariants:
     - root `.dockerignore` remains a strict allowlist unless a narrower documented correction is required
     - production topology stays split: backend image via `IMAGE_REF`, frontend/Caddy via `frontend/Dockerfile.caddy-spa`
-    - signed provenance stays deferred while the documented buildx/GHA cache seam requires `provenance: false`
-    - no Dagger or alternate control-plane pilot before image-budget telemetry baseline is merged
+    - signed provenance restoration is active only for pushed-image lanes; `load: true` jobs stay on `provenance: false`
+    - no Dagger or alternate control-plane pilot before image-budget telemetry, hard-budget, and provenance lanes stabilize
   - canonical packet:
     - [`docs/orchestration/DOCKER_CI_DISCIPLINE_PR_SERIES_PACKET_2026-04-16.md`](./DOCKER_CI_DISCIPLINE_PR_SERIES_PACKET_2026-04-16.md)
 - For the METATRON Track A lane (offensive lab **out-of-band**; no product runtime):

--- a/docs/orchestration/DOCKER_CI_DISCIPLINE_PR_SERIES_PACKET_2026-04-16.md
+++ b/docs/orchestration/DOCKER_CI_DISCIPLINE_PR_SERIES_PACKET_2026-04-16.md
@@ -21,16 +21,15 @@ This packet applies to Docker/deploy governance slices only:
   image topology
 - runtime slimming after install-profile split
 - image size / largest-layer / build-context telemetry and regression reporting
+- hard-budget enforcement for the production backend image
+- signed provenance restore for pushed-image lanes after the baseline stabilizes
 
 Out of scope for this lane:
 
 - Dagger, Jenkins, GitLab CI, Tekton, Argo Workflows, Flux, or other new
   control-plane introductions
-- signed provenance / attestation re-enablement while the documented buildx/GHA
-  cache seam still requires `provenance: false`
-  (`.github/workflows/build.yml:42-56`;
-  `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md:47-60`;
-  `docs/roadmap/BACKLOG_LEDGER.md:629-643`)
+- provenance enablement for `load: true` jobs or any proof path that does not
+  verify the exact pushed image digest from OCI-backed attestations
 - broad runtime feature work unrelated to Docker/build/install discipline
 - monolithic backend+frontend image redesign
 
@@ -70,11 +69,10 @@ Out of scope for this lane:
     `frontend/Dockerfile.caddy-spa`
     (`deploy/docker-compose.production.yaml:41-46`;
     `frontend/Dockerfile.caddy-spa:1-25`)
-- Signed provenance remains intentionally deferred while buildx/GHA cache
-  stability still requires `provenance: false`
-  (`.github/workflows/build.yml:42-56`;
-  `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md:47-60`;
-  `docs/roadmap/BACKLOG_LEDGER.md:629-643`).
+- Telemetry baseline and hard-budget slices have already landed on `main`
+  (`PR #1492`, `PR #1498`), so the active next slice is signed provenance
+  restoration on pushed-image lanes only. `load: true` jobs remain intentionally
+  excluded from provenance recovery.
 - Neighboring governance slices already have their own canonical review
   artifacts (`docs/review/PR_1432_FIXED_MAPPING.md:1-35`;
   `docs/review/PR_1433_FIXED_MAPPING.md:1-39`). If another overlapping PR
@@ -211,6 +209,40 @@ Outcome:
 - build-context evidence is visible in PR-time reporting
 - regression-only gating exists before any future Dagger discussion
 
+### PR-6: Image Hard Budget Gate
+
+Files:
+
+- `.github/workflows/build.yml`
+- `.github/workflows/docker-image.yml`
+- `.github/workflows/trivy.yml`
+- helper scripts/tests under `scripts/ci/` and `tests/`
+
+Outcome:
+
+- the production backend image has a deterministic absolute cap and positive
+  delta threshold
+- the gate uses the same telemetry artifact contract introduced by `PR #1492`
+- Docker baseline evidence is strong enough to support the next provenance slice
+
+### PR-7: Restore Signed Build Provenance
+
+Files:
+
+- `.github/workflows/build.yml`
+- `.github/workflows/cd.yml`
+- `scripts/ci/check_docker_provenance_attestation.py`
+- `tests/test_python_supply_chain_controls.py`
+- docs/ADR/backlog artifacts tied to the provenance workaround
+
+Outcome:
+
+- pushed-image lanes restore `provenance: mode=max`
+- pushed-image lanes emit SBOM attestations alongside provenance
+- staging and production deploys fail closed unless provenance + SPDX SBOM
+  attestations verify by exact digest
+- `load: true` jobs remain on `provenance: false`
+
 ## Dagger / Alternate Control Plane Policy
 
 Do not introduce Dagger or any alternate CI/CD control plane in this wave.
@@ -221,10 +253,9 @@ A future Dagger pilot may be considered only after all of the following are true
 - PR-3 deploy contract reconciliation is landed
 - PR-5 image-budget telemetry is landed and producing deterministic evidence
   (`docs/roadmap/BACKLOG_LEDGER.md:532-552`)
-- signed provenance remains explicitly tracked as a separate deferred lane rather
-  than mixed into the pilot
-  (`docs/roadmap/BACKLOG_LEDGER.md:629-643`;
-  `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md:47-60`)
+- PR-6 hard-budget gate is landed and stable
+- PR-7 signed provenance restore is either landed and stable or explicitly
+  re-deferred with current-head evidence
 
 ## Mandatory PR Loop
 

--- a/docs/orchestration/DOCKER_SIGNED_BUILD_PROVENANCE_TASK_PACKET_2026-04-23.md
+++ b/docs/orchestration/DOCKER_SIGNED_BUILD_PROVENANCE_TASK_PACKET_2026-04-23.md
@@ -1,0 +1,51 @@
+# Docker Signed Build Provenance Task Packet — 2026-04-23
+
+Status: Active PR-7 slice in the Docker / CI discipline series
+
+## Summary
+
+After telemetry baseline and the hard-budget gate landed on April 22, 2026 via
+`PR #1492` and `PR #1498`, this slice restores signed build provenance on
+push-to-registry Docker lanes and verifies both provenance and SPDX SBOM
+attestations before any staging or production deploy continues.
+
+## Branch / worktree
+
+- Branch: `codex/docker-restore-signed-build-provenance`
+- Worktree: `worktrees/docker-signed-provenance-pr7`
+
+## Mandatory role order
+
+1. `agent-coordinator`
+2. `architecture-specialist`
+3. `security-auditor`
+4. `backend-engineer`
+5. `dev-operator`
+6. post-open `qa-engineer-agent`
+7. post-open `bug-hunter`
+
+No ad hoc role stack may replace this order.
+
+## Scope
+
+- restore `provenance: mode=max` on pushed-image steps in `build.yml` and `cd.yml`
+- emit SBOM attestations on the same pushed-image steps
+- add one GitHub-native verifier helper under `scripts/ci/`
+- gate staging and production deploy flow on exact-digest attestation verification
+- reconcile backlog/docs/ADR text so provenance becomes the active next slice
+
+## Non-goals
+
+- no provenance enablement on `load: true` jobs
+- no Shared Safety audit extraction
+- no Dagger or alternate control plane
+- no frontend/Caddy topology changes
+- no multi-arch restore
+
+## Acceptance criteria
+
+- `build.yml` publish and `cd.yml` push lanes use `provenance: mode=max`
+- pushed-image steps emit SBOM attestations alongside provenance
+- CD verifies provenance and SPDX SBOM attestations by digest before deploy
+- CI publishes deterministic JSON/Markdown evidence for attestation verification
+- docs and backlog keep Shared Safety as a separate follow-up and Dagger deferred

--- a/docs/orchestration/DOCKER_SIGNED_BUILD_PROVENANCE_TASK_PACKET_2026-04-23.md
+++ b/docs/orchestration/DOCKER_SIGNED_BUILD_PROVENANCE_TASK_PACKET_2026-04-23.md
@@ -46,6 +46,6 @@ No ad hoc role stack may replace this order.
 
 - `build.yml` publish and `cd.yml` push lanes use `provenance: mode=max`
 - pushed-image steps emit SBOM attestations alongside provenance
-- CD verifies provenance and SPDX SBOM attestations by digest before deploy
+- CD creates GitHub-signed provenance/SBOM attestations and verifies both by digest before deploy
 - CI publishes deterministic JSON/Markdown evidence for attestation verification
 - docs and backlog keep Shared Safety as a separate follow-up and Dagger deferred

--- a/docs/review/PR_1503_FIXED_MAPPING.md
+++ b/docs/review/PR_1503_FIXED_MAPPING.md
@@ -14,7 +14,19 @@ Record every actionable human/bot disposition here before resolving threads on G
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 39d77cf8c
+Evidence: `pytest -q tests/test_check_docker_provenance_attestation.py tests/test_python_supply_chain_controls.py` -> 54 passed. The fix commit hardens the helper timeout, parser, failure evidence path, workflow verification condition, workflow-contract tests, ADR markdown links, ADR evidence anchors, and ledger traceability.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131356723 -> 39d77cf8c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131356747 -> 39d77cf8c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131356752 -> 39d77cf8c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131356759 -> 39d77cf8c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131357170 -> 39d77cf8c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131386002 -> 39d77cf8c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131386015 -> 39d77cf8c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131386020 -> 39d77cf8c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131386032 -> 39d77cf8c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#pullrequestreview-4163115645 -> 39d77cf8c
 
 ## Merge Readiness
 
@@ -29,15 +41,15 @@ Merge-readiness contract:
 - [ ] Required checks complete (no pending jobs)
   Evidence: pending current-head GitHub checks after PR open.
 - [ ] All review threads resolved on GitHub after disposition updates
-  Evidence: pending initial review cycle.
+  Evidence: pending GitHub thread resolution after latest mapping update.
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: pending post-open review cycle on current head.
+  Evidence: CodeRabbit/Sourcery/Codex comments mapped above; pending mapping-comment self-proof commit and final bot recheck.
 - [x] Pre-commit green on latest pushed head
   Evidence: `pre-commit run --all-files` passed before commit `0b6ea053e`.
 - [ ] `make verify` green on latest pushed head
-  Evidence: not run for this lane yet.
-- [ ] Mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed
-  Evidence: pending post-open review lane.
+  Evidence: pending final local gate on latest pushed head.
+- [x] Mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed
+  Evidence: local coordinator lane findings captured below and fixed before ready-for-review cycle.
 
 Post-open QA notes:
 
@@ -52,6 +64,11 @@ Post-open QA notes:
   the BuildKit-incompatible `/v2.3` suffix; fixed by adding explicit
   GitHub-signed provenance/SBOM attestation steps before verification and by
   verifying the SPDX predicate `https://spdx.dev/Document`.
+- Sourcery, Codex, and CodeRabbit found post-ready hardening gaps in helper
+  timeout/configurability, parser shape tolerance, failure evidence emission,
+  verification-step execution after attestation failures, production workflow
+  contract coverage, ADR markdownlint/evidence anchors, and ledger
+  traceability; fixed in commit `39d77cf8c`.
 
 ## Deferred / Follow-ups
 

--- a/docs/review/PR_1503_FIXED_MAPPING.md
+++ b/docs/review/PR_1503_FIXED_MAPPING.md
@@ -39,6 +39,7 @@ Evidence: `docs/review/PR_1503_FIXED_MAPPING.md:43-48` keeps the actual final me
 Reason: the CodeRabbit follow-up misread the current artifact state; the merge-cycle checkboxes it flagged are already unchecked on the latest head, so no code or docs change is required beyond recording the disposition.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3133574264
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#pullrequestreview-4165661733
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#pullrequestreview-4165727884
 
 ## Merge Readiness
 
@@ -55,13 +56,13 @@ Merge-readiness contract:
 - [x] All review threads resolved on GitHub after disposition updates
   Evidence: GraphQL review-thread check returned `0` unresolved threads after coordinator resolution pass.
 - [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: Sourcery, CodeRabbit, and Codex actionables are mapped above, including review-level Sourcery URL `#pullrequestreview-4163080758`.
+  Evidence: Sourcery, CodeRabbit, and Codex actionables are mapped above, including review-level URLs `#pullrequestreview-4163080758`, `#pullrequestreview-4165661733`, and `#pullrequestreview-4165727884`.
 - [x] Pre-commit green on latest pushed head
   Evidence: `pre-commit run --all-files` passed on the governance-evidence tree before push.
-- [x] `make verify` green on latest pushed head
-  Evidence: launchd-supervised `make verify` completed with exit `0` on the governance-evidence tree before push; earlier attached runs were SIGTERM-killed by the local session during `diff-cov`, not by test failures.
-- [x] Mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed
-  Evidence: local coordinator lane findings captured below and fixed before ready-for-review cycle.
+- [ ] `make verify` green on latest pushed head
+  Evidence: the governance-refresh head after this artifact update still needs a fresh exact-head `make verify` pass before merge claim.
+- [ ] Mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed
+  Evidence: `qa-engineer-agent` completed on the current head; `bug-hunter` still needs to run after the governance-refresh push.
 
 Post-open QA notes:
 

--- a/docs/review/PR_1503_FIXED_MAPPING.md
+++ b/docs/review/PR_1503_FIXED_MAPPING.md
@@ -17,6 +17,7 @@ Record every actionable human/bot disposition here before resolving threads on G
 Disposition: FIXED
 Commit: 39d77cf8c
 Evidence: `pytest -q tests/test_check_docker_provenance_attestation.py tests/test_python_supply_chain_controls.py` -> 54 passed. The fix commit hardens the helper timeout, parser, failure evidence path, workflow verification condition, workflow-contract tests, ADR markdown links, ADR evidence anchors, and ledger traceability.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#pullrequestreview-4163080758 -> 39d77cf8c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131356723 -> 39d77cf8c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131356747 -> 39d77cf8c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131356752 -> 39d77cf8c
@@ -40,19 +41,19 @@ Merge-readiness contract:
 `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
 
 - [ ] Mandatory wait-window satisfied (final check pass completed, then waited >=1 review cycle after latest bot/review activity)
-  Evidence: pending initial review and current-head CI cycle.
+  Evidence: latest bot/review activity was the post-ready review cycle on April 23, 2026; coordinator reran checks and delayed merge claim until after the subsequent push + CI cycle.
 - [ ] Current-head CI is green for PR branch head
-  Evidence: pending current-head GitHub checks after PR open.
+  Evidence: the next PR head after this governance-evidence update still needs a green CI cycle before merge claim.
 - [ ] Required checks complete (no pending jobs)
-  Evidence: pending current-head GitHub checks after PR open.
-- [ ] All review threads resolved on GitHub after disposition updates
-  Evidence: pending GitHub thread resolution after latest mapping update.
-- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: CodeRabbit/Sourcery/Codex comments mapped above; pending final bot recheck after push.
+  Evidence: the next PR head after this governance-evidence update still needs a completed green CI cycle before merge claim.
+- [x] All review threads resolved on GitHub after disposition updates
+  Evidence: GraphQL review-thread check returned `0` unresolved threads after coordinator resolution pass.
+- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: Sourcery, CodeRabbit, and Codex actionables are mapped above, including review-level Sourcery URL `#pullrequestreview-4163080758`.
 - [x] Pre-commit green on latest pushed head
-  Evidence: `pre-commit run --all-files` passed before commit `0b6ea053e`.
-- [ ] `make verify` green on latest pushed head
-  Evidence: pending final local gate on latest pushed head.
+  Evidence: `pre-commit run --all-files` passed on the governance-evidence tree before push.
+- [x] `make verify` green on latest pushed head
+  Evidence: launchd-supervised `make verify` completed with exit `0` on the governance-evidence tree before push; earlier attached runs were SIGTERM-killed by the local session during `diff-cov`, not by test failures.
 - [x] Mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed
   Evidence: local coordinator lane findings captured below and fixed before ready-for-review cycle.
 

--- a/docs/review/PR_1503_FIXED_MAPPING.md
+++ b/docs/review/PR_1503_FIXED_MAPPING.md
@@ -34,6 +34,12 @@ Commit: 0fdeaa100
 Evidence: `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1503 --body "$(gh pr view 1503 --json body --jq .body)"` -> passed; canonical artifact now enumerates bot/agent dispositions instead of `No actionable review comments`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131386028 -> 0fdeaa100
 
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1503_FIXED_MAPPING.md:43-48` keeps the actual final merge-cycle items (`Mandatory wait-window satisfied`, `Current-head CI is green`, `Required checks complete`) unchecked while only already-confirmed local items remain checked below.
+Reason: the CodeRabbit follow-up misread the current artifact state; the merge-cycle checkboxes it flagged are already unchecked on the latest head, so no code or docs change is required beyond recording the disposition.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3133574264
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#pullrequestreview-4165661733
+
 ## Merge Readiness
 
 Merge-readiness contract:

--- a/docs/review/PR_1503_FIXED_MAPPING.md
+++ b/docs/review/PR_1503_FIXED_MAPPING.md
@@ -39,6 +39,20 @@ Merge-readiness contract:
 - [ ] Mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed
   Evidence: pending post-open review lane.
 
+Post-open QA notes:
+
+- `qa-engineer-agent` found the earlier seed mapping artifact used prose where
+  the Phase2 parser requires `- No actionable review comments`; fixed in
+  commit `256ba89d7`.
+- `qa-engineer-agent` found scoped Docker lane docs still described provenance
+  as deferred and the active ledger item still targeted a TBD PR; fixed in the
+  follow-up commit after PR open.
+- `bug-hunter` found CD verification was checking for GitHub signed
+  attestations without first generating them and that the SBOM predicate used
+  the BuildKit-incompatible `/v2.3` suffix; fixed by adding explicit
+  GitHub-signed provenance/SBOM attestation steps before verification and by
+  verifying the SPDX predicate `https://spdx.dev/Document`.
+
 ## Deferred / Follow-ups
 
 - `docs/roadmap/BACKLOG_LEDGER.md` line 540 (`P1: Shared Safety audit script after install-profile split`)

--- a/docs/review/PR_1503_FIXED_MAPPING.md
+++ b/docs/review/PR_1503_FIXED_MAPPING.md
@@ -1,0 +1,47 @@
+# PR #1503 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+This artifact is created immediately after the PR is opened per repo governance.
+Record every actionable human/bot disposition here before resolving threads on GitHub.
+
+## Fixed in Commit Mapping
+
+No actionable human or bot review threads are recorded on the current head yet.
+Update this section before resolving any GitHub thread.
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:93-112`;
+`docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:153-216`.
+
+- [ ] Mandatory wait-window satisfied (final check pass completed, then waited >=1 review cycle after latest bot/review activity)
+  Evidence: pending initial review and current-head CI cycle.
+- [ ] Current-head CI is green for PR branch head
+  Evidence: pending current-head GitHub checks after PR open.
+- [ ] Required checks complete (no pending jobs)
+  Evidence: pending current-head GitHub checks after PR open.
+- [ ] All review threads resolved on GitHub after disposition updates
+  Evidence: pending initial review cycle.
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+  Evidence: pending post-open review cycle on current head.
+- [x] Pre-commit green on latest pushed head
+  Evidence: `pre-commit run --all-files` passed before commit `0b6ea053e`.
+- [ ] `make verify` green on latest pushed head
+  Evidence: not run for this lane yet.
+- [ ] Mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed
+  Evidence: pending post-open review lane.
+
+## Deferred / Follow-ups
+
+- `docs/roadmap/BACKLOG_LEDGER.md` line 540 (`P1: Shared Safety audit script after install-profile split`)
+- Dagger follow-up after Docker baseline and provenance stabilization
+  Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-dagger-pilot-after-docker-baseline`

--- a/docs/review/PR_1503_FIXED_MAPPING.md
+++ b/docs/review/PR_1503_FIXED_MAPPING.md
@@ -14,8 +14,7 @@ Record every actionable human/bot disposition here before resolving threads on G
 
 ## Fixed in Commit Mapping
 
-No actionable human or bot review threads are recorded on the current head yet.
-Update this section before resolving any GitHub thread.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1503_FIXED_MAPPING.md
+++ b/docs/review/PR_1503_FIXED_MAPPING.md
@@ -16,7 +16,7 @@ Record every actionable human/bot disposition here before resolving threads on G
 
 Disposition: FIXED
 Commit: 39d77cf8c
-Evidence: `pytest -q tests/test_check_docker_provenance_attestation.py tests/test_python_supply_chain_controls.py` -> 54 passed. The fix commit hardens the helper timeout, parser, failure evidence path, workflow verification condition, workflow-contract tests, ADR markdown links, ADR evidence anchors, and ledger traceability.
+Evidence: `pytest -q tests/test_check_docker_provenance_attestation.py tests/test_python_supply_chain_controls.py` -> 54 passed. The fix commit hardens the helper timeout, parser, failure evidence path, workflow verification condition, workflow-contract tests, ADR Markdown links, ADR evidence anchors, and ledger traceability.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#pullrequestreview-4163080758 -> 39d77cf8c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131356723 -> 39d77cf8c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131356747 -> 39d77cf8c
@@ -41,6 +41,11 @@ Reason: the CodeRabbit follow-up misread the current artifact state; the merge-c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#pullrequestreview-4165661733
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#pullrequestreview-4165727884
 
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1503_FIXED_MAPPING.md:49-64` keeps the merge-readiness checklist intentionally conservative and uses review-level URLs as rollup references for artifact-only follow-ups.
+Reason: the review-level CodeRabbit summary is a rollup comment over optional style guidance and checklist-state guidance on this same artifact; recording the review URL here is sufficient and does not require a distinct commit mapping entry.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#pullrequestreview-4165903700
+
 ## Merge Readiness
 
 Merge-readiness contract:
@@ -53,11 +58,11 @@ Merge-readiness contract:
   Evidence: the next PR head after this governance-evidence update still needs a green CI cycle before merge claim.
 - [ ] Required checks complete (no pending jobs)
   Evidence: the next PR head after this governance-evidence update still needs a completed green CI cycle before merge claim.
-- [x] All review threads resolved on GitHub after disposition updates
+- [ ] All review threads resolved on GitHub after disposition updates
   Evidence: GraphQL review-thread check returned `0` unresolved threads after coordinator resolution pass.
-- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
   Evidence: Sourcery, CodeRabbit, and Codex actionables are mapped above, including review-level URLs `#pullrequestreview-4163080758`, `#pullrequestreview-4165661733`, and `#pullrequestreview-4165727884`.
-- [x] Pre-commit green on latest pushed head
+- [ ] Pre-commit green on latest pushed head
   Evidence: `pre-commit run --all-files` passed on the governance-evidence tree before push.
 - [ ] `make verify` green on latest pushed head
   Evidence: the governance-refresh head after this artifact update still needs a fresh exact-head `make verify` pass before merge claim.
@@ -72,7 +77,7 @@ Post-open QA notes:
 - `qa-engineer-agent` found scoped Docker lane docs still described provenance
   as deferred and the active ledger item still targeted a TBD PR; fixed in the
   follow-up commit after PR open.
-- `bug-hunter` found CD verification was checking for GitHub signed
+- `bug-hunter` found CD verification was checking for GitHub-signed
   attestations without first generating them and that the SBOM predicate used
   the BuildKit-incompatible `/v2.3` suffix; fixed by adding explicit
   GitHub-signed provenance/SBOM attestation steps before verification and by

--- a/docs/review/PR_1503_FIXED_MAPPING.md
+++ b/docs/review/PR_1503_FIXED_MAPPING.md
@@ -28,6 +28,11 @@ Evidence: `pytest -q tests/test_check_docker_provenance_attestation.py tests/tes
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131386032 -> 39d77cf8c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#pullrequestreview-4163115645 -> 39d77cf8c
 
+Disposition: FIXED
+Commit: 0fdeaa100
+Evidence: `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1503 --body "$(gh pr view 1503 --json body --jq .body)"` -> passed; canonical artifact now enumerates bot/agent dispositions instead of `No actionable review comments`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#discussion_r3131386028 -> 0fdeaa100
+
 ## Merge Readiness
 
 Merge-readiness contract:
@@ -43,7 +48,7 @@ Merge-readiness contract:
 - [ ] All review threads resolved on GitHub after disposition updates
   Evidence: pending GitHub thread resolution after latest mapping update.
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
-  Evidence: CodeRabbit/Sourcery/Codex comments mapped above; pending mapping-comment self-proof commit and final bot recheck.
+  Evidence: CodeRabbit/Sourcery/Codex comments mapped above; pending final bot recheck after push.
 - [x] Pre-commit green on latest pushed head
   Evidence: `pre-commit run --all-files` passed before commit `0b6ea053e`.
 - [ ] `make verify` green on latest pushed head

--- a/docs/review/PR_1503_FIXED_MAPPING.md
+++ b/docs/review/PR_1503_FIXED_MAPPING.md
@@ -46,6 +46,11 @@ Evidence: `docs/review/PR_1503_FIXED_MAPPING.md:49-64` keeps the merge-readiness
 Reason: the review-level CodeRabbit summary is a rollup comment over optional style guidance and checklist-state guidance on this same artifact; recording the review URL here is sufficient and does not require a distinct commit mapping entry.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#pullrequestreview-4165903700
 
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1503_FIXED_MAPPING.md:81-83` now records the exact historical fix commit `a61b7c1d9` for the QA note that previously said `follow-up commit after PR open`.
+Reason: the review-level CodeRabbit summary is an artifact auditability rollup; the underlying note is now concrete and no implementation change is required.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1503#pullrequestreview-4165977146
+
 ## Merge Readiness
 
 Merge-readiness contract:
@@ -75,8 +80,8 @@ Post-open QA notes:
   the Phase2 parser requires `- No actionable review comments`; fixed in
   commit `256ba89d7`.
 - `qa-engineer-agent` found scoped Docker lane docs still described provenance
-  as deferred and the active ledger item still targeted a TBD PR; fixed in the
-  follow-up commit after PR open.
+  as deferred and the active ledger item still targeted a TBD PR; fixed in
+  commit `a61b7c1d9`.
 - `bug-hunter` found CD verification was checking for GitHub-signed
   attestations without first generating them and that the SBOM predicate used
   the BuildKit-incompatible `/v2.3` suffix; fixed by adding explicit

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -617,7 +617,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Priority: P1
   - Target PR: PR #1490 (`fix(docker): slim runtime after profile split`)
   - Area: docker / runtime / supply-chain
-  - Status note: Merged on April 22, 2026 via `PR #1490`. Production-target Docker builds now use `requirements-docker-runtime.txt`; telemetry baseline and hard-budget follow-ups have since landed, while Shared Safety audit extraction remains deferred and the next active Docker/CI slice is signed provenance restoration on pushed-image lanes.
+  - Status note: Merged on April 22, 2026 via `PR #1490`. Production-target Docker builds now use `requirements-docker-runtime.txt`; telemetry baseline ([Docker image budget and telemetry baseline](#ledger-p1-docker-image-budget-telemetry); DoD: measured baseline artifact and docs) and hard-budget follow-up ([Docker image hard budget gate after telemetry baseline](#ledger-p1-docker-image-hard-budget-gate); DoD: fail-closed budget gate) have since landed, while [Shared Safety audit extraction](#ledger-p1-safety-audit-shared-script-after-pr1479) remains deferred and the next active Docker/CI slice is signed provenance restoration on pushed-image lanes.
   - Depends on:
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-ci-install-profile-split-after-disk-unblock`
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-docker-deploy-contract-reconciliation`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -764,7 +764,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Restore signed build provenance after cache/buildx workaround is removed
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (supply-chain maturity after tooling-surface guard baseline)
-  - Target PR: PR-TBD-DOCKER-SIGNED-PROVENANCE
+  - Target PR: PR #1503
   - Status: 🟡 Active next slice after `PR #1498`
   - Reason (EN): Docker baseline and hard-budget gates are now stable enough to restore signed provenance on pushed-image lanes without widening scope into `load: true` jobs or alternate control planes. This slice must re-enable provenance/SBOM attestations on registry pushes and fail closed before staging or production deploy if digest verification breaks.
   - Links:

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -617,7 +617,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Priority: P1
   - Target PR: PR #1490 (`fix(docker): slim runtime after profile split`)
   - Area: docker / runtime / supply-chain
-  - Status note: Merged on April 22, 2026 via `PR #1490`. Production-target Docker builds now use `requirements-docker-runtime.txt`; the next main Docker/CI slice is the warning-only image-budget and telemetry baseline, while Shared Safety audit extraction remains deferred.
+  - Status note: Merged on April 22, 2026 via `PR #1490`. Production-target Docker builds now use `requirements-docker-runtime.txt`; telemetry baseline and hard-budget follow-ups have since landed, while Shared Safety audit extraction remains deferred and the next active Docker/CI slice is signed provenance restoration on pushed-image lanes.
   - Depends on:
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-ci-install-profile-split-after-disk-unblock`
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-docker-deploy-contract-reconciliation`
@@ -638,12 +638,12 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Supply-chain guardrails and proxy install contract remain intact
 
 <a id="ledger-p1-docker-image-budget-telemetry"></a>
-- [ ] P1: Docker image budget and telemetry baseline
+- [x] P1: Docker image budget and telemetry baseline
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR #1492
   - Area: CI / docker / telemetry
-  - Status note: Active PR-5 slice after `PR #1490` merged on April 22, 2026. This lane establishes one canonical backend-image baseline, prefers the latest successful `main` artifact, falls back to a checked-in seed baseline, and keeps delta reporting warning-only.
+  - Status note: Merged on April 22, 2026 via `PR #1492`. The lane established one canonical backend-image baseline, prefers the latest successful `main` artifact, falls back to a checked-in seed baseline, and kept delta reporting warning-only.
   - Depends on:
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-ci-install-profile-split-after-disk-unblock`
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-docker-deploy-contract-reconciliation`
@@ -664,12 +664,12 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Follow-up provenance or Dagger decisions can cite this baseline explicitly
 
 <a id="ledger-p1-docker-image-hard-budget-gate"></a>
-- [ ] P1: Docker image hard budget gate after telemetry baseline
+- [x] P1: Docker image hard budget gate after telemetry baseline
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-DOCKER-HARD-BUDGET-GATE
+  - Target PR: PR #1498
   - Area: CI / docker / telemetry
-  - Status note: Active PR-6 slice after `PR #1492` merged on April 22, 2026. This lane promotes the production backend image from warning-only telemetry to a deterministic hybrid hard gate with an absolute cap and a maximum positive delta vs baseline.
+  - Status note: Merged on April 22, 2026 via `PR #1498`. The lane promotes the production backend image from warning-only telemetry to a deterministic hybrid hard gate with an absolute cap and a maximum positive delta vs baseline.
   - Depends on:
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-docker-image-budget-telemetry`
   - Reason: The repo should not enforce a hard image-size failure threshold until the warning-only baseline has stabilized on `main` and the canonical telemetry evidence is trustworthy enough to gate merges deterministically.
@@ -764,16 +764,21 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Restore signed build provenance after cache/buildx workaround is removed
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (supply-chain maturity after tooling-surface guard baseline)
-  - Target PR: TBD
-  - Status: 📋 Planned
-  - Reason (EN): Workflow pinning and tooling-surface guards can be enforced immediately, but signed provenance and downstream verification remain intentionally deferred until the documented Docker/buildx cache seam is removed and attestation can be re-enabled without destabilizing the release path.
+  - Target PR: PR-TBD-DOCKER-SIGNED-PROVENANCE
+  - Status: 🟡 Active next slice after `PR #1498`
+  - Reason (EN): Docker baseline and hard-budget gates are now stable enough to restore signed provenance on pushed-image lanes without widening scope into `load: true` jobs or alternate control planes. This slice must re-enable provenance/SBOM attestations on registry pushes and fail closed before staging or production deploy if digest verification breaks.
   - Links:
+    - `docs/orchestration/DOCKER_SIGNED_BUILD_PROVENANCE_TASK_PACKET_2026-04-23.md`
     - `.github/workflows/build.yml`
+    - `.github/workflows/cd.yml`
+    - `scripts/ci/check_docker_provenance_attestation.py`
     - `docs/architecture/ADR_DOCKER_BUILD_PROVENANCE_WORKAROUND_2026-03-01.md`
     - `docs/security/TOOLING_SURFACE_POLICY.md`
   - DoD:
-    - Build provenance is enabled again in the canonical image workflow
-    - Signed provenance/SBOM verification is enforced before deploy
+    - `build.yml` and `cd.yml` pushed-image lanes use `provenance: mode=max`
+    - pushed-image lanes emit SBOM attestations alongside provenance
+    - CD verifies provenance and SPDX SBOM attestations by exact pushed digest before any deploy step
+    - `load: true` jobs remain on `provenance: false`
     - Follow-up docs and CI checks explicitly cover the restored path
 
 <a id="ledger-p1-sbom-vex-signed-security-artifacts"></a>

--- a/docs/security/TOOLING_SURFACE_POLICY.md
+++ b/docs/security/TOOLING_SURFACE_POLICY.md
@@ -31,4 +31,5 @@ Keep developer tooling, CI actions, and workspace recommendations pinned and rev
 
 - default workflow permissions should stay least-privilege (`contents: read` unless stricter access is justified)
 - SBOM generation remains enabled
-- provenance/cosign verification is deferred until the documented build workaround is removed
+- pushed-image Docker lanes must emit `provenance: mode=max` and `sbom: true`
+- CD must verify provenance and SPDX SBOM attestations by exact digest before deploy using `scripts/ci/check_docker_provenance_attestation.py`

--- a/docs/security/TOOLING_SURFACE_POLICY.md
+++ b/docs/security/TOOLING_SURFACE_POLICY.md
@@ -32,4 +32,5 @@ Keep developer tooling, CI actions, and workspace recommendations pinned and rev
 - default workflow permissions should stay least-privilege (`contents: read` unless stricter access is justified)
 - SBOM generation remains enabled
 - pushed-image Docker lanes must emit `provenance: mode=max` and `sbom: true`
+- CD jobs that create GitHub-signed provenance/SBOM attestations must grant `attestations: write`
 - CD must verify provenance and SPDX SBOM attestations by exact digest before deploy using `scripts/ci/check_docker_provenance_attestation.py`

--- a/scripts/ci/check_docker_provenance_attestation.py
+++ b/scripts/ci/check_docker_provenance_attestation.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Verify OCI image provenance and SBOM attestations with the GitHub CLI.
+
+The helper is intentionally fail-closed: it verifies the exact pushed image
+digest from OCI-backed attestations and emits JSON/Markdown evidence for CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+import shutil
+import subprocess  # nosec B404: bounded gh CLI verification is required for OCI attestation checks (remove-by: 2026-09-30, ref: PR-docker-signed-provenance)
+import sys
+
+GH_TIMEOUT_SECONDS = 60
+PROVENANCE_PREDICATE_TYPE = "https://slsa.dev/provenance/v1"
+SBOM_PREDICATE_TYPE = "https://spdx.dev/Document/v2.3"
+BUNDLE_SOURCE = "oci-registry"
+
+
+@dataclass(frozen=True)
+class VerifiedPredicate:
+    """Evidence summary for a single verified attestation predicate."""
+
+    name: str
+    predicate_type: str
+    attestation_count: int
+    verification_result: tuple[dict[str, object], ...]
+
+
+@dataclass(frozen=True)
+class VerificationBundle:
+    """Deterministic verification bundle written to CI evidence artifacts."""
+
+    passed: bool
+    artifact_uri: str
+    repo: str
+    signer_workflow: str
+    source_ref: str
+    bundle_source: str
+    provenance: VerifiedPredicate
+    sbom: VerifiedPredicate
+
+
+def build_artifact_uri(image_name: str, digest: str) -> str:
+    """Return the exact OCI artifact URI for a pushed image digest."""
+
+    normalized_image_name = image_name.strip()
+    normalized_digest = digest.strip()
+    if not normalized_image_name:
+        raise RuntimeError("image_name must be a non-empty string.")
+    if normalized_image_name.startswith("oci://"):
+        raise RuntimeError("image_name must not include the oci:// prefix.")
+    if not normalized_digest.startswith("sha256:"):
+        raise RuntimeError("digest must use the sha256:<hex> format.")
+    return f"oci://{normalized_image_name}@{normalized_digest}"
+
+
+def _gh_path() -> str:
+    """Return the absolute gh binary path or fail closed."""
+
+    gh_path = shutil.which("gh")
+    if gh_path is None:
+        raise RuntimeError("gh binary is not available on PATH.")
+    return gh_path
+
+
+def _run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run gh with a resolved binary path and strict timeout/error handling."""
+
+    try:
+        return subprocess.run(  # nosec B603: argv uses a resolved gh path with fixed attestation-verification subcommands only (remove-by: 2026-09-30, ref: PR-docker-signed-provenance)
+            [_gh_path(), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"gh attestation verify timed out after {GH_TIMEOUT_SECONDS}s: {' '.join(args)}"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip()
+        stdout = exc.stdout.strip()
+        detail = stderr or stdout or str(exc)
+        raise RuntimeError(f"gh attestation verify failed: {detail}") from exc
+
+
+def _parse_verification_output(
+    *,
+    stdout: str,
+    predicate_type: str,
+    label: str,
+) -> tuple[dict[str, object], ...]:
+    """Parse and validate gh attestation verify JSON output."""
+
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{label} verification output is not valid JSON.") from exc
+    if not isinstance(payload, list) or not payload:
+        raise RuntimeError(f"{label} verification must return at least one attestation.")
+
+    normalized: list[dict[str, object]] = []
+    for index, item in enumerate(payload):
+        if not isinstance(item, dict):
+            raise RuntimeError(f"{label} verification item #{index} is not a JSON object.")
+        verification_result = item.get("verificationResult")
+        if not isinstance(verification_result, dict):
+            raise RuntimeError(f"{label} verification item #{index} is missing verificationResult.")
+        statement = verification_result.get("statement")
+        if not isinstance(statement, dict):
+            raise RuntimeError(f"{label} verification item #{index} is missing statement.")
+        actual_predicate_type = statement.get("predicateType")
+        if actual_predicate_type != predicate_type:
+            raise RuntimeError(
+                f"{label} verification item #{index} has predicate "
+                f"{actual_predicate_type!r}, expected {predicate_type!r}."
+            )
+        normalized.append(item)
+    return tuple(normalized)
+
+
+def _verify_predicate(
+    *,
+    artifact_uri: str,
+    repo: str,
+    signer_workflow: str,
+    source_ref: str,
+    predicate_type: str,
+    label: str,
+) -> VerifiedPredicate:
+    """Verify one predicate type against the exact pushed OCI image digest."""
+
+    args = [
+        "attestation",
+        "verify",
+        artifact_uri,
+        "--repo",
+        repo,
+        "--signer-workflow",
+        signer_workflow,
+        "--source-ref",
+        source_ref,
+        "--bundle-from-oci",
+        "--deny-self-hosted-runners",
+        "--format",
+        "json",
+    ]
+    if predicate_type != PROVENANCE_PREDICATE_TYPE:
+        args.extend(["--predicate-type", predicate_type])
+    completed = _run_gh(args)
+    verification_result = _parse_verification_output(
+        stdout=completed.stdout,
+        predicate_type=predicate_type,
+        label=label,
+    )
+    return VerifiedPredicate(
+        name=label,
+        predicate_type=predicate_type,
+        attestation_count=len(verification_result),
+        verification_result=verification_result,
+    )
+
+
+def verify_attestations(
+    *,
+    image_name: str,
+    digest: str,
+    repo: str,
+    signer_workflow: str,
+    source_ref: str,
+) -> VerificationBundle:
+    """Verify provenance and SBOM attestations for one OCI image digest."""
+
+    artifact_uri = build_artifact_uri(image_name, digest)
+    provenance = _verify_predicate(
+        artifact_uri=artifact_uri,
+        repo=repo,
+        signer_workflow=signer_workflow,
+        source_ref=source_ref,
+        predicate_type=PROVENANCE_PREDICATE_TYPE,
+        label="provenance",
+    )
+    sbom = _verify_predicate(
+        artifact_uri=artifact_uri,
+        repo=repo,
+        signer_workflow=signer_workflow,
+        source_ref=source_ref,
+        predicate_type=SBOM_PREDICATE_TYPE,
+        label="sbom",
+    )
+    return VerificationBundle(
+        passed=True,
+        artifact_uri=artifact_uri,
+        repo=repo,
+        signer_workflow=signer_workflow,
+        source_ref=source_ref,
+        bundle_source=BUNDLE_SOURCE,
+        provenance=provenance,
+        sbom=sbom,
+    )
+
+
+def render_markdown(bundle: VerificationBundle) -> str:
+    """Render a concise Markdown summary for CI step summaries/artifacts."""
+
+    lines = [
+        "# OCI Image Attestation Verification",
+        "",
+        f"- Passed: `{str(bundle.passed).lower()}`",
+        f"- Artifact: `{bundle.artifact_uri}`",
+        f"- Repo: `{bundle.repo}`",
+        f"- Signer workflow: `{bundle.signer_workflow}`",
+        f"- Source ref: `{bundle.source_ref}`",
+        f"- Bundle source: `{bundle.bundle_source}`",
+        f"- Provenance attestations verified: `{bundle.provenance.attestation_count}`",
+        f"- SBOM attestations verified: `{bundle.sbom.attestation_count}`",
+        f"- Provenance predicate: `{bundle.provenance.predicate_type}`",
+        f"- SBOM predicate: `{bundle.sbom.predicate_type}`",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    """Write a deterministic JSON evidence file."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    """Write a UTF-8 text evidence file."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    """Return the CLI argument parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image-name", required=True, help="Registry/repository image name.")
+    parser.add_argument("--digest", required=True, help="Exact pushed image digest (sha256:...).")
+    parser.add_argument("--repo", required=True, help="GitHub repository in owner/name format.")
+    parser.add_argument(
+        "--signer-workflow",
+        required=True,
+        help="Signer workflow in owner/name/.github/workflows/file.yml format.",
+    )
+    parser.add_argument("--source-ref", required=True, help="Git ref expected in the certificate.")
+    parser.add_argument("--json-out", required=True, help="Path to the JSON evidence artifact.")
+    parser.add_argument(
+        "--markdown-out",
+        required=True,
+        help="Path to the Markdown evidence artifact.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+
+    parser = _build_argument_parser()
+    args = parser.parse_args(argv)
+    json_out = Path(args.json_out)
+    markdown_out = Path(args.markdown_out)
+
+    try:
+        bundle = verify_attestations(
+            image_name=args.image_name,
+            digest=args.digest,
+            repo=args.repo,
+            signer_workflow=args.signer_workflow,
+            source_ref=args.source_ref,
+        )
+    except RuntimeError as exc:
+        failure_payload = {
+            "passed": False,
+            "error": str(exc),
+            "artifact_uri": (
+                build_artifact_uri(args.image_name, args.digest)
+                if args.image_name and args.digest.startswith("sha256:")
+                else None
+            ),
+            "repo": args.repo,
+            "signer_workflow": args.signer_workflow,
+            "source_ref": args.source_ref,
+            "bundle_source": BUNDLE_SOURCE,
+        }
+        failure_markdown = "\n".join(
+            [
+                "# OCI Image Attestation Verification",
+                "",
+                "- Passed: `false`",
+                f"- Repo: `{args.repo}`",
+                f"- Signer workflow: `{args.signer_workflow}`",
+                f"- Source ref: `{args.source_ref}`",
+                f"- Bundle source: `{BUNDLE_SOURCE}`",
+                f"- Error: `{exc}`",
+                "",
+            ]
+        )
+        _write_json(json_out, failure_payload)
+        _write_text(markdown_out, failure_markdown)
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    _write_json(json_out, asdict(bundle))
+    _write_text(markdown_out, render_markdown(bundle))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_docker_provenance_attestation.py
+++ b/scripts/ci/check_docker_provenance_attestation.py
@@ -10,15 +10,18 @@ from __future__ import annotations
 import argparse
 from dataclasses import asdict, dataclass
 import json
+import os
 from pathlib import Path
 import shutil
 import subprocess  # nosec B404: bounded gh CLI verification is required for OCI attestation checks (remove-by: 2026-09-30, ref: PR-docker-signed-provenance)
 import sys
 
-GH_TIMEOUT_SECONDS = 60
+GH_TIMEOUT_SECONDS_DEFAULT = 180
+GH_TIMEOUT_SECONDS_ENV = "PULSEPLATE_DOCKER_ATTESTATION_GH_TIMEOUT_SECONDS"
 PROVENANCE_PREDICATE_TYPE = "https://slsa.dev/provenance/v1"
 SBOM_PREDICATE_TYPE = "https://spdx.dev/Document"
 BUNDLE_SOURCE = "oci-registry"
+MAX_ERROR_STDOUT_CHARS = 500
 
 
 @dataclass(frozen=True)
@@ -68,20 +71,34 @@ def _gh_path() -> str:
     return gh_path
 
 
+def _gh_timeout_seconds() -> int:
+    """Return a bounded gh timeout, configurable for slower registries."""
+
+    raw_value = os.getenv(GH_TIMEOUT_SECONDS_ENV, str(GH_TIMEOUT_SECONDS_DEFAULT)).strip()
+    try:
+        timeout_seconds = int(raw_value)
+    except ValueError:
+        return GH_TIMEOUT_SECONDS_DEFAULT
+    if timeout_seconds <= 0:
+        return GH_TIMEOUT_SECONDS_DEFAULT
+    return timeout_seconds
+
+
 def _run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
     """Run gh with a resolved binary path and strict timeout/error handling."""
 
+    timeout_seconds = _gh_timeout_seconds()
     try:
         return subprocess.run(  # nosec B603: argv uses a resolved gh path with fixed attestation-verification subcommands only (remove-by: 2026-09-30, ref: PR-docker-signed-provenance)
             [_gh_path(), *args],
             check=True,
             capture_output=True,
             text=True,
-            timeout=GH_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(
-            f"gh attestation verify timed out after {GH_TIMEOUT_SECONDS}s: {' '.join(args)}"
+            f"gh attestation verify timed out after {timeout_seconds}s: {' '.join(args)}"
         ) from exc
     except subprocess.CalledProcessError as exc:
         stderr = exc.stderr.strip()
@@ -102,11 +119,21 @@ def _parse_verification_output(
         payload = json.loads(stdout)
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"{label} verification output is not valid JSON.") from exc
-    if not isinstance(payload, list) or not payload:
+
+    if isinstance(payload, list):
+        verification_items = payload
+    elif isinstance(payload, dict) and isinstance(payload.get("verifications"), list):
+        verification_items = payload["verifications"]
+    else:
+        raise RuntimeError(
+            f"{label} verification returned an unexpected JSON shape: " f"{_trim_for_error(stdout)}"
+        )
+
+    if not verification_items:
         raise RuntimeError(f"{label} verification must return at least one attestation.")
 
     normalized: list[dict[str, object]] = []
-    for index, item in enumerate(payload):
+    for index, item in enumerate(verification_items):
         if not isinstance(item, dict):
             raise RuntimeError(f"{label} verification item #{index} is not a JSON object.")
         verification_result = item.get("verificationResult")
@@ -123,6 +150,15 @@ def _parse_verification_output(
             )
         normalized.append(item)
     return tuple(normalized)
+
+
+def _trim_for_error(value: str) -> str:
+    """Return a one-line bounded string for fail-closed diagnostics."""
+
+    normalized = value.strip().replace("\n", "\\n")
+    if len(normalized) <= MAX_ERROR_STDOUT_CHARS:
+        return normalized
+    return f"{normalized[:MAX_ERROR_STDOUT_CHARS]}..."
 
 
 def _verify_predicate(
@@ -226,6 +262,15 @@ def render_markdown(bundle: VerificationBundle) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _safe_artifact_uri(image_name: str, digest: str) -> str | None:
+    """Build an artifact URI for evidence without masking the root failure."""
+
+    try:
+        return build_artifact_uri(image_name, digest)
+    except RuntimeError:
+        return None
+
+
 def _write_json(path: Path, payload: dict[str, object]) -> None:
     """Write a deterministic JSON evidence file."""
 
@@ -282,11 +327,7 @@ def main(argv: list[str] | None = None) -> int:
         failure_payload = {
             "passed": False,
             "error": str(exc),
-            "artifact_uri": (
-                build_artifact_uri(args.image_name, args.digest)
-                if args.image_name and args.digest.startswith("sha256:")
-                else None
-            ),
+            "artifact_uri": _safe_artifact_uri(args.image_name, args.digest),
             "repo": args.repo,
             "signer_workflow": args.signer_workflow,
             "source_ref": args.source_ref,

--- a/scripts/ci/check_docker_provenance_attestation.py
+++ b/scripts/ci/check_docker_provenance_attestation.py
@@ -17,7 +17,7 @@ import sys
 
 GH_TIMEOUT_SECONDS = 60
 PROVENANCE_PREDICATE_TYPE = "https://slsa.dev/provenance/v1"
-SBOM_PREDICATE_TYPE = "https://spdx.dev/Document/v2.3"
+SBOM_PREDICATE_TYPE = "https://spdx.dev/Document"
 BUNDLE_SOURCE = "oci-registry"
 
 

--- a/tests/test_check_docker_provenance_attestation.py
+++ b/tests/test_check_docker_provenance_attestation.py
@@ -1,0 +1,166 @@
+"""Tests for OCI image attestation verification helper."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+
+import scripts.ci.check_docker_provenance_attestation as verifier
+
+
+def _completed_process(payload: list[dict[str, object]]) -> subprocess.CompletedProcess[str]:
+    """Return a completed process with JSON stdout."""
+
+    return subprocess.CompletedProcess(
+        args=["gh", "attestation", "verify"],
+        returncode=0,
+        stdout=json.dumps(payload),
+        stderr="",
+    )
+
+
+def _verified_payload(predicate_type: str) -> list[dict[str, object]]:
+    """Return a minimal successful verification payload."""
+
+    return [
+        {
+            "verificationResult": {
+                "statement": {
+                    "predicateType": predicate_type,
+                }
+            }
+        }
+    ]
+
+
+def test_build_artifact_uri_uses_exact_digest() -> None:
+    assert (
+        verifier.build_artifact_uri("ghcr.io/katsiarynakavaleuskaya/pulseplate", "sha256:abc123")
+        == "oci://ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:abc123"
+    )
+
+
+@pytest.mark.parametrize(
+    ("image_name", "digest", "error"),
+    (
+        ("", "sha256:abc123", "image_name"),
+        ("oci://ghcr.io/test/image", "sha256:abc123", "oci://"),
+        ("ghcr.io/test/image", "latest", "sha256"),
+    ),
+)
+def test_build_artifact_uri_rejects_invalid_inputs(
+    image_name: str,
+    digest: str,
+    error: str,
+) -> None:
+    with pytest.raises(RuntimeError, match=error):
+        verifier.build_artifact_uri(image_name, digest)
+
+
+def test_verify_attestations_runs_provenance_and_sbom_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        predicate_type = verifier.PROVENANCE_PREDICATE_TYPE
+        if "--predicate-type" in args:
+            predicate_type = args[args.index("--predicate-type") + 1]
+        return _completed_process(_verified_payload(predicate_type))
+
+    monkeypatch.setattr(verifier, "_run_gh", fake_run_gh)
+
+    bundle = verifier.verify_attestations(
+        image_name="ghcr.io/katsiarynakavaleuskaya/pulseplate",
+        digest="sha256:abc123",
+        repo="Katsiarynakavaleuskaya/PulsePlate",
+        signer_workflow="Katsiarynakavaleuskaya/PulsePlate/.github/workflows/cd.yml",
+        source_ref="refs/heads/main",
+    )
+
+    assert bundle.passed is True
+    assert bundle.artifact_uri == "oci://ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:abc123"
+    assert bundle.provenance.attestation_count == 1
+    assert bundle.sbom.attestation_count == 1
+    assert len(calls) == 2
+
+    provenance_call, sbom_call = calls
+    assert provenance_call[0:3] == [
+        "attestation",
+        "verify",
+        "oci://ghcr.io/katsiarynakavaleuskaya/pulseplate@sha256:abc123",
+    ]
+    assert "--repo" in provenance_call
+    assert "--signer-workflow" in provenance_call
+    assert "--source-ref" in provenance_call
+    assert "--bundle-from-oci" in provenance_call
+    assert "--deny-self-hosted-runners" in provenance_call
+    assert "--predicate-type" not in provenance_call
+
+    assert "--predicate-type" in sbom_call
+    assert sbom_call[sbom_call.index("--predicate-type") + 1] == verifier.SBOM_PREDICATE_TYPE
+
+
+def test_verify_attestations_fails_closed_on_missing_attestations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"count": 0}
+
+    def fake_run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return _completed_process(_verified_payload(verifier.PROVENANCE_PREDICATE_TYPE))
+        return _completed_process([])
+
+    monkeypatch.setattr(verifier, "_run_gh", fake_run_gh)
+
+    with pytest.raises(RuntimeError, match="at least one attestation"):
+        verifier.verify_attestations(
+            image_name="ghcr.io/katsiarynakavaleuskaya/pulseplate",
+            digest="sha256:abc123",
+            repo="Katsiarynakavaleuskaya/PulsePlate",
+            signer_workflow="Katsiarynakavaleuskaya/PulsePlate/.github/workflows/cd.yml",
+            source_ref="refs/heads/main",
+        )
+
+
+def test_main_writes_failure_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    json_out = tmp_path / "attestation.json"
+    markdown_out = tmp_path / "attestation.md"
+
+    def fake_verify_attestations(**_: object) -> verifier.VerificationBundle:
+        raise RuntimeError("verification failed")
+
+    monkeypatch.setattr(verifier, "verify_attestations", fake_verify_attestations)
+
+    exit_code = verifier.main(
+        [
+            "--image-name",
+            "ghcr.io/katsiarynakavaleuskaya/pulseplate",
+            "--digest",
+            "sha256:abc123",
+            "--repo",
+            "Katsiarynakavaleuskaya/PulsePlate",
+            "--signer-workflow",
+            "Katsiarynakavaleuskaya/PulsePlate/.github/workflows/cd.yml",
+            "--source-ref",
+            "refs/heads/main",
+            "--json-out",
+            str(json_out),
+            "--markdown-out",
+            str(markdown_out),
+        ]
+    )
+
+    assert exit_code == 1
+    failure_payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert failure_payload["passed"] is False
+    assert failure_payload["error"] == "verification failed"
+    assert "Passed: `false`" in markdown_out.read_text(encoding="utf-8")

--- a/tests/test_check_docker_provenance_attestation.py
+++ b/tests/test_check_docker_provenance_attestation.py
@@ -11,7 +11,7 @@ import pytest
 import scripts.ci.check_docker_provenance_attestation as verifier
 
 
-def _completed_process(payload: list[dict[str, object]]) -> subprocess.CompletedProcess[str]:
+def _completed_process(payload: object) -> subprocess.CompletedProcess[str]:
     """Return a completed process with JSON stdout."""
 
     return subprocess.CompletedProcess(
@@ -128,6 +128,58 @@ def test_verify_attestations_fails_closed_on_missing_attestations(
         )
 
 
+def test_parser_accepts_wrapped_verification_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GitHub CLI format drift should stay debuggable but fail closed."""
+
+    calls = {"count": 0}
+
+    def fake_run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+        calls["count"] += 1
+        predicate_type = verifier.PROVENANCE_PREDICATE_TYPE
+        if "--predicate-type" in args:
+            predicate_type = args[args.index("--predicate-type") + 1]
+        return _completed_process({"verifications": _verified_payload(predicate_type)})
+
+    monkeypatch.setattr(verifier, "_run_gh", fake_run_gh)
+
+    bundle = verifier.verify_attestations(
+        image_name="ghcr.io/katsiarynakavaleuskaya/pulseplate",
+        digest="sha256:abc123",
+        repo="Katsiarynakavaleuskaya/PulsePlate",
+        signer_workflow="Katsiarynakavaleuskaya/PulsePlate/.github/workflows/cd.yml",
+        source_ref="refs/heads/main",
+    )
+
+    assert calls["count"] == 2
+    assert bundle.provenance.attestation_count == 1
+    assert bundle.sbom.attestation_count == 1
+
+
+def test_parser_reports_unexpected_shape_with_trimmed_stdout() -> None:
+    oversized_stdout = json.dumps({"unexpected": "x" * 600})
+
+    with pytest.raises(RuntimeError, match="unexpected JSON shape"):
+        verifier._parse_verification_output(
+            stdout=oversized_stdout,
+            predicate_type=verifier.PROVENANCE_PREDICATE_TYPE,
+            label="provenance",
+        )
+
+
+def test_gh_timeout_is_configurable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(verifier.GH_TIMEOUT_SECONDS_ENV, "240")
+
+    assert verifier._gh_timeout_seconds() == 240
+
+
+def test_gh_timeout_falls_back_on_invalid_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(verifier.GH_TIMEOUT_SECONDS_ENV, "not-an-int")
+
+    assert verifier._gh_timeout_seconds() == verifier.GH_TIMEOUT_SECONDS_DEFAULT
+
+
 def test_main_writes_failure_artifacts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -163,4 +215,41 @@ def test_main_writes_failure_artifacts(
     failure_payload = json.loads(json_out.read_text(encoding="utf-8"))
     assert failure_payload["passed"] is False
     assert failure_payload["error"] == "verification failed"
+    assert "Passed: `false`" in markdown_out.read_text(encoding="utf-8")
+
+
+def test_main_writes_failure_artifacts_for_invalid_artifact_uri(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    json_out = tmp_path / "attestation.json"
+    markdown_out = tmp_path / "attestation.md"
+
+    def fake_verify_attestations(**_: object) -> verifier.VerificationBundle:
+        raise RuntimeError("image_name must not include the oci:// prefix.")
+
+    monkeypatch.setattr(verifier, "verify_attestations", fake_verify_attestations)
+
+    exit_code = verifier.main(
+        [
+            "--image-name",
+            "oci://ghcr.io/katsiarynakavaleuskaya/pulseplate",
+            "--digest",
+            "sha256:abc123",
+            "--repo",
+            "Katsiarynakavaleuskaya/PulsePlate",
+            "--signer-workflow",
+            "Katsiarynakavaleuskaya/PulsePlate/.github/workflows/cd.yml",
+            "--source-ref",
+            "refs/heads/main",
+            "--json-out",
+            str(json_out),
+            "--markdown-out",
+            str(markdown_out),
+        ]
+    )
+
+    assert exit_code == 1
+    failure_payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert failure_payload["artifact_uri"] is None
     assert "Passed: `false`" in markdown_out.read_text(encoding="utf-8")

--- a/tests/test_check_docker_provenance_attestation.py
+++ b/tests/test_check_docker_provenance_attestation.py
@@ -102,7 +102,7 @@ def test_verify_attestations_runs_provenance_and_sbom_checks(
     assert "--predicate-type" not in provenance_call
 
     assert "--predicate-type" in sbom_call
-    assert sbom_call[sbom_call.index("--predicate-type") + 1] == verifier.SBOM_PREDICATE_TYPE
+    assert sbom_call[sbom_call.index("--predicate-type") + 1] == "https://spdx.dev/Document"
 
 
 def test_verify_attestations_fails_closed_on_missing_attestations(

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -778,10 +778,30 @@ def test_push_to_registry_workflows_restore_signed_attestations_on_publish_lanes
         "build",
         "Verify staged image attestations",
     )
+    staging_provenance_step = _workflow_step_by_name(
+        ".github/workflows/cd.yml",
+        "build",
+        "Attest staged image provenance",
+    )
+    staging_sbom_step = _workflow_step_by_name(
+        ".github/workflows/cd.yml",
+        "build",
+        "Attest staged image SBOM",
+    )
     production_verify_step = _workflow_step_by_name(
         ".github/workflows/cd.yml",
         "build-production",
         "Verify production image attestations",
+    )
+    production_provenance_step = _workflow_step_by_name(
+        ".github/workflows/cd.yml",
+        "build-production",
+        "Attest production image provenance",
+    )
+    production_sbom_step = _workflow_step_by_name(
+        ".github/workflows/cd.yml",
+        "build-production",
+        "Attest production image SBOM",
     )
     staging_upload_step = _workflow_step_by_name(
         ".github/workflows/cd.yml",
@@ -798,11 +818,28 @@ def test_push_to_registry_workflows_restore_signed_attestations_on_publish_lanes
 
     assert local_build_step["with"]["load"] is True
     assert local_build_step["with"]["provenance"] is False
+    assert cd_workflow["jobs"]["build"]["permissions"]["attestations"] == "write"
+    assert cd_workflow["jobs"]["build-production"]["permissions"]["attestations"] == "write"
 
     for step in (publish_step, staging_step, production_step):
         assert step["with"]["push"] is True
         assert step["with"]["provenance"] == "mode=max"
         assert step["with"]["sbom"] is True
+
+    for provenance_step in (staging_provenance_step, production_provenance_step):
+        assert provenance_step["uses"].startswith(
+            "actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215"
+        )
+        assert provenance_step["with"]["push-to-registry"] is True
+        assert provenance_step["with"]["subject-digest"] == "${{ steps.build.outputs.digest }}"
+
+    for sbom_step in (staging_sbom_step, production_sbom_step):
+        assert sbom_step["uses"].startswith(
+            "actions/attest@281a49d4cbb0a72c9575a50d18f6deb515a11deb"
+        )
+        assert sbom_step["with"]["push-to-registry"] is True
+        assert sbom_step["with"]["sbom-path"] == "docker-image-sbom.spdx.json"
+        assert sbom_step["with"]["subject-digest"] == "${{ steps.build.outputs.digest }}"
 
     for verify_step in (staging_verify_step, production_verify_step):
         verify_script = verify_step["run"]
@@ -823,6 +860,9 @@ def test_push_to_registry_workflows_restore_signed_attestations_on_publish_lanes
     assert staging_upload_step["with"]["if-no-files-found"] == "warn"
     assert production_upload_step["with"]["if-no-files-found"] == "warn"
     assert staging_step_names.index("Build & Push image (staging)") < staging_step_names.index(
+        "Attest staged image provenance"
+    )
+    assert staging_step_names.index("Attest staged image SBOM") < staging_step_names.index(
         "Verify staged image attestations"
     )
     assert staging_step_names.index("Verify staged image attestations") < staging_step_names.index(
@@ -830,6 +870,9 @@ def test_push_to_registry_workflows_restore_signed_attestations_on_publish_lanes
     )
     assert production_step_names.index(
         "Build & Push image (production)"
+    ) < production_step_names.index("Attest production image provenance")
+    assert production_step_names.index(
+        "Attest production image SBOM"
     ) < production_step_names.index("Verify production image attestations")
 
 

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -749,6 +749,90 @@ def test_docker_workflows_emit_image_telemetry_artifacts() -> None:
     )
 
 
+def test_push_to_registry_workflows_restore_signed_attestations_on_publish_lanes() -> None:
+    build_workflow = _load_workflow(".github/workflows/build.yml")
+    cd_workflow = _load_workflow(".github/workflows/cd.yml")
+
+    local_build_step = _workflow_step_by_name(
+        ".github/workflows/build.yml",
+        "build",
+        "Build Docker image (local, for tests)",
+    )
+    publish_step = _workflow_step_by_name(
+        ".github/workflows/build.yml",
+        "publish",
+        "Build and push Docker image",
+    )
+    staging_step = _workflow_step_by_name(
+        ".github/workflows/cd.yml",
+        "build",
+        "Build & Push image (staging)",
+    )
+    production_step = _workflow_step_by_name(
+        ".github/workflows/cd.yml",
+        "build-production",
+        "Build & Push image (production)",
+    )
+    staging_verify_step = _workflow_step_by_name(
+        ".github/workflows/cd.yml",
+        "build",
+        "Verify staged image attestations",
+    )
+    production_verify_step = _workflow_step_by_name(
+        ".github/workflows/cd.yml",
+        "build-production",
+        "Verify production image attestations",
+    )
+    staging_upload_step = _workflow_step_by_name(
+        ".github/workflows/cd.yml",
+        "build",
+        "Upload staging attestation verification artifact",
+    )
+    production_upload_step = _workflow_step_by_name(
+        ".github/workflows/cd.yml",
+        "build-production",
+        "Upload production attestation verification artifact",
+    )
+    staging_step_names = _workflow_step_names(".github/workflows/cd.yml", "build")
+    production_step_names = _workflow_step_names(".github/workflows/cd.yml", "build-production")
+
+    assert local_build_step["with"]["load"] is True
+    assert local_build_step["with"]["provenance"] is False
+
+    for step in (publish_step, staging_step, production_step):
+        assert step["with"]["push"] is True
+        assert step["with"]["provenance"] == "mode=max"
+        assert step["with"]["sbom"] is True
+
+    for verify_step in (staging_verify_step, production_verify_step):
+        verify_script = verify_step["run"]
+        assert "scripts/ci/check_docker_provenance_attestation.py" in verify_script
+        assert '--repo "${{ github.repository }}"' in verify_script
+        assert '--signer-workflow "${{ github.repository }}/.github/workflows/cd.yml"' in (
+            verify_script
+        )
+        assert '--source-ref "${{ github.ref }}"' in verify_script
+        assert "docker-provenance-attestation-check.json" in verify_script
+        assert "docker-provenance-attestation-check.md" in verify_script
+
+    assert staging_upload_step["with"]["name"] == "docker-provenance-attestation-check-cd-staging"
+    assert (
+        production_upload_step["with"]["name"]
+        == "docker-provenance-attestation-check-cd-production"
+    )
+    assert staging_upload_step["with"]["if-no-files-found"] == "warn"
+    assert production_upload_step["with"]["if-no-files-found"] == "warn"
+    assert staging_step_names.index("Build & Push image (staging)") < staging_step_names.index(
+        "Verify staged image attestations"
+    )
+    assert staging_step_names.index("Verify staged image attestations") < staging_step_names.index(
+        "Check staging deploy readiness"
+    )
+    assert production_step_names.index(
+        "Build & Push image (production)"
+    ) < production_step_names.index("Verify production image attestations")
+
+
 def test_checked_in_docker_image_baseline_seed_has_expected_schema() -> None:
     baseline_payload = json.loads(
         (REPO_ROOT / "docs" / "telemetry" / "docker_image_baseline.production.json").read_text(

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -843,6 +843,7 @@ def test_push_to_registry_workflows_restore_signed_attestations_on_publish_lanes
 
     for verify_step in (staging_verify_step, production_verify_step):
         verify_script = verify_step["run"]
+        assert verify_step["if"] == "${{ always() && steps.build.outcome == 'success' }}"
         assert "scripts/ci/check_docker_provenance_attestation.py" in verify_script
         assert '--repo "${{ github.repository }}"' in verify_script
         assert '--signer-workflow "${{ github.repository }}/.github/workflows/cd.yml"' in (
@@ -874,6 +875,13 @@ def test_push_to_registry_workflows_restore_signed_attestations_on_publish_lanes
     assert production_step_names.index(
         "Attest production image SBOM"
     ) < production_step_names.index("Verify production image attestations")
+    assert production_step_names.index("Verify production image attestations") < (
+        production_step_names.index("Upload production attestation verification artifact")
+    )
+    assert cd_workflow["jobs"]["production-deploy-config"]["needs"] == [
+        "production-gates",
+        "build-production",
+    ]
 
 
 def test_checked_in_docker_image_baseline_seed_has_expected_schema() -> None:


### PR DESCRIPTION
## Summary
- restore signed provenance and SBOM attestations on pushed-image Docker lanes
- gate staging and production deploy flow on exact-digest GitHub-native attestation verification
- reconcile Docker backlog/ADR/docs so signed provenance is the active next slice

## Split Justification
This PR intentionally keeps workflow, verifier helper, deterministic tests, and the Docker provenance governance docs together because the deploy gate is unsafe unless all four move atomically: CD must generate GitHub-signed provenance/SBOM attestations, verify the exact pushed digest, and update the ADR/backlog/tooling policy that previously marked the path deferred. Splitting would create an intermediate PR where workflows or docs claim provenance restored without enforceable current-head verification.

## Testing
- pytest -q tests/test_check_docker_provenance_attestation.py tests/test_python_supply_chain_controls.py
- python3 scripts/orchestration/check_agent_consistency.py
- python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1503 --body "$body"
- pre-commit run --all-files
- make verify
- pre-push hook bundle during git push (backend tests, bandit, docker build test)
- current-head GitHub CI is expected to restart on 23d9080b0 after the governance-evidence push

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1503_FIXED_MAPPING.md`

## Merge Readiness
- Current-head GitHub CI must complete green on `23d9080b0`; do not merge while required jobs are pending or failed
- Pre-commit and `make verify` are green on the governance-evidence tree for `23d9080b0`
- Mandatory post-open qa-engineer-agent -> bug-hunter pass completed locally on PR head
- All review threads are resolved and Sourcery/CodeRabbit/Codex actionables are mapped in the canonical artifact
- Canonical artifact: docs/review/PR_1503_FIXED_MAPPING.md

## Deferred / Follow-ups
- Shared Safety audit extraction remains separate: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-safety-audit-shared-script-after-pr1479
- Dagger remains deferred until Docker baseline/provenance stabilization: docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-dagger-pilot-after-docker-baseline

## Summary by Sourcery

Восстановить подписанную доказуемость (provenance) Docker и аттестации SBOM для workflows с публикацией образов и добавить контроль допуска выкладок на staging/production, основанный на проверенных аттестациях образов.

New Features:
- Добавить нативный для GitHub вспомогательный скрипт для проверки доказуемости OCI-образов и аттестаций SBOM по точному опубликованному дайджесту и вывода доказательств в формате JSON/Markdown.
- Включить генерацию и аттестацию SPDX SBOM вместе с доказуемостью для Docker-образов, публикуемых в build- и CD-workflows, с публикацией результатов проверки в итогах job’ов и артефактах.

Enhancements:
- Обновить build- и CD-workflows, чтобы повторно включить доказуемость при push’е в реестр, выдать права на аттестацию и обеспечить обязательную проверку аттестаций перед шагами выкладки на staging и production.
- Расширить тесты supply chain, чтобы покрыть восстановленные настройки provenance/SBOM и подключение проверки аттестаций в Docker-workflows.
- Обновить документацию по Docker CI (governance, ADR, оркестрация, инструменты безопасности и backlog), чтобы рассматривать восстановление подписанной доказуемости для потоков публикации образов как актуальный срез и задокументировать новый контракт проверки.

Documentation:
- Задокументировать контракт проверки Docker-аттестаций, использование CLI для нового helper’а, рекомендации по откату и обновлённый пакет норм Docker CI, отражающий срез с подписанной доказуемостью.

Tests:
- Добавить модульные и интеграционные тесты для helper’а проверки аттестаций, а также для конфигурации и порядка выполнения provenance/SBOM на уровне workflow’ов в Docker-pipeline’ах.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore signed Docker provenance and SBOM attestations for pushed-image workflows and gate staging/production deploys on verified image attestations.

New Features:
- Add a GitHub-native helper script to verify OCI image provenance and SBOM attestations by exact pushed digest and emit JSON/Markdown evidence.
- Enable generation and attestation of SPDX SBOMs alongside provenance for Docker images pushed in build and CD workflows, with verification published to job summaries and artifacts.

Enhancements:
- Update build and CD workflows to re-enable provenance on push-to-registry lanes, grant attestation permissions, and enforce attestation verification before staging and production deploy steps.
- Extend supply-chain tests to cover restored provenance/SBOM settings and attestation verification wiring in Docker workflows.
- Refresh Docker CI governance, ADR, orchestration, security tooling, and backlog docs to treat signed provenance restoration on pushed-image lanes as the active slice and document the new verification contract.

Documentation:
- Document the Docker attestation verification contract, CLI usage for the new helper, rollback guidance, and updated Docker CI discipline packet reflecting the signed provenance slice.

Tests:
- Add unit and integration-style tests for the attestation verification helper and for workflow-level provenance/SBOM configuration and ordering in Docker pipelines.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled signed provenance attestations and SPDX SBOM generation for pushed Docker images; CI/CD now emits, verifies, and publishes attestations for exact image digests before deploy (fail-closed).

* **Documentation**
  * Updated architecture, deployment, orchestration, roadmap, and security docs to reflect restored provenance/SBOM attestation and verification requirements.

* **Tests**
  * Added verification helper and CI tests to validate attestation emission, verification, artifact publishing, and fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
