### PR TITLE
feat(ai-runtime): add philosophical speed optimization to recursive stack

### DIFF
--- a/app/services/insight_runtime.py
+++ b/app/services/insight_runtime.py
@@ -133,6 +133,11 @@ async def _traced_retrieve_and_validate_rag(
             philo_validation_enabled=philo_validation_enabled,
             recursive_rag_enabled=recursive_rollout_policy.recursive_path_enabled,
             optimization_enabled=recursive_rollout_policy.optimization_path_enabled,
+            recursive_optimization_hints=(
+                recursive_rollout_policy.optimization_hints
+                if recursive_rollout_policy.optimization_path_enabled
+                else None
+            ),
             subject_id=subject_id,
             knowledge_policy=knowledge_policy,
         )

--- a/core/ai/insight_runtime.py
+++ b/core/ai/insight_runtime.py
@@ -24,7 +24,7 @@ from core.insight.philosophical_runtime import (
     RouteDecision,
     RouteType,
 )
-from core.rag.contracts import RAGDegradedReason
+from core.rag.contracts import RAGDegradedReason, RecursiveOptimizationHints
 
 
 class InsightProviderLoadError(RuntimeError):
@@ -50,6 +50,7 @@ class RecursiveRolloutPolicy:
     use_rag: bool
     recursive_rag_enabled: bool
     recursive_rag_optimization_enabled: bool
+    optimization_hints: RecursiveOptimizationHints | None = None
 
     @property
     def recursive_path_enabled(self) -> bool:
@@ -197,16 +198,21 @@ def prepare_insight_runtime(
         linguistic_enabled=philosophy_linguistic_enabled,
         pragmatic_enabled=philosophy_pragmatic_enabled,
     )
-    recursive_rollout_policy = RecursiveRolloutPolicy(
-        use_rag=use_rag,
-        recursive_rag_enabled=recursive_rag_enabled,
-        recursive_rag_optimization_enabled=recursive_rag_optimization_enabled,
-    )
     decision = runtime.preview_route(
         text=text,
         lang=None,
         router_enabled=rollout_policy.preview_router_enabled,
         use_rag=use_rag,
+    )
+    recursive_rollout_policy = RecursiveRolloutPolicy(
+        use_rag=use_rag,
+        recursive_rag_enabled=recursive_rag_enabled,
+        recursive_rag_optimization_enabled=recursive_rag_optimization_enabled,
+        optimization_hints=(
+            _build_recursive_optimization_hints(decision=decision)
+            if use_rag and recursive_rag_optimization_enabled
+            else None
+        ),
     )
 
     if transparency_loader is None:
@@ -249,4 +255,34 @@ def _build_default_knowledge_policy(*, decision: RouteDecision) -> KnowledgePoli
         deny_degraded_reasons=tuple(reason.value for reason in RAGDegradedReason),
         subject_scope_required=True,
         rail="product_ai_runtime",
+    )
+
+
+def _build_recursive_optimization_hints(
+    *, decision: RouteDecision
+) -> RecursiveOptimizationHints | None:
+    """Project existing route truth into bounded recursive optimization hints."""
+
+    route_type_value = getattr(getattr(decision, "route_type", None), "value", None)
+    if route_type_value is None:
+        route_type_value = getattr(decision, "route_type", None)
+    route_type_key = (
+        route_type_value.upper() if isinstance(route_type_value, str) else route_type_value
+    )
+    needs_rag = bool(
+        getattr(
+            decision,
+            "needs_rag",
+            route_type_key in {RouteType.RAG_FACTUAL.value, RouteType.DEEP_REASONING.value},
+        )
+    )
+    if not needs_rag:
+        return None
+
+    target_depth_cap = max(1, min(int(getattr(decision, "target_depth", 3)), 3))
+    optimization_applied = bool(getattr(decision, "optimization_applied", False))
+    return RecursiveOptimizationHints(
+        target_depth_cap=target_depth_cap,
+        aggressive_short_circuit_allowed=optimization_applied and target_depth_cap <= 2,
+        pragmatic_early_stop_allowed=optimization_applied,
     )

--- a/core/ai/insight_runtime.py
+++ b/core/ai/insight_runtime.py
@@ -263,19 +263,15 @@ def _build_recursive_optimization_hints(
 ) -> RecursiveOptimizationHints | None:
     """Project existing route truth into bounded recursive optimization hints."""
 
-    route_type_value = getattr(getattr(decision, "route_type", None), "value", None)
-    if route_type_value is None:
-        route_type_value = getattr(decision, "route_type", None)
+    route_type = getattr(decision, "route_type", None)
+    route_type_value = getattr(route_type, "value", route_type)
     route_type_key = (
         route_type_value.upper() if isinstance(route_type_value, str) else route_type_value
     )
-    needs_rag = bool(
-        getattr(
-            decision,
-            "needs_rag",
-            route_type_key in {RouteType.RAG_FACTUAL.value, RouteType.DEEP_REASONING.value},
-        )
-    )
+    if hasattr(decision, "needs_rag"):
+        needs_rag = bool(decision.needs_rag)
+    else:
+        needs_rag = route_type_key in {RouteType.RAG_FACTUAL.value, RouteType.DEEP_REASONING.value}
     if not needs_rag:
         return None
 

--- a/core/rag/contracts.py
+++ b/core/rag/contracts.py
@@ -68,6 +68,15 @@ class OptimizationStats(TypedDict):
     early_stop_latency_budget: bool
 
 
+@dataclass(frozen=True)
+class RecursiveOptimizationHints:
+    """Prepared internal hints for bounded recursive speed optimization."""
+
+    target_depth_cap: int
+    aggressive_short_circuit_allowed: bool = False
+    pragmatic_early_stop_allowed: bool = False
+
+
 @dataclass
 class RAGChunk:
     """Single retrieved chunk with provenance and score."""

--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -201,6 +201,12 @@ async def retrieve_and_validate_rag(
         Whether to run philosophy validation on chunks (feature flag).
     recursive_rag_enabled:
         Whether to run recursive multi-hop retrieval path.
+    optimization_enabled:
+        Enables recursive optimization behavior when recursive retrieval runs.
+    recursive_optimization_hints:
+        Optional prepared recursive optimization constraints forwarded to
+        recursive retrieval. Defaults to `None` and has no effect unless
+        `optimization_enabled` is true.
     subject_id:
         Authenticated tenant/user identifier for personalized retrieval.
         Pass a concrete value for tenant-scoped `user_knowledge` access.

--- a/core/rag/orchestration.py
+++ b/core/rag/orchestration.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Optional, Sequence, SupportsFloat, cast
 if TYPE_CHECKING:
     from core.knowledge.contracts import KnowledgeFactCandidate
     from core.knowledge.policy import KnowledgePolicy
-    from core.rag.contracts import RAGChunk
+    from core.rag.contracts import RAGChunk, RecursiveOptimizationHints
     from core.verification.contracts import VerificationBundle
 
 from core.rag.contracts import RAGContext, RAGDegradedReason
@@ -182,6 +182,7 @@ async def retrieve_and_validate_rag(
     philo_validation_enabled: bool = False,
     recursive_rag_enabled: bool = False,
     optimization_enabled: bool = False,
+    recursive_optimization_hints: "RecursiveOptimizationHints | None" = None,
     subject_id: int | None = None,
     knowledge_policy: "KnowledgePolicy | None" = None,
 ) -> RAGOrchestrationResult:
@@ -227,6 +228,7 @@ async def retrieve_and_validate_rag(
         philo_validation_enabled,
         recursive_rag_enabled,
         optimization_enabled,
+        recursive_optimization_hints,
         subject_id,
         knowledge_policy,
     )
@@ -238,6 +240,7 @@ async def _run_orchestration(
     philo_enabled: bool,
     recursive_enabled: bool,
     optimization_enabled: bool,
+    recursive_optimization_hints: "RecursiveOptimizationHints | None",
     subject_id: int | None,
     knowledge_policy: "KnowledgePolicy | None",
 ) -> RAGOrchestrationResult:
@@ -261,6 +264,7 @@ async def _run_orchestration(
                 subject_id=subject_id,
                 philo_validation_enabled=False,
                 optimization_enabled=optimization_enabled,
+                optimization_hints=recursive_optimization_hints,
             )
             recursive_executed = True
         else:

--- a/core/rag/recursive_retrieval.py
+++ b/core/rag/recursive_retrieval.py
@@ -12,7 +12,13 @@ import time
 from typing import Dict, Iterable, List, cast
 
 from core.data_sanitizer import sanitize_rag_markdown
-from core.rag.contracts import OptimizationStats, OptimizationStopReason, RAGChunk, RAGContext
+from core.rag.contracts import (
+    OptimizationStats,
+    OptimizationStopReason,
+    RAGChunk,
+    RAGContext,
+    RecursiveOptimizationHints,
+)
 from core.rag.rag_constants import (
     MAX_HOP_VECTOR_CACHE_ENTRIES,
     MAX_RAG_HOPS,
@@ -344,6 +350,7 @@ def retrieve_recursive_context_structured(
     *,
     philo_validation_enabled: bool = False,
     optimization_enabled: bool = False,
+    optimization_hints: RecursiveOptimizationHints | None = None,
 ) -> RAGContext:
     """Retrieve context with bounded recursive refinement.
 
@@ -362,6 +369,9 @@ def retrieve_recursive_context_structured(
     previous_confidence = 0.0
     hops_done = 0
     limit = max(1, min(max_chunks, MAX_SOURCES_IN_RESPONSE))
+    max_hops = MAX_RAG_HOPS
+    if optimization_enabled and optimization_hints is not None:
+        max_hops = max(1, min(MAX_RAG_HOPS, optimization_hints.target_depth_cap))
     optimization_stats = _make_optimization_stats() if optimization_enabled else None
     refinement_token_cache: dict[tuple[str, str], list[str]] | None = (
         {} if optimization_enabled else None
@@ -371,7 +381,7 @@ def retrieve_recursive_context_structured(
     )
 
     try:
-        for hop in range(1, MAX_RAG_HOPS + 1):
+        for hop in range(1, max_hops + 1):
             elapsed_sec = time.perf_counter() - start_ts
             if elapsed_sec >= RAG_PIPELINE_TIMEOUT_SEC:
                 _set_stop_reason(
@@ -454,6 +464,9 @@ def retrieve_recursive_context_structured(
 
             merged_chunks = candidate_chunks
             previous_confidence = confidence
+
+            if optimization_enabled and optimization_hints is not None and hop >= max_hops:
+                break
 
             if (
                 optimization_enabled

--- a/core/rag/recursive_retrieval.py
+++ b/core/rag/recursive_retrieval.py
@@ -465,9 +465,6 @@ def retrieve_recursive_context_structured(
             merged_chunks = candidate_chunks
             previous_confidence = confidence
 
-            if optimization_enabled and optimization_hints is not None and hop >= max_hops:
-                break
-
             if (
                 optimization_enabled
                 and (time.perf_counter() - start_ts) >= RAG_PIPELINE_TIMEOUT_SEC
@@ -477,6 +474,11 @@ def retrieve_recursive_context_structured(
                     OptimizationStopReason.LATENCY_BUDGET,
                     early_stop_key="early_stop_latency_budget",
                 )
+                break
+
+            if optimization_enabled and optimization_hints is not None and hop >= max_hops:
+                # Explicit hint caps should not prepare a refined query for a hop
+                # that the bounded loop will never execute.
                 break
 
             if len(refined_queries) - 1 >= MAX_REFINEMENT_PASSES:

--- a/docs/orchestration/WAVE6_A8_RECURSIVE_SPEED_OPTIMIZATION_W1_PACKET_2026-04-23.md
+++ b/docs/orchestration/WAVE6_A8_RECURSIVE_SPEED_OPTIMIZATION_W1_PACKET_2026-04-23.md
@@ -1,0 +1,200 @@
+# Wave 6 A8 Recursive Speed Optimization W1 Packet
+
+**Date:** 23 April 2026
+**Scope:** bounded Wave 6 product-AI runtime follow-up for philosophical speed
+optimization on the recursive stack
+**Mode:** planning packet
+
+## Purpose
+
+Freeze one narrow Wave 6 follow-up slice after merged `PR-A7` that reduces
+recursive latency using the already-landed philosophical routing primitives and
+bounded recursive seams.
+
+This packet exists to:
+
+- keep `PR-A8` limited to speed optimization for the existing recursive stack;
+- reuse speech-act classification, language-game detection, adaptive depth, and
+  pragmatic early stopping already present in `main`;
+- preserve `VerificationBundle` / verify-before-write semantics from `PR-V1`;
+- keep app/service seams thin and public transport contracts unchanged;
+- defer any comparative speed or quality claims to `PR-A9` evidence.
+
+## Current-head truth
+
+- `core/insight/philosophical_runtime.py` already owns the philosophical query
+  router, public runtime metadata, phase12 rewrite/fallback logic, pragmatic
+  validator usage, and adaptive depth selection through the existing bounded
+  runtime contract
+  (`core/insight/philosophical_runtime.py:128-187`,
+  `core/insight/philosophical_runtime.py:236-338`,
+  `core/insight/philosophical_runtime.py:386-603`,
+  `core/insight/philosophical_runtime.py:721-874`).
+- `core/insight/linguistic/__init__.py` already contains cheap deterministic
+  speech-act and language-game classification used by the router
+  (`core/insight/linguistic/__init__.py:13-88`).
+- `core/insight/post_analytical/__init__.py` already contains pragmatic
+  assessment and hermeneutic depth optimization used for bounded stopping and
+  depth control (`core/insight/post_analytical/__init__.py:12-79`).
+- `core/ai/insight_runtime.py` already owns prepared runtime truth for both the
+  philosophy rollout policy and recursive rollout policy and must stay the only
+  authoritative pre-execution seam
+  (`core/ai/insight_runtime.py:42-61`,
+  `core/ai/insight_runtime.py:155-223`).
+- `core/rag/recursive_retrieval.py` already provides deterministic recursive
+  retrieval with bounded hops, refinement passes, verification passes, timeout
+  budget, and request-local optimization diagnostics
+  (`core/rag/recursive_retrieval.py:63-156`,
+  `core/rag/recursive_retrieval.py:338-510`).
+- `core/rag/orchestration.py` already owns recursive execution metadata,
+  degraded reasons, and `VerificationBundle` assembly and must remain the
+  canonical owner for retrieval-path verification truth
+  (`core/rag/orchestration.py:28-73`,
+  `core/rag/orchestration.py:240-382`,
+  `core/rag/orchestration.py:546-579`).
+- `app/services/insight_runtime.py` and
+  `app/services/insight_application_service.py` already form the thin tracing /
+  app handoff seam and must stay observational rather than authoritative
+  (`app/services/insight_runtime.py:63-104`,
+  `app/services/insight_runtime.py:124-205`,
+  `app/services/insight_application_service.py:113-214`).
+- The epic and backlog still place `PR-A8` next and keep semantic cache
+  deferred (`docs/roadmap/PulsePlate_RAG_LLM_Karpathy_Epic_Pipeline.md:475-489`,
+  `docs/roadmap/BACKLOG_LEDGER.md:2088-2115`).
+
+## Hard boundaries
+
+- No `legacy_app.py` edits
+- No `app/routers/*` edits
+- No OpenAPI or public response-shape changes
+- No new route-layer DTOs
+- No semantic cache, Redis/GPTCache, GraphRAG, or ContextManifest work
+- No recursive learning lane
+- No provider-side chain-of-thought / tree-of-thought widening
+- No verification-registry redesign
+- No public latency or quality claims without replay evidence
+
+## Canonical implementation surfaces
+
+### Primary runtime seams
+
+- `core/insight/philosophical_runtime.py`
+- `core/insight/linguistic/__init__.py`
+- `core/insight/post_analytical/__init__.py`
+- `core/ai/insight_runtime.py`
+- `core/rag/recursive_retrieval.py`
+- `core/rag/orchestration.py`
+- `app/services/insight_runtime.py`
+- `app/services/insight_application_service.py`
+
+### Support surfaces only if needed
+
+- `core/rag/contracts.py`
+- `app/utils/feature_flags.py`
+
+### Canonical planning evidence
+
+- `docs/orchestration/WAVE6_A8_TASK_ANALYSIS_2026-04-23.md`
+- `docs/roadmap/PulsePlate_RAG_LLM_Karpathy_Epic_Pipeline.md:475-489`
+- `docs/roadmap/BACKLOG_LEDGER.md:2088-2115`
+- `docs/insights/PHILOSOPHICAL_SPEED_OPTIMIZATION.md`
+
+## Required invariants
+
+- `PR-A8` is a bounded speed-optimization lane, not a philosophy rewrite or a
+  new recursive architecture.
+- Prepared runtime ownership remains in `core.ai.prepare_insight_runtime(...)`;
+  app/service layers must not become a second speed-optimization authority.
+- Existing public metadata fields only:
+  `route_type`, `depth_used`, `verification_rate`, `falsifiability_rate`,
+  `contradiction_count`, `reason_codes`, `optimization_applied`.
+- `VerificationBundle` / verify-before-write semantics from `PR-V1` remain in
+  force.
+- Recursive budgets, deterministic stop reasons, and observational
+  `verification_calls` remain hard boundaries.
+- Semantic cache remains deferred.
+- Replay/evidence remains the only source of truth for comparative performance
+  claims.
+
+## Required role-agent order for this lane
+
+1. `agent-coordinator`
+2. `architecture-specialist`
+3. `data-scientist-agent`
+4. `backend-engineer`
+5. `security-auditor`
+6. `qa-engineer-agent`
+7. `bug-hunter`
+
+Rules:
+
+- every assigned role agent must be used in this order;
+- no assigned role agent may be skipped without an explicit packet update;
+- the canonical post-open `qa-engineer-agent -> bug-hunter` pass remains
+  mandatory.
+
+## W1 scope
+
+### In scope
+
+- reuse existing speech-act and language-game classifiers to tighten runtime
+  path selection;
+- reuse existing adaptive depth and pragmatic assessment to reduce unnecessary
+  recursive depth;
+- preserve and, if needed, refine early-stop behavior across recursive/RAG and
+  phase12 validation paths;
+- keep the prepared runtime and thin app handoff seams explicit;
+- add deterministic tests for bounded speed behavior and no public contract
+  drift.
+
+### Out of scope
+
+- semantic cache, persistence, or replay/publication work
+- provider-side recursive reasoning expansion
+- recursive learning / personalization
+- new public metadata fields
+- benchmark or marketing narrative work
+
+## First-cut guardrails
+
+The first implementation cut must preserve these exact guardrails:
+
+- no weakening of `VerificationBundle` and knowledge-promotion admission
+- no app/tracing recomputation of rollout or speed truth after prepared runtime
+- no new response fields or metadata widening
+- no medical/local direct-path drift
+- no replacement of deterministic recursive budgets or stop reasons
+
+## Primary tests
+
+- `tests/test_core_ai_insight_runtime.py`
+- `tests/test_insight_application_service.py`
+- `tests/test_recursive_rag.py`
+- `tests/test_rag_orchestration.py`
+- `tests/test_philosophical_runtime.py`
+
+Fallback only if needed:
+
+- `tests/test_app_insight_runtime.py`
+- `tests/test_remaining_modules.py`
+
+## Validation
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- targeted `pytest -q` on the primary test surfaces above
+- `pre-commit run --all-files`
+- `make verify`
+
+## Plugin / Skill Recommendation
+
+Planning / implementation stage:
+
+- no plugin family is required for the code change itself
+- `GitHub` becomes relevant only once the PR opens
+- `CodeRabbit` becomes relevant only in the post-open review cycle
+
+Keep unused for this lane:
+
+- `Computer Use`, `Hugging Face`, `Cloudflare`, `Figma`, `Jam`, `Expo`,
+  `build-*`, `Life Science Research`

--- a/docs/orchestration/WAVE6_A8_TASK_ANALYSIS_2026-04-23.md
+++ b/docs/orchestration/WAVE6_A8_TASK_ANALYSIS_2026-04-23.md
@@ -1,0 +1,104 @@
+# WAVE6 A8 Task Analysis
+
+## Task Analysis
+
+**Task:** Implement `PR-A8` as a bounded Wave 6 runtime slice for
+philosophical speed optimization on the existing recursive stack.
+
+**Domain(s):** AI/ML | Architecture | Security | Multiple
+
+**Complexity:** Complex
+
+**Priority:** P1
+
+- **Priority track (P0-A / P0-B / P1):** P1
+
+**Expected Outcome:** A narrow A8 lane reduces recursive latency through
+existing philosophical routing primitives, bounded early stopping, and adaptive
+depth selection without widening public contracts, semantic cache scope, or the
+verify-before-write admission model.
+
+**Invariants Affected:**
+- [ ] One BMI Engine
+- [x] Thin HTTP Adapter Policy
+- [x] Layer Separation
+- [x] Contract-First
+- [x] Other: bounded Wave 6 product-AI runtime rail
+
+**Risks:**
+1. Speed optimization could drift into a second routing authority outside the
+   prepared runtime seam; mitigate by keeping rollout ownership in
+   `core.ai.prepare_insight_runtime(...)` and treating app/services as thin
+   handoff only.
+2. Early stopping could weaken `VerificationBundle` or fail-closed knowledge
+   admission; mitigate by preserving the existing bundle path and never
+   short-circuiting write-admission semantics.
+3. Scope could widen into semantic cache, replay claims, or public contract
+   changes; mitigate by keeping A8 limited to runtime internals and existing
+   metadata fields only.
+4. Diff-cover could push test sprawl into non-canonical files; mitigate by
+   extending the existing runtime/RAG test surfaces first and using
+   `tests/test_remaining_modules.py` only as a fallback.
+
+**Proposed Approach:**
+1. Freeze a dedicated A8 packet from live `HEAD` truth, not from older packet
+   snapshots.
+2. Reuse the existing linguistic and post-analytical helpers that already feed
+   the philosophical router and depth optimizer.
+3. Thread those signals into the recursive/runtime path without changing route
+   DTOs, OpenAPI, or response fields.
+4. Keep public metadata limited to the existing runtime fields while improving
+   internal early-stop/depth selection behavior.
+5. Add deterministic tests on the canonical runtime/RAG surfaces and keep any
+   speed-uplift claims deferred to the evidence lane.
+
+**Evidence / Current-head anchors:**
+- Prepared runtime ownership and recursive rollout seam:
+  `core/ai/insight_runtime.py:42-61`,
+  `core/ai/insight_runtime.py:155-223`
+- Philosophical router, adaptive depth, pragmatic stop, and public runtime
+  metadata:
+  `core/insight/philosophical_runtime.py:128-187`,
+  `core/insight/philosophical_runtime.py:236-338`,
+  `core/insight/philosophical_runtime.py:386-603`,
+  `core/insight/philosophical_runtime.py:721-874`
+- Deterministic recursive retrieval and bounded verification passes:
+  `core/rag/recursive_retrieval.py:63-156`,
+  `core/rag/recursive_retrieval.py:338-510`
+- Orchestration-owned recursive metadata and verification bundle assembly:
+  `core/rag/orchestration.py:28-73`,
+  `core/rag/orchestration.py:240-382`,
+  `core/rag/orchestration.py:546-579`
+- Thin tracing/service handoff:
+  `app/services/insight_runtime.py:63-104`,
+  `app/services/insight_runtime.py:124-205`,
+  `app/services/insight_application_service.py:113-214`
+- Epic + backlog anchors:
+  `docs/roadmap/PulsePlate_RAG_LLM_Karpathy_Epic_Pipeline.md:475-489`,
+  `docs/roadmap/BACKLOG_LEDGER.md:2088-2115`
+
+**Agent Assignment:**
+- **Primary:** `agent-coordinator` - owns scope, role order, synthesis, and DoD.
+- **Secondary:** `architecture-specialist` - enforces bounded speed seam and
+  anti-drift review.
+- **Secondary:** `data-scientist-agent` - reviews early-stop and adaptive-depth
+  hypotheses and claim boundaries.
+- **Secondary:** `backend-engineer` - implements the bounded runtime changes.
+- **Secondary:** `security-auditor` - verifies fail-closed behavior and no
+  contract widening.
+- **Secondary:** `qa-engineer-agent` - adds deterministic runtime/RAG tests.
+- **Secondary:** `bug-hunter` - mandatory final defect pass.
+
+**Constraints:**
+- No `legacy_app.py` edits
+- No `app/routers/*` edits
+- No OpenAPI, DTO, or public response-shape changes
+- No semantic cache, Redis/GPTCache, GraphRAG, or ContextManifest work
+- No recursive learning or provider-side reasoning expansion
+- No verification-registry redesign
+- No public latency or quality claims without replay/evidence
+
+---
+
+**Analysis by:** agent-coordinator
+**Date:** 2026-04-23

--- a/docs/review/PR_1506_FIXED_MAPPING.md
+++ b/docs/review/PR_1506_FIXED_MAPPING.md
@@ -16,16 +16,14 @@ threads on GitHub.
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
-Commit: `19537b47f207e3b9dab7c47dd68169bc0034d3b1`
+Commit: 19537b47f207e3b9dab7c47dd68169bc0034d3b1
 Evidence: `core/ai/insight_runtime.py` uses `decision.needs_rag` with a narrow route fallback; `core/rag/recursive_retrieval.py` documents the explicit hint-cap stop; `tests/test_rag_orchestration.py` documents the CI-surface depth-cap anchor.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1506#pullrequestreview-4163433365 -> 19537b47f207e3b9dab7c47dd68169bc0034d3b1
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1506#discussion_r3131650729 -> 19537b47f207e3b9dab7c47dd68169bc0034d3b1
 
 Disposition: FIXED
-Commit: `f9d8d1031956d70f670100cdc09942d4f040a903`
+Commit: f9d8d1031956d70f670100cdc09942d4f040a903
 Evidence: `core/rag/orchestration.py` documents `recursive_optimization_hints`; `tests/test_core_ai_insight_runtime.py` removes the duplicate hint assertion; this artifact keeps local proof outside unchecked merge-readiness checklist items.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1506#pullrequestreview-4163675713 -> f9d8d1031956d70f670100cdc09942d4f040a903
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1506#discussion_r3131846658 -> f9d8d1031956d70f670100cdc09942d4f040a903
 

--- a/docs/review/PR_1506_FIXED_MAPPING.md
+++ b/docs/review/PR_1506_FIXED_MAPPING.md
@@ -22,11 +22,18 @@ Evidence: `core/ai/insight_runtime.py` uses `decision.needs_rag` with a narrow r
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1506#pullrequestreview-4163433365 -> 19537b47f207e3b9dab7c47dd68169bc0034d3b1
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1506#discussion_r3131650729 -> 19537b47f207e3b9dab7c47dd68169bc0034d3b1
 
+Disposition: FIXED
+Commit: `f9d8d1031956d70f670100cdc09942d4f040a903`
+Evidence: `core/rag/orchestration.py` documents `recursive_optimization_hints`; `tests/test_core_ai_insight_runtime.py` removes the duplicate hint assertion; this artifact keeps local proof outside unchecked merge-readiness checklist items.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1506#pullrequestreview-4163675713 -> f9d8d1031956d70f670100cdc09942d4f040a903
+
 ## Initial Implementation Commits
 
 - `cce682990` - `feat(ai-runtime): add recursive speed hints`
 - `ded2c006f` - `docs(pr): add PR 1506 mapping`
 - `19537b47f` - `fix(ai-runtime): address recursive speed review`
+- `f9d8d1031` - `fix(ai-runtime): address CodeRabbit review`
 
 ## Merge Readiness
 
@@ -47,4 +54,5 @@ Merge-readiness contract:
       completed or replaced by accepted current-head required CI evidence.
 
 Local proof note: `pre-commit run --all-files` passed before commit
-`19537b47f`; pre-push hooks passed before `cbabbf60d`.
+`19537b47f`; pre-push hooks passed before `cbabbf60d`; targeted tests passed
+before commit `f9d8d1031`.

--- a/docs/review/PR_1506_FIXED_MAPPING.md
+++ b/docs/review/PR_1506_FIXED_MAPPING.md
@@ -17,12 +17,7 @@ threads on GitHub.
 
 Disposition: FIXED
 Commit: `19537b47f207e3b9dab7c47dd68169bc0034d3b1`
-Evidence: `core/ai/insight_runtime.py` now uses `decision.needs_rag`
-directly when available with a narrow route fallback;
-`core/rag/recursive_retrieval.py` documents why explicit hint caps stop before
-preparing an unused refined query; `tests/test_rag_orchestration.py` documents
-why the CI-surface depth-cap anchor intentionally complements the
-recursive-unit test.
+Evidence: `core/ai/insight_runtime.py` uses `decision.needs_rag` with a narrow route fallback; `core/rag/recursive_retrieval.py` documents the explicit hint-cap stop; `tests/test_rag_orchestration.py` documents the CI-surface depth-cap anchor.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1506#pullrequestreview-4163433365 -> 19537b47f207e3b9dab7c47dd68169bc0034d3b1
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1506#discussion_r3131650729 -> 19537b47f207e3b9dab7c47dd68169bc0034d3b1

--- a/docs/review/PR_1506_FIXED_MAPPING.md
+++ b/docs/review/PR_1506_FIXED_MAPPING.md
@@ -1,0 +1,41 @@
+# PR #1506 - Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md`;
+`docs/orchestration/AGENTS.md`.
+
+- [x] Discussion-thread pass initialized
+- [x] Fixed in commit mapping initialized
+
+This artifact is created immediately after the draft PR is opened per repo
+governance. Record every actionable human/bot disposition here before resolving
+threads on GitHub.
+
+## Fixed in Commit Mapping
+
+No review comments yet.
+
+Initial implementation commit:
+
+- cce682990 - `feat(ai-runtime): add recursive speed hints`
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md`.
+
+- [ ] Current-head CI is green for PR branch head
+- [ ] Required checks complete (no pending jobs)
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] After latest bot/review activity, perform a final check and wait at least
+      one review cycle before merging
+- [x] `pre-commit run --all-files` green on latest local head
+      Local proof: passed before commit `cce682990`.
+- [ ] `make verify` green on latest pushed head
+      Local proof: `make verify` passed `verify-env`, `lint`, `typecheck`, and
+      `test-fast`, then was manually stopped during the long full
+      coverage/diff-cover sweep. Do not mark merge-ready until this is
+      completed or replaced by accepted current-head required CI evidence.

--- a/docs/review/PR_1506_FIXED_MAPPING.md
+++ b/docs/review/PR_1506_FIXED_MAPPING.md
@@ -6,8 +6,8 @@ Canonical review-governance artifact and PR-body mirror requirements:
 `AGENTS.md`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md`;
 `docs/orchestration/AGENTS.md`.
 
-- [x] Discussion-thread pass initialized
-- [x] Fixed in commit mapping initialized
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 This artifact is created immediately after the draft PR is opened per repo
 governance. Record every actionable human/bot disposition here before resolving
@@ -15,11 +15,12 @@ threads on GitHub.
 
 ## Fixed in Commit Mapping
 
-No review comments yet.
+- No actionable review comments
 
-Initial implementation commit:
+## Initial Implementation Commits
 
-- cce682990 - `feat(ai-runtime): add recursive speed hints`
+- `cce682990` - `feat(ai-runtime): add recursive speed hints`
+- `ded2c006f` - `docs(pr): add PR 1506 mapping`
 
 ## Merge Readiness
 

--- a/docs/review/PR_1506_FIXED_MAPPING.md
+++ b/docs/review/PR_1506_FIXED_MAPPING.md
@@ -39,10 +39,12 @@ Merge-readiness contract:
 - [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
 - [ ] After latest bot/review activity, perform a final check and wait at least
       one review cycle before merging
-- [x] `pre-commit run --all-files` green on latest local head
-      Local proof: passed before commit `19537b47f`.
+- [ ] `pre-commit run --all-files` green on latest local head
 - [ ] `make verify` green on latest pushed head
       Local proof: `make verify` passed `verify-env`, `lint`, `typecheck`, and
       `test-fast`, then was manually stopped during the long full
       coverage/diff-cover sweep. Do not mark merge-ready until this is
       completed or replaced by accepted current-head required CI evidence.
+
+Local proof note: `pre-commit run --all-files` passed before commit
+`19537b47f`; pre-push hooks passed before `cbabbf60d`.

--- a/docs/review/PR_1506_FIXED_MAPPING.md
+++ b/docs/review/PR_1506_FIXED_MAPPING.md
@@ -27,6 +27,7 @@ Commit: `f9d8d1031956d70f670100cdc09942d4f040a903`
 Evidence: `core/rag/orchestration.py` documents `recursive_optimization_hints`; `tests/test_core_ai_insight_runtime.py` removes the duplicate hint assertion; this artifact keeps local proof outside unchecked merge-readiness checklist items.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1506#pullrequestreview-4163675713 -> f9d8d1031956d70f670100cdc09942d4f040a903
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1506#discussion_r3131846658 -> f9d8d1031956d70f670100cdc09942d4f040a903
 
 ## Initial Implementation Commits
 

--- a/docs/review/PR_1506_FIXED_MAPPING.md
+++ b/docs/review/PR_1506_FIXED_MAPPING.md
@@ -15,12 +15,23 @@ threads on GitHub.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: `19537b47f207e3b9dab7c47dd68169bc0034d3b1`
+Evidence: `core/ai/insight_runtime.py` now uses `decision.needs_rag`
+directly when available with a narrow route fallback;
+`core/rag/recursive_retrieval.py` documents why explicit hint caps stop before
+preparing an unused refined query; `tests/test_rag_orchestration.py` documents
+why the CI-surface depth-cap anchor intentionally complements the
+recursive-unit test.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1506#pullrequestreview-4163433365 -> 19537b47f207e3b9dab7c47dd68169bc0034d3b1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1506#discussion_r3131650729 -> 19537b47f207e3b9dab7c47dd68169bc0034d3b1
 
 ## Initial Implementation Commits
 
 - `cce682990` - `feat(ai-runtime): add recursive speed hints`
 - `ded2c006f` - `docs(pr): add PR 1506 mapping`
+- `19537b47f` - `fix(ai-runtime): address recursive speed review`
 
 ## Merge Readiness
 
@@ -34,7 +45,7 @@ Merge-readiness contract:
 - [ ] After latest bot/review activity, perform a final check and wait at least
       one review cycle before merging
 - [x] `pre-commit run --all-files` green on latest local head
-      Local proof: passed before commit `cce682990`.
+      Local proof: passed before commit `19537b47f`.
 - [ ] `make verify` green on latest pushed head
       Local proof: `make verify` passed `verify-env`, `lint`, `typecheck`, and
       `test-fast`, then was manually stopped during the long full

--- a/tests/test_app_insight_runtime.py
+++ b/tests/test_app_insight_runtime.py
@@ -8,7 +8,8 @@ from typing import Any
 
 import pytest
 
-from app.services.insight_runtime import TracedInsightProvider
+from app.services.insight_runtime import TracedInsightProvider, generate_traced_insight
+from core.ai.insight_runtime import RecursiveOptimizationHints, RecursiveRolloutPolicy
 
 
 @pytest.mark.asyncio
@@ -51,3 +52,101 @@ async def test_traced_provider_updates_span_provider_name_after_fallback(
     assert result == "fallback response"
     assert traced.name == "stub"
     assert observed_attrs["gen_ai.provider.name"] == "stub"
+
+
+@pytest.mark.asyncio
+async def test_generate_traced_insight_forwards_prepared_recursive_optimization_hints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tracing adapter must pass prepared recursive hints without recomputing them."""
+
+    observed: dict[str, Any] = {}
+
+    @contextmanager
+    def _fake_chain_span(*_args: object, **_kwargs: object) -> Any:
+        yield SimpleNamespace()
+
+    @contextmanager
+    def _fake_retrieval_span(*_args: object, **_kwargs: object) -> Any:
+        yield SimpleNamespace()
+
+    async def _fake_retrieve_and_validate_rag(*args: object, **kwargs: object) -> Any:
+        observed["retrieve_args"] = args
+        observed["retrieve_kwargs"] = kwargs
+        return SimpleNamespace(hops=1)
+
+    class _FakeRuntime:
+        async def generate_insight(self, **kwargs: object) -> object:
+            observed["runtime_kwargs"] = kwargs
+            rag_retriever = kwargs["rag_retriever"]
+            await rag_retriever(
+                "hello",
+                max_chunks=3,
+                philo_validation_enabled=False,
+                recursive_rag_enabled=True,
+                subject_id=123,
+                knowledge_policy={"enabled": True},
+            )
+            return SimpleNamespace(
+                insight="ok",
+                provider_name="provider",
+                source_dicts=[],
+                confidence=0.8,
+                rag_used=True,
+                hops=1,
+                latency_ms=5,
+                knowledge_candidates=[],
+                metadata=SimpleNamespace(
+                    route_type="deep_reasoning",
+                    depth_used=2,
+                    verification_rate=None,
+                    falsifiability_rate=None,
+                    contradiction_count=0,
+                    reason_codes=["legacy_path"],
+                    optimization_applied=False,
+                ),
+            )
+
+    monkeypatch.setattr("app.services.insight_runtime.chain_span", _fake_chain_span, raising=True)
+    monkeypatch.setattr(
+        "app.services.insight_runtime.retrieval_span",
+        _fake_retrieval_span,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "app.services.insight_runtime.rag_orchestration.retrieve_and_validate_rag",
+        _fake_retrieve_and_validate_rag,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "app.services.insight_runtime.set_attributes",
+        lambda *_args, **_kwargs: None,
+        raising=True,
+    )
+
+    await generate_traced_insight(
+        runtime=_FakeRuntime(),
+        text="hello",
+        lang=None,
+        provider=SimpleNamespace(name="provider", generate=lambda text: text),
+        use_rag=True,
+        philo_validation_enabled=False,
+        recursive_rag_enabled=True,
+        recursive_rag_optimization_enabled=True,
+        route_path="/api/v1/insight",
+        route_type="deep_reasoning",
+        user_tier="VIP",
+        subject_id=123,
+        knowledge_policy={"enabled": True},
+        recursive_rollout_policy=RecursiveRolloutPolicy(
+            use_rag=True,
+            recursive_rag_enabled=True,
+            recursive_rag_optimization_enabled=True,
+            optimization_hints=RecursiveOptimizationHints(target_depth_cap=2),
+        ),
+    )
+
+    assert observed["runtime_kwargs"]["recursive_rag_enabled"] is True
+    assert observed["retrieve_kwargs"][
+        "recursive_optimization_hints"
+    ] == RecursiveOptimizationHints(target_depth_cap=2)

--- a/tests/test_core_ai_insight_runtime.py
+++ b/tests/test_core_ai_insight_runtime.py
@@ -354,9 +354,6 @@ def test_prepare_insight_runtime_returns_recursive_rollout_policy(
     )
     assert prepared.recursive_rollout_policy.recursive_path_enabled is True
     assert prepared.recursive_rollout_policy.optimization_path_enabled is True
-    assert prepared.recursive_rollout_policy.optimization_hints == RecursiveOptimizationHints(
-        target_depth_cap=3,
-    )
 
 
 def test_prepare_insight_runtime_derives_recursive_speed_hints_from_route_truth(

--- a/tests/test_core_ai_insight_runtime.py
+++ b/tests/test_core_ai_insight_runtime.py
@@ -13,6 +13,7 @@ from core.ai.insight_runtime import (
     InsightProviderLoadError,
     KnowledgePolicy,
     RecursiveRolloutPolicy,
+    RecursiveOptimizationHints,
     InsightTransparencyNotice,
     InsightTransparencyUnavailableError,
     load_insight_provider,
@@ -218,6 +219,7 @@ def test_prepare_insight_runtime_uses_provider_loader_for_generation(
         use_rag=True,
         recursive_rag_enabled=False,
         recursive_rag_optimization_enabled=False,
+        optimization_hints=None,
     )
     assert prepared.knowledge_policy == KnowledgePolicy(
         enabled=False,
@@ -348,9 +350,51 @@ def test_prepare_insight_runtime_returns_recursive_rollout_policy(
         use_rag=True,
         recursive_rag_enabled=True,
         recursive_rag_optimization_enabled=True,
+        optimization_hints=RecursiveOptimizationHints(target_depth_cap=3),
     )
     assert prepared.recursive_rollout_policy.recursive_path_enabled is True
     assert prepared.recursive_rollout_policy.optimization_path_enabled is True
+    assert prepared.recursive_rollout_policy.optimization_hints == RecursiveOptimizationHints(
+        target_depth_cap=3,
+    )
+
+
+def test_prepare_insight_runtime_derives_recursive_speed_hints_from_route_truth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prepared recursive hints must come from the existing route decision only."""
+
+    class _FakeRuntime:
+        def preview_route(
+            self, *, text: str, lang: str | None, router_enabled: bool, use_rag: bool
+        ) -> SimpleNamespace:
+            del text, lang, router_enabled, use_rag
+            return SimpleNamespace(
+                needs_generation=True,
+                needs_rag=True,
+                target_depth=2,
+                optimization_applied=True,
+                route_type=SimpleNamespace(value="RAG_FACTUAL"),
+            )
+
+    monkeypatch.setattr("core.ai.insight_runtime.PhilosophicalRuntime", _FakeRuntime, raising=True)
+
+    prepared = prepare_insight_runtime(
+        text="hello",
+        use_rag=True,
+        philosophy_router_enabled=True,
+        philosophy_linguistic_enabled=True,
+        recursive_rag_enabled=True,
+        recursive_rag_optimization_enabled=True,
+        provider_loader=lambda: _FakeProvider(),
+        transparency_loader=lambda: ("ai_generated_insight", "Wellness only."),
+    )
+
+    assert prepared.recursive_rollout_policy.optimization_hints == RecursiveOptimizationHints(
+        target_depth_cap=2,
+        aggressive_short_circuit_allowed=True,
+        pragmatic_early_stop_allowed=True,
+    )
 
 
 def test_prepare_insight_runtime_uses_direct_transparency_notice(

--- a/tests/test_core_ai_insight_runtime.py
+++ b/tests/test_core_ai_insight_runtime.py
@@ -397,6 +397,37 @@ def test_prepare_insight_runtime_derives_recursive_speed_hints_from_route_truth(
     )
 
 
+def test_prepare_insight_runtime_skips_recursive_speed_hints_for_non_rag_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Plain-string non-RAG route decisions must not create recursive hints."""
+
+    class _FakeRuntime:
+        def preview_route(
+            self, *, text: str, lang: str | None, router_enabled: bool, use_rag: bool
+        ) -> SimpleNamespace:
+            del text, lang, router_enabled, use_rag
+            return SimpleNamespace(
+                needs_generation=False,
+                route_type="local_direct",
+            )
+
+    monkeypatch.setattr("core.ai.insight_runtime.PhilosophicalRuntime", _FakeRuntime, raising=True)
+
+    prepared = prepare_insight_runtime(
+        text="hello",
+        use_rag=True,
+        philosophy_router_enabled=True,
+        philosophy_linguistic_enabled=True,
+        recursive_rag_enabled=True,
+        recursive_rag_optimization_enabled=True,
+        provider_loader=lambda: _FakeProvider(),
+        transparency_loader=lambda: ("ai_generated_insight", "Wellness only."),
+    )
+
+    assert prepared.recursive_rollout_policy.optimization_hints is None
+
+
 def test_prepare_insight_runtime_uses_direct_transparency_notice(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_insight_application_service.py
+++ b/tests/test_insight_application_service.py
@@ -14,7 +14,11 @@ from app.services.insight_application_service import (
     INSIGHT_TEXT_MAX_LENGTH,
     execute_insight_request,
 )
-from core.ai.insight_runtime import InsightTransparencyNotice, RecursiveRolloutPolicy
+from core.ai.insight_runtime import (
+    InsightTransparencyNotice,
+    RecursiveOptimizationHints,
+    RecursiveRolloutPolicy,
+)
 from core.insight.philosophical_runtime import PhilosophyRolloutPolicy
 from core.knowledge.policy import KnowledgePolicy
 from core.insight.llm_provider_loader import LLMProvider
@@ -88,11 +92,13 @@ def _recursive_rollout_policy(
     use_rag: bool = False,
     recursive_rag_enabled: bool = False,
     recursive_rag_optimization_enabled: bool = False,
+    optimization_hints: RecursiveOptimizationHints | None = None,
 ) -> RecursiveRolloutPolicy:
     return RecursiveRolloutPolicy(
         use_rag=use_rag,
         recursive_rag_enabled=recursive_rag_enabled,
         recursive_rag_optimization_enabled=recursive_rag_optimization_enabled,
+        optimization_hints=optimization_hints,
     )
 
 
@@ -530,6 +536,7 @@ async def test_execute_insight_request_uses_prepared_recursive_rollout_policy_as
     assert observed["generate_kwargs"]["recursive_rollout_policy"] is (
         prepared_runtime.recursive_rollout_policy
     )
+    assert observed["generate_kwargs"]["recursive_rollout_policy"].optimization_hints is None
     assert observed["generate_kwargs"]["use_rag"] is True
     assert observed["generate_kwargs"]["recursive_rag_enabled"] is True
     assert observed["generate_kwargs"]["recursive_rag_optimization_enabled"] is False

--- a/tests/test_insight_rag_response_fields.py
+++ b/tests/test_insight_rag_response_fields.py
@@ -110,10 +110,11 @@ def _make_fake_recursive_structured(
     subject_id: int | None = None,
     philo_validation_enabled: bool = False,
     optimization_enabled: bool = False,
+    optimization_hints: object | None = None,
 ) -> _FakeRAGContext:
     """Fake recursive retriever with deeper hops and refined query chain."""
     # Intentionally unused: keep signature parity with real recursive retriever.
-    _ = (philo_validation_enabled, optimization_enabled, subject_id)
+    _ = (philo_validation_enabled, optimization_enabled, optimization_hints, subject_id)
     chunks = [
         _FakeRAGChunk(
             chunk_id="recursive.md:1",

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -19,7 +19,13 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from core.knowledge.policy import KnowledgePolicy
-from core.rag.contracts import OptimizationStats, RAGChunk, RAGContext, RAGDegradedReason
+from core.rag.contracts import (
+    OptimizationStats,
+    RAGChunk,
+    RAGContext,
+    RAGDegradedReason,
+    RecursiveOptimizationHints,
+)
 from core.insight.safety import redact_rag_context_for_insight
 from core.rag.formatting import build_rag_source_dicts, format_rag_chunks_for_prompt
 from core.rag.orchestration import (
@@ -334,6 +340,41 @@ class TestRetrieveAndValidateRag:
         assert to_thread_mock.call_args.kwargs["optimization_enabled"] is False
         assert result.rag_actually_used is True
         assert result.hops == 2
+
+    @pytest.mark.asyncio
+    async def test_recursive_enabled_forwards_optimization_hints(self) -> None:
+        """Orchestration must pass prepared recursive optimization hints unchanged."""
+        chunks = [_make_chunk("c1", score=0.9)]
+        rag_ctx = _make_rag_context(chunks=chunks, confidence=0.9, hops=2)
+        hints = RecursiveOptimizationHints(target_depth_cap=2)
+
+        with (
+            patch(
+                "asyncio.to_thread",
+                new_callable=AsyncMock,
+                return_value=rag_ctx,
+            ) as to_thread_mock,
+            patch("core.rag.recursive_retrieval.retrieve_recursive_context_structured"),
+            patch(
+                "core.rag.formatting.format_rag_chunks_for_prompt",
+                return_value="Chunk1",
+            ),
+            patch(
+                "core.insight.safety.redact_rag_context_for_insight",
+                return_value="Chunk1",
+            ),
+        ):
+            result = await retrieve_and_validate_rag(
+                "test prompt",
+                philo_validation_enabled=False,
+                recursive_rag_enabled=True,
+                optimization_enabled=True,
+                recursive_optimization_hints=hints,
+            )
+
+        assert to_thread_mock.call_args.kwargs["optimization_enabled"] is True
+        assert to_thread_mock.call_args.kwargs["optimization_hints"] == hints
+        assert result.rag_actually_used is True
 
     @pytest.mark.asyncio
     async def test_recursive_empty_retrieval_preserves_recursive_metadata(self) -> None:

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -382,6 +382,9 @@ class TestRetrieveAndValidateRag:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """CI contract surface must cover the hint-gated recursive depth cap."""
+        # This duplicates the recursive-unit anchor intentionally because CI
+        # diff-cover runs this orchestration surface, not the full recursive
+        # suite, before enforcing changed-line coverage.
         import core.rag.recursive_retrieval as recursive
 
         monkeypatch.setattr(recursive, "MAX_RAG_HOPS", 4)

--- a/tests/test_rag_orchestration.py
+++ b/tests/test_rag_orchestration.py
@@ -38,6 +38,7 @@ from core.rag.orchestration import (
     retrieve_and_validate_rag,
 )
 from core.rag.philosophy_pipeline import PipelineResult, StageResult
+from core.rag.recursive_retrieval import retrieve_recursive_context_structured
 from core.rag.validation import ValidationResult
 
 
@@ -375,6 +376,45 @@ class TestRetrieveAndValidateRag:
         assert to_thread_mock.call_args.kwargs["optimization_enabled"] is True
         assert to_thread_mock.call_args.kwargs["optimization_hints"] == hints
         assert result.rag_actually_used is True
+
+    def test_recursive_optimization_hints_cap_depth_on_ci_surface(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """CI contract surface must cover the hint-gated recursive depth cap."""
+        import core.rag.recursive_retrieval as recursive
+
+        monkeypatch.setattr(recursive, "MAX_RAG_HOPS", 4)
+        monkeypatch.setattr(recursive, "MAX_REFINEMENT_PASSES", 4)
+        monkeypatch.setattr(recursive, "MAX_VERIFICATION_QUERIES", 0)
+        monkeypatch.setattr(recursive, "MIN_CONFIDENCE_GAIN_PER_HOP", -1.0)
+
+        def _fake_retrieve(query: str, **_: object) -> RAGContext:
+            chunk = RAGChunk(
+                chunk_id=f"doc:{len(query)}",
+                file="doc.md",
+                content="nutrition guidance for bounded recursive retrieval",
+                score=0.7,
+            )
+            return RAGContext(
+                query=query,
+                refined_queries=[query],
+                chunks=[chunk],
+                confidence=0.7,
+                hops=1,
+                latency_ms=1,
+            )
+
+        monkeypatch.setattr("core.rag.vector_rag.retrieve_context_structured", _fake_retrieve)
+
+        result = retrieve_recursive_context_structured(
+            "meal plan",
+            optimization_enabled=True,
+            optimization_hints=RecursiveOptimizationHints(target_depth_cap=1),
+        )
+
+        assert result.hops == 1
+        assert result.refined_queries == ["meal plan"]
 
     @pytest.mark.asyncio
     async def test_recursive_empty_retrieval_preserves_recursive_metadata(self) -> None:

--- a/tests/test_recursive_rag.py
+++ b/tests/test_recursive_rag.py
@@ -7,7 +7,12 @@ from typing import Any
 import pytest
 
 from core.knowledge.policy import KnowledgePolicy
-from core.rag.contracts import OptimizationStopReason, RAGChunk, RAGContext
+from core.rag.contracts import (
+    OptimizationStopReason,
+    RAGChunk,
+    RAGContext,
+    RecursiveOptimizationHints,
+)
 from core.rag.orchestration import retrieve_and_validate_rag
 from core.rag.philosophy_pipeline import PipelineResult
 from core.rag.recursive_retrieval import retrieve_recursive_context_structured
@@ -87,6 +92,37 @@ def test_recursive_respects_hops_and_refinement_budgets(
     result = retrieve_recursive_context_structured("meal plan")
     assert result.hops <= 2
     assert len(result.refined_queries) <= 2
+
+
+def test_recursive_optimization_hints_cap_depth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prepared target depth cap must bound recursive hops deterministically."""
+    import core.rag.recursive_retrieval as recursive
+
+    monkeypatch.setattr(recursive, "MAX_RAG_HOPS", 4)
+    monkeypatch.setattr(recursive, "MAX_REFINEMENT_PASSES", 4)
+    monkeypatch.setattr(recursive, "MAX_VERIFICATION_QUERIES", 0)
+    monkeypatch.setattr(recursive, "MIN_CONFIDENCE_GAIN_PER_HOP", -1.0)
+
+    def _fake_retrieve(query: str, **_: Any) -> RAGContext:
+        token = f"signal{len(query)}"
+        chunk = RAGChunk(
+            chunk_id=f"doc:{len(query)}",
+            file="doc.md",
+            content=f"{token} nutrition guidance for meal planning",
+            score=0.7,
+        )
+        return _ctx(query, [chunk], confidence=0.7)
+
+    monkeypatch.setattr("core.rag.vector_rag.retrieve_context_structured", _fake_retrieve)
+
+    result = retrieve_recursive_context_structured(
+        "meal plan",
+        optimization_enabled=True,
+        optimization_hints=RecursiveOptimizationHints(target_depth_cap=1),
+    )
+
+    assert result.hops == 1
+    assert result.refined_queries == ["meal plan"]
 
 
 def test_recursive_respects_verification_budget(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

PR-A8 W1 threads route-derived recursive speed hints through the existing prepared runtime and RAG orchestration seams. The slice keeps `prepare_insight_runtime(...)` as the rollout source of truth, keeps app/service handoff thin, and bounds recursive depth only when the recursive optimization rollout path is active.

## Scope

- Added internal `RecursiveOptimizationHints` for bounded recursive depth and early-stop readiness.
- Derived hints from existing philosophical `RouteDecision` truth inside `core/ai/insight_runtime.py`.
- Forwarded prepared hints through `app/services/insight_runtime.py` and `core/rag/orchestration.py` into recursive retrieval.
- Made hints inert unless `recursive_rag_optimization_enabled` / `optimization_enabled` is active.
- Added A8 task-analysis, packet docs, and canonical review mapping artifact from live repo truth.

## Boundaries

- No route, OpenAPI, DTO, or public response-shape changes.
- No `legacy_app.py` changes.
- No semantic cache, Redis/GPTCache, GraphRAG, ContextManifest, or replay-promotion work.
- No verification-registry or knowledge-promotion admission changes.
- No public latency or quality claims; evidence remains deferred to PR-A9.

## Orchestration / Role Pass

Required role order was followed:

1. `agent-coordinator`
2. `architecture-specialist`
3. `data-scientist-agent`
4. `backend-engineer`
5. `security-auditor`
6. `qa-engineer-agent`
7. `bug-hunter`

The initial architecture pass found one blocker: optimization hints could affect behavior when the optimization path was disabled. This was fixed before the remaining role passes. Final architecture/security/QA/bug-hunter passes reported no findings.

## Validation

Passed:

- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 -m py_compile core/rag/contracts.py core/ai/insight_runtime.py app/services/insight_runtime.py core/rag/orchestration.py core/rag/recursive_retrieval.py tests/test_core_ai_insight_runtime.py tests/test_insight_application_service.py tests/test_app_insight_runtime.py tests/test_recursive_rag.py tests/test_rag_orchestration.py`
- `pytest -q tests/test_core_ai_insight_runtime.py tests/test_insight_application_service.py tests/test_app_insight_runtime.py tests/test_recursive_rag.py tests/test_rag_orchestration.py`
- `python3 -m mypy --no-incremental --cache-dir=/dev/null core/rag/contracts.py core/ai/insight_runtime.py app/services/insight_runtime.py core/rag/orchestration.py core/rag/recursive_retrieval.py`
- `pre-commit run --all-files`
- commit hooks
- pre-push hooks, including changed-files mypy, pip-audit, backend pytest, full-repo bandit, and docker build test where applicable

Not yet merge-ready:

- `make verify` was started and passed `verify-env`, `lint`, `typecheck`, and `test-fast`, then was manually stopped during the long full coverage/diff-cover sweep after no failures had appeared. This draft PR still needs a completed `make verify` or equivalent current-head required CI evidence before readiness can be claimed.

## Security Notes

This PR does not change write-admission, verification bundles, route-layer behavior, or public trust claims. Recursive speed hints are fail-closed/inert unless the dedicated recursive optimization path is enabled.

## Marketing & GTM

No user-facing claims are introduced. Any latency or reliability claims remain deferred to the scientific evidence lane (`PR-A9`).

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_1506_FIXED_MAPPING.md`

## Merge Readiness

Draft only. Not merge-ready until current-head CI, review-disposition governance, required checks, bot passes, wait-window, and full repo gates are satisfied.

## Summary by Sourcery

Добавить внутренние подсказки для рекурсивной оптимизации, выведенные из философских решений маршрутизации, и протянуть их через insight runtime и RAG-оркестрацию, чтобы ограничить глубину рекурсивного извлечения при включённой оптимизации.

Новые возможности:
- Ввести `RecursiveOptimizationHints` как внутренний контракт для ограниченной рекурсивной оптимизации скорости в рекурсивном стеке RAG.

Улучшения:
- Расширить `RecursiveRolloutPolicy` и рекурсивное извлечение, чтобы они принимали необязательные подсказки оптимизации, ограничивающие число рекурсивных переходов без изменения публичных API.
- Выводить рекурсивные подсказки оптимизации из существующих решений маршрутизации в `prepare_insight_runtime` и распространять их через сервисы app insight и RAG-оркестрацию.
- Добавить покрытие на уровне оркестрации и CI-интерфейса, чтобы гарантировать, что подсказки оптимизации передаются без изменений и детерминированно ограничивают рекурсивную глубину.

Документация:
- Добавить планирование Wave 6 A8 и пакеты анализа задач, а также канонический документ сопоставления review fixed-in-commit, описывающий направление рекурсивной оптимизации скорости.

Тесты:
- Добавить и расширить тесты для `prepare_insight_runtime`, app insight runtime, рекурсивного RAG-извлечения и RAG-оркестрации, чтобы проверить распространение и эффекты рекурсивных подсказок оптимизации.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add internal recursive optimization hints derived from philosophical routing decisions and thread them through the insight runtime and RAG orchestration to bound recursive retrieval depth when optimization is enabled.

New Features:
- Introduce RecursiveOptimizationHints as an internal contract for bounded recursive speed optimization in the recursive RAG stack.

Enhancements:
- Extend RecursiveRolloutPolicy and recursive retrieval to accept optional optimization hints that cap recursive hops without changing public APIs.
- Derive recursive optimization hints from existing route decisions in prepare_insight_runtime and propagate them through app insight services and RAG orchestration.
- Add orchestration and CI-surface coverage to ensure optimization hints are forwarded unchanged and deterministically cap recursive depth.

Documentation:
- Add Wave 6 A8 planning and task-analysis packets plus a canonical fixed-in-commit review mapping document describing the recursive speed optimization lane.

Tests:
- Add and extend tests for prepare_insight_runtime, app insight runtime, recursive RAG retrieval, and RAG orchestration to validate propagation and effects of recursive optimization hints.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recursive RAG retrieval accepts optional optimization hints that enable bounded depth capping and early-stop/short-circuit strategies when recursive optimization is enabled.

* **Tests**
  * Added end-to-end and unit tests validating hint propagation, depth capping, and refinement behavior under recursive optimization.

* **Documentation**
  * New orchestration guidance and review documents describing the bounded recursive speed-optimization scope, invariants, and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->