### PR TITLE
test(evals): add selective graph-eval schema contract tests

### DIFF
--- a/docs/review/PR_1507_FIXED_MAPPING.md
+++ b/docs/review/PR_1507_FIXED_MAPPING.md
@@ -18,6 +18,7 @@ or claiming merge readiness.
 Disposition: FIXED
 Commit: 4a8458cfa
 Evidence: tests/evals/test_selective_graph_eval_contract.py
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1507#pullrequestreview-4163423930 -> 4a8458cfa
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1507#discussion_r3131643787 -> 4a8458cfa
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1507#discussion_r3131643802 -> 4a8458cfa
 
@@ -29,6 +30,7 @@ Evidence: tests/evals/test_selective_graph_eval_contract.py
 Disposition: FIXED
 Commit: 4a8458cfa
 Evidence: docs/review/PR_1507_FIXED_MAPPING.md
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1507#pullrequestreview-4163429311 -> 4a8458cfa
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1507#issuecomment-4305275175 -> 4a8458cfa
 
 ## Merge Readiness

--- a/docs/review/PR_1507_FIXED_MAPPING.md
+++ b/docs/review/PR_1507_FIXED_MAPPING.md
@@ -15,8 +15,16 @@ or claiming merge readiness.
 
 ### Fixed in Commit Mapping
 
-- Sourcery review on `f29c0858d` -> pending fix commit
-- CodeRabbit wait-window checklist nitpick on `f29c0858d` -> pending fix commit
+Disposition: FIXED
+Commit: 4a8458cfa
+Evidence: tests/evals/test_selective_graph_eval_contract.py
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1507#discussion_r3131643787 -> 4a8458cfa
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1507#discussion_r3131643802 -> 4a8458cfa
+
+Disposition: FIXED
+Commit: 48781cf76
+Evidence: tests/evals/test_selective_graph_eval_contract.py
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1507#discussion_r3131647785 -> 48781cf76
 
 ## Merge Readiness
 

--- a/docs/review/PR_1507_FIXED_MAPPING.md
+++ b/docs/review/PR_1507_FIXED_MAPPING.md
@@ -1,0 +1,27 @@
+# PR #1507 — Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md:42-52`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:41-90`;
+`docs/orchestration/AGENTS.md:79-82`.
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping initialized
+
+This artifact is the source of truth for review dispositions on PR #1507.
+Record every actionable human or bot review item here before resolving threads
+or claiming merge readiness.
+
+### Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- Targeted contract tests: `pytest -q tests/evals/test_selective_graph_eval_contract.py`
+- Pre-commit: `pre-commit run --all-files`
+- Cheap validation: `make validate-min`
+- Lint: `make lint`
+- Typecheck: `make typecheck`
+- Fast tests: `make test-fast`

--- a/docs/review/PR_1507_FIXED_MAPPING.md
+++ b/docs/review/PR_1507_FIXED_MAPPING.md
@@ -15,10 +15,13 @@ or claiming merge readiness.
 
 ### Fixed in Commit Mapping
 
-- No actionable review comments
+- Sourcery review on `f29c0858d` -> pending fix commit
+- CodeRabbit wait-window checklist nitpick on `f29c0858d` -> pending fix commit
 
 ## Merge Readiness
 
+- [ ] Final post-activity check pass completed after latest bot/review activity
+- [ ] Waited at least one full review cycle after the final check pass
 - Targeted contract tests: `pytest -q tests/evals/test_selective_graph_eval_contract.py`
 - Pre-commit: `pre-commit run --all-files`
 - Cheap validation: `make validate-min`

--- a/docs/review/PR_1507_FIXED_MAPPING.md
+++ b/docs/review/PR_1507_FIXED_MAPPING.md
@@ -41,3 +41,4 @@ Evidence: docs/review/PR_1507_FIXED_MAPPING.md
 - Lint: `make lint`
 - Typecheck: `make typecheck`
 - Fast tests: `make test-fast`
+- Phase2 body/artifact gate: `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1507`

--- a/docs/review/PR_1507_FIXED_MAPPING.md
+++ b/docs/review/PR_1507_FIXED_MAPPING.md
@@ -7,7 +7,7 @@ Canonical review-governance artifact and PR-body mirror requirements:
 `docs/orchestration/AGENTS.md:79-82`.
 
 - [x] Discussion-thread pass completed
-- [x] Fixed in commit mapping initialized
+- [x] Fixed in commit mapping completed
 
 This artifact is the source of truth for review dispositions on PR #1507.
 Record every actionable human or bot review item here before resolving threads

--- a/docs/review/PR_1507_FIXED_MAPPING.md
+++ b/docs/review/PR_1507_FIXED_MAPPING.md
@@ -26,6 +26,11 @@ Commit: 48781cf76
 Evidence: tests/evals/test_selective_graph_eval_contract.py
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1507#discussion_r3131647785 -> 48781cf76
 
+Disposition: FIXED
+Commit: 4a8458cfa
+Evidence: docs/review/PR_1507_FIXED_MAPPING.md
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1507#issuecomment-4305275175 -> 4a8458cfa
+
 ## Merge Readiness
 
 - [ ] Final post-activity check pass completed after latest bot/review activity

--- a/tests/evals/test_selective_graph_eval_contract.py
+++ b/tests/evals/test_selective_graph_eval_contract.py
@@ -54,8 +54,6 @@ FORBIDDEN_RUNTIME_OR_GATE_FIELDS = {
     "threshold_results",
     "gate_checks",
     "release_decision",
-    "PASS",
-    "NO-GO",
     "provider_output",
     "runtime_trace",
     "graph_execution_trace",
@@ -66,6 +64,7 @@ FORBIDDEN_RUNTIME_OR_GATE_FIELDS = {
     "score",
     "scores",
 }
+FORBIDDEN_RUNTIME_OR_GATE_VALUES = {"PASS", "NO-GO"}
 
 
 def _load_schema() -> dict[str, Any]:
@@ -94,8 +93,25 @@ def _find_keys(payload: Any) -> set[str]:
     return set()
 
 
+def _find_string_values(payload: Any) -> set[str]:
+    if isinstance(payload, dict):
+        values: set[str] = set()
+        for value in payload.values():
+            values.update(_find_string_values(value))
+        return values
+    if isinstance(payload, list):
+        values = set()
+        for item in payload:
+            values.update(_find_string_values(item))
+        return values
+    if isinstance(payload, str):
+        return {payload}
+    return set()
+
+
 def _bullets_after_marker(text: str, marker: str) -> list[str]:
     lines = text.splitlines()
+    assert marker in lines
     marker_index = lines.index(marker)
     bullets: list[str] = []
     for line in lines[marker_index + 1 :]:
@@ -109,6 +125,7 @@ def _bullets_after_marker(text: str, marker: str) -> list[str]:
 def test_schema_contract_enums_are_bounded_to_selective_graph_eval() -> None:
     schema = _load_schema()
 
+    assert set(EXPECTED_KIND_BY_SURFACE) == ALLOWED_SURFACES
     assert set(schema["required"]) == REQUIRED_TOP_LEVEL_FIELDS
     assert schema["additionalProperties"] is False
 
@@ -199,20 +216,22 @@ def test_fixture_rows_match_offline_graph_eval_contract() -> None:
 def test_fixture_rows_do_not_contain_runtime_gate_or_cache_fields() -> None:
     for record in _load_fixture_rows():
         leaked_keys = _find_keys(record) & FORBIDDEN_RUNTIME_OR_GATE_FIELDS
+        leaked_values = _find_string_values(record) & FORBIDDEN_RUNTIME_OR_GATE_VALUES
         assert leaked_keys == set()
+        assert leaked_values == set()
 
 
 def test_contract_doc_keeps_graph_eval_offline_and_subordinate() -> None:
     contract_doc = CONTRACT_DOC_PATH.read_text(encoding="utf-8")
 
-    assert _bullets_after_marker(contract_doc, "It does not introduce:") == [
+    assert set(_bullets_after_marker(contract_doc, "It does not introduce:")) == {
         "- runtime GraphRAG rollout",
         "- semantic cache widening",
         "- provider behavior changes",
         "- a graph runner",
         "- graph-specific CI thresholds",
         "- a second canonical evaluation rail",
-    ]
+    }
     assert (
         "- [`PULSEPLATE_RAG_RELEASE_GATES.md`](./PULSEPLATE_RAG_RELEASE_GATES.md)\n"
         "  owns threshold vocabulary, gate checks, and `PASS` / `NO-GO` semantics" in contract_doc

--- a/tests/evals/test_selective_graph_eval_contract.py
+++ b/tests/evals/test_selective_graph_eval_contract.py
@@ -233,7 +233,7 @@ def test_contract_doc_keeps_graph_eval_offline_and_subordinate() -> None:
         "- a second canonical evaluation rail",
     }
     assert (
-        "- [`PULSEPLATE_RAG_RELEASE_GATES.md`](./PULSEPLATE_RAG_RELEASE_GATES.md)\n"
-        "  owns threshold vocabulary, gate checks, and `PASS` / `NO-GO` semantics" in contract_doc
+        "- [`PULSEPLATE_RAG_RELEASE_GATES.md`](./PULSEPLATE_RAG_RELEASE_GATES.md)" in contract_doc
     )
+    assert "owns threshold vocabulary, gate checks" in contract_doc
     assert "must not create a second evaluation source of truth" in contract_doc

--- a/tests/evals/test_selective_graph_eval_contract.py
+++ b/tests/evals/test_selective_graph_eval_contract.py
@@ -94,6 +94,18 @@ def _find_keys(payload: Any) -> set[str]:
     return set()
 
 
+def _bullets_after_marker(text: str, marker: str) -> list[str]:
+    lines = text.splitlines()
+    marker_index = lines.index(marker)
+    bullets: list[str] = []
+    for line in lines[marker_index + 1 :]:
+        if line.startswith("## "):
+            break
+        if line.startswith("- "):
+            bullets.append(line)
+    return bullets
+
+
 def test_schema_contract_enums_are_bounded_to_selective_graph_eval() -> None:
     schema = _load_schema()
 
@@ -101,25 +113,30 @@ def test_schema_contract_enums_are_bounded_to_selective_graph_eval() -> None:
     assert schema["additionalProperties"] is False
 
     properties = schema["properties"]
+    assert set(properties) == REQUIRED_TOP_LEVEL_FIELDS
     assert set(properties["surface"]["enum"]) == ALLOWED_SURFACES
 
     graph_context = properties["graph_context"]
     assert graph_context["additionalProperties"] is False
     assert set(graph_context["required"]) == {"nodes", "edges"}
+    assert set(graph_context["properties"]) == {"nodes", "edges"}
 
     node_schema = graph_context["properties"]["nodes"]["items"]
     assert node_schema["additionalProperties"] is False
     assert set(node_schema["required"]) == {"id", "type", "label"}
+    assert set(node_schema["properties"]) == {"id", "type", "label"}
     assert set(node_schema["properties"]["type"]["enum"]) == ALLOWED_NODE_TYPES
 
     edge_schema = graph_context["properties"]["edges"]["items"]
     assert edge_schema["additionalProperties"] is False
     assert set(edge_schema["required"]) == {"source", "relation", "target"}
+    assert set(edge_schema["properties"]) == {"source", "relation", "target"}
     assert set(edge_schema["properties"]["relation"]["enum"]) == ALLOWED_EDGE_RELATIONS
 
     reasoning_schema = properties["reasoning_expectation"]
     assert reasoning_schema["additionalProperties"] is False
     assert set(reasoning_schema["required"]) == {"kind"}
+    assert set(reasoning_schema["properties"]) == {"kind"}
     assert set(reasoning_schema["properties"]["kind"]["enum"]) == ALLOWED_REASONING_KINDS
 
 
@@ -188,15 +205,16 @@ def test_fixture_rows_do_not_contain_runtime_gate_or_cache_fields() -> None:
 def test_contract_doc_keeps_graph_eval_offline_and_subordinate() -> None:
     contract_doc = CONTRACT_DOC_PATH.read_text(encoding="utf-8")
 
-    required_phrases = [
-        "runtime GraphRAG rollout",
-        "semantic cache widening",
-        "provider behavior changes",
-        "a graph runner",
-        "graph-specific CI thresholds",
-        "a second canonical evaluation rail",
-        "owns threshold vocabulary, gate checks, and `PASS` / `NO-GO` semantics",
-        "must not create a second evaluation source of truth",
+    assert _bullets_after_marker(contract_doc, "It does not introduce:") == [
+        "- runtime GraphRAG rollout",
+        "- semantic cache widening",
+        "- provider behavior changes",
+        "- a graph runner",
+        "- graph-specific CI thresholds",
+        "- a second canonical evaluation rail",
     ]
-    for phrase in required_phrases:
-        assert phrase in contract_doc
+    assert (
+        "- [`PULSEPLATE_RAG_RELEASE_GATES.md`](./PULSEPLATE_RAG_RELEASE_GATES.md)\n"
+        "  owns threshold vocabulary, gate checks, and `PASS` / `NO-GO` semantics" in contract_doc
+    )
+    assert "must not create a second evaluation source of truth" in contract_doc

--- a/tests/evals/test_selective_graph_eval_contract.py
+++ b/tests/evals/test_selective_graph_eval_contract.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = REPO_ROOT / "data/evals/pulseplate_selective_graph_eval_schema.json"
+FIXTURE_PATH = REPO_ROOT / "data/evals/pulseplate_selective_graph_eval_sample.jsonl"
+CONTRACT_DOC_PATH = REPO_ROOT / "docs/evals/PULSEPLATE_SELECTIVE_GRAPH_EVAL_CONTRACT.md"
+
+REQUIRED_TOP_LEVEL_FIELDS = {
+    "id",
+    "surface",
+    "question",
+    "reference_answer",
+    "graph_context",
+    "expected_claims",
+    "reasoning_expectation",
+}
+ALLOWED_SURFACES = {
+    "corpus_level_nutrition_summarization",
+    "multi_hop_contraindication_reasoning",
+    "plan_explainability",
+}
+ALLOWED_NODE_TYPES = {
+    "foods",
+    "nutrients",
+    "conditions",
+    "restrictions",
+    "meal_templates",
+    "guideline_concepts",
+}
+ALLOWED_EDGE_RELATIONS = {
+    "contains",
+    "rich_in",
+    "contraindicated_for",
+    "recommended_for",
+    "substitutable_with",
+}
+ALLOWED_REASONING_KINDS = {
+    "global_summary",
+    "multi_hop",
+    "comparative_explanation",
+}
+EXPECTED_KIND_BY_SURFACE = {
+    "corpus_level_nutrition_summarization": "global_summary",
+    "multi_hop_contraindication_reasoning": "multi_hop",
+    "plan_explainability": "comparative_explanation",
+}
+FORBIDDEN_RUNTIME_OR_GATE_FIELDS = {
+    "thresholds",
+    "threshold_results",
+    "gate_checks",
+    "release_decision",
+    "PASS",
+    "NO-GO",
+    "provider_output",
+    "runtime_trace",
+    "graph_execution_trace",
+    "semantic_cache",
+    "semantic_cache_key",
+    "semantic_cache_enabled",
+    "cache_hit",
+    "score",
+    "scores",
+}
+
+
+def _load_schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _load_fixture_rows() -> list[dict[str, Any]]:
+    rows = []
+    for line in FIXTURE_PATH.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+    return rows
+
+
+def _find_keys(payload: Any) -> set[str]:
+    if isinstance(payload, dict):
+        keys = set(payload)
+        for value in payload.values():
+            keys.update(_find_keys(value))
+        return keys
+    if isinstance(payload, list):
+        keys: set[str] = set()
+        for item in payload:
+            keys.update(_find_keys(item))
+        return keys
+    return set()
+
+
+def test_schema_contract_enums_are_bounded_to_selective_graph_eval() -> None:
+    schema = _load_schema()
+
+    assert set(schema["required"]) == REQUIRED_TOP_LEVEL_FIELDS
+    assert schema["additionalProperties"] is False
+
+    properties = schema["properties"]
+    assert set(properties["surface"]["enum"]) == ALLOWED_SURFACES
+
+    graph_context = properties["graph_context"]
+    assert graph_context["additionalProperties"] is False
+    assert set(graph_context["required"]) == {"nodes", "edges"}
+
+    node_schema = graph_context["properties"]["nodes"]["items"]
+    assert node_schema["additionalProperties"] is False
+    assert set(node_schema["required"]) == {"id", "type", "label"}
+    assert set(node_schema["properties"]["type"]["enum"]) == ALLOWED_NODE_TYPES
+
+    edge_schema = graph_context["properties"]["edges"]["items"]
+    assert edge_schema["additionalProperties"] is False
+    assert set(edge_schema["required"]) == {"source", "relation", "target"}
+    assert set(edge_schema["properties"]["relation"]["enum"]) == ALLOWED_EDGE_RELATIONS
+
+    reasoning_schema = properties["reasoning_expectation"]
+    assert reasoning_schema["additionalProperties"] is False
+    assert set(reasoning_schema["required"]) == {"kind"}
+    assert set(reasoning_schema["properties"]["kind"]["enum"]) == ALLOWED_REASONING_KINDS
+
+
+def test_fixture_contains_exactly_one_record_per_allowed_surface() -> None:
+    records = _load_fixture_rows()
+
+    assert len(records) == 3
+    assert Counter(record["surface"] for record in records) == Counter(
+        {surface: 1 for surface in ALLOWED_SURFACES}
+    )
+    assert len({record["id"] for record in records}) == len(records)
+
+
+def test_fixture_rows_match_offline_graph_eval_contract() -> None:
+    for record in _load_fixture_rows():
+        assert set(record) == REQUIRED_TOP_LEVEL_FIELDS
+        assert record["surface"] in ALLOWED_SURFACES
+
+        for field_name in ("id", "question", "reference_answer"):
+            assert isinstance(record[field_name], str)
+            assert record[field_name].strip()
+
+        expected_claims = record["expected_claims"]
+        assert isinstance(expected_claims, list)
+        assert expected_claims
+        assert all(isinstance(claim, str) and claim.strip() for claim in expected_claims)
+
+        graph_context = record["graph_context"]
+        assert set(graph_context) == {"nodes", "edges"}
+
+        nodes = graph_context["nodes"]
+        edges = graph_context["edges"]
+        assert isinstance(nodes, list)
+        assert isinstance(edges, list)
+        assert nodes
+        assert edges
+
+        node_ids = {node["id"] for node in nodes}
+        assert len(node_ids) == len(nodes)
+
+        for node in nodes:
+            assert set(node) == {"id", "type", "label"}
+            assert isinstance(node["id"], str)
+            assert node["id"].strip()
+            assert node["type"] in ALLOWED_NODE_TYPES
+            assert isinstance(node["label"], str)
+            assert node["label"].strip()
+
+        for edge in edges:
+            assert set(edge) == {"source", "relation", "target"}
+            assert edge["source"] in node_ids
+            assert edge["target"] in node_ids
+            assert edge["relation"] in ALLOWED_EDGE_RELATIONS
+
+        reasoning_expectation = record["reasoning_expectation"]
+        assert set(reasoning_expectation) == {"kind"}
+        assert reasoning_expectation["kind"] == EXPECTED_KIND_BY_SURFACE[record["surface"]]
+
+
+def test_fixture_rows_do_not_contain_runtime_gate_or_cache_fields() -> None:
+    for record in _load_fixture_rows():
+        leaked_keys = _find_keys(record) & FORBIDDEN_RUNTIME_OR_GATE_FIELDS
+        assert leaked_keys == set()
+
+
+def test_contract_doc_keeps_graph_eval_offline_and_subordinate() -> None:
+    contract_doc = CONTRACT_DOC_PATH.read_text(encoding="utf-8")
+
+    required_phrases = [
+        "runtime GraphRAG rollout",
+        "semantic cache widening",
+        "provider behavior changes",
+        "a graph runner",
+        "graph-specific CI thresholds",
+        "a second canonical evaluation rail",
+        "owns threshold vocabulary, gate checks, and `PASS` / `NO-GO` semantics",
+        "must not create a second evaluation source of truth",
+    ]
+    for phrase in required_phrases:
+        assert phrase in contract_doc


### PR DESCRIPTION
## Summary

Add deterministic offline tests for the merged selective graph-eval schema and fixture contract.

This PR is a tests-only follow-up. It does not add a runner, runtime GraphRAG rollout, semantic cache behavior, provider/request-path changes, or a second canonical eval rail.

## Why

The previous docs/schema lane committed the offline selective graph-eval contract. This PR adds deterministic guard coverage so future edits preserve:

- the three approved graph-eval surfaces
- the bounded starter graph schema vocabulary
- the exactly-three-record curated fixture shape
- the offline-only boundary with no gate/runtime/cache fields

## Scope

In scope:
- `tests/evals/test_selective_graph_eval_contract.py`
- `docs/review/PR_1507_FIXED_MAPPING.md`

Out of scope:
- graph-eval runner code
- runtime GraphRAG
- semantic cache widening
- provider behavior changes
- canonical release-gate threshold changes
- RAGAS runner changes

## Test Plan

- `pytest -q tests/evals/test_selective_graph_eval_contract.py`
- `pre-commit run --all-files`
- `make validate-min`
- `make lint`
- `make typecheck`
- `make test-fast`
- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1507`

Heavy coverage remains delegated to current-head GitHub checks for this small tests-only PR.

## Deferred / Follow-ups

No new backlog umbrella is introduced. Future graph-eval runner, scoring, and CI threshold work remain deferred under the existing evaluation/reliability anchors and must stay subordinate to the canonical release-gates lane.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- Canonical artifact: `docs/review/PR_1507_FIXED_MAPPING.md`
- Sourcery review comments fixed in `4a8458cfa`
- Codex review comment fixed in `48781cf76`
- CodeRabbit nitpick fixed in `4a8458cfa`

## Merge Readiness

- [x] `pre-commit run --all-files`
- [x] `make validate-min`
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test-fast`
- [x] current-head GitHub checks are PASS
- [x] mandatory post-open `qa-engineer-agent -> bug-hunter` pass completed
- [x] final post-activity check pass completed after latest bot/review activity
- [x] waited at least one full review cycle after the final check pass
- [x] canonical merge-readiness wrapper passes
