### PR TITLE
fix(ci): shard py312 main tests without xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       workflow_privileged: ${{ steps.risk_profile.outputs.workflow_privileged }}
       backend_shared: ${{ steps.risk_profile.outputs.backend_shared }}
       run_backend_blocking: ${{ steps.risk_profile.outputs.run_backend_blocking }}
+      run_main_ci_diagnostic: ${{ steps.risk_profile.outputs.run_main_ci_diagnostic }}
       run_security: ${{ steps.risk_profile.outputs.run_security }}
       run_openapi_sync: ${{ steps.risk_profile.outputs.run_openapi_sync }}
       billing_entitlement: ${{ steps.risk_profile.outputs.billing_entitlement }}
@@ -1008,7 +1009,8 @@ jobs:
 
   # Comprehensive testing for main branch
   test-main:
-    if: github.ref == 'refs/heads/main'
+    needs: [changes]
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && needs.changes.outputs.run_main_ci_diagnostic == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: ${{ matrix.timeout-minutes }}
     permissions:
@@ -1099,12 +1101,14 @@ jobs:
           echo "TEST_STEP_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           python -c "import sys; print('PY', sys.version)"
           if [[ "$PYVER" == 3.12* ]]; then
-            echo "PY312_MAIN_SHARDS=2"
-            echo "PY312_MAIN_MAX_PARALLEL=2"
+            PY312_MAIN_SHARDS=2
+            PY312_MAIN_MAX_PARALLEL=2
+            echo "PY312_MAIN_SHARDS=${PY312_MAIN_SHARDS}"
+            echo "PY312_MAIN_MAX_PARALLEL=${PY312_MAIN_MAX_PARALLEL}"
             set +e
             time python scripts/ci/run_py312_main_shards.py \
-              --shard-count 2 \
-              --max-parallel 2
+              --shard-count "${PY312_MAIN_SHARDS}" \
+              --max-parallel "${PY312_MAIN_MAX_PARALLEL}"
             test_exit_code=$?
             set -e
             echo "TEST_STEP_FINISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1089,23 +1089,32 @@ jobs:
           # IMPORTANT: main branch must maintain 97% coverage per project standards
           # See .cursorrules and AGENTS.md
           #
-          # CI stability: Python 3.12 has shown repeated xdist worker termination on the
-          # full main-branch suite, while Python 3.13 has seen intermittent segfaults under
-          # xdist+coverage. Keep the fallback scoped to unstable main-only interpreters.
+          # CI stability: Python 3.12 exceeded the 60-minute main window after xdist
+          # containment. Run isolated process-level shards for 3.12 instead of pytest-xdist
+          # workers, preserving the test-main (3.12, 60) required-check identity.
+          # Python 3.13 has seen intermittent segfaults under xdist+coverage.
           # Intentionally removed `--cov-context=test` due to flaky coverage DB corruption under xdist
           # on Python 3.13 ("no such table: context"). Revisit after pytest/hypothesis upgrades.
           PYVER="${MATRIX_PYTHON_VERSION}"
-          if [[ "$PYVER" == 3.13* ]]; then
+          echo "TEST_STEP_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          python -c "import sys; print('PY', sys.version)"
+          if [[ "$PYVER" == 3.12* ]]; then
+            echo "PY312_MAIN_SHARDS=2"
+            echo "PY312_MAIN_MAX_PARALLEL=2"
+            set +e
+            time python scripts/ci/run_py312_main_shards.py \
+              --shard-count 2 \
+              --max-parallel 2
+            test_exit_code=$?
+            set -e
+            echo "TEST_STEP_FINISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            exit "$test_exit_code"
+          elif [[ "$PYVER" == 3.13* ]]; then
             # Fully disable xdist plugin on 3.13 (more stable than `-n 0`)
-            PYTEST_XDIST_ARGS=(-p no:xdist)
-          elif [[ "$PYVER" == 3.12* ]]; then
-            # Fully disable xdist on 3.12 after narrower mitigations still timed out.
             PYTEST_XDIST_ARGS=(-p no:xdist)
           else
             PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)
           fi
-          echo "TEST_STEP_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          python -c "import sys; print('PY', sys.version)"
           echo "PYTEST_XDIST_ARGS=${PYTEST_XDIST_ARGS[*]}"
           set +e
           time python -X faulthandler -m pytest \
@@ -1140,6 +1149,7 @@ jobs:
           name: junit-${{ matrix.python-version }}
           path: |
             tests/results.xml
+            tests/results-py312-shard-*.xml
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,7 +164,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 608
+        "line_number": 609
       }
     ],
     ".github/workflows/frontend-ci.yml": [
@@ -1632,5 +1632,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-23T13:23:34Z"
+  "generated_at": "2026-04-23T20:14:05Z"
 }

--- a/docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md
+++ b/docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md
@@ -46,7 +46,8 @@ Each process receives:
 
 - a deterministic file shard balanced by file size;
 - `-p no:xdist`;
-- a unique `PYTEST_XDIST_WORKER` value for DB isolation;
+- a unique `PY312_MAIN_SHARD` value while intentionally removing
+  `PYTEST_XDIST_WORKER` so xdist-only DB routing is not faked;
 - a unique coverage data file;
 - a shard-specific JUnit XML file;
 - `faulthandler_timeout=300` and expanded duration reporting.
@@ -74,8 +75,8 @@ then runs on the PR head as an explicit diagnostic proof path.
 ## Acceptance
 
 - Local workflow contract tests pass.
-- `make test-fast` passes before merge-ready.
-- `make cov-check` passes before merge-ready.
+- `make test-fast` passes before push.
+- `make cov-check` passes before push.
 - `make validate-changed` passes before push.
 - `pre-commit run --all-files` passes before push.
 - Draft PR current-head CI proves `test-main (3.12, 60)` completes without
@@ -88,4 +89,4 @@ For any `tests/**/*.py` changes made while fixing red CI:
 2. Reproduce the cohort locally before changing behavior where feasible.
 3. Fix code and tests in the same PR; update the nearest `AGENTS.md` only when
    the test contract itself changes.
-4. Re-run `make test-fast` and `make cov-check` before merge-ready.
+4. Re-run `make test-fast` and `make cov-check` before push.

--- a/docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md
+++ b/docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md
@@ -30,6 +30,10 @@ Mandatory post-open review remains `qa-engineer-agent -> bug-hunter`.
   step was running from `2026-04-23T15:26:19Z`.
 - Main run `24849990678` still had `test-main (3.12, 60)` in progress from
   `2026-04-23T19:02:48Z` when this lane was scoped; `3.11` already passed.
+- Main run `24854923154` later failed `test-main (3.12, 60)` at roughly 20%
+  with `Segmentation fault (core dumped)` in the sequential no-xdist command:
+  `python -X faulthandler -m pytest "${PYTEST_XDIST_ARGS[@]}" -m "not slow"`
+  with coverage enabled.
 
 ## Decision
 
@@ -48,6 +52,11 @@ Each process receives:
 
 After all shards pass, the runner combines coverage and enforces the existing
 97% coverage threshold. Any shard failure fails the job.
+
+If a shard process exits via native crash and breaks the worker pool, the parent
+runner emits `PY312_SHARD_EXCEPTION index=<n> ...` before failing the job. This
+preserves the failing shard boundary for the next root-cause pass instead of
+turning the crash into an unscoped job-level failure.
 
 ## Non-Goals
 

--- a/docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md
+++ b/docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md
@@ -2,22 +2,23 @@
 
 Date: 2026-04-23
 Branch: `codex/main-ci-py312-timeout-root-cause`
-Scope: `.github/workflows/ci.yml`, `scripts/ci/run_py312_main_shards.py`,
+Scope: `.github/workflows/ci.yml`, `scripts/ci/ci_risk_profile.py`,
+`scripts/ci/run_py312_main_shards.py`,
 `tests/test_ci_workflow_pr_size_governance_contract.py`,
-`tests/test_py312_main_shards.py`, and this packet/backlog wiring.
+`tests/test_ci_risk_profile.py`, `tests/test_py312_main_shards.py`, and this
+packet/backlog wiring.
 
 ## Coordinator Scope Lock
 
 Use the Tier 1 CI/CD lane order:
 
 1. `agent-coordinator`
-2. `dev-operator`
-3. `architecture-specialist`
+2. `architecture-specialist`
+3. `security-auditor`
 4. `backend-engineer`
-5. `security-auditor`
+5. `dev-operator`
 6. `qa-engineer-agent`
 7. `bug-hunter`
-8. `agent-coordinator`
 
 Mandatory post-open review remains `qa-engineer-agent -> bug-hunter`.
 
@@ -58,6 +59,11 @@ runner emits `PY312_SHARD_EXCEPTION index=<n> ...` before failing the job. This
 preserves the failing shard boundary for the next root-cause pass instead of
 turning the crash into an unscoped job-level failure.
 
+PR CI normally skips `test-main` because the comprehensive matrix is main-only.
+For this lane class, `ci_risk_profile.py` emits `run_main_ci_diagnostic=true`
+when the diff touches the Python 3.12 main-CI runner/workflow contract; `test-main`
+then runs on the PR head as an explicit diagnostic proof path.
+
 ## Non-Goals
 
 - No runtime API, OpenAPI, product UI, Cloudflare, deployment, or customer-facing
@@ -68,8 +74,18 @@ turning the crash into an unscoped job-level failure.
 ## Acceptance
 
 - Local workflow contract tests pass.
+- `make test-fast` passes before merge-ready.
+- `make cov-check` passes before merge-ready.
 - `make validate-changed` passes before push.
 - `pre-commit run --all-files` passes before push.
 - Draft PR current-head CI proves `test-main (3.12, 60)` completes without
   timeout and without xdist worker-node termination before any non-draft or
   merge-ready claim.
+
+For any `tests/**/*.py` changes made while fixing red CI:
+
+1. Identify the failing test cohort and the exact GitHub/local command.
+2. Reproduce the cohort locally before changing behavior where feasible.
+3. Fix code and tests in the same PR; update the nearest `AGENTS.md` only when
+   the test contract itself changes.
+4. Re-run `make test-fast` and `make cov-check` before merge-ready.

--- a/docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md
+++ b/docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md
@@ -1,0 +1,66 @@
+# Main CI Python 3.12 Timeout Root-Cause Packet
+
+Date: 2026-04-23
+Branch: `codex/main-ci-py312-timeout-root-cause`
+Scope: `.github/workflows/ci.yml`, `scripts/ci/run_py312_main_shards.py`,
+`tests/test_ci_workflow_pr_size_governance_contract.py`,
+`tests/test_py312_main_shards.py`, and this packet/backlog wiring.
+
+## Coordinator Scope Lock
+
+Use the Tier 1 CI/CD lane order:
+
+1. `agent-coordinator`
+2. `dev-operator`
+3. `architecture-specialist`
+4. `backend-engineer`
+5. `security-auditor`
+6. `qa-engineer-agent`
+7. `bug-hunter`
+8. `agent-coordinator`
+
+Mandatory post-open review remains `qa-engineer-agent -> bug-hunter`.
+
+## Evidence
+
+- PR #1494 reduced Python 3.12 xdist pressure but did not stabilize main.
+- PR #1501 split serial tests but did not stabilize main.
+- PR #1505 fully disabled xdist for Python 3.12 as containment.
+- Main run `24843626627` cancelled `test-main (3.12, 60)` while the test
+  step was running from `2026-04-23T15:26:19Z`.
+- Main run `24849990678` still had `test-main (3.12, 60)` in progress from
+  `2026-04-23T19:02:48Z` when this lane was scoped; `3.11` already passed.
+
+## Decision
+
+Do not raise the timeout and do not rename the required check.
+
+For Python 3.12 only, keep pytest-xdist disabled but regain wall-clock budget
+with two isolated pytest processes in the same `test-main (3.12, 60)` job.
+Each process receives:
+
+- a deterministic file shard balanced by file size;
+- `-p no:xdist`;
+- a unique `PYTEST_XDIST_WORKER` value for DB isolation;
+- a unique coverage data file;
+- a shard-specific JUnit XML file;
+- `faulthandler_timeout=300` and expanded duration reporting.
+
+After all shards pass, the runner combines coverage and enforces the existing
+97% coverage threshold. Any shard failure fails the job.
+
+## Non-Goals
+
+- No runtime API, OpenAPI, product UI, Cloudflare, deployment, or customer-facing
+  changes.
+- No `continue-on-error`, ignored pytest failures, or coverage weakening.
+- No broad timeout bump as the primary mitigation.
+
+## Acceptance
+
+- Local workflow contract tests pass.
+- `make validate-changed` passes before push.
+- `pre-commit run --all-files` passes before push.
+- Draft PR current-head CI proves `test-main (3.12, 60)` completes without
+  timeout and without xdist worker-node termination before any non-draft or
+  merge-ready claim.

--- a/docs/review/PR_1511_FIXED_MAPPING.md
+++ b/docs/review/PR_1511_FIXED_MAPPING.md
@@ -23,6 +23,20 @@ Evidence: CodeRabbit actionables fixed in workflow, runner, packet, and tests.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3133512274 -> 853694874
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#pullrequestreview-4165580559 -> 853694874
 
+Disposition: FIXED
+Commit: e5673b71c
+Evidence: Review actionables fixed in shard runner, tests, packet, backlog, and
+mapping wording.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3136788725 -> e5673b71c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3136788739 -> e5673b71c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3136788760 -> e5673b71c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3136799288 -> e5673b71c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3136811065 -> e5673b71c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3136811075 -> e5673b71c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#pullrequestreview-4169448952 -> e5673b71c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#pullrequestreview-4169459758 -> e5673b71c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#pullrequestreview-4169472607 -> e5673b71c
+
 ## Initial Evidence
 
 - `python3 scripts/orchestration/check_preflight.py --path .github/workflows/ci.yml --path tests/test_ci_workflow_pr_size_governance_contract.py --path docs/orchestration --path docs/roadmap/BACKLOG_LEDGER.md` PASS.

--- a/docs/review/PR_1511_FIXED_MAPPING.md
+++ b/docs/review/PR_1511_FIXED_MAPPING.md
@@ -43,7 +43,7 @@ Evidence: Review actionables fixed in shard runner, tests, packet, backlog, and 
 - `PYENV_VERSION=3.12.7 python -m pytest -q tests/test_py312_main_shards.py tests/test_ci_workflow_pr_size_governance_contract.py` PASS.
 - `PYENV_VERSION=3.12.7 python scripts/ci/run_py312_main_shards.py --list-shards --shard-count 2` PASS.
 - `pre-commit run --all-files --show-diff-on-failure` PASS.
-- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` PASS.
+- `VENV_PYTHON=.venv/bin/python make validate-changed` PASS.
 - Push pre-push hooks PASS: yaml, workflow check, black, ruff, mypy changed
   files, pip-audit, backend pre-push pytest, full-repo bandit, docker build
   test.
@@ -69,9 +69,9 @@ Evidence: Review actionables fixed in shard runner, tests, packet, backlog, and 
 
 ## Merge Readiness
 
-- [x] Current-head `test-main (3.12, 60)` completes without timeout.
-- [x] Current-head `test-main (3.12, 60)` has no xdist worker-node termination.
-- [x] `test-main (3.11, 60)` and `test-main (3.13, 90)` do not regress.
+- [ ] Current-head `test-main (3.12, 60)` completes without timeout.
+- [ ] Current-head `test-main (3.12, 60)` has no xdist worker-node termination.
+- [ ] `test-main (3.11, 60)` and `test-main (3.13, 90)` do not regress.
 - [ ] CodeRabbit, Sourcery, and Cubic actionables are mapped or explicitly
   marked non-actionable.
 - [ ] Final check pass completed after latest bot/review activity.

--- a/docs/review/PR_1511_FIXED_MAPPING.md
+++ b/docs/review/PR_1511_FIXED_MAPPING.md
@@ -6,8 +6,8 @@ Date: 2026-04-23
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 - Status: Draft PR opened for current-head GitHub CI proof. No human or bot
   review actionables were present when this artifact was created.

--- a/docs/review/PR_1511_FIXED_MAPPING.md
+++ b/docs/review/PR_1511_FIXED_MAPPING.md
@@ -15,7 +15,7 @@ Date: 2026-04-23
 
 ## Fixed in Commit Mapping
 
-- No actionable review threads yet.
+- No actionable review comments
 
 ## Initial Evidence
 

--- a/docs/review/PR_1511_FIXED_MAPPING.md
+++ b/docs/review/PR_1511_FIXED_MAPPING.md
@@ -28,6 +28,9 @@ Date: 2026-04-23
 - Push pre-push hooks PASS: yaml, workflow check, black, ruff, mypy changed
   files, pip-audit, backend pre-push pytest, full-repo bandit, docker build
   test.
+- Additional main evidence from 2026-04-23: run `24854923154`, job
+  `72765173124`, failed `test-main (3.12, 60)` with `Segmentation fault
+  (core dumped)` at roughly 20% under the sequential no-xdist coverage command.
 
 ## Deferred Follow-up
 

--- a/docs/review/PR_1511_FIXED_MAPPING.md
+++ b/docs/review/PR_1511_FIXED_MAPPING.md
@@ -7,7 +7,7 @@ Date: 2026-04-23
 ## Discussion Thread Pass
 
 - [x] Discussion-thread pass completed
-- [x] Fixed-in-commit mapping completed
+- [x] Fixed in commit mapping completed
 
 - Status: Current-head GitHub CI proof completed for commit `b3edd4ff`;
   required post-proof review cycle is still pending.
@@ -25,8 +25,7 @@ Evidence: CodeRabbit actionables fixed in workflow, runner, packet, and tests.
 
 Disposition: FIXED
 Commit: e5673b71c
-Evidence: Review actionables fixed in shard runner, tests, packet, backlog, and
-mapping wording.
+Evidence: Review actionables fixed in shard runner, tests, packet, backlog, and mapping wording.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3136788725 -> e5673b71c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3136788739 -> e5673b71c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3136788760 -> e5673b71c

--- a/docs/review/PR_1511_FIXED_MAPPING.md
+++ b/docs/review/PR_1511_FIXED_MAPPING.md
@@ -7,7 +7,7 @@ Date: 2026-04-23
 ## Discussion Thread Pass
 
 - [x] Discussion-thread pass completed
-- [x] Fixed in commit mapping completed
+- [x] Fixed-in-commit mapping completed
 
 - Status: Current-head GitHub CI proof completed for commit `b3edd4ff`;
   required post-proof review cycle is still pending.
@@ -60,6 +60,6 @@ Evidence: CodeRabbit actionables fixed in workflow, runner, packet, and tests.
 - [x] Current-head `test-main (3.12, 60)` has no xdist worker-node termination.
 - [x] `test-main (3.11, 60)` and `test-main (3.13, 90)` do not regress.
 - [ ] CodeRabbit, Sourcery, and Cubic actionables are mapped or explicitly
-  marked no-actionable.
+  marked non-actionable.
 - [ ] Final check pass completed after latest bot/review activity.
 - [ ] Waited at least one review cycle before merge.

--- a/docs/review/PR_1511_FIXED_MAPPING.md
+++ b/docs/review/PR_1511_FIXED_MAPPING.md
@@ -15,28 +15,13 @@ Date: 2026-04-23
 
 ## Fixed in Commit Mapping
 
+Disposition: FIXED
+Commit: 853694874
+Evidence: CodeRabbit actionables fixed in workflow, runner, packet, and tests.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3133512254 -> 853694874
-  - Disposition: FIXED
-  - Evidence:
-    `docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md`
-    now uses the reviewer-requested role order and removes the duplicate
-    trailing `agent-coordinator`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3133512268 -> 853694874
-  - Disposition: FIXED
-  - Evidence:
-    `docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md`
-    now lists `make test-fast`, `make cov-check`, and the `tests/**/*.py`
-    reproduction/fix checklist.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3133512274 -> 853694874
-  - Disposition: FIXED
-  - Evidence: `scripts/ci/run_py312_main_shards.py` now always uses a spawned
-    `ProcessPoolExecutor`; `tests/test_py312_main_shards.py` includes a
-    `max_parallel=1` child-process isolation regression.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#pullrequestreview-4165580559 -> 853694874
-  - Disposition: FIXED
-  - Evidence: `.github/workflows/ci.yml` now assigns
-    `PY312_MAIN_SHARDS` / `PY312_MAIN_MAX_PARALLEL` once and uses those
-    variables for both logging and runner CLI arguments.
 
 ## Initial Evidence
 

--- a/docs/review/PR_1511_FIXED_MAPPING.md
+++ b/docs/review/PR_1511_FIXED_MAPPING.md
@@ -9,13 +9,34 @@ Date: 2026-04-23
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-- Status: Draft PR opened for current-head GitHub CI proof. No human or bot
-  review actionables were present when this artifact was created.
-- Current implementation commit: `80b51e5ca`.
+- Status: Draft PR opened for current-head GitHub CI proof. CodeRabbit
+  actionables from 2026-04-23 were fixed and mapped below.
+- Current implementation commit: `853694874`.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3133512254 -> 853694874
+  - Disposition: FIXED
+  - Evidence:
+    `docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md`
+    now uses the reviewer-requested role order and removes the duplicate
+    trailing `agent-coordinator`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3133512268 -> 853694874
+  - Disposition: FIXED
+  - Evidence:
+    `docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md`
+    now lists `make test-fast`, `make cov-check`, and the `tests/**/*.py`
+    reproduction/fix checklist.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3133512274 -> 853694874
+  - Disposition: FIXED
+  - Evidence: `scripts/ci/run_py312_main_shards.py` now always uses a spawned
+    `ProcessPoolExecutor`; `tests/test_py312_main_shards.py` includes a
+    `max_parallel=1` child-process isolation regression.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#pullrequestreview-4165580559 -> 853694874
+  - Disposition: FIXED
+  - Evidence: `.github/workflows/ci.yml` now assigns
+    `PY312_MAIN_SHARDS` / `PY312_MAIN_MAX_PARALLEL` once and uses those
+    variables for both logging and runner CLI arguments.
 
 ## Initial Evidence
 
@@ -31,6 +52,10 @@ Date: 2026-04-23
 - Additional main evidence from 2026-04-23: run `24854923154`, job
   `72765173124`, failed `test-main (3.12, 60)` with `Segmentation fault
   (core dumped)` at roughly 20% under the sequential no-xdist coverage command.
+- QA post-open review found that PR CI skipped `test-main`; fixed by adding
+  `run_main_ci_diagnostic` routing so PRs changing the main-CI Python 3.12
+  runner/workflow contract execute the `test-main` matrix before merge.
+- CodeRabbit review `4165580559` fixed by `853694874`.
 
 ## Deferred Follow-up
 

--- a/docs/review/PR_1511_FIXED_MAPPING.md
+++ b/docs/review/PR_1511_FIXED_MAPPING.md
@@ -36,6 +36,13 @@ Evidence: Review actionables fixed in shard runner, tests, packet, backlog, and 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#pullrequestreview-4169459758 -> e5673b71c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#pullrequestreview-4169472607 -> e5673b71c
 
+Disposition: FIXED
+Commit: 7efd97436
+Evidence: CodeRabbit governance notes fixed in this artifact by removing the local absolute path and keeping merge-readiness boxes unchecked until the final cycle.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3136987919 -> 7efd97436
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#discussion_r3136987945 -> 7efd97436
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511#pullrequestreview-4169663658 -> 7efd97436
+
 ## Initial Evidence
 
 - `python3 scripts/orchestration/check_preflight.py --path .github/workflows/ci.yml --path tests/test_ci_workflow_pr_size_governance_contract.py --path docs/orchestration --path docs/roadmap/BACKLOG_LEDGER.md` PASS.

--- a/docs/review/PR_1511_FIXED_MAPPING.md
+++ b/docs/review/PR_1511_FIXED_MAPPING.md
@@ -1,0 +1,48 @@
+# PR #1511 Fixed Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1511>
+Branch: `codex/main-ci-py312-timeout-root-cause`
+Date: 2026-04-23
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+- Status: Draft PR opened for current-head GitHub CI proof. No human or bot
+  review actionables were present when this artifact was created.
+- Current implementation commit: `80b51e5ca`.
+
+## Fixed in Commit Mapping
+
+- No actionable review threads yet.
+
+## Initial Evidence
+
+- `python3 scripts/orchestration/check_preflight.py --path .github/workflows/ci.yml --path tests/test_ci_workflow_pr_size_governance_contract.py --path docs/orchestration --path docs/roadmap/BACKLOG_LEDGER.md` PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS.
+- `PYENV_VERSION=3.12.7 python -m pytest -q tests/test_py312_main_shards.py tests/test_ci_workflow_pr_size_governance_contract.py` PASS.
+- `PYENV_VERSION=3.12.7 python scripts/ci/run_py312_main_shards.py --list-shards --shard-count 2` PASS.
+- `pre-commit run --all-files --show-diff-on-failure` PASS.
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` PASS.
+- Push pre-push hooks PASS: yaml, workflow check, black, ruff, mypy changed
+  files, pip-audit, backend pre-push pytest, full-repo bandit, docker build
+  test.
+
+## Deferred Follow-up
+
+- `make verify` is deferred while PR #1511 is draft because the governing
+  failure mode is the full main-suite Python 3.12 runtime budget. Current-head
+  GitHub CI is the heavy signal for this lane.
+- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-py312-xdist-root-cause-hardening`
+  remains the follow-up anchor for any future pytest-xdist restoration audit.
+
+## Merge Readiness
+
+- [ ] Current-head `test-main (3.12, 60)` completes without timeout.
+- [ ] Current-head `test-main (3.12, 60)` has no xdist worker-node termination.
+- [ ] `test-main (3.11, 60)` and `test-main (3.13, 90)` do not regress.
+- [ ] CodeRabbit, Sourcery, and Cubic actionables are mapped or explicitly
+  marked no-actionable.
+- [ ] Final check pass completed after latest bot/review activity.
+- [ ] Waited at least one review cycle before merge.

--- a/docs/review/PR_1511_FIXED_MAPPING.md
+++ b/docs/review/PR_1511_FIXED_MAPPING.md
@@ -9,9 +9,9 @@ Date: 2026-04-23
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-- Status: Draft PR opened for current-head GitHub CI proof. CodeRabbit
-  actionables from 2026-04-23 were fixed and mapped below.
-- Current implementation commit: `853694874`.
+- Status: Current-head GitHub CI proof completed for commit `b3edd4ff`;
+  required post-proof review cycle is still pending.
+- Current implementation commit: `b3edd4ff`.
 
 ## Fixed in Commit Mapping
 
@@ -41,20 +41,24 @@ Evidence: CodeRabbit actionables fixed in workflow, runner, packet, and tests.
   `run_main_ci_diagnostic` routing so PRs changing the main-CI Python 3.12
   runner/workflow contract execute the `test-main` matrix before merge.
 - CodeRabbit review `4165580559` fixed by `853694874`.
+- Current-head CI run `24859466516` on commit `b3edd4ff` passed:
+  `test-main (3.12, 60)` in `37m42s`, `test-main (3.11, 60)` in `6m58s`,
+  `test-main (3.13, 90)` in `1h21m9s`, `coverage-pr` in `13s`, and
+  `diff-coverage` in `55s`.
 
 ## Deferred Follow-up
 
-- `make verify` is deferred while PR #1511 is draft because the governing
-  failure mode is the full main-suite Python 3.12 runtime budget. Current-head
-  GitHub CI is the heavy signal for this lane.
+- `make verify` is deferred because the governing failure mode is the full
+  main-suite Python 3.12 runtime budget. Current-head GitHub CI is the heavy
+  signal for this lane.
 - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-py312-xdist-root-cause-hardening`
   remains the follow-up anchor for any future pytest-xdist restoration audit.
 
 ## Merge Readiness
 
-- [ ] Current-head `test-main (3.12, 60)` completes without timeout.
-- [ ] Current-head `test-main (3.12, 60)` has no xdist worker-node termination.
-- [ ] `test-main (3.11, 60)` and `test-main (3.13, 90)` do not regress.
+- [x] Current-head `test-main (3.12, 60)` completes without timeout.
+- [x] Current-head `test-main (3.12, 60)` has no xdist worker-node termination.
+- [x] `test-main (3.11, 60)` and `test-main (3.13, 90)` do not regress.
 - [ ] CodeRabbit, Sourcery, and Cubic actionables are mapped or explicitly
   marked no-actionable.
 - [ ] Final check pass completed after latest bot/review activity.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -9597,8 +9597,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Main CI xdist worker stability on Python 3.12 full suite
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (CI stability / merge-signal integrity)
-  - Target PR: PR #1494 (`codex/fix-ci-xdist-worker-stability`) -> PR #1501 (`codex/main-ci-py312-root-cause-plus-uuid117`) -> containment PR (`codex/main-py312-containment`)
-  - Status: PR #1494 and PR #1501 landed partial mitigations by April 23, 2026, but live main run `24811914187` still cancelled `test-main (3.12, 60)` after the coverage step reached the 60-minute containment window. The active containment lane is `codex/main-py312-containment`.
+  - Target PR: PR #1494 (`codex/fix-ci-xdist-worker-stability`) -> PR #1501 (`codex/main-ci-py312-root-cause-plus-uuid117`) -> containment PR (`codex/main-py312-containment`) -> active timeout root-cause lane (`codex/main-ci-py312-timeout-root-cause`)
+  - Status: PR #1494 and PR #1501 landed partial mitigations by April 23, 2026, but live main run `24811914187` still cancelled `test-main (3.12, 60)` after the coverage step reached the 60-minute containment window. PR #1505 containment disabled xdist for Python 3.12, but main run `24849990678` still had `test-main (3.12, 60)` running inside the coverage step after `2026-04-23T19:04:22Z`. The active root-cause lane is `codex/main-ci-py312-timeout-root-cause`.
   - Reason: the `main`-branch `CI` full-suite lane continues to surface
     user-reported `"[gw1] node down: Not properly terminated"` instability in
     the xdist-backed `test-main` path. Current lane evidence shows
@@ -9606,13 +9606,17 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     `test-main (3.12, 60)` cancels after the test step reaches its timeout.
     PR #1494 reduced worker pressure and PR #1501 split serial tests out of
     the 3.12 xdist cohort, but the remaining 3.12 parallel segment still lacks
-    a live green main signal. The containment lane disables xdist for Python
-    3.12 only and defers deeper root-cause hardening to a follow-up item.
+    a live green main signal. PR #1505 disabled xdist for Python 3.12 only;
+    the active follow-up keeps xdist disabled but uses isolated process-level
+    shards to recover the `60` minute budget without changing the required
+    check identity or weakening pytest/coverage failure semantics.
   - Links:
     - `docs/orchestration/MAINLINE_CI_XDIST_WORKER_STABILITY_PACKET_2026-04-22.md`
     - `docs/orchestration/MAINLINE_CI_XDIST_ROOT_CAUSE_AND_UUID117_PACKET_2026-04-23.md`
     - `docs/orchestration/MAIN_CI_PY312_CONTAINMENT_PACKET_2026-04-23.md`
+    - `docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md`
     - `.github/workflows/ci.yml`
+    - `scripts/ci/run_py312_main_shards.py`
     - `.github/workflows/nightly.yml`
     - `pyproject.toml`
     - `tests/test_ci_workflow_pr_size_governance_contract.py`
@@ -9627,9 +9631,9 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Green nightly reference: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24760590280>
   - DoD:
     - `test-main` keeps the same job identity and required-check topology
-    - `3.12` runs the full `-m "not slow"` test cohort sequentially with
-      `-p no:xdist` while `3.11` stays parallel and `3.13` keeps its existing
-      sequential fallback
+    - `3.12` runs the full `-m "not slow"` test cohort through isolated
+      no-xdist process shards while `3.11` stays parallel and `3.13` keeps its
+      existing sequential fallback
     - A regression test freezes the workflow contract
     - `pre-commit run --all-files`, `make validate-changed`, and branch/current-head
       `CI` pass on the remediation branch
@@ -9640,19 +9644,22 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: Python 3.12 xdist root-cause hardening after containment
   - Owner: CI/QA
   - Priority: P2 (CI hardening after required-check containment)
-  - Target PR: follow-up after `codex/main-py312-containment`
-  - Status: Deferred from the containment lane so main can recover required-check stability without changing required-check topology or hiding failures.
-  - Reason: disabling xdist for Python 3.12 is a containment policy, not a root-cause fix. The worker-node termination pattern still needs a bounded audit of fixture/process cleanup, xdist-hostile tests, and timeout instrumentation before Python 3.12 parallelism can be safely restored.
+  - Target PR: `codex/main-ci-py312-timeout-root-cause`
+  - Status: Active as of April 23, 2026. PR #1505 containment disabled xdist for Python 3.12 but did not prove the main `60` minute budget. This lane adds deterministic no-xdist process sharding and diagnostics before any future pytest-xdist restoration attempt.
+  - Reason: disabling xdist for Python 3.12 is a containment policy, not a root-cause fix. The worker-node termination pattern still needs bounded fixture/process cleanup evidence before pytest-xdist can be safely restored; meanwhile the sequential no-xdist suite must fit the required `test-main (3.12, 60)` check without hiding failures.
   - Links:
     - `.github/workflows/ci.yml`
     - `tests/AGENTS.md`
     - `tests/test_ci_workflow_pr_size_governance_contract.py`
     - `docs/orchestration/MAIN_CI_PY312_CONTAINMENT_PACKET_2026-04-23.md`
+    - `docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md`
+    - Active timeout lane: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/tree/codex/main-ci-py312-timeout-root-cause>
     - Historical worker-node failure: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24771474555/job/72483372336>
     - Containment gate run: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24811914187>
   - DoD:
-    - Identify the minimal xdist-hostile test group or runtime fixture pattern
-    - Add deterministic evidence or instrumentation for the failure mode
+    - Add deterministic evidence or instrumentation for the Python 3.12 main timeout mode
+    - Keep 3.12 pytest-xdist disabled until a later bounded audit identifies the minimal xdist-hostile test group or runtime fixture pattern
+    - Prove the isolated no-xdist shard runner preserves coverage/JUnit artifacts and fails closed on shard failures
     - Restore Python 3.12 parallelism only if the same current-head CI proves no worker-node termination or timeout
     - Keep required job identity and matrix topology unchanged unless a separate architecture review approves a contract change
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -9649,8 +9649,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: CI/QA
   - Priority: P2 (CI hardening after required-check containment)
   - Target PR: `codex/main-ci-py312-timeout-root-cause`
-  - Status: Active as of April 23, 2026. PR #1505 containment disabled xdist for Python 3.12 but did not prove the main `60` minute budget. This lane adds deterministic no-xdist process sharding and diagnostics before any future pytest-xdist restoration attempt.
-  - Reason: disabling xdist for Python 3.12 is a containment policy, not a root-cause fix. The worker-node termination pattern still needs bounded fixture/process cleanup evidence before pytest-xdist can be safely restored; meanwhile the sequential no-xdist suite must fit the required `test-main (3.12, 60)` check without hiding failures.
+  - Status: Active as of April 23, 2026. Pointer entry for the active root-cause lane; the detailed chronology remains in `#ledger-p1-main-ci-xdist-worker-stability`.
+  - Reason: PR #1505 containment is not the final root-cause fix. This follow-up tracks bounded evidence for any future pytest-xdist restoration after the deterministic no-xdist shard runner proves the required `test-main (3.12, 60)` budget.
   - Links:
     - `.github/workflows/ci.yml`
     - `tests/AGENTS.md`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -9616,6 +9616,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/MAIN_CI_PY312_CONTAINMENT_PACKET_2026-04-23.md`
     - `docs/orchestration/MAIN_CI_PY312_TIMEOUT_ROOT_CAUSE_PACKET_2026-04-23.md`
     - `.github/workflows/ci.yml`
+    - `scripts/ci/ci_risk_profile.py`
     - `scripts/ci/run_py312_main_shards.py`
     - `.github/workflows/nightly.yml`
     - `pyproject.toml`
@@ -9635,6 +9636,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `3.12` runs the full `-m "not slow"` test cohort through isolated
       no-xdist process shards while `3.11` stays parallel and `3.13` keeps its
       existing sequential fallback
+    - PRs that change the main-CI Python 3.12 runner/workflow contract run the
+      same `test-main` matrix as a scoped diagnostic proof path before merge
     - A regression test freezes the workflow contract
     - `pre-commit run --all-files`, `make validate-changed`, and branch/current-head
       `CI` pass on the remediation branch

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -9598,7 +9598,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (CI stability / merge-signal integrity)
   - Target PR: PR #1494 (`codex/fix-ci-xdist-worker-stability`) -> PR #1501 (`codex/main-ci-py312-root-cause-plus-uuid117`) -> containment PR (`codex/main-py312-containment`) -> active timeout root-cause lane (`codex/main-ci-py312-timeout-root-cause`)
-  - Status: PR #1494 and PR #1501 landed partial mitigations by April 23, 2026, but live main run `24811914187` still cancelled `test-main (3.12, 60)` after the coverage step reached the 60-minute containment window. PR #1505 containment disabled xdist for Python 3.12, but main run `24849990678` still had `test-main (3.12, 60)` running inside the coverage step after `2026-04-23T19:04:22Z`. The active root-cause lane is `codex/main-ci-py312-timeout-root-cause`.
+  - Status: PR #1494 and PR #1501 landed partial mitigations by April 23, 2026, but live main run `24811914187` still cancelled `test-main (3.12, 60)` after the coverage step reached the 60-minute containment window. PR #1505 containment disabled xdist for Python 3.12, but main run `24849990678` still had `test-main (3.12, 60)` running inside the coverage step after `2026-04-23T19:04:22Z`. Main run `24854923154` then failed the same job with `Segmentation fault (core dumped)` at roughly 20% under the sequential no-xdist coverage command. The active root-cause lane is `codex/main-ci-py312-timeout-root-cause`.
   - Reason: the `main`-branch `CI` full-suite lane continues to surface
     user-reported `"[gw1] node down: Not properly terminated"` instability in
     the xdist-backed `test-main` path. Current lane evidence shows
@@ -9627,6 +9627,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Later late-zone reproduction with timeout tail: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24799632664/job/72578492861>
     - Live gate run: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24811914187>
     - Cancelled `test-main (3.12, 60)` gate job: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24811914187/job/72651217023>
+    - Sequential no-xdist segfault job: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24854923154/job/72765173124>
     - Healthy comparator `test-main (3.11, 60)` job: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24771474555/job/72483386535>
     - Green nightly reference: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24760590280>
   - DoD:

--- a/scripts/ci/ci_risk_profile.py
+++ b/scripts/ci/ci_risk_profile.py
@@ -83,6 +83,14 @@ WORKFLOW_PRIVILEGED_PREFIXES: tuple[str, ...] = (
     "docs/orchestration/",
     "scripts/ci/",
 )
+MAIN_CI_DIAGNOSTIC_EXACT: tuple[str, ...] = (
+    ".github/workflows/ci.yml",
+    "scripts/ci/ci_risk_profile.py",
+    "scripts/ci/run_py312_main_shards.py",
+    "tests/test_ci_risk_profile.py",
+    "tests/test_ci_workflow_pr_size_governance_contract.py",
+    "tests/test_py312_main_shards.py",
+)
 GIT_DIFF_TIMEOUT_SECONDS = 60
 RISK_GROUP_PATTERNS: dict[str, tuple[str, ...]] = {
     "billing_entitlement": (
@@ -169,6 +177,7 @@ class RiskProfile:
     workflow_privileged: bool
     backend_shared: bool
     run_backend_blocking: bool
+    run_main_ci_diagnostic: bool
     run_security: bool
     run_openapi_sync: bool
     billing_entitlement: bool
@@ -188,6 +197,7 @@ class RiskProfile:
             "workflow_privileged": _bool_text(self.workflow_privileged),
             "backend_shared": _bool_text(self.backend_shared),
             "run_backend_blocking": _bool_text(self.run_backend_blocking),
+            "run_main_ci_diagnostic": _bool_text(self.run_main_ci_diagnostic),
             "run_security": _bool_text(self.run_security),
             "run_openapi_sync": _bool_text(self.run_openapi_sync),
             "billing_entitlement": _bool_text(self.billing_entitlement),
@@ -239,6 +249,11 @@ def _is_backend_shared(path: str) -> bool:
     )
 
 
+def _is_main_ci_diagnostic_surface(path: str) -> bool:
+    normalized = _normalize_path(path)
+    return normalized in MAIN_CI_DIAGNOSTIC_EXACT
+
+
 def _is_docs_path(path: str) -> bool:
     normalized = _normalize_path(path)
     return normalized.startswith(DOCS_PREFIXES) or normalized.endswith(".md")
@@ -285,6 +300,7 @@ def build_risk_profile(changed_files: list[str] | tuple[str, ...]) -> RiskProfil
             workflow_privileged=False,
             backend_shared=False,
             run_backend_blocking=False,
+            run_main_ci_diagnostic=False,
             run_security=False,
             run_openapi_sync=False,
             billing_entitlement=False,
@@ -325,6 +341,7 @@ def build_risk_profile(changed_files: list[str] | tuple[str, ...]) -> RiskProfil
         or group_hits["openapi_contract"]
         or group_hits["food_catalog"]
     )
+    run_main_ci_diagnostic = any(_is_main_ci_diagnostic_surface(path) for path in normalized_files)
     run_security = run_backend_blocking
     run_openapi_sync = run_backend_blocking
 
@@ -336,6 +353,7 @@ def build_risk_profile(changed_files: list[str] | tuple[str, ...]) -> RiskProfil
         workflow_privileged=workflow_privileged,
         backend_shared=backend_shared,
         run_backend_blocking=run_backend_blocking,
+        run_main_ci_diagnostic=run_main_ci_diagnostic,
         run_security=run_security,
         run_openapi_sync=run_openapi_sync,
         billing_entitlement=group_hits["billing_entitlement"],

--- a/scripts/ci/run_py312_main_shards.py
+++ b/scripts/ci/run_py312_main_shards.py
@@ -76,7 +76,8 @@ def partition_test_files(test_files: Sequence[TestFile], shard_count: int) -> li
     if not test_files:
         raise ValueError("no pytest files discovered")
 
-    shards = [TestShard(index=index) for index in range(1, shard_count + 1)]
+    effective_shard_count = min(shard_count, len(test_files))
+    shards = [TestShard(index=index) for index in range(1, effective_shard_count + 1)]
     for test_file in sorted(test_files, key=lambda item: (-item.weight, str(item.path))):
         shard = min(shards, key=lambda item: (item.weight, item.index))
         shard.add(test_file)
@@ -179,7 +180,7 @@ def collect_shard_results(
     for future, shard_index in futures.items():
         try:
             results[shard_index] = future.result()
-        except BaseException as exc:
+        except Exception as exc:
             print(
                 f"PY312_SHARD_EXCEPTION index={shard_index} "
                 f"type={type(exc).__name__} message={exc}",
@@ -188,6 +189,16 @@ def collect_shard_results(
             )
             results[shard_index] = 1
     return results
+
+
+def _log_coverage_failure(phase: str, returncode: int) -> None:
+    """Log the coverage phase that failed after all shards completed."""
+
+    print(
+        f"PY312_COVERAGE_{phase.upper()}_FAILED exit_code={returncode}",
+        file=sys.stderr,
+        flush=True,
+    )
 
 
 def run_all_shards(
@@ -204,14 +215,18 @@ def run_all_shards(
         raise ValueError("at least one shard is required")
 
     process_context = multiprocessing.get_context("spawn")
-    with concurrent.futures.ProcessPoolExecutor(
-        max_workers=min(max_parallel, len(shards)),
-        mp_context=process_context,
-    ) as executor:
-        futures = {
-            executor.submit(run_shard, repo_root, shard, base_env): shard.index for shard in shards
-        }
-        results = collect_shard_results(futures)
+    results: dict[int, int] = {}
+    for batch_start in range(0, len(shards), max_parallel):
+        batch = shards[batch_start : batch_start + max_parallel]
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=len(batch),
+            mp_context=process_context,
+        ) as executor:
+            futures = {
+                executor.submit(run_shard, repo_root, shard, base_env): shard.index
+                for shard in batch
+            }
+            results.update(collect_shard_results(futures))
 
     failing_shards = [
         shard_index for shard_index, exit_code in sorted(results.items()) if exit_code != 0
@@ -223,11 +238,16 @@ def run_all_shards(
     coverage_files = [shard.coverage_file for shard in shards]
     combine_status = run_coverage_command(repo_root, ["combine", *coverage_files])
     if combine_status != 0:
+        _log_coverage_failure("combine", combine_status)
         return combine_status
     xml_status = run_coverage_command(repo_root, ["xml"])
     if xml_status != 0:
+        _log_coverage_failure("xml", xml_status)
         return xml_status
-    return run_coverage_command(repo_root, ["report", "-m", "--fail-under=97"])
+    report_status = run_coverage_command(repo_root, ["report", "-m", "--fail-under=97"])
+    if report_status != 0:
+        _log_coverage_failure("report", report_status)
+    return report_status
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:

--- a/scripts/ci/run_py312_main_shards.py
+++ b/scripts/ci/run_py312_main_shards.py
@@ -114,7 +114,8 @@ def build_shard_env(base_env: dict[str, str], shard: TestShard, repo_root: Path)
     """Return an isolated environment for one pytest shard."""
 
     env = base_env.copy()
-    env["PYTEST_XDIST_WORKER"] = f"py312main{shard.index}"
+    env.pop("PYTEST_XDIST_WORKER", None)
+    env["PY312_MAIN_SHARD"] = str(shard.index)
     env["COVERAGE_FILE"] = str(repo_root / shard.coverage_file)
     env["COV_CORE_DATAFILE"] = str(repo_root / shard.coverage_file)
     env.setdefault("PYTEST_FAULTHANDLER_TIMEOUT_S", str(DEFAULT_FAULTHANDLER_TIMEOUT_SECONDS))
@@ -128,6 +129,7 @@ def run_shard(repo_root: Path, shard: TestShard, base_env: dict[str, str]) -> in
 
     pytest_args = build_pytest_args(shard)
     env = build_shard_env(base_env, shard, repo_root)
+    os.environ.pop("PYTEST_XDIST_WORKER", None)
     os.environ.update(env)
     os.chdir(repo_root)
     print(
@@ -135,6 +137,7 @@ def run_shard(repo_root: Path, shard: TestShard, base_env: dict[str, str]) -> in
         f"weight={shard.weight} junit={shard.junit_file}",
         flush=True,
     )
+    sys.argv = ["pytest"]
     exit_code = pytest.main(pytest_args)
     print(
         f"PY312_SHARD_FINISHED index={shard.index} exit_code={exit_code}",

--- a/scripts/ci/run_py312_main_shards.py
+++ b/scripts/ci/run_py312_main_shards.py
@@ -10,7 +10,7 @@ import os
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Sequence
+from typing import Mapping, Sequence
 
 DEFAULT_SHARD_COUNT = 2
 DEFAULT_MAX_PARALLEL = 2
@@ -167,6 +167,26 @@ def remove_previous_outputs(repo_root: Path, shards: Sequence[TestShard]) -> Non
             junit_path.unlink()
 
 
+def collect_shard_results(
+    futures: Mapping[concurrent.futures.Future[int], int],
+) -> dict[int, int]:
+    """Collect shard results and preserve diagnostics for crashed worker processes."""
+
+    results: dict[int, int] = {}
+    for future, shard_index in futures.items():
+        try:
+            results[shard_index] = future.result()
+        except BaseException as exc:
+            print(
+                f"PY312_SHARD_EXCEPTION index={shard_index} "
+                f"type={type(exc).__name__} message={exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+            results[shard_index] = 1
+    return results
+
+
 def run_all_shards(
     repo_root: Path,
     shards: Sequence[TestShard],
@@ -190,7 +210,7 @@ def run_all_shards(
                 executor.submit(run_shard, repo_root, shard, base_env): shard.index
                 for shard in shards
             }
-            results = {shard_index: future.result() for future, shard_index in futures.items()}
+            results = collect_shard_results(futures)
 
     failing_shards = [
         shard_index for shard_index, exit_code in sorted(results.items()) if exit_code != 0

--- a/scripts/ci/run_py312_main_shards.py
+++ b/scripts/ci/run_py312_main_shards.py
@@ -197,20 +197,18 @@ def run_all_shards(
 
     if max_parallel < 1:
         raise ValueError("max_parallel must be >= 1")
+    if not shards:
+        raise ValueError("at least one shard is required")
 
-    if max_parallel == 1:
-        results = {shard.index: run_shard(repo_root, shard, base_env) for shard in shards}
-    else:
-        process_context = multiprocessing.get_context("spawn")
-        with concurrent.futures.ProcessPoolExecutor(
-            max_workers=max_parallel,
-            mp_context=process_context,
-        ) as executor:
-            futures = {
-                executor.submit(run_shard, repo_root, shard, base_env): shard.index
-                for shard in shards
-            }
-            results = collect_shard_results(futures)
+    process_context = multiprocessing.get_context("spawn")
+    with concurrent.futures.ProcessPoolExecutor(
+        max_workers=min(max_parallel, len(shards)),
+        mp_context=process_context,
+    ) as executor:
+        futures = {
+            executor.submit(run_shard, repo_root, shard, base_env): shard.index for shard in shards
+        }
+        results = collect_shard_results(futures)
 
     failing_shards = [
         shard_index for shard_index, exit_code in sorted(results.items()) if exit_code != 0

--- a/scripts/ci/run_py312_main_shards.py
+++ b/scripts/ci/run_py312_main_shards.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Run Python 3.12 main-branch pytest shards without pytest-xdist."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import multiprocessing
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_SHARD_COUNT = 2
+DEFAULT_MAX_PARALLEL = 2
+DEFAULT_FAULTHANDLER_TIMEOUT_SECONDS = 300
+JUNIT_FAMILY = "legacy"
+SLOW_MARK_EXPRESSION = "not slow"
+
+
+@dataclass(frozen=True)
+class TestFile:
+    """A pytest file with a deterministic balancing weight."""
+
+    path: Path
+    weight: int
+
+
+@dataclass
+class TestShard:
+    """A collection of pytest files assigned to one process."""
+
+    index: int
+    files: list[TestFile] = field(default_factory=list)
+    weight: int = 0
+
+    def add(self, test_file: TestFile) -> None:
+        self.files.append(test_file)
+        self.weight += test_file.weight
+
+    @property
+    def coverage_file(self) -> str:
+        return f".coverage.py312-main-shard-{self.index}"
+
+    @property
+    def junit_file(self) -> str:
+        return f"tests/results-py312-shard-{self.index}.xml"
+
+
+def discover_test_files(repo_root: Path) -> list[TestFile]:
+    """Return all first-class pytest files for the main suite."""
+
+    tests_root = repo_root / "tests"
+    disabled_root = tests_root / "disabled_hypothesis"
+    discovered: list[TestFile] = []
+    for test_path in sorted(tests_root.rglob("test_*.py")):
+        if disabled_root in test_path.parents:
+            continue
+        if any(part.startswith(".") for part in test_path.relative_to(repo_root).parts):
+            continue
+        discovered.append(
+            TestFile(
+                path=test_path.relative_to(repo_root),
+                weight=max(test_path.stat().st_size, 1),
+            )
+        )
+    return discovered
+
+
+def partition_test_files(test_files: Sequence[TestFile], shard_count: int) -> list[TestShard]:
+    """Greedily balance files by size while keeping deterministic shard output."""
+
+    if shard_count < 1:
+        raise ValueError("shard_count must be >= 1")
+    if not test_files:
+        raise ValueError("no pytest files discovered")
+
+    shards = [TestShard(index=index) for index in range(1, shard_count + 1)]
+    for test_file in sorted(test_files, key=lambda item: (-item.weight, str(item.path))):
+        shard = min(shards, key=lambda item: (item.weight, item.index))
+        shard.add(test_file)
+
+    for shard in shards:
+        shard.files.sort(key=lambda item: str(item.path))
+    return shards
+
+
+def build_pytest_args(shard: TestShard) -> list[str]:
+    """Build one no-xdist pytest argv for a shard."""
+
+    return [
+        "-c",
+        "pyproject.toml",
+        "-p",
+        "no:xdist",
+        "-m",
+        SLOW_MARK_EXPRESSION,
+        "--durations=25",
+        "--durations-min=10.0",
+        "-o",
+        f"faulthandler_timeout={DEFAULT_FAULTHANDLER_TIMEOUT_SECONDS}",
+        "--cov=.",
+        "--cov-report=",
+        "--junitxml",
+        shard.junit_file,
+        "-o",
+        f"junit_family={JUNIT_FAMILY}",
+        *[str(test_file.path) for test_file in shard.files],
+    ]
+
+
+def build_shard_env(base_env: dict[str, str], shard: TestShard, repo_root: Path) -> dict[str, str]:
+    """Return an isolated environment for one pytest shard."""
+
+    env = base_env.copy()
+    env["PYTEST_XDIST_WORKER"] = f"py312main{shard.index}"
+    env["COVERAGE_FILE"] = str(repo_root / shard.coverage_file)
+    env["COV_CORE_DATAFILE"] = str(repo_root / shard.coverage_file)
+    env.setdefault("PYTEST_FAULTHANDLER_TIMEOUT_S", str(DEFAULT_FAULTHANDLER_TIMEOUT_SECONDS))
+    return env
+
+
+def run_shard(repo_root: Path, shard: TestShard, base_env: dict[str, str]) -> int:
+    """Run one pytest shard and return its process exit code."""
+
+    import pytest
+
+    pytest_args = build_pytest_args(shard)
+    env = build_shard_env(base_env, shard, repo_root)
+    os.environ.update(env)
+    os.chdir(repo_root)
+    print(
+        f"PY312_SHARD_STARTED index={shard.index} files={len(shard.files)} "
+        f"weight={shard.weight} junit={shard.junit_file}",
+        flush=True,
+    )
+    exit_code = pytest.main(pytest_args)
+    print(
+        f"PY312_SHARD_FINISHED index={shard.index} exit_code={exit_code}",
+        flush=True,
+    )
+    return int(exit_code)
+
+
+def run_coverage_command(repo_root: Path, args: Sequence[str]) -> int:
+    """Run a coverage command after all pytest shards pass."""
+
+    import coverage.cmdline
+
+    old_cwd = Path.cwd()
+    try:
+        os.chdir(repo_root)
+        return int(coverage.cmdline.main(list(args)) or 0)
+    finally:
+        os.chdir(old_cwd)
+
+
+def remove_previous_outputs(repo_root: Path, shards: Sequence[TestShard]) -> None:
+    """Remove stale shard coverage and JUnit files before execution."""
+
+    for coverage_file in repo_root.glob(".coverage.py312-main-shard-*"):
+        coverage_file.unlink()
+    for shard in shards:
+        junit_path = repo_root / shard.junit_file
+        if junit_path.exists():
+            junit_path.unlink()
+
+
+def run_all_shards(
+    repo_root: Path,
+    shards: Sequence[TestShard],
+    max_parallel: int,
+    base_env: dict[str, str],
+) -> int:
+    """Run all shards, then combine and enforce coverage if all pass."""
+
+    if max_parallel < 1:
+        raise ValueError("max_parallel must be >= 1")
+
+    if max_parallel == 1:
+        results = {shard.index: run_shard(repo_root, shard, base_env) for shard in shards}
+    else:
+        process_context = multiprocessing.get_context("spawn")
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=max_parallel,
+            mp_context=process_context,
+        ) as executor:
+            futures = {
+                executor.submit(run_shard, repo_root, shard, base_env): shard.index
+                for shard in shards
+            }
+            results = {shard_index: future.result() for future, shard_index in futures.items()}
+
+    failing_shards = [
+        shard_index for shard_index, exit_code in sorted(results.items()) if exit_code != 0
+    ]
+    if failing_shards:
+        print(f"PY312_SHARDS_FAILED shards={failing_shards}", file=sys.stderr)
+        return 1
+
+    coverage_files = [shard.coverage_file for shard in shards]
+    combine_status = run_coverage_command(repo_root, ["combine", *coverage_files])
+    if combine_status != 0:
+        return combine_status
+    xml_status = run_coverage_command(repo_root, ["xml"])
+    if xml_status != 0:
+        return xml_status
+    return run_coverage_command(repo_root, ["report", "-m", "--fail-under=97"])
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--shard-count", type=int, default=DEFAULT_SHARD_COUNT)
+    parser.add_argument("--max-parallel", type=int, default=DEFAULT_MAX_PARALLEL)
+    parser.add_argument(
+        "--list-shards",
+        action="store_true",
+        help="Print deterministic shard assignment without running pytest.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    repo_root = args.repo_root.resolve()
+    test_files = discover_test_files(repo_root)
+    shards = partition_test_files(test_files, args.shard_count)
+
+    for shard in shards:
+        print(
+            f"PY312_SHARD_PLAN index={shard.index} files={len(shard.files)} "
+            f"weight={shard.weight}",
+            flush=True,
+        )
+        if args.list_shards:
+            for test_file in shard.files:
+                print(f"  {test_file.path}")
+
+    if args.list_shards:
+        return 0
+
+    remove_previous_outputs(repo_root, shards)
+    return run_all_shards(repo_root, shards, args.max_parallel, os.environ.copy())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_risk_profile.py
+++ b/tests/test_ci_risk_profile.py
@@ -21,6 +21,7 @@ def test_empty_changed_files_uses_default_risk_profile() -> None:
     assert profile.workflow_privileged is False
     assert profile.backend_shared is False
     assert profile.run_backend_blocking is False
+    assert profile.run_main_ci_diagnostic is False
     assert profile.run_security is False
     assert profile.run_openapi_sync is False
     assert profile.billing_entitlement is False
@@ -71,8 +72,26 @@ def test_hidden_workflow_path_preserves_leading_dot_for_routing() -> None:
     assert profile.workflow_privileged is True
     assert profile.merge_governance is True
     assert profile.run_backend_blocking is True
+    assert profile.run_main_ci_diagnostic is True
     assert profile.run_openapi_sync is True
     assert profile.contract_risk_groups == risk_profile.ALL_RISK_GROUPS
+
+
+def test_main_ci_diagnostic_is_scoped_to_main_ci_surfaces() -> None:
+    positive_profile = risk_profile.build_risk_profile(
+        [
+            "scripts/ci/run_py312_main_shards.py",
+            "tests/test_py312_main_shards.py",
+        ],
+    )
+    negative_profile = risk_profile.build_risk_profile(
+        ["scripts/ci/check_docs_phase1_gates.py"],
+    )
+
+    assert positive_profile.workflow_privileged is True
+    assert positive_profile.run_main_ci_diagnostic is True
+    assert negative_profile.workflow_privileged is True
+    assert negative_profile.run_main_ci_diagnostic is False
 
 
 def test_hidden_github_scripts_path_is_workflow_privileged() -> None:
@@ -299,6 +318,7 @@ def test_cli_writes_github_outputs(
     assert payload["billing_entitlement"] is True
     written = github_output.read_text(encoding="utf-8")
     assert "run_backend_blocking=true" in written
+    assert "run_main_ci_diagnostic=false" in written
     assert "billing_entitlement=true" in written
 
 

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -210,6 +210,13 @@ def test_main_branch_py312_sharded_runner_preserves_required_check_policy() -> N
 
     test_main = jobs["test-main"]
     assert isinstance(test_main, dict)
+    test_main_needs = test_main["needs"]
+    assert isinstance(test_main_needs, list)
+    assert "changes" in test_main_needs
+    test_main_if = test_main["if"]
+    assert isinstance(test_main_if, str)
+    assert "github.ref == 'refs/heads/main'" in test_main_if
+    assert "needs.changes.outputs.run_main_ci_diagnostic == 'true'" in test_main_if
     matrix = test_main["strategy"]["matrix"]["include"]
     assert isinstance(matrix, list)
 
@@ -236,10 +243,12 @@ def test_main_branch_py312_sharded_runner_preserves_required_check_policy() -> N
     )
 
     assert "python scripts/ci/run_py312_main_shards.py" in py312_block
-    assert "--shard-count 2" in py312_block
-    assert "--max-parallel 2" in py312_block
+    assert '--shard-count "${PY312_MAIN_SHARDS}"' in py312_block
+    assert '--max-parallel "${PY312_MAIN_MAX_PARALLEL}"' in py312_block
     assert "PY312_MAIN_SHARDS=2" in py312_block
     assert "PY312_MAIN_MAX_PARALLEL=2" in py312_block
+    assert 'echo "PY312_MAIN_SHARDS=${PY312_MAIN_SHARDS}"' in py312_block
+    assert 'echo "PY312_MAIN_MAX_PARALLEL=${PY312_MAIN_MAX_PARALLEL}"' in py312_block
     assert "PYTEST_XDIST_ARGS=(-p no:xdist)" not in py312_block
     assert "PYTEST_XDIST_ARGS=(-n 2 --dist=loadscope)" not in py312_block
     assert "PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)" not in py312_block

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -203,7 +203,7 @@ def test_ios_unit_tests_stay_in_blocking_ios_job() -> None:
     assert 'ONLY_TESTING="$(../scripts/ios_test_targets.sh)"' not in ios_ui_smoke_section
 
 
-def test_main_branch_xdist_fallback_stays_scoped_to_unstable_interpreters() -> None:
+def test_main_branch_py312_sharded_runner_preserves_required_check_policy() -> None:
     workflow = _load_ci_workflow()
     jobs = workflow["jobs"]
     assert isinstance(jobs, dict)
@@ -219,14 +219,14 @@ def test_main_branch_xdist_fallback_stays_scoped_to_unstable_interpreters() -> N
     workflow_text = CI_WORKFLOW_PATH.read_text(encoding="utf-8")
     test_main_section = _extract_job_section(workflow_text, "  test-main:")
 
-    py313_block = _extract_shell_conditional_block(
-        test_main_section,
-        'if [[ "$PYVER" == 3.13* ]]; then',
-        '          elif [[ "$PYVER" == 3.12* ]]; then',
-    )
     py312_block = _extract_shell_conditional_block(
         test_main_section,
-        '          elif [[ "$PYVER" == 3.12* ]]; then',
+        'if [[ "$PYVER" == 3.12* ]]; then',
+        '          elif [[ "$PYVER" == 3.13* ]]; then',
+    )
+    py313_block = _extract_shell_conditional_block(
+        test_main_section,
+        '          elif [[ "$PYVER" == 3.13* ]]; then',
         "          else",
     )
     default_block = _extract_shell_conditional_block(
@@ -235,18 +235,27 @@ def test_main_branch_xdist_fallback_stays_scoped_to_unstable_interpreters() -> N
         "          fi",
     )
 
+    assert "python scripts/ci/run_py312_main_shards.py" in py312_block
+    assert "--shard-count 2" in py312_block
+    assert "--max-parallel 2" in py312_block
+    assert "PY312_MAIN_SHARDS=2" in py312_block
+    assert "PY312_MAIN_MAX_PARALLEL=2" in py312_block
+    assert "PYTEST_XDIST_ARGS=(-p no:xdist)" not in py312_block
+    assert "PYTEST_XDIST_ARGS=(-n 2 --dist=loadscope)" not in py312_block
+    assert "PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)" not in py312_block
+    assert "TEST_STEP_STARTED_AT=" in test_main_section
+    assert "TEST_STEP_FINISHED_AT=" in py312_block
+
     assert "PYTEST_XDIST_ARGS=(-p no:xdist)" in py313_block
     assert "PYTEST_XDIST_ARGS=(-n 2 --dist=loadscope)" not in py313_block
     assert "PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)" not in py313_block
 
-    assert "PYTEST_XDIST_ARGS=(-p no:xdist)" in py312_block
-    assert "PYTEST_XDIST_ARGS=(-n 2 --dist=loadscope)" not in py312_block
-    assert "PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)" not in py312_block
     assert '-m "not slow"' in test_main_section
     assert '-m "not serial and not slow"' not in test_main_section
     assert '-m "serial and not slow"' not in test_main_section
     assert "--cov-append" not in test_main_section
     assert "tests/results-serial.xml" not in test_main_section
+    assert "tests/results-py312-shard-*.xml" in test_main_section
 
     assert "PYTEST_XDIST_ARGS=(-n 4 --dist=loadscope)" in default_block
     assert "PYTEST_XDIST_ARGS=(-p no:xdist)" not in default_block

--- a/tests/test_py312_main_shards.py
+++ b/tests/test_py312_main_shards.py
@@ -145,6 +145,8 @@ def test_run_all_shards_max_parallel_one_uses_child_process_isolation(
         weight=1,
     )
     original_cwd = Path.cwd()
+    original_probe = os.environ.get("PY312_PARENT_LEAK_PROBE")
+    original_worker = os.environ.get("PYTEST_XDIST_WORKER")
     base_env = {
         key: value
         for key, value in os.environ.items()
@@ -161,8 +163,8 @@ def test_run_all_shards_max_parallel_one_uses_child_process_isolation(
 
     assert runner.run_all_shards(tmp_path, [shard], 1, base_env) == 0
     assert Path.cwd() == original_cwd
-    assert os.environ.get("PY312_PARENT_LEAK_PROBE") is None
-    assert os.environ.get("PYTEST_XDIST_WORKER") is None
+    assert os.environ.get("PY312_PARENT_LEAK_PROBE") == original_probe
+    assert os.environ.get("PYTEST_XDIST_WORKER") == original_worker
     assert coverage_calls == [
         ["combine", ".coverage.py312-main-shard-1"],
         ["xml"],

--- a/tests/test_py312_main_shards.py
+++ b/tests/test_py312_main_shards.py
@@ -1,0 +1,180 @@
+"""Regression tests for the Python 3.12 main-suite shard runner."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import coverage.cmdline
+import pytest
+
+from scripts.ci import run_py312_main_shards as runner
+
+
+def _write_test_file(repo_root: Path, relative_path: str, content: str) -> Path:
+    path = repo_root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_discover_test_files_includes_edges_and_excludes_disabled(tmp_path: Path) -> None:
+    _write_test_file(tmp_path, "tests/test_alpha.py", "def test_alpha(): pass\n")
+    _write_test_file(tmp_path, "tests/edges/test_beta.py", "def test_beta(): pass\n")
+    _write_test_file(
+        tmp_path,
+        "tests/disabled_hypothesis/test_gamma.py",
+        "def test_gamma(): pass\n",
+    )
+    _write_test_file(tmp_path, "tests/helper_alpha.py", "VALUE = 1\n")
+
+    discovered = runner.discover_test_files(tmp_path)
+
+    assert [test_file.path.as_posix() for test_file in discovered] == [
+        "tests/edges/test_beta.py",
+        "tests/test_alpha.py",
+    ]
+
+
+def test_partition_test_files_balances_by_weight_and_keeps_all_files() -> None:
+    files = [
+        runner.TestFile(Path("tests/test_big.py"), 100),
+        runner.TestFile(Path("tests/test_medium.py"), 60),
+        runner.TestFile(Path("tests/test_small.py"), 20),
+        runner.TestFile(Path("tests/test_tiny.py"), 10),
+    ]
+
+    shards = runner.partition_test_files(files, shard_count=2)
+
+    assert [shard.weight for shard in shards] == [100, 90]
+    assert {test_file.path.as_posix() for shard in shards for test_file in shard.files} == {
+        "tests/test_big.py",
+        "tests/test_medium.py",
+        "tests/test_small.py",
+        "tests/test_tiny.py",
+    }
+
+
+def test_partition_test_files_rejects_invalid_input() -> None:
+    with pytest.raises(ValueError, match="shard_count"):
+        runner.partition_test_files([runner.TestFile(Path("tests/test_alpha.py"), 1)], 0)
+
+    with pytest.raises(ValueError, match="no pytest files"):
+        runner.partition_test_files([], 1)
+
+
+def test_build_pytest_args_disables_xdist_and_emits_junit() -> None:
+    shard = runner.TestShard(
+        index=2,
+        files=[runner.TestFile(Path("tests/test_alpha.py"), 10)],
+        weight=10,
+    )
+
+    pytest_args = runner.build_pytest_args(shard)
+
+    assert pytest_args[:2] == ["-c", "pyproject.toml"]
+    assert "-p" in pytest_args
+    assert "no:xdist" in pytest_args
+    assert "-m" in pytest_args
+    assert runner.SLOW_MARK_EXPRESSION in pytest_args
+    assert f"junit_family={runner.JUNIT_FAMILY}" in pytest_args
+    assert shard.junit_file in pytest_args
+    assert "tests/test_alpha.py" in pytest_args
+
+
+def test_build_shard_env_isolates_database_and_coverage(tmp_path: Path) -> None:
+    shard = runner.TestShard(index=1)
+    env = runner.build_shard_env({"EXISTING": "1"}, shard, tmp_path)
+
+    assert env["EXISTING"] == "1"
+    assert env["PYTEST_XDIST_WORKER"] == "py312main1"
+    assert env["COVERAGE_FILE"] == str(tmp_path / ".coverage.py312-main-shard-1")
+    assert env["COV_CORE_DATAFILE"] == str(tmp_path / ".coverage.py312-main-shard-1")
+    assert env["PYTEST_FAULTHANDLER_TIMEOUT_S"] == "300"
+
+
+def test_remove_previous_outputs_deletes_stale_shard_files(tmp_path: Path) -> None:
+    shard = runner.TestShard(index=1)
+    coverage_file = tmp_path / shard.coverage_file
+    junit_file = tmp_path / shard.junit_file
+    coverage_file.write_text("old", encoding="utf-8")
+    junit_file.parent.mkdir(parents=True, exist_ok=True)
+    junit_file.write_text("old", encoding="utf-8")
+
+    runner.remove_previous_outputs(tmp_path, [shard])
+
+    assert not coverage_file.exists()
+    assert not junit_file.exists()
+
+
+def test_run_all_shards_returns_failure_without_coverage_combine(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    shard = runner.TestShard(index=1)
+    calls: list[str] = []
+
+    def fake_run_shard(
+        repo_root: Path,
+        test_shard: runner.TestShard,
+        base_env: dict[str, str],
+    ) -> int:
+        calls.append(f"shard:{test_shard.index}:{repo_root == tmp_path}:{bool(base_env)}")
+        return 5
+
+    def fake_coverage(repo_root: Path, args: list[str]) -> int:
+        calls.append(f"coverage:{args}")
+        return 0
+
+    monkeypatch.setattr(runner, "run_shard", fake_run_shard)
+    monkeypatch.setattr(runner, "run_coverage_command", fake_coverage)
+
+    assert runner.run_all_shards(tmp_path, [shard], 1, os.environ.copy()) == 1
+    assert calls == ["shard:1:True:True"]
+
+
+def test_run_all_shards_combines_coverage_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    shard = runner.TestShard(index=1)
+    coverage_calls: list[list[str]] = []
+
+    monkeypatch.setattr(
+        runner,
+        "run_shard",
+        lambda repo_root, test_shard, base_env: 0,
+    )
+
+    def fake_coverage(repo_root: Path, args: list[str]) -> int:
+        coverage_calls.append(list(args))
+        return 0
+
+    monkeypatch.setattr(runner, "run_coverage_command", fake_coverage)
+
+    assert runner.run_all_shards(tmp_path, [shard], 1, os.environ.copy()) == 0
+    assert coverage_calls == [
+        ["combine", ".coverage.py312-main-shard-1"],
+        ["xml"],
+        ["report", "-m", "--fail-under=97"],
+    ]
+
+
+def test_run_coverage_command_uses_coverage_api(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_main(args: list[str]) -> int:
+        captured["args"] = args
+        captured["cwd"] = Path.cwd()
+        return 0
+
+    monkeypatch.setattr(coverage.cmdline, "main", fake_main)
+
+    assert runner.run_coverage_command(tmp_path, ["xml"]) == 0
+    assert captured == {
+        "args": ["xml"],
+        "cwd": tmp_path,
+    }

--- a/tests/test_py312_main_shards.py
+++ b/tests/test_py312_main_shards.py
@@ -85,10 +85,15 @@ def test_build_pytest_args_disables_xdist_and_emits_junit() -> None:
 
 def test_build_shard_env_isolates_database_and_coverage(tmp_path: Path) -> None:
     shard = runner.TestShard(index=1)
-    env = runner.build_shard_env({"EXISTING": "1"}, shard, tmp_path)
+    env = runner.build_shard_env(
+        {"EXISTING": "1", "PYTEST_XDIST_WORKER": "gw0"},
+        shard,
+        tmp_path,
+    )
 
     assert env["EXISTING"] == "1"
-    assert env["PYTEST_XDIST_WORKER"] == "py312main1"
+    assert "PYTEST_XDIST_WORKER" not in env
+    assert env["PY312_MAIN_SHARD"] == "1"
     assert env["COVERAGE_FILE"] == str(tmp_path / ".coverage.py312-main-shard-1")
     assert env["COV_CORE_DATAFILE"] == str(tmp_path / ".coverage.py312-main-shard-1")
     assert env["PYTEST_FAULTHANDLER_TIMEOUT_S"] == "300"
@@ -128,12 +133,15 @@ def test_run_all_shards_max_parallel_one_uses_child_process_isolation(
         "\n".join(
             [
                 "import os",
+                "import sys",
                 "from pathlib import Path",
                 "",
                 "def test_mutates_process_state():",
                 "    os.environ['PY312_PARENT_LEAK_PROBE'] = 'child-only'",
                 "    os.chdir(Path.cwd() / 'tests')",
-                "    assert os.environ['PYTEST_XDIST_WORKER'] == 'py312main1'",
+                "    assert 'PYTEST_XDIST_WORKER' not in os.environ",
+                "    assert os.environ['PY312_MAIN_SHARD'] == '1'",
+                "    assert sys.argv == ['pytest']",
                 "",
             ]
         ),

--- a/tests/test_py312_main_shards.py
+++ b/tests/test_py312_main_shards.py
@@ -108,52 +108,61 @@ def test_remove_previous_outputs_deletes_stale_shard_files(tmp_path: Path) -> No
     assert not junit_file.exists()
 
 
-def test_run_all_shards_returns_failure_without_coverage_combine(
+def test_run_all_shards_rejects_invalid_parallelism(tmp_path: Path) -> None:
+    shard = runner.TestShard(index=1)
+
+    with pytest.raises(ValueError, match="max_parallel"):
+        runner.run_all_shards(tmp_path, [shard], 0, {})
+
+    with pytest.raises(ValueError, match="at least one shard"):
+        runner.run_all_shards(tmp_path, [], 1, {})
+
+
+def test_run_all_shards_max_parallel_one_uses_child_process_isolation(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    shard = runner.TestShard(index=1)
-    calls: list[str] = []
-
-    def fake_run_shard(
-        repo_root: Path,
-        test_shard: runner.TestShard,
-        base_env: dict[str, str],
-    ) -> int:
-        calls.append(f"shard:{test_shard.index}:{repo_root == tmp_path}:{bool(base_env)}")
-        return 5
-
-    def fake_coverage(repo_root: Path, args: list[str]) -> int:
-        calls.append(f"coverage:{args}")
-        return 0
-
-    monkeypatch.setattr(runner, "run_shard", fake_run_shard)
-    monkeypatch.setattr(runner, "run_coverage_command", fake_coverage)
-
-    assert runner.run_all_shards(tmp_path, [shard], 1, os.environ.copy()) == 1
-    assert calls == ["shard:1:True:True"]
-
-
-def test_run_all_shards_combines_coverage_after_success(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    shard = runner.TestShard(index=1)
+    test_path = _write_test_file(
+        tmp_path,
+        "tests/test_child_process_isolation.py",
+        "\n".join(
+            [
+                "import os",
+                "from pathlib import Path",
+                "",
+                "def test_mutates_process_state():",
+                "    os.environ['PY312_PARENT_LEAK_PROBE'] = 'child-only'",
+                "    os.chdir(Path.cwd() / 'tests')",
+                "    assert os.environ['PYTEST_XDIST_WORKER'] == 'py312main1'",
+                "",
+            ]
+        ),
+    )
+    (tmp_path / "pyproject.toml").write_text("[tool.pytest.ini_options]\n", encoding="utf-8")
+    shard = runner.TestShard(
+        index=1,
+        files=[runner.TestFile(test_path.relative_to(tmp_path), 1)],
+        weight=1,
+    )
+    original_cwd = Path.cwd()
+    base_env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in {"PY312_PARENT_LEAK_PROBE", "PYTEST_XDIST_WORKER"}
+    }
     coverage_calls: list[list[str]] = []
 
-    monkeypatch.setattr(
-        runner,
-        "run_shard",
-        lambda repo_root, test_shard, base_env: 0,
-    )
-
     def fake_coverage(repo_root: Path, args: list[str]) -> int:
+        assert repo_root == tmp_path
         coverage_calls.append(list(args))
         return 0
 
     monkeypatch.setattr(runner, "run_coverage_command", fake_coverage)
 
-    assert runner.run_all_shards(tmp_path, [shard], 1, os.environ.copy()) == 0
+    assert runner.run_all_shards(tmp_path, [shard], 1, base_env) == 0
+    assert Path.cwd() == original_cwd
+    assert os.environ.get("PY312_PARENT_LEAK_PROBE") is None
+    assert os.environ.get("PYTEST_XDIST_WORKER") is None
     assert coverage_calls == [
         ["combine", ".coverage.py312-main-shard-1"],
         ["xml"],

--- a/tests/test_py312_main_shards.py
+++ b/tests/test_py312_main_shards.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from concurrent.futures import Future
 from pathlib import Path
 
 import coverage.cmdline
@@ -158,6 +159,22 @@ def test_run_all_shards_combines_coverage_after_success(
         ["xml"],
         ["report", "-m", "--fail-under=97"],
     ]
+
+
+def test_collect_shard_results_reports_worker_exceptions(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    success: Future[int] = Future()
+    failure: Future[int] = Future()
+    success.set_result(0)
+    failure.set_exception(RuntimeError("native crash"))
+
+    results = runner.collect_shard_results({success: 1, failure: 2})
+
+    assert results == {1: 0, 2: 1}
+    assert "PY312_SHARD_EXCEPTION index=2 type=RuntimeError message=native crash" in (
+        capsys.readouterr().err
+    )
 
 
 def test_run_coverage_command_uses_coverage_api(

--- a/tests/test_py312_main_shards.py
+++ b/tests/test_py312_main_shards.py
@@ -56,6 +56,15 @@ def test_partition_test_files_balances_by_weight_and_keeps_all_files() -> None:
     }
 
 
+def test_partition_test_files_never_returns_empty_shards() -> None:
+    files = [runner.TestFile(Path("tests/test_only.py"), 100)]
+
+    shards = runner.partition_test_files(files, shard_count=4)
+
+    assert len(shards) == 1
+    assert shards[0].files == files
+
+
 def test_partition_test_files_rejects_invalid_input() -> None:
     with pytest.raises(ValueError, match="shard_count"):
         runner.partition_test_files([runner.TestFile(Path("tests/test_alpha.py"), 1)], 0)
@@ -127,9 +136,9 @@ def test_run_all_shards_max_parallel_one_uses_child_process_isolation(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    test_path = _write_test_file(
+    first_test_path = _write_test_file(
         tmp_path,
-        "tests/test_child_process_isolation.py",
+        "tests/test_child_process_isolation_first.py",
         "\n".join(
             [
                 "import os",
@@ -146,10 +155,30 @@ def test_run_all_shards_max_parallel_one_uses_child_process_isolation(
             ]
         ),
     )
+    second_test_path = _write_test_file(
+        tmp_path,
+        "tests/test_child_process_isolation_second.py",
+        "\n".join(
+            [
+                "import os",
+                "",
+                "def test_does_not_see_previous_shard_state():",
+                "    assert os.environ.get('PY312_PARENT_LEAK_PROBE') is None",
+                "    assert 'PYTEST_XDIST_WORKER' not in os.environ",
+                "    assert os.environ['PY312_MAIN_SHARD'] == '2'",
+                "",
+            ]
+        ),
+    )
     (tmp_path / "pyproject.toml").write_text("[tool.pytest.ini_options]\n", encoding="utf-8")
-    shard = runner.TestShard(
+    first_shard = runner.TestShard(
         index=1,
-        files=[runner.TestFile(test_path.relative_to(tmp_path), 1)],
+        files=[runner.TestFile(first_test_path.relative_to(tmp_path), 1)],
+        weight=1,
+    )
+    second_shard = runner.TestShard(
+        index=2,
+        files=[runner.TestFile(second_test_path.relative_to(tmp_path), 1)],
         weight=1,
     )
     original_cwd = Path.cwd()
@@ -169,12 +198,12 @@ def test_run_all_shards_max_parallel_one_uses_child_process_isolation(
 
     monkeypatch.setattr(runner, "run_coverage_command", fake_coverage)
 
-    assert runner.run_all_shards(tmp_path, [shard], 1, base_env) == 0
+    assert runner.run_all_shards(tmp_path, [first_shard, second_shard], 1, base_env) == 0
     assert Path.cwd() == original_cwd
     assert os.environ.get("PY312_PARENT_LEAK_PROBE") == original_probe
     assert os.environ.get("PYTEST_XDIST_WORKER") == original_worker
     assert coverage_calls == [
-        ["combine", ".coverage.py312-main-shard-1"],
+        ["combine", ".coverage.py312-main-shard-1", ".coverage.py312-main-shard-2"],
         ["xml"],
         ["report", "-m", "--fail-under=97"],
     ]
@@ -192,6 +221,70 @@ def test_collect_shard_results_reports_worker_exceptions(
 
     assert results == {1: 0, 2: 1}
     assert "PY312_SHARD_EXCEPTION index=2 type=RuntimeError message=native crash" in (
+        capsys.readouterr().err
+    )
+
+
+def test_collect_shard_results_propagates_termination_signals() -> None:
+    interrupted: Future[int] = Future()
+    interrupted.set_exception(KeyboardInterrupt())
+
+    with pytest.raises(KeyboardInterrupt):
+        runner.collect_shard_results({interrupted: 1})
+
+
+@pytest.mark.parametrize(
+    ("phase", "coverage_calls", "expected_status"),
+    [
+        ("combine", [(["combine", ".coverage.py312-main-shard-1"], 2)], 2),
+        (
+            "xml",
+            [
+                (["combine", ".coverage.py312-main-shard-1"], 0),
+                (["xml"], 3),
+            ],
+            3,
+        ),
+        (
+            "report",
+            [
+                (["combine", ".coverage.py312-main-shard-1"], 0),
+                (["xml"], 0),
+                (["report", "-m", "--fail-under=97"], 4),
+            ],
+            4,
+        ),
+    ],
+)
+def test_run_all_shards_logs_coverage_phase_failures(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    phase: str,
+    coverage_calls: list[tuple[list[str], int]],
+    expected_status: int,
+) -> None:
+    test_path = _write_test_file(tmp_path, "tests/test_alpha.py", "def test_alpha(): pass\n")
+    (tmp_path / "pyproject.toml").write_text("[tool.pytest.ini_options]\n", encoding="utf-8")
+    shard = runner.TestShard(
+        index=1,
+        files=[runner.TestFile(test_path.relative_to(tmp_path), 1)],
+        weight=1,
+    )
+
+    pending_calls = list(coverage_calls)
+
+    def fake_coverage(repo_root: Path, args: list[str]) -> int:
+        assert repo_root == tmp_path
+        expected_args, status = pending_calls.pop(0)
+        assert args == expected_args
+        return status
+
+    monkeypatch.setattr(runner, "run_coverage_command", fake_coverage)
+
+    assert runner.run_all_shards(tmp_path, [shard], 1, {}) == expected_status
+    assert pending_calls == []
+    assert f"PY312_COVERAGE_{phase.upper()}_FAILED exit_code={expected_status}" in (
         capsys.readouterr().err
     )
 


### PR DESCRIPTION
## Summary

- Preserves the required `test-main (3.12, 60)` check identity and timeout.
- Replaces the Python 3.12 main-branch single sequential no-xdist pytest invocation with deterministic process-level file shards, still with `-p no:xdist`.
- Combines shard coverage and enforces the existing 97% threshold after all shards pass.
- Adds shard-specific JUnit artifacts, root-cause lane governance docs/backlog wiring, and a PR-only diagnostic gate for main-CI Python 3.12 contract changes.
- Reports `PY312_SHARD_EXCEPTION index=<n>` if a native crash breaks a shard worker process.

## Evidence

- PR #1494 reduced Python 3.12 xdist pressure but did not stabilize main.
- PR #1501 split serial tests but did not stabilize main.
- PR #1505 disabled xdist for Python 3.12 as containment.
- Main run `24843626627` cancelled `test-main (3.12, 60)` after its test step started at `2026-04-23T15:26:19Z`.
- Main run `24849990678` cancelled `test-main (3.12, 60)` while the coverage step ran from `2026-04-23T19:04:22Z` to `2026-04-23T19:36:03Z`.
- Main run `24854923154`, job `72765173124`, failed `test-main (3.12, 60)` at roughly 20% with `Segmentation fault (core dumped)` in the sequential no-xdist coverage command.

## Split Justification

The Python 3.12 timeout/crash fix must keep the required `test-main (3.12, 60)` check identity, workflow contract, shard runner, governance tests, root-cause packet, backlog entry, and fixed-mapping artifact in one PR. Splitting the runner from the workflow/governance proof would create a merge window where CI behavior and policy assertions disagree.

## CI Contract

- No timeout bump.
- No `continue-on-error`.
- No pytest failure masking.
- No coverage gate weakening.
- Python 3.11 stays on xdist `-n 4 --dist=loadscope`.
- Python 3.12 uses spawned process-level shards, including `--max-parallel 1` isolation if that mode is selected.
- Python 3.13 keeps the existing no-xdist fallback.
- PRs touching the Python 3.12 main-CI runner/workflow contract run the `test-main` matrix through `run_main_ci_diagnostic` before merge.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Canonical artifact: `docs/review/PR_1511_FIXED_MAPPING.md`.

### Fixed in Commit Mapping

- CodeRabbit review `4165580559` actionables fixed in `853694874` and mapped in `docs/review/PR_1511_FIXED_MAPPING.md`.
- QA post-open blocker fixed in `853694874`: PR CI now runs `test-main` for scoped main-CI diagnostic changes instead of skipping the proof path.

## Validation

- `PYENV_VERSION=3.12.7 python -m pytest -q tests/test_ci_risk_profile.py tests/test_ci_workflow_pr_size_governance_contract.py tests/test_py312_main_shards.py` PASS.
- `python3 scripts/orchestration/check_preflight.py --path .github/workflows/ci.yml --path scripts/ci/ci_risk_profile.py --path scripts/ci/run_py312_main_shards.py --path tests/test_ci_risk_profile.py --path tests/test_ci_workflow_pr_size_governance_contract.py --path docs/orchestration --path docs/roadmap/BACKLOG_LEDGER.md` PASS.
- `python3 scripts/orchestration/check_agent_consistency.py` PASS.
- `VENV_PYTHON=.venv/bin/python make validate-changed` PASS.
- `pre-commit run --all-files` PASS.
- Push pre-push hooks PASS: yaml, workflow check, black, ruff, mypy changed files, pip-audit, backend pre-push pytest, full-repo bandit, docker build test.
- Local CodeRabbit CLI `coderabbit review --plain -t committed --base main -c AGENTS.md` PASS after fixes.

## Current Gate

This PR is ready for current-head CI proof but is not merge-ready until `test-main (3.12, 60)`, Python 3.11/3.13, iOS Xcode 26 jobs, review governance, and the final merge-readiness wrapper pass on the latest head. Local full `make verify` is deferred because the known failure mode is the full main-suite runtime budget; GitHub current-head CI is the heavy signal for this lane.

## Merge Readiness

- [ ] Current-head `test-main (3.12, 60)` completes without timeout.
- [ ] Current-head `test-main (3.12, 60)` has no xdist worker-node termination.
- [ ] `test-main (3.11, 60)` and `test-main (3.13, 90)` do not regress.
- [ ] CodeRabbit, Sourcery, and Cubic actionables are mapped or explicitly marked non-actionable.
- [ ] Final check pass completed after latest bot/review activity.
- [ ] Waited at least one review cycle before merge.

## Security Notes

This changes CI orchestration only. It does not broaden workflow permissions, use privileged events, ignore failures, add `continue-on-error`, or weaken coverage. The shard runner avoids shell/subprocess execution and runs pytest shards through Python spawned process workers.

## Marketing & GTM

No product-facing impact. No release messaging needed.

## Summary by Sourcery

Ввести детерминированный шардированный раннер без xdist для основной CI-матрицы Python 3.12 и подключить его к CI‑workflow с целевой диагностикой при сохранении существующего контракта обязательных проверок (required checks).

Новые возможности:
- Добавить Python‑основанный shard runner, который разбивает основную тестовую матрицу Python 3.12 на детерминированные шардированные процессы с объединённым coverage и отдельными JUnit‑артефактами для каждого шарда.
- Включить опциональный диагностический путь основной CI, который запускает полную матрицу test-main для pull request’ов, затрагивающих раннер или workflow‑контракт основной CI для Python 3.12.

Улучшения:
- Обновить основной CI‑workflow, чтобы направлять задания Python 3.12 test-main через новый shard runner, включая метаданные по времени выполнения и сбор артефактов, при этом не изменяя поведение для Python 3.11 и 3.13.
- Расширить логику профилирования рисков в CI для обнаружения изменений, связанных с main CI, и эмитировать флаг `run_main_ci_diagnostic`, потребляемый workflow.
- Укрепить governance‑тесты, чтобы зафиксировать новый роутинг test-main, конфигурацию шардов и условия обязательных проверок (required checks) для Python 3.12.
- Задокументировать lane, связанный с первопричиной таймаутов в Python 3.12, и его CI‑контракт, а также обновить записи в backlog‑ledger с учётом новой стратегии смягчения риска и плана последующих действий.
- Зафиксировать привязку fixed-in-commit и исходные подтверждающие данные для этого PR в ревью‑документации.

Тесты:
- Добавить модульные тесты для shard runner’а Python 3.12, покрывающие поиск файлов, разбиение на части, изоляцию окружения, оркестрацию coverage и диагностику сбоев.
- Расширить тесты профиля рисков CI, чтобы покрыть новый флаг `run_main_ci_diagnostic` и его поведение в маршрутизации.
- Обновить тесты workflow‑контракта CI для проверки подключения шардированного раннера Python 3.12, временных маркеров и схемы именования JUnit‑артефактов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a deterministic, no-xdist sharded runner for the Python 3.12 main CI suite and wire it into the CI workflow with targeted diagnostics while preserving the existing required-check contract.

New Features:
- Add a Python-based shard runner that splits the Python 3.12 main test suite into deterministic process-level shards with combined coverage and shard-specific JUnit outputs.
- Enable an opt-in main CI diagnostic path that runs the full test-main matrix on pull requests that touch the Python 3.12 main CI runner or workflow contract.

Enhancements:
- Update the main CI workflow to route Python 3.12 test-main jobs through the new shard runner, including timing metadata and artifact collection, while keeping Python 3.11 and 3.13 behavior unchanged.
- Extend the CI risk profiling logic to detect main-CI-related changes and emit a run_main_ci_diagnostic flag consumed by the workflow.
- Strengthen governance tests to lock in the new test-main routing, shard configuration, and required-check conditions for Python 3.12.
- Document the Python 3.12 timeout root-cause lane and its CI contract, and update backlog ledger entries to reflect the new mitigation and follow-up plan.
- Record fixed-in-commit mapping and initial evidence for this PR in the review documentation.

Tests:
- Add unit tests for the Python 3.12 shard runner covering file discovery, partitioning, environment isolation, coverage orchestration, and crash diagnostics.
- Extend CI risk profile tests to cover the new run_main_ci_diagnostic flag and its routing behavior.
- Update CI workflow contract tests to validate the Python 3.12 sharded runner wiring, timing markers, and JUnit artifact naming.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched Python 3.12 main-CI to deterministic, isolated shard runs (no xdist) with per-shard test and coverage outputs; shards fail-closed and coverage is recombined with the existing threshold.
  * CI workflow can run these diagnostics on PRs when the new diagnostic flag is set.

* **Tests**
  * Added/updated tests to validate sharded execution, artifact collection, failure propagation, and the diagnostic routing flag.

* **Documentation**
  * Added a root-cause packet, backlog updates, and PR review notes describing the 3.12 timeout diagnostic plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
