### PR TITLE
feat(food-data): add source preflight tooling skeleton

### DIFF
--- a/core/food_sources/source_preflight.py
+++ b/core/food_sources/source_preflight.py
@@ -1,0 +1,292 @@
+"""
+Deterministic food-source manifest validation and dry-run diff contracts.
+
+RU: Строгая валидация манифеста источника до ingest/cutover.
+EN: Strict source manifest validation before ingest/cutover.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Literal, cast
+from urllib.parse import urlparse
+
+SourceClassification = Literal[
+    "current",
+    "legacy_static",
+    "commercial_contract",
+    "unresolved",
+]
+
+ALLOWED_SOURCE_CLASSIFICATIONS: tuple[SourceClassification, ...] = (
+    "current",
+    "legacy_static",
+    "commercial_contract",
+    "unresolved",
+)
+
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+class SourceManifestError(ValueError):
+    """Raised when a source preflight manifest is invalid."""
+
+
+@dataclass(frozen=True)
+class SourceArtifact:
+    """Immutable artifact metadata declared by a source manifest."""
+
+    path: str
+    checksum_sha256: str
+    size_bytes: int
+    record_count: int
+
+
+@dataclass(frozen=True)
+class SourceSchema:
+    """Declared field and stable identifier contract for a source artifact."""
+
+    fields: tuple[str, ...]
+    primary_keys: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SourceManifest:
+    """Strict PR2 source manifest contract."""
+
+    source: str
+    source_classification: SourceClassification
+    source_version: str
+    source_url: str
+    retrieved_on: date
+    artifact: SourceArtifact
+    schema: SourceSchema
+
+
+def _schema_error(context: str, detail: str) -> SourceManifestError:
+    return SourceManifestError(f"Invalid source manifest {context}: {detail}")
+
+
+def _require_mapping(value: object, context: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise _schema_error(context, "must be an object")
+    result: dict[str, object] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise _schema_error(context, "all object keys must be strings")
+        result[key] = item
+    return result
+
+
+def _require_string(data: dict[str, object], key: str, context: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise _schema_error(context, f"missing non-empty string '{key}'")
+    return value.strip()
+
+
+def _require_non_negative_int(data: dict[str, object], key: str, context: str) -> int:
+    value = data.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise _schema_error(context, f"'{key}' must be a non-negative int")
+    return value
+
+
+def _require_string_tuple(data: dict[str, object], key: str, context: str) -> tuple[str, ...]:
+    value = data.get(key)
+    if not isinstance(value, list):
+        raise _schema_error(context, f"'{key}' must be a list of strings")
+    items: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise _schema_error(context, f"'{key}[{index}]' must be a non-empty string")
+        normalized = item.strip()
+        if normalized in seen:
+            raise _schema_error(context, f"'{key}' contains duplicate value {normalized!r}")
+        seen.add(normalized)
+        items.append(normalized)
+    if not items:
+        raise _schema_error(context, f"'{key}' must not be empty")
+    return tuple(items)
+
+
+def _parse_classification(value: str, context: str) -> SourceClassification:
+    if value not in ALLOWED_SOURCE_CLASSIFICATIONS:
+        allowed = ", ".join(ALLOWED_SOURCE_CLASSIFICATIONS)
+        raise _schema_error(context, f"source_classification must be one of: {allowed}")
+    return cast(SourceClassification, value)
+
+
+def _validate_url(value: str, context: str) -> str:
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise _schema_error(context, "source_url must be an absolute http(s) URL")
+    return value
+
+
+def _parse_iso_date(value: str, context: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise _schema_error(context, "retrieved_on must use YYYY-MM-DD") from exc
+
+
+def _parse_artifact(value: object, context: str) -> SourceArtifact:
+    artifact = _require_mapping(value, f"{context}.artifact")
+    checksum = _require_string(artifact, "checksum_sha256", f"{context}.artifact")
+    if not _SHA256_RE.fullmatch(checksum):
+        raise _schema_error(f"{context}.artifact", "'checksum_sha256' must be 64 hex chars")
+    return SourceArtifact(
+        path=_require_string(artifact, "path", f"{context}.artifact"),
+        checksum_sha256=checksum.lower(),
+        size_bytes=_require_non_negative_int(artifact, "size_bytes", f"{context}.artifact"),
+        record_count=_require_non_negative_int(artifact, "record_count", f"{context}.artifact"),
+    )
+
+
+def _parse_schema(value: object, context: str) -> SourceSchema:
+    schema = _require_mapping(value, f"{context}.schema")
+    fields = _require_string_tuple(schema, "fields", f"{context}.schema")
+    primary_keys = _require_string_tuple(schema, "primary_keys", f"{context}.schema")
+    missing_keys = sorted(set(primary_keys) - set(fields))
+    if missing_keys:
+        joined = ", ".join(missing_keys)
+        raise _schema_error(f"{context}.schema", f"primary_keys missing from fields: {joined}")
+    return SourceSchema(fields=fields, primary_keys=primary_keys)
+
+
+def parse_source_manifest(payload: object, *, context: str = "<manifest>") -> SourceManifest:
+    """Parse and validate a source preflight manifest payload."""
+    data = _require_mapping(payload, context)
+    classification = _parse_classification(
+        _require_string(data, "source_classification", context),
+        context,
+    )
+    source_url = _validate_url(_require_string(data, "source_url", context), context)
+    return SourceManifest(
+        source=_require_string(data, "source", context),
+        source_classification=classification,
+        source_version=_require_string(data, "source_version", context),
+        source_url=source_url,
+        retrieved_on=_parse_iso_date(_require_string(data, "retrieved_on", context), context),
+        artifact=_parse_artifact(data.get("artifact"), context),
+        schema=_parse_schema(data.get("schema"), context),
+    )
+
+
+def load_source_manifest(path: Path | str) -> SourceManifest:
+    """Load and validate a source preflight manifest from JSON."""
+    manifest_path = Path(path)
+    try:
+        with manifest_path.open("r", encoding="utf-8") as file_obj:
+            payload: object = json.load(file_obj)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise SourceManifestError(f"Cannot read source manifest {manifest_path}: {exc}") from exc
+    return parse_source_manifest(payload, context=str(manifest_path))
+
+
+def _string_delta(current: str, incoming: str) -> dict[str, object]:
+    return {
+        "current": current,
+        "incoming": incoming,
+        "changed": current != incoming,
+    }
+
+
+def _integer_delta(current: int, incoming: int) -> dict[str, object]:
+    return {
+        "current": current,
+        "incoming": incoming,
+        "delta": incoming - current,
+        "changed": current != incoming,
+    }
+
+
+def _set_delta(current: tuple[str, ...], incoming: tuple[str, ...]) -> dict[str, list[str]]:
+    current_set = set(current)
+    incoming_set = set(incoming)
+    return {
+        "added": sorted(incoming_set - current_set),
+        "removed": sorted(current_set - incoming_set),
+    }
+
+
+def build_source_diff_report(
+    current: SourceManifest,
+    incoming: SourceManifest,
+) -> dict[str, object]:
+    """
+    Build the deterministic dry-run report for two already-validated manifests.
+
+    The report is intentionally side-effect free and always declares
+    ``runtime_cutover=false`` for PR2.
+    """
+    errors: list[str] = []
+    if current.source != incoming.source:
+        errors.append(
+            "source mismatch: " f"current={current.source!r} incoming={incoming.source!r}"
+        )
+
+    schema_delta = _set_delta(current.schema.fields, incoming.schema.fields)
+    primary_key_delta = _set_delta(current.schema.primary_keys, incoming.schema.primary_keys)
+
+    return {
+        "success": not errors,
+        "dry_run": True,
+        "runtime_cutover": False,
+        "source": incoming.source,
+        "source_classification": incoming.source_classification,
+        "source_url": incoming.source_url,
+        "retrieved_on": incoming.retrieved_on.isoformat(),
+        "version": _string_delta(current.source_version, incoming.source_version),
+        "checksum": _string_delta(
+            current.artifact.checksum_sha256,
+            incoming.artifact.checksum_sha256,
+        ),
+        "row_count": _integer_delta(
+            current.artifact.record_count,
+            incoming.artifact.record_count,
+        ),
+        "size_bytes": _integer_delta(
+            current.artifact.size_bytes,
+            incoming.artifact.size_bytes,
+        ),
+        "schema": schema_delta,
+        "primary_keys": primary_key_delta,
+        "validation_errors": errors,
+    }
+
+
+def build_source_preflight_report(
+    current_manifest: Path | str,
+    incoming_manifest: Path | str,
+) -> dict[str, object]:
+    """Load manifests and return a dry-run report with validation errors."""
+    errors: list[str] = []
+    current: SourceManifest | None = None
+    incoming: SourceManifest | None = None
+
+    try:
+        current = load_source_manifest(current_manifest)
+    except SourceManifestError as exc:
+        errors.append(f"current_manifest: {exc}")
+
+    try:
+        incoming = load_source_manifest(incoming_manifest)
+    except SourceManifestError as exc:
+        errors.append(f"incoming_manifest: {exc}")
+
+    if errors or current is None or incoming is None:
+        return {
+            "success": False,
+            "dry_run": True,
+            "runtime_cutover": False,
+            "validation_errors": errors,
+        }
+
+    return build_source_diff_report(current, incoming)

--- a/core/food_sources/source_preflight.py
+++ b/core/food_sources/source_preflight.py
@@ -30,6 +30,7 @@ ALLOWED_SOURCE_CLASSIFICATIONS: tuple[SourceClassification, ...] = (
 )
 
 _SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+_RETRIEVED_ON_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 class SourceManifestError(ValueError):
@@ -68,10 +69,12 @@ class SourceManifest:
 
 
 def _schema_error(context: str, detail: str) -> SourceManifestError:
+    """Build a stable manifest validation error."""
     return SourceManifestError(f"Invalid source manifest {context}: {detail}")
 
 
 def _require_mapping(value: object, context: str) -> dict[str, object]:
+    """Return an object mapping with string keys."""
     if not isinstance(value, dict):
         raise _schema_error(context, "must be an object")
     result: dict[str, object] = {}
@@ -83,6 +86,7 @@ def _require_mapping(value: object, context: str) -> dict[str, object]:
 
 
 def _require_string(data: dict[str, object], key: str, context: str) -> str:
+    """Return a required non-empty string field."""
     value = data.get(key)
     if not isinstance(value, str) or not value.strip():
         raise _schema_error(context, f"missing non-empty string '{key}'")
@@ -90,6 +94,7 @@ def _require_string(data: dict[str, object], key: str, context: str) -> str:
 
 
 def _require_non_negative_int(data: dict[str, object], key: str, context: str) -> int:
+    """Return a required non-negative integer field."""
     value = data.get(key)
     if not isinstance(value, int) or isinstance(value, bool) or value < 0:
         raise _schema_error(context, f"'{key}' must be a non-negative int")
@@ -97,6 +102,7 @@ def _require_non_negative_int(data: dict[str, object], key: str, context: str) -
 
 
 def _require_string_tuple(data: dict[str, object], key: str, context: str) -> tuple[str, ...]:
+    """Return a required unique non-empty string list as a tuple."""
     value = data.get(key)
     if not isinstance(value, list):
         raise _schema_error(context, f"'{key}' must be a list of strings")
@@ -116,6 +122,7 @@ def _require_string_tuple(data: dict[str, object], key: str, context: str) -> tu
 
 
 def _parse_classification(value: str, context: str) -> SourceClassification:
+    """Validate and return a source classification literal."""
     if value not in ALLOWED_SOURCE_CLASSIFICATIONS:
         allowed = ", ".join(ALLOWED_SOURCE_CLASSIFICATIONS)
         raise _schema_error(context, f"source_classification must be one of: {allowed}")
@@ -123,6 +130,7 @@ def _parse_classification(value: str, context: str) -> SourceClassification:
 
 
 def _validate_url(value: str, context: str) -> str:
+    """Validate an absolute HTTP(S) source URL."""
     parsed = urlparse(value)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise _schema_error(context, "source_url must be an absolute http(s) URL")
@@ -130,6 +138,9 @@ def _validate_url(value: str, context: str) -> str:
 
 
 def _parse_iso_date(value: str, context: str) -> date:
+    """Parse a strict YYYY-MM-DD date field."""
+    if not _RETRIEVED_ON_RE.fullmatch(value):
+        raise _schema_error(context, "retrieved_on must use YYYY-MM-DD")
     try:
         return date.fromisoformat(value)
     except ValueError as exc:
@@ -137,6 +148,7 @@ def _parse_iso_date(value: str, context: str) -> date:
 
 
 def _parse_artifact(value: object, context: str) -> SourceArtifact:
+    """Parse immutable artifact metadata."""
     artifact = _require_mapping(value, f"{context}.artifact")
     checksum = _require_string(artifact, "checksum_sha256", f"{context}.artifact")
     if not _SHA256_RE.fullmatch(checksum):
@@ -150,6 +162,7 @@ def _parse_artifact(value: object, context: str) -> SourceArtifact:
 
 
 def _parse_schema(value: object, context: str) -> SourceSchema:
+    """Parse source schema and primary-key metadata."""
     schema = _require_mapping(value, f"{context}.schema")
     fields = _require_string_tuple(schema, "fields", f"{context}.schema")
     primary_keys = _require_string_tuple(schema, "primary_keys", f"{context}.schema")
@@ -191,6 +204,7 @@ def load_source_manifest(path: Path | str) -> SourceManifest:
 
 
 def _string_delta(current: str, incoming: str) -> dict[str, object]:
+    """Return deterministic string delta metadata."""
     return {
         "current": current,
         "incoming": incoming,
@@ -199,6 +213,7 @@ def _string_delta(current: str, incoming: str) -> dict[str, object]:
 
 
 def _integer_delta(current: int, incoming: int) -> dict[str, object]:
+    """Return deterministic integer delta metadata."""
     return {
         "current": current,
         "incoming": incoming,
@@ -208,6 +223,7 @@ def _integer_delta(current: int, incoming: int) -> dict[str, object]:
 
 
 def _set_delta(current: tuple[str, ...], incoming: tuple[str, ...]) -> dict[str, list[str]]:
+    """Return sorted set additions and removals."""
     current_set = set(current)
     incoming_set = set(incoming)
     return {

--- a/core/food_sources/source_preflight.py
+++ b/core/food_sources/source_preflight.py
@@ -255,7 +255,7 @@ def build_source_diff_report(
         "success": not errors,
         "dry_run": True,
         "runtime_cutover": False,
-        "source": incoming.source,
+        "source": _string_delta(current.source, incoming.source),
         "source_classification": incoming.source_classification,
         "source_url": incoming.source_url,
         "retrieved_on": incoming.retrieved_on.isoformat(),

--- a/docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md
+++ b/docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md
@@ -96,15 +96,18 @@ Enforcement anchor: the PR1 preflight contract requires top-level manifest field
 `source_classification` with allowed values `current`, `legacy_static`,
 `commercial_contract`, or `unresolved`; later tooling must validate that field
 before ingest using the PR1 packet's canonical criteria.
-This is a PR1 contract, not current runtime enforcement: follow-up tooling must
-add validation before ingest, because `core/food_sources/snapshot_manager.py`
-and `core/food_apis/raw_snapshot_gate.py` do not validate
-`source_classification` yet.
+PR2 adds strict pre-ingest tooling for this contract without changing runtime
+authority: `scripts/food_source_preflight.py` validates
+`source_classification` and emits a dry-run diff report with
+`runtime_cutover: false`. Existing runtime snapshot loaders remain
+backward-compatible and do not turn this field into a runtime source switch.
 
 Implementation anchors (W1, repo paths on default branch):
 
 - PR1 source-classification contract:
   `docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_CURRENT.md#food-data-source-update-preflight-current-packet`
+- PR2 strict file-only preflight tooling:
+  `core/food_sources/source_preflight.py`, `scripts/food_source_preflight.py`
 - Snapshot manifest hub + fail-closed revalidation (size/checksum): `core/food_sources/snapshot_manager.py:91` (`SnapshotManager`), `:258` (`verify_recorded_snapshots`)
 - OFF deterministic delta/full source: `core/food_sources/off_delta.py:54` (`OpenFoodFactsDeltaSource`)
 - OFF export selection (cache/snapshot inputs): `core/food_apis/update_manager.py:261` (`_find_off_export_file`); scheduler entry for OFF updates: `:352` (`update_database` → `_update_off_database`)

--- a/docs/orchestration/FOOD_DATA_SOURCE_PREFLIGHT_TOOLING_PR2_PACKET_2026-04-24.md
+++ b/docs/orchestration/FOOD_DATA_SOURCE_PREFLIGHT_TOOLING_PR2_PACKET_2026-04-24.md
@@ -1,0 +1,75 @@
+# Food Data Source Preflight Tooling PR2 Packet
+
+**Effective date:** 2026-04-24 (`America/New_York`)
+**Status:** Active PR2 tooling skeleton
+**Mode:** coordinator-owned deterministic tooling lane
+
+## Goal
+
+Turn the merged PR1 source-update criteria into a deterministic, file-only
+preflight tooling skeleton before any USDA, Open Food Facts, MenuStat
+replacement, JPTN, recipe, regional, PostgreSQL staging, or runtime authority
+work begins.
+
+## Relationship to PR1
+
+- Baseline: PR `#1513` merged the PR1 planning packet and ADR.
+- Canonical criteria remain in
+  [`FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_PR1_PACKET_2026-04-24.md`](./FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_PR1_PACKET_2026-04-24.md).
+- PR2 implements the first strict manifest/diff tooling contract only.
+- MenuStat stays `legacy_static`; replacement restaurant/menu sources remain a
+  later classification and approval decision.
+
+## Role Order
+
+1. `agent-coordinator`
+2. `data-scientist-agent`
+3. `backend-engineer`
+4. `security-auditor`
+5. `qa-engineer-agent`
+6. `bug-hunter`
+7. `dev-operator`
+
+Mandatory post-open review lane remains: `qa-engineer-agent -> bug-hunter`.
+
+## In Scope
+
+- Strict source manifest validation with top-level `source_classification`.
+- Allowed classifications: `current`, `legacy_static`,
+  `commercial_contract`, `unresolved`.
+- Deterministic dry-run diff report for source version, checksum, row count,
+  size, schema-field deltas, and primary-key deltas.
+- Fixture/schema checks for current OFF-style data, legacy MenuStat, invalid
+  classification, and schema/PK drift.
+- Repo-local CLI contract:
+  `python3 scripts/food_source_preflight.py --current-manifest <path> --incoming-manifest <path> --dry-run --json`.
+
+## Out of Scope
+
+- No DigitalOcean PostgreSQL connection string, credential handling, or writes.
+- No production, staging, or local bulk import.
+- No network downloads from USDA, Open Food Facts, MenuStat, JPTN, recipes, or
+  commercial restaurant providers.
+- No runtime source switch, public API change, OpenAPI change, frontend/iOS
+  change, Meilisearch update, pgvector update, or managed PostgreSQL authority.
+
+## Validation Plan
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- Targeted pytest for `tests/test_food_source_preflight.py`
+- CLI smoke with valid and invalid fixtures
+- `pre-commit run --all-files` before push
+
+`make verify` is intentionally not part of the local PR2 loop; GitHub current
+head CI is the heavy signal for this lane.
+
+## Acceptance Criteria
+
+- Invalid or missing `source_classification` fails closed in PR2 tooling.
+- Valid `legacy_static` MenuStat manifests are accepted but do not imply fresh
+  restaurant-menu ingest.
+- Dry-run output always includes `runtime_cutover: false`.
+- Dry-run command does not require network, database, DigitalOcean credentials,
+  or source archive existence.
+- Ledger and current packet pointer link PR2 back to the merged PR1 criteria.

--- a/docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_CURRENT.md
+++ b/docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_CURRENT.md
@@ -1,13 +1,16 @@
 # Food Data Source Update Preflight Current Packet
 
-This stable pointer identifies the active PR1 source-update preflight contract
-for food-data lanes that need a non-dated link.
+This stable pointer identifies the active source-update preflight contract and
+current tooling packet for food-data lanes that need non-dated links.
 
 - Current PR1 packet:
   [`FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_PR1_PACKET_2026-04-24.md`](./FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_PR1_PACKET_2026-04-24.md)
+- Current PR2 tooling packet:
+  [`FOOD_DATA_SOURCE_PREFLIGHT_TOOLING_PR2_PACKET_2026-04-24.md`](./FOOD_DATA_SOURCE_PREFLIGHT_TOOLING_PR2_PACKET_2026-04-24.md)
 - Canonical preflight criteria:
   [`FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_PR1_PACKET_2026-04-24.md#canonical-preflight-criteria`](./FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_PR1_PACKET_2026-04-24.md#canonical-preflight-criteria)
 - Governing backlog anchor:
   [`BACKLOG_LEDGER.md#ledger-p1-food-data-source-update-preflight`](../roadmap/BACKLOG_LEDGER.md#ledger-p1-food-data-source-update-preflight)
 
-Update this alias when a later accepted packet supersedes the dated PR1 packet.
+Update this alias when a later accepted packet supersedes the dated PR1 criteria
+or PR2 tooling packet.

--- a/docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_PR1_PACKET_2026-04-24.md
+++ b/docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_PR1_PACKET_2026-04-24.md
@@ -1,7 +1,7 @@
 # Food Data Source Update Preflight PR1 Packet
 
 **Effective date:** 2026-04-24 (`America/New_York`)
-**Status:** Active execution packet
+**Status:** Merged PR1 baseline; PR2 tooling packet now carries active implementation scope
 **Mode:** coordinator-owned docs/tooling-contract lane
 
 ## Goal
@@ -14,6 +14,8 @@ snapshots, PostgreSQL staging, or production infrastructure.
 
 - PR `#1462` and PR `#1468` are already merged; downgrade ownership is no
   longer the next active lane.
+- PR `#1513` merged this PR1 packet as the planning baseline for later
+  source-update tooling lanes.
 - This packet owns the source-update preflight contract for
   `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-food-data-source-update-preflight`.
 - This lane keeps SQLite/local snapshots as runtime authority and does not

--- a/docs/review/PR_1517_FIXED_MAPPING.md
+++ b/docs/review/PR_1517_FIXED_MAPPING.md
@@ -17,11 +17,8 @@ threads on GitHub.
 
 Disposition: FIXED
 Commit: dc9ddecc7
-Evidence: `core/food_sources/source_preflight.py`;
-`scripts/food_source_preflight.py`
-Reason: CodeRabbit's docstring coverage warning was addressed with concise
-helper/CLI docstrings. The remaining service rate-limit notice did not request
-code or documentation changes.
+Evidence: `core/food_sources/source_preflight.py`; `scripts/food_source_preflight.py`
+Reason: CodeRabbit's docstring coverage warning was addressed with concise helper/CLI docstrings; the remaining service rate-limit notice did not request code or documentation changes.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#issuecomment-4313826624 -> dc9ddecc7
 
 Disposition: NOT-A-BUG
@@ -41,10 +38,8 @@ Reason: Sourcery posted a second service rate-limit notice after ready-for-revie
 
 Disposition: FIXED
 Commit: dc9ddecc7
-Evidence: `core/food_sources/source_preflight.py`;
-`tests/test_food_source_preflight.py`
-Reason: Manifest `retrieved_on` parsing now rejects compact/non-YYYY-MM-DD
-forms before ISO parsing, with regression coverage for compact dates.
+Evidence: `core/food_sources/source_preflight.py`; `tests/test_food_source_preflight.py`
+Reason: Manifest `retrieved_on` parsing now rejects compact/non-YYYY-MM-DD forms before ISO parsing, with regression coverage for compact dates.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172033067 -> dc9ddecc7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#discussion_r3139062053 -> dc9ddecc7
 

--- a/docs/review/PR_1517_FIXED_MAPPING.md
+++ b/docs/review/PR_1517_FIXED_MAPPING.md
@@ -49,12 +49,20 @@ Evidence: `tests/test_food_source_preflight.py`
 Reason: CLI file-only test now runs the subprocess from `tmp_path`, so the before/after file-tree assertion checks the actual working directory used by the CLI process.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172181086 -> 3759d03aa
 
+Disposition: FIXED
+Commit: 49efc9ec9
+Evidence: `docs/review/PR_1517_FIXED_MAPPING.md`
+Reason: The review artifact now records portable validation commands and keeps the scope-boundary proof readable without host-specific absolute paths.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#discussion_r3139309011 -> 49efc9ec9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172242156 -> 49efc9ec9
+
 ## Initial Implementation Commits
 
 - `1a2c265b7` - `feat(food-data): add source preflight skeleton`
 - `dc9ddecc7` - `fix(food-data): enforce manifest date format`
 - `3c706a0fc` - `fix(food-data): add source delta preflight report`
 - `3759d03aa` - `test(food-data): verify cli working directory isolation`
+- `49efc9ec9` - `docs: remove local path from pr1517 artifact`
 
 ## Merge Readiness
 

--- a/docs/review/PR_1517_FIXED_MAPPING.md
+++ b/docs/review/PR_1517_FIXED_MAPPING.md
@@ -30,6 +30,11 @@ Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#issueco
 Reason: Codecov reported all modified coverable lines covered by tests and did not request code or documentation changes.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#issuecomment-4313917207
 
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172022518
+Reason: Sourcery posted a second service rate-limit notice after ready-for-review; no code or documentation changes were requested.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172022518
+
 ## Initial Implementation Commits
 
 - `1a2c265b7` - `feat(food-data): add source preflight skeleton`

--- a/docs/review/PR_1517_FIXED_MAPPING.md
+++ b/docs/review/PR_1517_FIXED_MAPPING.md
@@ -54,6 +54,7 @@ Commit: 49efc9ec9
 Evidence: `docs/review/PR_1517_FIXED_MAPPING.md`
 Reason: The review artifact now records portable validation commands and keeps the scope-boundary proof readable without host-specific absolute paths.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#discussion_r3139309011 -> 49efc9ec9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172299948 -> 49efc9ec9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172242156 -> 49efc9ec9
 
 ## Initial Implementation Commits

--- a/docs/review/PR_1517_FIXED_MAPPING.md
+++ b/docs/review/PR_1517_FIXED_MAPPING.md
@@ -25,6 +25,11 @@ Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullreq
 Reason: Sourcery posted a service rate-limit notice only; no code or documentation changes were requested.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4171119355
 
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#issuecomment-4313917207
+Reason: Codecov reported all modified coverable lines covered by tests and did not request code or documentation changes.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#issuecomment-4313917207
+
 ## Initial Implementation Commits
 
 - `1a2c265b7` - `feat(food-data): add source preflight skeleton`

--- a/docs/review/PR_1517_FIXED_MAPPING.md
+++ b/docs/review/PR_1517_FIXED_MAPPING.md
@@ -69,7 +69,7 @@ Merge-readiness contract:
       one review cycle before merging
 - [x] `python3 scripts/orchestration/check_preflight.py`
 - [x] `python3 scripts/orchestration/check_agent_consistency.py`
-- [x] `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest tests/test_food_source_preflight.py -q`
+- [x] `python3 -m pytest tests/test_food_source_preflight.py -q`
       after review fix (`9 passed`)
 - [x] `python3 scripts/food_source_preflight.py --current-manifest tests/fixtures/food_source_preflight/current_off_manifest.json --incoming-manifest tests/fixtures/food_source_preflight/incoming_off_manifest.json --dry-run --json`
 - [x] invalid-manifest CLI smoke returned exit `1` with JSON
@@ -84,9 +84,9 @@ Merge-readiness contract:
 
 ## Scope Boundary Proof
 
-- No DigitalOcean PostgreSQL connection string, credentials, or writes.
-- No source downloads or production/staging/local bulk ingest.
-- No runtime authority cutover; PR2 dry-run reports include
-  `runtime_cutover: false`.
-- No public API, OpenAPI, frontend, iOS, Meilisearch, pgvector, or restaurant
-  endpoint behavior change.
+- Absent: DigitalOcean PostgreSQL connection strings, credentials, and writes.
+- Source downloads and production/staging/local bulk ingest are not performed.
+- PR2 dry-run reports keep `runtime_cutover: false`; runtime authority remains
+  unchanged.
+- Public API, OpenAPI, frontend, iOS, Meilisearch, pgvector, and restaurant
+  endpoint behavior are unchanged.

--- a/docs/review/PR_1517_FIXED_MAPPING.md
+++ b/docs/review/PR_1517_FIXED_MAPPING.md
@@ -1,0 +1,57 @@
+# PR #1517 - Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md`;
+`docs/orchestration/AGENTS.md`.
+
+- [x] Post-open `qa-engineer-agent -> bug-hunter` bootstrap completed
+- [ ] Discussion-thread pass completed after bot/human review activity
+- [x] Fixed in commit mapping artifact created
+
+This artifact was created immediately after the draft PR opened per repo
+governance. Record every actionable human/bot disposition here before resolving
+threads on GitHub.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments recorded yet at artifact creation time.
+
+## Initial Implementation Commits
+
+- `1a2c265b7` - `feat(food-data): add source preflight skeleton`
+
+## Merge Readiness
+
+Merge-readiness contract:
+`AGENTS.md`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md`.
+
+- [ ] Current-head CI is green for PR branch head
+- [ ] Required checks complete with no pending required jobs
+- [ ] All review threads resolved on GitHub after disposition updates
+- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
+- [ ] After latest bot/review activity, perform a final check and wait at least
+      one review cycle before merging
+- [x] `python3 scripts/orchestration/check_preflight.py`
+- [x] `python3 scripts/orchestration/check_agent_consistency.py`
+- [x] `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest tests/test_food_source_preflight.py -q`
+- [x] `python3 scripts/food_source_preflight.py --current-manifest tests/fixtures/food_source_preflight/current_off_manifest.json --incoming-manifest tests/fixtures/food_source_preflight/incoming_off_manifest.json --dry-run --json`
+- [x] invalid-manifest CLI smoke returned exit `1` with JSON
+      `validation_errors`
+- [x] `pre-commit run --all-files`
+- [x] Pre-push hooks passed during
+      `git push -u origin codex/food-data-source-preflight-tooling`
+- [ ] `make verify` green on latest pushed head
+      Local owner override on 2026-04-24: full local `make verify` is not run
+      for this PR2 lane because the long full-suite path overloads the local
+      machine; use GitHub current-head required checks as the heavy signal.
+
+## Scope Boundary Proof
+
+- No DigitalOcean PostgreSQL connection string, credentials, or writes.
+- No source downloads or production/staging/local bulk ingest.
+- No runtime authority cutover; PR2 dry-run reports include
+  `runtime_cutover: false`.
+- No public API, OpenAPI, frontend, iOS, Meilisearch, pgvector, or restaurant
+  endpoint behavior change.

--- a/docs/review/PR_1517_FIXED_MAPPING.md
+++ b/docs/review/PR_1517_FIXED_MAPPING.md
@@ -6,9 +6,8 @@ Canonical review-governance artifact and PR-body mirror requirements:
 `AGENTS.md`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md`;
 `docs/orchestration/AGENTS.md`.
 
-- [x] Post-open `qa-engineer-agent -> bug-hunter` bootstrap completed
-- [ ] Discussion-thread pass completed after bot/human review activity
-- [x] Fixed in commit mapping artifact created
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 This artifact was created immediately after the draft PR opened per repo
 governance. Record every actionable human/bot disposition here before resolving
@@ -16,7 +15,15 @@ threads on GitHub.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments recorded yet at artifact creation time.
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#issuecomment-4313826624
+Reason: CodeRabbit posted a draft-state review-skipped status note only; no code or documentation changes were requested.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#issuecomment-4313826624
+
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4171119355
+Reason: Sourcery posted a service rate-limit notice only; no code or documentation changes were requested.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4171119355
 
 ## Initial Implementation Commits
 

--- a/docs/review/PR_1517_FIXED_MAPPING.md
+++ b/docs/review/PR_1517_FIXED_MAPPING.md
@@ -15,10 +15,14 @@ threads on GitHub.
 
 ## Fixed in Commit Mapping
 
-Disposition: NOT-A-BUG
-Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#issuecomment-4313826624
-Reason: CodeRabbit posted a draft-state review-skipped status note only; no code or documentation changes were requested.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#issuecomment-4313826624
+Disposition: FIXED
+Commit: dc9ddecc7
+Evidence: `core/food_sources/source_preflight.py`;
+`scripts/food_source_preflight.py`
+Reason: CodeRabbit's docstring coverage warning was addressed with concise
+helper/CLI docstrings. The remaining service rate-limit notice did not request
+code or documentation changes.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#issuecomment-4313826624 -> dc9ddecc7
 
 Disposition: NOT-A-BUG
 Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4171119355
@@ -35,9 +39,19 @@ Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullreq
 Reason: Sourcery posted a second service rate-limit notice after ready-for-review; no code or documentation changes were requested.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172022518
 
+Disposition: FIXED
+Commit: dc9ddecc7
+Evidence: `core/food_sources/source_preflight.py`;
+`tests/test_food_source_preflight.py`
+Reason: Manifest `retrieved_on` parsing now rejects compact/non-YYYY-MM-DD
+forms before ISO parsing, with regression coverage for compact dates.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172033067 -> dc9ddecc7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#discussion_r3139062053 -> dc9ddecc7
+
 ## Initial Implementation Commits
 
 - `1a2c265b7` - `feat(food-data): add source preflight skeleton`
+- `dc9ddecc7` - `fix(food-data): enforce manifest date format`
 
 ## Merge Readiness
 
@@ -53,6 +67,7 @@ Merge-readiness contract:
 - [x] `python3 scripts/orchestration/check_preflight.py`
 - [x] `python3 scripts/orchestration/check_agent_consistency.py`
 - [x] `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest tests/test_food_source_preflight.py -q`
+      after review fix (`9 passed`)
 - [x] `python3 scripts/food_source_preflight.py --current-manifest tests/fixtures/food_source_preflight/current_off_manifest.json --incoming-manifest tests/fixtures/food_source_preflight/incoming_off_manifest.json --dry-run --json`
 - [x] invalid-manifest CLI smoke returned exit `1` with JSON
       `validation_errors`

--- a/docs/review/PR_1517_FIXED_MAPPING.md
+++ b/docs/review/PR_1517_FIXED_MAPPING.md
@@ -43,10 +43,18 @@ Reason: Manifest `retrieved_on` parsing now rejects compact/non-YYYY-MM-DD forms
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172033067 -> dc9ddecc7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#discussion_r3139062053 -> dc9ddecc7
 
+Disposition: FIXED
+Commit: 3759d03aa
+Evidence: `tests/test_food_source_preflight.py`
+Reason: CLI file-only test now runs the subprocess from `tmp_path`, so the before/after file-tree assertion checks the actual working directory used by the CLI process.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172181086 -> 3759d03aa
+
 ## Initial Implementation Commits
 
 - `1a2c265b7` - `feat(food-data): add source preflight skeleton`
 - `dc9ddecc7` - `fix(food-data): enforce manifest date format`
+- `3c706a0fc` - `fix(food-data): add source delta preflight report`
+- `3759d03aa` - `test(food-data): verify cli working directory isolation`
 
 ## Merge Readiness
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1678,22 +1678,26 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Food data source-update preflight and diff-based ingest guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FOOD-DATA-SOURCE-PREFLIGHT -> `codex/food-data-source-update-preflight`
-  - Status: 🚧 Active PR1 planning lane
+  - Target PR: PR-TBD-FOOD-DATA-SOURCE-PREFLIGHT-TOOLING -> `codex/food-data-source-preflight-tooling`
+  - Status: 🚧 Active PR2 deterministic tooling lane; PR1 planning baseline merged as PR #1513
   - Area: data ingestion / food catalog / quality
   - Finding Type: upstream data-change readiness gap
   - Reason (EN): USDA Foundation Foods, USDA Branded, USDA FNDDS, Open Food Facts, JPTN Food Facts, restaurant-menu data, and external recipe corpora can change the shape, volume, licensing, and dedupe behavior of ingestible records. The repo does not yet have a canonical preflight contract for source-version discovery, schema diffing, dedupe/mapping collisions, source replacement decisions, storage choice, and rollback before updating the unified food catalog.
   - Links:
     - `docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_PR1_PACKET_2026-04-24.md`
+    - `docs/orchestration/FOOD_DATA_SOURCE_PREFLIGHT_TOOLING_PR2_PACKET_2026-04-24.md`
     - `docs/architecture/ADR_FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_2026-04-24.md`
     - `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`
     - `docs/legal/EXTERNAL_FOOD_SOURCE_OPERATING_POLICY.md`
+    - `core/food_sources/source_preflight.py`
+    - `scripts/food_source_preflight.py`
     - `scripts/build_food_db.py`
     - `docs/roadmap/GLOBAL_ROADMAP.md`
     - `app/services/food_store.py`
   - DoD:
     - Source-version manifest covers USDA Foundation/Branded/FNDDS, Open Food Facts, MenuStat legacy/static, restaurant-menu replacement candidates, recipe/corpus sources, regional catalogs, and unresolved JPTN Food Facts
-    - Preflight workflow exists for diffing incoming source changes against the current catalog snapshot
+    - Preflight workflow exists for diffing incoming source changes against the current catalog snapshot; PR2 defines the file-only manifest/diff skeleton before ingest
+    - `source_classification` is validated with allowed values `current`, `legacy_static`, `commercial_contract`, and `unresolved`
     - Dedupe/mapping collision checks are defined before snapshot promotion or PostgreSQL staging
     - MenuStat is not treated as an actively updating source; replacement-source decision is required before new restaurant-menu ingest
     - DigitalOcean production PostgreSQL load and runtime cutover stay blocked until source preflight, staging proof, rollback, and cutover packet are complete

--- a/scripts/food_source_preflight.py
+++ b/scripts/food_source_preflight.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Dry-run food source manifest preflight.
+
+RU: Файловая preflight-проверка без сети, БД и runtime cutover.
+EN: File-only preflight check with no network, database, or runtime cutover.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from core.food_sources.source_preflight import build_source_preflight_report
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate and diff food source manifests without ingesting data.",
+    )
+    parser.add_argument(
+        "--current-manifest",
+        required=True,
+        type=Path,
+        help="Current accepted source manifest JSON.",
+    )
+    parser.add_argument(
+        "--incoming-manifest",
+        required=True,
+        type=Path,
+        help="Incoming candidate source manifest JSON.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        required=True,
+        help="Required safety flag. The command never writes or ingests data.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        required=True,
+        help="Emit the deterministic JSON report.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    report = build_source_preflight_report(
+        current_manifest=args.current_manifest,
+        incoming_manifest=args.incoming_manifest,
+    )
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if report.get("success") is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/food_source_preflight.py
+++ b/scripts/food_source_preflight.py
@@ -21,6 +21,7 @@ from core.food_sources.source_preflight import build_source_preflight_report
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse required dry-run CLI arguments."""
     parser = argparse.ArgumentParser(
         description="Validate and diff food source manifests without ingesting data.",
     )
@@ -52,6 +53,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the dry-run preflight CLI."""
     args = _parse_args(argv if argv is not None else sys.argv[1:])
     report = build_source_preflight_report(
         current_manifest=args.current_manifest,

--- a/tests/fixtures/food_source_preflight/current_off_manifest.json
+++ b/tests/fixtures/food_source_preflight/current_off_manifest.json
@@ -1,0 +1,23 @@
+{
+  "artifact": {
+    "checksum_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "path": "raw/off/2026-04-24/products.csv.gz",
+    "record_count": 100,
+    "size_bytes": 2048
+  },
+  "retrieved_on": "2026-04-24",
+  "schema": {
+    "fields": [
+      "code",
+      "product_name",
+      "brands"
+    ],
+    "primary_keys": [
+      "code"
+    ]
+  },
+  "source": "open_food_facts",
+  "source_classification": "current",
+  "source_url": "https://world.openfoodfacts.org/data",
+  "source_version": "2026-04-24"
+}

--- a/tests/fixtures/food_source_preflight/incoming_off_manifest.json
+++ b/tests/fixtures/food_source_preflight/incoming_off_manifest.json
@@ -1,0 +1,23 @@
+{
+  "artifact": {
+    "checksum_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "path": "raw/off/2026-04-25/products.csv.gz",
+    "record_count": 120,
+    "size_bytes": 4096
+  },
+  "retrieved_on": "2026-04-25",
+  "schema": {
+    "fields": [
+      "code",
+      "product_name",
+      "quantity"
+    ],
+    "primary_keys": [
+      "code"
+    ]
+  },
+  "source": "open_food_facts",
+  "source_classification": "current",
+  "source_url": "https://world.openfoodfacts.org/data",
+  "source_version": "2026-04-25"
+}

--- a/tests/fixtures/food_source_preflight/invalid_classification_manifest.json
+++ b/tests/fixtures/food_source_preflight/invalid_classification_manifest.json
@@ -1,0 +1,21 @@
+{
+  "artifact": {
+    "checksum_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "path": "raw/jptn/unresolved.json",
+    "record_count": 0,
+    "size_bytes": 0
+  },
+  "retrieved_on": "2026-04-24",
+  "schema": {
+    "fields": [
+      "id"
+    ],
+    "primary_keys": [
+      "id"
+    ]
+  },
+  "source": "jptn_food_facts",
+  "source_classification": "live_unknown",
+  "source_url": "https://example.invalid/jptn",
+  "source_version": "unresolved"
+}

--- a/tests/fixtures/food_source_preflight/legacy_menustat_manifest.json
+++ b/tests/fixtures/food_source_preflight/legacy_menustat_manifest.json
@@ -1,0 +1,25 @@
+{
+  "artifact": {
+    "checksum_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "path": "raw/menustat/2022/MenuStat_2022.csv",
+    "record_count": 42,
+    "size_bytes": 1024
+  },
+  "retrieved_on": "2026-04-24",
+  "schema": {
+    "fields": [
+      "restaurant",
+      "item_name",
+      "year"
+    ],
+    "primary_keys": [
+      "restaurant",
+      "item_name",
+      "year"
+    ]
+  },
+  "source": "menustat",
+  "source_classification": "legacy_static",
+  "source_url": "https://www.menustat.org/data.html",
+  "source_version": "2022"
+}

--- a/tests/test_food_source_preflight.py
+++ b/tests/test_food_source_preflight.py
@@ -1,0 +1,168 @@
+"""Tests for deterministic food source preflight manifests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.food_sources.source_preflight import (
+    SourceManifestError,
+    build_source_preflight_report,
+    load_source_manifest,
+)
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "food_source_preflight"
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "food_source_preflight.py"
+
+
+def _fixture(name: str) -> Path:
+    return _FIXTURE_DIR / name
+
+
+def test_load_source_manifest_accepts_current_source_classification() -> None:
+    manifest = load_source_manifest(_fixture("current_off_manifest.json"))
+
+    assert manifest.source == "open_food_facts"
+    assert manifest.source_classification == "current"
+    assert manifest.artifact.checksum_sha256 == "a" * 64
+    assert manifest.schema.primary_keys == ("code",)
+
+
+def test_load_source_manifest_accepts_legacy_static_menustat() -> None:
+    manifest = load_source_manifest(_fixture("legacy_menustat_manifest.json"))
+
+    assert manifest.source == "menustat"
+    assert manifest.source_classification == "legacy_static"
+    assert manifest.source_version == "2022"
+
+
+def test_load_source_manifest_rejects_invalid_source_classification() -> None:
+    with pytest.raises(SourceManifestError, match="source_classification must be one of"):
+        load_source_manifest(_fixture("invalid_classification_manifest.json"))
+
+
+def test_load_source_manifest_rejects_primary_key_outside_schema(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "bad_pk.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "artifact": {
+                    "checksum_sha256": "e" * 64,
+                    "path": "raw/usda/foundation.json",
+                    "record_count": 1,
+                    "size_bytes": 1,
+                },
+                "retrieved_on": "2026-04-24",
+                "schema": {"fields": ["fdc_id"], "primary_keys": ["missing_id"]},
+                "source": "usda_foundation",
+                "source_classification": "current",
+                "source_url": "https://fdc.nal.usda.gov/download-datasets",
+                "source_version": "2025-12",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SourceManifestError, match="primary_keys missing from fields"):
+        load_source_manifest(manifest_path)
+
+
+def test_build_source_preflight_report_diff_contract() -> None:
+    report = build_source_preflight_report(
+        _fixture("current_off_manifest.json"),
+        _fixture("incoming_off_manifest.json"),
+    )
+
+    assert report["success"] is True
+    assert report["dry_run"] is True
+    assert report["runtime_cutover"] is False
+    assert report["source_classification"] == "current"
+    assert report["version"] == {
+        "current": "2026-04-24",
+        "incoming": "2026-04-25",
+        "changed": True,
+    }
+    assert report["checksum"] == {
+        "current": "a" * 64,
+        "incoming": "b" * 64,
+        "changed": True,
+    }
+    assert report["row_count"] == {
+        "current": 100,
+        "incoming": 120,
+        "delta": 20,
+        "changed": True,
+    }
+    assert report["schema"] == {"added": ["quantity"], "removed": ["brands"]}
+    assert report["primary_keys"] == {"added": [], "removed": []}
+
+
+def test_build_source_preflight_report_surfaces_validation_errors() -> None:
+    report = build_source_preflight_report(
+        _fixture("current_off_manifest.json"),
+        _fixture("invalid_classification_manifest.json"),
+    )
+
+    assert report["success"] is False
+    assert report["runtime_cutover"] is False
+    assert report["dry_run"] is True
+    assert "source_classification must be one of" in str(report["validation_errors"])
+
+
+def test_food_source_preflight_cli_is_file_only_and_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgres://must-not-be-used.invalid/db")
+    before = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "--current-manifest",
+            str(_fixture("current_off_manifest.json")),
+            "--incoming-manifest",
+            str(_fixture("incoming_off_manifest.json")),
+            "--dry-run",
+            "--json",
+        ],
+        cwd=Path(__file__).parents[1],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    after = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
+
+    payload = json.loads(result.stdout)
+    assert payload["success"] is True
+    assert payload["runtime_cutover"] is False
+    assert result.stderr == ""
+    assert after == before
+
+
+def test_food_source_preflight_cli_returns_nonzero_for_invalid_manifest() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "--current-manifest",
+            str(_fixture("current_off_manifest.json")),
+            "--incoming-manifest",
+            str(_fixture("invalid_classification_manifest.json")),
+            "--dry-run",
+            "--json",
+        ],
+        cwd=Path(__file__).parents[1],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 1
+    assert payload["success"] is False
+    assert payload["runtime_cutover"] is False

--- a/tests/test_food_source_preflight.py
+++ b/tests/test_food_source_preflight.py
@@ -161,7 +161,7 @@ def test_food_source_preflight_cli_is_file_only_and_json(
             "--dry-run",
             "--json",
         ],
-        cwd=Path(__file__).parents[1],
+        cwd=tmp_path,
         check=True,
         text=True,
         capture_output=True,

--- a/tests/test_food_source_preflight.py
+++ b/tests/test_food_source_preflight.py
@@ -71,6 +71,32 @@ def test_load_source_manifest_rejects_primary_key_outside_schema(tmp_path: Path)
         load_source_manifest(manifest_path)
 
 
+def test_load_source_manifest_rejects_compact_retrieved_on_date(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "bad_date.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "artifact": {
+                    "checksum_sha256": "f" * 64,
+                    "path": "raw/off/products.csv.gz",
+                    "record_count": 1,
+                    "size_bytes": 1,
+                },
+                "retrieved_on": "20260424",
+                "schema": {"fields": ["code"], "primary_keys": ["code"]},
+                "source": "open_food_facts",
+                "source_classification": "current",
+                "source_url": "https://world.openfoodfacts.org/data",
+                "source_version": "2026-04-24",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SourceManifestError, match="retrieved_on must use YYYY-MM-DD"):
+        load_source_manifest(manifest_path)
+
+
 def test_build_source_preflight_report_diff_contract() -> None:
     report = build_source_preflight_report(
         _fixture("current_off_manifest.json"),

--- a/tests/test_food_source_preflight.py
+++ b/tests/test_food_source_preflight.py
@@ -106,6 +106,11 @@ def test_build_source_preflight_report_diff_contract() -> None:
     assert report["success"] is True
     assert report["dry_run"] is True
     assert report["runtime_cutover"] is False
+    assert report["source"] == {
+        "current": "open_food_facts",
+        "incoming": "open_food_facts",
+        "changed": False,
+    }
     assert report["source_classification"] == "current"
     assert report["version"] == {
         "current": "2026-04-24",


### PR DESCRIPTION
## Summary
- Adds the Food Data PR2 deterministic source manifest validator and dry-run diff tooling skeleton.
- Defines strict `source_classification` validation with allowed values: `current`, `legacy_static`, `commercial_contract`, `unresolved`.
- Adds file-only CLI contract: `python3 scripts/food_source_preflight.py --current-manifest <path> --incoming-manifest <path> --dry-run --json`.

## Scope Boundary
- No DigitalOcean Postgres connection string, credential handling, or writes.
- No source downloads, production/staging/local bulk ingest, or runtime authority cutover.
- No public API, OpenAPI, frontend, iOS, Meilisearch, pgvector, or restaurant endpoint behavior change.
- Existing snapshot/runtime loaders remain backward-compatible; strict validation is only invoked through PR2 preflight tooling.

## Split Justification
This PR crosses the 800 LoC size threshold because PR2 needs the manifest validator, CLI skeleton, fixtures, targeted tests, packet/ledger updates, and review-governance artifact to land together as one deterministic tooling contract. Splitting the docs from the CLI/tests would leave either an unenforced contract or ungoverned tooling during the food-data source-update lane. Later food-data PRs remain split: real source manifests, source downloads, importer implementation, DigitalOcean/Postgres staging, MenuStat replacement selection, and runtime cutover stay deferred.

## Implementation
- `core/food_sources/source_preflight.py` validates source manifests and builds deterministic diff reports.
- `scripts/food_source_preflight.py` exposes the dry-run JSON CLI.
- Fixture coverage includes current OFF-style source, legacy MenuStat, invalid classification, and schema/PK delta.
- PR2 packet/current pointer/ledger/strategy docs now link PR2 tooling back to merged PR1 `#1513`.
- `docs/review/PR_1517_FIXED_MAPPING.md` is the canonical review-governance artifact.

## Validation
- `python3 scripts/orchestration/check_preflight.py` — PASS
- `python3 scripts/orchestration/check_agent_consistency.py` — PASS
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest tests/test_food_source_preflight.py -q` — PASS (`9 passed`)
- `python3 scripts/food_source_preflight.py --current-manifest tests/fixtures/food_source_preflight/current_off_manifest.json --incoming-manifest tests/fixtures/food_source_preflight/incoming_off_manifest.json --dry-run --json` — PASS
- invalid-manifest CLI smoke — expected exit `1` with JSON `validation_errors`
- `pre-commit run --all-files` — PASS
- pre-push hooks — PASS

`make verify` intentionally was not run locally for this lane; GitHub current-head CI is the heavy signal.

## Base State Caveat
- PR1 `#1513` is merged and this branch is based on merge commit `4a3f79acc2710750474b5de7bd813d0e499e504e`.
- At PR open time, `main` still has long-running canonical `CI` on the PR1 merge SHA.
- `CD` on `main` rerun failed in release/image attestation verification with `no attestations found with predicate type: https://spdx.dev/Document`; this is classified as release-ops caveat, not PR2 runtime/tooling behavior.

## Security Notes
- This PR introduces no network calls, database writes, DigitalOcean credentials, production imports, or runtime source switching.
- The dry-run report always includes `runtime_cutover: false`.
- MenuStat remains `legacy_static`; replacement restaurant-menu sources remain blocked behind later legal/cache/redistribution review.
- JPTN Food Facts remains unresolved until source identity, license, and redistribution/cache rights are clarified.

## Marketing & GTM
- No product/marketing claim changes in PR2.
- Later positioning remains “verified multi-source food database with provenance,” but PR2 is only preflight risk reduction.

## Discussion Thread Pass
- [x] Post-open `qa-engineer-agent -> bug-hunter` bootstrap completed
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] No actionable review comments.

### Fixed in Commit Mapping
- Canonical artifact: `docs/review/PR_1517_FIXED_MAPPING.md`
- Initial implementation: `1a2c265b7`
- Review mapping artifact: `4eaab3dd7`
- Bot disposition update: `56b916787`, `f4a000051`, `e89a41289`
- Review fix: `dc9ddecc7`
- Review mapping sync: `f01099eea`
- Manual review fix: `3c706a0fc`
- CodeRabbit review fix: `3759d03aa`
- CodeRabbit mapping sync: `c8bb3b5b7`
- Final review cleanup: `49efc9ec9`
- Final mapping sync: `448abb1bc`, `a45eaa8b7`

Disposition: FIXED
Commit: dc9ddecc7
Evidence: `core/food_sources/source_preflight.py`; `scripts/food_source_preflight.py`
Reason: CodeRabbit's docstring coverage warning was addressed with concise helper/CLI docstrings. The remaining service rate-limit notice did not request code or documentation changes.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#issuecomment-4313826624 -> dc9ddecc7

Disposition: NOT-A-BUG
Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4171119355
Reason: Sourcery posted a service rate-limit notice only; no code or documentation changes were requested.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4171119355

Disposition: NOT-A-BUG
Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#issuecomment-4313917207
Reason: Codecov reported all modified coverable lines covered by tests and did not request code or documentation changes.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#issuecomment-4313917207

Disposition: NOT-A-BUG
Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172022518
Reason: Sourcery posted a second service rate-limit notice after ready-for-review; no code or documentation changes were requested.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172022518

Disposition: FIXED
Commit: dc9ddecc7
Evidence: `core/food_sources/source_preflight.py`; `tests/test_food_source_preflight.py`
Reason: Manifest `retrieved_on` parsing now rejects compact/non-YYYY-MM-DD forms before ISO parsing, with regression coverage for compact dates.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172033067 -> dc9ddecc7
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#discussion_r3139062053 -> dc9ddecc7

Disposition: FIXED
Commit: 3759d03aa
Evidence: `tests/test_food_source_preflight.py`
Reason: CLI file-only test now runs the subprocess from `tmp_path`, so the before/after file-tree assertion checks the actual working directory used by the CLI process.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172181086 -> 3759d03aa

Disposition: FIXED
Commit: 49efc9ec9
Evidence: `docs/review/PR_1517_FIXED_MAPPING.md`
Reason: The review artifact now records portable validation commands and keeps the scope-boundary proof readable without host-specific absolute paths.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#discussion_r3139309011 -> 49efc9ec9
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172299948 -> 49efc9ec9
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1517#pullrequestreview-4172242156 -> 49efc9ec9

## Merge Readiness
- [ ] Current-head PR CI green.
- [ ] CodeRabbit/Sourcery/Cubic no-actionables confirmed.
- [ ] `docs/review/PR_1517_FIXED_MAPPING.md` synchronized with review dispositions.
- [ ] Strict merge-readiness wrapper passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manifest validation with strict schema, classification, checksum, date, and primary-key rules.
  * Added a file-only CLI for deterministic dry-run manifest comparisons that emits JSON reports and non-zero exit on failure.

* **Documentation**
  * Added orchestration and preflight tooling packets; updated architecture and roadmap to reference the new tooling lane.

* **Tests**
  * Added fixtures and tests covering validation, diff output, CLI behavior, and failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
