### PR TITLE
fix(frontend): bump postcss to 8.5.10

### DIFF
--- a/docs/orchestration/DEPENDABOT_PR_1520_POSTCSS_REPLACEMENT_PACKET_2026-04-24.md
+++ b/docs/orchestration/DEPENDABOT_PR_1520_POSTCSS_REPLACEMENT_PACKET_2026-04-24.md
@@ -1,0 +1,94 @@
+# Dependabot PR #1520 PostCSS Replacement Packet
+
+## Goal
+
+Create a user-owned replacement PR for Dependabot `#1520` that preserves the
+narrow frontend dependency update from `postcss 8.5.8` to `8.5.10` without
+editing the Dependabot bot branch or widening into frontend runtime, API,
+OpenAPI, iOS, backend, or deployment behavior.
+
+## Current Truth
+
+- Source PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1520>
+- Source head branch:
+  `dependabot/npm_and_yarn/frontend/npm_and_yarn-754666cf41`
+- Replacement branch: `codex/pr1520-postcss-8.5.10-replacement`
+- Replacement worktree: `worktrees/pr1520-postcss-8.5.10-replacement`
+- Intended dependency delta:
+  - `frontend/package.json`: `postcss` spec `^8.4.38` to `^8.5.10`
+  - `frontend/package-lock.json`: root `postcss` spec `^8.4.38` to `^8.5.10`
+  - `frontend/package-lock.json`: locked `node_modules/postcss` package
+    `8.5.8` to `8.5.10`
+- Observed source-PR blocker: current-head runtime checks were green for the
+  frontend dependency surface, while `PR Body Phase2 gates` and
+  `Merge readiness gate` failed because the canonical review mapping artifact
+  `docs/review/PR_1520_FIXED_MAPPING.md` was absent.
+- Start-gate override: live `main` health was not fully settled when this lane
+  started, so the replacement PR must open as draft and must not claim
+  merge-readiness until current-head `main` health is rechecked.
+
+## Mandatory Role Order
+
+1. `agent-coordinator`
+2. `frontend-engineer`
+3. `security-auditor`
+4. `qa-engineer-agent`
+5. `bug-hunter`
+6. `agent-coordinator`
+
+Rules:
+
+- This role order is mandatory for the lane.
+- `dev-operator` may assist with command execution and evidence gathering only.
+- No ad hoc parallel role stack may replace this order.
+- The post-open review pass remains `qa-engineer-agent -> bug-hunter`.
+
+## Scope Lock
+
+### In Scope
+
+- Reproduce the exact Dependabot `postcss 8.5.8 -> 8.5.10` frontend dependency
+  update on a user-owned replacement branch.
+- Create and maintain the canonical PR fixed-mapping artifact after the
+  replacement PR number exists.
+- Keep the replacement PR body mirror aligned with the canonical Phase2
+  governance headings and checklist labels.
+- Disposition source PR `#1520` as superseded by the replacement PR.
+
+### Out of Scope
+
+- Editing the Dependabot bot branch directly.
+- Frontend UI, API client, OpenAPI, backend, iOS, deployment, Docker, or
+  product behavior changes.
+- Broad dependency-governance redesign.
+- Any merge-ready claim while current-head `main`, replacement PR CI, review
+  threads, bot actionables, or the mandatory wait-window remain unresolved.
+
+## Validation Baseline
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+cd frontend && npm install
+cd frontend && npm run build
+pre-commit run --all-files
+```
+
+Merge-readiness also requires the strict current-head wrapper:
+
+```bash
+GH_TOKEN="$(gh auth token)" GITHUB_TOKEN="$(gh auth token)" \
+  python3 scripts/orchestration/check_merge_ready.py \
+  --pr-number <replacement-pr-number> \
+  --repo Katsiarynakavaleuskaya/PulsePlate \
+  --require-auth
+```
+
+## Stop Conditions
+
+- The diff expands beyond the three intended `postcss` dependency lines plus
+  governance artifacts.
+- `npm install` introduces unrelated lockfile churn.
+- Current-head `main` remains unstable when moving out of draft.
+- Any actionable CodeRabbit, Sourcery, Cubic, or human review item remains
+  unmapped or unresolved.

--- a/docs/orchestration/DEPENDABOT_PR_1520_POSTCSS_REPLACEMENT_PACKET_2026-04-24.md
+++ b/docs/orchestration/DEPENDABOT_PR_1520_POSTCSS_REPLACEMENT_PACKET_2026-04-24.md
@@ -22,7 +22,7 @@ OpenAPI, iOS, backend, or deployment behavior.
 - Observed source-PR blocker: current-head runtime checks were green for the
   frontend dependency surface, while `PR Body Phase2 gates` and
   `Merge readiness gate` failed because the canonical review mapping artifact
-  `docs/review/PR_1520_FIXED_MAPPING.md` was absent.
+  `docs/review/PR_1523_FIXED_MAPPING.md` was absent.
 - Start-gate override: live `main` health was not fully settled when this lane
   started, so the replacement PR must open as draft and must not claim
   merge-readiness until current-head `main` health is rechecked.

--- a/docs/review/PR_1523_FIXED_MAPPING.md
+++ b/docs/review/PR_1523_FIXED_MAPPING.md
@@ -9,8 +9,19 @@
 
 Disposition: NOT-A-BUG
 Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#issuecomment-4316487688
-Reason: CodeRabbit posted a draft-state `Review skipped` status note and did not request code, documentation, dependency, or governance changes on the current draft head.
+Reason: CodeRabbit's walkthrough/pre-merge summary has no standalone action beyond
+the inline review comments explicitly dispositioned below.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#issuecomment-4316487688
+
+Disposition: FIXED
+Commit: 5ffc3f9c6
+Evidence: `docs/orchestration/DEPENDABOT_PR_1520_POSTCSS_REPLACEMENT_PACKET_2026-04-24.md` now points to `docs/review/PR_1523_FIXED_MAPPING.md` for this replacement lane.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#discussion_r3140520208 -> 5ffc3f9c6
+
+Disposition: FIXED
+Commit: 5ffc3f9c6
+Evidence: `docs/review/PR_1523_FIXED_MAPPING.md` keeps merge-readiness checklist items unchecked until the final merge cycle.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#discussion_r3140520217 -> 5ffc3f9c6
 
 Disposition: NOT-A-BUG
 Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#issuecomment-4316489543

--- a/docs/review/PR_1523_FIXED_MAPPING.md
+++ b/docs/review/PR_1523_FIXED_MAPPING.md
@@ -27,6 +27,16 @@ Commit: 5ffc3f9c6
 Evidence: CodeRabbit's actionable review summary aggregated the two inline comments above, both fixed by commit `5ffc3f9c6`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#pullrequestreview-4173659698 -> 5ffc3f9c6
 
+Disposition: FIXED
+Commit: 4f83fbf59
+Evidence: `docs/review/PR_1523_FIXED_MAPPING.md` uses `Phase 2` wording in the merge-readiness checklist.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#discussion_r3140593205 -> 4f83fbf59
+
+Disposition: FIXED
+Commit: 4f83fbf59
+Evidence: CodeRabbit's actionable review summary for `Phase2` wording is covered by the inline comment fix above.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#pullrequestreview-4173743422 -> 4f83fbf59
+
 Disposition: NOT-A-BUG
 Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#issuecomment-4316489543
 Reason: Sourcery generated a reviewer guide and summary only; it contains no requested fixes or unresolved action items for this PR head.

--- a/docs/review/PR_1523_FIXED_MAPPING.md
+++ b/docs/review/PR_1523_FIXED_MAPPING.md
@@ -1,0 +1,35 @@
+# PR 1523 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#issuecomment-4316487688
+Reason: CodeRabbit posted a draft-state `Review skipped` status note and did not request code, documentation, dependency, or governance changes on the current draft head.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#issuecomment-4316487688
+
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#issuecomment-4316489543
+Reason: Sourcery generated a reviewer guide and summary only; it contains no requested fixes or unresolved action items for this PR head.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#issuecomment-4316489543
+
+## Merge Readiness
+
+- [ ] Current-head `main` health rechecked and stable
+- [ ] Current-head PR CI green with no pending required jobs
+- [x] Canonical fixed-mapping artifact exists and validates
+- [ ] PR body Phase2 mirror validates on current head
+- [x] No unresolved review threads at artifact initialization time
+- [x] No actionable CodeRabbit, Sourcery, or Cubic items at artifact initialization time
+- [ ] Strict merge wrapper passes with auth
+- [ ] Mandatory wait-window elapsed after latest bot/review activity
+
+Notes:
+
+- This PR remains draft and is not merge-ready.
+- The source Dependabot PR is `#1520`; this replacement branch does not edit the bot branch directly.
+- Re-check review threads, bot comments, current-head checks, and `main` health before moving out of draft.

--- a/docs/review/PR_1523_FIXED_MAPPING.md
+++ b/docs/review/PR_1523_FIXED_MAPPING.md
@@ -22,6 +22,11 @@ Commit: 5ffc3f9c6
 Evidence: `docs/review/PR_1523_FIXED_MAPPING.md` keeps merge-readiness checklist items unchecked until the final merge cycle.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#discussion_r3140520217 -> 5ffc3f9c6
 
+Disposition: FIXED
+Commit: 5ffc3f9c6
+Evidence: CodeRabbit's actionable review summary aggregated the two inline comments above, both fixed by commit `5ffc3f9c6`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#pullrequestreview-4173659698 -> 5ffc3f9c6
+
 Disposition: NOT-A-BUG
 Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#issuecomment-4316489543
 Reason: Sourcery generated a reviewer guide and summary only; it contains no requested fixes or unresolved action items for this PR head.

--- a/docs/review/PR_1523_FIXED_MAPPING.md
+++ b/docs/review/PR_1523_FIXED_MAPPING.md
@@ -9,8 +9,7 @@
 
 Disposition: NOT-A-BUG
 Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#issuecomment-4316487688
-Reason: CodeRabbit's walkthrough/pre-merge summary has no standalone action beyond
-the inline review comments explicitly dispositioned below.
+Reason: CodeRabbit's walkthrough/pre-merge summary has no standalone action beyond the inline review comments explicitly dispositioned below.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#issuecomment-4316487688
 
 Disposition: FIXED

--- a/docs/review/PR_1523_FIXED_MAPPING.md
+++ b/docs/review/PR_1523_FIXED_MAPPING.md
@@ -21,15 +21,16 @@ Reason: Sourcery generated a reviewer guide and summary only; it contains no req
 
 - [ ] Current-head `main` health rechecked and stable
 - [ ] Current-head PR CI green with no pending required jobs
-- [x] Canonical fixed-mapping artifact exists and validates
+- [ ] Canonical fixed-mapping artifact exists and validates
 - [ ] PR body Phase2 mirror validates on current head
-- [x] No unresolved review threads at artifact initialization time
-- [x] No actionable CodeRabbit, Sourcery, or Cubic items at artifact initialization time
+- [ ] No unresolved review threads at artifact initialization time
+- [ ] No actionable CodeRabbit, Sourcery, or Cubic items at artifact initialization time
 - [ ] Strict merge wrapper passes with auth
 - [ ] Mandatory wait-window elapsed after latest bot/review activity
 
 Notes:
 
-- This PR remains draft and is not merge-ready.
+- This PR is not merge-ready until the current review cycle, current-head checks,
+  main-health gate, strict wrapper, and wait-window are complete.
 - The source Dependabot PR is `#1520`; this replacement branch does not edit the bot branch directly.
 - Re-check review threads, bot comments, current-head checks, and `main` health before moving out of draft.

--- a/docs/review/PR_1523_FIXED_MAPPING.md
+++ b/docs/review/PR_1523_FIXED_MAPPING.md
@@ -37,7 +37,7 @@ Reason: Sourcery generated a reviewer guide and summary only; it contains no req
 - [ ] Current-head `main` health rechecked and stable
 - [ ] Current-head PR CI green with no pending required jobs
 - [ ] Canonical fixed-mapping artifact exists and validates
-- [ ] PR body Phase2 mirror validates on current head
+- [ ] PR body Phase 2 mirror validates on current head
 - [ ] No unresolved review threads at artifact initialization time
 - [ ] No actionable CodeRabbit, Sourcery, or Cubic items at artifact initialization time
 - [ ] Strict merge wrapper passes with auth

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -66,7 +66,7 @@
         "jsdom": "^24.1.0",
         "msw": "^2.11.3",
         "openapi-typescript": "7.10.1",
-        "postcss": "^8.4.38",
+        "postcss": "^8.5.10",
         "storybook": "8.6.17",
         "style-dictionary": "5.3.3",
         "tailwindcss": "^3.4.4",
@@ -8517,9 +8517,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -83,7 +83,7 @@
     "jsdom": "^24.1.0",
     "msw": "^2.11.3",
     "openapi-typescript": "7.10.1",
-    "postcss": "^8.4.38",
+    "postcss": "^8.5.10",
     "storybook": "8.6.17",
     "style-dictionary": "5.3.3",
     "tailwindcss": "^3.4.4",


### PR DESCRIPTION
## Summary

User-owned replacement for Dependabot PR #1520.

This PR preserves the narrow frontend dependency update:

- `postcss` `8.5.8` -> `8.5.10`
- `frontend/package.json` spec `^8.4.38` -> `^8.5.10`
- `frontend/package-lock.json` root spec and locked `node_modules/postcss` entry updated

It does not edit the Dependabot bot branch directly.

## Scope

In scope:

- PostCSS dependency/lockfile update in `frontend/`
- Coordinator-first replacement packet:
  `docs/orchestration/DEPENDABOT_PR_1520_POSTCSS_REPLACEMENT_PACKET_2026-04-24.md`
- Canonical fixed-mapping artifact:
  `docs/review/PR_1523_FIXED_MAPPING.md`

Out of scope:

- Public API, backend, OpenAPI, iOS, runtime behavior, UI behavior, scripts, secrets, deployment, Docker, and Dependabot config changes
- Any merge-ready claim before current-head `main` health, current-head PR CI, bot review, mapping/body, and wait-window gates pass

## Local Validation

- `python3 scripts/orchestration/check_preflight.py --path frontend/package.json --path frontend/package-lock.json --path docs/orchestration/DEPENDABOT_PR_1520_POSTCSS_REPLACEMENT_PACKET_2026-04-24.md` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `cd frontend && npm install` PASS, `0 vulnerabilities`
- `cd frontend && npm run build` PASS
- `cd frontend && npm test -- --run src/api/__tests__/thin-client-guards.test.ts` PASS
- `pre-commit run --all-files` PASS
- commit/pre-push hooks PASS

## Role Review

Coordinator-approved role order completed before draft open:

1. `agent-coordinator`
2. `frontend-engineer`
3. `security-auditor`
4. `qa-engineer-agent`
5. `bug-hunter`
6. `agent-coordinator`

All role reviews approved proceeding to draft PR open. This is not a merge-ready approval.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_1523_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#issuecomment-4316487688
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#discussion_r3140520208 -> 5ffc3f9c6
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#discussion_r3140520217 -> 5ffc3f9c6
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#pullrequestreview-4173659698 -> 5ffc3f9c6
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#discussion_r3140593205 -> 4f83fbf59
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#pullrequestreview-4173743422 -> 4f83fbf59
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1523#issuecomment-4316489543

## Merge Readiness

- [ ] Current-head `main` health rechecked and stable
- [ ] Current-head PR CI green with no pending required jobs
- [x] Canonical fixed-mapping artifact exists and validates
- [x] PR body Phase 2 mirror validates
- [ ] No unresolved review threads after the current review cycle
- [ ] CodeRabbit, Sourcery, and Cubic have no actionable items after the current review cycle
- [ ] Strict merge wrapper passes with auth
- [ ] Mandatory wait-window elapsed after latest bot/review activity

## Pending Main Health Gate

This PR is on review, but it must not be called merge-ready until live `main`
health, current-head PR checks, review-thread disposition, strict wrapper, and
the mandatory wait-window are all satisfied.

Supersedes #1520.

## Summary by Sourcery

Обновить фронтенд-зависимость PostCSS и добавить документацию по управлению для lane-замены Dependabot.

Исправления ошибок:
- Синхронизировать фронтенд-зависимость PostCSS и lockfile с версией 8.5.10, чтобы включить апстрим-исправления из 8.5.8.

Улучшения:
- Добавить orchestration packet, документирующий пользовательскую (user-owned) замену для Dependabot PR #1520 и ее правила управления проверкой/слиянием (validation/merge governance).
- Добавить каноничный артефакт ревью с фиксированным сопоставлением, фиксирующий решения бота по ревью и контрольные условия готовности к слиянию для этого PR.

Сборка:
- Обновить записи PostCSS в frontend `package.json` и `package-lock.json`, чтобы нацелиться на версию 8.5.10.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the frontend PostCSS dependency and add governance documentation for the Dependabot replacement lane.

Bug Fixes:
- Align the frontend PostCSS dependency and lockfile to version 8.5.10 to incorporate upstream fixes from 8.5.8.

Enhancements:
- Add an orchestration packet documenting the user-owned replacement for Dependabot PR #1520 and its validation/merge governance.
- Add a canonical fixed-mapping review artifact capturing bot review dispositions and merge-readiness gates for this PR.

Build:
- Refresh frontend package.json and package-lock.json PostCSS entries to target version 8.5.10.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added orchestration and PR-review guidance documents that define replacement process, gating rules, validation and merge-readiness checks for dependency update PRs.
* **Dependencies**
  * Updated PostCSS development dependency to 8.5.10 to align frontend build tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
