### PR TITLE
fix(deps): align ruff and remove blocked pip pin on main

### DIFF
--- a/docs/review/PR_1541_FIXED_MAPPING.md
+++ b/docs/review/PR_1541_FIXED_MAPPING.md
@@ -1,0 +1,29 @@
+# PR #1541 Fixed Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1541>
+Branch: `codex/fix-main-dependabot-main-gates`
+Date: 2026-04-26
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+No actionable review comments were raised.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1541#pullrequestreview-4177261902
+Disposition: NOT-A-BUG
+Evidence: requirements-dev.in:1-4
+Evidence: requirements-dev.txt:1-4
+Reason: This PR only re-aligns dependency version surfaces; no functional behavior change is introduced.
+
+## Initial Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` (PASS)
+- `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
+- `pre-commit run --all-files` (PASS)
+- `make validate-changed` (PASS)
+- `pytest -q tests/test_dependency_security_guard.py::test_dependency_security_guard_enforces_blocked_versions[surface6]` (PASS)
+- `pytest -q tests/test_install_locked_python_requirements.py::test_repo_ruff_emergency_fallback_matches_dev_requirement_surfaces` (PASS)

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -30,5 +30,5 @@ mypy==1.20.2
 types-pyyaml~=6.0.12
 yamllint~=1.38.0
 black~=26.3.1
-ruff~=0.15.12
+ruff~=0.15.11
 nh3>=0.3.2  # HTML sanitization (required for data_sanitizer security tests)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -217,7 +217,7 @@ rich==14.3.3
     # via
     #   bandit
     #   pip-audit
-ruff==0.15.12
+ruff==0.15.11
     # via -r requirements-dev.in
 sortedcontainers==2.4.0
     # via
@@ -247,10 +247,6 @@ yamllint==1.38.0
     # via -r requirements-dev.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.0.1
-    # via
-    #   pip-api
-    #   pip-tools
 setuptools==78.1.1
     # via
     #   -c requirements.txt

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -161,6 +161,8 @@ requests==2.33.0
     # via
     #   -r requirements.in
     #   opentelemetry-exporter-otlp-proto-http
+ruff==0.15.11
+    # via -r requirements-dev.in
 six==1.17.0
     # via python-dateutil
 slowapi==0.1.9


### PR DESCRIPTION
## Summary

This PR fixes dependency-gate failures on `main` introduced after recent Dependabot updates by reconciling development fallback/emergency dependency surfaces.

- `requirements-dev.in`: set `ruff~=0.15.11` to align with the fallback manifest.
- `requirements-dev.txt`: set `ruff==0.15.11` and remove blocked `pip==26.0.1` requirement.
- `requirements-lock.txt`: add `ruff==0.15.11` for lock/dev parity.

## Evidence

- `python3 scripts/orchestration/check_preflight.py` (PASS)
- `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
- `pre-commit run --all-files` (PASS)
- `make validate-changed` (PASS)
- `pytest -q tests/test_dependency_security_guard.py::test_dependency_security_guard_enforces_blocked_versions[surface6]` (PASS)
- `pytest -q tests/test_install_locked_python_requirements.py::test_repo_ruff_emergency_fallback_matches_dev_requirement_surfaces` (PASS)

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_1541_FIXED_MAPPING.md`

## Merge Readiness

- [x] Canonical mapping artifact `docs/review/PR_1541_FIXED_MAPPING.md` exists and validates.
- [x] PR-body phase2 mirror is present.
- [x] No unresolved review threads or unmapped actionable findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Downgraded the `ruff` development dependency from version 0.15.12 to 0.15.11.
  * Updated development dependency lock files to reflect the new version constraint.
  * Added documentation for verification completion and test execution records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->