### PR TITLE
fix(security): suppress trivy CVE-2026-41989

### DIFF
--- a/docs/review/PR_1542_FIXED_MAPPING.md
+++ b/docs/review/PR_1542_FIXED_MAPPING.md
@@ -9,7 +9,7 @@ Date: 2026-04-26
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-No actionable review comments were raised.
+Actionable bot comments are mapped below.
 
 ## Fixed in Commit Mapping
 
@@ -22,6 +22,11 @@ Evidence: `docs/roadmap/BACKLOG_LEDGER.md`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#pullrequestreview-4177348529 -> 300a9c345
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#discussion_r3144027974 -> 300a9c345
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#discussion_r3144027978 -> 300a9c345
+
+Disposition: FIXED
+Commit: 93cbdbe85
+Evidence: `trivy/ignore-policy.rego`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#pullrequestreview-4177366702 -> 93cbdbe85
 
 ## Initial Evidence
 

--- a/docs/review/PR_1542_FIXED_MAPPING.md
+++ b/docs/review/PR_1542_FIXED_MAPPING.md
@@ -14,13 +14,13 @@ No actionable review comments were raised.
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
-Commit: a4d92885d
+Commit: 300a9c345
 Evidence: `trivy/ignore-policy.rego`
 Evidence: `docs/security/CVE-2026-41989-libgcrypt20.md`
 Evidence: `docs/roadmap/BACKLOG_LEDGER.md`
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#pullrequestreview-4177348529 -> a4d92885d
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#discussion_r3144027974 -> a4d92885d
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#discussion_r3144027978 -> a4d92885d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#pullrequestreview-4177351787 -> 300a9c345
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#discussion_r3144027974 -> 300a9c345
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#discussion_r3144027978 -> 300a9c345
 
 ## Initial Evidence
 

--- a/docs/review/PR_1542_FIXED_MAPPING.md
+++ b/docs/review/PR_1542_FIXED_MAPPING.md
@@ -19,6 +19,7 @@ Evidence: `trivy/ignore-policy.rego`
 Evidence: `docs/security/CVE-2026-41989-libgcrypt20.md`
 Evidence: `docs/roadmap/BACKLOG_LEDGER.md`
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#pullrequestreview-4177351787 -> 300a9c345
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#pullrequestreview-4177348529 -> 300a9c345
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#discussion_r3144027974 -> 300a9c345
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#discussion_r3144027978 -> 300a9c345
 

--- a/docs/review/PR_1542_FIXED_MAPPING.md
+++ b/docs/review/PR_1542_FIXED_MAPPING.md
@@ -1,0 +1,30 @@
+# PR #1542 Fixed Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542>
+Branch: `codex/fix-trivy-41989-suppression`
+Date: 2026-04-26
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+No actionable review comments were raised.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/586
+- Evidence: `trivy/ignore-policy.rego`
+- Evidence: `docs/security/CVE-2026-41989-libgcrypt20.md`
+- Evidence: `docs/roadmap/BACKLOG_LEDGER.md`
+
+## Initial Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` (PASS)
+- `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
+- `pre-commit run --all-files` (PASS)
+- `pytest -q 'tests/test_dependency_security_guard.py::test_dependency_security_guard_enforces_blocked_versions[surface6]'`
+  (PASS, existing regression guard)
+- `pytest -q tests/test_install_locked_python_requirements.py::test_repo_ruff_emergency_fallback_matches_dev_requirement_surfaces`
+  (PASS, existing regression guard)
+- Manual GitHub alert verification: <https://api.github.com/repos/Katsiarynakavaleuskaya/PulsePlate/code-scanning/alerts/586>

--- a/docs/review/PR_1542_FIXED_MAPPING.md
+++ b/docs/review/PR_1542_FIXED_MAPPING.md
@@ -13,10 +13,14 @@ No actionable review comments were raised.
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/586
-- Evidence: `trivy/ignore-policy.rego`
-- Evidence: `docs/security/CVE-2026-41989-libgcrypt20.md`
-- Evidence: `docs/roadmap/BACKLOG_LEDGER.md`
+Disposition: FIXED
+Commit: a4d92885d
+Evidence: `trivy/ignore-policy.rego`
+Evidence: `docs/security/CVE-2026-41989-libgcrypt20.md`
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#pullrequestreview-4177348529 -> a4d92885d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#discussion_r3144027974 -> a4d92885d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1542#discussion_r3144027978 -> a4d92885d
 
 ## Initial Evidence
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -3681,6 +3681,28 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Trivy Code Scanning alerts #572, #574, #576, and #577 remain closed on
       `main`
 
+- [ ] Remove Trivy suppression for libgcrypt20 CVE-2026-41989
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: TBD (follow-up after upstream fix)
+  - Status: Open
+  - Area: security / base-image / code-scanning
+  - Finding Type: container base image vulnerability
+  - Reason: `build.yml:publish` on `main` currently reports open Trivy alert `#586` on
+    `libgcrypt20` at version `1.10.1-3` with no published fixed-version metadata
+    as of 2026-04-26. This CVE is addressed by targeted suppression in
+    `trivy/ignore-policy.rego` while monitoring upstream/base-image progress.
+  - Links:
+    - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/586
+    - docs/security/CVE-2026-41989-libgcrypt20.md
+    - trivy/ignore-policy.rego
+    - .github/workflows/build.yml
+  - DoD:
+    - Debian or Trivy metadata publishes a fixed `libgcrypt20` package context
+    - Remove suppression rule from `trivy/ignore-policy.rego`
+    - Mark `docs/security/CVE-2026-41989-libgcrypt20.md` resolved or remove after fix
+    - Trivy Code Scanning alert `#586` remains closed on `main`
+
 - [ ] Security suppression expiry monitoring
   - Owner: @katsiaryna_kavaleuskaya
   - Target PR: N/A (ongoing)

--- a/docs/security/CVE-2026-41989-libgcrypt20.md
+++ b/docs/security/CVE-2026-41989-libgcrypt20.md
@@ -1,0 +1,73 @@
+# CVE-2026-41989 — libgcrypt20 (Debian bookworm) — Trivy code-scanning suppression
+
+## Summary
+
+- **CVE**: CVE-2026-41989
+- **Source package**: `libgcrypt20`
+- **Affected binary package in our image alert set**: `libgcrypt20`
+- **Observed installed version**: `1.10.1-3`
+- **Trivy rule**: `OsPackageVulnerability`
+- **Severity (Trivy security severity level)**: High
+- **GitHub alert**: `#586`
+
+This finding is reported by Trivy against the Debian base-image layer used by our Docker
+publish lane.
+
+At triage time, published metadata reports an empty `Fixed Version` for
+`CVE-2026-41989` on the observed package version.
+
+## Why we suppress (temporarily)
+
+- This is an **OS package** CVE in the base image stack, not a Python dependency
+  introduced by this repository.
+- The Python/FastAPI runtime is not linked to `libgcrypt20` cryptographic pathways in
+  a way that materially exposes this application surface.
+- Trivy alerts in current workflow context report the package as vulnerable with no
+  fixed package version, so the practical remediation in this repo is to monitor the
+  upstream image line and remove this suppression once a fix is available.
+
+We therefore apply a narrow suppression scoped to:
+
+- `CVE-2026-41989`
+- package `libgcrypt20`
+- exact observed version `1.10.1-3`
+- exact `PkgID` prefix for that package version
+
+## Observed alert evidence
+
+Exact payload from the open GitHub code-scanning alert on `main`:
+
+```text
+$ gh api repos/Katsiarynakavaleuskaya/PulsePlate/code-scanning/alerts/586 --jq '.most_recent_instance.message.text'
+Package: libgcrypt20
+Installed Version: 1.10.1-3
+Vulnerability CVE-2026-41989
+Severity: HIGH
+Fixed Version:
+Link: [CVE-2026-41989](https://avd.aquasec.com/nvd/cve-2026-41989)
+```
+
+## Monitor / upstream status
+
+- **Debian Security Tracker**: <https://security-tracker.debian.org/tracker/source-package/libgcrypt20>
+- **NVD**: <https://nvd.nist.gov/vuln/detail/CVE-2026-41989>
+- **Trivy message endpoint**: <https://avd.aquasec.com/nvd/cve-2026-41989>
+
+## Removal condition
+
+Remove this suppression when either:
+
+1. The Python base image used by publish receives a fixed `libgcrypt20` package
+   for this CVE, or
+2. Trivy metadata starts reporting a non-empty `Fixed Version` for the observed
+   package context.
+
+## Suppression implementation
+
+- Policy file: `trivy/ignore-policy.rego`
+- Ledger anchor (expected): `docs/roadmap/BACKLOG_LEDGER.md` security suppression
+  tracking section
+
+## Review / expiry
+
+- **Next review target**: 2026-05-27 (aligned with existing Trivy suppression window)

--- a/docs/security/CVE-2026-41989-libgcrypt20.md
+++ b/docs/security/CVE-2026-41989-libgcrypt20.md
@@ -44,14 +44,19 @@ Installed Version: 1.10.1-3
 Vulnerability CVE-2026-41989
 Severity: HIGH
 Fixed Version:
-Link: [CVE-2026-41989](https://avd.aquasec.com/nvd/cve-2026-41989)
+Link: [CVE-2026-41989](https://www.cve.org/CVERecord?id=CVE-2026-41989)
 ```
 
 ## Monitor / upstream status
 
-- **Debian Security Tracker**: <https://security-tracker.debian.org/tracker/source-package/libgcrypt20>
-- **NVD**: <https://nvd.nist.gov/vuln/detail/CVE-2026-41989>
-- **Trivy message endpoint**: <https://avd.aquasec.com/nvd/cve-2026-41989>
+- **CVE record**: <https://www.cve.org/CVERecord?id=CVE-2026-41989>
+- **Debian source package tracker**: <https://security-tracker.debian.org/tracker/source-package/libgcrypt20>
+- **Debian CVE page**: <https://security-tracker.debian.org/tracker/CVE-2026-41989?version=Debian>
+
+## Link accessibility check
+
+- As of 2026-04-26, `https://nvd.nist.gov/vuln/detail/CVE-2026-41989` returns HTTP 403.
+- As of 2026-04-26, `https://avd.aquasec.com/nvd/cve-2026-41989` returns HTTP 404.
 
 ## Removal condition
 

--- a/docs/security/CVE-2026-41989-libgcrypt20.md
+++ b/docs/security/CVE-2026-41989-libgcrypt20.md
@@ -73,6 +73,12 @@ Remove this suppression when either:
 - Ledger anchor (expected): `docs/roadmap/BACKLOG_LEDGER.md` security suppression
   tracking section
 
+## Evidence anchors
+
+- `trivy/ignore-policy.rego:129`
+- `trivy/ignore-policy.rego:162`
+- `docs/roadmap/BACKLOG_LEDGER.md:3684`
+
 ## Review / expiry
 
 - **Next review target**: 2026-05-27 (aligned with existing Trivy suppression window)

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -139,7 +139,6 @@ cve_2026_41989_libgcrypt20_version := "1.10.1-3"
 cve_2026_41989_image_reference_match if {
 	# Scope by image reference when available in Trivy input.
 	# Fallback remains broad when the field is absent.
-	input.Image
 	startswith(input.Image, "ghcr.io/katsiarynakavaleuskaya/pulseplate")
 }
 
@@ -150,7 +149,6 @@ cve_2026_41989_image_reference_match if {
 cve_2026_41989_distro_match if {
 	# Scope by distro when available in Trivy input.
 	# Fallback remains broad when distro field is absent.
-	input.Distro
 	input.Distro == "debian"
 }
 

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -126,6 +126,23 @@ ignore if {
 	cve_2026_27171_pkgid_match
 }
 
+# CVE-2026-41989 (libgcrypt20) - no fixed release for observed Debian package at triage time
+# Review-by: 2026-05-27 (manual removal)
+# Rationale: Trivy security scan reports libgcrypt20 fixed-version unknown for `1.10.1-3` in base image; no repository-level remediation path exists right now.
+# Monitor: https://avd.aquasec.com/nvd/cve-2026-41989
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2026-41989
+# Documented in: docs/security/CVE-2026-41989-libgcrypt20.md
+# Removal condition: Remove when Debian publishes fixed libgcrypt20 package / Trivy metadata gains fixed version for this package context
+
+cve_2026_41989_libgcrypt20_version := "1.10.1-3"
+
+ignore if {
+	input.VulnerabilityID == "CVE-2026-41989"
+	input.PkgName == "libgcrypt20"
+	input.InstalledVersion == cve_2026_41989_libgcrypt20_version
+	startswith(input.PkgID, sprintf("libgcrypt20@%s", [cve_2026_41989_libgcrypt20_version]))
+}
+
 # CVE-2025-14831 (gnutls) - base image not yet updated to fixed version
 # Review-by: 2026-05-27 (check if base image updated to deb12u6)
 # Rationale: Fix available in 3.7.9-2+deb12u6 but base image still has deb12u5

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -136,10 +136,34 @@ ignore if {
 
 cve_2026_41989_libgcrypt20_version := "1.10.1-3"
 
+cve_2026_41989_image_reference_match if {
+	# Scope by image reference when available in Trivy input.
+	# Fallback remains broad when the field is absent.
+	input.Image
+	startswith(input.Image, "ghcr.io/katsiarynakavaleuskaya/pulseplate")
+}
+
+cve_2026_41989_image_reference_match if {
+	not input.Image
+}
+
+cve_2026_41989_distro_match if {
+	# Scope by distro when available in Trivy input.
+	# Fallback remains broad when distro field is absent.
+	input.Distro
+	input.Distro == "debian"
+}
+
+cve_2026_41989_distro_match if {
+	not input.Distro
+}
+
 ignore if {
 	input.VulnerabilityID == "CVE-2026-41989"
 	input.PkgName == "libgcrypt20"
 	input.InstalledVersion == cve_2026_41989_libgcrypt20_version
+	cve_2026_41989_image_reference_match
+	cve_2026_41989_distro_match
 	startswith(input.PkgID, sprintf("libgcrypt20@%s", [cve_2026_41989_libgcrypt20_version]))
 }
 


### PR DESCRIPTION
## Summary

This PR documents and applies a narrow, temporary suppression for Trivy alert `#586` (`CVE-2026-41989`) while upstream base-image remediation is not yet available.

Scope is intentionally limited:

- Added a tightly constrained rule in `trivy/ignore-policy.rego` for `libgcrypt20` version `1.10.1-3`.
- Added a security evidence document at `docs/security/CVE-2026-41989-libgcrypt20.md`.
- Added a backlog tracker item in `docs/roadmap/BACKLOG_LEDGER.md` with explicit removal criteria.

This does not change application runtime behavior.

## Evidence

- `python3 scripts/orchestration/check_preflight.py` (PASS)
- `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
- `pre-commit run --all-files` (PASS)
- `pytest -q 'tests/test_dependency_security_guard.py::test_dependency_security_guard_enforces_blocked_versions[surface6]'` (PASS)
- `pytest -q tests/test_install_locked_python_requirements.py::test_repo_ruff_emergency_fallback_matches_dev_requirement_surfaces` (PASS)
- `make validate-changed` could not run in this environment because `VENV_PYTHON` is missing; local pre-push path was executed during `git push` and passed.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- `docs/review/PR_1542_FIXED_MAPPING.md`

## Merge Readiness

- [x] Canonical mapping artifact exists: `docs/review/PR_1542_FIXED_MAPPING.md`
- [x] PR-body sections are present: `## Discussion Thread Pass`, `### Fixed in Commit Mapping`, `## Merge Readiness`
- [ ] Actionable bot comments/threads are reviewed and resolved with disposition (post-open check)
- [ ] `check_merge_ready.py --require-auth` pending after this PR is opened in GitHub

## Summary by Sourcery

Задокументировать и временно подавить конкретную уязвимость базового образа контейнера Trivy, одновременно отслеживая её последующее устранение.

Новые возможности:
- Добавить узко сфокусированное правило политики игнорирования Trivy для CVE-2026-41989, затрагивающей libgcrypt20 версии 1.10.1-3.

Улучшения:
- Зафиксировать временное подавление и план мониторинга для CVE-2026-41989 в реестре бэклога по безопасности с чётким указанием ответственных, DoD и ссылками на артефакты-доказательства.
- Добавить отдельный документ с артефактами по безопасности, описывающий обоснование, область действия и условия удаления подавления для CVE-2026-41989.
- Добавить артефакт ревью PR fixed-mapping, содержащий связанное оповещение Trivy и команды для проверки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document and temporarily suppress a specific Trivy container base-image vulnerability while tracking its eventual removal.

New Features:
- Add a narrowly scoped Trivy ignore-policy rule for CVE-2026-41989 affecting libgcrypt20 at version 1.10.1-3.

Enhancements:
- Record the temporary suppression and monitoring plan for CVE-2026-41989 in the security backlog ledger with clear ownership, DoD, and links to evidence.
- Add a dedicated security evidence document describing the rationale, scope, and removal conditions for the CVE-2026-41989 suppression.
- Add a PR fixed-mapping review artifact capturing the associated Trivy alert and verification commands.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily suppresses `CVE-2026-41989` for `libgcrypt20@1.10.1-3` with a narrowly scoped Trivy ignore in `trivy/ignore-policy.rego`, limited by `PkgID` prefix, Debian distro, and the `ghcr.io/katsiarynakavaleuskaya/pulseplate` image, with safe fallbacks when Trivy omits image or distro fields. Updates evidence and tracking (including fixed-mapping) in `docs/security/CVE-2026-41989-libgcrypt20.md`, `docs/roadmap/BACKLOG_LEDGER.md`, and `docs/review/PR_1542_FIXED_MAPPING.md`; no runtime changes.

<sup>Written for commit 589625f4447ac0c33ea65178ca434050abf11980. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added security guidance for CVE-2026-41989 (libgcrypt20) including observed evidence, scoped suppression criteria, explicit removal conditions, monitoring/upstream links, and a next-review date.
  * Added a backlog entry to track retirement of the temporary vulnerability suppression.
  * Added a review record documenting the review outcome and verification steps.

* **Chores**
  * Added a targeted Trivy suppression rule for CVE-2026-41989.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->