### PR TITLE
fix(ci): stabilize main nightly and python tests

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -49,8 +49,10 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install dependencies
-        run: |
-          python scripts/ci/install_locked_python_requirements.py --python-executable python --constraints-file constraints.txt --install-dev
+        uses: ./.github/actions/python-setup
+        with:
+          python-version: '3.13.6'
+          requirements-profile: 'ci-test'
 
       - name: Install root Node dependencies
         uses: ./.github/actions/npm-ci-with-retry

--- a/core/food_sources/source_preflight.py
+++ b/core/food_sources/source_preflight.py
@@ -12,7 +12,7 @@ import re
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal
 from urllib.parse import urlparse
 
 SourceClassification = Literal[
@@ -235,7 +235,7 @@ def _parse_collision_policy(
     return SourceCollisionPolicy(
         dedupe_fields=dedupe_fields,
         mapping_fields=mapping_fields,
-        collision_resolution=cast(CollisionResolution, resolution),
+        collision_resolution=resolution,
     )
 
 

--- a/core/food_sources/source_preflight.py
+++ b/core/food_sources/source_preflight.py
@@ -214,6 +214,12 @@ def _parse_collision_policy(
             f"{context}.collision_policy",
             "collision_resolution must be one of: reject, quarantine, skip",
         )
+    if resolution == "reject":
+        collision_resolution: CollisionResolution = "reject"
+    elif resolution == "quarantine":
+        collision_resolution = "quarantine"
+    else:
+        collision_resolution = "skip"
 
     allowed_fields = set(schema.fields)
     out_of_schema_dedupe = sorted(set(dedupe_fields) - allowed_fields)
@@ -235,7 +241,7 @@ def _parse_collision_policy(
     return SourceCollisionPolicy(
         dedupe_fields=dedupe_fields,
         mapping_fields=mapping_fields,
-        collision_resolution=resolution,
+        collision_resolution=collision_resolution,
     )
 
 

--- a/docs/review/PR_1544_FIXED_MAPPING.md
+++ b/docs/review/PR_1544_FIXED_MAPPING.md
@@ -1,4 +1,4 @@
-# PR #1544 Fixed Mapping
+# PR #1544 - Fixed in Commit Mapping (canonical)
 
 PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544>
 Branch: `codex/fix-main-nightly-python-tests-2026-04-27`
@@ -6,20 +6,46 @@ Date: 2026-04-27
 
 ## Discussion Thread Pass
 
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md`.
+
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
+This artifact was updated after the mandatory post-open `qa-engineer-agent -> bug-hunter` cycle and must stay aligned with PR body.
+
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: bb8c9d3af
+Evidence: scripts/install_codex_skills.sh:291-300.
+Reason: `unlink_skills` now guards canonical path resolution failures before comparisons, and avoids duplicate canonicalization calls while preserving unlink safety for copied mirrors.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#discussion_r3146875221 -> bb8c9d3af
+
+Disposition: FIXED
+Commit: bb8c9d3af
+Evidence: core/food_sources/source_preflight.py:235-239.
+Reason: Removed a redundant cast warning path by returning `collision_resolution` directly from the validated Literal, restoring `make typecheck` pass under this PR.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#discussion_r3146869212 -> bb8c9d3af
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#pullrequestreview-4180427280 -> bb8c9d3af
+
+Disposition: FIXED
+Commit: bb8c9d3af
+Evidence: `make typecheck` passes locally after `bb8c9d3af`; `tests/test_install_codex_skills.py` remains aligned.
+Reason: The earlier CodeRabbit process gate issue was resolved by the above code-level fixes that remove pre-existing blockages.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#pullrequestreview-4180433907 -> bb8c9d3af
 
 ## Initial Evidence
 
 - `python3 scripts/orchestration/check_preflight.py` (PASS)
 - `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
 - `make lint` (PASS)
-- `make typecheck` (fails: pre-existing `core/food_sources/source_preflight.py:238` cast warning)
+- `make typecheck` (PASS)
 - `make test-fast` (PASS)
 - `make diff-cov` (blocked by local process semaphore env: `SC_SEM_NSEMS_MAX` in `run_main_test_shards`)
 - `pre-commit run --all-files` (PASS)
 - `python3 -m pytest tests/test_install_codex_skills.py::test_repo_agents_skills_mirror_points_to_codex_skill_sources` (PASS)
+
+## Initial Implementation Commits
+
+- `bb8c9d3af` - `fix: harden skill unlink and collision resolution typing`

--- a/docs/review/PR_1544_FIXED_MAPPING.md
+++ b/docs/review/PR_1544_FIXED_MAPPING.md
@@ -23,17 +23,17 @@ Reason: `unlink_skills` now guards canonical path resolution failures before com
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#discussion_r3146875221 -> bb8c9d3af
 
 Disposition: FIXED
-Commit: bb8c9d3af
-Evidence: core/food_sources/source_preflight.py:235-239.
-Reason: Removed a redundant cast warning path by returning `collision_resolution` directly from the validated Literal, restoring `make typecheck` pass under this PR.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#discussion_r3146869212 -> bb8c9d3af
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#pullrequestreview-4180427280 -> bb8c9d3af
+Commit: 6a4dfd325
+Evidence: core/food_sources/source_preflight.py:235-249.
+Reason: `collision_resolution` is normalized through explicit `Literal`-safe branching after validation, and no longer passes a raw `str` into the typed policy constructor.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#discussion_r3146869212 -> 6a4dfd325
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#pullrequestreview-4180427280 -> 6a4dfd325
 
 Disposition: FIXED
-Commit: bb8c9d3af
-Evidence: `make typecheck` passes locally after `bb8c9d3af`; `tests/test_install_codex_skills.py` remains aligned.
-Reason: The earlier CodeRabbit process gate issue was resolved by the above code-level fixes that remove pre-existing blockages.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#pullrequestreview-4180433907 -> bb8c9d3af
+Commit: 6a4dfd325
+Evidence: `make typecheck` passes locally after `6a4dfd325`; `tests/test_install_codex_skills.py` remains aligned.
+Reason: The earlier CodeRabbit process-gate issue was resolved by the code-level fixes in `scripts/install_codex_skills.sh` and `core/food_sources/source_preflight.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#pullrequestreview-4180433907 -> 6a4dfd325
 
 ## Initial Evidence
 
@@ -49,3 +49,5 @@ Reason: The earlier CodeRabbit process gate issue was resolved by the above code
 ## Initial Implementation Commits
 
 - `bb8c9d3af` - `fix: harden skill unlink and collision resolution typing`
+- `c8cbb2615` - `docs(review): map actionable bot findings for PR 1544`
+- `6a4dfd325` - `fix: tighten collision resolution typing`

--- a/docs/review/PR_1544_FIXED_MAPPING.md
+++ b/docs/review/PR_1544_FIXED_MAPPING.md
@@ -1,0 +1,25 @@
+# PR #1544 Fixed Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544>
+Branch: `codex/fix-main-nightly-python-tests-2026-04-27`
+Date: 2026-04-27
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- 0f2825bc3 -> stabilize nightly dependency install + codex skill path marker
+
+## Initial Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` (PASS)
+- `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
+- `make lint` (PASS)
+- `make typecheck` (fails: pre-existing `core/food_sources/source_preflight.py:238` cast warning)
+- `make test-fast` (PASS)
+- `make diff-cov` (blocked by local process semaphore env: `SC_SEM_NSEMS_MAX` in `run_main_test_shards`)
+- `pre-commit run --all-files` (PASS)
+- `python3 -m pytest tests/test_install_codex_skills.py::test_repo_agents_skills_mirror_points_to_codex_skill_sources` (PASS)

--- a/docs/review/PR_1544_FIXED_MAPPING.md
+++ b/docs/review/PR_1544_FIXED_MAPPING.md
@@ -11,7 +11,7 @@ Date: 2026-04-27
 
 ## Fixed in Commit Mapping
 
-- 0f2825bc3 -> stabilize nightly dependency install + codex skill path marker
+- No actionable review comments
 
 ## Initial Evidence
 

--- a/scripts/install_codex_skills.sh
+++ b/scripts/install_codex_skills.sh
@@ -42,6 +42,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 COPY_MARKER_FILE=".pulseplate_codex_skill_source"
 
+canonical_path() {
+  local path=$1
+
+  if [[ -d "${path}" ]]; then
+    (cd "${path}" && pwd -P)
+  else
+    return 1
+  fi
+}
+
 AGENTS_HOME_DEFAULT="${AGENTS_HOME:-${HOME}/.agents}"
 CODEX_HOME_DEFAULT="${CODEX_HOME:-${HOME}/.codex}"
 DEFAULT_DEST_ROOT="${AGENTS_HOME_DEFAULT}/skills"
@@ -247,8 +257,10 @@ install_skills() {
     fi
 
     if [[ "${install_mode}" == "copy" ]]; then
+      local canonical_src_dir
       cp -R "${src_dir}" "${dest_dir}"
-      printf '%s\n' "${src_dir}" > "${dest_dir}/${COPY_MARKER_FILE}"
+      canonical_src_dir="$(canonical_path "${src_dir}")"
+      printf '%s\n' "${canonical_src_dir}" > "${dest_dir}/${COPY_MARKER_FILE}"
       echo "Copied: ${skill_name}"
     else
       ln -s "${src_dir}" "${dest_dir}"
@@ -280,7 +292,7 @@ unlink_skills() {
       if [[ -f "${dest_dir}/${COPY_MARKER_FILE}" ]]; then
         local marker_source
         marker_source="$(cat "${dest_dir}/${COPY_MARKER_FILE}")"
-        if [[ "${marker_source}" == "${src_dir}" ]]; then
+        if [[ "$(canonical_path "${marker_source}")" == "$(canonical_path "${src_dir}")" ]]; then
           rm -rf "${dest_dir}"
           echo "Removed copied skill: ${skill_name}"
         else

--- a/scripts/install_codex_skills.sh
+++ b/scripts/install_codex_skills.sh
@@ -291,8 +291,18 @@ unlink_skills() {
     if [[ -d "${dest_dir}" && -f "${dest_dir}/SKILL.md" ]]; then
       if [[ -f "${dest_dir}/${COPY_MARKER_FILE}" ]]; then
         local marker_source
+        local marker_canon
+        local src_canon
         marker_source="$(cat "${dest_dir}/${COPY_MARKER_FILE}")"
-        if [[ "$(canonical_path "${marker_source}")" == "$(canonical_path "${src_dir}")" ]]; then
+        if ! marker_canon="$(canonical_path "${marker_source}")"; then
+          echo "Skip copied skill for ${skill_name}: stale marker path missing ${marker_source}" >&2
+          continue
+        fi
+        if ! src_canon="$(canonical_path "${src_dir}")"; then
+          echo "Skip copied skill for ${skill_name}: source path missing ${src_dir}" >&2
+          continue
+        fi
+        if [[ "${marker_canon}" == "${src_canon}" ]]; then
           rm -rf "${dest_dir}"
           echo "Removed copied skill: ${skill_name}"
         else

--- a/tests/test_install_codex_skills.py
+++ b/tests/test_install_codex_skills.py
@@ -374,7 +374,9 @@ def test_repo_agents_skills_mirror_points_to_codex_skill_sources() -> None:
             assert not mirrored_skill.is_symlink()
             marker = mirrored_skill / ".pulseplate_codex_skill_source"
             assert marker.exists(), f"{skill_name} mirror must carry source marker"
-            assert marker.read_text(encoding="utf-8").strip() == str(source_skill)
+            assert (
+                Path(marker.read_text(encoding="utf-8").strip()).resolve() == source_skill.resolve()
+            )
             assert (mirrored_skill / "SKILL.md").exists()
         else:
             assert mirrored_skill.is_symlink(), f"{skill_name} must be exposed via .agents/skills"


### PR DESCRIPTION
## Summary
- fix: stabilize main-nightly regression surface for CI/test install and codex skill mirror path handling

## Scope
- `.github/workflows/nightly-tests.yml`
- `scripts/install_codex_skills.sh`
- `tests/test_install_codex_skills.py`
- `core/food_sources/source_preflight.py`

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

Disposition: FIXED
Commit: bb8c9d3af
Evidence: scripts/install_codex_skills.sh:291-300.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#discussion_r3146875221 -> bb8c9d3af

Disposition: FIXED
Commit: 6a4dfd325
Evidence: core/food_sources/source_preflight.py:235-249.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#discussion_r3146869212 -> 6a4dfd325
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#pullrequestreview-4180427280 -> 6a4dfd325

Disposition: FIXED
Commit: 6a4dfd325
Evidence: local `make typecheck` pass and `tests/test_install_codex_skills.py`.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1544#pullrequestreview-4180433907 -> 6a4dfd325

## Merge Readiness
- preflight: PASS
- agent consistency: PASS
- required local validation: PASS
- `make lint`: PASS
- `make typecheck`: PASS
- `make test-fast`: PASS
- `make diff-cov`: blocked locally (SC_SEM_NSEMS_MAX)
- `pre-commit run --all-files`: PASS
- no actionable bot comments remain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Robustness Improvements**
  * Enhanced skill installation path handling with improved canonicalization for more reliable directory operations

* **Tests**
  * Updated test assertions for path comparison

* **Chores**
  * Updated CI/CD workflows and internal review documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->