### PR TITLE
fix(ci): stabilize codex skill marker path in CI

### DIFF
--- a/.agents/skills/pulseplate-pr-review/.pulseplate_codex_skill_source
+++ b/.agents/skills/pulseplate-pr-review/.pulseplate_codex_skill_source
@@ -1,1 +1,1 @@
-/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/tools/codex_skills/pulseplate-pr-review
+tools/codex_skills/pulseplate-pr-review

--- a/docs/review/PR_1545_FIXED_MAPPING.md
+++ b/docs/review/PR_1545_FIXED_MAPPING.md
@@ -5,17 +5,11 @@ Branch: `codex/fix-pr-review-skill-marker-mainly`
 Date: 2026-04-27
 
 ## Discussion Thread Pass
-
-- [x] Discussion-thread pass is pending initialization (no open actionable threads yet).
-- [x] Fixed in commit mapping documented in this artifact.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-
-Disposition: FIXED
-Commit: 39155b6f1
-Evidence: .agents/skills/pulseplate-pr-review/.pulseplate_codex_skill_source and tests/test_install_codex_skills.py
-Reason: Replace absolute marker path with repository-relative path and make path assertion environment-stable.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1545/files -> 39155b6f1
+- No actionable review comments
 
 ## Initial Evidence
 

--- a/docs/review/PR_1545_FIXED_MAPPING.md
+++ b/docs/review/PR_1545_FIXED_MAPPING.md
@@ -1,0 +1,25 @@
+# PR #1545 - Fixed in Commit Mapping (canonical)
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1545>
+Branch: `codex/fix-pr-review-skill-marker-mainly`
+Date: 2026-04-27
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass is pending initialization (no open actionable threads yet).
+- [x] Fixed in commit mapping documented in this artifact.
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 39155b6f1
+Evidence: .agents/skills/pulseplate-pr-review/.pulseplate_codex_skill_source and tests/test_install_codex_skills.py
+Reason: Replace absolute marker path with repository-relative path and make path assertion environment-stable.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1545/files -> 39155b6f1
+
+## Initial Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` (PASS)
+- `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
+- `pre-commit run --all-files` (PASS)
+- `python3 -m pytest tests/test_install_codex_skills.py::test_repo_agents_skills_mirror_points_to_codex_skill_sources -q` (PASS)

--- a/tests/test_install_codex_skills.py
+++ b/tests/test_install_codex_skills.py
@@ -374,9 +374,9 @@ def test_repo_agents_skills_mirror_points_to_codex_skill_sources() -> None:
             assert not mirrored_skill.is_symlink()
             marker = mirrored_skill / ".pulseplate_codex_skill_source"
             assert marker.exists(), f"{skill_name} mirror must carry source marker"
-            assert (
-                Path(marker.read_text(encoding="utf-8").strip()).resolve() == source_skill.resolve()
-            )
+            marker_parts = tuple(Path(marker.read_text(encoding="utf-8").strip()).parts)
+            expected_parts = source_skill.relative_to(REPO_ROOT).parts
+            assert marker_parts[-len(expected_parts) :] == expected_parts
             assert (mirrored_skill / "SKILL.md").exists()
         else:
             assert mirrored_skill.is_symlink(), f"{skill_name} must be exposed via .agents/skills"


### PR DESCRIPTION
## Summary
- CI regression in `tests/test_install_codex_skills.py::test_repo_agents_skills_mirror_points_to_codex_skill_sources` was caused by an absolute marker path in `.agents/skills/pulseplate-pr-review/.pulseplate_codex_skill_source`.
- This mismatch is environment-specific (`/Users/...` vs `/home/runner/...`) and caused CI instability after PR merge.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] No actionable review comments

### Fixed in Commit Mapping
- [x] Fixed in commit mapping completed
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1545/files -> 39155b6f1

## Merge Readiness
- [ ] PR-authoritative mapping file updated.
- [ ] Required checks green on current head.
- [ ] Review comments disposition completed before merge.

## Summary by Sourcery

Стабилизировать маркеры источников навыков codex, сделав тесты и маркеры устойчивыми к зависящим от окружения абсолютным путям.

Исправления ошибок:
- Обновить тест зеркала навыка codex, чтобы сравнивать пути маркеров относительно репозитория вместо абсолютных разрешённых путей.

Документация:
- Добавить каноничный документ сопоставления «исправлено в коммите» для PR #1545 с подтверждающими доказательствами.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize codex skill source markers by making tests and markers resilient to environment-specific absolute paths.

Bug Fixes:
- Update codex skill mirror test to compare repo-relative marker paths instead of absolute resolved paths.

Documentation:
- Add a canonical fixed-in-commit mapping document for PR #1545 with verification evidence.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Стабилизировать маркеры источников навыков codex, сделав тесты и маркеры устойчивыми к зависящим от окружения абсолютным путям.

Исправления ошибок:
- Обновить тест зеркала навыка codex, чтобы сравнивать пути маркеров относительно репозитория вместо абсолютных разрешённых путей.

Документация:
- Добавить каноничный документ сопоставления «исправлено в коммите» для PR #1545 с подтверждающими доказательствами.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize codex skill source markers by making tests and markers resilient to environment-specific absolute paths.

Bug Fixes:
- Update codex skill mirror test to compare repo-relative marker paths instead of absolute resolved paths.

Documentation:
- Add a canonical fixed-in-commit mapping document for PR #1545 with verification evidence.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes CI by making the codex skill source marker repository‑relative and updating the test to compare repo‑relative suffixes. Adds and normalizes a canonical fixed‑mapping doc for traceability.

- **Bug Fixes**
  - Changed `.agents/skills/pulseplate-pr-review/.pulseplate_codex_skill_source` to `tools/codex_skills/pulseplate-pr-review`.
  - Updated `tests/test_install_codex_skills.py::test_repo_agents_skills_mirror_points_to_codex_skill_sources` to compare `REPO_ROOT`‑relative suffixes.
  - Added and normalized `docs/review/PR_1545_FIXED_MAPPING.md` with passing evidence.

<sup>Written for commit 4475e38fb1ca3073913f42f268bd835bc4219e7f. Summary will update on new commits. <a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1545?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation capturing PR review metadata, verification status, and completion checklists for tracking purposes.

* **Tests**
  * Enhanced path verification logic for skill source detection to support flexible path reference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->