### PR TITLE
fix(ci): add emergency mypy cp313 wheel fallback

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -443,44 +443,51 @@
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "7a70b9366b18c4abd3d04de94c77124ca90bd822",
+        "hashed_secret": "7ab56d932ca71392d0d6f5c7584972c6d403a559",
         "is_verified": false,
-        "line_number": 90
+        "line_number": 89
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "58af8df3d18fd6b6ccfd75d6dd2b05bba68f5e07",
+        "hashed_secret": "7a70b9366b18c4abd3d04de94c77124ca90bd822",
         "is_verified": false,
         "line_number": 97
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "32b39bf851676b2992116bdc163f05656b2396e7",
+        "hashed_secret": "58af8df3d18fd6b6ccfd75d6dd2b05bba68f5e07",
         "is_verified": false,
         "line_number": 104
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "8dd39e27e184590c790cbecd95f65e0ceaf61b46",
+        "hashed_secret": "32b39bf851676b2992116bdc163f05656b2396e7",
         "is_verified": false,
         "line_number": 111
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "d17b1dc21afd47e49ba9ece8f526d561059f8a7d",
+        "hashed_secret": "8dd39e27e184590c790cbecd95f65e0ceaf61b46",
         "is_verified": false,
         "line_number": 118
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "b777d4f08355af27079aa47b08fd59962aedf588",
+        "hashed_secret": "d17b1dc21afd47e49ba9ece8f526d561059f8a7d",
         "is_verified": false,
         "line_number": 125
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "scripts/ci/emergency_python_wheels.json",
+        "hashed_secret": "b777d4f08355af27079aa47b08fd59962aedf588",
+        "is_verified": false,
+        "line_number": 132
       }
     ],
     "scripts/ensure_database_versions.py": [
@@ -1632,5 +1639,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-24T12:54:26Z"
+  "generated_at": "2026-04-27T14:42:18Z"
 }

--- a/docs/review/PR_1546_FIXED_MAPPING.md
+++ b/docs/review/PR_1546_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+# PR #1546 - Fixed in Commit Mapping (canonical)
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1546>
+Branch: `fix/mypy-emergency-wheel-cp313`
+Date: 2026-04-27
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Initial Evidence
+- `pre-commit run --all-files` (PASS)
+- `make validate-min` (PASS)
+- `pytest -q tests/test_install_locked_python_requirements.py::test_repo_mypy_emergency_fallback_matches_dev_requirement_surfaces` (covered by `pre-commit` changed-file backend tests and `make validate-min` suite)

--- a/docs/review/PR_1546_FIXED_MAPPING.md
+++ b/docs/review/PR_1546_FIXED_MAPPING.md
@@ -9,7 +9,11 @@ Date: 2026-04-27
 - [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1546#pullrequestreview-4181890326
+
+Disposition: NOT-A-BUG
+Evidence: tests/test_install_locked_python_requirements.py
+Reason: The ruff and mypy assertions intentionally differ because `requirements-lock.txt` currently pins `ruff` but does not pin `mypy`; parametrizing now would blur this explicit policy distinction and reduce clarity for lock-surface governance.
 
 ## Initial Evidence
 - `pre-commit run --all-files` (PASS)

--- a/scripts/ci/emergency_python_wheels.json
+++ b/scripts/ci/emergency_python_wheels.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-04-19",
-  "expires_at": "2026-05-17",
-  "reason": "Temporary exact-wheel fallback for cryptography, Pillow, python-multipart, pytest, faker, hypothesis, sentence-transformers, ruff, types-pyyaml, and transformers while the approved private proxy lags the patched upstream releases used by active dependency PRs.",
+  "generated_at": "2026-04-27",
+  "expires_at": "2026-05-27",
+  "reason": "Temporary exact-wheel fallback for cryptography, Pillow, python-multipart, pytest, faker, hypothesis, mypy (cp313 manylinux), sentence-transformers, ruff, types-pyyaml, and transformers while the approved private proxy lags the patched upstream releases used by active dependency PRs.",
   "artifacts": [
     {
       "package": "cryptography",
@@ -80,6 +80,13 @@
       "filename": "hypothesis-6.152.1-py3-none-any.whl",
       "url": "https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl",
       "sha256": "40a3619d9e0cb97b018857c7986f75cf5de2e5ec0fa8a0b172d00747758f749e"
+    },
+    {
+      "package": "mypy",
+      "version": "1.20.2",
+      "filename": "mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/a1/32/4c49da27a606167391ff0c39aa955707a00edc500572e562f7c36c08a71f/mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+      "sha256": "bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15"
     },
     {
       "package": "mako",

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -110,6 +110,17 @@ def test_repo_ruff_emergency_fallback_matches_dev_requirement_surfaces() -> None
     assert ("ruff", expected_version) in _exact_requirement_pairs(requirements_lock_txt)
 
 
+def test_repo_mypy_emergency_fallback_matches_dev_requirement_surfaces() -> None:
+    manifest = _repo_emergency_manifest()
+    expected_version = _manifest_artifact_version(manifest, "mypy")
+
+    requirements_dev_in = (REPO_ROOT / "requirements-dev.in").read_text(encoding="utf-8")
+    requirements_dev_txt = (REPO_ROOT / "requirements-dev.txt").read_text(encoding="utf-8")
+
+    assert ("mypy", expected_version) in _exact_requirement_pairs(requirements_dev_in)
+    assert ("mypy", expected_version) in _exact_requirement_pairs(requirements_dev_txt)
+
+
 def test_compatible_release_version_accepts_environment_markers() -> None:
     contents = 'ruff~=0.15.11 ; python_version >= "3.13"\n'
 


### PR DESCRIPTION
## Summary
- add `mypy==1.20.2` `cp313` manylinux emergency wheel to `scripts/ci/emergency_python_wheels.json` for proxy-miss installs with `--only-binary :all:` on GHA Python 3.13
- add `test_repo_mypy_emergency_fallback_matches_dev_requirement_surfaces` to keep manifest mypy version aligned with `requirements-dev.in` and `requirements-dev.txt`
- refresh detect-secrets baseline for the new high-entropy hash entry in the emergency wheel manifest

## Problem context
Nightly run [24977946949](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/24977946949) failed because pip could not resolve a binary distribution for `mypy==1.20.2` through the approved proxy under `--only-binary :all:` on Python 3.13/manylinux, even though the wheel exists on PyPI.

## Test plan
- `pre-commit run --all-files`
- `make validate-min`
- `pytest -q tests/test_install_locked_python_requirements.py::test_repo_mypy_emergency_fallback_matches_dev_requirement_surfaces`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1546_FIXED_MAPPING.md`

## Deferred / Follow-ups
- Lockfile parity for mypy vs `requirements-lock.txt` is intentionally deferred in this PR because `requirements-lock.txt` currently does not pin `mypy==...`; if lock generation adds mypy later, extend parity assertions to lock surface in the same PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added emergency wheel support for mypy on Python 3.13 (manylinux) and updated manifest metadata and expiration.

* **Tests**
  * Added a deterministic test ensuring the emergency wheel manifest matches development requirements.

* **Documentation**
  * Added review documentation documenting the fix and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->