### PR TITLE
feat(ui): align Input API with runtime-set parity

### DIFF
--- a/docs/design/FIGMA_RUNTIME_SET_AUDIT_2026-04-27.md
+++ b/docs/design/FIGMA_RUNTIME_SET_AUDIT_2026-04-27.md
@@ -20,7 +20,7 @@ For traceability without blocking on node-id capture in this governance PR:
 ## Evidence anchors (repo contracts)
 
 - Web `Button` API: `frontend/src/components/ui/Button.tsx:3-4` (`ButtonVariant` including success/warning, `ButtonSize`); loading props in `frontend/src/components/ui/Button.tsx:10-11`.
-- Web `Input`: `frontend/src/components/ui/Input.tsx:4-24` (generic `HTMLInputElement` wrapper; no dedicated size/accessory/loading API).
+- Web `Input`: `frontend/src/components/ui/Input.tsx` (core RuntimeSet parity API: `size`, `invalid`, `loading`, `fullWidth`, native input `type` support).
 
 ## Visual PASS
 
@@ -68,8 +68,12 @@ Variants:
 
 Code parity:
 
-- Generic text/number/search/password usage maps to HTML input semantics via `Input` props.
-- `size`, `unit`, `loading`, `prefix`, `suffix`, and clear-action require repo API promotion before becoming canonical.
+- Core Input RuntimeSet parity is backed by `Input.tsx`: `size`, `invalid`, `loading`, native HTML input `type`, and disabled behavior.
+- `type=text`, `type=number`, `type=search`, and `type=secret` map to native input types (`text`, `number`, `search`, `password`).
+- `type=text, state=default, size=sm` maps to `size="sm"`.
+- `state=error` maps to `invalid` / `aria-invalid`.
+- `state=disabled` maps to native `disabled`.
+- Unit, prefix, suffix, and clear-action remain accessory-shell follow-ups and are not promoted in PR #1553.
 
 ### PP/Shared/FormField/RuntimeSet
 
@@ -142,4 +146,4 @@ Related backlog:
 ## Follow-ups
 
 - Button RuntimeSet parity: **resolved in PR #1552** (`Button.tsx`, Vitest, Storybook, audit anchors above).
-- Input code parity PR: decide size/unit/loading/prefix/suffix/clear-action API.
+- Input core parity: **resolved in PR #1553** (`Input.tsx`, Vitest, Storybook, audit anchors above).

--- a/docs/design/FIGMA_RUNTIME_SET_AUDIT_2026-04-27.md
+++ b/docs/design/FIGMA_RUNTIME_SET_AUDIT_2026-04-27.md
@@ -20,7 +20,7 @@ For traceability without blocking on node-id capture in this governance PR:
 ## Evidence anchors (repo contracts)
 
 - Web `Button` API: `frontend/src/components/ui/Button.tsx:3-4` (`ButtonVariant` including success/warning, `ButtonSize`); loading props in `frontend/src/components/ui/Button.tsx:10-11`.
-- Web `Input`: `frontend/src/components/ui/Input.tsx` (core RuntimeSet parity API: `size`, `invalid`, `loading`, `fullWidth`, native input `type` support).
+- Web `Input`: `frontend/src/components/ui/Input.tsx:5-11` (`InputSize` + `InputProps` parity API), `frontend/src/components/ui/Input.tsx:47-76` (runtime `loading`/`invalid`/`fullWidth` behavior), `frontend/src/components/ui/__tests__/Input.test.tsx:30-41` (native `type` passthrough).
 
 ## Visual PASS
 
@@ -68,11 +68,11 @@ Variants:
 
 Code parity:
 
-- Core Input RuntimeSet parity is backed by `Input.tsx`: `size`, `invalid`, `loading`, native HTML input `type`, and disabled behavior.
-- `type=text`, `type=number`, `type=search`, and `type=secret` map to native input types (`text`, `number`, `search`, `password`).
-- `type=text, state=default, size=sm` maps to `size="sm"`.
-- `state=error` maps to `invalid` / `aria-invalid`.
-- `state=disabled` maps to native `disabled`.
+- Core Input RuntimeSet parity is backed by `frontend/src/components/ui/Input.tsx:5-11`, `frontend/src/components/ui/Input.tsx:47-76`: `size`, `invalid`, `loading`, native HTML input `type`, and disabled behavior.
+- `type=text`, `type=number`, `type=search`, and `type=secret` map to native input types (`text`, `number`, `search`, `password`) via passthrough in `frontend/src/components/ui/Input.tsx:66-76` and tests in `frontend/src/components/ui/__tests__/Input.test.tsx:30-41`.
+- `type=text, state=default, size=sm` maps to `size="sm"` (`frontend/src/components/ui/Input.tsx:14-17`, `frontend/src/components/ui/__tests__/Input.test.tsx:18-22`).
+- `state=error` maps to `invalid` / `aria-invalid` (`frontend/src/components/ui/Input.tsx:60-69`, `frontend/src/components/ui/__tests__/Input.test.tsx:44-60`).
+- `state=disabled` maps to native `disabled` and loading-enforced disabled (`frontend/src/components/ui/Input.tsx:61-76`, `frontend/src/components/ui/__tests__/Input.test.tsx:62-81`).
 - Unit, prefix, suffix, and clear-action remain accessory-shell follow-ups and are not promoted in PR #1553.
 
 ### PP/Shared/FormField/RuntimeSet

--- a/docs/review/PR_1553_FIXED_MAPPING.md
+++ b/docs/review/PR_1553_FIXED_MAPPING.md
@@ -50,6 +50,10 @@ Reason: Merge-readiness governance requires mapping the aggregate bot review URL
 Disposition: FIXED
 Evidence: Actionable CodeRabbit review comments in this aggregate review were addressed via mapped thread fixes above.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1553#pullrequestreview-4186552163 -> d86208f27
+Disposition: FIXED
+Evidence: This follow-up aggregate review references the same actionable thread set now mapped and resolved in this artifact.
+
 ## Scope (PR-1553)
 
 - `frontend/src/components/ui/Input.tsx` — core RuntimeSet parity.

--- a/docs/review/PR_1553_FIXED_MAPPING.md
+++ b/docs/review/PR_1553_FIXED_MAPPING.md
@@ -6,12 +6,10 @@ Date: 2026-04-28
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
-
-Pending review.
 
 ## Scope (PR-1553)
 

--- a/docs/review/PR_1553_FIXED_MAPPING.md
+++ b/docs/review/PR_1553_FIXED_MAPPING.md
@@ -11,6 +11,11 @@ Date: 2026-04-28
 
 ## Fixed in Commit Mapping
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1553#pullrequestreview-4186460720
+Disposition: NOT-A-BUG
+Evidence: Sourcery aggregate review URL is tracked; actionable scope is resolved in Input core parity commits `61830a897`, `c49573f26`, `7b1a48717`.
+Reason: Merge-readiness governance requires mapping the aggregate bot review URL in the canonical artifact.
+
 ## Scope (PR-1553)
 
 - `frontend/src/components/ui/Input.tsx` — core RuntimeSet parity.

--- a/docs/review/PR_1553_FIXED_MAPPING.md
+++ b/docs/review/PR_1553_FIXED_MAPPING.md
@@ -11,10 +11,35 @@ Date: 2026-04-28
 
 ## Fixed in Commit Mapping
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1553#discussion_r3152124458 -> d86208f27
+Disposition: FIXED
+Evidence: Added line-precise `file:line` anchors for Input parity claims in `docs/design/FIGMA_RUNTIME_SET_AUDIT_2026-04-27.md`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1553#discussion_r3152124465 -> 1f525aa7e
+Disposition: FIXED
+Evidence: `docs/review/PR_1553_FIXED_MAPPING.md` checkboxes are checked in the canonical artifact.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1553#discussion_r3152124469
+Disposition: NOT-A-BUG
+Evidence: Canonical artifact contract for this lane requires `## Discussion Thread Pass` and `## Fixed in Commit Mapping`; merge-readiness truth is validated by CI gate, not a mandatory artifact section in this PR.
+Reason: Keeping the artifact aligned to active repo policy avoids introducing non-canonical sections.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1553#discussion_r3152124477 -> d86208f27
+Disposition: FIXED
+Evidence: Expanded `ledger-p1-design-input-runtime-code-parity` DoD into explicit, testable acceptance bullets in `docs/roadmap/BACKLOG_LEDGER.md`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1553#discussion_r3152124480 -> d86208f27
+Disposition: FIXED
+Evidence: Preserved explicit `aria-invalid` token values (`grammar|spelling`) in `frontend/src/components/ui/Input.tsx` and updated focused test expectations.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1553#pullrequestreview-4186460720
 Disposition: NOT-A-BUG
 Evidence: Sourcery aggregate review URL is tracked; actionable scope is resolved in Input core parity commits `61830a897`, `c49573f26`, `7b1a48717`.
 Reason: Merge-readiness governance requires mapping the aggregate bot review URL in the canonical artifact.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1553#pullrequestreview-4186485199 -> d86208f27
+Disposition: FIXED
+Evidence: Actionable CodeRabbit review comments in this aggregate review were addressed via mapped thread fixes above.
 
 ## Scope (PR-1553)
 

--- a/docs/review/PR_1553_FIXED_MAPPING.md
+++ b/docs/review/PR_1553_FIXED_MAPPING.md
@@ -1,0 +1,47 @@
+# PR #1553 - Fixed in Commit Mapping (canonical)
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1553>
+Branch: `feat/input-runtime-set-code-parity`
+Date: 2026-04-28
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Pending review.
+
+## Scope (PR-1553)
+
+- `frontend/src/components/ui/Input.tsx` — core RuntimeSet parity.
+- `frontend/src/components/ui/__tests__/Input.test.tsx` — focused tests.
+- `frontend/src/components/ui/Input.stories.tsx` — Storybook stories.
+- `docs/design/FIGMA_RUNTIME_SET_AUDIT_2026-04-27.md` — Input code parity notes.
+- `docs/roadmap/BACKLOG_LEDGER.md` — Input parity / accessory follow-up tracking.
+
+## Role stack execution log (PR #1553)
+
+| Step | Role | Result |
+|------|------|--------|
+| 1 | agent-coordinator | GO — scope locked to Input core parity and governance surfaces only. |
+| 2 | architecture-specialist | GO — enforce thin primitive contract with `size/invalid/loading/fullWidth` and native `type` passthrough. |
+| 3 | frontend-engineer | GO — implemented Input parity API plus focused tests/stories in allowed files. |
+| 4 | designer-artist-agent | GO — visual review surface matches requested RuntimeSet parity stories. |
+| 5 | creative-designer | GO — style consistency with PulsePlate token language; only minor non-blocking refinements suggested. |
+| 6 | qa-engineer-agent | GO — targeted `Input.test.tsx` deterministic and passing; optional extra edge-case tests noted. |
+| 7 | bug-hunter | GO — no scope violations in component surface; process reminder to avoid build artifact commits. |
+| 8 | cursor-specialist-agent | GO — merge governance checklist and mapping/disposition workflow aligned with repo policy. |
+
+## Validation
+
+Run locally before merge:
+
+- `cd frontend && npm run test:ci -- src/components/ui/__tests__/Input.test.tsx`
+- `cd frontend && npm run build-storybook`
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `pre-commit run --all-files`
+- `make validate-changed`
+- `make validate-min`

--- a/docs/review/PR_1553_FIXED_MAPPING.md
+++ b/docs/review/PR_1553_FIXED_MAPPING.md
@@ -11,6 +11,15 @@ Date: 2026-04-28
 
 ## Fixed in Commit Mapping
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1553#discussion_r3152112602
+Disposition: NOT-A-BUG
+Evidence: PR scope for #1553 is locked to `Input` core RuntimeSet parity and governance docs; wrapper API harmonization is tracked as follow-up work (`docs/roadmap/BACKLOG_LEDGER.md` accessory/runtime follow-up lane).
+Reason: Avoid scope creep in a bounded parity PR; no runtime regression is introduced in touched surfaces.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1553#discussion_r3152112604 -> d86208f27
+Disposition: FIXED
+Evidence: `frontend/src/components/ui/Input.tsx` now preserves explicit `aria-invalid` tokens (`grammar|spelling`) while still synthesizing invalid state from boolean prop.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1553#discussion_r3152124458 -> d86208f27
 Disposition: FIXED
 Evidence: Added line-precise `file:line` anchors for Input parity claims in `docs/design/FIGMA_RUNTIME_SET_AUDIT_2026-04-27.md`.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1405,7 +1405,12 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `frontend/src/components/ui/Input.stories.tsx`
     - `docs/review/PR_1553_FIXED_MAPPING.md`
   - DoD:
-    - Core Input parity (`size`, `invalid`, `loading`, native `type`) is implemented and covered by tests/stories in PR #1553
+    - `size` supports `sm|md|lg` and maps to expected runtime classes in `frontend/src/components/ui/Input.tsx`.
+    - `invalid` enforces error styling and `aria-invalid` semantics (including explicit token preservation for `grammar|spelling`).
+    - `loading` sets `aria-busy` and deterministically enforces disabled-while-loading behavior.
+    - Native `type` passthrough remains supported for `text`, `number`, `search`, `password` (runtime "secret" maps to native `password`).
+    - Focused Vitest coverage for these behaviors exists in `frontend/src/components/ui/__tests__/Input.test.tsx` and passes in CI.
+    - Storybook coverage for these behaviors exists in `frontend/src/components/ui/Input.stories.tsx` and passes `build-storybook`.
     - Accessory shell API (`unit`, `prefix`, `suffix`, `clear-action`) stays deferred to a dedicated PR
 
 <a id="ledger-p1-design-input-accessory-shell-parity"></a>

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1393,20 +1393,37 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Input RuntimeSet code parity (Figma vs `Input.tsx`)
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-DESIGN-INPUT-RUNTIME-PARITY
-  - Status: OPEN
+  - Target PR: PR #1553
+  - Status: CORE PARITY IN PR #1553; accessory-shell follow-up remains open
   - Area: design-system / frontend / governance
   - Finding Type: Figma runtime audit follow-up (2026-04-27)
   - Reason (EN): The Figma Input RuntimeSet includes size, number/search/secret, small default, filled/error/disabled, and prep notes for unit/loading/prefix/suffix/clear action. Current `Input.tsx` is a generic HTML input wrapper without explicit size or accessory API (`frontend/src/components/ui/Input.tsx:4-24`).
   - Links:
     - `docs/design/FIGMA_RUNTIME_SET_AUDIT_2026-04-27.md`
     - `frontend/src/components/ui/Input.tsx`
+    - `frontend/src/components/ui/__tests__/Input.test.tsx`
+    - `frontend/src/components/ui/Input.stories.tsx`
+    - `docs/review/PR_1553_FIXED_MAPPING.md`
   - DoD:
-    - Decide which Input variants are canonical component API vs usage examples
-    - Decide size API
-    - Decide unit/prefix/suffix/clear-action API
-    - Decide loading state handling
-    - Update `Input.tsx`, tests/stories/docs in a dedicated PR
+    - Core Input parity (`size`, `invalid`, `loading`, native `type`) is implemented and covered by tests/stories in PR #1553
+    - Accessory shell API (`unit`, `prefix`, `suffix`, `clear-action`) stays deferred to a dedicated PR
+
+<a id="ledger-p1-design-input-accessory-shell-parity"></a>
+- [ ] P1: Input accessory shell parity
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD-DESIGN-INPUT-ACCESSORY-SHELL
+  - Status: OPEN
+  - Area: design-system / frontend / governance
+  - Finding Type: Figma runtime audit follow-up
+  - Reason (EN): Unit, prefix, suffix, and clear-action require a compound input shell rather than the core `Input` primitive.
+  - Links:
+    - `docs/design/FIGMA_RUNTIME_SET_AUDIT_2026-04-27.md`
+    - `frontend/src/components/ui/Input.tsx`
+  - DoD:
+    - Decide whether accessory behavior belongs in `Input`, `InputGroup`, or FormField composition.
+    - Define prefix/suffix/unit/clear-action API.
+    - Add tests/stories/docs in a dedicated PR.
 
 <a id="ledger-p1-rebuild-runtime-vocabulary-promotion-decision"></a>
 - [ ] P1: Rebuild runtime family vocabulary promotion decision

--- a/frontend/src/components/ui/Input.stories.tsx
+++ b/frontend/src/components/ui/Input.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Input } from './Input';
+
+const meta = {
+  title: 'HPP/Input',
+  component: Input,
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TextDefault: Story = {
+  args: {
+    'aria-label': 'Text input',
+    placeholder: 'Placeholder',
+    type: 'text',
+  },
+};
+
+export const TextFilled: Story = {
+  args: {
+    'aria-label': 'Filled input',
+    readOnly: true,
+    value: 'Value',
+    type: 'text',
+  },
+};
+
+export const TextError: Story = {
+  args: {
+    'aria-label': 'Error input',
+    type: 'text',
+    invalid: true,
+    placeholder: 'Placeholder',
+  },
+};
+
+export const TextDisabled: Story = {
+  args: {
+    'aria-label': 'Disabled input',
+    type: 'text',
+    disabled: true,
+    value: 'Disabled',
+  },
+};
+
+export const NumberDefault: Story = {
+  args: {
+    'aria-label': 'Calories',
+    type: 'number',
+    value: 1800,
+    readOnly: true,
+  },
+};
+
+export const SearchDefault: Story = {
+  args: {
+    'aria-label': 'Search foods',
+    type: 'search',
+    placeholder: 'Search foods',
+  },
+};
+
+export const SecretDefault: Story = {
+  args: {
+    'aria-label': 'API key',
+    type: 'password',
+    value: 'secret-key',
+    readOnly: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    'aria-label': 'Async validation',
+    loading: true,
+    placeholder: 'Validating…',
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex w-[320px] flex-col gap-3">
+      <Input aria-label="Small input" placeholder="Small" size="sm" />
+      <Input aria-label="Medium input" placeholder="Medium" size="md" />
+      <Input aria-label="Large input" placeholder="Large" size="lg" />
+    </div>
+  ),
+};

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -45,7 +45,16 @@ export function inputClasses({
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { className = '', size = 'md', invalid, loading = false, fullWidth = true, disabled, 'aria-invalid': ariaInvalid, ...props },
+  {
+    className = '',
+    size = 'md',
+    invalid,
+    loading = false,
+    fullWidth = true,
+    disabled,
+    'aria-invalid': ariaInvalid,
+    ...props
+  },
   ref
 ) {
   const isInvalid = hasInvalidState(ariaInvalid, invalid);

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -59,13 +59,19 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
 ) {
   const isInvalid = hasInvalidState(ariaInvalid, invalid);
   const isDisabled = Boolean(disabled) || loading;
+  const ariaInvalidValue =
+    !isInvalid
+      ? undefined
+      : ariaInvalid === 'grammar' || ariaInvalid === 'spelling'
+        ? ariaInvalid
+        : true;
 
   return (
     <input
       ref={ref}
       {...props}
       aria-busy={loading ? true : undefined}
-      aria-invalid={isInvalid || undefined}
+      aria-invalid={ariaInvalidValue}
       className={inputClasses({
         size,
         invalid: isInvalid,

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,24 +1,69 @@
 import { forwardRef } from 'react';
 import type { InputHTMLAttributes } from 'react';
+import { hasInvalidState } from './fieldState';
 
-type InputProps = InputHTMLAttributes<HTMLInputElement>;
+export type InputSize = 'sm' | 'md' | 'lg';
+
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  size?: InputSize;
+  invalid?: boolean;
+  loading?: boolean;
+  fullWidth?: boolean;
+}
+
+const sizeClasses: Record<InputSize, string> = {
+  sm: 'min-h-[40px] rounded-lg px-3 py-2 text-sm',
+  md: 'min-h-[44px] rounded-lg px-3 py-2 text-sm',
+  lg: 'min-h-[48px] rounded-xl px-4 py-3 text-base',
+};
+
+export function inputClasses({
+  size = 'md',
+  invalid = false,
+  fullWidth = true,
+  className = '',
+}: {
+  size?: InputSize;
+  invalid?: boolean;
+  fullWidth?: boolean;
+  className?: string;
+}): string {
+  return [
+    fullWidth ? 'w-full' : '',
+    'border bg-[var(--color-bg)]',
+    'text-[var(--color-text)] placeholder:text-[var(--color-text-muted)]',
+    'focus:outline-none focus:ring-2 focus:ring-offset-1',
+    'disabled:cursor-not-allowed disabled:opacity-60',
+    invalid
+      ? 'border-[var(--color-error)] focus:ring-[var(--color-error)]'
+      : 'border-[var(--color-border)] focus:ring-[var(--color-primary)]',
+    sizeClasses[size],
+    className,
+  ]
+    .join(' ')
+    .trim();
+}
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { className = '', ...props },
+  { className = '', size = 'md', invalid, loading = false, fullWidth = true, disabled, 'aria-invalid': ariaInvalid, ...props },
   ref
 ) {
+  const isInvalid = hasInvalidState(ariaInvalid, invalid);
+  const isDisabled = Boolean(disabled) || loading;
+
   return (
     <input
       ref={ref}
-      className={[
-        'w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2',
-        'text-[var(--color-text)] placeholder:text-[var(--color-text-muted)]',
-        'focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-offset-1',
-        className,
-      ]
-        .join(' ')
-        .trim()}
       {...props}
+      aria-busy={loading ? true : undefined}
+      aria-invalid={isInvalid || undefined}
+      className={inputClasses({
+        size,
+        invalid: isInvalid,
+        fullWidth,
+        className,
+      })}
+      disabled={isDisabled}
     />
   );
 });

--- a/frontend/src/components/ui/__tests__/Input.test.tsx
+++ b/frontend/src/components/ui/__tests__/Input.test.tsx
@@ -1,0 +1,98 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Input, inputClasses } from '../Input';
+
+describe('Input', () => {
+  it('renders text md by default', () => {
+    render(<Input aria-label="Name" placeholder="Placeholder" />);
+
+    const input = screen.getByRole('textbox', { name: 'Name' });
+
+    expect(input).toHaveClass('w-full');
+    expect(input).toHaveClass('min-h-[44px]');
+    expect(input).toHaveClass('border-[var(--color-border)]');
+    expect(input).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('supports sm md lg size classes', () => {
+    expect(inputClasses({ size: 'sm' })).toContain('min-h-[40px]');
+    expect(inputClasses({ size: 'md' })).toContain('min-h-[44px]');
+    expect(inputClasses({ size: 'lg' })).toContain('min-h-[48px]');
+  });
+
+  it('supports filled value through native input props', () => {
+    render(<Input aria-label="Calories" readOnly value="1800" />);
+
+    expect(screen.getByDisplayValue('1800')).toBeInTheDocument();
+  });
+
+  it('supports number search and password types through native input props', () => {
+    render(
+      <div>
+        <Input aria-label="Calories" type="number" />
+        <Input aria-label="Food search" type="search" />
+        <Input aria-label="API key" type="password" />
+      </div>
+    );
+
+    expect(screen.getByLabelText('Calories')).toHaveAttribute('type', 'number');
+    expect(screen.getByLabelText('Food search')).toHaveAttribute('type', 'search');
+    expect(screen.getByLabelText('API key')).toHaveAttribute('type', 'password');
+  });
+
+  it('maps invalid prop to aria-invalid and error border', () => {
+    render(<Input aria-label="Weight" invalid />);
+
+    const input = screen.getByRole('textbox', { name: 'Weight' });
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveClass('border-[var(--color-error)]');
+  });
+
+  it('maps aria-invalid string values to invalid state', () => {
+    render(<Input aria-invalid="grammar" aria-label="Notes" />);
+
+    const input = screen.getByRole('textbox', { name: 'Notes' });
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveClass('border-[var(--color-error)]');
+  });
+
+  it('supports disabled state', () => {
+    render(<Input aria-label="Disabled field" disabled />);
+
+    expect(screen.getByRole('textbox', { name: 'Disabled field' })).toBeDisabled();
+  });
+
+  it('supports loading as disabled and busy', () => {
+    render(<Input aria-label="Async field" loading />);
+
+    const input = screen.getByRole('textbox', { name: 'Async field' });
+
+    expect(input).toBeDisabled();
+    expect(input).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('does not let disabled=false override loading disabled semantics', () => {
+    render(<Input aria-label="Async field" loading disabled={false} />);
+
+    expect(screen.getByRole('textbox', { name: 'Async field' })).toBeDisabled();
+  });
+
+  it('does not set aria-busy when not loading', () => {
+    render(<Input aria-label="Idle field" />);
+
+    expect(screen.getByRole('textbox', { name: 'Idle field' })).not.toHaveAttribute('aria-busy');
+  });
+
+  it('supports non-full-width composition', () => {
+    const classes = inputClasses({
+      fullWidth: false,
+      className: 'custom-input',
+    });
+
+    expect(classes).not.toContain('w-full');
+    expect(classes).toContain('custom-input');
+  });
+});

--- a/frontend/src/components/ui/__tests__/Input.test.tsx
+++ b/frontend/src/components/ui/__tests__/Input.test.tsx
@@ -55,7 +55,7 @@ describe('Input', () => {
 
     const input = screen.getByRole('textbox', { name: 'Notes' });
 
-    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-invalid', 'grammar');
     expect(input).toHaveClass('border-[var(--color-error)]');
   });
 


### PR DESCRIPTION
## Summary

Aligns the web Input primitive with the core Figma Input RuntimeSet.

## Scope

- Adds `size="sm|md|lg"`.
- Adds `invalid`.
- Adds `loading` with `aria-busy` and disabled-while-loading.
- Preserves native input `type` support for text/number/search/password.
- Adds focused Vitest coverage.
- Adds Storybook review coverage.
- Updates audit/backlog governance.

## Out of scope

- No Figma edits.
- No Button changes.
- No FormField changes.
- No token changes.
- No unit/prefix/suffix/clear-action wrapper.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1553#pullrequestreview-4186460720

Canonical source of truth: `docs/review/PR_1553_FIXED_MAPPING.md`.

## Validation

- [x] `python3 scripts/orchestration/check_preflight.py`
- [x] `python3 scripts/orchestration/check_agent_consistency.py`
- [x] `cd frontend && npm run test:ci -- src/components/ui/__tests__/Input.test.tsx`
- [x] `cd frontend && npm run build-storybook`
- [x] `pre-commit run --all-files`
- [x] `make validate-changed`
- [x] `make validate-min`

## Deferred / Follow-ups

- Input accessory shell parity:
  `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-design-input-accessory-shell-parity`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Input adds size variants (sm/md/lg), full-width option, loading state (sets aria-busy + disables), improved invalid/error mapping (aria-invalid behavior), and native type passthrough (e.g., secret→password).

* **UI Examples**
  * Storybook stories demonstrating states, sizes, and variants (default, filled, error, disabled, number, search, password, loading, combined sizes).

* **Tests**
  * New tests for variants, accessibility attributes, loading/disabled interactions, and native prop passthrough.

* **Documentation**
  * Design, roadmap, and review docs updated: core Input parity marked resolved; accessory-shell work deferred.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->