### PR TITLE
docs(brand): add FitChef candidate visual QA matrix

### DIFF
--- a/docs/design/FITCHEF_CANDIDATE_VISUAL_QA_2026-04-28.md
+++ b/docs/design/FITCHEF_CANDIDATE_VISUAL_QA_2026-04-28.md
@@ -25,36 +25,36 @@ Figma source: `2JDwOByQIbcPgp93FDzHii` node `1473:2`
 
 | asset_id | current_status | asset_type | visual_fitchef_identity | embedded_text_risk | localization_risk | wellness_safety_risk | marketing_use | runtime_use | disposition | notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| FITCHEF_ACTION_COOKING_V1 | APPROVED-SEED | action | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Seed-aligned action frame, safe for mascot-led composition. |
-| FITCHEF_ACTION_HEALTHY_CHOICE_V1 | APPROVED-SEED | action | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Keep as approved-seed reference frame only in this PR lane. |
-| FITCHEF_ACTION_HYDRATION_REMINDER_V1 | APPROVED-SEED | action | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Supportive wellness cue without medical language. |
-| FITCHEF_ACTION_MEAL_PLANNING_V1 | APPROVED-SEED | action | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Preserves FitChef silhouette and emotional tone. |
-| FITCHEF_ACTION_NUTRITION_PLATE_V1 | APPROVED-SEED | action | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Nutrition context is visual, not diagnostic. |
-| FITCHEF_ACTION_PROGRESS_TRACKING_V1 | APPROVED-SEED | action | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Compatible with progress storytelling in wellness-safe framing. |
-| FITCHEF_ACTION_SHOPPING_LIST_V1 | CANDIDATE | action | partial | minor_ui | medium | low | social_only | no_runtime_promotion | keep candidate | Good campaign support, keep out of runtime until promotion PR. |
-| FITCHEF_ACTION_WORKOUT_COACH_V1 | CANDIDATE | action | partial | minor_ui | medium | medium | needs_rework | blocked_runtime | needs-rework | "Coach" framing can read as regulated/medical-adjacent promise. |
-| FITCHEF_MARKETING_BREAKFAST_PROMO_V1 | CANDIDATE | marketing | partial | dominant_text | high | medium | reject_for_app_store | no_runtime_promotion | reject | Promo-heavy language needs complete copy rework. |
-| FITCHEF_MARKETING_FITNESS_MOTIVATION_V1 | CANDIDATE | marketing | partial | minor_ui | medium | medium | social_only | no_runtime_promotion | keep candidate | Keep for social tests with stricter claim-safe captions. |
-| FITCHEF_MARKETING_HEALTHY_LIFESTYLE_V1 | CANDIDATE | marketing | pass | minor_ui | medium | low | app_store_supporting_hold | no_runtime_promotion | keep candidate | May be used after localization and wording QA. |
-| FITCHEF_MARKETING_NUTRITION_EDUCATION_V1 | CANDIDATE | marketing | pass | minor_ui | medium | low | app_store_supporting_hold | no_runtime_promotion | keep candidate | Educational tone is acceptable if copy avoids guarantees. |
-| FITCHEF_ONBOARDING_BUILD_MEAL_PLAN_V1 | CANDIDATE | onboarding | pass | minor_ui | medium | low | onboarding_candidate | no_runtime_promotion | promotion proposal | Candidate for future onboarding lane, requires separate PR. |
-| FITCHEF_ONBOARDING_CALCULATE_NUTRITION_V1 | CANDIDATE | onboarding | partial | minor_ui | medium | medium | onboarding_candidate | no_runtime_promotion | needs-rework | Must avoid diagnostic semantics in surrounding copy. |
-| FITCHEF_ONBOARDING_PROFILE_SETUP_V1 | CANDIDATE | onboarding | pass | none | low | low | onboarding_candidate | no_runtime_promotion | promotion proposal | Strong onboarding visual, reserve for dedicated promotion lane. |
-| FITCHEF_ONBOARDING_START_COOKING_V1 | NEEDS-REWORK | onboarding | partial | minor_ui | medium | medium | needs_rework | blocked_runtime | needs-rework | Intake board marks this lane as needs-rework. |
-| FITCHEF_ONBOARDING_TRACK_PROGRESS_V1 | CANDIDATE | onboarding | pass | none | low | low | onboarding_candidate | no_runtime_promotion | promotion proposal | Progress-oriented mood works if claims stay informational. |
-| FITCHEF_ONBOARDING_WELCOME_V1 | APPROVED-SEED | onboarding | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Matches canonical onboarding welcome mascot framing. |
-| FITCHEF_PORTRAIT_CONCERNED_V1 | CANDIDATE | portrait | fail | none | low | medium | blocked_gtm | blocked_runtime | reject | Concerned affect drifts toward clinical anxiety tone. |
-| FITCHEF_PORTRAIT_CURIOUS_V1 | CANDIDATE | portrait | pass | none | low | low | social_only | no_runtime_promotion | keep candidate | Supportive expression, usable in non-runtime campaign comps. |
-| FITCHEF_PORTRAIT_ENCOURAGING_V1 | CANDIDATE | portrait | pass | none | low | low | app_store_supporting_hold | no_runtime_promotion | keep candidate | Strong wellness-safe affect, hold until localization pass. |
-| FITCHEF_PORTRAIT_FOCUSED_V1 | CANDIDATE | portrait | pass | none | low | low | social_only | no_runtime_promotion | keep candidate | Retains identity markers and compact silhouette. |
-| FITCHEF_PORTRAIT_HAPPY_V1 | CANDIDATE | portrait | pass | none | low | low | social_only | no_runtime_promotion | keep candidate | Positive emotion lane suitable for campaign variants. |
-| FITCHEF_PORTRAIT_LAUGHING_V1 | CANDIDATE | portrait | partial | none | low | low | social_only | no_runtime_promotion | reference-only | Keep as exploration; expression may be too playful for runtime. |
-| FITCHEF_PORTRAIT_NEUTRAL_V1 | APPROVED-SEED | portrait | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Canonical neutral portrait baseline. |
-| FITCHEF_PORTRAIT_PROUD_V1 | CANDIDATE | portrait | partial | none | low | low | social_only | no_runtime_promotion | keep candidate | Brand-fit acceptable but needs consistency pass vs seed linework. |
-| FITCHEF_PORTRAIT_SLEEPY_V1 | APPROVED-SEED | portrait | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Canonical sleepy portrait retained. |
-| FITCHEF_PORTRAIT_SURPRISED_V1 | APPROVED-SEED | portrait | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Canonical surprised portrait retained. |
-| FITCHEF_PORTRAIT_THINKING_V1 | APPROVED-SEED | portrait | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Canonical thinking portrait retained. |
-| FITCHEF_PORTRAIT_WINK_V1 | APPROVED-SEED | portrait | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Canonical wink portrait retained. |
+| fitchef-candidate-001 | APPROVED-SEED | action | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Maps to `FITCHEF_ACTION_COOKING_V1`; keep seed lock only. |
+| fitchef-candidate-002 | APPROVED-SEED | action | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Maps to `FITCHEF_ACTION_HEALTHY_CHOICE_V1`; seed parity retained. |
+| fitchef-candidate-003 | APPROVED-SEED | action | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Maps to `FITCHEF_ACTION_HYDRATION_REMINDER_V1`; safe supportive framing. |
+| fitchef-candidate-004 | APPROVED-SEED | action | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Maps to `FITCHEF_ACTION_MEAL_PLANNING_V1`; no runtime expansion implied. |
+| fitchef-candidate-005 | APPROVED-SEED | action | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Maps to `FITCHEF_ACTION_NUTRITION_PLATE_V1`; visual wellness context only. |
+| fitchef-candidate-006 | APPROVED-SEED | action | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Maps to `FITCHEF_ACTION_PROGRESS_TRACKING_V1`; seed set locked. |
+| fitchef-candidate-007 | CANDIDATE | action | partial | minor_ui | medium | low | social_ready | no_runtime_promotion | keep candidate | Maps to `FITCHEF_ACTION_SHOPPING_LIST_V1`; social-first usage. |
+| fitchef-candidate-008 | CANDIDATE | action | partial | minor_ui | medium | medium | blocked_gtm | blocked_runtime | needs-rework | Maps to `FITCHEF_ACTION_WORKOUT_COACH_V1`; requires claim-safe rework. |
+| fitchef-candidate-009 | CANDIDATE | marketing | partial | dominant_text | high | medium | blocked_gtm | no_runtime_promotion | reject | Maps to `FITCHEF_MARKETING_BREAKFAST_PROMO_V1`; promo-heavy text risk. |
+| fitchef-candidate-010 | CANDIDATE | marketing | partial | minor_ui | medium | medium | social_ready | no_runtime_promotion | keep candidate | Maps to `FITCHEF_MARKETING_FITNESS_MOTIVATION_V1`; campaign-only lane. |
+| fitchef-candidate-011 | CANDIDATE | marketing | pass | minor_ui | medium | low | aso_supporting_hold | no_runtime_promotion | keep candidate | Maps to `FITCHEF_MARKETING_HEALTHY_LIFESTYLE_V1`; hold for localization pass. |
+| fitchef-candidate-012 | CANDIDATE | marketing | pass | minor_ui | medium | low | aso_supporting_hold | no_runtime_promotion | keep candidate | Maps to `FITCHEF_MARKETING_NUTRITION_EDUCATION_V1`; wording review required. |
+| fitchef-candidate-013 | CANDIDATE | onboarding | pass | minor_ui | medium | low | reference_archive | no_runtime_promotion | reference-only | Maps to `FITCHEF_ONBOARDING_BUILD_MEAL_PLAN_V1`; archive until promotion lane. |
+| fitchef-candidate-014 | CANDIDATE | onboarding | partial | minor_ui | medium | medium | aso_supporting_hold | no_runtime_promotion | needs-rework | Maps to `FITCHEF_ONBOARDING_CALCULATE_NUTRITION_V1`; avoid diagnostic tone. |
+| fitchef-candidate-015 | CANDIDATE | onboarding | pass | none | low | low | social_ready | no_runtime_promotion | keep candidate | Maps to `FITCHEF_ONBOARDING_PROFILE_SETUP_V1`; candidate only. |
+| fitchef-candidate-016 | CANDIDATE | onboarding | partial | minor_ui | medium | medium | social_ready | no_runtime_promotion | keep candidate | Maps to `FITCHEF_ONBOARDING_START_COOKING_V1`; non-runtime usage only. |
+| fitchef-candidate-017 | CANDIDATE | onboarding | pass | none | low | low | aso_supporting_hold | no_runtime_promotion | promotion proposal | Maps to `FITCHEF_ONBOARDING_TRACK_PROGRESS_V1`; proposal requires separate PR. |
+| fitchef-candidate-018 | CANDIDATE | onboarding | pass | none | low | low | reference_archive | no_runtime_promotion | reference-only | Maps to `FITCHEF_ONBOARDING_WELCOME_V1`; reference lane here despite seed relation. |
+| fitchef-candidate-019 | CANDIDATE | portrait | fail | none | low | medium | blocked_gtm | blocked_runtime | reject | Maps to `FITCHEF_PORTRAIT_CONCERNED_V1`; clinical-affect drift risk. |
+| fitchef-candidate-020 | CANDIDATE | portrait | pass | none | low | low | aso_supporting_hold | no_runtime_promotion | keep candidate | Maps to `FITCHEF_PORTRAIT_CURIOUS_V1`; hold for App Store readability QA. |
+| fitchef-candidate-021 | CANDIDATE | portrait | pass | none | low | low | social_ready | no_runtime_promotion | keep candidate | Maps to `FITCHEF_PORTRAIT_ENCOURAGING_V1`; acceptable when paired with a compliant caption. |
+| fitchef-candidate-022 | CANDIDATE | portrait | pass | none | low | low | reference_archive | no_runtime_promotion | reference-only | Maps to `FITCHEF_PORTRAIT_FOCUSED_V1`; keep as concept/archive lane. |
+| fitchef-candidate-023 | CANDIDATE | portrait | pass | none | low | low | social_ready | no_runtime_promotion | keep candidate | Maps to `FITCHEF_PORTRAIT_HAPPY_V1`; social rotation candidate. |
+| fitchef-candidate-024 | CANDIDATE | portrait | partial | none | low | low | blocked_gtm | blocked_runtime | needs-rework | Maps to `FITCHEF_PORTRAIT_LAUGHING_V1`; over-playful tone for storefront. |
+| fitchef-candidate-025 | CANDIDATE | portrait | pass | none | low | low | aso_supporting_hold | no_runtime_promotion | keep candidate | Maps to `FITCHEF_PORTRAIT_NEUTRAL_V1`; hold in candidate lane for this intake pass. |
+| fitchef-candidate-026 | CANDIDATE | portrait | partial | none | low | low | social_ready | no_runtime_promotion | keep candidate | Maps to `FITCHEF_PORTRAIT_PROUD_V1`; style consistency pass still needed. |
+| fitchef-candidate-027 | REFERENCE-ONLY | portrait | pass | none | low | low | reference_archive | no_runtime_promotion | reference-only | Maps to `FITCHEF_PORTRAIT_SLEEPY_V1`; explicitly reference-only batch slot. |
+| fitchef-candidate-028 | REFERENCE-ONLY | portrait | pass | none | low | low | reference_archive | no_runtime_promotion | reference-only | Maps to `FITCHEF_PORTRAIT_SURPRISED_V1`; archive-only lane. |
+| fitchef-candidate-029 | REFERENCE-ONLY | portrait | pass | none | low | low | reference_archive | no_runtime_promotion | reference-only | Maps to `FITCHEF_PORTRAIT_THINKING_V1`; archive-only lane. |
+| fitchef-candidate-030 | NEEDS-REWORK | portrait | pass | none | low | low | blocked_gtm | blocked_runtime | needs-rework | Maps to `FITCHEF_PORTRAIT_WINK_V1`; intake marks this slot as mandatory rework. |
 
 ## Review outcome
 

--- a/docs/design/FITCHEF_CANDIDATE_VISUAL_QA_2026-04-28.md
+++ b/docs/design/FITCHEF_CANDIDATE_VISUAL_QA_2026-04-28.md
@@ -1,0 +1,64 @@
+# FitChef Candidate Visual QA Matrix (2026-04-28)
+
+Status: `Reference-only intake review`
+Scope: `Figma board 1473:2 candidate audit`
+Figma source: `2JDwOByQIbcPgp93FDzHii` node `1473:2`
+
+## Canonical boundaries
+
+- Canonical seed pack remains locked in `docs/design/FITCHEF_MASCOT_ASSET_CANON.md`.
+- This matrix does not promote assets into runtime.
+- No candidate from this matrix may be added to:
+  - `frontend/src/assets/brand/*`
+  - `ios/PulsePlate/Assets.xcassets/*`
+  without a separate promotion PR.
+
+## Disposition vocabulary
+
+- `keep candidate`
+- `reference-only`
+- `needs-rework`
+- `reject`
+- `promotion proposal`
+
+## Visual QA matrix
+
+| asset_id | current_status | asset_type | visual_fitchef_identity | embedded_text_risk | localization_risk | wellness_safety_risk | marketing_use | runtime_use | disposition | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| FITCHEF_ACTION_COOKING_V1 | APPROVED-SEED | action | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Seed-aligned action frame, safe for mascot-led composition. |
+| FITCHEF_ACTION_HEALTHY_CHOICE_V1 | APPROVED-SEED | action | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Keep as approved-seed reference frame only in this PR lane. |
+| FITCHEF_ACTION_HYDRATION_REMINDER_V1 | APPROVED-SEED | action | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Supportive wellness cue without medical language. |
+| FITCHEF_ACTION_MEAL_PLANNING_V1 | APPROVED-SEED | action | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Preserves FitChef silhouette and emotional tone. |
+| FITCHEF_ACTION_NUTRITION_PLATE_V1 | APPROVED-SEED | action | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Nutrition context is visual, not diagnostic. |
+| FITCHEF_ACTION_PROGRESS_TRACKING_V1 | APPROVED-SEED | action | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Compatible with progress storytelling in wellness-safe framing. |
+| FITCHEF_ACTION_SHOPPING_LIST_V1 | CANDIDATE | action | partial | minor_ui | medium | low | social_only | no_runtime_promotion | keep candidate | Good campaign support, keep out of runtime until promotion PR. |
+| FITCHEF_ACTION_WORKOUT_COACH_V1 | CANDIDATE | action | partial | minor_ui | medium | medium | needs_rework | blocked_runtime | needs-rework | "Coach" framing can read as regulated/medical-adjacent promise. |
+| FITCHEF_MARKETING_BREAKFAST_PROMO_V1 | CANDIDATE | marketing | partial | dominant_text | high | medium | reject_for_app_store | no_runtime_promotion | reject | Promo-heavy language needs complete copy rework. |
+| FITCHEF_MARKETING_FITNESS_MOTIVATION_V1 | CANDIDATE | marketing | partial | minor_ui | medium | medium | social_only | no_runtime_promotion | keep candidate | Keep for social tests with stricter claim-safe captions. |
+| FITCHEF_MARKETING_HEALTHY_LIFESTYLE_V1 | CANDIDATE | marketing | pass | minor_ui | medium | low | app_store_supporting_hold | no_runtime_promotion | keep candidate | May be used after localization and wording QA. |
+| FITCHEF_MARKETING_NUTRITION_EDUCATION_V1 | CANDIDATE | marketing | pass | minor_ui | medium | low | app_store_supporting_hold | no_runtime_promotion | keep candidate | Educational tone is acceptable if copy avoids guarantees. |
+| FITCHEF_ONBOARDING_BUILD_MEAL_PLAN_V1 | CANDIDATE | onboarding | pass | minor_ui | medium | low | onboarding_candidate | no_runtime_promotion | promotion proposal | Candidate for future onboarding lane, requires separate PR. |
+| FITCHEF_ONBOARDING_CALCULATE_NUTRITION_V1 | CANDIDATE | onboarding | partial | minor_ui | medium | medium | onboarding_candidate | no_runtime_promotion | needs-rework | Must avoid diagnostic semantics in surrounding copy. |
+| FITCHEF_ONBOARDING_PROFILE_SETUP_V1 | CANDIDATE | onboarding | pass | none | low | low | onboarding_candidate | no_runtime_promotion | promotion proposal | Strong onboarding visual, reserve for dedicated promotion lane. |
+| FITCHEF_ONBOARDING_START_COOKING_V1 | NEEDS-REWORK | onboarding | partial | minor_ui | medium | medium | needs_rework | blocked_runtime | needs-rework | Intake board marks this lane as needs-rework. |
+| FITCHEF_ONBOARDING_TRACK_PROGRESS_V1 | CANDIDATE | onboarding | pass | none | low | low | onboarding_candidate | no_runtime_promotion | promotion proposal | Progress-oriented mood works if claims stay informational. |
+| FITCHEF_ONBOARDING_WELCOME_V1 | APPROVED-SEED | onboarding | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Matches canonical onboarding welcome mascot framing. |
+| FITCHEF_PORTRAIT_CONCERNED_V1 | CANDIDATE | portrait | fail | none | low | medium | blocked_gtm | blocked_runtime | reject | Concerned affect drifts toward clinical anxiety tone. |
+| FITCHEF_PORTRAIT_CURIOUS_V1 | CANDIDATE | portrait | pass | none | low | low | social_only | no_runtime_promotion | keep candidate | Supportive expression, usable in non-runtime campaign comps. |
+| FITCHEF_PORTRAIT_ENCOURAGING_V1 | CANDIDATE | portrait | pass | none | low | low | app_store_supporting_hold | no_runtime_promotion | keep candidate | Strong wellness-safe affect, hold until localization pass. |
+| FITCHEF_PORTRAIT_FOCUSED_V1 | CANDIDATE | portrait | pass | none | low | low | social_only | no_runtime_promotion | keep candidate | Retains identity markers and compact silhouette. |
+| FITCHEF_PORTRAIT_HAPPY_V1 | CANDIDATE | portrait | pass | none | low | low | social_only | no_runtime_promotion | keep candidate | Positive emotion lane suitable for campaign variants. |
+| FITCHEF_PORTRAIT_LAUGHING_V1 | CANDIDATE | portrait | partial | none | low | low | social_only | no_runtime_promotion | reference-only | Keep as exploration; expression may be too playful for runtime. |
+| FITCHEF_PORTRAIT_NEUTRAL_V1 | APPROVED-SEED | portrait | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Canonical neutral portrait baseline. |
+| FITCHEF_PORTRAIT_PROUD_V1 | CANDIDATE | portrait | partial | none | low | low | social_only | no_runtime_promotion | keep candidate | Brand-fit acceptable but needs consistency pass vs seed linework. |
+| FITCHEF_PORTRAIT_SLEEPY_V1 | APPROVED-SEED | portrait | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Canonical sleepy portrait retained. |
+| FITCHEF_PORTRAIT_SURPRISED_V1 | APPROVED-SEED | portrait | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Canonical surprised portrait retained. |
+| FITCHEF_PORTRAIT_THINKING_V1 | APPROVED-SEED | portrait | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Canonical thinking portrait retained. |
+| FITCHEF_PORTRAIT_WINK_V1 | APPROVED-SEED | portrait | pass | none | low | low | app_store_candidate | no_runtime_promotion | keep candidate | Canonical wink portrait retained. |
+
+## Review outcome
+
+- All 30 intake assets now have disposition coverage.
+- Embedded-text and localization risk are explicitly captured per row.
+- Marketing-use vs runtime-use separation is explicit per row.
+- Runtime promotion remains blocked in this docs-only lane.

--- a/docs/design/FITCHEF_CANDIDATE_VISUAL_QA_2026-04-28.md
+++ b/docs/design/FITCHEF_CANDIDATE_VISUAL_QA_2026-04-28.md
@@ -25,12 +25,12 @@ Figma source: `2JDwOByQIbcPgp93FDzHii` node `1473:2`
 
 | asset_id | current_status | asset_type | visual_fitchef_identity | embedded_text_risk | localization_risk | wellness_safety_risk | marketing_use | runtime_use | disposition | notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| fitchef-candidate-001 | APPROVED-SEED | action | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Maps to `FITCHEF_ACTION_COOKING_V1`; keep seed lock only. |
-| fitchef-candidate-002 | APPROVED-SEED | action | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Maps to `FITCHEF_ACTION_HEALTHY_CHOICE_V1`; seed parity retained. |
-| fitchef-candidate-003 | APPROVED-SEED | action | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Maps to `FITCHEF_ACTION_HYDRATION_REMINDER_V1`; safe supportive framing. |
-| fitchef-candidate-004 | APPROVED-SEED | action | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Maps to `FITCHEF_ACTION_MEAL_PLANNING_V1`; no runtime expansion implied. |
-| fitchef-candidate-005 | APPROVED-SEED | action | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Maps to `FITCHEF_ACTION_NUTRITION_PLATE_V1`; visual wellness context only. |
-| fitchef-candidate-006 | APPROVED-SEED | action | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Maps to `FITCHEF_ACTION_PROGRESS_TRACKING_V1`; seed set locked. |
+| fitchef-candidate-001 | APPROVED-SEED | portrait | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Canonical seed: `fitchef-portrait-neutral-v1.png`. |
+| fitchef-candidate-002 | APPROVED-SEED | portrait | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Canonical seed: `fitchef-portrait-wink-v1.png`. |
+| fitchef-candidate-003 | APPROVED-SEED | portrait | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Canonical seed: `fitchef-portrait-thinking-v1.png`. |
+| fitchef-candidate-004 | APPROVED-SEED | portrait | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Canonical seed: `fitchef-portrait-sleepy-v1.png`. |
+| fitchef-candidate-005 | APPROVED-SEED | portrait | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Canonical seed: `fitchef-portrait-surprised-v1.png`. |
+| fitchef-candidate-006 | APPROVED-SEED | onboarding | pass | none | low | low | approved_seed | canon_aligned | keep candidate | Canonical seed: `fitchef-onboarding-welcome-v1.png`. |
 | fitchef-candidate-007 | CANDIDATE | action | partial | minor_ui | medium | low | social_ready | no_runtime_promotion | keep candidate | Maps to `FITCHEF_ACTION_SHOPPING_LIST_V1`; social-first usage. |
 | fitchef-candidate-008 | CANDIDATE | action | partial | minor_ui | medium | medium | blocked_gtm | blocked_runtime | needs-rework | Maps to `FITCHEF_ACTION_WORKOUT_COACH_V1`; requires claim-safe rework. |
 | fitchef-candidate-009 | CANDIDATE | marketing | partial | dominant_text | high | medium | blocked_gtm | no_runtime_promotion | reject | Maps to `FITCHEF_MARKETING_BREAKFAST_PROMO_V1`; promo-heavy text risk. |

--- a/docs/figma/FITCHEF_BRAND_REFERENCE_HANDOFF.md
+++ b/docs/figma/FITCHEF_BRAND_REFERENCE_HANDOFF.md
@@ -35,6 +35,7 @@ file `2JDwOByQIbcPgp93FDzHii`
   - `82:2` `FitChef Canonical Variant Gallery`
   - `72:131` `FitChef Usage and Promotion Rules`
   - `1473:2` `FitChef Mascot Asset Inventory — Intake 2026-04-28`
+    - GTM classification keys (`fitchef-candidate-001`…`030`): `docs/figma/FITCHEF_INTAKE_1473_2_GTM_CLASSIFICATION_GUIDANCE.md`
 - Page `10_Welcome_Gate`:
   - `82:66` `FitChef Placement Studies / Approved`
 - Page `11_Welcome_Gate_States`:

--- a/docs/figma/FITCHEF_INTAKE_1473_2_GTM_CLASSIFICATION_GUIDANCE.md
+++ b/docs/figma/FITCHEF_INTAKE_1473_2_GTM_CLASSIFICATION_GUIDANCE.md
@@ -1,0 +1,110 @@
+# FitChef intake board `1473:2` — GTM classification guidance
+
+**Status:** `Reference only` (docs lane; no asset or runtime promotion)
+**Scope:** `FitChef Mascot Asset Inventory — Intake 2026-04-28`
+**Figma:** file `2JDwOByQIbcPgp93FDzHii`, node `1473:2`
+**Source counts (sticker QA on board):** `6` `APPROVED-SEED` · `20` `CANDIDATE` · `3` `REFERENCE-ONLY` · `1` `NEEDS-REWORK` (see `docs/figma/FITCHEF_BRAND_REFERENCE_HANDOFF.md:50`)
+
+This document assigns **marketing_use** and **runtime_use** posture per repo key `fitchef-candidate-001`…`030`. Row order **`001–006`** map to the six **APPROVED-SEED** assets named in `docs/design/FITCHEF_MASCOT_ASSET_CANON.md`. Rows **`007–026`** correspond to the **20** `CANDIDATE` frames in **gallery sort order left-to-right, top-to-bottom** on `1473:2` (reconcile visually in Figma before locking ASO picks). Rows **`027–029`** map to **`REFERENCE-ONLY`**. Row **`030`** maps to **`NEEDS-REWORK`**.
+
+---
+
+## 1) Bucket policy mapping (`marketing_use` / `runtime_use`)
+
+Use these enums in spreadsheets, backlog notes, or future promotion PRs. They are **classification labels**, not App Store submissions.
+
+### `marketing_use`
+
+| Value | Meaning | ASO screenshot | Social / paid | Allowed embedded copy |
+| --- | --- | --- | --- | --- |
+| `approved_seed` | Approved seed PNG from repo canon (`FITCHEF_MASCOT_ASSET_CANON.md`). Safe brand anchor. | **Yes** (mascot corner / personality; not substitute for UI truth) | **Yes** | RU-first or bilingual per market; reject dominant English-only where RU/US campaign rules require locality |
+| `social_ready` | OK for IG/TikTok/Stories when composition avoids medical/diagnostic/guarantees and fake product UI reads as illustrative. | Tertiary / supporting only unless paired with compliant headline | **Preferred** | Short wellness lifestyle only |
+| `aso_supporting_hold` | Not blocked structurally but **blocked for primary ASO** until localization and text QA pass | Do not ship as Shot 1–3 hero until cleared | Allowed with disclaimers (“illustration”) where needed | Audit for English dominance |
+| `reference_archive` | Exploration, mood, or comps; **do not** imply shipped product behavior | **No** (reference / deck / internal only) | Optional with heavy “concept” labeling | Prefer no claim-like text |
+| `blocked_gtm` | Fails policy: medical/diagnostic, guarantees, fake UI as truth, or dominant non-localized English per target market rules | **No** | **No** (or creative-only with full rework) | Reject copy as written |
+
+### `runtime_use`
+
+| Value | Meaning |
+| --- | --- |
+| `canon_aligned` | Asset already has a named file in `docs/design/FITCHEF_MASCOT_ASSET_CANON.md` / `frontend/src/assets/brand/`; runtime mirror may exist in iOS catalog. No **new** promotion from this intake doc. |
+| `no_runtime_promotion` | Default for all **CANDIDATE / REFERENCE-ONLY / NEEDS-REWORK** on `1473:2` until a separate PR promotes a governed export per `AGENTS.md` / canon rules. |
+| `blocked_runtime` | Must not ship in app UI: typically fake metrics UI, diagnostic framing, or unreleased screens presented as live. |
+
+### Automatic flags (overlay any row)
+
+Apply these **in addition** to the row decision:
+
+- **Dominant embedded English** (where RU/CIS is primary): downgrade `marketing_use` by one tier toward `aso_supporting_hold` or `blocked_gtm` for CIS campaigns unless artist supplies localized overlay.
+- **Medical/diagnostic** (“diagnose”, “treatment”, pathology claims, clinician replacement): **`blocked_gtm`** / **`blocked_runtime`**.
+- **Guarantee** (“guaranteed lose”, “cure”, “100% results”): **`blocked_gtm`**.
+- **Fake UI promises** (mock nutrition score / meal plan screenshot presented as guaranteed live feature): **`blocked_runtime`** for in-app use; **`reference_archive`** or **`blocked_gtm`** for public marketing unless reworked per `FITCHEF_APP_STORE_VISUAL_CONTRACT.md` (real UI mass, illustrative labeling).
+
+Cross-ref: wellness copy posture `docs/contracts/FITCHEF_APP_STORE_VISUAL_CONTRACT.md`; FitChef lane `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md`.
+
+---
+
+## 2) Thirty row decisions (`fitchef-candidate-001` … `030`)
+
+| Key | Mapped asset / intake slot | `marketing_use` | `runtime_use` | Rationale snippet |
+| --- | --- | --- | --- | --- |
+| fitchef-candidate-001 | Seed: neutral (`fitchef-portrait-neutral-v1`) | approved_seed | canon_aligned | Baseline mascot; wellness lifestyle; suitable for ASO corner placement and social; no diagnostics in asset class. |
+| fitchef-candidate-002 | Seed: wink (`fitchef-portrait-wink-v1`) | approved_seed | canon_aligned | Positive feedback emotion; ASO/supporting screens; verify no overloaded English captions if composited. |
+| fitchef-candidate-003 | Seed: thinking (`fitchef-portrait-thinking-v1`) | approved_seed | canon_aligned | Planning/reflection vibe; fits “nutrition insight” metaphors without medical claims when paired with lawful copy. |
+| fitchef-candidate-004 | Seed: sleepy (`fitchef-portrait-sleepy-v1`) | approved_seed | canon_aligned | Rest/calm lanes; ASO tertiary; avoid implying sleep/medical outcome guarantees in surrounding copy. |
+| fitchef-candidate-005 | Seed: surprised (`fitchef-portrait-surprised-v1`) | approved_seed | canon_aligned | Attention/grab; social-friendly; headline must remain wellness-informational per contract. |
+| fitchef-candidate-006 | Seed: onboarding (`fitchef-onboarding-welcome-v1`) | approved_seed | canon_aligned | Welcome/hero archetype; strongest ASO candidate among seeds **if** layout matches composition rules (`FITCHEF_APP_STORE_VISUAL_CONTRACT.md`); still no fake standalone UI chrome. |
+| fitchef-candidate-007 | CANDIDATE #1 | social_ready¹ | no_runtime_promotion | Default CANDIDATE: OK for organic social once scanned for embedded English/medical/guarantee/fake UI; hold ASO first position until cleared. |
+| fitchef-candidate-008 | CANDIDATE #2 | social_ready¹ | no_runtime_promotion | Same tier as #007; prioritize short-form clips and Stories CTA to real product flows. |
+| fitchef-candidate-009 | CANDIDATE #3 | aso_supporting_hold¹ | no_runtime_promotion | Typical compositional drift risk; localize text layers before placing in ASO carousel. |
+| fitchef-candidate-010 | CANDIDATE #4 | social_ready¹ | no_runtime_promotion | Social-first; screenshot order only after text-risk pass. |
+| fitchef-candidate-011 | CANDIDATE #5 | aso_supporting_hold¹ | no_runtime_promotion | Audit for mock dashboard density; may read as “fake UI promise” if copy overclaims. |
+| fitchef-candidate-012 | CANDIDATE #6 | social_ready¹ | no_runtime_promotion | Mascot-forward variant; default social when English does not dominate. |
+| fitchef-candidate-013 | CANDIDATE #7 | reference_archive¹ | no_runtime_promotion | Often layout exploration; defer ASO hero use until aligns with seven-shot honesty rules. |
+| fitchef-candidate-014 | CANDIDATE #8 | aso_supporting_hold¹ | no_runtime_promotion | If frame nests dense metrics, downgrade to blocked_gtm for CIS until rewritten. |
+| fitchef-candidate-015 | CANDIDATE #9 | social_ready¹ | no_runtime_promotion | Short-form friendly; companion to paid UGC tests. |
+| fitchef-candidate-016 | CANDIDATE #10 | social_ready¹ | no_runtime_promotion | Default paid social carousel tile if visual passes compliance scan. |
+| fitchef-candidate-017 | CANDIDATE #11 | aso_supporting_hold¹ | no_runtime_promotion | Check FitChef-plus-data compositions for “results guarantee” implication. |
+| fitchef-candidate-018 | CANDIDATE #12 | reference_archive¹ | no_runtime_promotion | Reserve for decks / qualitative testing; rarely primary ASO. |
+| fitchef-candidate-019 | CANDIDATE #13 | blocked_gtm¹ | blocked_runtime | **Flag slot:** commonly food/chart composites—scrub for diagnostic language (“your risk”) and fake live scores; escalate to `aso_supporting_hold`/`social_ready` after rework proof.² |
+| fitchef-candidate-020 | CANDIDATE #14 | aso_supporting_hold¹ | no_runtime_promotion | Mid-funnel nurture; localize before Apple-facing use. |
+| fitchef-candidate-021 | CANDIDATE #15 | social_ready¹ | no_runtime_promotion | Acceptable mascot-led social proof when paired compliant caption. |
+| fitchef-candidate-022 | CANDIDATE #16 | reference_archive¹ | no_runtime_promotion | Mood/atmosphere comps; marketing reference only unless simplified. |
+| fitchef-candidate-023 | CANDIDATE #17 | social_ready¹ | no_runtime_promotion | Variant rotation for A/B creatives; watch English density. |
+| fitchef-candidate-024 | CANDIDATE #18 | blocked_gtm¹ | blocked_runtime | **Flag slot:** high risk of mock-phone UI implying shipped feature set; treat as illustrative only pending product parity review.² |
+| fitchef-candidate-025 | CANDIDATE #19 | aso_supporting_hold¹ | no_runtime_promotion | Conditional ASO: only if headline/supporting lines pass wellness guard; else downgrade. |
+| fitchef-candidate-026 | CANDIDATE #20 | social_ready¹ | no_runtime_promotion | Closing social tile in campaigns; reinforce “wellness informational” disclaimers where required. |
+| fitchef-candidate-027 | REFERENCE-ONLY #1 | reference_archive | no_runtime_promotion | Board label dictates archive use; internal/Figma-aligned messaging only—not App Store carousel. |
+| fitchef-candidate-028 | REFERENCE-ONLY #2 | reference_archive | no_runtime_promotion | Same as #027; no paid promotion asserting product truth without redesign. |
+| fitchef-candidate-029 | REFERENCE-ONLY #3 | reference_archive | no_runtime_promotion | Same as #027–028; training / partner deck only. |
+| fitchef-candidate-030 | NEEDS-REWORK | blocked_gtm | blocked_runtime | Do not ship in marketing or runtime until rework lands; expect medical/fake-UI/text fixes in Figma export. |
+
+¹ **Supersedable:** If the frame at that index is clearly mascot-only with no hazardous copy, operator may raise one tier (e.g. `aso_supporting_hold` → `social_ready`). If scan finds English/medical/guarantee/fake UI, apply **Automatic flags** and lower tier.
+² **High-churn slots:** If your Figma sort places a safe mascot-only frame at #19 or #24, swap classification with the nearest `social_ready` neighbor after documented QA.
+
+---
+
+## 3) Shortlist: App Store screenshot vs social-only vs reference-only
+
+| Track | Keys | Notes |
+| --- | --- | --- |
+| **App Store screenshot candidate (primary / early shots)** | `fitchef-candidate-001`–`006` | Only seed pack with known filenames; pair with real UI stills per `FITCHEF_APP_STORE_VISUAL_CONTRACT.md`. |
+| **App Store screenshot (supporting / later shots)** | `fitchef-candidate-009`, `011`, `014`, `017`, `020`, `025` **if** QA upgrades from `aso_supporting_hold` to cleared state | All require localized, non-guarantee headlines. |
+| **Social-only (organic + paid)** | `007`, `008`, `010`, `012`, `015`, `016`, `021`, `023`, `026` when `social_ready` holds after scan | Prefer Stories/Reels/short carousel; disclose illustrative composites if mock UI appears. |
+| **Reference-only (internal / partner / training)** | `013`, `018`, `022`, **`027`–`029`** | Reference boards; not for consumer ASO shelf without rework PR. |
+| **Hold / rework before any public use** | `019`, `024`, **`030`** + any row bumped by **Automatic flags** | Blocklisted until caption or pixels prove wellness-safe parity. |
+
+---
+
+## Evidence anchors
+
+- `docs/figma/FITCHEF_BRAND_REFERENCE_HANDOFF.md:33` (`1473:2` board inventory counts)
+- `docs/design/FITCHEF_MASCOT_ASSET_CANON.md` (six approved seed filenames)
+- `docs/contracts/FITCHEF_APP_STORE_VISUAL_CONTRACT.md` (composition and copy posture)
+
+---
+
+## Deferred / Follow-ups
+
+- Per-frame QA with screenshots: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-fitchef-candidate-intake-visual-qa`
+- Any repo binary promotion remains a separate PR; this doc **does not** authorize runtime asset changes.

--- a/docs/figma/FITCHEF_INTAKE_1473_2_GTM_CLASSIFICATION_GUIDANCE.md
+++ b/docs/figma/FITCHEF_INTAKE_1473_2_GTM_CLASSIFICATION_GUIDANCE.md
@@ -36,8 +36,8 @@ Use these enums in spreadsheets, backlog notes, or future promotion PRs. They ar
 Apply these **in addition** to the row decision:
 
 - **Dominant embedded English** (where RU/CIS is primary): downgrade `marketing_use` by one tier toward `aso_supporting_hold` or `blocked_gtm` for CIS campaigns unless artist supplies localized overlay.
-- **Medical/diagnostic** (“diagnose”, “treatment”, pathology claims, clinician replacement): **`blocked_gtm`** / **`blocked_runtime`**.
-- **Guarantee** (“guaranteed lose”, “cure”, “100% results”): **`blocked_gtm`**.
+- **Medical/diagnostic** (“diagnose”, “treatment”, pathology claims, clinician replacement): **`blocked_gtm`** / **`blocked_runtime`**. `pulseplate-allow:blocker-example`
+- **Guarantee** (“guaranteed lose”, “cure”, “100% results”): **`blocked_gtm`**. `pulseplate-allow:blocker-example`
 - **Fake UI promises** (mock nutrition score / meal plan screenshot presented as guaranteed live feature): **`blocked_runtime`** for in-app use; **`reference_archive`** or **`blocked_gtm`** for public marketing unless reworked per `FITCHEF_APP_STORE_VISUAL_CONTRACT.md` (real UI mass, illustrative labeling).
 
 Cross-ref: wellness copy posture `docs/contracts/FITCHEF_APP_STORE_VISUAL_CONTRACT.md`; FitChef lane `docs/contracts/FITCHEF_INITIATIVE_FOUNDATION.md`.
@@ -68,7 +68,7 @@ Cross-ref: wellness copy posture `docs/contracts/FITCHEF_APP_STORE_VISUAL_CONTRA
 | fitchef-candidate-018 | CANDIDATE #12 | reference_archive¹ | no_runtime_promotion | Reserve for decks / qualitative testing; rarely primary ASO. |
 | fitchef-candidate-019 | CANDIDATE #13 | blocked_gtm¹ | blocked_runtime | **Flag slot:** commonly food/chart composites—scrub for diagnostic language (“your risk”) and fake live scores; escalate to `aso_supporting_hold`/`social_ready` after rework proof.² |
 | fitchef-candidate-020 | CANDIDATE #14 | aso_supporting_hold¹ | no_runtime_promotion | Mid-funnel nurture; localize before Apple-facing use. |
-| fitchef-candidate-021 | CANDIDATE #15 | social_ready¹ | no_runtime_promotion | Acceptable mascot-led social proof when paired compliant caption. |
+| fitchef-candidate-021 | CANDIDATE #15 | social_ready¹ | no_runtime_promotion | Acceptable mascot-led social proof when paired with a compliant caption. |
 | fitchef-candidate-022 | CANDIDATE #16 | reference_archive¹ | no_runtime_promotion | Mood/atmosphere comps; marketing reference only unless simplified. |
 | fitchef-candidate-023 | CANDIDATE #17 | social_ready¹ | no_runtime_promotion | Variant rotation for A/B creatives; watch English density. |
 | fitchef-candidate-024 | CANDIDATE #18 | blocked_gtm¹ | blocked_runtime | **Flag slot:** high risk of mock-phone UI implying shipped feature set; treat as illustrative only pending product parity review.² |

--- a/docs/review/PR_1556_FIXED_MAPPING.md
+++ b/docs/review/PR_1556_FIXED_MAPPING.md
@@ -1,0 +1,27 @@
+# PR #1556 - Fixed in Commit Mapping (canonical)
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556>
+Branch: `docs/fitchef-candidate-visual-qa-matrix`
+Date: 2026-04-28
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- Pending review threads.
+
+## Scope (PR-1556)
+
+- `docs/design/FITCHEF_CANDIDATE_VISUAL_QA_2026-04-28.md` - add 30-row candidate visual QA matrix for board `1473:2` with disposition, text/localization risk, wellness safety risk, and marketing/runtime separation.
+- `docs/figma/FITCHEF_INTAKE_1473_2_GTM_CLASSIFICATION_GUIDANCE.md` - classify `fitchef-candidate-001..030` for GTM/App Store suitability while keeping runtime promotion blocked.
+- `docs/figma/FITCHEF_BRAND_REFERENCE_HANDOFF.md` - link intake board to GTM classification guidance.
+- `docs/roadmap/BACKLOG_LEDGER.md` - bind `ledger-p1-fitchef-candidate-intake-visual-qa` to PR #1556 with in-review status.
+- `docs/review/PR_1556_FIXED_MAPPING.md` - canonical review-governance artifact for this PR.
+
+## Validation
+
+- `pre-commit run --all-files`
+- `git diff --name-only origin/main...HEAD | rg -v "\\.md$|README\\.md$|AGENTS\\.md$|RUNBOOK_AGENT\\.md$|DEPLOYMENT\\.md$"`

--- a/docs/review/PR_1556_FIXED_MAPPING.md
+++ b/docs/review/PR_1556_FIXED_MAPPING.md
@@ -41,6 +41,37 @@ Disposition: FIXED
 Commit: 8171f925c
 Evidence: Addressed CodeRabbit actionable review items in both matrix/governance docs while preserving docs-only scope.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155713773 -> 676b30764
+Disposition: FIXED
+Commit: 676b30764
+Evidence: Added required canonical artifact structure updates including completed discussion-pass checklist; merge-readiness section added in this commit chain to satisfy review-governance template requirements.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#pullrequestreview-4190636819
+Disposition: NOT-A-BUG
+Evidence: Review summary entry only; actionable inline item from this review (`discussion_r3155674057`) was fixed in `676b30764` and mapped below.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#pullrequestreview-4190648149
+Disposition: NOT-A-BUG
+Evidence: Duplicate-summary review with no additional actionable delta beyond already mapped discussion item.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#pullrequestreview-4190682743
+Disposition: FIXED
+Commit: 676b30764
+Evidence: Actionable requirement addressed by adding/validating required canonical artifact sections.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155674057 -> 676b30764
+Disposition: FIXED
+Commit: 676b30764
+Evidence: `docs/review/PR_1556_FIXED_MAPPING.md` discussion-pass checkboxes were set to checked state as required.
+
+## Merge Readiness
+
+- [ ] No unresolved review threads
+- [ ] Required checks PASS
+- [ ] Approved by required reviewers
+- [ ] PR body mirror updated with canonical sections
+- [ ] Docs-only scope verified (no non-doc files changed)
+
 ## Scope (PR-1556)
 
 - `docs/design/FITCHEF_CANDIDATE_VISUAL_QA_2026-04-28.md` - add 30-row candidate visual QA matrix for board `1473:2` with disposition, text/localization risk, wellness safety risk, and marketing/runtime separation.

--- a/docs/review/PR_1556_FIXED_MAPPING.md
+++ b/docs/review/PR_1556_FIXED_MAPPING.md
@@ -16,9 +16,9 @@ Disposition: FIXED
 Commit: 8171f925c
 Evidence: `docs/design/FITCHEF_CANDIDATE_VISUAL_QA_2026-04-28.md` now uses canonical keyspace `fitchef-candidate-001..030`, exact intake distribution (`6` approved-seed, `20` candidate, `3` reference-only, `1` needs-rework), and GTM/runtime enums aligned to `docs/figma/FITCHEF_INTAKE_1473_2_GTM_CLASSIFICATION_GUIDANCE.md`.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155584473 -> PENDING_COMMIT_SHA
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155584473 -> a9494b9c1
 Disposition: FIXED
-Commit: PENDING_COMMIT_SHA
+Commit: a9494b9c1
 Evidence: The approved-seed rows in `docs/design/FITCHEF_CANDIDATE_VISUAL_QA_2026-04-28.md` now map only to canonical seed files from `docs/design/FITCHEF_MASCOT_ASSET_CANON.md`, removing action-asset mislabeling.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155595159 -> 8171f925c

--- a/docs/review/PR_1556_FIXED_MAPPING.md
+++ b/docs/review/PR_1556_FIXED_MAPPING.md
@@ -41,10 +41,10 @@ Disposition: FIXED
 Commit: 8171f925c
 Evidence: Addressed CodeRabbit actionable review items in both matrix/governance docs while preserving docs-only scope.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155713773 -> 676b30764
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155713773 -> e8635d94c
 Disposition: FIXED
-Commit: 676b30764
-Evidence: Added required canonical artifact structure updates including completed discussion-pass checklist; merge-readiness section added in this commit chain to satisfy review-governance template requirements.
+Commit: e8635d94c
+Evidence: Added required canonical `## Merge Readiness` section in the review artifact with checklist scaffold expected by governance tooling.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#pullrequestreview-4190636819
 Disposition: NOT-A-BUG
@@ -54,9 +54,9 @@ Evidence: Review summary entry only; actionable inline item from this review (`d
 Disposition: NOT-A-BUG
 Evidence: Duplicate-summary review with no additional actionable delta beyond already mapped discussion item.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#pullrequestreview-4190682743
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#pullrequestreview-4190682743 -> e8635d94c
 Disposition: FIXED
-Commit: 676b30764
+Commit: e8635d94c
 Evidence: Actionable requirement addressed by adding/validating required canonical artifact sections.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155674057 -> 676b30764

--- a/docs/review/PR_1556_FIXED_MAPPING.md
+++ b/docs/review/PR_1556_FIXED_MAPPING.md
@@ -16,6 +16,11 @@ Disposition: FIXED
 Commit: 8171f925c
 Evidence: `docs/design/FITCHEF_CANDIDATE_VISUAL_QA_2026-04-28.md` now uses canonical keyspace `fitchef-candidate-001..030`, exact intake distribution (`6` approved-seed, `20` candidate, `3` reference-only, `1` needs-rework), and GTM/runtime enums aligned to `docs/figma/FITCHEF_INTAKE_1473_2_GTM_CLASSIFICATION_GUIDANCE.md`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155584473 -> PENDING_COMMIT_SHA
+Disposition: FIXED
+Commit: PENDING_COMMIT_SHA
+Evidence: The approved-seed rows in `docs/design/FITCHEF_CANDIDATE_VISUAL_QA_2026-04-28.md` now map only to canonical seed files from `docs/design/FITCHEF_MASCOT_ASSET_CANON.md`, removing action-asset mislabeling.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155595159 -> 8171f925c
 Disposition: FIXED
 Commit: 8171f925c

--- a/docs/review/PR_1556_FIXED_MAPPING.md
+++ b/docs/review/PR_1556_FIXED_MAPPING.md
@@ -11,7 +11,25 @@ Date: 2026-04-28
 
 ## Fixed in Commit Mapping
 
-- Pending review threads.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155595152 -> 8171f925c
+Disposition: FIXED
+Commit: 8171f925c
+Evidence: `docs/design/FITCHEF_CANDIDATE_VISUAL_QA_2026-04-28.md` now uses canonical keyspace `fitchef-candidate-001..030`, exact intake distribution (`6` approved-seed, `20` candidate, `3` reference-only, `1` needs-rework), and GTM/runtime enums aligned to `docs/figma/FITCHEF_INTAKE_1473_2_GTM_CLASSIFICATION_GUIDANCE.md`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155595159 -> 8171f925c
+Disposition: FIXED
+Commit: 8171f925c
+Evidence: Policy-example lines in `docs/figma/FITCHEF_INTAKE_1473_2_GTM_CLASSIFICATION_GUIDANCE.md` now include `pulseplate-allow:blocker-example` markers and keep the wellness guard fail-closed without broad allowlist changes.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#pullrequestreview-4190520460 -> 8171f925c
+Disposition: FIXED
+Commit: 8171f925c
+Evidence: Addressed Sourcery thread guidance by adding explicit candidate-key to mapped-asset traceability in matrix `notes` and fixing grammar in GTM rationale (`when paired with a compliant caption`).
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#pullrequestreview-4190539368 -> 8171f925c
+Disposition: FIXED
+Commit: 8171f925c
+Evidence: Addressed CodeRabbit actionable review items in both matrix/governance docs while preserving docs-only scope.
 
 ## Scope (PR-1556)
 

--- a/docs/review/PR_1556_FIXED_MAPPING.md
+++ b/docs/review/PR_1556_FIXED_MAPPING.md
@@ -6,8 +6,8 @@ Date: 2026-04-28
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 

--- a/docs/review/PR_1556_FIXED_MAPPING.md
+++ b/docs/review/PR_1556_FIXED_MAPPING.md
@@ -26,6 +26,11 @@ Disposition: FIXED
 Commit: 8171f925c
 Evidence: Policy-example lines in `docs/figma/FITCHEF_INTAKE_1473_2_GTM_CLASSIFICATION_GUIDANCE.md` now include `pulseplate-allow:blocker-example` markers and keep the wellness guard fail-closed without broad allowlist changes.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155581650 -> 8171f925c
+Disposition: FIXED
+Commit: 8171f925c
+Evidence: Grammar in GTM row `fitchef-candidate-021` updated to “when paired with a compliant caption”.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#pullrequestreview-4190520460 -> 8171f925c
 Disposition: FIXED
 Commit: 8171f925c

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -6702,7 +6702,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: FitChef candidate intake visual QA and selective promotion plan
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FITCHEF-CANDIDATE-VISUAL-QA
+  - Target PR: PR #1556 (`docs/fitchef-candidate-visual-qa-matrix`)
+  - Status: In review (PR #1556, opened 2026-04-28)
   - Area: design / brand / marketing assets
   - Reason: Figma intake board now contains 30 FitChef assets, but only 6
     repo-backed seed assets are canonical. Candidate/reference/rework assets


### PR DESCRIPTION
## Summary
- add `docs/design/FITCHEF_CANDIDATE_VISUAL_QA_2026-04-28.md` with 30-row candidate visual QA matrix for Figma intake board `1473:2`
- add GTM classification guidance doc for `fitchef-candidate-001..030` and link it from the FitChef handoff board section
- keep runtime boundaries explicit: no asset/runtime promotion in this docs-only lane

## Test plan
- pre-commit run --all-files
- git diff --name-only origin/main...HEAD | rg -v "\\.md$|README\\.md$|AGENTS\\.md$|RUNBOOK_AGENT\\.md$|DEPLOYMENT\\.md$"

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155581650 -> 8171f925c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155584473 -> a9494b9c1
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155595152 -> 8171f925c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#discussion_r3155595159 -> 8171f925c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#pullrequestreview-4190520460 -> 8171f925c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1556#pullrequestreview-4190539368 -> 8171f925c

## Deferred / Follow-ups
- close/update `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-fitchef-candidate-intake-visual-qa` status after merge confirmation if any final disposition tuning is requested in review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a 30-asset FitChef visual QA matrix with per-asset dispositions (keep, reference-only, needs-rework, reject), embedded-text/localization/wellness-safety risk capture, and marketing_use vs runtime_use classifications that block runtime promotion from this intake lane.
  * Added GTM classification guidance and brand handoff links for candidate assets, plus a canonical review/governance artifact documenting fixes and validation steps.
* **Backlog**
  * Updated backlog entry to reference the new intake matrix and review artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->