### PR TITLE
feat(pr-review): add dry-run report runner

### DIFF
--- a/.agents/skills/pulseplate-pr-review/SKILL.md
+++ b/.agents/skills/pulseplate-pr-review/SKILL.md
@@ -64,7 +64,15 @@ Use this default order unless the active packet declares a narrower compatible s
    rg -n "CodeRabbit|Sourcery|Cubic|Disposition:|FIXED|NOT-A-BUG|DEFERRED" docs/review docs/orchestration
    ```
 
-3. Classify findings with the required schema:
+3. For deterministic dry-run mode, collect context and render the report:
+
+   ```bash
+   python3 scripts/orchestration/pr_review_context.py --pr <PR_NUMBER> --output /tmp/pulseplate_pr_review_context.json
+   python3 scripts/orchestration/pr_review_report.py --context /tmp/pulseplate_pr_review_context.json --format markdown
+   python3 scripts/orchestration/pr_review_report.py --context /tmp/pulseplate_pr_review_context.json --format json
+   ```
+
+4. Classify findings with the required schema:
    - `severity`: `critical`, `major`, `minor`, or `note`
    - `role_agent`: owning reviewer agent
    - `category`: correctness, security, architecture, tests, docs, wellness, release, or governance
@@ -74,7 +82,7 @@ Use this default order unless the active packet declares a narrower compatible s
    - `gate_to_run`: exact command that proves the fix
    - `disposition_candidate`: `FIXED`, `NOT-A-BUG`, `DEFERRED`, or `NEEDS-HUMAN`
 
-4. Keep plugin evidence optional:
+5. Keep plugin evidence optional:
    - GitHub: PR metadata, checks, reviews, and future dry-run-to-comment path.
    - CodeRabbit: reference workflow only; do not depend on available review quota.
    - Hugging Face: optional model/paper scouting for code review and vulnerability-detection methods.
@@ -109,3 +117,5 @@ Use this default order unless the active packet declares a narrower compatible s
 - `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`
 - `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md`
 - `docs/roadmap/BACKLOG_LEDGER.md`
+- `scripts/orchestration/pr_review_context.py`
+- `scripts/orchestration/pr_review_report.py`

--- a/docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR2_CONTEXT_COLLECTOR_PACKET_2026-04-26.md
+++ b/docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR2_CONTEXT_COLLECTOR_PACKET_2026-04-26.md
@@ -33,7 +33,7 @@ collector and mirror synchronization step for deterministic Codex review runs.
 - `tests/test_install_codex_skills.py`
 - `docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR2_CONTEXT_COLLECTOR_PACKET_2026-04-26.md`
 - `docs/review/PR_<N>_FIXED_MAPPING.md` after PR number is assigned
-- `/.agents/skills/pulseplate-pr-review`
+- `.agents/skills/pulseplate-pr-review`
 
 ## Role Order
 

--- a/docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR3_DRY_RUN_REPORT_PACKET_2026-04-28.md
+++ b/docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR3_DRY_RUN_REPORT_PACKET_2026-04-28.md
@@ -1,0 +1,53 @@
+# PulsePlate PR Review Skill PR3 Dry-Run Report Packet
+
+## Purpose
+
+Implement PR3 for `pulseplate-pr-review`: a side-effect-free dry-run report runner
+that consumes `scripts/orchestration/pr_review_context.py` JSON and emits stable
+Markdown or JSON review reports.
+
+## Scope
+
+### IN
+
+- Add `scripts/orchestration/pr_review_report.py`.
+- Render `dry-run-report` output in Markdown and JSON.
+- Preserve coordinator-first role order:
+  `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> data-scientist-agent`.
+- Update the skill documentation and discovery mirror.
+- Close out the merged PR2 collector ledger item for PR #1539.
+
+### OUT
+
+- GitHub review comment posting.
+- PR thread resolution.
+- Merge automation or merge-readiness claims.
+- Runtime dependency on Browser Use, Computer Use, Expo, Hugging Face, Life Science Research, CodeRabbit, Sourcery, or Cubic.
+
+## Role Order
+
+1. `agent-coordinator`
+2. `architecture-specialist`
+3. `security-auditor`
+4. `qa-engineer-agent`
+5. `bug-hunter`
+6. `data-scientist-agent`
+
+## Validation Plan
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `python3 scripts/orchestration/sync_skill_mirror.py --name pulseplate-pr-review --force`
+- `python3 -m pytest tests/test_pr_review_context.py tests/test_pr_review_report.py tests/test_sync_skill_mirror.py tests/test_install_codex_skills.py -q`
+- `pre-commit run --all-files`
+- `make validate-min`
+- `make validate-changed` if touched scope widens
+
+## Decision Log
+
+- The runner is advisory only and mutates nothing unless `--output` is explicitly
+  used to write the generated report.
+- Report output does not replace fixed-mapping governance, CodeRabbit/Sourcery/Cubic
+  review signals, `make verify`, or `check_merge_ready.py`.
+- Plugin evidence channels remain optional and documented; no external plugin is a
+  hard runtime dependency for ordinary PR review.

--- a/docs/review/PR_1558_FIXED_MAPPING.md
+++ b/docs/review/PR_1558_FIXED_MAPPING.md
@@ -1,0 +1,35 @@
+# PR #1558 Fixed Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558>
+Branch: `codex/pulseplate-pr-review-dry-run-runner-pr3`
+Date: 2026-04-28
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Initial Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` (PASS)
+- `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
+- `python3 scripts/orchestration/sync_skill_mirror.py --name pulseplate-pr-review --force` (PASS)
+- `python3 -m pytest tests/test_pr_review_context.py tests/test_pr_review_report.py tests/test_sync_skill_mirror.py tests/test_install_codex_skills.py -q` (PASS, 26 passed)
+- `python3 -m pytest tests/test_pr_review_report.py tests/test_sync_skill_mirror.py -q` (PASS, 8 passed)
+- `.venv/bin/mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/pr_review_report.py scripts/orchestration/sync_skill_mirror.py` (PASS)
+- `pre-commit run --all-files` (PASS)
+- `make validate-min` (PASS)
+- `make validate-changed` (PASS)
+- pre-push hooks: mypy, pip-audit, backend pytest, full-repo bandit, docker build test (PASS)
+
+## Merge Readiness
+
+- [ ] CI green on current head
+- [ ] No unresolved actionable review threads
+- [ ] CodeRabbit/Sourcery/Cubic statuses reviewed and mapped
+- [ ] Fixed-mapping artifact and PR body mirror aligned
+- [ ] `check_merge_ready.py --require-auth` PASS

--- a/docs/review/PR_1558_FIXED_MAPPING.md
+++ b/docs/review/PR_1558_FIXED_MAPPING.md
@@ -11,7 +11,27 @@ Date: 2026-04-28
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 467d4556f
+Evidence: tests/test_sync_skill_mirror.py covers both canonical and fallback marker path layouts for sync_skill_mirror.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#discussion_r3156053099 -> 467d4556f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#pullrequestreview-4191079725 -> 467d4556f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#pullrequestreview-4191098638 -> 467d4556f
+
+Disposition: FIXED
+Commit: 467d4556f
+Evidence: scripts/orchestration/pr_review_report.py preserves gate order while deduping and uses stable context-provided generated_at_utc report metadata.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#discussion_r3156064227 -> 467d4556f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#pullrequestreview-4191093231 -> 467d4556f
+
+Disposition: FIXED
+Commit: 467d4556f
+Evidence: tests/test_pr_review_report.py annotates the monkeypatch fixture as pytest.MonkeyPatch.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#discussion_r3156068684 -> 467d4556f
+
+Disposition: NOT-A-BUG
+Evidence: scripts/orchestration/pr_review_report.py keeps LARGE_DIFF_CHANGED_LINES and VERY_LARGE_DIFF_CHANGED_LINES as repo-native constants for deterministic PR governance, not cross-repo runtime configuration.
+Reason: This runner is PulsePlate-specific and the thresholds are part of the local advisory review policy for PR3; no runtime or multi-repo tuning surface is required in this slice.
 
 ## Initial Evidence
 
@@ -25,6 +45,9 @@ Date: 2026-04-28
 - `make validate-min` (PASS)
 - `make validate-changed` (PASS)
 - pre-push hooks: mypy, pip-audit, backend pytest, full-repo bandit, docker build test (PASS)
+- Post-review fix validation: `python3 -m pytest tests/test_pr_review_context.py tests/test_pr_review_report.py tests/test_sync_skill_mirror.py tests/test_install_codex_skills.py -q` (PASS, 28 passed)
+- Post-review fix validation: `.venv/bin/mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/pr_review_report.py scripts/orchestration/sync_skill_mirror.py` (PASS)
+- Post-review fix validation: `pre-commit run --all-files` (PASS)
 
 ## Merge Readiness
 

--- a/docs/review/PR_1558_FIXED_MAPPING.md
+++ b/docs/review/PR_1558_FIXED_MAPPING.md
@@ -33,21 +33,34 @@ Disposition: NOT-A-BUG
 Evidence: scripts/orchestration/pr_review_report.py keeps LARGE_DIFF_CHANGED_LINES and VERY_LARGE_DIFF_CHANGED_LINES as repo-native constants for deterministic PR governance, not cross-repo runtime configuration.
 Reason: This runner is PulsePlate-specific and the thresholds are part of the local advisory review policy for PR3; no runtime or multi-repo tuning surface is required in this slice.
 
+Disposition: FIXED
+Commit: 0d5e653a2
+Evidence: scripts/orchestration/pr_review_report.py now reports unreadable context JSON with a clean SystemExit and treats missing or malformed fixed_mapping context as a qa-engineer-agent governance finding; tests/test_pr_review_report.py covers both paths.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#discussion_r3156149301 -> 0d5e653a2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#discussion_r3156149314 -> 0d5e653a2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#pullrequestreview-4191196512 -> 0d5e653a2
+
 ## Initial Evidence
 
 - `python3 scripts/orchestration/check_preflight.py` (PASS)
 - `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
 - `python3 scripts/orchestration/sync_skill_mirror.py --name pulseplate-pr-review --force` (PASS)
-- `python3 -m pytest tests/test_pr_review_context.py tests/test_pr_review_report.py tests/test_sync_skill_mirror.py tests/test_install_codex_skills.py -q` (PASS, 26 passed)
-- `python3 -m pytest tests/test_pr_review_report.py tests/test_sync_skill_mirror.py -q` (PASS, 8 passed)
+- `python3 -m pytest tests/test_pr_review_context.py tests/test_pr_review_report.py tests/test_sync_skill_mirror.py tests/test_install_codex_skills.py -q` (PASS, 30 passed)
+- `python3 -m pytest tests/test_pr_review_report.py tests/test_sync_skill_mirror.py -q` (PASS, 12 passed)
 - `.venv/bin/mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/pr_review_report.py scripts/orchestration/sync_skill_mirror.py` (PASS)
 - `pre-commit run --all-files` (PASS)
 - `make validate-min` (PASS)
 - `make validate-changed` (PASS)
 - pre-push hooks: mypy, pip-audit, backend pytest, full-repo bandit, docker build test (PASS)
-- Post-review fix validation: `python3 -m pytest tests/test_pr_review_context.py tests/test_pr_review_report.py tests/test_sync_skill_mirror.py tests/test_install_codex_skills.py -q` (PASS, 28 passed)
+- Post-review fix validation: `python3 -m pytest tests/test_pr_review_context.py tests/test_pr_review_report.py tests/test_sync_skill_mirror.py tests/test_install_codex_skills.py -q` (PASS, 30 passed)
 - Post-review fix validation: `.venv/bin/mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/pr_review_report.py scripts/orchestration/sync_skill_mirror.py` (PASS)
 - Post-review fix validation: `pre-commit run --all-files` (PASS)
+- Follow-up CodeRabbit fix validation: `python3 -m pytest tests/test_pr_review_report.py tests/test_sync_skill_mirror.py -q` (PASS, 12 passed)
+- Follow-up CodeRabbit fix validation: `.venv/bin/mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/pr_review_report.py scripts/orchestration/sync_skill_mirror.py` (PASS)
+- Follow-up CodeRabbit fix validation: `python3 -m pytest tests/test_pr_review_context.py tests/test_pr_review_report.py tests/test_sync_skill_mirror.py tests/test_install_codex_skills.py -q` (PASS, 30 passed)
+- Follow-up CodeRabbit fix validation: `pre-commit run --all-files` (PASS)
+- Follow-up CodeRabbit fix validation: `make validate-min` (PASS)
+- Follow-up CodeRabbit fix validation: `make validate-changed` (PASS)
 
 ## Merge Readiness
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4019,11 +4019,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 ### P2
 
 <a id="ledger-p2-pulseplate-pr-review-context-collector"></a>
-- [ ] P2: Add read-only context collector for PulsePlate PR review skill
+- [x] P2: Add read-only context collector for PulsePlate PR review skill
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2 (review automation follow-up)
   - Target PR: PR #1539 (`docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR2_CONTEXT_COLLECTOR_PACKET_2026-04-26.md`, docs/review/PR_1539_FIXED_MAPPING.md)
-  - Status: Open (closeout in docs-only follow-up PR)
+  - Status: Completed in PR #1539; closeout recorded in PR3 dry-run report runner lane
   - Area: orchestration / PR review / Codex skills
   - Reason: PR1 intentionally keeps `pulseplate-pr-review` passive and documentation/router-only. A separate follow-up should add a read-only collector for changed files, diff stats, scoped `AGENTS.md`, PR metadata, fixed-mapping state, and relevant test suggestions after the skill contract is merged and reviewed.
   - Links:
@@ -4035,6 +4035,24 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - collector output has a stable JSON schema usable by `pulseplate-pr-review`
     - tests cover branch diff, scoped `AGENTS.md` discovery, missing PR metadata, and fixed-mapping absence
     - the collector remains advisory and does not post GitHub comments, resolve threads, or claim merge readiness
+
+<a id="ledger-p2-pulseplate-pr-review-dry-run-report-runner"></a>
+- [ ] P2: Add dry-run report runner for PulsePlate PR review skill
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2 (review automation follow-up)
+  - Target PR: PR-TBD (`docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR3_DRY_RUN_REPORT_PACKET_2026-04-28.md`)
+  - Status: In progress in PR3 dry-run report runner lane
+  - Area: orchestration / PR review / Codex skills
+  - Reason: PR2 provides read-only review context JSON, but reviewers still need a deterministic Markdown/JSON dry-run report that follows the `pulseplate-pr-review` role order and finding schema without posting comments or resolving threads.
+  - Links:
+    - `scripts/orchestration/pr_review_context.py`
+    - `tools/codex_skills/pulseplate-pr-review/SKILL.md`
+    - `docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR3_DRY_RUN_REPORT_PACKET_2026-04-28.md`
+  - DoD:
+    - `scripts/orchestration/pr_review_report.py` consumes context JSON from file or stdin
+    - report output supports stable Markdown and JSON formats
+    - findings follow the `pulseplate-pr-review` schema and coordinator role order
+    - runner remains advisory and does not post GitHub comments, resolve review threads, or claim merge readiness
 
 <a id="ledger-p2-rag-release-gates-runtime-warnings-dedup"></a>
 - [ ] P2: Deduplicate `EvalRuntimeState.warnings` in RAG release-gates runner

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4040,7 +4040,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: Add dry-run report runner for PulsePlate PR review skill
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2 (review automation follow-up)
-  - Target PR: PR-TBD (`docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR3_DRY_RUN_REPORT_PACKET_2026-04-28.md`)
+  - Target PR: PR #1558 (`docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR3_DRY_RUN_REPORT_PACKET_2026-04-28.md`, docs/review/PR_1558_FIXED_MAPPING.md)
   - Status: In progress in PR3 dry-run report runner lane
   - Area: orchestration / PR review / Codex skills
   - Reason: PR2 provides read-only review context JSON, but reviewers still need a deterministic Markdown/JSON dry-run report that follows the `pulseplate-pr-review` role order and finding schema without posting comments or resolving threads.

--- a/scripts/orchestration/pr_review_report.py
+++ b/scripts/orchestration/pr_review_report.py
@@ -6,8 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from dataclasses import dataclass
-from datetime import datetime, timezone
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
@@ -39,10 +38,6 @@ class Finding:
     disposition_candidate: str
 
 
-def _utc_now() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
 def _load_context(path: str | None) -> dict[str, Any]:
     raw = Path(path).read_text(encoding="utf-8") if path else sys.stdin.read()
     try:
@@ -72,6 +67,17 @@ def _dedupe_strings(values: list[Any]) -> list[str]:
         seen.add(item)
         deduped.append(item)
     return deduped
+
+
+def _ordered_unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
 
 
 def _context_path(context: dict[str, Any], default: str) -> str:
@@ -214,7 +220,7 @@ def _build_gate_plan(context: dict[str, Any], findings: list[Finding]) -> list[s
         "python3 -m pytest tests/test_pr_review_report.py tests/test_pr_review_context.py -q",
     ]
     finding_gates = [finding.gate_to_run for finding in findings if finding.gate_to_run]
-    return sorted(set(base + suggestions + finding_gates))
+    return _ordered_unique(base + suggestions + finding_gates)
 
 
 def build_report(
@@ -226,7 +232,7 @@ def build_report(
     findings = build_findings(context)
     return {
         "schema_version": SCHEMA_VERSION,
-        "generated_at_utc": _utc_now(),
+        "generated_at_utc": str(context.get("generated_at_utc") or "unknown"),
         "mode": "dry-run-report",
         "coordinator_packet": {
             "task_packet_id": packet_id,
@@ -235,7 +241,7 @@ def build_report(
         },
         "scope_reviewed": _build_scope(context),
         "findings_count": len(findings),
-        "findings": [finding.__dict__ for finding in findings],
+        "findings": [asdict(finding) for finding in findings],
         "role_review": _build_role_reviews(findings),
         "gate_plan": _build_gate_plan(context, findings),
         "deferred_followups": [],

--- a/scripts/orchestration/pr_review_report.py
+++ b/scripts/orchestration/pr_review_report.py
@@ -39,7 +39,10 @@ class Finding:
 
 
 def _load_context(path: str | None) -> dict[str, Any]:
-    raw = Path(path).read_text(encoding="utf-8") if path else sys.stdin.read()
+    try:
+        raw = Path(path).read_text(encoding="utf-8") if path else sys.stdin.read()
+    except OSError as exc:
+        raise SystemExit(f"Unable to read context JSON: {exc}") from exc
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError as exc:
@@ -123,8 +126,8 @@ def build_findings(context: dict[str, Any]) -> list[Finding]:
             )
         )
 
-    fixed_mapping = context.get("fixed_mapping")
-    if isinstance(fixed_mapping, dict) and not fixed_mapping.get("exists"):
+    fixed_mapping = _as_dict(context.get("fixed_mapping"))
+    if not fixed_mapping.get("exists"):
         findings.append(
             Finding(
                 severity="note",

--- a/scripts/orchestration/pr_review_report.py
+++ b/scripts/orchestration/pr_review_report.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Render deterministic dry-run reports for the PulsePlate PR review skill."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "1.0.0"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ROLE_ORDER = [
+    "agent-coordinator",
+    "architecture-specialist",
+    "security-auditor",
+    "qa-engineer-agent",
+    "bug-hunter",
+    "data-scientist-agent",
+]
+
+LARGE_DIFF_CHANGED_LINES = 300
+VERY_LARGE_DIFF_CHANGED_LINES = 800
+
+
+@dataclass(frozen=True)
+class Finding:
+    severity: str
+    role_agent: str
+    category: str
+    file: str
+    line: int | None
+    evidence: str
+    suggested_fix: str
+    gate_to_run: str
+    disposition_candidate: str
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _load_context(path: str | None) -> dict[str, Any]:
+    raw = Path(path).read_text(encoding="utf-8") if path else sys.stdin.read()
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid context JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SystemExit("Invalid context JSON: expected object at top level.")
+    return payload
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _dedupe_strings(values: list[Any]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        item = str(value).strip()
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        deduped.append(item)
+    return deduped
+
+
+def _context_path(context: dict[str, Any], default: str) -> str:
+    query = _as_dict(context.get("query"))
+    pr_number = query.get("pr_number")
+    if pr_number:
+        return f"docs/review/PR_{pr_number}_FIXED_MAPPING.md"
+    return default
+
+
+def build_findings(context: dict[str, Any]) -> list[Finding]:
+    """Build conservative advisory findings from context collector output."""
+
+    findings: list[Finding] = []
+    warnings = _dedupe_strings(_as_list(context.get("warnings")))
+    for warning in warnings:
+        findings.append(
+            Finding(
+                severity="note",
+                role_agent="agent-coordinator",
+                category="governance",
+                file="scripts/orchestration/pr_review_context.py",
+                line=None,
+                evidence=warning,
+                suggested_fix="Review the warning before using this report as PR evidence.",
+                gate_to_run="python3 scripts/orchestration/pr_review_context.py --pr <PR_NUMBER>",
+                disposition_candidate="NEEDS-HUMAN",
+            )
+        )
+
+    if context.get("pr") is None:
+        findings.append(
+            Finding(
+                severity="note",
+                role_agent="agent-coordinator",
+                category="governance",
+                file="scripts/orchestration/pr_review_context.py",
+                line=None,
+                evidence="PR metadata is unavailable in the supplied context.",
+                suggested_fix="Run the context collector with --pr and --repo when a PR exists.",
+                gate_to_run="python3 scripts/orchestration/pr_review_context.py --pr <PR_NUMBER> --repo <OWNER/REPO>",
+                disposition_candidate="NEEDS-HUMAN",
+            )
+        )
+
+    fixed_mapping = context.get("fixed_mapping")
+    if isinstance(fixed_mapping, dict) and not fixed_mapping.get("exists"):
+        findings.append(
+            Finding(
+                severity="note",
+                role_agent="qa-engineer-agent",
+                category="governance",
+                file=_context_path(context, "docs/review/PR_<N>_FIXED_MAPPING.md"),
+                line=None,
+                evidence="Fixed-mapping artifact is missing or not available.",
+                suggested_fix="Create the canonical fixed-mapping artifact after the PR number is assigned.",
+                gate_to_run="python3 scripts/orchestration/check_review_threads_disposition.py --pr-number <PR_NUMBER> --require-auth",
+                disposition_candidate="NEEDS-HUMAN",
+            )
+        )
+
+    agents_discovery = context.get("agents_discovery")
+    scoped_agents = []
+    if isinstance(agents_discovery, dict):
+        scoped_agents = [str(item) for item in _as_list(agents_discovery.get("scoped_agents_md"))]
+    if not scoped_agents:
+        findings.append(
+            Finding(
+                severity="note",
+                role_agent="architecture-specialist",
+                category="architecture",
+                file="AGENTS.md",
+                line=None,
+                evidence="No scoped AGENTS.md files were discovered for the changed files.",
+                suggested_fix="Confirm the changed paths and load the applicable scoped AGENTS.md before review.",
+                gate_to_run="python3 scripts/orchestration/check_preflight.py",
+                disposition_candidate="NEEDS-HUMAN",
+            )
+        )
+
+    diff = _as_dict(context.get("diff"))
+    summary = _as_dict(diff.get("summary"))
+    changed_lines = int(summary.get("changed_lines") or 0)
+    if changed_lines > LARGE_DIFF_CHANGED_LINES:
+        threshold = (
+            VERY_LARGE_DIFF_CHANGED_LINES
+            if changed_lines > VERY_LARGE_DIFF_CHANGED_LINES
+            else LARGE_DIFF_CHANGED_LINES
+        )
+        findings.append(
+            Finding(
+                severity="note",
+                role_agent="bug-hunter",
+                category="tests",
+                file="docs/roadmap/BACKLOG_LEDGER.md",
+                line=None,
+                evidence=f"Diff contains {changed_lines} changed lines, above review-risk threshold {threshold}.",
+                suggested_fix="Confirm PR split rationale and targeted deterministic gates before opening review.",
+                gate_to_run="make validate-changed",
+                disposition_candidate="NEEDS-HUMAN",
+            )
+        )
+
+    return findings
+
+
+def _build_role_reviews(findings: list[Finding]) -> list[dict[str, str]]:
+    reviews: list[dict[str, str]] = []
+    for role in DEFAULT_ROLE_ORDER:
+        owned = [finding for finding in findings if finding.role_agent == role]
+        if owned:
+            summary = f"{role} flagged {len(owned)} advisory finding(s) for human review."
+        elif role == "data-scientist-agent":
+            summary = (
+                "data-scientist-agent has no scoring calibration changes in this dry-run report."
+            )
+        else:
+            summary = f"{role} has no deterministic findings from the supplied context."
+        reviews.append({"role_agent": role, "summary": summary})
+    return reviews
+
+
+def _build_scope(context: dict[str, Any]) -> dict[str, Any]:
+    diff = _as_dict(context.get("diff"))
+    agents = _as_dict(context.get("agents_discovery"))
+    files = _as_list(diff.get("files"))
+    return {
+        "changed_files": [str(item.get("path", "")) for item in files if isinstance(item, dict)],
+        "diff_summary": diff.get("summary", {}),
+        "scoped_agents_md": agents.get("scoped_agents_md", []),
+        "omitted_surfaces": ["GitHub posting", "PR thread resolution", "merge readiness claims"],
+    }
+
+
+def _build_gate_plan(context: dict[str, Any], findings: list[Finding]) -> list[str]:
+    suggestions = [str(item) for item in _as_list(context.get("test_suggestions"))]
+    base = [
+        "python3 scripts/orchestration/check_preflight.py",
+        "python3 scripts/orchestration/check_agent_consistency.py",
+        "python3 -m pytest tests/test_pr_review_report.py tests/test_pr_review_context.py -q",
+    ]
+    finding_gates = [finding.gate_to_run for finding in findings if finding.gate_to_run]
+    return sorted(set(base + suggestions + finding_gates))
+
+
+def build_report(
+    context: dict[str, Any],
+    *,
+    packet_id: str = "",
+    packet_path: str = "",
+) -> dict[str, Any]:
+    findings = build_findings(context)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": _utc_now(),
+        "mode": "dry-run-report",
+        "coordinator_packet": {
+            "task_packet_id": packet_id,
+            "path": packet_path,
+            "role_order": DEFAULT_ROLE_ORDER,
+        },
+        "scope_reviewed": _build_scope(context),
+        "findings_count": len(findings),
+        "findings": [finding.__dict__ for finding in findings],
+        "role_review": _build_role_reviews(findings),
+        "gate_plan": _build_gate_plan(context, findings),
+        "deferred_followups": [],
+        "decision_log": [
+            "This report is advisory and side-effect free.",
+            "This report does not post GitHub comments, resolve review threads, merge PRs, or claim merge readiness.",
+            "External CodeRabbit, Sourcery, and Cubic statuses remain separate PR governance signals.",
+        ],
+        "warnings": _dedupe_strings(_as_list(context.get("warnings"))),
+    }
+
+
+def _format_value(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# PulsePlate PR Review Dry-Run Report",
+        "",
+        "## Coordinator Packet",
+    ]
+    packet = report["coordinator_packet"]
+    lines.append(f"- Task packet: `{packet.get('task_packet_id') or 'unknown'}`")
+    lines.append(f"- Packet path: `{packet.get('path') or 'unknown'}`")
+    lines.append("- Role order: " + " -> ".join(packet["role_order"]))
+    lines.extend(["", "## Scope Reviewed"])
+    scope = report["scope_reviewed"]
+    summary = scope.get("diff_summary", {})
+    lines.append(
+        "- Diff summary: "
+        f"{summary.get('files', 0)} files, "
+        f"{summary.get('additions', 0)} additions, "
+        f"{summary.get('deletions', 0)} deletions"
+    )
+    changed_files = scope.get("changed_files") or []
+    lines.append("- Changed files:")
+    if changed_files:
+        lines.extend(f"  - `{path}`" for path in changed_files)
+    else:
+        lines.append("  - none discovered")
+    lines.extend(["", "## Findings"])
+    findings = report.get("findings") or []
+    if not findings:
+        lines.append("- No deterministic findings from supplied context.")
+    for finding in findings:
+        location = finding["file"]
+        if finding.get("line"):
+            location = f"{location}:{finding['line']}"
+        lines.extend(
+            [
+                f"- `{finding['severity']}` `{finding['role_agent']}` `{finding['category']}` at `{location}`",
+                f"  - Evidence: {_format_value(finding.get('evidence'))}",
+                f"  - Suggested fix: {_format_value(finding.get('suggested_fix'))}",
+                f"  - Gate: `{_format_value(finding.get('gate_to_run'))}`",
+                f"  - Disposition candidate: `{_format_value(finding.get('disposition_candidate'))}`",
+            ]
+        )
+    lines.extend(["", "## Role Review"])
+    for review in report["role_review"]:
+        lines.append(f"- `{review['role_agent']}`: {review['summary']}")
+    lines.extend(["", "## Gate Plan"])
+    lines.extend(f"- `{gate}`" for gate in report["gate_plan"])
+    lines.extend(["", "## Deferred / Follow-ups"])
+    followups = report.get("deferred_followups") or []
+    if followups:
+        lines.extend(f"- {item}" for item in followups)
+    else:
+        lines.append("- None recorded by this dry-run report.")
+    lines.extend(["", "## Warnings"])
+    warnings = report.get("warnings") or []
+    if warnings:
+        lines.extend(f"- {warning}" for warning in warnings)
+    else:
+        lines.append("- None.")
+    lines.extend(["", "## Decision Log"])
+    lines.extend(f"- {entry}" for entry in report["decision_log"])
+    return "\n".join(lines) + "\n"
+
+
+def _validate_output_path(path: str) -> Path:
+    output_path = Path(path).resolve()
+    try:
+        rel = output_path.relative_to(REPO_ROOT)
+    except ValueError:
+        return output_path
+    if rel.parts and rel.parts[0] == "artifacts":
+        return output_path
+    raise SystemExit("Refusing to write report inside repo outside gitignored artifacts/.")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render a side-effect-free PulsePlate PR review dry-run report."
+    )
+    parser.add_argument(
+        "--context", help="Path to pr_review_context.py JSON output; stdin if omitted"
+    )
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    parser.add_argument("--output", help="Write report to file instead of stdout")
+    parser.add_argument("--packet-id", default="", help="Coordinator task packet id")
+    parser.add_argument("--packet-path", default="", help="Coordinator task packet path")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    context = _load_context(args.context)
+    report = build_report(context, packet_id=args.packet_id, packet_path=args.packet_path)
+    rendered = (
+        json.dumps(report, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+        if args.format == "json"
+        else render_markdown(report)
+    )
+    if args.output:
+        _validate_output_path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/sync_skill_mirror.py
+++ b/scripts/orchestration/sync_skill_mirror.py
@@ -30,9 +30,21 @@ def _clear_existing_path(path: Path) -> None:
         shutil.rmtree(path)
 
 
-def _copy_with_marker(source: Path, destination: Path) -> None:
+def _source_marker_value(source: Path, source_root: Path) -> str:
+    """Return a portable marker path for the copied skill source."""
+
+    if source_root.name == "codex_skills" and source_root.parent.name == "tools":
+        repo_root = source_root.parent.parent
+        return source.relative_to(repo_root).as_posix()
+    return source.relative_to(source_root).as_posix()
+
+
+def _copy_with_marker(source: Path, source_root: Path, destination: Path) -> None:
     shutil.copytree(source, destination)
-    (destination / SOURCE_MARKER).write_text(f"{source}\n", encoding="utf-8")
+    (destination / SOURCE_MARKER).write_text(
+        f"{_source_marker_value(source, source_root)}\n",
+        encoding="utf-8",
+    )
 
 
 def sync_skill_mirror(
@@ -56,7 +68,7 @@ def sync_skill_mirror(
         _clear_existing_path(destination)
 
     mirror_root.mkdir(parents=True, exist_ok=True)
-    _copy_with_marker(source, destination)
+    _copy_with_marker(source, source_root, destination)
 
 
 def _parse_args() -> argparse.Namespace:

--- a/tests/test_pr_review_report.py
+++ b/tests/test_pr_review_report.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from scripts.orchestration import pr_review_report as report_runner
 
 
 def _base_context() -> dict[str, object]:
     return {
         "schema_version": "1.0.0",
+        "generated_at_utc": "2026-04-28T17:00:00Z",
         "query": {
             "repo": "Katsiarynakavaleuskaya/PulsePlate",
             "pr_number": 1539,
@@ -57,6 +60,7 @@ def test_build_report_has_no_findings_for_complete_context() -> None:
     )
 
     assert report["mode"] == "dry-run-report"
+    assert report["generated_at_utc"] == "2026-04-28T17:00:00Z"
     assert report["findings"] == []
     assert report["findings_count"] == 0
     assert report["coordinator_packet"]["task_packet_id"] == "packet-1"
@@ -97,6 +101,9 @@ def test_build_report_flags_large_diff() -> None:
     assert report["findings"][0]["role_agent"] == "bug-hunter"
     assert "905 changed lines" in report["findings"][0]["evidence"]
     assert "make validate-changed" in report["gate_plan"]
+    assert report["gate_plan"].index("python3 scripts/orchestration/check_preflight.py") < report[
+        "gate_plan"
+    ].index("make validate-changed")
 
 
 def test_render_markdown_contains_required_sections() -> None:
@@ -114,7 +121,10 @@ def test_render_markdown_contains_required_sections() -> None:
     assert "agent-coordinator -> architecture-specialist" in markdown
 
 
-def test_main_writes_json_report(tmp_path: Path, monkeypatch) -> None:
+def test_main_writes_json_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     context_path = tmp_path / "context.json"
     output_path = tmp_path / "report.json"
     context_path.write_text(json.dumps(_base_context()), encoding="utf-8")

--- a/tests/test_pr_review_report.py
+++ b/tests/test_pr_review_report.py
@@ -1,0 +1,139 @@
+"""Tests for PulsePlate PR review dry-run report runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.orchestration import pr_review_report as report_runner
+
+
+def _base_context() -> dict[str, object]:
+    return {
+        "schema_version": "1.0.0",
+        "query": {
+            "repo": "Katsiarynakavaleuskaya/PulsePlate",
+            "pr_number": 1539,
+            "base_ref": "base",
+            "head_ref": "head",
+        },
+        "pr": {
+            "number": 1539,
+            "title": "PR2",
+            "state": "open",
+            "url": "https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1539",
+        },
+        "diff": {
+            "summary": {"files": 1, "additions": 4, "deletions": 1, "changed_lines": 5},
+            "files": [
+                {
+                    "path": "scripts/orchestration/pr_review_context.py",
+                    "additions": 4,
+                    "deletions": 1,
+                }
+            ],
+        },
+        "agents_discovery": {
+            "scoped_agents_md": ["AGENTS.md", "scripts/AGENTS.md"],
+            "files_seen": ["scripts/orchestration/pr_review_context.py"],
+        },
+        "fixed_mapping": {
+            "path": "docs/review/PR_1539_FIXED_MAPPING.md",
+            "exists": True,
+            "entries": {},
+            "no_actionable": True,
+            "errors": [],
+        },
+        "test_suggestions": ["python3 scripts/orchestration/check_preflight.py"],
+        "warnings": [],
+    }
+
+
+def test_build_report_has_no_findings_for_complete_context() -> None:
+    report = report_runner.build_report(
+        _base_context(),
+        packet_id="packet-1",
+        packet_path="artifacts/orchestration/task_packets/packet-1.json",
+    )
+
+    assert report["mode"] == "dry-run-report"
+    assert report["findings"] == []
+    assert report["findings_count"] == 0
+    assert report["coordinator_packet"]["task_packet_id"] == "packet-1"
+    assert report["coordinator_packet"]["role_order"] == report_runner.DEFAULT_ROLE_ORDER
+    assert "GitHub posting" in report["scope_reviewed"]["omitted_surfaces"]
+
+
+def test_build_report_flags_missing_metadata_mapping_and_agents() -> None:
+    context = _base_context()
+    context["pr"] = None
+    context["fixed_mapping"] = {"exists": False}
+    context["agents_discovery"] = {"scoped_agents_md": [], "files_seen": []}
+    context["warnings"] = ["Cannot read PR metadata: repository slug unavailable."]
+
+    report = report_runner.build_report(context)
+    findings = report["findings"]
+
+    assert len(findings) == 4
+    assert {finding["role_agent"] for finding in findings} == {
+        "agent-coordinator",
+        "qa-engineer-agent",
+        "architecture-specialist",
+    }
+    assert all(finding["disposition_candidate"] == "NEEDS-HUMAN" for finding in findings)
+
+
+def test_build_report_flags_large_diff() -> None:
+    context = _base_context()
+    context["diff"] = {
+        "summary": {"files": 12, "additions": 901, "deletions": 4, "changed_lines": 905},
+        "files": [
+            {"path": "scripts/orchestration/pr_review_report.py", "additions": 901, "deletions": 4}
+        ],
+    }
+
+    report = report_runner.build_report(context)
+
+    assert report["findings"][0]["role_agent"] == "bug-hunter"
+    assert "905 changed lines" in report["findings"][0]["evidence"]
+    assert "make validate-changed" in report["gate_plan"]
+
+
+def test_render_markdown_contains_required_sections() -> None:
+    report = report_runner.build_report(_base_context(), packet_id="packet-1")
+
+    markdown = report_runner.render_markdown(report)
+
+    assert "# PulsePlate PR Review Dry-Run Report" in markdown
+    assert "## Coordinator Packet" in markdown
+    assert "## Scope Reviewed" in markdown
+    assert "## Findings" in markdown
+    assert "## Deferred / Follow-ups" in markdown
+    assert "## Warnings" in markdown
+    assert "No deterministic findings" in markdown
+    assert "agent-coordinator -> architecture-specialist" in markdown
+
+
+def test_main_writes_json_report(tmp_path: Path, monkeypatch) -> None:
+    context_path = tmp_path / "context.json"
+    output_path = tmp_path / "report.json"
+    context_path.write_text(json.dumps(_base_context()), encoding="utf-8")
+    monkeypatch.setattr(
+        report_runner.sys,
+        "argv",
+        [
+            "pr_review_report.py",
+            "--context",
+            str(context_path),
+            "--format",
+            "json",
+            "--output",
+            str(output_path),
+        ],
+    )
+
+    assert report_runner.main() == 0
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert payload["mode"] == "dry-run-report"
+    assert payload["findings"] == []

--- a/tests/test_pr_review_report.py
+++ b/tests/test_pr_review_report.py
@@ -87,6 +87,17 @@ def test_build_report_flags_missing_metadata_mapping_and_agents() -> None:
     assert all(finding["disposition_candidate"] == "NEEDS-HUMAN" for finding in findings)
 
 
+def test_build_report_flags_malformed_fixed_mapping_context() -> None:
+    context = _base_context()
+    context["fixed_mapping"] = None
+
+    report = report_runner.build_report(context)
+
+    assert report["findings_count"] == 1
+    assert report["findings"][0]["role_agent"] == "qa-engineer-agent"
+    assert report["findings"][0]["file"] == "docs/review/PR_1539_FIXED_MAPPING.md"
+
+
 def test_build_report_flags_large_diff() -> None:
     context = _base_context()
     context["diff"] = {
@@ -147,3 +158,10 @@ def test_main_writes_json_report(
 
     assert payload["mode"] == "dry-run-report"
     assert payload["findings"] == []
+
+
+def test_load_context_reports_unreadable_file(tmp_path: Path) -> None:
+    missing_context = tmp_path / "missing-context.json"
+
+    with pytest.raises(SystemExit, match="Unable to read context JSON"):
+        report_runner._load_context(str(missing_context))

--- a/tests/test_sync_skill_mirror.py
+++ b/tests/test_sync_skill_mirror.py
@@ -36,6 +36,50 @@ def test_sync_skill_mirror_copies_source_and_writes_marker(tmp_path: Path) -> No
     assert marker.read_text(encoding="utf-8").strip() == "tools/codex_skills/pulseplate-pr-review"
 
 
+def test_sync_skill_mirror_writes_source_root_relative_marker_for_custom_root(
+    tmp_path: Path,
+) -> None:
+    source_root = tmp_path / "custom_tools"
+    skill_name = "custom-review-skill"
+    source_skill = source_root / skill_name
+    source_skill.mkdir(parents=True)
+    source_skill.joinpath("SKILL.md").write_text("# custom", encoding="utf-8")
+
+    mirror_root = tmp_path / "custom_mirror"
+
+    sync_skill_mirror.sync_skill_mirror(
+        skill_name=skill_name,
+        source_root=source_root,
+        mirror_root=mirror_root,
+        force=False,
+    )
+
+    marker = mirror_root / skill_name / ".pulseplate_codex_skill_source"
+    assert marker.exists()
+    assert marker.read_text(encoding="utf-8").strip() == skill_name
+
+
+def test_sync_skill_mirror_writes_nested_fallback_marker(tmp_path: Path) -> None:
+    source_root = tmp_path
+    skill_name = "custom_layout/pulseplate-pr-review"
+    source_skill = source_root / skill_name
+    source_skill.mkdir(parents=True)
+    source_skill.joinpath("SKILL.md").write_text("# nested", encoding="utf-8")
+
+    mirror_root = tmp_path / "nested_mirror"
+
+    sync_skill_mirror.sync_skill_mirror(
+        skill_name=skill_name,
+        source_root=source_root,
+        mirror_root=mirror_root,
+        force=False,
+    )
+
+    marker = mirror_root / skill_name / ".pulseplate_codex_skill_source"
+    assert marker.exists()
+    assert marker.read_text(encoding="utf-8").strip() == "custom_layout/pulseplate-pr-review"
+
+
 def test_sync_skill_mirror_rejects_existing_without_force(tmp_path: Path) -> None:
     source_root = tmp_path / "tools" / "codex_skills" / "pulseplate-pr-review"
     source_root.mkdir(parents=True)

--- a/tests/test_sync_skill_mirror.py
+++ b/tests/test_sync_skill_mirror.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+
 import pytest
 
 from scripts.orchestration import sync_skill_mirror
@@ -32,7 +33,7 @@ def test_sync_skill_mirror_copies_source_and_writes_marker(tmp_path: Path) -> No
     assert mirrored_skill.joinpath("SKILL.md").exists()
     marker = mirrored_skill / ".pulseplate_codex_skill_source"
     assert marker.exists()
-    assert marker.read_text(encoding="utf-8").strip() == str(source_skill)
+    assert marker.read_text(encoding="utf-8").strip() == "tools/codex_skills/pulseplate-pr-review"
 
 
 def test_sync_skill_mirror_rejects_existing_without_force(tmp_path: Path) -> None:
@@ -57,7 +58,6 @@ def test_sync_skill_mirror_rejects_existing_without_force(tmp_path: Path) -> Non
 def test_sync_skill_mirror_force_replaces_existing_destination(tmp_path: Path) -> None:
     source_root = tmp_path / "tools" / "codex_skills" / "pulseplate-pr-review"
     source_root.mkdir(parents=True)
-    source_skill = source_root
     source_root.joinpath("SKILL.md").write_text("# source", encoding="utf-8")
 
     mirror_root = tmp_path / "mirror"
@@ -77,4 +77,4 @@ def test_sync_skill_mirror_force_replaces_existing_destination(tmp_path: Path) -
     assert not destination.joinpath("stale.txt").exists()
     assert destination.joinpath("SKILL.md").exists()
     marker = destination / ".pulseplate_codex_skill_source"
-    assert marker.read_text(encoding="utf-8").strip() == str(source_skill)
+    assert marker.read_text(encoding="utf-8").strip() == "tools/codex_skills/pulseplate-pr-review"

--- a/tools/codex_skills/pulseplate-pr-review/SKILL.md
+++ b/tools/codex_skills/pulseplate-pr-review/SKILL.md
@@ -64,7 +64,15 @@ Use this default order unless the active packet declares a narrower compatible s
    rg -n "CodeRabbit|Sourcery|Cubic|Disposition:|FIXED|NOT-A-BUG|DEFERRED" docs/review docs/orchestration
    ```
 
-3. Classify findings with the required schema:
+3. For deterministic dry-run mode, collect context and render the report:
+
+   ```bash
+   python3 scripts/orchestration/pr_review_context.py --pr <PR_NUMBER> --output /tmp/pulseplate_pr_review_context.json
+   python3 scripts/orchestration/pr_review_report.py --context /tmp/pulseplate_pr_review_context.json --format markdown
+   python3 scripts/orchestration/pr_review_report.py --context /tmp/pulseplate_pr_review_context.json --format json
+   ```
+
+4. Classify findings with the required schema:
    - `severity`: `critical`, `major`, `minor`, or `note`
    - `role_agent`: owning reviewer agent
    - `category`: correctness, security, architecture, tests, docs, wellness, release, or governance
@@ -74,7 +82,7 @@ Use this default order unless the active packet declares a narrower compatible s
    - `gate_to_run`: exact command that proves the fix
    - `disposition_candidate`: `FIXED`, `NOT-A-BUG`, `DEFERRED`, or `NEEDS-HUMAN`
 
-4. Keep plugin evidence optional:
+5. Keep plugin evidence optional:
    - GitHub: PR metadata, checks, reviews, and future dry-run-to-comment path.
    - CodeRabbit: reference workflow only; do not depend on available review quota.
    - Hugging Face: optional model/paper scouting for code review and vulnerability-detection methods.
@@ -109,3 +117,5 @@ Use this default order unless the active packet declares a narrower compatible s
 - `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`
 - `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md`
 - `docs/roadmap/BACKLOG_LEDGER.md`
+- `scripts/orchestration/pr_review_context.py`
+- `scripts/orchestration/pr_review_report.py`


### PR DESCRIPTION
## Summary

- Add PR3 `pulseplate-pr-review` dry-run report runner.
- Consume read-only `pr_review_context.py` JSON and emit deterministic Markdown/JSON reports.
- Keep GitHub posting, review-thread resolution, auto-merge, and merge-readiness claims out of scope.
- Close PR2 collector ledger truth for merged PR #1539 and fix the stale repo mirror path in the PR2 packet.

## Coordinator / Role Agents

Coordinator packet: `artifacts/orchestration/task_packets/12568c4a9aea.json` (local, gitignored)

Role order:

1. `agent-coordinator`
2. `architecture-specialist`
3. `security-auditor`
4. `qa-engineer-agent`
5. `bug-hunter`
6. `data-scientist-agent`

Required / used skills:

- `pulseplate-workflow`
- `pulseplate-gates`
- `pulseplate-guards`
- `pulseplate-ledger`
- `pulseplate-graphmap` consulted; no graph artifact change needed
- `pulseplate-pr-review`

Plugin roles are advisory/documented only for this PR: GitHub/CodeRabbit for review governance, Hugging Face and Life Science Research for future research evidence, Browser Use / Computer Use / Expo only when relevant surfaces exist.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

Canonical artifact: `docs/review/PR_1558_FIXED_MAPPING.md`

Disposition: FIXED
Commit: 467d4556f
Evidence: tests/test_sync_skill_mirror.py covers both canonical and fallback marker path layouts for sync_skill_mirror.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#discussion_r3156053099 -> 467d4556f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#pullrequestreview-4191079725 -> 467d4556f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#pullrequestreview-4191098638 -> 467d4556f

Disposition: FIXED
Commit: 467d4556f
Evidence: scripts/orchestration/pr_review_report.py preserves gate order while deduping and uses stable context-provided generated_at_utc report metadata.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#discussion_r3156064227 -> 467d4556f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#pullrequestreview-4191093231 -> 467d4556f

Disposition: FIXED
Commit: 467d4556f
Evidence: tests/test_pr_review_report.py annotates the monkeypatch fixture as pytest.MonkeyPatch.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#discussion_r3156068684 -> 467d4556f

Disposition: NOT-A-BUG
Evidence: scripts/orchestration/pr_review_report.py keeps LARGE_DIFF_CHANGED_LINES and VERY_LARGE_DIFF_CHANGED_LINES as repo-native constants for deterministic PR governance, not cross-repo runtime configuration.
Reason: This runner is PulsePlate-specific and the thresholds are part of the local advisory review policy for PR3; no runtime or multi-repo tuning surface is required in this slice.

Disposition: FIXED
Commit: 0d5e653a2
Evidence: scripts/orchestration/pr_review_report.py now reports unreadable context JSON with a clean SystemExit and treats missing or malformed fixed_mapping context as a qa-engineer-agent governance finding; tests/test_pr_review_report.py covers both paths.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#discussion_r3156149301 -> 0d5e653a2
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#discussion_r3156149314 -> 0d5e653a2
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1558#pullrequestreview-4191196512 -> 0d5e653a2

## Risk & Impact

- Runner is side-effect free by default and writes only to stdout unless `--output` is explicitly used.
- `--output` refuses writes inside the repo outside gitignored `artifacts/`.
- Runner has no GitHub posting, review resolution, or merge automation code path.
- Report output is advisory evidence only and does not replace fixed-mapping governance, CodeRabbit/Sourcery/Cubic signals, `make verify`, or `check_merge_ready.py`.

## Test Plan

Local gates run:

- `python3 scripts/orchestration/check_preflight.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `python3 scripts/orchestration/sync_skill_mirror.py --name pulseplate-pr-review --force` PASS
- `python3 -m pytest tests/test_pr_review_context.py tests/test_pr_review_report.py tests/test_sync_skill_mirror.py tests/test_install_codex_skills.py -q` PASS (`30 passed`)
- `python3 -m pytest tests/test_pr_review_report.py tests/test_sync_skill_mirror.py -q` PASS (`12 passed`)
- `.venv/bin/mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/pr_review_report.py scripts/orchestration/sync_skill_mirror.py` PASS
- `pre-commit run --all-files` PASS
- `make validate-min` PASS
- `make validate-changed` PASS
- pre-push hooks PASS: mypy, pip-audit, backend pytest, full-repo bandit, docker build test

Full local `make verify` not run for this tooling/orchestration PR; GitHub current-head CI is expected to provide the heavy signal before merge readiness.

## Deferred / Follow-ups

- GitHub review comment posting remains out of scope until false-positive calibration is trusted.
- PR thread resolution remains governed by fixed-mapping and merge-readiness checks.
- Any scoring/eval rubric stays advisory for a future `data-scientist-agent` slice.

## Merge Readiness

- [ ] CI green on current head
- [ ] No unresolved actionable review threads
- [ ] CodeRabbit/Sourcery/Cubic statuses reviewed and mapped
- [ ] Fixed-mapping artifact and PR body mirror aligned
- [ ] `check_merge_ready.py --require-auth` PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deterministic PR review dry-run report generation with stable Markdown and JSON outputs.

* **Documentation**
  * Added dry-run runner docs and workflow step; added new documentation packets and backlog/PR review records.
  * Updated skill path references to use relative paths; added new scripts to canonical links.
  * Expanded optional evidence sources (Browser Use / Computer Use, Figma, Sentry/Jam, Life Science Research).

* **Tests**
  * Added tests for the dry-run report runner and marker/path behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->