### PR TITLE
feat(pr-review): calibrate dry-run rubric

### DIFF
--- a/.agents/skills/pulseplate-pr-review/SKILL.md
+++ b/.agents/skills/pulseplate-pr-review/SKILL.md
@@ -72,7 +72,19 @@ Use this default order unless the active packet declares a narrower compatible s
    python3 scripts/orchestration/pr_review_report.py --context /tmp/pulseplate_pr_review_context.json --format json
    ```
 
-4. Classify findings with the required schema:
+4. For calibration mode, confirm the report includes calibration metadata before
+   any future dry-run-to-comment path:
+
+   ```bash
+   python3 -m pytest tests/test_pr_review_report.py -q
+   python3 scripts/orchestration/pr_review_report.py --context /tmp/pulseplate_pr_review_context.json --format json
+   ```
+
+   Calibration must prove clean context, governance findings, warning-bearing
+   context, benign fixed-mapping patterns, and large diff risk stay distinct.
+   Calibration never makes GitHub posting eligible by itself.
+
+5. Classify findings with the required schema:
    - `severity`: `critical`, `major`, `minor`, or `note`
    - `role_agent`: owning reviewer agent
    - `category`: correctness, security, architecture, tests, docs, wellness, release, or governance
@@ -82,7 +94,7 @@ Use this default order unless the active packet declares a narrower compatible s
    - `gate_to_run`: exact command that proves the fix
    - `disposition_candidate`: `FIXED`, `NOT-A-BUG`, `DEFERRED`, or `NEEDS-HUMAN`
 
-5. Keep plugin evidence optional:
+6. Keep plugin evidence optional:
    - GitHub: PR metadata, checks, reviews, and future dry-run-to-comment path.
    - CodeRabbit: reference workflow only; do not depend on available review quota.
    - Hugging Face: optional model/paper scouting for code review and vulnerability-detection methods.

--- a/docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR4_CALIBRATION_PACKET_2026-04-28.md
+++ b/docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR4_CALIBRATION_PACKET_2026-04-28.md
@@ -1,0 +1,75 @@
+# PulsePlate PR Review Skill PR4 Calibration Packet
+
+## Purpose
+
+Calibrate the `pulseplate-pr-review` dry-run report runner before any future
+GitHub posting path. PR4 adds a deterministic false-positive rubric and fixture
+coverage while keeping the runner advisory and side-effect free.
+
+## Scope
+
+### IN
+
+- Close the merged PR3 ledger item for PR #1558.
+- Add PR4 calibration metadata to `scripts/orchestration/pr_review_report.py`.
+- Add deterministic tests for clean context, governance findings,
+  warning-bearing context, benign fixed-mapping patterns, and large diff risk.
+- Update the skill documentation and discovery mirror.
+
+### OUT
+
+- GitHub review comment posting.
+- PR thread resolution.
+- Auto-merge or merge-readiness claims.
+- Runtime dependency on Browser Use, Computer Use, Expo, Hugging Face, Life
+  Science Research, CodeRabbit, Sourcery, or Cubic.
+- LLM scoring, model calls, or automatic disposition decisions.
+
+## Role Order
+
+1. `agent-coordinator`
+2. `architecture-specialist`
+3. `security-auditor`
+4. `qa-engineer-agent`
+5. `bug-hunter`
+6. `data-scientist-agent`
+
+## Required Skills
+
+- `pulseplate-workflow`
+- `pulseplate-gates`
+- `pulseplate-guards`
+- `pulseplate-ledger`
+- `pulseplate-pr-review`
+- `bug-triage`
+- `agents-md`
+- `code-review-expert`
+
+## Calibration Contract
+
+- Clean context with PR metadata, fixed mapping, scoped `AGENTS.md`, no warnings,
+  and a small diff must produce zero findings.
+- Missing or malformed fixed mapping remains a governance finding owned by
+  `qa-engineer-agent`.
+- Context warnings remain `NEEDS-HUMAN` advisory findings and are not eligible
+  for automatic posting.
+- Large diff risk remains a review-planning signal owned by `bug-hunter`, not a
+  merge-readiness claim.
+- `NOT-A-BUG` fixed-mapping patterns must not create findings when the rest of
+  the context is complete.
+
+## Validation Plan
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `python3 scripts/orchestration/sync_skill_mirror.py --name pulseplate-pr-review --force`
+- `python3 -m pytest tests/test_pr_review_context.py tests/test_pr_review_report.py tests/test_install_codex_skills.py -q`
+- `pre-commit run --all-files`
+- `make validate-min`
+- `make validate-changed`
+
+## Decision Log
+
+- PR4 calibrates report quality before any future dry-run-to-comment path.
+- The calibration metadata is advisory; it does not make posting eligible.
+- External reviewer tools remain governance signals, not runtime dependencies.

--- a/docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR4_CALIBRATION_PACKET_2026-04-28.md
+++ b/docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR4_CALIBRATION_PACKET_2026-04-28.md
@@ -4,7 +4,7 @@
 
 Calibrate the `pulseplate-pr-review` dry-run report runner before any future
 GitHub posting path. PR4 adds a deterministic false-positive rubric and fixture
-coverage while keeping the runner advisory and side-effect free.
+coverage while keeping the runner advisory and side-effect-free.
 
 ## Scope
 

--- a/docs/review/PR_1560_FIXED_MAPPING.md
+++ b/docs/review/PR_1560_FIXED_MAPPING.md
@@ -16,7 +16,7 @@ mapping artifact.
 
 Disposition: FIXED
 Commit: 3f433db91
-Evidence: docs/review/PR_1560_FIXED_MAPPING.md uses the required checked discussion-pass markers enforced by review_mapping_artifact.py and records the phase2 artifact status.
+Evidence: docs/review/PR_1560_FIXED_MAPPING.md uses the required discussion-pass markers set to checked, as enforced by review_mapping_artifact.py, and records the phase2 artifact status.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#discussion_r3156449223 -> 3f433db91
 
 Disposition: FIXED

--- a/docs/review/PR_1560_FIXED_MAPPING.md
+++ b/docs/review/PR_1560_FIXED_MAPPING.md
@@ -31,6 +31,12 @@ Evidence: docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR4_CALIBRATION_PACKET_2
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#discussion_r3156449219 -> 13615e272
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#pullrequestreview-4191546077 -> 13615e272
 
+Disposition: FIXED
+Commit: 7a85e0ebd
+Evidence: docs/review/PR_1560_FIXED_MAPPING.md now uses clearer wording for the checked discussion-pass marker evidence sentence.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#discussion_r3156497476 -> 7a85e0ebd
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#pullrequestreview-4191601594 -> 7a85e0ebd
+
 ## Initial Evidence
 
 - `python3 scripts/orchestration/check_preflight.py` (PASS)

--- a/docs/review/PR_1560_FIXED_MAPPING.md
+++ b/docs/review/PR_1560_FIXED_MAPPING.md
@@ -11,7 +11,22 @@ Date: 2026-04-28
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 08b465a93
+Evidence: docs/review/PR_1560_FIXED_MAPPING.md uses the required checked discussion-pass markers enforced by review_mapping_artifact.py.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#discussion_r3156449223 -> 08b465a93
+
+Disposition: FIXED
+Commit: 13615e272
+Evidence: tests/test_pr_review_report.py now asserts the rendered calibration case label, posting gate, and false-positive controls; scripts/orchestration/pr_review_report.py uses a specific large-diff signal and top-level FALSE_POSITIVE_CONTROLS.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#discussion_r3156440269 -> 13615e272
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#pullrequestreview-4191535825 -> 13615e272
+
+Disposition: FIXED
+Commit: 13615e272
+Evidence: docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR4_CALIBRATION_PACKET_2026-04-28.md hyphenates side-effect-free; scripts/orchestration/pr_review_report.py renders false-positive controls in Markdown.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#discussion_r3156449219 -> 13615e272
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#pullrequestreview-4191546077 -> 13615e272
 
 ## Initial Evidence
 

--- a/docs/review/PR_1560_FIXED_MAPPING.md
+++ b/docs/review/PR_1560_FIXED_MAPPING.md
@@ -9,6 +9,9 @@ Date: 2026-04-28
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
+Artifact status: phase2 discussion-pass markers are checked in this PR-open
+mapping artifact.
+
 ## Fixed in Commit Mapping
 
 Disposition: FIXED

--- a/docs/review/PR_1560_FIXED_MAPPING.md
+++ b/docs/review/PR_1560_FIXED_MAPPING.md
@@ -1,0 +1,36 @@
+# PR #1560 Fixed Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560>
+Branch: `codex/pulseplate-pr-review-calibration-pr4`
+Date: 2026-04-28
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+No review comments mapped yet. This artifact is created at PR-open time so
+review dispositions have a canonical home before any thread is resolved.
+
+## Initial Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` (PASS)
+- `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
+- `python3 scripts/orchestration/sync_skill_mirror.py --name pulseplate-pr-review --force` (PASS)
+- `python3 -m pytest tests/test_pr_review_report.py -q` (PASS, 8 passed)
+- `python3 -m pytest tests/test_pr_review_context.py tests/test_pr_review_report.py tests/test_install_codex_skills.py -q` (PASS, 26 passed)
+- `.venv/bin/mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/pr_review_report.py` (PASS)
+- `pre-commit run --all-files` (PASS after Black formatting, rerun PASS)
+- `make validate-min` (PASS)
+- `make validate-changed` (PASS)
+- pre-push hooks: mypy, pip-audit, backend pytest, full-repo bandit, docker build test (PASS)
+
+## Merge Readiness
+
+- [ ] CI green on current head
+- [ ] No unresolved actionable review threads
+- [ ] CodeRabbit/Sourcery/Cubic statuses reviewed and mapped
+- [ ] Fixed-mapping artifact and PR body mirror aligned
+- [ ] `check_merge_ready.py --require-auth` PASS

--- a/docs/review/PR_1560_FIXED_MAPPING.md
+++ b/docs/review/PR_1560_FIXED_MAPPING.md
@@ -15,9 +15,9 @@ mapping artifact.
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
-Commit: 08b465a93
-Evidence: docs/review/PR_1560_FIXED_MAPPING.md uses the required checked discussion-pass markers enforced by review_mapping_artifact.py.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#discussion_r3156449223 -> 08b465a93
+Commit: 3f433db91
+Evidence: docs/review/PR_1560_FIXED_MAPPING.md uses the required checked discussion-pass markers enforced by review_mapping_artifact.py and records the phase2 artifact status.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#discussion_r3156449223 -> 3f433db91
 
 Disposition: FIXED
 Commit: 13615e272

--- a/docs/review/PR_1560_FIXED_MAPPING.md
+++ b/docs/review/PR_1560_FIXED_MAPPING.md
@@ -6,13 +6,12 @@ Date: 2026-04-28
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-No review comments mapped yet. This artifact is created at PR-open time so
-review dispositions have a canonical home before any thread is resolved.
+- No actionable review comments
 
 ## Initial Evidence
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4037,11 +4037,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - the collector remains advisory and does not post GitHub comments, resolve threads, or claim merge readiness
 
 <a id="ledger-p2-pulseplate-pr-review-dry-run-report-runner"></a>
-- [ ] P2: Add dry-run report runner for PulsePlate PR review skill
+- [x] P2: Add dry-run report runner for PulsePlate PR review skill
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2 (review automation follow-up)
   - Target PR: PR #1558 (`docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR3_DRY_RUN_REPORT_PACKET_2026-04-28.md`, docs/review/PR_1558_FIXED_MAPPING.md)
-  - Status: In progress in PR3 dry-run report runner lane
+  - Status: Completed in merged PR #1558; closeout recorded in PR4 calibration lane
   - Area: orchestration / PR review / Codex skills
   - Reason: PR2 provides read-only review context JSON, but reviewers still need a deterministic Markdown/JSON dry-run report that follows the `pulseplate-pr-review` role order and finding schema without posting comments or resolving threads.
   - Links:
@@ -4052,6 +4052,25 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `scripts/orchestration/pr_review_report.py` consumes context JSON from file or stdin
     - report output supports stable Markdown and JSON formats
     - findings follow the `pulseplate-pr-review` schema and coordinator role order
+    - runner remains advisory and does not post GitHub comments, resolve review threads, or claim merge readiness
+
+<a id="ledger-p2-pulseplate-pr-review-calibration-rubric"></a>
+- [ ] P2: Calibrate PulsePlate PR review dry-run false-positive rubric
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2 (review automation follow-up)
+  - Target PR: PR-TBD (`docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR4_CALIBRATION_PACKET_2026-04-28.md`)
+  - Status: In progress in PR4 calibration lane
+  - Area: orchestration / PR review / Codex skills
+  - Reason: PR3 added a side-effect-free dry-run report runner, but any future dry-run-to-comment path needs deterministic calibration first so benign context and `NOT-A-BUG` reviewer patterns do not become noisy actionable comments.
+  - Links:
+    - `scripts/orchestration/pr_review_report.py`
+    - `tests/test_pr_review_report.py`
+    - `tools/codex_skills/pulseplate-pr-review/SKILL.md`
+    - `docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR4_CALIBRATION_PACKET_2026-04-28.md`
+  - DoD:
+    - report output includes explicit calibration metadata that never claims posting eligibility
+    - tests cover clean context, governance findings, warning-bearing context, benign fixed-mapping patterns, and large diff risk
+    - skill docs state calibration is required before any future GitHub posting path
     - runner remains advisory and does not post GitHub comments, resolve review threads, or claim merge readiness
 
 <a id="ledger-p2-rag-release-gates-runtime-warnings-dedup"></a>

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4058,7 +4058,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: Calibrate PulsePlate PR review dry-run false-positive rubric
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2 (review automation follow-up)
-  - Target PR: PR-TBD (`docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR4_CALIBRATION_PACKET_2026-04-28.md`)
+  - Target PR: PR #1560 (`docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR4_CALIBRATION_PACKET_2026-04-28.md`, docs/review/PR_1560_FIXED_MAPPING.md)
   - Status: In progress in PR4 calibration lane
   - Area: orchestration / PR review / Codex skills
   - Reason: PR3 added a side-effect-free dry-run report runner, but any future dry-run-to-comment path needs deterministic calibration first so benign context and `NOT-A-BUG` reviewer patterns do not become noisy actionable comments.

--- a/scripts/orchestration/pr_review_report.py
+++ b/scripts/orchestration/pr_review_report.py
@@ -23,6 +23,7 @@ DEFAULT_ROLE_ORDER = [
 
 LARGE_DIFF_CHANGED_LINES = 300
 VERY_LARGE_DIFF_CHANGED_LINES = 800
+CALIBRATION_RUBRIC_VERSION = "pr4-2026-04-28"
 
 
 @dataclass(frozen=True)
@@ -226,6 +227,36 @@ def _build_gate_plan(context: dict[str, Any], findings: list[Finding]) -> list[s
     return _ordered_unique(base + suggestions + finding_gates)
 
 
+def _build_calibration(context: dict[str, Any], findings: list[Finding]) -> dict[str, Any]:
+    warnings = _dedupe_strings(_as_list(context.get("warnings")))
+    categories = {finding.category for finding in findings}
+    role_agents = {finding.role_agent for finding in findings}
+    case_labels: list[str] = []
+    false_positive_controls: list[str] = [
+        "clean context must produce zero findings",
+        "benign fixed-mapping presence must not become a governance finding",
+        "warnings are advisory NEEDS-HUMAN findings, not auto-postable comments",
+        "large diff risk is review-planning evidence, not a merge-readiness claim",
+    ]
+
+    if not findings:
+        case_labels.append("clean-context")
+    if warnings:
+        case_labels.append("warning-bearing-context")
+    if "governance" in categories:
+        case_labels.append("governance-finding")
+    if "bug-hunter" in role_agents:
+        case_labels.append("large-diff-risk")
+
+    return {
+        "rubric_version": CALIBRATION_RUBRIC_VERSION,
+        "case_labels": case_labels,
+        "false_positive_controls": false_positive_controls,
+        "posting_eligible": False,
+        "posting_gate": "GitHub posting remains out of scope until a dedicated calibrated posting PR.",
+    }
+
+
 def build_report(
     context: dict[str, Any],
     *,
@@ -245,6 +276,7 @@ def build_report(
         "scope_reviewed": _build_scope(context),
         "findings_count": len(findings),
         "findings": [asdict(finding) for finding in findings],
+        "calibration": _build_calibration(context, findings),
         "role_review": _build_role_reviews(findings),
         "gate_plan": _build_gate_plan(context, findings),
         "deferred_followups": [],
@@ -305,6 +337,16 @@ def render_markdown(report: dict[str, Any]) -> str:
                 f"  - Disposition candidate: `{_format_value(finding.get('disposition_candidate'))}`",
             ]
         )
+    lines.extend(["", "## Calibration"])
+    calibration = report["calibration"]
+    lines.append(f"- Rubric version: `{calibration['rubric_version']}`")
+    labels = calibration.get("case_labels") or []
+    if labels:
+        lines.append("- Case labels: " + ", ".join(f"`{label}`" for label in labels))
+    else:
+        lines.append("- Case labels: none")
+    lines.append(f"- GitHub posting eligible: `{str(calibration['posting_eligible']).lower()}`")
+    lines.append(f"- Posting gate: {calibration['posting_gate']}")
     lines.extend(["", "## Role Review"])
     for review in report["role_review"]:
         lines.append(f"- `{review['role_agent']}`: {review['summary']}")

--- a/scripts/orchestration/pr_review_report.py
+++ b/scripts/orchestration/pr_review_report.py
@@ -24,6 +24,12 @@ DEFAULT_ROLE_ORDER = [
 LARGE_DIFF_CHANGED_LINES = 300
 VERY_LARGE_DIFF_CHANGED_LINES = 800
 CALIBRATION_RUBRIC_VERSION = "pr4-2026-04-28"
+FALSE_POSITIVE_CONTROLS = (
+    "clean context must produce zero findings",
+    "benign fixed-mapping presence must not become a governance finding",
+    "warnings are advisory NEEDS-HUMAN findings, not auto-postable comments",
+    "large diff risk is review-planning evidence, not a merge-readiness claim",
+)
 
 
 @dataclass(frozen=True)
@@ -230,14 +236,14 @@ def _build_gate_plan(context: dict[str, Any], findings: list[Finding]) -> list[s
 def _build_calibration(context: dict[str, Any], findings: list[Finding]) -> dict[str, Any]:
     warnings = _dedupe_strings(_as_list(context.get("warnings")))
     categories = {finding.category for finding in findings}
-    role_agents = {finding.role_agent for finding in findings}
     case_labels: list[str] = []
-    false_positive_controls: list[str] = [
-        "clean context must produce zero findings",
-        "benign fixed-mapping presence must not become a governance finding",
-        "warnings are advisory NEEDS-HUMAN findings, not auto-postable comments",
-        "large diff risk is review-planning evidence, not a merge-readiness claim",
-    ]
+    has_large_diff_risk = any(
+        finding.category == "tests"
+        and finding.role_agent == "bug-hunter"
+        and finding.gate_to_run == "make validate-changed"
+        and "changed lines" in finding.evidence
+        for finding in findings
+    )
 
     if not findings:
         case_labels.append("clean-context")
@@ -245,13 +251,13 @@ def _build_calibration(context: dict[str, Any], findings: list[Finding]) -> dict
         case_labels.append("warning-bearing-context")
     if "governance" in categories:
         case_labels.append("governance-finding")
-    if "bug-hunter" in role_agents:
+    if has_large_diff_risk:
         case_labels.append("large-diff-risk")
 
     return {
         "rubric_version": CALIBRATION_RUBRIC_VERSION,
         "case_labels": case_labels,
-        "false_positive_controls": false_positive_controls,
+        "false_positive_controls": list(FALSE_POSITIVE_CONTROLS),
         "posting_eligible": False,
         "posting_gate": "GitHub posting remains out of scope until a dedicated calibrated posting PR.",
     }
@@ -347,6 +353,12 @@ def render_markdown(report: dict[str, Any]) -> str:
         lines.append("- Case labels: none")
     lines.append(f"- GitHub posting eligible: `{str(calibration['posting_eligible']).lower()}`")
     lines.append(f"- Posting gate: {calibration['posting_gate']}")
+    controls = calibration.get("false_positive_controls") or []
+    lines.append("- False-positive controls:")
+    if controls:
+        lines.extend(f"  - {control}" for control in controls)
+    else:
+        lines.append("  - none")
     lines.extend(["", "## Role Review"])
     for review in report["role_review"]:
         lines.append(f"- `{review['role_agent']}`: {review['summary']}")

--- a/tests/test_pr_review_report.py
+++ b/tests/test_pr_review_report.py
@@ -152,7 +152,14 @@ def test_build_report_flags_large_diff() -> None:
 
 
 def test_render_markdown_contains_required_sections() -> None:
-    report = report_runner.build_report(_base_context(), packet_id="packet-1")
+    context = _base_context()
+    context["diff"] = {
+        "summary": {"files": 12, "additions": 901, "deletions": 4, "changed_lines": 905},
+        "files": [
+            {"path": "scripts/orchestration/pr_review_report.py", "additions": 901, "deletions": 4}
+        ],
+    }
+    report = report_runner.build_report(context, packet_id="packet-1")
 
     markdown = report_runner.render_markdown(report)
 
@@ -163,8 +170,11 @@ def test_render_markdown_contains_required_sections() -> None:
     assert "## Calibration" in markdown
     assert "## Deferred / Follow-ups" in markdown
     assert "## Warnings" in markdown
-    assert "No deterministic findings" in markdown
+    assert "Case labels: `large-diff-risk`" in markdown
     assert "GitHub posting eligible: `false`" in markdown
+    assert "Posting gate: GitHub posting remains out of scope" in markdown
+    assert "False-positive controls:" in markdown
+    assert "clean context must produce zero findings" in markdown
     assert "agent-coordinator -> architecture-specialist" in markdown
 
 

--- a/tests/test_pr_review_report.py
+++ b/tests/test_pr_review_report.py
@@ -63,6 +63,9 @@ def test_build_report_has_no_findings_for_complete_context() -> None:
     assert report["generated_at_utc"] == "2026-04-28T17:00:00Z"
     assert report["findings"] == []
     assert report["findings_count"] == 0
+    assert report["calibration"]["rubric_version"] == "pr4-2026-04-28"
+    assert report["calibration"]["case_labels"] == ["clean-context"]
+    assert report["calibration"]["posting_eligible"] is False
     assert report["coordinator_packet"]["task_packet_id"] == "packet-1"
     assert report["coordinator_packet"]["role_order"] == report_runner.DEFAULT_ROLE_ORDER
     assert "GitHub posting" in report["scope_reviewed"]["omitted_surfaces"]
@@ -85,6 +88,35 @@ def test_build_report_flags_missing_metadata_mapping_and_agents() -> None:
         "architecture-specialist",
     }
     assert all(finding["disposition_candidate"] == "NEEDS-HUMAN" for finding in findings)
+    assert report["calibration"]["case_labels"] == [
+        "warning-bearing-context",
+        "governance-finding",
+    ]
+
+
+def test_build_report_keeps_false_positive_controls_for_benign_context() -> None:
+    context = _base_context()
+    context["fixed_mapping"] = {
+        "path": "docs/review/PR_1539_FIXED_MAPPING.md",
+        "exists": True,
+        "entries": {
+            "https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1539#discussion": {
+                "disposition": "NOT-A-BUG",
+                "evidence": "docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR2_CONTEXT_COLLECTOR_PACKET_2026-04-26.md",
+            }
+        },
+        "no_actionable": True,
+        "errors": [],
+    }
+
+    report = report_runner.build_report(context)
+
+    assert report["findings"] == []
+    assert report["calibration"]["case_labels"] == ["clean-context"]
+    assert (
+        "benign fixed-mapping presence must not become a governance finding"
+        in report["calibration"]["false_positive_controls"]
+    )
 
 
 def test_build_report_flags_malformed_fixed_mapping_context() -> None:
@@ -96,6 +128,7 @@ def test_build_report_flags_malformed_fixed_mapping_context() -> None:
     assert report["findings_count"] == 1
     assert report["findings"][0]["role_agent"] == "qa-engineer-agent"
     assert report["findings"][0]["file"] == "docs/review/PR_1539_FIXED_MAPPING.md"
+    assert report["calibration"]["case_labels"] == ["governance-finding"]
 
 
 def test_build_report_flags_large_diff() -> None:
@@ -112,6 +145,7 @@ def test_build_report_flags_large_diff() -> None:
     assert report["findings"][0]["role_agent"] == "bug-hunter"
     assert "905 changed lines" in report["findings"][0]["evidence"]
     assert "make validate-changed" in report["gate_plan"]
+    assert report["calibration"]["case_labels"] == ["large-diff-risk"]
     assert report["gate_plan"].index("python3 scripts/orchestration/check_preflight.py") < report[
         "gate_plan"
     ].index("make validate-changed")
@@ -126,9 +160,11 @@ def test_render_markdown_contains_required_sections() -> None:
     assert "## Coordinator Packet" in markdown
     assert "## Scope Reviewed" in markdown
     assert "## Findings" in markdown
+    assert "## Calibration" in markdown
     assert "## Deferred / Follow-ups" in markdown
     assert "## Warnings" in markdown
     assert "No deterministic findings" in markdown
+    assert "GitHub posting eligible: `false`" in markdown
     assert "agent-coordinator -> architecture-specialist" in markdown
 
 

--- a/tools/codex_skills/pulseplate-pr-review/SKILL.md
+++ b/tools/codex_skills/pulseplate-pr-review/SKILL.md
@@ -72,7 +72,19 @@ Use this default order unless the active packet declares a narrower compatible s
    python3 scripts/orchestration/pr_review_report.py --context /tmp/pulseplate_pr_review_context.json --format json
    ```
 
-4. Classify findings with the required schema:
+4. For calibration mode, confirm the report includes calibration metadata before
+   any future dry-run-to-comment path:
+
+   ```bash
+   python3 -m pytest tests/test_pr_review_report.py -q
+   python3 scripts/orchestration/pr_review_report.py --context /tmp/pulseplate_pr_review_context.json --format json
+   ```
+
+   Calibration must prove clean context, governance findings, warning-bearing
+   context, benign fixed-mapping patterns, and large diff risk stay distinct.
+   Calibration never makes GitHub posting eligible by itself.
+
+5. Classify findings with the required schema:
    - `severity`: `critical`, `major`, `minor`, or `note`
    - `role_agent`: owning reviewer agent
    - `category`: correctness, security, architecture, tests, docs, wellness, release, or governance
@@ -82,7 +94,7 @@ Use this default order unless the active packet declares a narrower compatible s
    - `gate_to_run`: exact command that proves the fix
    - `disposition_candidate`: `FIXED`, `NOT-A-BUG`, `DEFERRED`, or `NEEDS-HUMAN`
 
-5. Keep plugin evidence optional:
+6. Keep plugin evidence optional:
    - GitHub: PR metadata, checks, reviews, and future dry-run-to-comment path.
    - CodeRabbit: reference workflow only; do not depend on available review quota.
    - Hugging Face: optional model/paper scouting for code review and vulnerability-detection methods.


### PR DESCRIPTION
## Summary

- Add PR4 calibration metadata for `pulseplate-pr-review` dry-run reports.
- Add deterministic false-positive controls for clean context, benign `NOT-A-BUG` fixed-mapping patterns, warning-bearing context, governance gaps, and large diff risk.
- Close the merged PR3 ledger item for PR #1558 and add the PR4 calibration ledger lane.
- Keep GitHub posting, review-thread resolution, auto-merge, and merge-readiness claims out of scope.

## Coordinator / Role Agents

Coordinator packet: `artifacts/orchestration/task_packets/648d725e2c64.json` (local, gitignored)
Post-open packet: `artifacts/orchestration/task_packets/a1ca3f28dc66.json` (local, gitignored)

Role order:

1. `agent-coordinator`
2. `architecture-specialist`
3. `security-auditor`
4. `qa-engineer-agent`
5. `bug-hunter`
6. `data-scientist-agent`

Required skills used:

- `pulseplate-workflow`
- `pulseplate-gates`
- `pulseplate-guards`
- `pulseplate-ledger`
- `pulseplate-pr-review`
- `bug-triage`
- `agents-md`
- `code-review-expert`

Plugin roles are advisory/documented only for this PR: GitHub/CodeRabbit for review governance, Hugging Face and Life Science Research for optional future research evidence, Browser Use / Computer Use / Expo only when relevant surfaces exist.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

Canonical artifact: `docs/review/PR_1560_FIXED_MAPPING.md`

Disposition: FIXED
Commit: 3f433db91
Evidence: docs/review/PR_1560_FIXED_MAPPING.md uses the required discussion-pass markers set to checked, as enforced by review_mapping_artifact.py, and records the phase2 artifact status.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#discussion_r3156449223 -> 3f433db91

Disposition: FIXED
Commit: 13615e272
Evidence: tests/test_pr_review_report.py now asserts the rendered calibration case label, posting gate, and false-positive controls; scripts/orchestration/pr_review_report.py uses a specific large-diff signal and top-level FALSE_POSITIVE_CONTROLS.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#discussion_r3156440269 -> 13615e272
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#pullrequestreview-4191535825 -> 13615e272

Disposition: FIXED
Commit: 13615e272
Evidence: docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PR4_CALIBRATION_PACKET_2026-04-28.md hyphenates side-effect-free; scripts/orchestration/pr_review_report.py renders false-positive controls in Markdown.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#discussion_r3156449219 -> 13615e272
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#pullrequestreview-4191546077 -> 13615e272

Disposition: FIXED
Commit: 7a85e0ebd
Evidence: docs/review/PR_1560_FIXED_MAPPING.md now uses clearer wording for the checked discussion-pass marker evidence sentence.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#discussion_r3156497476 -> 7a85e0ebd
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1560#pullrequestreview-4191601594 -> 7a85e0ebd

## Risk & Impact

- Report schema remains additive: existing fields stay unchanged and `calibration` is advisory metadata.
- `posting_eligible` is hard false in PR4.
- No GitHub posting, thread resolution, auto-merge, model calls, or external plugin runtime dependency is introduced.

## Test Plan

Local gates run:

- `python3 scripts/orchestration/check_preflight.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `python3 scripts/orchestration/sync_skill_mirror.py --name pulseplate-pr-review --force` PASS
- `python3 -m pytest tests/test_pr_review_report.py -q` PASS (`8 passed`)
- `python3 -m pytest tests/test_pr_review_context.py tests/test_pr_review_report.py tests/test_install_codex_skills.py -q` PASS (`26 passed`)
- `.venv/bin/mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/pr_review_report.py` PASS
- `pre-commit run --all-files` PASS after Black reformatted `tests/test_pr_review_report.py`, rerun PASS
- `make validate-min` PASS
- `make validate-changed` PASS after commit (`tests/test_pr_review_report.py`, 8 passed)
- pre-push hooks PASS: mypy, pip-audit, backend pytest, full-repo bandit, docker build test

Full local `make verify` not run for this orchestration/tooling PR; GitHub current-head CI is expected to provide the heavy signal before merge readiness.

## Deferred / Follow-ups

- GitHub review comment posting remains out of scope until a dedicated calibrated posting PR.
- Automatic review-thread resolution remains out of scope.
- Any scoring/eval rubric beyond deterministic metadata remains a future `data-scientist-agent` slice.

## Merge Readiness

- [ ] CI green on current head
- [ ] No unresolved actionable review threads
- [ ] CodeRabbit/Sourcery/Cubic statuses reviewed and mapped
- [ ] Fixed-mapping artifact and PR body mirror aligned
- [ ] `check_merge_ready.py --require-auth` PASS
