### PR TITLE
feat(food-data): add USDA source manifest preflight gate

### DIFF
--- a/core/food_sources/source_preflight.py
+++ b/core/food_sources/source_preflight.py
@@ -35,6 +35,8 @@ ALLOWED_COLLISION_RESOLUTIONS: tuple[CollisionResolution, ...] = (
     "quarantine",
     "skip",
 )
+ELIGIBLE_PREFLIGHT_ONBOARDING_STATUS = "eligible_preflight"
+MANIFEST_PREFLIGHT_ONLY_INGESTION_PATH = "manifest_preflight_only"
 
 _SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 _RETRIEVED_ON_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
@@ -377,6 +379,9 @@ def build_source_diff_report(
 def build_source_preflight_report(
     current_manifest: Path | str,
     incoming_manifest: Path | str,
+    *,
+    catalog_path: Path | str | None = None,
+    onboarding_path: Path | str | None = None,
 ) -> dict[str, object]:
     """Load manifests and return a dry-run report with validation errors."""
     errors: list[str] = []
@@ -401,7 +406,23 @@ def build_source_preflight_report(
             "validation_errors": errors,
         }
 
-    return build_source_diff_report(current, incoming)
+    if (catalog_path is None) != (onboarding_path is None):
+        errors.append("source_contract: catalog_path and onboarding_path must be provided together")
+    elif catalog_path is not None and onboarding_path is not None:
+        errors.extend(
+            f"source_contract: {error}"
+            for error in validate_manifest_source_contract(
+                incoming,
+                catalog_path=catalog_path,
+                onboarding_path=onboarding_path,
+            )
+        )
+
+    report = build_source_diff_report(current, incoming)
+    if errors:
+        report["success"] = False
+        report["validation_errors"] = [*report["validation_errors"], *errors]
+    return report
 
 
 def validate_manifest_source_contract(
@@ -467,16 +488,16 @@ def validate_manifest_source_contract(
     if onboarding_entry is None:
         errors.append(f"onboarding: missing source {manifest.source!r}")
     else:
-        if onboarding_entry.onboarding_status != "eligible_preflight":
+        if onboarding_entry.onboarding_status != ELIGIBLE_PREFLIGHT_ONBOARDING_STATUS:
             errors.append(
                 "onboarding: "
-                f"{manifest.source!r} must be eligible_preflight, got "
+                f"{manifest.source!r} must be {ELIGIBLE_PREFLIGHT_ONBOARDING_STATUS}, got "
                 f"{onboarding_entry.onboarding_status!r}"
             )
-        if onboarding_entry.ingestion_path != "manifest_preflight_only":
+        if onboarding_entry.ingestion_path != MANIFEST_PREFLIGHT_ONLY_INGESTION_PATH:
             errors.append(
                 "onboarding: "
-                f"{manifest.source!r} must use manifest_preflight_only, got "
+                f"{manifest.source!r} must use {MANIFEST_PREFLIGHT_ONLY_INGESTION_PATH}, got "
                 f"{onboarding_entry.ingestion_path!r}"
             )
 

--- a/core/food_sources/source_preflight.py
+++ b/core/food_sources/source_preflight.py
@@ -420,8 +420,12 @@ def build_source_preflight_report(
 
     report = build_source_diff_report(current, incoming)
     if errors:
+        diff_errors = report.get("validation_errors")
+        existing_errors = (
+            [str(error) for error in diff_errors] if isinstance(diff_errors, list) else []
+        )
         report["success"] = False
-        report["validation_errors"] = [*report["validation_errors"], *errors]
+        report["validation_errors"] = [*existing_errors, *errors]
     return report
 
 

--- a/core/food_sources/source_preflight.py
+++ b/core/food_sources/source_preflight.py
@@ -38,6 +38,7 @@ ALLOWED_COLLISION_RESOLUTIONS: tuple[CollisionResolution, ...] = (
 
 _SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 _RETRIEVED_ON_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class SourceManifestError(ValueError):
@@ -401,3 +402,104 @@ def build_source_preflight_report(
         }
 
     return build_source_diff_report(current, incoming)
+
+
+def validate_manifest_source_contract(
+    manifest: SourceManifest,
+    *,
+    catalog_path: Path | str,
+    onboarding_path: Path | str,
+) -> list[str]:
+    """
+    Validate a manifest against the governed catalog/onboarding preflight contract.
+
+    RU: Проверка только файлового допуска preflight, без ingest/сети/БД.
+    EN: File-only preflight eligibility check, with no ingest/network/database side effects.
+    """
+    from core.food_sources.source_catalog import SourceCatalogError, load_source_catalog
+    from core.food_sources.source_onboarding import (
+        SourceOnboardingError,
+        load_source_onboarding,
+    )
+
+    errors: list[str] = []
+    try:
+        catalog = load_source_catalog(catalog_path)
+    except SourceCatalogError as exc:
+        return [f"catalog: {exc}"]
+
+    expected_catalog_ref = _expected_catalog_ref(catalog_path)
+    try:
+        onboarding = load_source_onboarding(
+            onboarding_path,
+            catalog=catalog,
+            expected_catalog_ref=expected_catalog_ref,
+        )
+    except SourceOnboardingError as exc:
+        return [f"onboarding: {exc}"]
+
+    catalog_entries = {entry.source: entry for entry in catalog.sources}
+    catalog_entry = catalog_entries.get(manifest.source)
+    if catalog_entry is None:
+        errors.append(f"catalog: unknown source {manifest.source!r}")
+    else:
+        if manifest.source_classification != catalog_entry.source_classification:
+            errors.append(
+                "catalog: source_classification mismatch for "
+                f"{manifest.source!r}: manifest={manifest.source_classification!r} "
+                f"catalog={catalog_entry.source_classification!r}"
+            )
+        if manifest.source_url != catalog_entry.source_url:
+            errors.append(
+                "catalog: source_url mismatch for "
+                f"{manifest.source!r}: manifest={manifest.source_url!r} "
+                f"catalog={catalog_entry.source_url!r}"
+            )
+        if not catalog_entry.manifest_required:
+            errors.append(f"catalog: {manifest.source!r} must require a manifest")
+        if not catalog_entry.preflight_required:
+            errors.append(f"catalog: {manifest.source!r} must require preflight")
+        if not catalog_entry.active_update_source:
+            errors.append(f"catalog: {manifest.source!r} must be an active update source")
+
+    onboarding_entries = {entry.source: entry for entry in onboarding.sources}
+    onboarding_entry = onboarding_entries.get(manifest.source)
+    if onboarding_entry is None:
+        errors.append(f"onboarding: missing source {manifest.source!r}")
+    else:
+        if onboarding_entry.onboarding_status != "eligible_preflight":
+            errors.append(
+                "onboarding: "
+                f"{manifest.source!r} must be eligible_preflight, got "
+                f"{onboarding_entry.onboarding_status!r}"
+            )
+        if onboarding_entry.ingestion_path != "manifest_preflight_only":
+            errors.append(
+                "onboarding: "
+                f"{manifest.source!r} must use manifest_preflight_only, got "
+                f"{onboarding_entry.ingestion_path!r}"
+            )
+
+    if onboarding.runtime_cutover:
+        errors.append("onboarding: runtime_cutover must remain false")
+    if onboarding.digitalocean_postgres_load:
+        errors.append("onboarding: digitalocean_postgres_load must remain false")
+    if onboarding.bulk_ingest:
+        errors.append("onboarding: bulk_ingest must remain false")
+    if not onboarding.file_only:
+        errors.append("onboarding: file_only must remain true")
+    if onboarding.network_allowed:
+        errors.append("onboarding: network_allowed must remain false")
+    if onboarding.db_writes_allowed:
+        errors.append("onboarding: db_writes_allowed must remain false")
+
+    return errors
+
+
+def _expected_catalog_ref(catalog_path: Path | str) -> str:
+    """Return the repository-relative catalog ref used by onboarding snapshots."""
+    path = Path(catalog_path)
+    try:
+        return path.resolve().relative_to(_REPO_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()

--- a/docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_CURRENT.md
+++ b/docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_CURRENT.md
@@ -13,6 +13,8 @@ current tooling packet for food-data lanes that need non-dated links.
   [`FOOD_DATA_SOURCE_ONBOARDING_GATE_PR5_PACKET_2026-04-28.md`](./FOOD_DATA_SOURCE_ONBOARDING_GATE_PR5_PACKET_2026-04-28.md)
 - Current PR5 source-onboarding gate:
   [`FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json`](../architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json)
+- Current PR6 USDA manifest preflight packet:
+  [`FOOD_DATA_USDA_MANIFEST_PREFLIGHT_PR6_PACKET_2026-04-28.md`](./FOOD_DATA_USDA_MANIFEST_PREFLIGHT_PR6_PACKET_2026-04-28.md)
 - Current PR3 source catalog packet:
   [`FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md`](./FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md)
 - Current PR3 source catalog:
@@ -23,5 +25,5 @@ current tooling packet for food-data lanes that need non-dated links.
   [`BACKLOG_LEDGER.md#ledger-p1-food-data-source-update-preflight`](../roadmap/BACKLOG_LEDGER.md#ledger-p1-food-data-source-update-preflight)
 
 Update this alias when a later accepted packet supersedes the dated PR1
-criteria, PR2 tooling packet, PR3 source catalog, PR4 collision policy, or PR5
-source-onboarding gate.
+criteria, PR2 tooling packet, PR3 source catalog, PR4 collision policy, PR5
+source-onboarding gate, or PR6 USDA manifest preflight gate.

--- a/docs/orchestration/FOOD_DATA_USDA_MANIFEST_PREFLIGHT_PR6_PACKET_2026-04-28.md
+++ b/docs/orchestration/FOOD_DATA_USDA_MANIFEST_PREFLIGHT_PR6_PACKET_2026-04-28.md
@@ -1,0 +1,104 @@
+# Food Data PR6: USDA Source Manifest Preflight Gate
+
+## Summary
+
+PR6 adds deterministic, file-only USDA manifest fixtures for FoodData Central
+Foundation, Branded, and FNDDS sources. It proves that USDA manifests can pass
+the PR2 dry-run preflight shape while staying governed by the PR3 source catalog
+and PR5 onboarding gate.
+
+PR6 does not download USDA data, compute live checksums, ingest records, connect
+to a database, write to DigitalOcean Postgres, or change runtime food search.
+
+## Coordinator Start
+
+- Coordinator: `agent-coordinator`
+- Branch: `codex/food-data-usda-manifest-preflight-pr6`
+- Required role order:
+  `agent-coordinator -> data-scientist-agent -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter -> dev-operator`
+- Mandatory post-open lane: `qa-engineer-agent -> bug-hunter`
+
+## Scope
+
+- Add deterministic USDA manifest fixtures for:
+  - `usda_foundation`
+  - `usda_branded`
+  - `usda_fndds`
+- Keep `source_classification=current` and source URL
+  `https://fdc.nal.usda.gov/download-datasets`.
+- Validate fixture manifests through the existing PR2 manifest parser and dry-run
+  diff contract.
+- Add a file-only source contract helper proving the manifest source is allowed
+  by:
+  - PR3 catalog identity/classification;
+  - PR3 active update, manifest, and preflight flags;
+  - PR5 onboarding `eligible_preflight` and `manifest_preflight_only` policy;
+  - PR5 safety flags: `runtime_cutover=false`,
+    `digitalocean_postgres_load=false`, `bulk_ingest=false`,
+    `network_allowed=false`, and `db_writes_allowed=false`.
+
+## Out Of Scope
+
+- USDA source downloads.
+- Live USDA row-count/checksum discovery.
+- Snapshot promotion.
+- Bulk ingest.
+- PostgreSQL staging or DigitalOcean production load.
+- Runtime authority or food-search cutover.
+- OFF, JPTN, MenuStat replacement, restaurant-menu, recipe/corpus, or regional
+  source onboarding.
+
+## Fixture Policy
+
+The USDA checksums, byte sizes, row counts, and artifact paths in PR6 fixtures
+are synthetic deterministic metadata. They exist only to exercise the manifest
+shape, diff output, schema/primary-key deltas, and collision policy validation.
+
+USDA Foundation and FNDDS use `fdc_id` as primary key with reject-on-collision
+policy. USDA Branded uses `fdc_id` as primary key, `gtin_upc` as dedupe field,
+and quarantine-on-collision policy because branded package identifiers can
+collide or be reused across provider changes.
+
+## Validation
+
+Required start gates:
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR6 USDA manifest preflight gate" --task-class "Orchestration" --pr-phase pre_open
+```
+
+Targeted PR6 validation:
+
+```bash
+python3 -m pytest tests/test_food_source_preflight.py tests/test_food_source_catalog.py tests/test_food_source_onboarding.py -q
+python3 scripts/food_source_preflight.py --current-manifest tests/fixtures/food_source_preflight/current_usda_foundation_manifest.json --incoming-manifest tests/fixtures/food_source_preflight/incoming_usda_foundation_manifest.json --dry-run --json
+pytest -q tests/test_repo_policy_guards.py
+pre-commit run --all-files
+```
+
+Do not run local `make verify` for this lane; GitHub current-head CI remains the
+machine-heavy signal.
+
+## Security Notes
+
+- PR6 is file-only.
+- No network, database, credential, DigitalOcean, or production import path is
+  allowed.
+- The validator must fail closed when catalog identity, classification,
+  onboarding status, ingestion path, or safety flags drift.
+
+## Marketing & GTM
+
+No product, API, UX, launch, pricing, or public dataset claim changes in PR6.
+The later marketable claim remains: governed multi-source food data with
+provenance, only after source-specific ingest and runtime authority lanes are
+approved.
+
+## Decision Log
+
+- PR5 source-onboarding gate is the landed baseline in PR `#1559`.
+- PR6 opens the first source-specific manifest preflight lane for USDA only.
+- Fixture metadata is intentionally synthetic and must be replaced by verified
+  source metadata in a later USDA ingest/staging PR.

--- a/docs/orchestration/FOOD_DATA_USDA_MANIFEST_PREFLIGHT_PR6_PACKET_2026-04-28.md
+++ b/docs/orchestration/FOOD_DATA_USDA_MANIFEST_PREFLIGHT_PR6_PACKET_2026-04-28.md
@@ -73,7 +73,7 @@ Targeted PR6 validation:
 
 ```bash
 python3 -m pytest tests/test_food_source_preflight.py tests/test_food_source_catalog.py tests/test_food_source_onboarding.py -q
-python3 scripts/food_source_preflight.py --current-manifest tests/fixtures/food_source_preflight/current_usda_foundation_manifest.json --incoming-manifest tests/fixtures/food_source_preflight/incoming_usda_foundation_manifest.json --dry-run --json
+python3 scripts/food_source_preflight.py --current-manifest tests/fixtures/food_source_preflight/current_usda_foundation_manifest.json --incoming-manifest tests/fixtures/food_source_preflight/incoming_usda_foundation_manifest.json --dry-run --json --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json
 pytest -q tests/test_repo_policy_guards.py
 pre-commit run --all-files
 ```

--- a/docs/review/PR_1563_FIXED_MAPPING.md
+++ b/docs/review/PR_1563_FIXED_MAPPING.md
@@ -23,12 +23,14 @@ Disposition: FIXED
 Commit: d6efa02de
 Evidence: core/food_sources/source_preflight.py defines ELIGIBLE_PREFLIGHT_ONBOARDING_STATUS and MANIFEST_PREFLIGHT_ONLY_INGESTION_PATH constants and uses them in onboarding status/path checks.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1563#discussion_r3156892903 -> d6efa02de
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1563#pullrequestreview-4192051812 -> d6efa02de
 
 Disposition: NOT-A-BUG
 Evidence: core/food_sources/source_preflight.py ALLOWED_SOURCE_CLASSIFICATIONS intentionally allows only current, legacy_static, commercial_contract, and unresolved. tests/test_food_source_preflight.py validates incoming USDA fixtures as source_classification=current and rejects invalid classifications; changing fixture classification to incoming would violate the PR2 manifest contract.
 Reason: incoming_* fixture filenames describe the candidate manifest position in a dry-run pair, not a source_classification enum value.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1563#discussion_r3156901601
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1563#discussion_r3156901623
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1563#pullrequestreview-4192061903
 
 ## Initial Evidence
 

--- a/docs/review/PR_1563_FIXED_MAPPING.md
+++ b/docs/review/PR_1563_FIXED_MAPPING.md
@@ -1,0 +1,40 @@
+# PR #1563 Fixed Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1563>
+Branch: `codex/food-data-usda-manifest-preflight-pr6`
+Date: 2026-04-28
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Artifact status: PR opened as draft while `main` current-head CI was still in
+progress. No human or bot review threads were present when this artifact was
+created.
+
+## Fixed in Commit Mapping
+
+No actionable review threads have been posted yet.
+
+## Initial Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` (PASS)
+- `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
+- `python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR6 USDA manifest preflight gate" --task-class "Orchestration" --pr-phase pre_open` (PASS)
+- `python3 -m pytest tests/test_food_source_preflight.py tests/test_food_source_catalog.py tests/test_food_source_onboarding.py -q` (PASS, 63 passed)
+- `python3 scripts/food_source_preflight.py --current-manifest tests/fixtures/food_source_preflight/current_usda_foundation_manifest.json --incoming-manifest tests/fixtures/food_source_preflight/incoming_usda_foundation_manifest.json --dry-run --json` (PASS)
+- `pytest -q tests/test_repo_policy_guards.py` (PASS, 13 passed)
+- `pre-commit run --all-files` (PASS)
+- Pre-push hooks: mypy changed files, pip-audit, backend pytest, full-repo bandit, and docker build test (PASS)
+
+Local `make verify` was intentionally deferred for this machine-heavy food lane
+per operator policy; GitHub current-head CI remains the heavy signal.
+
+## Merge Readiness
+
+- [ ] CI green on current head
+- [ ] No unresolved actionable review threads
+- [ ] CodeRabbit/Sourcery/Cubic statuses reviewed and mapped if present
+- [ ] Fixed-mapping artifact and PR body mirror aligned
+- [ ] `check_merge_ready.py --require-auth` PASS

--- a/docs/review/PR_1563_FIXED_MAPPING.md
+++ b/docs/review/PR_1563_FIXED_MAPPING.md
@@ -10,20 +10,33 @@ Date: 2026-04-28
 - [x] Fixed in commit mapping completed
 
 Artifact status: PR opened as draft while `main` current-head CI was still in
-progress. No human or bot review threads were present when this artifact was
-created.
+progress. Post-open bot comments are mapped below.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: d6efa02de
+Evidence: core/food_sources/source_preflight.py now invokes strict source-contract validation from build_source_preflight_report when catalog/onboarding paths are provided; scripts/food_source_preflight.py exposes optional --catalog/--onboarding args; tests/test_food_source_preflight.py covers the strict failure path and USDA CLI contract path.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1563#discussion_r3156893650 -> d6efa02de
+
+Disposition: FIXED
+Commit: d6efa02de
+Evidence: core/food_sources/source_preflight.py defines ELIGIBLE_PREFLIGHT_ONBOARDING_STATUS and MANIFEST_PREFLIGHT_ONLY_INGESTION_PATH constants and uses them in onboarding status/path checks.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1563#discussion_r3156892903 -> d6efa02de
+
+Disposition: NOT-A-BUG
+Evidence: core/food_sources/source_preflight.py ALLOWED_SOURCE_CLASSIFICATIONS intentionally allows only current, legacy_static, commercial_contract, and unresolved. tests/test_food_source_preflight.py validates incoming USDA fixtures as source_classification=current and rejects invalid classifications; changing fixture classification to incoming would violate the PR2 manifest contract.
+Reason: incoming_* fixture filenames describe the candidate manifest position in a dry-run pair, not a source_classification enum value.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1563#discussion_r3156901601
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1563#discussion_r3156901623
 
 ## Initial Evidence
 
 - `python3 scripts/orchestration/check_preflight.py` (PASS)
 - `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
 - `python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR6 USDA manifest preflight gate" --task-class "Orchestration" --pr-phase pre_open` (PASS)
-- `python3 -m pytest tests/test_food_source_preflight.py tests/test_food_source_catalog.py tests/test_food_source_onboarding.py -q` (PASS, 63 passed)
-- `python3 scripts/food_source_preflight.py --current-manifest tests/fixtures/food_source_preflight/current_usda_foundation_manifest.json --incoming-manifest tests/fixtures/food_source_preflight/incoming_usda_foundation_manifest.json --dry-run --json` (PASS)
+- `python3 -m pytest tests/test_food_source_preflight.py tests/test_food_source_catalog.py tests/test_food_source_onboarding.py -q` (PASS, 64 passed after review fix)
+- `python3 scripts/food_source_preflight.py --current-manifest tests/fixtures/food_source_preflight/current_usda_foundation_manifest.json --incoming-manifest tests/fixtures/food_source_preflight/incoming_usda_foundation_manifest.json --dry-run --json --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json` (PASS)
 - `pytest -q tests/test_repo_policy_guards.py` (PASS, 13 passed)
 - `pre-commit run --all-files` (PASS)
 - Pre-push hooks: mypy changed files, pip-audit, backend pytest, full-repo bandit, and docker build test (PASS)

--- a/docs/review/PR_1563_FIXED_MAPPING.md
+++ b/docs/review/PR_1563_FIXED_MAPPING.md
@@ -15,7 +15,7 @@ created.
 
 ## Fixed in Commit Mapping
 
-No actionable review threads have been posted yet.
+- No actionable review comments
 
 ## Initial Evidence
 

--- a/docs/review/PR_1563_FIXED_MAPPING.md
+++ b/docs/review/PR_1563_FIXED_MAPPING.md
@@ -32,6 +32,11 @@ Reason: incoming_* fixture filenames describe the candidate manifest position in
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1563#discussion_r3156901623
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1563#pullrequestreview-4192061903
 
+Disposition: NOT-A-BUG
+Evidence: core/food_sources/source_preflight.py returns a deterministic validation error when only one strict source-contract path is supplied; core/food_sources/source_onboarding.py validates onboarding source_classification against the catalog before SourceOnboarding is returned; tests/test_food_source_preflight.py uses the conventional unused parameter marker for the current fixture in a parametrized test.
+Reason: The latest CodeRabbit review contains optional nitpick-only suggestions, not merge-blocking correctness issues for PR6.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1563#pullrequestreview-4192340151
+
 ## Initial Evidence
 
 - `python3 scripts/orchestration/check_preflight.py` (PASS)

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1792,8 +1792,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Food data source-update preflight and diff-based ingest guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR `#1559`
-  - Status: 🚧 Active PR5 source-onboarding gate lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, and PR3 lineage hardening merged as PR #1532
+  - Target PR: PR-TBD-FOOD-DATA-PR6-USDA-MANIFEST-PREFLIGHT
+  - Status: 🚧 Active PR6 USDA manifest preflight lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, PR3 lineage hardening merged as PR #1532, and PR5 source-onboarding gate merged as PR #1559
   - Area: data ingestion / food catalog / quality
   - Finding Type: upstream data-change readiness gap
   - Reason (EN): USDA Foundation Foods, USDA Branded, USDA FNDDS, Open Food Facts, JPTN Food Facts, restaurant-menu data, and external recipe corpora can change the shape, volume, licensing, and dedupe behavior of ingestible records. The repo does not yet have a canonical preflight contract for source-version discovery, schema diffing, dedupe/mapping collisions, source replacement decisions, storage choice, and rollback before updating the unified food catalog.
@@ -1802,6 +1802,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/FOOD_DATA_SOURCE_PREFLIGHT_TOOLING_PR2_PACKET_2026-04-24.md`
     - `docs/orchestration/FOOD_DATA_SOURCE_DEDUPE_COLLISION_PR4_PACKET_2026-04-25.md`
     - `docs/orchestration/FOOD_DATA_SOURCE_ONBOARDING_GATE_PR5_PACKET_2026-04-28.md`
+    - `docs/orchestration/FOOD_DATA_USDA_MANIFEST_PREFLIGHT_PR6_PACKET_2026-04-28.md`
     - `docs/orchestration/FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md`
     - `docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json`
     - `docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json`
@@ -1821,6 +1822,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `source_classification` is validated with allowed values `current`, `legacy_static`, `commercial_contract`, and `unresolved`
     - Dedupe/mapping collision checks are defined before snapshot promotion or PostgreSQL staging
     - Source-onboarding gate defines cache, display, attribution, redistribution, and contract-review decisions before any source-specific ingest
+    - USDA Foundation, Branded, and FNDDS have deterministic manifest fixtures that pass source-specific dry-run preflight against PR2, PR3, and PR5 contracts before any USDA ingest lane opens
     - MenuStat is not treated as an actively updating source; replacement-source decision is required before new restaurant-menu ingest
     - DigitalOcean production PostgreSQL load and runtime cutover stay blocked until source preflight, staging proof, rollback, and cutover packet are complete
     - Data-ingest docs and runbooks point to the same preflight source of truth

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1792,7 +1792,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Food data source-update preflight and diff-based ingest guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-FOOD-DATA-PR6-USDA-MANIFEST-PREFLIGHT
+  - Target PR: PR `#1563`
   - Status: 🚧 Active PR6 USDA manifest preflight lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, PR3 lineage hardening merged as PR #1532, and PR5 source-onboarding gate merged as PR #1559
   - Area: data ingestion / food catalog / quality
   - Finding Type: upstream data-change readiness gap

--- a/scripts/food_source_preflight.py
+++ b/scripts/food_source_preflight.py
@@ -49,6 +49,16 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         required=True,
         help="Emit the deterministic JSON report.",
     )
+    parser.add_argument(
+        "--catalog",
+        type=Path,
+        help="Optional source catalog JSON for strict source-contract validation.",
+    )
+    parser.add_argument(
+        "--onboarding",
+        type=Path,
+        help="Optional source onboarding JSON for strict source-contract validation.",
+    )
     return parser.parse_args(argv)
 
 
@@ -58,6 +68,8 @@ def main(argv: list[str] | None = None) -> int:
     report = build_source_preflight_report(
         current_manifest=args.current_manifest,
         incoming_manifest=args.incoming_manifest,
+        catalog_path=args.catalog,
+        onboarding_path=args.onboarding,
     )
     print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
     return 0 if report.get("success") is True else 1

--- a/tests/fixtures/food_source_preflight/current_usda_branded_manifest.json
+++ b/tests/fixtures/food_source_preflight/current_usda_branded_manifest.json
@@ -1,0 +1,29 @@
+{
+  "source": "usda_branded",
+  "source_classification": "current",
+  "source_version": "fixture-2025-12-branded-current",
+  "source_url": "https://fdc.nal.usda.gov/download-datasets",
+  "retrieved_on": "2026-04-24",
+  "artifact": {
+    "path": "fixtures/usda/branded_current.json",
+    "checksum_sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+    "size_bytes": 2048,
+    "record_count": 200
+  },
+  "schema": {
+    "fields": [
+      "fdc_id",
+      "gtin_upc",
+      "brand_owner",
+      "description",
+      "serving_size",
+      "branded_food_category"
+    ],
+    "primary_keys": ["fdc_id"]
+  },
+  "collision_policy": {
+    "dedupe_fields": ["gtin_upc"],
+    "mapping_fields": ["fdc_id", "gtin_upc", "description"],
+    "collision_resolution": "quarantine"
+  }
+}

--- a/tests/fixtures/food_source_preflight/current_usda_fndds_manifest.json
+++ b/tests/fixtures/food_source_preflight/current_usda_fndds_manifest.json
@@ -1,0 +1,22 @@
+{
+  "source": "usda_fndds",
+  "source_classification": "current",
+  "source_version": "fixture-2025-12-fndds-current",
+  "source_url": "https://fdc.nal.usda.gov/download-datasets",
+  "retrieved_on": "2026-04-24",
+  "artifact": {
+    "path": "fixtures/usda/fndds_current.json",
+    "checksum_sha256": "5555555555555555555555555555555555555555555555555555555555555555",
+    "size_bytes": 1536,
+    "record_count": 150
+  },
+  "schema": {
+    "fields": ["fdc_id", "food_code", "description", "start_date", "end_date"],
+    "primary_keys": ["fdc_id"]
+  },
+  "collision_policy": {
+    "dedupe_fields": ["food_code"],
+    "mapping_fields": ["fdc_id", "food_code", "description"],
+    "collision_resolution": "reject"
+  }
+}

--- a/tests/fixtures/food_source_preflight/current_usda_foundation_manifest.json
+++ b/tests/fixtures/food_source_preflight/current_usda_foundation_manifest.json
@@ -1,0 +1,22 @@
+{
+  "source": "usda_foundation",
+  "source_classification": "current",
+  "source_version": "fixture-2025-12-foundation-current",
+  "source_url": "https://fdc.nal.usda.gov/download-datasets",
+  "retrieved_on": "2026-04-24",
+  "artifact": {
+    "path": "fixtures/usda/foundation_current.json",
+    "checksum_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+    "size_bytes": 1024,
+    "record_count": 100
+  },
+  "schema": {
+    "fields": ["fdc_id", "description", "food_category_id", "publication_date"],
+    "primary_keys": ["fdc_id"]
+  },
+  "collision_policy": {
+    "dedupe_fields": ["fdc_id"],
+    "mapping_fields": ["fdc_id", "description"],
+    "collision_resolution": "reject"
+  }
+}

--- a/tests/fixtures/food_source_preflight/incoming_usda_branded_manifest.json
+++ b/tests/fixtures/food_source_preflight/incoming_usda_branded_manifest.json
@@ -1,0 +1,30 @@
+{
+  "source": "usda_branded",
+  "source_classification": "current",
+  "source_version": "fixture-2025-12-branded-incoming",
+  "source_url": "https://fdc.nal.usda.gov/download-datasets",
+  "retrieved_on": "2026-04-24",
+  "artifact": {
+    "path": "fixtures/usda/branded_incoming.json",
+    "checksum_sha256": "4444444444444444444444444444444444444444444444444444444444444444",
+    "size_bytes": 2304,
+    "record_count": 240
+  },
+  "schema": {
+    "fields": [
+      "fdc_id",
+      "gtin_upc",
+      "brand_owner",
+      "description",
+      "serving_size",
+      "serving_size_unit",
+      "branded_food_category"
+    ],
+    "primary_keys": ["fdc_id"]
+  },
+  "collision_policy": {
+    "dedupe_fields": ["gtin_upc"],
+    "mapping_fields": ["fdc_id", "gtin_upc", "description"],
+    "collision_resolution": "quarantine"
+  }
+}

--- a/tests/fixtures/food_source_preflight/incoming_usda_fndds_manifest.json
+++ b/tests/fixtures/food_source_preflight/incoming_usda_fndds_manifest.json
@@ -1,0 +1,29 @@
+{
+  "source": "usda_fndds",
+  "source_classification": "current",
+  "source_version": "fixture-2025-12-fndds-incoming",
+  "source_url": "https://fdc.nal.usda.gov/download-datasets",
+  "retrieved_on": "2026-04-24",
+  "artifact": {
+    "path": "fixtures/usda/fndds_incoming.json",
+    "checksum_sha256": "6666666666666666666666666666666666666666666666666666666666666666",
+    "size_bytes": 1664,
+    "record_count": 160
+  },
+  "schema": {
+    "fields": [
+      "fdc_id",
+      "food_code",
+      "description",
+      "start_date",
+      "end_date",
+      "survey_cycle"
+    ],
+    "primary_keys": ["fdc_id"]
+  },
+  "collision_policy": {
+    "dedupe_fields": ["food_code"],
+    "mapping_fields": ["fdc_id", "food_code", "description"],
+    "collision_resolution": "reject"
+  }
+}

--- a/tests/fixtures/food_source_preflight/incoming_usda_foundation_manifest.json
+++ b/tests/fixtures/food_source_preflight/incoming_usda_foundation_manifest.json
@@ -1,0 +1,28 @@
+{
+  "source": "usda_foundation",
+  "source_classification": "current",
+  "source_version": "fixture-2025-12-foundation-incoming",
+  "source_url": "https://fdc.nal.usda.gov/download-datasets",
+  "retrieved_on": "2026-04-24",
+  "artifact": {
+    "path": "fixtures/usda/foundation_incoming.json",
+    "checksum_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+    "size_bytes": 1280,
+    "record_count": 125
+  },
+  "schema": {
+    "fields": [
+      "fdc_id",
+      "description",
+      "food_category_id",
+      "publication_date",
+      "data_type"
+    ],
+    "primary_keys": ["fdc_id"]
+  },
+  "collision_policy": {
+    "dedupe_fields": ["fdc_id"],
+    "mapping_fields": ["fdc_id", "description"],
+    "collision_resolution": "reject"
+  }
+}

--- a/tests/test_food_source_preflight.py
+++ b/tests/test_food_source_preflight.py
@@ -13,10 +13,28 @@ from core.food_sources.source_preflight import (
     SourceManifestError,
     build_source_preflight_report,
     load_source_manifest,
+    validate_manifest_source_contract,
 )
 
 _FIXTURE_DIR = Path(__file__).parent / "fixtures" / "food_source_preflight"
 _SCRIPT = Path(__file__).parents[1] / "scripts" / "food_source_preflight.py"
+_CATALOG = (
+    Path(__file__).parents[1]
+    / "docs"
+    / "architecture"
+    / "FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json"
+)
+_ONBOARDING = (
+    Path(__file__).parents[1]
+    / "docs"
+    / "architecture"
+    / "FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json"
+)
+_USDA_MANIFEST_PAIRS = (
+    ("current_usda_foundation_manifest.json", "incoming_usda_foundation_manifest.json"),
+    ("current_usda_branded_manifest.json", "incoming_usda_branded_manifest.json"),
+    ("current_usda_fndds_manifest.json", "incoming_usda_fndds_manifest.json"),
+)
 
 
 def _fixture(name: str) -> Path:
@@ -42,6 +60,100 @@ def test_load_source_manifest_accepts_legacy_static_menustat() -> None:
     assert manifest.source_classification == "legacy_static"
     assert manifest.source_version == "2022"
     assert manifest.collision_policy.collision_resolution == "quarantine"
+
+
+@pytest.mark.parametrize("current_fixture,incoming_fixture", _USDA_MANIFEST_PAIRS)
+def test_load_source_manifest_accepts_usda_current_fixtures(
+    current_fixture: str,
+    incoming_fixture: str,
+) -> None:
+    current = load_source_manifest(_fixture(current_fixture))
+    incoming = load_source_manifest(_fixture(incoming_fixture))
+
+    assert current.source == incoming.source
+    assert current.source.startswith("usda_")
+    assert incoming.source_classification == "current"
+    assert incoming.source_url == "https://fdc.nal.usda.gov/download-datasets"
+    assert incoming.schema.primary_keys == ("fdc_id",)
+
+
+@pytest.mark.parametrize("current_fixture,incoming_fixture", _USDA_MANIFEST_PAIRS)
+def test_build_source_preflight_report_accepts_usda_dry_run_pairs(
+    current_fixture: str,
+    incoming_fixture: str,
+) -> None:
+    report = build_source_preflight_report(
+        _fixture(current_fixture),
+        _fixture(incoming_fixture),
+    )
+
+    assert report["success"] is True
+    assert report["dry_run"] is True
+    assert report["runtime_cutover"] is False
+    assert report["source_classification"] == "current"
+    assert report["source_url"] == "https://fdc.nal.usda.gov/download-datasets"
+    row_count = report["row_count"]
+    checksum = report["checksum"]
+    assert isinstance(row_count, dict)
+    assert isinstance(checksum, dict)
+    assert row_count["changed"] is True
+    assert checksum["changed"] is True
+
+
+@pytest.mark.parametrize("_,incoming_fixture", _USDA_MANIFEST_PAIRS)
+def test_validate_manifest_source_contract_accepts_usda_onboarding_gate(
+    _: str,
+    incoming_fixture: str,
+) -> None:
+    manifest = load_source_manifest(_fixture(incoming_fixture))
+
+    errors = validate_manifest_source_contract(
+        manifest,
+        catalog_path=_CATALOG,
+        onboarding_path=_ONBOARDING,
+    )
+
+    assert errors == []
+
+
+def test_validate_manifest_source_contract_rejects_unknown_source(tmp_path: Path) -> None:
+    payload = json.loads(_fixture("incoming_usda_foundation_manifest.json").read_text())
+    payload["source"] = "usda_unknown"
+    manifest_path = tmp_path / "unknown_usda_manifest.json"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    manifest = load_source_manifest(manifest_path)
+
+    errors = validate_manifest_source_contract(
+        manifest,
+        catalog_path=_CATALOG,
+        onboarding_path=_ONBOARDING,
+    )
+
+    assert errors == [
+        "catalog: unknown source 'usda_unknown'",
+        "onboarding: missing source 'usda_unknown'",
+    ]
+
+
+def test_validate_manifest_source_contract_rejects_classification_mismatch(
+    tmp_path: Path,
+) -> None:
+    payload = json.loads(_fixture("incoming_usda_foundation_manifest.json").read_text())
+    payload["source_classification"] = "legacy_static"
+    manifest_path = tmp_path / "classification_mismatch_manifest.json"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    manifest = load_source_manifest(manifest_path)
+
+    errors = validate_manifest_source_contract(
+        manifest,
+        catalog_path=_CATALOG,
+        onboarding_path=_ONBOARDING,
+    )
+
+    assert errors == [
+        "catalog: source_classification mismatch for 'usda_foundation': "
+        "manifest='legacy_static' catalog='current'"
+    ]
 
 
 def test_load_source_manifest_rejects_invalid_source_classification() -> None:
@@ -224,6 +336,38 @@ def test_food_source_preflight_cli_is_file_only_and_json(
     payload = json.loads(result.stdout)
     assert payload["success"] is True
     assert payload["runtime_cutover"] is False
+    assert result.stderr == ""
+    assert after == before
+
+
+def test_food_source_preflight_cli_accepts_usda_fixture_pair(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgres://must-not-be-used.invalid/db")
+    before = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "--current-manifest",
+            str(_fixture("current_usda_foundation_manifest.json")),
+            "--incoming-manifest",
+            str(_fixture("incoming_usda_foundation_manifest.json")),
+            "--dry-run",
+            "--json",
+        ],
+        cwd=tmp_path,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    after = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
+
+    payload = json.loads(result.stdout)
+    assert payload["success"] is True
+    assert payload["runtime_cutover"] is False
+    assert payload["source"]["incoming"] == "usda_foundation"
     assert result.stderr == ""
     assert after == before
 

--- a/tests/test_food_source_preflight.py
+++ b/tests/test_food_source_preflight.py
@@ -156,6 +156,30 @@ def test_validate_manifest_source_contract_rejects_classification_mismatch(
     ]
 
 
+def test_build_source_preflight_report_enforces_strict_source_contract(
+    tmp_path: Path,
+) -> None:
+    payload = json.loads(_fixture("incoming_usda_foundation_manifest.json").read_text())
+    payload["source"] = "usda_unknown"
+    incoming_manifest = tmp_path / "incoming_unknown_usda_manifest.json"
+    incoming_manifest.write_text(json.dumps(payload), encoding="utf-8")
+
+    report = build_source_preflight_report(
+        _fixture("current_usda_foundation_manifest.json"),
+        incoming_manifest,
+        catalog_path=_CATALOG,
+        onboarding_path=_ONBOARDING,
+    )
+
+    assert report["success"] is False
+    assert report["runtime_cutover"] is False
+    assert report["validation_errors"] == [
+        "source mismatch: current='usda_foundation' incoming='usda_unknown'",
+        "source_contract: catalog: unknown source 'usda_unknown'",
+        "source_contract: onboarding: missing source 'usda_unknown'",
+    ]
+
+
 def test_load_source_manifest_rejects_invalid_source_classification() -> None:
     with pytest.raises(SourceManifestError, match="source_classification must be one of"):
         load_source_manifest(_fixture("invalid_classification_manifest.json"))
@@ -356,6 +380,10 @@ def test_food_source_preflight_cli_accepts_usda_fixture_pair(
             str(_fixture("incoming_usda_foundation_manifest.json")),
             "--dry-run",
             "--json",
+            "--catalog",
+            str(_CATALOG),
+            "--onboarding",
+            str(_ONBOARDING),
         ],
         cwd=tmp_path,
         check=True,
@@ -368,6 +396,7 @@ def test_food_source_preflight_cli_accepts_usda_fixture_pair(
     assert payload["success"] is True
     assert payload["runtime_cutover"] is False
     assert payload["source"]["incoming"] == "usda_foundation"
+    assert payload["validation_errors"] == []
     assert result.stderr == ""
     assert after == before
 


### PR DESCRIPTION
## Summary
- Adds deterministic USDA Foundation, Branded, and FNDDS manifest fixtures for the food-data source preflight lane.
- Adds a file-only source contract helper proving USDA manifests remain allowed by PR3 catalog identity/classification and PR5 onboarding `eligible_preflight` policy.
- Updates the food-data current pointer and ledger to mark PR5 #1559 landed and PR6 active.

## Scope Boundaries
- No source download, ingest, runtime food search change, API/OpenAPI/frontend/iOS change, database authority change, DigitalOcean Postgres load, or runtime cutover.
- USDA fixture checksums, row counts, byte sizes, and artifact paths are synthetic deterministic metadata only.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- `docs/review/PR_1563_FIXED_MAPPING.md` maps Sourcery/Codex comments as FIXED and CodeRabbit incoming-classification comments as NOT-A-BUG.
- Fixed code commits: `d6efa02de`, `852ab922c`; mapping commits: `e3ab12a05`, `2b1007ade`, `a530f0c5f`.

## Merge Readiness
- Start gates: `check_preflight.py`, `check_agent_consistency.py`, and `task_bootstrap.py` passed before edits.
- Targeted local validation passed after review fixes: `python3 -m pytest tests/test_food_source_preflight.py tests/test_food_source_catalog.py tests/test_food_source_onboarding.py -q` (64 passed); `pytest -q tests/test_repo_policy_guards.py`; strict USDA CLI smoke with `--dry-run --json --catalog --onboarding`; direct mypy on `core/food_sources/source_preflight.py scripts/food_source_preflight.py`.
- `pre-commit run --all-files` passed after Black formatting rerun.
- Pre-push hooks passed, including mypy changed files, pip-audit, backend pytest pre-push, full bandit, and docker build test.
- Local strict review-governance gate passed with 0 unresolved threads and all actionable bot comments mapped.
- Local `make verify` intentionally not run for this machine-heavy food lane per operator policy; GitHub current-head CI remains the heavy signal.

## Security Notes
- File-only validator and fixtures.
- Safety boundaries stay fail-closed: `runtime_cutover=false`, `digitalocean_postgres_load=false`, `bulk_ingest=false`, `network_allowed=false`, `db_writes_allowed=false`.

## Marketing & GTM
- No product, UX, pricing, or public data claim changes in PR6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced manifest preflight validation that enforces paired catalog+onboarding checks and will mark reports unsuccessful on contract violations.
  * CLI accepts optional catalog and onboarding path arguments to enable strict source-contract validation.

* **Documentation**
  * New USDA manifest preflight orchestration packet and updated orchestration/backlog references to include the USDA PR6 lane.

* **Tests**
  * Added deterministic USDA manifest fixtures (Foundation, Branded, FNDDS) and expanded tests for contract validation and CLI handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
