### PR TITLE
fix(frontend): restore Tailwind asset delivery guards

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -167,6 +167,9 @@ jobs:
       - name: Build frontend
         run: npm run build
 
+      - name: Verify Tailwind CSS utilities
+        run: npm run smoke:css
+
       - name: Upload frontend build artifacts
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/deploy/PRODUCTION.md
+++ b/deploy/PRODUCTION.md
@@ -65,6 +65,8 @@ Canonical recovery order:
    image as well; the edge fix alone cannot add a missing FastAPI route.
 7. Remove full-host Access only after the private check passes, then reopen the
    apex with a narrow temporary bypass for public shell/discovery GET paths only.
+   The public CSS asset under `/assets/` must return `200` with `text/css`; keep
+   `/api*`, `/admin*`, and private probe surfaces out of the bypass.
 
 ## Global release-readiness lock (required)
 

--- a/deploy/WORKFLOW.md
+++ b/deploy/WORKFLOW.md
@@ -264,6 +264,9 @@ bash scripts/diagnose_web.sh
 - `/terms`
 - `/legacy/bmi-calculator`
 
+Проверяй `/assets/<hashed-css>.css`: ответ должен быть `200` и `text/css`,
+без редиректа на `pulseplate.cloudflareaccess.com`.
+
 Не ослабляй:
 
 - `/api*`

--- a/docs/deploy/CLOUDFLARE.md
+++ b/docs/deploy/CLOUDFLARE.md
@@ -280,6 +280,11 @@ temporary bypass для **public shell/discovery GET paths**:
 - `/terms`
 - `/legacy/bmi-calculator`
 
+Bypass must be scoped to safe HTTP methods for those public surfaces, preferably
+`GET` and `HEAD`. A CSS asset probe must return `200` with `text/css`; a
+redirect to `pulseplate.cloudflareaccess.com` means the public shell will render
+without production styles.
+
 Обязательно оставить защищёнными:
 
 - `/api*`

--- a/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
+++ b/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
@@ -60,8 +60,8 @@ shell/discovery surfaces:
 - `/terms`
 - `/legacy/bmi-calculator`
 
-The bypass must stay method-scoped to safe public requests, preferably `GET`
-and `HEAD`. A hashed CSS asset under `/assets/` must return `200` with
+The bypass must stay method-scoped to safe public requests: `GET` and `HEAD`
+only. A hashed CSS asset under `/assets/` must return `200` with
 `text/css`; any redirect to `pulseplate.cloudflareaccess.com` means the public
 SPA shell will render without production styles.
 

--- a/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
+++ b/docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
@@ -60,6 +60,11 @@ shell/discovery surfaces:
 - `/terms`
 - `/legacy/bmi-calculator`
 
+The bypass must stay method-scoped to safe public requests, preferably `GET`
+and `HEAD`. A hashed CSS asset under `/assets/` must return `200` with
+`text/css`; any redirect to `pulseplate.cloudflareaccess.com` means the public
+SPA shell will render without production styles.
+
 Keep these surfaces edge-protected during the reopen window:
 
 - `/api*`

--- a/docs/review/PR_1576_FIXED_MAPPING.md
+++ b/docs/review/PR_1576_FIXED_MAPPING.md
@@ -38,7 +38,7 @@ Evidence: CodeRabbit duplicate review was addressed in the canonical artifact: `
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162223775 -> 164959779
 Disposition: FIXED
 Commit: 164959779
-Evidence: `frontend/scripts/check-tailwind-utilities.mjs` had already been updated in commit `164959779` to use `fileURLToPath(...)`; CodeRabbit confirmed this thread was addressed by commits `1649597` to `daf433d`.
+Evidence: `frontend/scripts/check-tailwind-utilities.mjs` had already been updated in commit `164959779` to use `fileURLToPath(...)`; CodeRabbit confirmed this thread was addressed by commits `164959779` to `daf433d`.
 
 ## Implementation Evidence
 

--- a/docs/review/PR_1576_FIXED_MAPPING.md
+++ b/docs/review/PR_1576_FIXED_MAPPING.md
@@ -41,6 +41,11 @@ Disposition: FIXED
 Commit: 662931f42
 Evidence: `docs/review/PR_1576_FIXED_MAPPING.md` now uses the consistent full `164959779` commit reference in the CodeRabbit evidence sentence.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#pullrequestreview-4199355908
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1576_FIXED_MAPPING.md` currently uses the full `164959779` reference in the CodeRabbit evidence sentence.
+Reason: Duplicate CodeRabbit review was generated from an older commit range after the typo was already fixed in commit `662931f42`.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162223775 -> 164959779
 Disposition: FIXED
 Commit: 164959779

--- a/docs/review/PR_1576_FIXED_MAPPING.md
+++ b/docs/review/PR_1576_FIXED_MAPPING.md
@@ -30,6 +30,11 @@ Disposition: FIXED
 Commit: cb7f924ae
 Evidence: `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md` now states the public bypass is limited to `GET` and `HEAD` only; `docs/review/PR_1576_FIXED_MAPPING.md` now uses portable evidence commands instead of machine-specific absolute paths.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#pullrequestreview-4199308377 -> 54a9f3ecf
+Disposition: FIXED
+Commit: 54a9f3ecf
+Evidence: CodeRabbit duplicate review was addressed in the canonical artifact: `docs/review/PR_1576_FIXED_MAPPING.md` no longer contains machine-specific `/Users/...` evidence commands and now keeps resolved thread URLs in contiguous disposition blocks.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162223775 -> 164959779
 Disposition: FIXED
 Commit: 164959779

--- a/docs/review/PR_1576_FIXED_MAPPING.md
+++ b/docs/review/PR_1576_FIXED_MAPPING.md
@@ -15,6 +15,10 @@ Date: 2026-04-29
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162190364 -> 164959779
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#pullrequestreview-4198416972 -> 164959779
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162202726 -> 164959779
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#pullrequestreview-4198438962 -> cb7f924ae
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162223716 -> cb7f924ae
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162223768 -> cb7f924ae
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162223775 -> 164959779
 
 Disposition: FIXED
 Commit: 164959779
@@ -23,6 +27,10 @@ Evidence: `frontend/scripts/check-tailwind-utilities.mjs` now uses `fileURLToPat
 Disposition: FIXED
 Commit: 164959779
 Evidence: `scripts/diagnose_web.sh` now probes root HTML and `/assets/*.css` with `--no-access-headers`, preserving anonymous public CSS validation even when private Cloudflare Access service-token env vars are present; `tests/test_deploy_contract_scripts.py` asserts CSS probes do not receive `CF-Access-Client-*` headers.
+
+Disposition: FIXED
+Commit: cb7f924ae
+Evidence: `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md` now states the public bypass is limited to `GET` and `HEAD` only; `docs/review/PR_1576_FIXED_MAPPING.md` now uses portable evidence commands instead of machine-specific absolute paths.
 
 ## Implementation Evidence
 

--- a/docs/review/PR_1576_FIXED_MAPPING.md
+++ b/docs/review/PR_1576_FIXED_MAPPING.md
@@ -1,0 +1,47 @@
+# PR #1576 Fixed Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576>
+Branch: `codex/cloudflare-static-assets-tailwind-css`
+Date: 2026-04-29
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 65285f1b8
+Evidence: `frontend/src/index.css` and `frontend/postcss.config.cjs` restore Tailwind/PostCSS utility generation; `frontend/scripts/check-tailwind-utilities.mjs` and `.github/workflows/frontend-ci.yml` lock the CSS bundle smoke after build.
+
+Disposition: FIXED
+Commit: 65285f1b8
+Evidence: `scripts/diagnose_web.sh` now probes the hashed `/assets/*.css` bundle and fails on Cloudflare Access redirects or non-`text/css`; `tests/test_deploy_contract_scripts.py` covers the new static CSS diagnostic path.
+
+Disposition: FIXED
+Commit: 65285f1b8
+Evidence: `docs/deploy/CLOUDFLARE.md`, `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md`, `deploy/WORKFLOW.md`, and `deploy/PRODUCTION.md` document the narrow public GET/HEAD shell/static bypass while keeping `/api*`, `/admin*`, and private probe surfaces out of scope.
+
+## Initial Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` (PASS)
+- `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
+- `python3 scripts/orchestration/task_bootstrap.py --goal "Recover public static asset delivery and Tailwind CSS pipeline for pulseplate.app" --task-class "Design" --pr-phase pre_open` (PASS; packet `75e3d405a59d`)
+- `python3 scripts/orchestration/task_bootstrap.py --goal "Post-open review lane for PR 1576 Cloudflare static assets and Tailwind CSS pipeline" --task-class "Design" --pr-phase post_open_review` (PASS; packet `f162f381fb48`)
+- `cd frontend && npm run build` (PASS)
+- `cd frontend && npm run smoke:css` (PASS)
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pytest -q tests/test_deploy_contract_scripts.py -k 'diagnose_web'` (PASS; 8 passed)
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` (PASS; no Python files changed)
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pre-commit run --all-files` (PASS)
+- Pre-push hooks: backend pre-push pytest, full-repo Bandit, docker build test (PASS)
+- Local preview static CSS: `http://127.0.0.1:4174/assets/index-D42ApsRM.css` returned `200` with `Content-Type: text/css`
+- Live baseline before operator Access bypass: `curl -I https://pulseplate.app/assets/index-BN60ERUL.css` returned `302` to `pulseplate.cloudflareaccess.com`
+
+## Merge Readiness
+
+- [ ] CI green on current head
+- [ ] No unresolved actionable review threads
+- [ ] CodeRabbit/Sourcery/Cubic statuses reviewed and mapped
+- [ ] Fixed-mapping artifact and PR body mirror aligned
+- [ ] `check_merge_ready.py --require-auth` PASS

--- a/docs/review/PR_1576_FIXED_MAPPING.md
+++ b/docs/review/PR_1576_FIXED_MAPPING.md
@@ -35,6 +35,12 @@ Disposition: FIXED
 Commit: 54a9f3ecf
 Evidence: CodeRabbit duplicate review was addressed in the canonical artifact: `docs/review/PR_1576_FIXED_MAPPING.md` no longer contains machine-specific `/Users/...` evidence commands and now keeps resolved thread URLs in contiguous disposition blocks.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#pullrequestreview-4199331858 -> 662931f42
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162979862 -> 662931f42
+Disposition: FIXED
+Commit: 662931f42
+Evidence: `docs/review/PR_1576_FIXED_MAPPING.md` now uses the consistent full `164959779` commit reference in the CodeRabbit evidence sentence.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162223775 -> 164959779
 Disposition: FIXED
 Commit: 164959779

--- a/docs/review/PR_1576_FIXED_MAPPING.md
+++ b/docs/review/PR_1576_FIXED_MAPPING.md
@@ -6,10 +6,14 @@ Date: 2026-04-29
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Implementation Evidence
 
 Disposition: FIXED
 Commit: 65285f1b8

--- a/docs/review/PR_1576_FIXED_MAPPING.md
+++ b/docs/review/PR_1576_FIXED_MAPPING.md
@@ -46,16 +46,16 @@ Evidence: `docs/deploy/CLOUDFLARE.md`, `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
 - `python3 scripts/orchestration/task_bootstrap.py --goal "Post-open review lane for PR 1576 Cloudflare static assets and Tailwind CSS pipeline" --task-class "Design" --pr-phase post_open_review` (PASS; packet `f162f381fb48`)
 - `cd frontend && npm run build` (PASS)
 - `cd frontend && npm run smoke:css` (PASS)
-- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pytest -q tests/test_deploy_contract_scripts.py -k 'diagnose_web'` (PASS; 8 passed)
-- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` (PASS; no Python files changed)
-- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pre-commit run --all-files` (PASS)
+- `pytest -q tests/test_deploy_contract_scripts.py -k 'diagnose_web'` (PASS; 8 passed)
+- `make validate-changed` with `VENV_PYTHON` set to the repo virtualenv Python (PASS; no Python files changed)
+- `pre-commit run --all-files` from the repo virtualenv (PASS)
 - Pre-push hooks: backend pre-push pytest, full-repo Bandit, docker build test (PASS)
 - Local preview static CSS: `http://127.0.0.1:4174/assets/index-D42ApsRM.css` returned `200` with `Content-Type: text/css`
 - Live baseline before operator Access bypass: `curl -I https://pulseplate.app/assets/index-BN60ERUL.css` returned `302` to `pulseplate.cloudflareaccess.com`
 - `cd frontend && npm run build && npm run smoke:css` after review fixes (PASS)
-- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pytest -q tests/test_deploy_contract_scripts.py -k 'diagnose_web'` after review fixes (PASS; 8 passed)
-- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` after review fixes (PASS)
-- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pre-commit run --all-files` after review fixes (PASS after Black hook formatting was committed)
+- `pytest -q tests/test_deploy_contract_scripts.py -k 'diagnose_web'` after review fixes (PASS; 8 passed)
+- `make validate-changed` with `VENV_PYTHON` set to the repo virtualenv Python after review fixes (PASS)
+- `pre-commit run --all-files` from the repo virtualenv after review fixes (PASS after Black hook formatting was committed)
 
 ## Merge Readiness
 

--- a/docs/review/PR_1576_FIXED_MAPPING.md
+++ b/docs/review/PR_1576_FIXED_MAPPING.md
@@ -11,7 +11,18 @@ Date: 2026-04-29
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#pullrequestreview-4198402760 -> 164959779
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162190364 -> 164959779
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#pullrequestreview-4198416972 -> 164959779
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162202726 -> 164959779
+
+Disposition: FIXED
+Commit: 164959779
+Evidence: `frontend/scripts/check-tailwind-utilities.mjs` now uses `fileURLToPath(...)` before joining the built CSS bundle path, making the smoke script cross-platform.
+
+Disposition: FIXED
+Commit: 164959779
+Evidence: `scripts/diagnose_web.sh` now probes root HTML and `/assets/*.css` with `--no-access-headers`, preserving anonymous public CSS validation even when private Cloudflare Access service-token env vars are present; `tests/test_deploy_contract_scripts.py` asserts CSS probes do not receive `CF-Access-Client-*` headers.
 
 ## Implementation Evidence
 
@@ -41,6 +52,10 @@ Evidence: `docs/deploy/CLOUDFLARE.md`, `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md
 - Pre-push hooks: backend pre-push pytest, full-repo Bandit, docker build test (PASS)
 - Local preview static CSS: `http://127.0.0.1:4174/assets/index-D42ApsRM.css` returned `200` with `Content-Type: text/css`
 - Live baseline before operator Access bypass: `curl -I https://pulseplate.app/assets/index-BN60ERUL.css` returned `302` to `pulseplate.cloudflareaccess.com`
+- `cd frontend && npm run build && npm run smoke:css` after review fixes (PASS)
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pytest -q tests/test_deploy_contract_scripts.py -k 'diagnose_web'` after review fixes (PASS; 8 passed)
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` after review fixes (PASS)
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pre-commit run --all-files` after review fixes (PASS after Black hook formatting was committed)
 
 ## Merge Readiness
 

--- a/docs/review/PR_1576_FIXED_MAPPING.md
+++ b/docs/review/PR_1576_FIXED_MAPPING.md
@@ -13,24 +13,27 @@ Date: 2026-04-29
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#pullrequestreview-4198402760 -> 164959779
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162190364 -> 164959779
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#pullrequestreview-4198416972 -> 164959779
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162202726 -> 164959779
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#pullrequestreview-4198438962 -> cb7f924ae
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162223716 -> cb7f924ae
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162223768 -> cb7f924ae
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162223775 -> 164959779
-
 Disposition: FIXED
 Commit: 164959779
 Evidence: `frontend/scripts/check-tailwind-utilities.mjs` now uses `fileURLToPath(...)` before joining the built CSS bundle path, making the smoke script cross-platform.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#pullrequestreview-4198416972 -> 164959779
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162202726 -> 164959779
 Disposition: FIXED
 Commit: 164959779
 Evidence: `scripts/diagnose_web.sh` now probes root HTML and `/assets/*.css` with `--no-access-headers`, preserving anonymous public CSS validation even when private Cloudflare Access service-token env vars are present; `tests/test_deploy_contract_scripts.py` asserts CSS probes do not receive `CF-Access-Client-*` headers.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#pullrequestreview-4198438962 -> cb7f924ae
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162223716 -> cb7f924ae
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162223768 -> cb7f924ae
 Disposition: FIXED
 Commit: cb7f924ae
 Evidence: `docs/deploy/SPA_APEX_ROUTING_CONTRACT.md` now states the public bypass is limited to `GET` and `HEAD` only; `docs/review/PR_1576_FIXED_MAPPING.md` now uses portable evidence commands instead of machine-specific absolute paths.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1576#discussion_r3162223775 -> 164959779
+Disposition: FIXED
+Commit: 164959779
+Evidence: `frontend/scripts/check-tailwind-utilities.mjs` had already been updated in commit `164959779` to use `fileURLToPath(...)`; CodeRabbit confirmed this thread was addressed by commits `1649597` to `daf433d`.
 
 ## Implementation Evidence
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "smoke:css": "node ./scripts/check-tailwind-utilities.mjs",
     "tokens:build": "node ./scripts/build-tokens.mjs",
     "tokens:check": "node ./scripts/build-tokens.mjs --check",
     "storybook": "storybook dev -p 6006",

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/scripts/check-tailwind-utilities.mjs
+++ b/frontend/scripts/check-tailwind-utilities.mjs
@@ -1,0 +1,30 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const cssDirectory = new URL("../dist/assets/", import.meta.url);
+const requiredSelectors = [".grid", ".min-h-screen", ".rounded-2xl"];
+
+async function findBuiltCssFile() {
+  const files = await readdir(cssDirectory);
+  const cssFiles = files.filter((fileName) => /^index-.*\.css$/.test(fileName)).sort();
+
+  if (cssFiles.length === 0) {
+    throw new Error("No built frontend CSS bundle found in dist/assets.");
+  }
+
+  return join(cssDirectory.pathname, cssFiles[cssFiles.length - 1]);
+}
+
+const cssFile = await findBuiltCssFile();
+const css = await readFile(cssFile, "utf8");
+const missingSelectors = requiredSelectors.filter((selector) => {
+  return !css.includes(selector);
+});
+
+if (missingSelectors.length > 0) {
+  throw new Error(
+    `Built CSS bundle is missing Tailwind selectors: ${missingSelectors.join(", ")}`
+  );
+}
+
+console.log(`PASS: Tailwind utility selectors found in ${cssFile}`);

--- a/frontend/scripts/check-tailwind-utilities.mjs
+++ b/frontend/scripts/check-tailwind-utilities.mjs
@@ -1,18 +1,20 @@
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const cssDirectory = new URL("../dist/assets/", import.meta.url);
+const cssDirectoryUrl = new URL("../dist/assets/", import.meta.url);
+const cssDirectoryPath = fileURLToPath(cssDirectoryUrl);
 const requiredSelectors = [".grid", ".min-h-screen", ".rounded-2xl"];
 
 async function findBuiltCssFile() {
-  const files = await readdir(cssDirectory);
+  const files = await readdir(cssDirectoryPath);
   const cssFiles = files.filter((fileName) => /^index-.*\.css$/.test(fileName)).sort();
 
   if (cssFiles.length === 0) {
     throw new Error("No built frontend CSS bundle found in dist/assets.");
   }
 
-  return join(cssDirectory.pathname, cssFiles[cssFiles.length - 1]);
+  return join(cssDirectoryPath, cssFiles[cssFiles.length - 1]);
 }
 
 const cssFile = await findBuiltCssFile();

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,6 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 @media (prefers-reduced-motion: reduce) {
   * { animation: none !important; transition: none !important; }

--- a/scripts/diagnose_web.sh
+++ b/scripts/diagnose_web.sh
@@ -220,6 +220,61 @@ assert_html_200() {
     pass "${label}: ${path} serves the SPA shell with HTTP 200."
 }
 
+assert_public_css_asset() {
+    local label="$1"
+    local root_probe=""
+    root_probe="$(curl_probe "${label}-root" "${BASE_URL}/")" || {
+        fail "${label}: request to ${BASE_URL}/ failed."
+        return
+    }
+
+    IFS='|' read -r root_status _root_content_type _root_headers root_body_file <<<"${root_probe}"
+    if [[ "${root_status}" != "200" ]]; then
+        fail "${label}: expected root HTML HTTP 200 before CSS discovery, got ${root_status}."
+        return
+    fi
+
+    local css_path=""
+    css_path="$(
+        awk '
+            match($0, /href="[^"]*\/assets\/[^"]+\.css"/) {
+                css = substr($0, RSTART + 6, RLENGTH - 7)
+                print css
+                exit
+            }
+        ' "${root_body_file}"
+    )"
+    if [[ -z "${css_path}" ]]; then
+        fail "${label}: root HTML did not reference a Vite CSS asset under /assets/."
+        return
+    fi
+
+    local css_probe=""
+    css_probe="$(curl_probe "${label}" "${BASE_URL}${css_path}")" || {
+        fail "${label}: request to ${BASE_URL}${css_path} failed."
+        return
+    }
+
+    IFS='|' read -r status content_type headers_file body_file <<<"${css_probe}"
+    if grep -Eiq 'location: .*cloudflareaccess\.com' "${headers_file}"; then
+        fail "${label}: ${css_path} redirected to Cloudflare Access instead of public CSS."
+        return
+    fi
+    if [[ "${status}" != "200" ]]; then
+        fail "${label}: expected HTTP 200 for ${css_path}, got ${status}."
+        return
+    fi
+    if [[ "${content_type}" != text/css* ]]; then
+        fail "${label}: expected text/css for ${css_path}, got '${content_type:-<empty>}' ."
+        return
+    fi
+    if grep -Eiq 'cloudflare access|cf-access|/cdn-cgi/access' "${body_file}"; then
+        fail "${label}: ${css_path} body looks like a Cloudflare Access page."
+        return
+    fi
+    pass "${label}: ${css_path} is public CSS with HTTP 200."
+}
+
 assert_json_200() {
     local label="$1"
     local path="$2"
@@ -407,6 +462,7 @@ run_http_probes() {
     assert_html_200 "spa-profile" "/profile"
     assert_html_200 "spa-plate" "/plate"
     assert_html_200 "spa-progress" "/progress"
+    assert_public_css_asset "static-css"
 
     assert_json_200 "health-json" "/health"
     assert_json_backend "openapi-json" "/openapi.json"

--- a/scripts/diagnose_web.sh
+++ b/scripts/diagnose_web.sh
@@ -155,6 +155,12 @@ curl_probe() {
     local name="$1"
     local url="$2"
     shift 2
+    local use_access_headers=1
+
+    if [[ "${1:-}" == "--no-access-headers" ]]; then
+        use_access_headers=0
+        shift
+    fi
 
     local headers_file="${tmp_dir}/${name}.headers"
     local body_file="${tmp_dir}/${name}.body"
@@ -169,7 +175,7 @@ curl_probe() {
         -w '%{http_code}'
     )
 
-    if [[ "${ACCESS_HEADERS_ENABLED}" -eq 1 ]]; then
+    if [[ "${ACCESS_HEADERS_ENABLED}" -eq 1 && "${use_access_headers}" -eq 1 ]]; then
         curl_args+=("${ACCESS_CURL_HEADERS[@]}")
     fi
 
@@ -223,7 +229,7 @@ assert_html_200() {
 assert_public_css_asset() {
     local label="$1"
     local root_probe=""
-    root_probe="$(curl_probe "${label}-root" "${BASE_URL}/")" || {
+    root_probe="$(curl_probe "${label}-root" "${BASE_URL}/" --no-access-headers)" || {
         fail "${label}: request to ${BASE_URL}/ failed."
         return
     }
@@ -250,7 +256,7 @@ assert_public_css_asset() {
     fi
 
     local css_probe=""
-    css_probe="$(curl_probe "${label}" "${BASE_URL}${css_path}")" || {
+    css_probe="$(curl_probe "${label}" "${BASE_URL}${css_path}" --no-access-headers)" || {
         fail "${label}: request to ${BASE_URL}${css_path} failed."
         return
     }
@@ -264,10 +270,13 @@ assert_public_css_asset() {
         fail "${label}: expected HTTP 200 for ${css_path}, got ${status}."
         return
     fi
-    if [[ "${content_type}" != text/css* ]]; then
-        fail "${label}: expected text/css for ${css_path}, got '${content_type:-<empty>}' ."
-        return
-    fi
+    case "${content_type}" in
+        text/css*) ;;
+        *)
+            fail "${label}: expected text/css for ${css_path}, got '${content_type:-<empty>}' ."
+            return
+            ;;
+    esac
     if grep -Eiq 'cloudflare access|cf-access|/cdn-cgi/access' "${body_file}"; then
         fail "${label}: ${css_path} body looks like a Cloudflare Access page."
         return

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -1518,7 +1518,12 @@ case "$method:$url" in
   GET:https://pulseplate.test/|GET:https://pulseplate.test/bmi|GET:https://pulseplate.test/profile|GET:https://pulseplate.test/plate|GET:https://pulseplate.test/progress)
     status="200"
     content_type="text/html; charset=utf-8"
-    payload='<!doctype html><html><body><div id="root"></div></body></html>'
+    payload='<!doctype html><html><head><link rel="stylesheet" href="/assets/index-test.css"></head><body><div id="root"></div></body></html>'
+    ;;
+  GET:https://pulseplate.test/assets/index-test.css)
+    status="200"
+    content_type="text/css"
+    payload='.grid{display:grid}.min-h-screen{min-height:100vh}.rounded-2xl{border-radius:1rem}'
     ;;
   GET:https://pulseplate.test/health|GET:https://pulseplate.test/openapi.json)
     status="200"
@@ -1588,6 +1593,9 @@ printf '%s' "$status"
     )
 
     assert "PASS: spa-bmi: /bmi serves the SPA shell with HTTP 200." in completed.stdout
+    assert (
+        "PASS: static-css: /assets/index-test.css is public CSS with HTTP 200." in completed.stdout
+    )
     assert "PASS: health-json: /health reaches the JSON backend surface." in completed.stdout
     assert "PASS: sitemap-xml: /sitemap.xml reaches the XML sitemap surface." in completed.stdout
     assert (
@@ -1657,7 +1665,12 @@ case "$method:$url" in
   GET:https://pulseplate.test/|GET:https://pulseplate.test/bmi|GET:https://pulseplate.test/profile|GET:https://pulseplate.test/plate|GET:https://pulseplate.test/progress)
     status="200"
     content_type="text/html; charset=utf-8"
-    payload='<!doctype html><html><body><div id="root"></div></body></html>'
+    payload='<!doctype html><html><head><link rel="stylesheet" href="/assets/index-test.css"></head><body><div id="root"></div></body></html>'
+    ;;
+  GET:https://pulseplate.test/assets/index-test.css)
+    status="200"
+    content_type="text/css"
+    payload='.grid{{display:grid}}.min-h-screen{{min-height:100vh}}.rounded-2xl{{border-radius:1rem}}'
     ;;
   GET:https://pulseplate.test/health|GET:https://pulseplate.test/openapi.json)
     status="200"
@@ -1779,7 +1792,12 @@ case "$method:$url" in
   GET:https://pulseplate.test/|GET:https://pulseplate.test/bmi|GET:https://pulseplate.test/profile|GET:https://pulseplate.test/plate|GET:https://pulseplate.test/progress)
     status="200"
     content_type="text/html; charset=utf-8"
-    payload='<!doctype html><html><body><div id="root"></div></body></html>'
+    payload='<!doctype html><html><head><link rel="stylesheet" href="/assets/index-test.css"></head><body><div id="root"></div></body></html>'
+    ;;
+  GET:https://pulseplate.test/assets/index-test.css)
+    status="200"
+    content_type="text/css"
+    payload='.grid{display:grid}.min-h-screen{min-height:100vh}.rounded-2xl{border-radius:1rem}'
     ;;
   GET:https://pulseplate.test/health|GET:https://pulseplate.test/openapi.json)
     status="200"

--- a/tests/test_deploy_contract_scripts.py
+++ b/tests/test_deploy_contract_scripts.py
@@ -1744,6 +1744,13 @@ printf '%s' "$status"
     log_output = log_file.read_text(encoding="utf-8")
     assert "-H CF-Access-Client-Id: client-id" in log_output
     assert "-H CF-Access-Client-Secret: client-secret" in log_output
+    static_css_calls = [
+        line
+        for line in log_output.splitlines()
+        if "https://pulseplate.test/assets/index-test.css" in line
+    ]
+    assert static_css_calls
+    assert all("CF-Access-Client-" not in line for line in static_css_calls)
     assert (
         "PASS: Cloudflare Access service-token headers enabled for private probes."
         in completed.stdout


### PR DESCRIPTION
## Summary

Coordinator-first technical recovery slice for `pulseplate.app` styling:

- restore Tailwind/PostCSS utility generation in the frontend production CSS bundle
- add a deterministic frontend CSS bundle smoke (`npm run smoke:css`)
- wire the smoke into Frontend CI after `npm run build`
- extend `scripts/diagnose_web.sh` so edge diagnostics fail when the hashed `/assets/*.css` bundle redirects to Cloudflare Access or is not `200 text/css`
- tighten Cloudflare/public-reopen docs around narrow GET/HEAD static shell bypass only

Out of scope for this PR:

- homepage/GTM redesign
- Figma writes
- Cloudflare dashboard/API mutation
- widening public access for `/api*`, `/admin*`, `/ws*`, `/openapi.json`, `/health*`, or docs/debug surfaces

## Coordinator / Role Order

- `agent-coordinator` via `task_bootstrap.py` packet: `75e3d405a59d`
- `creative-designer`
- `senior-frontend-developer`
- `senior-cybersecurity-specialist`
- `qa-engineer-agent`
- `bug-hunter`

Post-open packet: `f162f381fb48`.
Sidecar review notes were applied from frontend/QA and security review agents.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1576_FIXED_MAPPING.md`

## Validation

Local gates run:

- `python3 scripts/orchestration/check_preflight.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `cd frontend && npm run build` PASS
- `cd frontend && npm run smoke:css` PASS
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pytest -q tests/test_deploy_contract_scripts.py -k 'diagnose_web'` PASS (`8 passed`)
- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` PASS (`No Python files changed`)
- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pre-commit run --all-files` PASS
- pre-push hooks PASS, including backend pre-push pytest, full-repo Bandit, and docker build test

Browser/local static smoke:

- `npm run preview -- --host 127.0.0.1 --port 4174`
- local built CSS returned `HTTP/1.1 200 OK` and `Content-Type: text/css`
- Browser-use local preview loaded `PulsePlate Frontend` / `PulsePlate Home`

Live baseline remains intentionally red until operator-approved Cloudflare Access bypass:

- `curl -I https://pulseplate.app/assets/index-BN60ERUL.css` currently returns `HTTP/2 302` to `pulseplate.cloudflareaccess.com`

## Security Notes

This PR does not disable Cloudflare Access globally. It documents and tests the intended narrow public shell/static asset behavior only. `/api*`, `/admin*`, private probes, and service-token verification remain protected by the documented contract.

## Deferred / Follow-ups

- After merge/deploy, operator applies the narrow Cloudflare Access bypass for public shell/static GET/HEAD paths.
- Next PR slice handles public launch homepage/GTM redesign once CSS delivery is stable.

## Merge Readiness

Draft until current-head GitHub CI and post-open review lane complete.

## Summary by Sourcery

Восстановить надёжную генерацию Tailwind CSS и проверки доставки публичных статических ресурсов для фронтенда, а также подключить их к диагностике, CI и документации по деплою.

New Features:
- Добавить скрипт smoke‑теста CSS для фронтенда, который проверяет наличие необходимых утилитарных селекторов Tailwind в собранном бандле и сделать его доступным через npm‑скрипт.
- Ввести HTTP‑диагностику, которая находит публичный CSS‑ресурс из SPA‑оболочки и проверяет, что он отдается с ответом 200 и типом `text/css` без вмешательства Cloudflare Access.

Enhancements:
- Включить Tailwind base, components и utilities в основной файл стилей фронтенда через конфигурацию PostCSS.
- Расширить скрипт диагностики деплоя, чтобы он проверял публичный CSS‑ресурс, и обновить существующие тесты для покрытия нового поведения проверки.

CI:
- Запускать новый smoke‑тест Tailwind CSS в CI‑воркфлоу фронтенда после шага сборки.

Documentation:
- Уточнить рекомендации по повторному открытию доступа через Cloudflare Access, требуя обхода, ограниченного методами GET/HEAD, и успешных ответов для публичных CSS‑ресурсов под путём `/assets/`.
- Обновить воркфлоу деплоя и эксплуатационные runbook’и явными проверками того, что хэшированные CSS‑ресурсы при повторном открытии и восстановлении отдают 200 с типом `text/css`.

Tests:
- Расширить контрактные тесты `diagnose_web`, чтобы они покрывали проверку CSS‑ресурсов и гарантировали, что новая диагностика статических CSS корректно сообщает состояния pass/fail.

Chores:
- Добавить артефакт ревью с фиксированным отображением, документирующий прохождение треда обсуждения и подтверждающие материалы для этого PR.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore reliable Tailwind CSS generation and public static asset delivery checks for the frontend, and wire them into diagnostics, CI, and deployment documentation.

New Features:
- Add a frontend CSS smoke test script that validates required Tailwind utility selectors in the built bundle and expose it via an npm script.
- Introduce an HTTP diagnostic that discovers the public CSS asset from the SPA shell and verifies it is served as a 200 text/css response without Cloudflare Access interference.

Enhancements:
- Enable Tailwind base, components, and utilities in the main frontend stylesheet via PostCSS configuration.
- Extend the deployment diagnose script to check the public CSS asset and update existing tests to cover the new probe behavior.

CI:
- Run the new Tailwind CSS smoke test in the frontend CI workflow after the build step.

Documentation:
- Clarify Cloudflare Access reopen guidance to require method-scoped GET/HEAD bypasses and successful public CSS asset responses under /assets/.
- Update deployment workflow and production runbooks with explicit checks for hashed CSS assets returning 200 text/css during reopen and recovery.

Tests:
- Expand diagnose_web contract tests to cover CSS asset probing and ensure the new static CSS diagnostics report pass/fail states correctly.

Chores:
- Add a fixed-mapping review artifact documenting the discussion-thread pass and evidence for this PR.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a frontend CSS smoke check to CI and integrated PostCSS/Tailwind processing to validate built utilities after each build.

* **Tests**
  * Updated diagnostic tests to verify public CSS asset availability, correct text/css responses, and that static probes do not send access headers.

* **Documentation**
  * Clarified deployment runbooks and SPA routing contract with concrete CSS-asset validation criteria and scoped public-access bypass guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->