### PR TITLE
feat(food-data): add JPTN identity license gate

### DIFF
--- a/core/food_sources/jptn_identity.py
+++ b/core/food_sources/jptn_identity.py
@@ -62,6 +62,12 @@ _IDENTITY_GATE_KEYS = frozenset(
         "notes",
     }
 )
+_CANONICAL_BLOCKING_REASONS = (
+    "Exact provider identity is not confirmed.",
+    "Canonical source URL and retrieval contract are not confirmed.",
+    "License, attribution, redistribution, and cache rights are not confirmed.",
+    "Schema, primary keys, units, locale, and normalization contract are not confirmed.",
+)
 
 JPTN_SOURCE = "jptn_food_facts"
 BLOCKED_GATE_DECISION = "blocked_until_verified"
@@ -338,6 +344,11 @@ def parse_jptn_identity_gate(
         )
     if gate.final_gate_decision != BLOCKED_GATE_DECISION:
         raise _identity_error(context, f"final_gate_decision must be {BLOCKED_GATE_DECISION}")
+    if gate.blocking_reasons != _CANONICAL_BLOCKING_REASONS:
+        raise _identity_error(
+            context,
+            "blocking_reasons must match the canonical unresolved evidence set",
+        )
 
     _validate_jptn_catalog_policy(_catalog_jptn_entry(catalog, context), context)
     _validate_jptn_onboarding_policy(_onboarding_jptn_entry(onboarding, context), context)

--- a/core/food_sources/jptn_identity.py
+++ b/core/food_sources/jptn_identity.py
@@ -1,0 +1,385 @@
+"""
+Deterministic JPTN source identity and license gate.
+
+RU: Файловая проверка статуса JPTN до допуска к preflight или ingest.
+EN: File-only JPTN status check before preflight eligibility or ingest.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+import json
+from pathlib import Path
+import re
+
+from core.food_sources.source_catalog import (
+    SourceCatalog,
+    SourceCatalogError,
+    SourceCatalogEntry,
+    load_source_catalog,
+)
+from core.food_sources.source_onboarding import (
+    SourceOnboarding,
+    SourceOnboardingEntry,
+    SourceOnboardingError,
+    load_source_onboarding,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_IDENTITY_SCHEMA_RE = re.compile(r"^food-data-jptn-identity\.v\d+$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_SAFETY_FLAG_TEMPLATE: dict[str, bool] = {
+    "runtime_cutover": False,
+    "digitalocean_postgres_load": False,
+    "bulk_ingest": False,
+    "file_only": True,
+    "network_allowed": False,
+    "db_writes_allowed": False,
+}
+
+JPTN_SOURCE = "jptn_food_facts"
+BLOCKED_GATE_DECISION = "blocked_until_verified"
+
+
+class JptnIdentityError(ValueError):
+    """Raised when the JPTN identity/license gate is invalid."""
+
+
+@dataclass(frozen=True)
+class JptnIdentityGate:
+    """Validated JPTN identity/license decision artifact."""
+
+    schema_version: str
+    generated_on: date
+    source: str
+    catalog_ref: str
+    onboarding_ref: str
+    runtime_cutover: bool
+    digitalocean_postgres_load: bool
+    bulk_ingest: bool
+    file_only: bool
+    network_allowed: bool
+    db_writes_allowed: bool
+    provider_identity_status: str
+    source_url_evidence_status: str
+    license_status: str
+    retrieval_contract_status: str
+    schema_unit_normalization_status: str
+    attribution_redistribution_status: str
+    final_gate_decision: str
+    blocking_reasons: tuple[str, ...]
+    reviewed_queries: tuple[str, ...]
+    notes: str
+
+
+def _identity_error(context: str, detail: str) -> JptnIdentityError:
+    return JptnIdentityError(f"Invalid JPTN identity gate {context}: {detail}")
+
+
+def _require_mapping(value: object, context: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise _identity_error(context, "must be an object")
+    result: dict[str, object] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise _identity_error(context, "all object keys must be strings")
+        result[key] = item
+    return result
+
+
+def _require_string(data: dict[str, object], key: str, context: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise _identity_error(context, f"missing non-empty string '{key}'")
+    return value.strip()
+
+
+def _require_bool(data: dict[str, object], key: str, context: str) -> bool:
+    value = data.get(key)
+    if not isinstance(value, bool):
+        raise _identity_error(context, f"'{key}' must be a boolean")
+    return value
+
+
+def _require_string_tuple(
+    data: dict[str, object],
+    key: str,
+    context: str,
+) -> tuple[str, ...]:
+    value = data.get(key)
+    if not isinstance(value, list):
+        raise _identity_error(context, f"'{key}' must be a list of strings")
+    items: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise _identity_error(context, f"'{key}[{index}]' must be a non-empty string")
+        normalized = item.strip()
+        if normalized in seen:
+            raise _identity_error(context, f"'{key}' contains duplicate value {normalized!r}")
+        seen.add(normalized)
+        items.append(normalized)
+    if not items:
+        raise _identity_error(context, f"'{key}' must not be empty")
+    return tuple(items)
+
+
+def _parse_date(value: str, context: str) -> date:
+    if not _DATE_RE.fullmatch(value):
+        raise _identity_error(context, "generated_on must use YYYY-MM-DD")
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise _identity_error(context, "generated_on must use YYYY-MM-DD") from exc
+
+
+def _require_safety_flags(data: dict[str, object], context: str) -> dict[str, bool]:
+    return {key: _require_bool(data, key, context) for key in _SAFETY_FLAG_TEMPLATE}
+
+
+def _relative_repo_path(path: Path | str) -> str:
+    resolved = Path(path).resolve()
+    try:
+        return resolved.relative_to(_REPO_ROOT).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
+def _catalog_jptn_entry(catalog: SourceCatalog, context: str) -> SourceCatalogEntry:
+    entries = {entry.source: entry for entry in catalog.sources}
+    entry = entries.get(JPTN_SOURCE)
+    if entry is None:
+        raise _identity_error(context, f"catalog must include {JPTN_SOURCE}")
+    return entry
+
+
+def _onboarding_jptn_entry(
+    onboarding: SourceOnboarding,
+    context: str,
+) -> SourceOnboardingEntry:
+    entries = {entry.source: entry for entry in onboarding.sources}
+    entry = entries.get(JPTN_SOURCE)
+    if entry is None:
+        raise _identity_error(context, f"onboarding must include {JPTN_SOURCE}")
+    return entry
+
+
+def _validate_jptn_catalog_policy(entry: SourceCatalogEntry, context: str) -> None:
+    if entry.source_classification != "unresolved":
+        raise _identity_error(context, "JPTN must remain source_classification=unresolved")
+    if entry.source_family != "unresolved":
+        raise _identity_error(context, "JPTN must remain source_family=unresolved")
+    if entry.status != "blocked_unresolved":
+        raise _identity_error(context, "JPTN must remain blocked_unresolved in catalog")
+    if entry.license_review != "unresolved_required":
+        raise _identity_error(context, "JPTN must require unresolved license review")
+    if entry.active_update_source:
+        raise _identity_error(context, "JPTN cannot be an active update source")
+
+
+def _validate_jptn_onboarding_policy(entry: SourceOnboardingEntry, context: str) -> None:
+    expected: dict[str, object] = {
+        "source_classification": "unresolved",
+        "source_family": "unresolved",
+        "onboarding_status": "unresolved_blocked",
+        "ingestion_path": "unresolved_identity_required",
+        "cache_decision": "blocked_unresolved",
+        "redistribution_decision": "blocked_unresolved",
+        "display_decision": "blocked_unresolved",
+        "attribution_required": True,
+        "commercial_risk": "unresolved",
+        "provider_policy_ref": None,
+        "source_specific_policy_required": True,
+    }
+    actual: dict[str, object] = {
+        "source_classification": entry.source_classification,
+        "source_family": entry.source_family,
+        "onboarding_status": entry.onboarding_status,
+        "ingestion_path": entry.ingestion_path,
+        "cache_decision": entry.cache_decision,
+        "redistribution_decision": entry.redistribution_decision,
+        "display_decision": entry.display_decision,
+        "attribution_required": entry.attribution_required,
+        "commercial_risk": entry.commercial_risk,
+        "provider_policy_ref": entry.provider_policy_ref,
+        "source_specific_policy_required": entry.source_specific_policy_required,
+    }
+    mismatches = [key for key, value in expected.items() if actual[key] != value]
+    if mismatches:
+        joined = ", ".join(mismatches)
+        raise _identity_error(context, f"JPTN onboarding must remain blocked: {joined}")
+
+
+def parse_jptn_identity_gate(
+    payload: object,
+    *,
+    catalog: SourceCatalog,
+    onboarding: SourceOnboarding,
+    expected_catalog_ref: str | None = None,
+    expected_onboarding_ref: str | None = None,
+    context: str = "<jptn-identity>",
+) -> JptnIdentityGate:
+    """Parse and validate the JPTN source identity/license gate."""
+    data = _require_mapping(payload, context)
+    schema_version = _require_string(data, "schema_version", context)
+    if not _IDENTITY_SCHEMA_RE.fullmatch(schema_version):
+        raise _identity_error(context, "schema_version must look like food-data-jptn-identity.vN")
+
+    source = _require_string(data, "source", context)
+    if source != JPTN_SOURCE:
+        raise _identity_error(context, f"source must be {JPTN_SOURCE!r}")
+
+    catalog_ref = _require_string(data, "catalog_ref", context)
+    if expected_catalog_ref is not None and catalog_ref != expected_catalog_ref:
+        raise _identity_error(context, f"catalog_ref must be {expected_catalog_ref!r}")
+    onboarding_ref = _require_string(data, "onboarding_ref", context)
+    if expected_onboarding_ref is not None and onboarding_ref != expected_onboarding_ref:
+        raise _identity_error(context, f"onboarding_ref must be {expected_onboarding_ref!r}")
+
+    safety_flags = _require_safety_flags(data, context)
+    if safety_flags != _SAFETY_FLAG_TEMPLATE:
+        raise _identity_error(
+            context,
+            "runtime_cutover, digitalocean_postgres_load, bulk_ingest, "
+            "network_allowed, and db_writes_allowed must be false; file_only must be true",
+        )
+
+    gate = JptnIdentityGate(
+        schema_version=schema_version,
+        generated_on=_parse_date(_require_string(data, "generated_on", context), context),
+        source=source,
+        catalog_ref=catalog_ref,
+        onboarding_ref=onboarding_ref,
+        runtime_cutover=safety_flags["runtime_cutover"],
+        digitalocean_postgres_load=safety_flags["digitalocean_postgres_load"],
+        bulk_ingest=safety_flags["bulk_ingest"],
+        file_only=safety_flags["file_only"],
+        network_allowed=safety_flags["network_allowed"],
+        db_writes_allowed=safety_flags["db_writes_allowed"],
+        provider_identity_status=_require_string(data, "provider_identity_status", context),
+        source_url_evidence_status=_require_string(data, "source_url_evidence_status", context),
+        license_status=_require_string(data, "license_status", context),
+        retrieval_contract_status=_require_string(data, "retrieval_contract_status", context),
+        schema_unit_normalization_status=_require_string(
+            data,
+            "schema_unit_normalization_status",
+            context,
+        ),
+        attribution_redistribution_status=_require_string(
+            data,
+            "attribution_redistribution_status",
+            context,
+        ),
+        final_gate_decision=_require_string(data, "final_gate_decision", context),
+        blocking_reasons=_require_string_tuple(data, "blocking_reasons", context),
+        reviewed_queries=_require_string_tuple(data, "reviewed_queries", context),
+        notes=_require_string(data, "notes", context),
+    )
+    if gate.provider_identity_status != "not_verified":
+        raise _identity_error(context, "provider_identity_status must be not_verified")
+    if gate.source_url_evidence_status != "no_confirmed_public_source":
+        raise _identity_error(
+            context,
+            "source_url_evidence_status must be no_confirmed_public_source",
+        )
+    if gate.license_status != "missing":
+        raise _identity_error(context, "license_status must be missing")
+    if gate.retrieval_contract_status != "missing":
+        raise _identity_error(context, "retrieval_contract_status must be missing")
+    if gate.schema_unit_normalization_status != "missing":
+        raise _identity_error(context, "schema_unit_normalization_status must be missing")
+    if gate.attribution_redistribution_status != "blocked_pending_license":
+        raise _identity_error(
+            context,
+            "attribution_redistribution_status must be blocked_pending_license",
+        )
+    if gate.final_gate_decision != BLOCKED_GATE_DECISION:
+        raise _identity_error(context, f"final_gate_decision must be {BLOCKED_GATE_DECISION}")
+
+    _validate_jptn_catalog_policy(_catalog_jptn_entry(catalog, context), context)
+    _validate_jptn_onboarding_policy(_onboarding_jptn_entry(onboarding, context), context)
+    return gate
+
+
+def load_jptn_identity_gate(
+    identity_path: Path | str,
+    *,
+    catalog: SourceCatalog,
+    onboarding: SourceOnboarding,
+    expected_catalog_ref: str | None = None,
+    expected_onboarding_ref: str | None = None,
+) -> JptnIdentityGate:
+    """Load and validate a JPTN identity/license JSON artifact."""
+    path = Path(identity_path)
+    try:
+        with path.open("r", encoding="utf-8") as file_obj:
+            payload: object = json.load(file_obj)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise JptnIdentityError(f"Cannot read JPTN identity gate {path}: {exc}") from exc
+    return parse_jptn_identity_gate(
+        payload,
+        catalog=catalog,
+        onboarding=onboarding,
+        expected_catalog_ref=expected_catalog_ref,
+        expected_onboarding_ref=expected_onboarding_ref,
+        context=str(path),
+    )
+
+
+def build_jptn_identity_report(
+    *,
+    catalog_path: Path | str,
+    onboarding_path: Path | str,
+    identity_path: Path | str,
+) -> dict[str, object]:
+    """Build a deterministic JSON report for the JPTN identity gate."""
+    expected_catalog_ref = _relative_repo_path(catalog_path)
+    expected_onboarding_ref = _relative_repo_path(onboarding_path)
+    report: dict[str, object] = {
+        "success": False,
+        "dry_run": True,
+        "source": JPTN_SOURCE,
+        "runtime_cutover": False,
+        "digitalocean_postgres_load": False,
+        "bulk_ingest": False,
+        "file_only": True,
+        "network_allowed": False,
+        "db_writes_allowed": False,
+        "final_gate_decision": BLOCKED_GATE_DECISION,
+        "validation_errors": [],
+    }
+    try:
+        catalog = load_source_catalog(catalog_path)
+        onboarding = load_source_onboarding(
+            onboarding_path,
+            catalog=catalog,
+            expected_catalog_ref=expected_catalog_ref,
+        )
+        gate = load_jptn_identity_gate(
+            identity_path,
+            catalog=catalog,
+            onboarding=onboarding,
+            expected_catalog_ref=expected_catalog_ref,
+            expected_onboarding_ref=expected_onboarding_ref,
+        )
+    except (JptnIdentityError, SourceCatalogError, SourceOnboardingError) as exc:
+        report["validation_errors"] = [str(exc)]
+        return report
+
+    report.update(
+        {
+            "success": True,
+            "catalog_ref": gate.catalog_ref,
+            "onboarding_ref": gate.onboarding_ref,
+            "provider_identity_status": gate.provider_identity_status,
+            "source_url_evidence_status": gate.source_url_evidence_status,
+            "license_status": gate.license_status,
+            "retrieval_contract_status": gate.retrieval_contract_status,
+            "schema_unit_normalization_status": gate.schema_unit_normalization_status,
+            "attribution_redistribution_status": gate.attribution_redistribution_status,
+            "blocking_reasons": list(gate.blocking_reasons),
+            "reviewed_query_count": len(gate.reviewed_queries),
+        }
+    )
+    return report

--- a/core/food_sources/jptn_identity.py
+++ b/core/food_sources/jptn_identity.py
@@ -37,6 +37,31 @@ _SAFETY_FLAG_TEMPLATE: dict[str, bool] = {
     "network_allowed": False,
     "db_writes_allowed": False,
 }
+_IDENTITY_GATE_KEYS = frozenset(
+    {
+        "schema_version",
+        "generated_on",
+        "source",
+        "catalog_ref",
+        "onboarding_ref",
+        "runtime_cutover",
+        "digitalocean_postgres_load",
+        "bulk_ingest",
+        "file_only",
+        "network_allowed",
+        "db_writes_allowed",
+        "provider_identity_status",
+        "source_url_evidence_status",
+        "license_status",
+        "retrieval_contract_status",
+        "schema_unit_normalization_status",
+        "attribution_redistribution_status",
+        "final_gate_decision",
+        "blocking_reasons",
+        "reviewed_queries",
+        "notes",
+    }
+)
 
 JPTN_SOURCE = "jptn_food_facts"
 BLOCKED_GATE_DECISION = "blocked_until_verified"
@@ -234,6 +259,11 @@ def parse_jptn_identity_gate(
 ) -> JptnIdentityGate:
     """Parse and validate the JPTN source identity/license gate."""
     data = _require_mapping(payload, context)
+    unexpected_keys = sorted(set(data) - _IDENTITY_GATE_KEYS)
+    if unexpected_keys:
+        joined = ", ".join(unexpected_keys)
+        raise _identity_error(context, f"unexpected keys: {joined}")
+
     schema_version = _require_string(data, "schema_version", context)
     if not _IDENTITY_SCHEMA_RE.fullmatch(schema_version):
         raise _identity_error(context, "schema_version must look like food-data-jptn-identity.vN")

--- a/core/food_sources/jptn_identity.py
+++ b/core/food_sources/jptn_identity.py
@@ -74,10 +74,12 @@ class JptnIdentityGate:
 
 
 def _identity_error(context: str, detail: str) -> JptnIdentityError:
+    """Build a stable validation error for the current artifact context."""
     return JptnIdentityError(f"Invalid JPTN identity gate {context}: {detail}")
 
 
 def _require_mapping(value: object, context: str) -> dict[str, object]:
+    """Return an object mapping or fail closed on malformed JSON payloads."""
     if not isinstance(value, dict):
         raise _identity_error(context, "must be an object")
     result: dict[str, object] = {}
@@ -89,6 +91,7 @@ def _require_mapping(value: object, context: str) -> dict[str, object]:
 
 
 def _require_string(data: dict[str, object], key: str, context: str) -> str:
+    """Read a required non-empty string field from a validated object."""
     value = data.get(key)
     if not isinstance(value, str) or not value.strip():
         raise _identity_error(context, f"missing non-empty string '{key}'")
@@ -96,6 +99,7 @@ def _require_string(data: dict[str, object], key: str, context: str) -> str:
 
 
 def _require_bool(data: dict[str, object], key: str, context: str) -> bool:
+    """Read a required boolean field without truthy/falsy coercion."""
     value = data.get(key)
     if not isinstance(value, bool):
         raise _identity_error(context, f"'{key}' must be a boolean")
@@ -107,6 +111,7 @@ def _require_string_tuple(
     key: str,
     context: str,
 ) -> tuple[str, ...]:
+    """Read a required non-empty string list and reject duplicate values."""
     value = data.get(key)
     if not isinstance(value, list):
         raise _identity_error(context, f"'{key}' must be a list of strings")
@@ -126,6 +131,7 @@ def _require_string_tuple(
 
 
 def _parse_date(value: str, context: str) -> date:
+    """Parse the canonical YYYY-MM-DD artifact date format."""
     if not _DATE_RE.fullmatch(value):
         raise _identity_error(context, "generated_on must use YYYY-MM-DD")
     try:
@@ -135,10 +141,12 @@ def _parse_date(value: str, context: str) -> date:
 
 
 def _require_safety_flags(data: dict[str, object], context: str) -> dict[str, bool]:
+    """Extract all safety flags before comparing them with the gate template."""
     return {key: _require_bool(data, key, context) for key in _SAFETY_FLAG_TEMPLATE}
 
 
 def _relative_repo_path(path: Path | str) -> str:
+    """Normalize a path to the repo-relative form used by canonical artifacts."""
     resolved = Path(path).resolve()
     try:
         return resolved.relative_to(_REPO_ROOT).as_posix()
@@ -147,6 +155,7 @@ def _relative_repo_path(path: Path | str) -> str:
 
 
 def _catalog_jptn_entry(catalog: SourceCatalog, context: str) -> SourceCatalogEntry:
+    """Find the JPTN catalog entry required by the identity gate."""
     entries = {entry.source: entry for entry in catalog.sources}
     entry = entries.get(JPTN_SOURCE)
     if entry is None:
@@ -158,6 +167,7 @@ def _onboarding_jptn_entry(
     onboarding: SourceOnboarding,
     context: str,
 ) -> SourceOnboardingEntry:
+    """Find the JPTN onboarding entry required by the identity gate."""
     entries = {entry.source: entry for entry in onboarding.sources}
     entry = entries.get(JPTN_SOURCE)
     if entry is None:
@@ -166,6 +176,7 @@ def _onboarding_jptn_entry(
 
 
 def _validate_jptn_catalog_policy(entry: SourceCatalogEntry, context: str) -> None:
+    """Ensure the catalog still treats JPTN as unresolved and blocked."""
     if entry.source_classification != "unresolved":
         raise _identity_error(context, "JPTN must remain source_classification=unresolved")
     if entry.source_family != "unresolved":
@@ -179,6 +190,7 @@ def _validate_jptn_catalog_policy(entry: SourceCatalogEntry, context: str) -> No
 
 
 def _validate_jptn_onboarding_policy(entry: SourceOnboardingEntry, context: str) -> None:
+    """Ensure onboarding cannot make JPTN preflight-eligible before verification."""
     expected: dict[str, object] = {
         "source_classification": "unresolved",
         "source_family": "unresolved",

--- a/docs/architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json
+++ b/docs/architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "food-data-jptn-identity.v1",
+  "generated_on": "2026-04-29",
+  "source": "jptn_food_facts",
+  "catalog_ref": "docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+  "onboarding_ref": "docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+  "runtime_cutover": false,
+  "digitalocean_postgres_load": false,
+  "bulk_ingest": false,
+  "file_only": true,
+  "network_allowed": false,
+  "db_writes_allowed": false,
+  "provider_identity_status": "not_verified",
+  "source_url_evidence_status": "no_confirmed_public_source",
+  "license_status": "missing",
+  "retrieval_contract_status": "missing",
+  "schema_unit_normalization_status": "missing",
+  "attribution_redistribution_status": "blocked_pending_license",
+  "final_gate_decision": "blocked_until_verified",
+  "blocking_reasons": [
+    "Exact provider identity is not confirmed.",
+    "Canonical source URL and retrieval contract are not confirmed.",
+    "License, attribution, redistribution, and cache rights are not confirmed.",
+    "Schema, primary keys, units, locale, and normalization contract are not confirmed."
+  ],
+  "reviewed_queries": [
+    "\"JPTN Food Facts\" nutrition database",
+    "\"JPTN\" \"Food Facts\"",
+    "\"jptn_food_facts\"",
+    "\"JPTN\" food database nutrition"
+  ],
+  "notes": "JPTN Food Facts remains blocked. The reviewed public search terms did not identify a confirmed food-data provider, license, schema, or retrieval contract. A later source-specific PR may replace this gate only with explicit provider evidence and legal review."
+}

--- a/docs/orchestration/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_PACKET_2026-04-29.md
+++ b/docs/orchestration/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_PACKET_2026-04-29.md
@@ -34,7 +34,7 @@ food search.
   - onboarding `onboarding_status=unresolved_blocked`;
   - `final_gate_decision=blocked_until_verified`.
 - Add a repo-local dry-run CLI:
-  `python3 scripts/food_source_jptn_identity.py --catalog <path> --onboarding <path> --identity <path> --json`.
+  `python3 -m scripts.food_source_jptn_identity --catalog <path> --onboarding <path> --identity <path> --json`.
 
 ## Out Of Scope
 
@@ -71,7 +71,7 @@ Targeted PR8 validation:
 
 ```bash
 python3 -m pytest tests/test_food_source_jptn_identity.py tests/test_food_source_onboarding.py tests/test_food_source_catalog.py tests/test_food_source_preflight.py -q
-python3 scripts/food_source_jptn_identity.py --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --identity docs/architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json --json
+python3 -m scripts.food_source_jptn_identity --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --identity docs/architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json --json
 pytest -q tests/test_repo_policy_guards.py
 pre-commit run --all-files
 ```

--- a/docs/orchestration/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_PACKET_2026-04-29.md
+++ b/docs/orchestration/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_PACKET_2026-04-29.md
@@ -1,0 +1,106 @@
+# Food Data PR8: JPTN Source Identity/License Resolution Gate
+
+## Summary
+
+PR8 adds a deterministic, file-only identity/license gate for
+`jptn_food_facts`. It records exactly why JPTN cannot advance to manifest
+preflight or ingest yet: provider identity, canonical source URL, license,
+retrieval contract, schema, units, attribution, and redistribution rights are
+not verified.
+
+PR8 does not remove JPTN from the catalog, ingest JPTN data, download source
+files, connect to a database, write to DigitalOcean Postgres, or change runtime
+food search.
+
+## Coordinator Start
+
+- Coordinator: `agent-coordinator`
+- Branch: `codex/food-data-jptn-identity-license-pr8`
+- Required role order:
+  `agent-coordinator -> data-scientist-agent -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter -> dev-operator`
+- Mandatory post-open lane: `qa-engineer-agent -> bug-hunter`
+
+## Scope
+
+- Add the canonical JPTN identity/license artifact:
+  [`FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json`](../architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json).
+- Validate JPTN against:
+  - PR3 catalog entry `jptn_food_facts`;
+  - PR5 onboarding entry `jptn_food_facts`;
+  - explicit no-cutover safety flags.
+- Keep JPTN blocked with:
+  - `source_classification=unresolved`;
+  - catalog `status=blocked_unresolved`;
+  - onboarding `onboarding_status=unresolved_blocked`;
+  - `final_gate_decision=blocked_until_verified`.
+- Add a repo-local dry-run CLI:
+  `python3 scripts/food_source_jptn_identity.py --catalog <path> --onboarding <path> --identity <path> --json`.
+
+## Out Of Scope
+
+- JPTN source downloads or live checksum discovery.
+- JPTN manifest fixtures.
+- JPTN ingest, staging, or snapshot promotion.
+- PostgreSQL staging or DigitalOcean production load.
+- Runtime authority or food-search cutover.
+- MenuStat replacement, restaurant-menu, recipe/corpus, regional source, USDA,
+  or OFF onboarding changes.
+
+## Evidence Policy
+
+The PR8 artifact records the reviewed query strings and the gate outcome. Public
+searches for `"JPTN Food Facts" nutrition database`, `"JPTN" "Food Facts"`,
+`"jptn_food_facts"`, and `"JPTN" food database nutrition` did not identify a
+confirmed food-data provider, license, schema, or retrieval contract.
+
+The committed validator performs no live search. Later PRs may update the
+artifact only with explicit provider evidence, source URL, legal review, schema
+contract, and retrieval policy.
+
+## Validation
+
+Required start gates:
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR8 JPTN identity license gate" --task-class "Orchestration" --pr-phase pre_open
+```
+
+Targeted PR8 validation:
+
+```bash
+python3 -m pytest tests/test_food_source_jptn_identity.py tests/test_food_source_onboarding.py tests/test_food_source_catalog.py tests/test_food_source_preflight.py -q
+python3 scripts/food_source_jptn_identity.py --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --identity docs/architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json --json
+pytest -q tests/test_repo_policy_guards.py
+pre-commit run --all-files
+```
+
+Do not run local `make verify` for this lane; GitHub current-head CI remains the
+machine-heavy signal.
+
+## Security Notes
+
+- PR8 is file-only.
+- No network, database, credential, DigitalOcean, production import, or runtime
+  cutover path is allowed in the validator.
+- JPTN remains blocked until source identity and legal rights are verified.
+- The CLI report must keep `runtime_cutover=false`,
+  `digitalocean_postgres_load=false`, `bulk_ingest=false`,
+  `network_allowed=false`, and `db_writes_allowed=false`.
+
+## Marketing & GTM
+
+No product, API, UX, launch, pricing, or public dataset claim changes in PR8.
+The later marketable claim remains a governed multi-source food database with
+provenance, only after source-specific ingest and runtime authority lanes are
+approved.
+
+## Decision Log
+
+- PR7 Open Food Facts manifest preflight landed in PR `#1572`.
+- PR8 does not delete JPTN. It records the unresolved identity/license gap and
+  makes the blocked gate deterministic.
+- A future JPTN source-specific PR must replace this blocked gate with verified
+  provider, license, schema, attribution, redistribution, and retrieval evidence
+  before any manifest preflight or ingest begins.

--- a/docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_CURRENT.md
+++ b/docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_CURRENT.md
@@ -17,6 +17,10 @@ current tooling packet for food-data lanes that need non-dated links.
   [`FOOD_DATA_USDA_MANIFEST_PREFLIGHT_PR6_PACKET_2026-04-28.md`](./FOOD_DATA_USDA_MANIFEST_PREFLIGHT_PR6_PACKET_2026-04-28.md)
 - Current PR7 Open Food Facts manifest preflight packet:
   [`FOOD_DATA_OFF_MANIFEST_PREFLIGHT_PR7_PACKET_2026-04-29.md`](./FOOD_DATA_OFF_MANIFEST_PREFLIGHT_PR7_PACKET_2026-04-29.md)
+- Current PR8 JPTN identity/license packet:
+  [`FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_PACKET_2026-04-29.md`](./FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_PACKET_2026-04-29.md)
+- Current PR8 JPTN identity/license gate:
+  [`FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json`](../architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json)
 - Current PR3 source catalog packet:
   [`FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md`](./FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md)
 - Current PR3 source catalog:
@@ -28,5 +32,5 @@ current tooling packet for food-data lanes that need non-dated links.
 
 Update this alias when a later accepted packet supersedes the dated PR1
 criteria, PR2 tooling packet, PR3 source catalog, PR4 collision policy, PR5
-source-onboarding gate, PR6 USDA manifest preflight gate, or PR7 Open Food
-Facts manifest preflight gate.
+source-onboarding gate, PR6 USDA manifest preflight gate, PR7 Open Food Facts
+manifest preflight gate, or PR8 JPTN identity/license gate.

--- a/docs/review/PR_1577_FIXED_MAPPING.md
+++ b/docs/review/PR_1577_FIXED_MAPPING.md
@@ -9,21 +9,18 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [x] Fixed in commit mapping initialized
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 Disposition: NOT-A-BUG
-Evidence: No human, CodeRabbit, Sourcery, or Cubic review threads existed when
-the PR was opened as draft.
-Reason: Initial mapping artifact exists so later review dispositions have a
-canonical home before any thread is resolved.
+Evidence: No human, CodeRabbit, Sourcery, or Cubic review threads existed when the PR was opened as draft.
+Reason: Initial mapping artifact exists so later review dispositions have a canonical home before any thread is resolved.
 
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
 Commit: 674984d5f
-Evidence: Added the JPTN identity/license artifact, file-only validator, CLI,
-PR8 packet, ledger/current-pointer updates, and focused tests.
+Evidence: Added the JPTN identity/license artifact, file-only validator, CLI, PR8 packet, ledger/current-pointer updates, and focused tests.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577 -> 674984d5f
 

--- a/docs/review/PR_1577_FIXED_MAPPING.md
+++ b/docs/review/PR_1577_FIXED_MAPPING.md
@@ -44,6 +44,7 @@ Disposition: FIXED
 Commit: e6bbf9f6b
 Evidence: Added canonical blocking-reason validation and a negative test so JPTN cannot pass with an incomplete unresolved evidence set.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3163748581 -> e6bbf9f6b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#pullrequestreview-4200227491 -> e6bbf9f6b
 
 Disposition: NOT-A-BUG
 Evidence: Sourcery review guide is a generated summary/reviewer guide with no requested code or documentation change.

--- a/docs/review/PR_1577_FIXED_MAPPING.md
+++ b/docs/review/PR_1577_FIXED_MAPPING.md
@@ -24,6 +24,12 @@ Evidence: Added the JPTN identity/license artifact, file-only validator, CLI, PR
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577 -> 674984d5f
 
+Disposition: FIXED
+Commit: 6abc29646
+Evidence: Added docstrings for JPTN identity helper functions and the CLI wrapper so the CodeRabbit docstring-coverage warning is addressed.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#issuecomment-4345149109 -> 6abc29646
+
 ## Merge Readiness
 
 - [ ] No unresolved review threads after disposition mapping/resolution

--- a/docs/review/PR_1577_FIXED_MAPPING.md
+++ b/docs/review/PR_1577_FIXED_MAPPING.md
@@ -21,19 +21,16 @@ Reason: Initial mapping artifact exists so later review dispositions have a cano
 Disposition: FIXED
 Commit: 674984d5f
 Evidence: Added the JPTN identity/license artifact, file-only validator, CLI, PR8 packet, ledger/current-pointer updates, and focused tests.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577 -> 674984d5f
 
 Disposition: FIXED
 Commit: 6abc29646
 Evidence: Added docstrings for JPTN identity helper functions and the CLI wrapper so the CodeRabbit docstring-coverage warning is addressed.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#issuecomment-4345149109 -> 6abc29646
 
 Disposition: FIXED
 Commit: a0dad389b
 Evidence: Rejected unexpected JPTN identity keys, updated the ledger target PR to `#1577`, removed the CLI `sys.path` mutation by switching docs/tests to the module entrypoint, strengthened the AST import guard, and surfaced non-JSON CLI validation errors.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162959217 -> a0dad389b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162959225 -> a0dad389b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162959232 -> a0dad389b
@@ -46,7 +43,6 @@ Evidence: Rejected unexpected JPTN identity keys, updated the ledger target PR t
 Disposition: NOT-A-BUG
 Evidence: Sourcery review guide is a generated summary/reviewer guide with no requested code or documentation change.
 Reason: The review guide is informational; actionable Sourcery suggestions are mapped separately above.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#pullrequestreview-4199334614
 
 ## Merge Readiness

--- a/docs/review/PR_1577_FIXED_MAPPING.md
+++ b/docs/review/PR_1577_FIXED_MAPPING.md
@@ -30,6 +30,25 @@ Evidence: Added docstrings for JPTN identity helper functions and the CLI wrappe
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#issuecomment-4345149109 -> 6abc29646
 
+Disposition: FIXED
+Commit: a0dad389b
+Evidence: Rejected unexpected JPTN identity keys, updated the ledger target PR to `#1577`, removed the CLI `sys.path` mutation by switching docs/tests to the module entrypoint, strengthened the AST import guard, and surfaced non-JSON CLI validation errors.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162959217 -> a0dad389b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162959225 -> a0dad389b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162959232 -> a0dad389b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162959237 -> a0dad389b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162997953 -> a0dad389b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162997974 -> a0dad389b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#pullrequestreview-4199309393 -> a0dad389b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#pullrequestreview-4199353124 -> a0dad389b
+
+Disposition: NOT-A-BUG
+Evidence: Sourcery review guide is a generated summary/reviewer guide with no requested code or documentation change.
+Reason: The review guide is informational; actionable Sourcery suggestions are mapped separately above.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#pullrequestreview-4199334614
+
 ## Merge Readiness
 
 - [ ] No unresolved review threads after disposition mapping/resolution

--- a/docs/review/PR_1577_FIXED_MAPPING.md
+++ b/docs/review/PR_1577_FIXED_MAPPING.md
@@ -44,7 +44,7 @@ Evidence: Added docstrings for JPTN identity helper functions and the CLI wrappe
 - `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
 - `python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR8 JPTN identity license gate" --task-class "Orchestration" --pr-phase pre_open` (PASS)
 - `python3 -m pytest tests/test_food_source_jptn_identity.py tests/test_food_source_onboarding.py tests/test_food_source_catalog.py tests/test_food_source_preflight.py -q` (PASS)
-- `python3 scripts/food_source_jptn_identity.py --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --identity docs/architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json --json` (PASS)
+- `python3 -m scripts.food_source_jptn_identity --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --identity docs/architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json --json` (PASS)
 - `pytest -q tests/test_repo_policy_guards.py` (PASS)
 - `pre-commit run --all-files` (PASS)
 - `git push -u origin codex/food-data-jptn-identity-license-pr8` pre-push hooks (PASS: changed-files mypy, backend pytest, full bandit, docker build test)

--- a/docs/review/PR_1577_FIXED_MAPPING.md
+++ b/docs/review/PR_1577_FIXED_MAPPING.md
@@ -40,6 +40,11 @@ Evidence: Rejected unexpected JPTN identity keys, updated the ledger target PR t
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#pullrequestreview-4199309393 -> a0dad389b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#pullrequestreview-4199353124 -> a0dad389b
 
+Disposition: FIXED
+Commit: e6bbf9f6b
+Evidence: Added canonical blocking-reason validation and a negative test so JPTN cannot pass with an incomplete unresolved evidence set.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3163748581 -> e6bbf9f6b
+
 Disposition: NOT-A-BUG
 Evidence: Sourcery review guide is a generated summary/reviewer guide with no requested code or documentation change.
 Reason: The review guide is informational; actionable Sourcery suggestions are mapped separately above.

--- a/docs/review/PR_1577_FIXED_MAPPING.md
+++ b/docs/review/PR_1577_FIXED_MAPPING.md
@@ -1,0 +1,55 @@
+# PR #1577 Fixed in Commit Mapping
+
+## Scope
+
+- PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577
+- Branch: `codex/food-data-jptn-identity-license-pr8`
+- Title: `feat(food-data): add JPTN identity license gate`
+- Primary commit: `674984d5f`
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [x] Fixed in commit mapping initialized
+
+Disposition: NOT-A-BUG
+Evidence: No human, CodeRabbit, Sourcery, or Cubic review threads existed when
+the PR was opened as draft.
+Reason: Initial mapping artifact exists so later review dispositions have a
+canonical home before any thread is resolved.
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 674984d5f
+Evidence: Added the JPTN identity/license artifact, file-only validator, CLI,
+PR8 packet, ledger/current-pointer updates, and focused tests.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577 -> 674984d5f
+
+## Merge Readiness
+
+- [ ] No unresolved review threads after disposition mapping/resolution
+- [ ] Required checks PASS on current-head CI
+- [ ] Branch up to date with `main` at PR8 head
+- [ ] Diff coverage >= 97%
+- [ ] Ready for strict squash merge after final wait-cycle
+
+## Local Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` (PASS)
+- `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
+- `python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR8 JPTN identity license gate" --task-class "Orchestration" --pr-phase pre_open` (PASS)
+- `python3 -m pytest tests/test_food_source_jptn_identity.py tests/test_food_source_onboarding.py tests/test_food_source_catalog.py tests/test_food_source_preflight.py -q` (PASS)
+- `python3 scripts/food_source_jptn_identity.py --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --identity docs/architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json --json` (PASS)
+- `pytest -q tests/test_repo_policy_guards.py` (PASS)
+- `pre-commit run --all-files` (PASS)
+- `git push -u origin codex/food-data-jptn-identity-license-pr8` pre-push hooks (PASS: changed-files mypy, backend pytest, full bandit, docker build test)
+
+## Machine-Heavy Local Deferral
+
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-food-data-source-update-preflight`
+Reason: Local `make verify` is intentionally deferred for this machine-heavy
+food-data lane per operator policy. PR #1577 uses targeted local gates plus
+GitHub current-head CI as the heavy signal.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1793,8 +1793,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Food data source-update preflight and diff-based ingest guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR `#1572` (`feat(food-data): add Open Food Facts manifest preflight gate`)
-  - Status: 🚧 Active PR7 Open Food Facts manifest preflight lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, PR3 lineage hardening merged as PR #1532, PR5 source-onboarding gate merged as PR #1559, and PR6 USDA manifest preflight merged as PR #1563
+  - Target PR: PR8 (`feat(food-data): add JPTN identity license gate`)
+  - Status: 🚧 Active PR8 JPTN identity/license gate lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, PR3 lineage hardening merged as PR #1532, PR5 source-onboarding gate merged as PR #1559, PR6 USDA manifest preflight merged as PR #1563, and PR7 Open Food Facts manifest preflight merged as PR #1572
   - Area: data ingestion / food catalog / quality
   - Finding Type: upstream data-change readiness gap
   - Reason (EN): USDA Foundation Foods, USDA Branded, USDA FNDDS, Open Food Facts, JPTN Food Facts, restaurant-menu data, and external recipe corpora can change the shape, volume, licensing, and dedupe behavior of ingestible records. The repo does not yet have a canonical preflight contract for source-version discovery, schema diffing, dedupe/mapping collisions, source replacement decisions, storage choice, and rollback before updating the unified food catalog.
@@ -1805,9 +1805,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/FOOD_DATA_SOURCE_ONBOARDING_GATE_PR5_PACKET_2026-04-28.md`
     - `docs/orchestration/FOOD_DATA_USDA_MANIFEST_PREFLIGHT_PR6_PACKET_2026-04-28.md`
     - `docs/orchestration/FOOD_DATA_OFF_MANIFEST_PREFLIGHT_PR7_PACKET_2026-04-29.md`
+    - `docs/orchestration/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_PACKET_2026-04-29.md`
     - `docs/orchestration/FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md`
     - `docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json`
     - `docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json`
+    - `docs/architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json`
     - `docs/architecture/ADR_FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_2026-04-24.md`
     - `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`
     - `docs/legal/EXTERNAL_FOOD_SOURCE_OPERATING_POLICY.md`
@@ -1826,6 +1828,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Source-onboarding gate defines cache, display, attribution, redistribution, and contract-review decisions before any source-specific ingest
     - USDA Foundation, Branded, and FNDDS have deterministic manifest fixtures that pass source-specific dry-run preflight against PR2, PR3, and PR5 contracts before any USDA ingest lane opens
     - Open Food Facts has deterministic full-dump and delta/export-style manifest fixtures that pass source-specific dry-run preflight against PR2, PR3, and PR5 contracts while preserving ODbL attribution and redistribution policy before any OFF ingest lane opens
+    - JPTN Food Facts has a deterministic identity/license gate that records missing provider identity, source URL, license, retrieval contract, schema/unit-normalization, attribution, and redistribution evidence while keeping JPTN blocked until verified
     - MenuStat is not treated as an actively updating source; replacement-source decision is required before new restaurant-menu ingest
     - DigitalOcean production PostgreSQL load and runtime cutover stay blocked until source preflight, staging proof, rollback, and cutover packet are complete
     - Data-ingest docs and runbooks point to the same preflight source of truth

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1793,7 +1793,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Food data source-update preflight and diff-based ingest guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR8 (`feat(food-data): add JPTN identity license gate`)
+  - Target PR: PR `#1577` (PR8: `feat(food-data): add JPTN identity license gate`)
   - Status: 🚧 Active PR8 JPTN identity/license gate lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, PR3 lineage hardening merged as PR #1532, PR5 source-onboarding gate merged as PR #1559, PR6 USDA manifest preflight merged as PR #1563, and PR7 Open Food Facts manifest preflight merged as PR #1572
   - Area: data ingestion / food catalog / quality
   - Finding Type: upstream data-change readiness gap

--- a/scripts/food_source_jptn_identity.py
+++ b/scripts/food_source_jptn_identity.py
@@ -43,8 +43,8 @@ def main(argv: list[str] | None = None) -> int:
         status = "PASS" if success else "FAIL"
         print(f"jptn_identity: {status}")
         if not success:
-            validation_errors = report.get("validation_errors") or []
-            if validation_errors:
+            validation_errors = report.get("validation_errors")
+            if isinstance(validation_errors, list) and validation_errors:
                 print("Validation errors:")
                 for error in validation_errors:
                     print(f"- {error}")

--- a/scripts/food_source_jptn_identity.py
+++ b/scripts/food_source_jptn_identity.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Dry-run JPTN source identity/license gate.
+
+RU: Файловая проверка JPTN без сети, БД и ingest.
+EN: File-only JPTN gate check with no network, database, or ingest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from core.food_sources.jptn_identity import build_jptn_identity_report
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate the JPTN source identity/license gate without ingesting data.",
+    )
+    parser.add_argument("--catalog", required=True, type=Path, help="Source catalog JSON.")
+    parser.add_argument("--onboarding", required=True, type=Path, help="Onboarding gate JSON.")
+    parser.add_argument("--identity", required=True, type=Path, help="JPTN identity gate JSON.")
+    parser.add_argument("--json", action="store_true", help="Emit the deterministic JSON report.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    report = build_jptn_identity_report(
+        catalog_path=args.catalog,
+        onboarding_path=args.onboarding,
+        identity_path=args.identity,
+    )
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        status = "PASS" if report.get("success") is True else "FAIL"
+        print(f"jptn_identity: {status}")
+    return 0 if report.get("success") is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/food_source_jptn_identity.py
+++ b/scripts/food_source_jptn_identity.py
@@ -21,6 +21,7 @@ from core.food_sources.jptn_identity import build_jptn_identity_report
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse CLI arguments for the file-only JPTN identity gate."""
     parser = argparse.ArgumentParser(
         description="Validate the JPTN source identity/license gate without ingesting data.",
     )
@@ -32,6 +33,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the JPTN identity validator and return a process exit code."""
     args = _parse_args(argv if argv is not None else sys.argv[1:])
     report = build_jptn_identity_report(
         catalog_path=args.catalog,

--- a/scripts/food_source_jptn_identity.py
+++ b/scripts/food_source_jptn_identity.py
@@ -13,10 +13,6 @@ import json
 from pathlib import Path
 import sys
 
-_PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(_PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(_PROJECT_ROOT))
-
 from core.food_sources.jptn_identity import build_jptn_identity_report
 
 
@@ -43,8 +39,15 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
     else:
-        status = "PASS" if report.get("success") is True else "FAIL"
+        success = report.get("success") is True
+        status = "PASS" if success else "FAIL"
         print(f"jptn_identity: {status}")
+        if not success:
+            validation_errors = report.get("validation_errors") or []
+            if validation_errors:
+                print("Validation errors:")
+                for error in validation_errors:
+                    print(f"- {error}")
     return 0 if report.get("success") is True else 1
 
 

--- a/tests/test_food_source_jptn_identity.py
+++ b/tests/test_food_source_jptn_identity.py
@@ -31,7 +31,7 @@ _ONBOARDING_PATH = (
 _IDENTITY_PATH = (
     _REPO_ROOT / "docs" / "architecture" / "FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json"
 )
-_SCRIPT = _REPO_ROOT / "scripts" / "food_source_jptn_identity.py"
+_CLI_MODULE = "scripts.food_source_jptn_identity"
 
 
 def _catalog():
@@ -135,6 +135,14 @@ def test_jptn_identity_gate_rejects_unsafe_flags(
         parse_jptn_identity_gate(payload, catalog=_catalog(), onboarding=_onboarding())
 
 
+def test_jptn_identity_gate_rejects_unexpected_keys() -> None:
+    payload = _identity_payload()
+    payload["eligible_preflight"] = True
+
+    with pytest.raises(JptnIdentityError, match="unexpected keys: eligible_preflight"):
+        parse_jptn_identity_gate(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
 def test_jptn_identity_report_rejects_onboarding_eligibility_drift(tmp_path: Path) -> None:
     onboarding_path = _mutate_jptn_onboarding(
         "onboarding_status",
@@ -203,7 +211,8 @@ def test_jptn_identity_cli_is_file_only_and_json(
     result = subprocess.run(
         [
             sys.executable,
-            str(_SCRIPT),
+            "-m",
+            _CLI_MODULE,
             "--catalog",
             str(_CATALOG_PATH),
             "--onboarding",
@@ -212,7 +221,7 @@ def test_jptn_identity_cli_is_file_only_and_json(
             str(_IDENTITY_PATH),
             "--json",
         ],
-        cwd=tmp_path,
+        cwd=_REPO_ROOT,
         check=True,
         text=True,
         capture_output=True,
@@ -238,7 +247,8 @@ def test_jptn_identity_cli_returns_nonzero_for_invalid_payload(tmp_path: Path) -
     result = subprocess.run(
         [
             sys.executable,
-            str(_SCRIPT),
+            "-m",
+            _CLI_MODULE,
             "--catalog",
             str(_CATALOG_PATH),
             "--onboarding",
@@ -247,7 +257,7 @@ def test_jptn_identity_cli_returns_nonzero_for_invalid_payload(tmp_path: Path) -
             str(bad_path),
             "--json",
         ],
-        cwd=tmp_path,
+        cwd=_REPO_ROOT,
         check=False,
         text=True,
         capture_output=True,
@@ -259,23 +269,59 @@ def test_jptn_identity_cli_returns_nonzero_for_invalid_payload(tmp_path: Path) -
     assert payload["runtime_cutover"] is False
 
 
+def test_jptn_identity_cli_prints_validation_errors_without_json(tmp_path: Path) -> None:
+    bad_path = tmp_path / "bad_identity.json"
+    payload = _identity_payload()
+    payload["network_allowed"] = True
+    bad_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            _CLI_MODULE,
+            "--catalog",
+            str(_CATALOG_PATH),
+            "--onboarding",
+            str(_ONBOARDING_PATH),
+            "--identity",
+            str(bad_path),
+        ],
+        cwd=_REPO_ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 1
+    assert "jptn_identity: FAIL" in result.stdout
+    assert "Validation errors:" in result.stdout
+    assert "network_allowed" in result.stdout
+
+
 def test_jptn_identity_has_no_network_or_db_dependencies() -> None:
     source_text = Path(jptn_identity.__file__).read_text(encoding="utf-8")
     syntax_tree = ast.parse(source_text)
 
-    blocked_modules = (
+    blocked_roots = {
         "requests",
         "httpx",
-        "urllib.request",
         "psycopg",
         "sqlalchemy",
         "digitalocean",
         "subprocess",
-    )
-    imported_modules: set[str] = set()
+    }
+    blocked_full_imports = {"urllib.request", "sqlite3"}
+    imported_roots: set[str] = set()
+    imported_full: set[str] = set()
     for node in ast.walk(syntax_tree):
         if isinstance(node, ast.Import):
-            imported_modules.update(alias.name for alias in node.names)
+            for alias in node.names:
+                imported_full.add(alias.name)
+                imported_roots.add(alias.name.split(".")[0])
         elif isinstance(node, ast.ImportFrom) and node.module:
-            imported_modules.add(node.module)
-    assert imported_modules.isdisjoint(blocked_modules)
+            imported_full.add(node.module)
+            imported_roots.add(node.module.split(".")[0])
+            imported_full.update(f"{node.module}.{alias.name}" for alias in node.names)
+    assert imported_roots.isdisjoint(blocked_roots)
+    assert imported_full.isdisjoint(blocked_full_imports)

--- a/tests/test_food_source_jptn_identity.py
+++ b/tests/test_food_source_jptn_identity.py
@@ -1,0 +1,281 @@
+"""Tests for the deterministic JPTN source identity/license gate."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.food_sources import jptn_identity
+from core.food_sources.jptn_identity import (
+    JptnIdentityError,
+    build_jptn_identity_report,
+    load_jptn_identity_gate,
+    parse_jptn_identity_gate,
+)
+from core.food_sources.source_catalog import load_source_catalog
+from core.food_sources.source_onboarding import load_source_onboarding
+
+_REPO_ROOT = Path(__file__).parents[1]
+_CATALOG_PATH = (
+    _REPO_ROOT / "docs" / "architecture" / "FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json"
+)
+_ONBOARDING_PATH = (
+    _REPO_ROOT / "docs" / "architecture" / "FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json"
+)
+_IDENTITY_PATH = (
+    _REPO_ROOT / "docs" / "architecture" / "FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json"
+)
+_SCRIPT = _REPO_ROOT / "scripts" / "food_source_jptn_identity.py"
+
+
+def _catalog():
+    return load_source_catalog(_CATALOG_PATH)
+
+
+def _onboarding():
+    return load_source_onboarding(
+        _ONBOARDING_PATH,
+        catalog=_catalog(),
+        expected_catalog_ref="docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+    )
+
+
+def _identity_payload() -> dict[str, object]:
+    return json.loads(_IDENTITY_PATH.read_text(encoding="utf-8"))
+
+
+def _onboarding_payload() -> dict[str, object]:
+    return json.loads(_ONBOARDING_PATH.read_text(encoding="utf-8"))
+
+
+def _mutate_jptn_onboarding(key: str, value: object, tmp_path: Path) -> Path:
+    payload = _onboarding_payload()
+    sources = payload["sources"]
+    assert isinstance(sources, list)
+    for source in sources:
+        if isinstance(source, dict) and source.get("source") == "jptn_food_facts":
+            source[key] = value
+            break
+    path = tmp_path / "onboarding.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_load_jptn_identity_gate_accepts_blocked_contract() -> None:
+    gate = load_jptn_identity_gate(
+        _IDENTITY_PATH,
+        catalog=_catalog(),
+        onboarding=_onboarding(),
+        expected_catalog_ref="docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+        expected_onboarding_ref="docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+    )
+
+    assert gate.source == "jptn_food_facts"
+    assert gate.provider_identity_status == "not_verified"
+    assert gate.license_status == "missing"
+    assert gate.final_gate_decision == "blocked_until_verified"
+    assert gate.runtime_cutover is False
+    assert gate.network_allowed is False
+    assert gate.db_writes_allowed is False
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value", "match"),
+    (
+        ("provider_identity_status", "verified", "provider_identity_status"),
+        ("source_url_evidence_status", "confirmed_public_source", "source_url_evidence_status"),
+        ("license_status", "approved", "license_status"),
+        ("retrieval_contract_status", "approved", "retrieval_contract_status"),
+        ("schema_unit_normalization_status", "approved", "schema_unit_normalization_status"),
+        (
+            "attribution_redistribution_status",
+            "allowed",
+            "attribution_redistribution_status",
+        ),
+        ("final_gate_decision", "eligible_preflight", "final_gate_decision"),
+    ),
+)
+def test_jptn_identity_gate_rejects_premature_resolution(
+    field_name: str,
+    field_value: object,
+    match: str,
+) -> None:
+    payload = _identity_payload()
+    payload[field_name] = field_value
+
+    with pytest.raises(JptnIdentityError, match=match):
+        parse_jptn_identity_gate(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+@pytest.mark.parametrize(
+    ("flag_name", "flag_value"),
+    (
+        ("runtime_cutover", True),
+        ("digitalocean_postgres_load", True),
+        ("bulk_ingest", True),
+        ("file_only", False),
+        ("network_allowed", True),
+        ("db_writes_allowed", True),
+    ),
+)
+def test_jptn_identity_gate_rejects_unsafe_flags(
+    flag_name: str,
+    flag_value: bool,
+) -> None:
+    payload = _identity_payload()
+    payload[flag_name] = flag_value
+
+    with pytest.raises(JptnIdentityError, match="must be false; file_only must be true"):
+        parse_jptn_identity_gate(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_jptn_identity_report_rejects_onboarding_eligibility_drift(tmp_path: Path) -> None:
+    onboarding_path = _mutate_jptn_onboarding(
+        "onboarding_status",
+        "eligible_preflight",
+        tmp_path,
+    )
+
+    report = build_jptn_identity_report(
+        catalog_path=_CATALOG_PATH,
+        onboarding_path=onboarding_path,
+        identity_path=_IDENTITY_PATH,
+    )
+
+    assert report["success"] is False
+    assert report["runtime_cutover"] is False
+    assert report["network_allowed"] is False
+    assert report["db_writes_allowed"] is False
+    errors = report["validation_errors"]
+    assert isinstance(errors, list)
+    assert "jptn_food_facts" in errors[0]
+
+
+def test_build_jptn_identity_report_is_deterministic_json_contract() -> None:
+    report = build_jptn_identity_report(
+        catalog_path=_CATALOG_PATH,
+        onboarding_path=_ONBOARDING_PATH,
+        identity_path=_IDENTITY_PATH,
+    )
+
+    assert report == {
+        "success": True,
+        "dry_run": True,
+        "source": "jptn_food_facts",
+        "runtime_cutover": False,
+        "digitalocean_postgres_load": False,
+        "bulk_ingest": False,
+        "file_only": True,
+        "network_allowed": False,
+        "db_writes_allowed": False,
+        "final_gate_decision": "blocked_until_verified",
+        "validation_errors": [],
+        "catalog_ref": "docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+        "onboarding_ref": "docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+        "provider_identity_status": "not_verified",
+        "source_url_evidence_status": "no_confirmed_public_source",
+        "license_status": "missing",
+        "retrieval_contract_status": "missing",
+        "schema_unit_normalization_status": "missing",
+        "attribution_redistribution_status": "blocked_pending_license",
+        "blocking_reasons": [
+            "Exact provider identity is not confirmed.",
+            "Canonical source URL and retrieval contract are not confirmed.",
+            "License, attribution, redistribution, and cache rights are not confirmed.",
+            "Schema, primary keys, units, locale, and normalization contract are not confirmed.",
+        ],
+        "reviewed_query_count": 4,
+    }
+
+
+def test_jptn_identity_cli_is_file_only_and_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgres://must-not-be-used.invalid/db")
+    before = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "--catalog",
+            str(_CATALOG_PATH),
+            "--onboarding",
+            str(_ONBOARDING_PATH),
+            "--identity",
+            str(_IDENTITY_PATH),
+            "--json",
+        ],
+        cwd=tmp_path,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    after = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
+
+    payload = json.loads(result.stdout)
+    assert payload["success"] is True
+    assert payload["final_gate_decision"] == "blocked_until_verified"
+    assert payload["runtime_cutover"] is False
+    assert payload["network_allowed"] is False
+    assert payload["db_writes_allowed"] is False
+    assert result.stderr == ""
+    assert after == before
+
+
+def test_jptn_identity_cli_returns_nonzero_for_invalid_payload(tmp_path: Path) -> None:
+    bad_path = tmp_path / "bad_identity.json"
+    payload = _identity_payload()
+    payload["network_allowed"] = True
+    bad_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "--catalog",
+            str(_CATALOG_PATH),
+            "--onboarding",
+            str(_ONBOARDING_PATH),
+            "--identity",
+            str(bad_path),
+            "--json",
+        ],
+        cwd=tmp_path,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 1
+    assert payload["success"] is False
+    assert payload["runtime_cutover"] is False
+
+
+def test_jptn_identity_has_no_network_or_db_dependencies() -> None:
+    source_text = Path(jptn_identity.__file__).read_text(encoding="utf-8")
+    syntax_tree = ast.parse(source_text)
+
+    blocked_modules = (
+        "requests",
+        "httpx",
+        "urllib.request",
+        "psycopg",
+        "sqlalchemy",
+        "digitalocean",
+        "subprocess",
+    )
+    imported_modules: set[str] = set()
+    for node in ast.walk(syntax_tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.add(node.module)
+    assert imported_modules.isdisjoint(blocked_modules)

--- a/tests/test_food_source_jptn_identity.py
+++ b/tests/test_food_source_jptn_identity.py
@@ -143,6 +143,16 @@ def test_jptn_identity_gate_rejects_unexpected_keys() -> None:
         parse_jptn_identity_gate(payload, catalog=_catalog(), onboarding=_onboarding())
 
 
+def test_jptn_identity_gate_rejects_missing_blocking_reason() -> None:
+    payload = _identity_payload()
+    blocking_reasons = payload["blocking_reasons"]
+    assert isinstance(blocking_reasons, list)
+    payload["blocking_reasons"] = blocking_reasons[:-1]
+
+    with pytest.raises(JptnIdentityError, match="canonical unresolved evidence set"):
+        parse_jptn_identity_gate(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
 def test_jptn_identity_report_rejects_onboarding_eligibility_drift(tmp_path: Path) -> None:
     onboarding_path = _mutate_jptn_onboarding(
         "onboarding_status",


### PR DESCRIPTION
## Summary
- Add deterministic, file-only JPTN identity/license gate for `jptn_food_facts`.
- Keep JPTN blocked until provider identity, source URL, license, retrieval contract, schema/unit normalization, attribution, and redistribution evidence are verified.
- Update food-data current pointer and backlog ledger: PR7 landed as #1572; PR8 is the active JPTN gate lane.

## Scope
- No ingest, source downloads, DB writes, DigitalOcean Postgres, runtime cutover, app API, frontend, iOS, or runtime food search changes.
- New repo-local CLI only: `python3 -m scripts.food_source_jptn_identity --catalog <path> --onboarding <path> --identity <path> --json`.

## Split Justification
This PR is over the size-governance threshold because it adds the complete first JPTN gate contract in one lane: canonical artifact, validator, CLI, packet, pointer updates, fixed-mapping artifact, and focused negative tests. Splitting the validator from its governing artifact/tests would create a false green path where JPTN policy could drift without the deterministic gate or evidence packet in the same reviewed PR.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- Mandatory post-open lane completed: `qa-engineer-agent -> bug-hunter` PASS.
- Canonical artifact: `docs/review/PR_1577_FIXED_MAPPING.md`.

### Fixed in Commit Mapping
Disposition: FIXED  
Commit: `674984d5f`  
Evidence: Added the JPTN identity/license artifact, file-only validator, CLI, PR8 packet, ledger/current-pointer updates, and focused tests.  
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577 -> `674984d5f`

Disposition: FIXED  
Commit: `6abc29646`  
Evidence: Added docstrings for JPTN identity helper functions and the CLI wrapper so the CodeRabbit docstring-coverage warning is addressed.  
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#issuecomment-4345149109 -> `6abc29646`

Disposition: FIXED  
Commit: `a0dad389b`  
Evidence: Rejected unexpected JPTN identity keys, updated the ledger target PR to `#1577`, removed the CLI `sys.path` mutation by switching docs/tests to the module entrypoint, strengthened the AST import guard, and surfaced non-JSON CLI validation errors.  
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162959217 -> `a0dad389b`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162959225 -> `a0dad389b`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162959232 -> `a0dad389b`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162959237 -> `a0dad389b`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162997953 -> `a0dad389b`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3162997974 -> `a0dad389b`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#pullrequestreview-4199309393 -> `a0dad389b`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#pullrequestreview-4199353124 -> `a0dad389b`

Disposition: FIXED  
Commit: `e6bbf9f6b`  
Evidence: Added canonical blocking-reason validation and a negative test so JPTN cannot pass with an incomplete unresolved evidence set.  
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#discussion_r3163748581 -> `e6bbf9f6b`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#pullrequestreview-4200227491 -> `e6bbf9f6b`

Disposition: NOT-A-BUG  
Evidence: Sourcery review guide is a generated summary/reviewer guide with no requested code or documentation change.  
Reason: The review guide is informational; actionable Sourcery suggestions are mapped separately above.  
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1577#pullrequestreview-4199334614

Disposition: NOT-A-BUG  
Evidence: No human review threads existed when the PR was opened as draft.  
Reason: Initial mapping artifact exists so later review dispositions have a canonical home before any thread is resolved.

## Merge Readiness
Local narrow gates run; local `make verify` intentionally not run for this food lane per operator policy.

- `python3 scripts/orchestration/check_preflight.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR8 JPTN identity license gate" --task-class "Orchestration" --pr-phase pre_open` PASS
- `python3 -m pytest tests/test_food_source_jptn_identity.py tests/test_food_source_onboarding.py tests/test_food_source_catalog.py tests/test_food_source_preflight.py -q` PASS
- `python3 -m scripts.food_source_jptn_identity --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --identity docs/architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json --json` PASS
- `pytest -q tests/test_repo_policy_guards.py` PASS
- `pre-commit run --all-files` PASS
- push pre-push hooks PASS, including changed-files mypy, backend pytest, full bandit, docker build test

## Security Notes
- Validator is file-only and imports no network, DB, DigitalOcean, or subprocess modules.
- Safety flags remain fail-closed: `runtime_cutover=false`, `digitalocean_postgres_load=false`, `bulk_ingest=false`, `network_allowed=false`, `db_writes_allowed=false`.
- JPTN remains blocked until legal/license and provider identity evidence are verified.

## Marketing & GTM
- No product, API, UX, launch, pricing, or public dataset claim changes.
- Future public positioning remains provenance-based only after source-specific ingest and runtime authority lanes are approved.

