### PR TITLE
docs(roadmap): close advisory wiki compiler ledger

### DIFF
--- a/docs/orchestration/KARPATHY_PR_B1_ADVISORY_WIKI_COMPILER_CLOSEOUT_PACKET_2026-04-29.md
+++ b/docs/orchestration/KARPATHY_PR_B1_ADVISORY_WIKI_COMPILER_CLOSEOUT_PACKET_2026-04-29.md
@@ -1,0 +1,76 @@
+# Karpathy PR-B1 Advisory Wiki Compiler Closeout Packet
+
+**Branch:** `codex/karpathy-advisory-wiki-compiler-b1-closeout`
+**Title:** `docs(roadmap): close advisory wiki compiler ledger`
+**Date:** 2026-04-29
+**Scope:** docs/governance closeout for Rail B1 advisory wiki compiler
+
+## Summary
+
+PR-B1 is a closeout reconciliation lane, not a compiler implementation lane.
+Live repository truth shows the advisory wiki compiler v1 already landed in
+PR #1371, with semantics hardening landed in PR #1372. This PR updates the
+roadmap/ledger spine so the stale B1 item no longer appears open.
+
+## Coordinator Workflow
+
+Role order:
+
+1. `agent-coordinator`
+2. `cursor-specialist-agent`
+3. `architecture-specialist`
+4. `security-auditor`
+5. `qa-engineer-agent`
+6. `bug-hunter`
+
+Active skills:
+
+- `pulseplate-workflow`
+- `pulseplate-gates`
+- `pulseplate-guards`
+- `pulseplate-pr-review`
+
+## Evidence
+
+- PR #1371 merged on 2026-04-07:
+  `72b665763db36291b132ee148d347d7d6d8d273e`
+- PR #1372 merged on 2026-04-08:
+  `0c997be2352603c1bd5820d6d98f1c6b25793204`
+- Canonical review artifacts:
+  `docs/review/PR_1371_FIXED_MAPPING.md`,
+  `docs/review/PR_1372_FIXED_MAPPING.md`
+- Implementation evidence:
+  `docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md`,
+  `scripts/orchestration/wiki_ingest.py`,
+  `scripts/orchestration/wiki_query.py`,
+  `scripts/orchestration/wiki_lint.py`,
+  `scripts/orchestration/wiki_promote.py`
+
+## Boundaries
+
+- Rail B1 remains advisory/operator memory only.
+- Advisory wiki artifacts remain local and gitignored under
+  `artifacts/orchestration/wiki/`.
+- The compiler does not authorize product RAG replacement, runtime truth,
+  public response logic, semantic cache, embeddings, vector DB, Redis/GPTCache,
+  GraphRAG, or ContextManifest work.
+- PR-B3 query/lint enrichment remains the next substantive workforce-memory
+  implementation slice and is not bundled into this closeout.
+
+## Validation
+
+Required local gates for this docs-only closeout:
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `git diff --check`
+- `pytest -q tests/test_repo_policy_guards.py`
+- Focused grep checks for PR #1371 / PR #1372 evidence, Rail B1 advisory-only
+  wording, semantic-cache deferral, Rail B2 separation, and PR-B3 separation.
+- `pre-commit run --all-files`
+- `make validate-changed`
+
+Full local `make verify` may be treated as machine-heavy if explicitly
+operator-exempted; if so, the PR body and `docs/review/PR_<N>_FIXED_MAPPING.md`
+must document the deferral and rely on current-head GitHub CI as the heavy
+signal.

--- a/docs/review/PR_1584_FIXED_MAPPING.md
+++ b/docs/review/PR_1584_FIXED_MAPPING.md
@@ -1,0 +1,46 @@
+# PR #1584 - Fixed in Commit Mapping (canonical)
+
+## Discussion Thread Pass
+
+Canonical review-governance artifact and PR-body mirror requirements:
+`AGENTS.md`; `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md`;
+`docs/orchestration/AGENTS.md`.
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Initial Implementation Commits
+
+- `cb057e153` - `docs(roadmap): close advisory wiki compiler ledger`
+
+## Local Validation
+
+- `python3 scripts/orchestration/check_preflight.py` PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS.
+- `python3 scripts/orchestration/task_bootstrap.py --goal "Close PR-B1 advisory wiki compiler ledger after merged PR #1371/#1372" --task-class "Orchestration" --pr-phase pre_open` PASS.
+- `python3 scripts/orchestration/task_bootstrap.py --goal "Post-open review for PR-B1 advisory wiki compiler closeout" --task-class "Orchestration" --pr-phase post_open_review` PASS.
+- `git diff --check` PASS.
+- `pytest -q tests/test_repo_policy_guards.py` PASS.
+- Focused grep checks PASS for PR #1371 / PR #1372 evidence, Rail B1 advisory-only boundaries, semantic-cache deferral, Rail B2 separation, and PR-B3 separation.
+- `pre-commit run --all-files` PASS.
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` PASS.
+
+## Machine-Heavy Gate Note
+
+This docs-only closeout uses PR-scoped local gates plus GitHub current-head CI as
+the heavy-suite signal. Full local `make verify` is deferred for machine budget
+and because no runtime or Python source files are changed.
+
+## Deferred / Follow-ups
+
+- Next substantive Rail B1 implementation slice remains PR-B3 / advisory wiki query-lint enrichment.
+
+## Review Notes
+
+No actionable human or bot review comments are present at artifact creation.
+Record every later actionable comment in `Fixed in Commit Mapping` before
+resolving threads on GitHub.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -3480,13 +3480,20 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Rail B1 advisory wiki remains a separate sibling rail, not a child of Rail B2
 
 <a id="ledger-p2-local-workforce-pr-d-advisory-wiki-compiler"></a>
-- [ ] P2: Local workforce PR-D — advisory wiki compiler over local support plane
+- [x] P2: Local workforce PR-D — advisory wiki compiler over local support plane
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR #1371 (branch `feat/local-workforce-pr-d-advisory-wiki-compiler`)
+  - Target PR: PR #1371 (branch `feat/local-workforce-pr-d-advisory-wiki-compiler`, merged)
   - Area: orchestration / local support plane / operator tooling
   - Finding Type: RFC follow-on slice (compiled advisory memory)
-  - Status (EN): Implementation on branch; merge closes this item when `docs/review/PR_<N>_FIXED_MAPPING.md` exists and checklist is complete.
+  - Status (EN): ✅ Closed. PR #1371 merged on 2026-04-07 as
+    `72b665763db36291b132ee148d347d7d6d8d273e`; advisory wiki compiler v1 is
+    present in `main` as local/operator-only compiled memory over the support
+    plane. PR #1372 merged on 2026-04-08 as
+    `0c997be2352603c1bd5820d6d98f1c6b25793204` and landed the semantics /
+    rollback hardening follow-up.
+  - Closeout packet:
+    `docs/orchestration/KARPATHY_PR_B1_ADVISORY_WIKI_COMPILER_CLOSEOUT_PACKET_2026-04-29.md`
   - Reason: Non-canonical wiki artifacts help operators navigate ingested repo slices without introducing embeddings, vector stores, or a second documentation SoT.
   - Dependencies:
     - `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-local-workforce-pr-c-support-plane`
@@ -3498,10 +3505,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `scripts/orchestration/wiki_lint.py`
     - `scripts/orchestration/wiki_promote.py`
     - `scripts/orchestration/local_support_plane.py`
+    - `docs/review/PR_1372_FIXED_MAPPING.md`
   - DoD:
-    - CLIs documented and covered by deterministic tests
-    - No writes to canonical `docs/**` tree from promote path; support-plane keys respect `normalize_key`
-    - Ledger + agent entrypoints reference the wiki doc in the same merge cycle
+    - ✅ CLIs documented and covered by deterministic tests.
+    - ✅ No writes to canonical `docs/**` tree from promote path; support-plane keys respect `normalize_key`.
+    - ✅ Ledger + agent entrypoints reference the wiki doc in the same merge cycle.
   - Deferred / follow-ups (post-v1 hardening, English-first):
     - Slug strategy after truncation (reject vs hash-suffix vs manifest) when paths differ but truncate to the same slug (`scripts/orchestration/_wiki_compiler_support.py` `path_to_slug`).
     - Readability refactor (no behavior change): extract staging filesystem rollback and support-plane failure rollback from `wiki_promote.promote_slug` into small helpers with docstrings (Sourcery review suggestion on PR #1372; current logic is correct and covered by `tests/test_wiki_promote.py`).

--- a/docs/roadmap/PulsePlate_RAG_LLM_Karpathy_Epic_Pipeline.md
+++ b/docs/roadmap/PulsePlate_RAG_LLM_Karpathy_Epic_Pipeline.md
@@ -578,10 +578,20 @@ and `docs/orchestration/KARPATHY_PR_B0_LAUNCHER_BOOTSTRAP_HARDENING_PACKET_2026-
 `feat(orchestration): advisory wiki compiler over local support plane`
 
 #### Current anchor
-existing local workforce PR-D entry
+Closed local workforce PR-D entry:
+`docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-local-workforce-pr-d-advisory-wiki-compiler`
 
 #### Goal
 Implement raw/wiki/index/log-style advisory memory.
+
+#### Current status
+Materially landed via PR #1371 on 2026-04-07
+(`72b665763db36291b132ee148d347d7d6d8d273e`) with PR #1372 hardening on
+2026-04-08 (`0c997be2352603c1bd5820d6d98f1c6b25793204`). Do not reopen or
+reimplement compiler v1 as a new baseline lane.
+
+#### Closeout packet
+`docs/orchestration/KARPATHY_PR_B1_ADVISORY_WIKI_COMPILER_CLOSEOUT_PACKET_2026-04-29.md`
 
 #### In scope
 - ingest
@@ -615,6 +625,9 @@ Non-destructive promote semantics + deterministic slug hardening.
 ## PR-B3 — query/lint enrichment
 #### Title
 `feat(orchestration): enrich advisory wiki query and lint without changing SoT`
+
+#### Current status
+Next substantive Rail B1 implementation slice after PR-B1 closeout.
 
 #### Optional follow-on
 - orphan detection


### PR DESCRIPTION
## Summary

Close the stale PR-B1 advisory wiki compiler ledger item using live merged evidence from PR #1371 and PR #1372.

This is a docs/governance closeout PR only. It does not reimplement or widen the advisory wiki compiler.

## Changes

- Add the PR-B1 closeout packet: `docs/orchestration/KARPATHY_PR_B1_ADVISORY_WIKI_COMPILER_CLOSEOUT_PACKET_2026-04-29.md`.
- Mark `ledger-p2-local-workforce-pr-d-advisory-wiki-compiler` closed with PR #1371 / PR #1372 evidence.
- Update the RAG/LLM/Karpathy epic spine so PR-B1 is materially landed and PR-B3 remains the next substantive query/lint enrichment slice.

## Boundaries

- No runtime, API, OpenAPI, frontend, iOS, DB, or product-RAG changes.
- No semantic cache, embeddings, vector DB, Redis/GPTCache, GraphRAG, or ContextManifest work.
- Rail B1 remains advisory/operator memory only, not product truth.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_1584_FIXED_MAPPING.md`

## Merge Readiness

- [x] Coordinator preflight passed locally.
- [x] Agent consistency passed locally.
- [x] `git diff --check` passed locally.
- [x] `pytest -q tests/test_repo_policy_guards.py` passed locally.
- [x] Focused grep checks passed locally for PR #1371/#1372 evidence and Rail B1 boundaries.
- [x] `pre-commit run --all-files` passed locally.
- [x] `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` passed locally.
- [x] Current-head PR checks green on `f3a02556e`.
- [x] Review-thread disposition guard clean locally after mapping artifact creation.
- [x] Merge-readiness wrapper pass after ready-for-review.

## Local Heavy Gate Note

This docs-only closeout uses PR-scoped local gates plus GitHub current-head CI as the heavy-suite signal. Full local `make verify` is deferred for machine budget and because no runtime or Python source files are changed.

## Deferred / Follow-ups

- Next substantive Rail B1 implementation slice remains PR-B3 / advisory wiki query-lint enrichment.


