### PR TITLE
fix(security): prevent basename spoofing in RAG small-fixture advisory

### DIFF
--- a/docs/review/PR_1585_FIXED_MAPPING.md
+++ b/docs/review/PR_1585_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+# PR #1585 Fixed Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1585>
+Branch: `codex/investigate-rag-release-gates-vulnerability`
+Date: 2026-04-29
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Sourcery raised actionable review feedback about canonical path reuse and
+public-interface coverage for the spoofed small-fixture advisory path.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1585#pullrequestreview-4200326196 -> a2f8ca5f9d934af32cc53722a8c846921110d6a4
+
+Disposition: FIXED
+Commit: a2f8ca5f9d934af32cc53722a8c846921110d6a4
+Evidence: `scripts/evals/run_rag_release_gates.py` uses module-level `CANONICAL_RAG_EVAL_SAMPLE_PATH`; `tests/test_rag_release_gates_runner.py` includes public `main(... --require-pass)` coverage for a spoofed canonical basename.

--- a/scripts/evals/run_rag_release_gates.py
+++ b/scripts/evals/run_rag_release_gates.py
@@ -141,7 +141,10 @@ def _small_fixture_numeric_gates_advisory(
 
     if trace_count <= 0 or trace_count > SMALL_FIXTURE_NUMERIC_GATES_ADVISORY_MAX_N:
         return False
-    return Path(dataset_path_used).name == CANONICAL_RAG_EVAL_SAMPLE_FILENAME
+    canonical_sample_path = (
+        Path(__file__).resolve().parents[2] / "data" / "evals" / CANONICAL_RAG_EVAL_SAMPLE_FILENAME
+    )
+    return Path(dataset_path_used).resolve() == canonical_sample_path.resolve()
 
 
 def _iso_now() -> str:

--- a/scripts/evals/run_rag_release_gates.py
+++ b/scripts/evals/run_rag_release_gates.py
@@ -89,6 +89,7 @@ ROUTING_CONFIDENCE_THRESHOLD = 0.65
 
 # Canonical committed eval fixture (weekly CI / workflow_dispatch default input).
 CANONICAL_RAG_EVAL_SAMPLE_FILENAME = "pulseplate_rag_eval_sample.jsonl"
+CANONICAL_RAG_EVAL_SAMPLE_PATH = DEFAULT_INPUT_PATH.resolve()
 # Numeric aggregate gates (A, B*, C2) are not statistically meaningful on tiny n;
 # weekly lane still enforces strict runtime hygiene (gate_d1) and calibration (gate_c1).
 SMALL_FIXTURE_NUMERIC_GATES_ADVISORY_MAX_N = 16
@@ -141,10 +142,7 @@ def _small_fixture_numeric_gates_advisory(
 
     if trace_count <= 0 or trace_count > SMALL_FIXTURE_NUMERIC_GATES_ADVISORY_MAX_N:
         return False
-    canonical_sample_path = (
-        Path(__file__).resolve().parents[2] / "data" / "evals" / CANONICAL_RAG_EVAL_SAMPLE_FILENAME
-    )
-    return Path(dataset_path_used).resolve() == canonical_sample_path.resolve()
+    return Path(dataset_path_used).resolve() == CANONICAL_RAG_EVAL_SAMPLE_PATH
 
 
 def _iso_now() -> str:

--- a/tests/test_rag_release_gates_runner.py
+++ b/tests/test_rag_release_gates_runner.py
@@ -499,6 +499,60 @@ def test_small_fixture_advisory_not_applied_for_spoofed_canonical_basename(
     )
 
 
+def test_require_pass_rejects_spoofed_canonical_sample_path(tmp_path: Path) -> None:
+    """Public runner must not apply advisory mode to a spoofed canonical basename."""
+
+    project_root = tmp_path / "repo"
+    (project_root / "docs").mkdir(parents=True)
+    (project_root / "core").mkdir()
+    (project_root / "app").mkdir()
+    (project_root / "tests" / "guards").mkdir(parents=True)
+    (project_root / "notebooks").mkdir()
+    (project_root / "artifacts").mkdir()
+    (project_root / "AGENTS.md").write_text("FREE PRO VIP", encoding="utf-8")
+    (project_root / "RUNBOOK_AGENT.md").write_text("retrieve_and_validate_rag", encoding="utf-8")
+    input_path = project_root / "data" / "evals" / "pulseplate_rag_eval_sample.jsonl"
+    input_path.parent.mkdir(parents=True)
+    input_path.write_text(
+        json.dumps(
+            {
+                "query_id": "q1",
+                "query_text": "What are the canonical tiers in PulsePlate?",
+                "gold_doc_ids": ["docs/does_not_exist.md"],
+                "gold_answer": "FREE PRO and VIP",
+                "expected_claims": ["PulsePlate canonical tiers are FREE PRO and VIP."],
+                "evidence_quotes": ["FREE", "PRO", "VIP"],
+                "user_tier": "PRO",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "--project-root",
+            str(project_root),
+            "--input-path",
+            str(input_path),
+            "--artifact-root",
+            str(project_root / "artifacts" / "rag_eval"),
+            "--experiment-id",
+            "spoofed_canonical_basename",
+            "--sample-size",
+            "1",
+            "--top-k",
+            "5",
+            "--retriever-mode",
+            "local_tfidf",
+            "--generator-mode",
+            "extractive_stub",
+            "--require-pass",
+        ],
+    )
+
+    assert exit_code == 2
+
+
 def test_expected_calibration_error_keeps_last_bin_bounded() -> None:
     """The terminal ECE bin must not double-count probabilities from lower bins."""
 

--- a/tests/test_rag_release_gates_runner.py
+++ b/tests/test_rag_release_gates_runner.py
@@ -481,6 +481,24 @@ def test_small_fixture_advisory_not_applied_for_non_canonical_dataset_name(
     assert release_decision == "NO-GO"
 
 
+def test_small_fixture_advisory_not_applied_for_spoofed_canonical_basename(
+    tmp_path: Path,
+) -> None:
+    """Advisory must not trigger for non-canonical paths with canonical basename."""
+
+    spoofed_dataset = tmp_path / "attacker" / "pulseplate_rag_eval_sample.jsonl"
+    spoofed_dataset.parent.mkdir(parents=True, exist_ok=True)
+    spoofed_dataset.write_text('{"query_id":"q1"}\n', encoding="utf-8")
+
+    assert (
+        runner._small_fixture_numeric_gates_advisory(
+            dataset_path_used=str(spoofed_dataset),
+            trace_count=5,
+        )
+        is False
+    )
+
+
 def test_expected_calibration_error_keeps_last_bin_bounded() -> None:
     """The terminal ECE bin must not double-count probabilities from lower bins."""
 


### PR DESCRIPTION
### Motivation
- The small-fixture advisory path previously activated based only on the input filename basename and small `trace_count`, which allowed a crafted file named `pulseplate_rag_eval_sample.jsonl` in an arbitrary location to bypass numeric gates and produce a `PASS` under `--require-pass`.

### Description
- Tighten `_small_fixture_numeric_gates_advisory(...)` to require the resolved `dataset_path_used` to equal the repository canonical sample path (`data/evals/pulseplate_rag_eval_sample.jsonl`) instead of matching the basename only, and add `test_small_fixture_advisory_not_applied_for_spoofed_canonical_basename` to `tests/test_rag_release_gates_runner.py` that ensures a spoofed file in a different directory does not activate advisory mode.

### Testing
- Attempted targeted test run with `pytest -q tests/test_rag_release_gates_runner.py -k 'small_fixture_advisory'`, which failed in this environment due to `pyenv` configuration (`3.13.6` not installed); running via `.venv` also failed because no `.venv` is present; running `PYENV_VERSION=3.13.8 python -m pytest -q ...` failed due to missing project dependencies (e.g. `ModuleNotFoundError: No module named 'fastapi'`), so the new regression test was added but could not be executed here; the test is expected to pass in a properly provisioned dev environment or CI with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f261a26760833391e82527e642898d)

## Summary by Sourcery

Ужесточить предупреждение о small-fixture в RAG так, чтобы оно срабатывало только для канонического пути к образцу набора данных, и добавить регрессионный тест, предотвращающий подмену на основе `basename`.

Bug Fixes:
- Не допускать активации режима предупреждения о small-fixture поддельными файлами, которые совпадают только с каноническим `basename` образца.

Tests:
- Добавить регрессионный тест, гарантирующий, что предупреждение о small-fixture не срабатывает для неканонических путей, которые совпадают с каноническим `basename` образца.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen the RAG small-fixture advisory so it only triggers for the canonical sample dataset path and add a regression test to prevent basename-based spoofing.

Bug Fixes:
- Prevent small-fixture advisory mode from being activated by spoofed files that only match the canonical sample basename.

Tests:
- Add a regression test ensuring the small-fixture advisory does not trigger for non-canonical paths sharing the canonical sample basename.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors the small-fixture advisory to the resolved canonical dataset path to block basename spoofing in RAG release gates. Adds public runner coverage to ensure spoofed files cannot pass under `--require-pass`.

- **Bug Fixes**
  - Require `Path(dataset_path_used).resolve() == CANONICAL_RAG_EVAL_SAMPLE_PATH` in `_small_fixture_numeric_gates_advisory`.
  - Add tests to reject a spoofed canonical basename (unit) and to ensure `main(... --require-pass)` returns failure for spoofed inputs (integration).

<sup>Written for commit 43311e0219d26c1d11edf9cfa1e7c2d6bb609965. Summary will update on new commits. <a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1585?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

### Codex follow-up
- Factored the canonical RAG sample path into `CANONICAL_RAG_EVAL_SAMPLE_PATH`.
- Added public runner coverage proving a spoofed `pulseplate_rag_eval_sample.jsonl` path still fails under `--require-pass`.
- Added canonical review mapping artifact `docs/review/PR_1585_FIXED_MAPPING.md` for the Sourcery actionable review.

### Local validation
- `python3 scripts/orchestration/check_preflight.py` (PASS)
- `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
- `.venv/bin/python -m pytest -q tests/test_rag_release_gates_runner.py -k "small_fixture_advisory or require_pass"` (PASS, 8 tests)
- `.venv/bin/python -m pytest -q tests/test_repo_policy_guards.py` (PASS, 14 tests)
- `make validate-changed` (PASS)
- `pre-commit run --all-files` (PASS)

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1585_FIXED_MAPPING.md`
