### PR TITLE
fix(pr-review): handle non-numeric diff.summary.changed_lines in dry-run report

### DIFF
--- a/docs/review/PR_1586_FIXED_MAPPING.md
+++ b/docs/review/PR_1586_FIXED_MAPPING.md
@@ -1,0 +1,22 @@
+# PR #1586 Fixed Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1586>
+Branch: `codex/fix-malformed-diff-summary-crash`
+Date: 2026-04-29
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+No actionable review comments were raised. Sourcery did not complete a review
+because the account hit its weekly diff-character rate limit.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Initial Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` (PASS)
+- `python3 scripts/orchestration/check_agent_consistency.py` (PASS)

--- a/scripts/orchestration/pr_review_report.py
+++ b/scripts/orchestration/pr_review_report.py
@@ -98,6 +98,13 @@ def _context_path(context: dict[str, Any], default: str) -> str:
     return default
 
 
+def _coerce_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def build_findings(context: dict[str, Any]) -> list[Finding]:
     """Build conservative advisory findings from context collector output."""
 
@@ -170,7 +177,22 @@ def build_findings(context: dict[str, Any]) -> list[Finding]:
 
     diff = _as_dict(context.get("diff"))
     summary = _as_dict(diff.get("summary"))
-    changed_lines = int(summary.get("changed_lines") or 0)
+    changed_lines = _coerce_int(summary.get("changed_lines") or 0)
+    if changed_lines is None:
+        findings.append(
+            Finding(
+                severity="note",
+                role_agent="qa-engineer-agent",
+                category="governance",
+                file="scripts/orchestration/pr_review_context.py",
+                line=None,
+                evidence="diff.summary.changed_lines is not numeric; treated as 0 for advisory planning.",
+                suggested_fix="Regenerate context or set diff.summary.changed_lines to an integer value.",
+                gate_to_run="python3 scripts/orchestration/pr_review_context.py --pr <PR_NUMBER>",
+                disposition_candidate="NEEDS-HUMAN",
+            )
+        )
+        changed_lines = 0
     if changed_lines > LARGE_DIFF_CHANGED_LINES:
         threshold = (
             VERY_LARGE_DIFF_CHANGED_LINES

--- a/tests/test_pr_review_report.py
+++ b/tests/test_pr_review_report.py
@@ -151,6 +151,21 @@ def test_build_report_flags_large_diff() -> None:
     ].index("make validate-changed")
 
 
+def test_build_report_handles_non_numeric_changed_lines() -> None:
+    context = _base_context()
+    context["diff"] = {
+        "summary": {"files": 1, "additions": 4, "deletions": 1, "changed_lines": "not-a-number"},
+        "files": [{"path": "scripts/orchestration/pr_review_report.py", "additions": 4, "deletions": 1}],
+    }
+
+    report = report_runner.build_report(context)
+
+    assert report["findings_count"] == 1
+    assert report["findings"][0]["role_agent"] == "qa-engineer-agent"
+    assert "changed_lines is not numeric" in report["findings"][0]["evidence"]
+    assert report["calibration"]["case_labels"] == ["governance-finding"]
+
+
 def test_render_markdown_contains_required_sections() -> None:
     context = _base_context()
     context["diff"] = {

--- a/tests/test_pr_review_report.py
+++ b/tests/test_pr_review_report.py
@@ -155,7 +155,9 @@ def test_build_report_handles_non_numeric_changed_lines() -> None:
     context = _base_context()
     context["diff"] = {
         "summary": {"files": 1, "additions": 4, "deletions": 1, "changed_lines": "not-a-number"},
-        "files": [{"path": "scripts/orchestration/pr_review_report.py", "additions": 4, "deletions": 1}],
+        "files": [
+            {"path": "scripts/orchestration/pr_review_report.py", "additions": 4, "deletions": 1}
+        ],
     }
 
     report = report_runner.build_report(context)


### PR DESCRIPTION
### Motivation
- The dry-run report runner crashed when `diff.summary.changed_lines` in the context JSON was a non-numeric value because the code called `int(...)` without handling `ValueError`/`TypeError`.
- The change aims to make the runner robust to malformed but syntactically valid context JSON and produce a deterministic advisory finding instead of an uncaught traceback.

### Description
- Add a safe coercion helper ` _coerce_int(value: Any) -> int | None` and replace the direct `int(...)` call with `changed_lines = _coerce_int(...)` in `scripts/orchestration/pr_review_report.py`.
- When coercion fails, append a deterministic advisory `Finding` (severity `note`, role `qa-engineer-agent`) explaining that `diff.summary.changed_lines` was not numeric and treat the value as `0` for planning.
- Add a regression test `test_build_report_handles_non_numeric_changed_lines` in `tests/test_pr_review_report.py` that supplies `changed_lines: "not-a-number"` and asserts the report is produced with a governance finding instead of crashing.

### Testing
- Added unit test `tests/test_pr_review_report.py::test_build_report_handles_non_numeric_changed_lines` which validates non-numeric `changed_lines` is handled and produces a `qa-engineer-agent` finding; the test is included in the patch.
- Attempted to run the test locally with `pytest -q tests/test_pr_review_report.py`, but the environment uses `pyenv` pointing at `3.13.6` (not installed) and `pytest` is not available for the invoked interpreters, so the test run could not complete in this environment (no successful test execution performed here).
- No CI run results are included in this change; recommend running `pytest -q tests/test_pr_review_report.py` or the repo validation bundle `make validate-min` / full `make verify` in a properly provisioned environment to confirm behavior in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2632ec78c83339f38a37ec8ab3450)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the PR review dry-run when `diff.summary.changed_lines` is non-numeric. The runner now coerces bad input, adds a governance note, and completes the report.

- **Bug Fixes**
  - Coerce `changed_lines` via `_coerce_int(...)`; treat invalid values as 0.
  - When invalid, add a governance `Finding` (severity `note`, role `qa-engineer-agent`) with `gate_to_run` and `NEEDS-HUMAN`, and label the report `governance-finding`.
  - Add regression test `tests/test_pr_review_report.py::test_build_report_handles_non_numeric_changed_lines`; add review doc `docs/review/PR_1586_FIXED_MAPPING.md`.

<sup>Written for commit 66c5cc966b2192fef3e3d8f3071aba4d17aa29e6. Summary will update on new commits. <a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1586?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

### Codex follow-up
- Applied the Black formatting required by CI for `tests/test_pr_review_report.py`.
- Added canonical no-actionable review mapping artifact `docs/review/PR_1586_FIXED_MAPPING.md`.

### Local validation
- `python3 scripts/orchestration/check_preflight.py` (PASS)
- `python3 scripts/orchestration/check_agent_consistency.py` (PASS)
- `.venv/bin/python -m pytest -q tests/test_pr_review_report.py` (PASS, 9 tests)
- `.venv/bin/python -m pytest -q tests/test_repo_policy_guards.py` (PASS, 14 tests)
- `make validate-changed` (PASS)
- `pre-commit run --all-files` (PASS)

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1586_FIXED_MAPPING.md`
