### PR TITLE
feat(food-data): define MenuStat replacement source gate

### DIFF
--- a/core/food_sources/menustat_replacement.py
+++ b/core/food_sources/menustat_replacement.py
@@ -1,0 +1,565 @@
+"""
+Deterministic MenuStat replacement-source decision gate.
+
+RU: Файловая проверка решения по замене MenuStat до restaurant-menu ingest.
+EN: File-only MenuStat replacement decision gate before restaurant-menu ingest.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+import json
+from pathlib import Path
+import re
+from urllib.parse import urlparse
+
+from core.food_sources.source_catalog import (
+    SourceCatalog,
+    SourceCatalogEntry,
+    SourceCatalogError,
+    load_source_catalog,
+)
+from core.food_sources.source_onboarding import (
+    SourceOnboarding,
+    SourceOnboardingEntry,
+    SourceOnboardingError,
+    load_source_onboarding,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DECISION_SCHEMA_RE = re.compile(r"^food-data-menustat-replacement\.v\d+$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_SAFETY_FLAG_TEMPLATE: dict[str, bool] = {
+    "runtime_cutover": False,
+    "digitalocean_postgres_load": False,
+    "bulk_ingest": False,
+    "file_only": True,
+    "network_allowed": False,
+    "db_writes_allowed": False,
+}
+_DECISION_KEYS = frozenset(
+    {
+        "schema_version",
+        "generated_on",
+        "legacy_source",
+        "catalog_ref",
+        "onboarding_ref",
+        "runtime_cutover",
+        "digitalocean_postgres_load",
+        "bulk_ingest",
+        "file_only",
+        "network_allowed",
+        "db_writes_allowed",
+        "final_gate_decision",
+        "candidate_sources",
+        "notes",
+    }
+)
+_CANDIDATE_KEYS = frozenset(
+    {
+        "source",
+        "replacement_for",
+        "source_classification",
+        "source_family",
+        "onboarding_status",
+        "candidate_gate_decision",
+        "authority_decision",
+        "evidence_status",
+        "contract_status",
+        "cache_policy_status",
+        "display_policy_status",
+        "redistribution_policy_status",
+        "freshness_status",
+        "source_evidence_refs",
+        "blocking_reasons",
+        "notes",
+    }
+)
+_EXPECTED_CANDIDATES = (
+    "nutritionix",
+    "fatsecret_platform",
+    "spoonacular",
+    "chain_public_nutrition_pages",
+)
+_EXPECTED_CANDIDATE_POLICY: dict[str, dict[str, object]] = {
+    "nutritionix": {
+        "source_classification": "commercial_contract",
+        "source_family": "restaurant_menu",
+        "onboarding_status": "contract_review_blocked",
+        "candidate_gate_decision": "blocked_contract_review_required",
+        "authority_decision": "not_approved",
+    },
+    "fatsecret_platform": {
+        "source_classification": "commercial_contract",
+        "source_family": "commercial_api",
+        "onboarding_status": "contract_review_blocked",
+        "candidate_gate_decision": "blocked_contract_review_required",
+        "authority_decision": "not_approved",
+    },
+    "spoonacular": {
+        "source_classification": "commercial_contract",
+        "source_family": "recipe_corpus",
+        "onboarding_status": "contract_review_blocked",
+        "candidate_gate_decision": "blocked_contract_review_required",
+        "authority_decision": "not_approved",
+    },
+    "chain_public_nutrition_pages": {
+        "source_classification": "unresolved",
+        "source_family": "restaurant_menu",
+        "onboarding_status": "unresolved_blocked",
+        "candidate_gate_decision": "blocked_unresolved_review_required",
+        "authority_decision": "not_approved",
+    },
+}
+_BLOCKED_STATUS_FIELDS = (
+    "evidence_status",
+    "contract_status",
+    "cache_policy_status",
+    "display_policy_status",
+    "redistribution_policy_status",
+    "freshness_status",
+)
+
+MENUSTAT_SOURCE = "menustat"
+BLOCKED_GATE_DECISION = "blocked_until_replacement_approved"
+
+
+class MenuStatReplacementError(ValueError):
+    """Raised when the MenuStat replacement decision gate is invalid."""
+
+
+@dataclass(frozen=True)
+class MenuStatReplacementCandidate:
+    """One blocked replacement-source candidate decision."""
+
+    source: str
+    replacement_for: str
+    source_classification: str
+    source_family: str
+    onboarding_status: str
+    candidate_gate_decision: str
+    authority_decision: str
+    evidence_status: str
+    contract_status: str
+    cache_policy_status: str
+    display_policy_status: str
+    redistribution_policy_status: str
+    freshness_status: str
+    source_evidence_refs: tuple[str, ...]
+    blocking_reasons: tuple[str, ...]
+    notes: str
+
+
+@dataclass(frozen=True)
+class MenuStatReplacementDecision:
+    """Validated MenuStat replacement-source decision artifact."""
+
+    schema_version: str
+    generated_on: date
+    legacy_source: str
+    catalog_ref: str
+    onboarding_ref: str
+    runtime_cutover: bool
+    digitalocean_postgres_load: bool
+    bulk_ingest: bool
+    file_only: bool
+    network_allowed: bool
+    db_writes_allowed: bool
+    final_gate_decision: str
+    candidate_sources: tuple[MenuStatReplacementCandidate, ...]
+    notes: str
+
+
+def _replacement_error(context: str, detail: str) -> MenuStatReplacementError:
+    """Build a stable validation error for the current decision artifact."""
+    return MenuStatReplacementError(f"Invalid MenuStat replacement gate {context}: {detail}")
+
+
+def _require_mapping(value: object, context: str) -> dict[str, object]:
+    """Return an object mapping or fail closed on malformed JSON payloads."""
+    if not isinstance(value, dict):
+        raise _replacement_error(context, "must be an object")
+    result: dict[str, object] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise _replacement_error(context, "all object keys must be strings")
+        result[key] = item
+    return result
+
+
+def _require_string(data: dict[str, object], key: str, context: str) -> str:
+    """Read a required non-empty string field from a validated object."""
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise _replacement_error(context, f"missing non-empty string '{key}'")
+    return value.strip()
+
+
+def _require_bool(data: dict[str, object], key: str, context: str) -> bool:
+    """Read a required boolean field without truthy/falsy coercion."""
+    value = data.get(key)
+    if not isinstance(value, bool):
+        raise _replacement_error(context, f"'{key}' must be a boolean")
+    return value
+
+
+def _require_string_tuple(
+    data: dict[str, object],
+    key: str,
+    context: str,
+) -> tuple[str, ...]:
+    """Read a required non-empty string list and reject duplicate values."""
+    value = data.get(key)
+    if not isinstance(value, list):
+        raise _replacement_error(context, f"'{key}' must be a list of strings")
+    items: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise _replacement_error(context, f"'{key}[{index}]' must be a non-empty string")
+        normalized = item.strip()
+        if normalized in seen:
+            raise _replacement_error(context, f"'{key}' contains duplicate value {normalized!r}")
+        seen.add(normalized)
+        items.append(normalized)
+    if not items:
+        raise _replacement_error(context, f"'{key}' must not be empty")
+    return tuple(items)
+
+
+def _require_url_tuple(
+    data: dict[str, object],
+    key: str,
+    context: str,
+) -> tuple[str, ...]:
+    """Read a required non-empty URL list and reject malformed references."""
+    urls = _require_string_tuple(data, key, context)
+    for url in urls:
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise _replacement_error(context, f"'{key}' must contain absolute http(s) URLs")
+    return urls
+
+
+def _parse_date(value: str, context: str) -> date:
+    """Parse the canonical YYYY-MM-DD artifact date format."""
+    if not _DATE_RE.fullmatch(value):
+        raise _replacement_error(context, "generated_on must use YYYY-MM-DD")
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise _replacement_error(context, "generated_on must use YYYY-MM-DD") from exc
+
+
+def _require_safety_flags(data: dict[str, object], context: str) -> dict[str, bool]:
+    """Extract all safety flags before comparing them with the gate template."""
+    return {key: _require_bool(data, key, context) for key in _SAFETY_FLAG_TEMPLATE}
+
+
+def _relative_repo_path(path: Path | str) -> str:
+    """Normalize a path to the repo-relative form used by canonical artifacts."""
+    resolved = Path(path).resolve()
+    try:
+        return resolved.relative_to(_REPO_ROOT).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
+def _entry_by_source(entries: tuple[object, ...]) -> dict[str, object]:
+    """Index catalog or onboarding entries by their source field."""
+    return {getattr(entry, "source"): entry for entry in entries}
+
+
+def _menustat_catalog_entry(catalog: SourceCatalog, context: str) -> SourceCatalogEntry:
+    """Find and validate the legacy MenuStat catalog entry."""
+    entry = _entry_by_source(catalog.sources).get(MENUSTAT_SOURCE)
+    if not isinstance(entry, SourceCatalogEntry):
+        raise _replacement_error(context, "catalog must include menustat")
+    if entry.source_classification != "legacy_static":
+        raise _replacement_error(
+            context, "menustat must remain source_classification=legacy_static"
+        )
+    if entry.status != "legacy_baseline":
+        raise _replacement_error(context, "menustat must remain legacy_baseline")
+    if entry.active_update_source:
+        raise _replacement_error(context, "menustat cannot be an active update source")
+    if not entry.replacement_required:
+        raise _replacement_error(context, "menustat must remain replacement_required")
+    return entry
+
+
+def _menustat_onboarding_entry(
+    onboarding: SourceOnboarding,
+    context: str,
+) -> SourceOnboardingEntry:
+    """Find and validate the legacy MenuStat onboarding entry."""
+    entry = _entry_by_source(onboarding.sources).get(MENUSTAT_SOURCE)
+    if not isinstance(entry, SourceOnboardingEntry):
+        raise _replacement_error(context, "onboarding must include menustat")
+    if entry.onboarding_status != "legacy_baseline_blocked":
+        raise _replacement_error(context, "menustat onboarding must remain legacy_baseline_blocked")
+    if entry.ingestion_path != "legacy_snapshot_review_only":
+        raise _replacement_error(
+            context, "menustat ingestion path must stay legacy_snapshot_review_only"
+        )
+    return entry
+
+
+def _parse_candidate(value: object, context: str) -> MenuStatReplacementCandidate:
+    """Parse one replacement candidate row from the decision artifact."""
+    data = _require_mapping(value, context)
+    unexpected_keys = sorted(set(data) - _CANDIDATE_KEYS)
+    if unexpected_keys:
+        joined = ", ".join(unexpected_keys)
+        raise _replacement_error(context, f"unexpected candidate keys: {joined}")
+    candidate = MenuStatReplacementCandidate(
+        source=_require_string(data, "source", context),
+        replacement_for=_require_string(data, "replacement_for", context),
+        source_classification=_require_string(data, "source_classification", context),
+        source_family=_require_string(data, "source_family", context),
+        onboarding_status=_require_string(data, "onboarding_status", context),
+        candidate_gate_decision=_require_string(data, "candidate_gate_decision", context),
+        authority_decision=_require_string(data, "authority_decision", context),
+        evidence_status=_require_string(data, "evidence_status", context),
+        contract_status=_require_string(data, "contract_status", context),
+        cache_policy_status=_require_string(data, "cache_policy_status", context),
+        display_policy_status=_require_string(data, "display_policy_status", context),
+        redistribution_policy_status=_require_string(data, "redistribution_policy_status", context),
+        freshness_status=_require_string(data, "freshness_status", context),
+        source_evidence_refs=_require_url_tuple(data, "source_evidence_refs", context),
+        blocking_reasons=_require_string_tuple(data, "blocking_reasons", context),
+        notes=_require_string(data, "notes", context),
+    )
+    if candidate.replacement_for != MENUSTAT_SOURCE:
+        raise _replacement_error(context, f"{candidate.source} must replace menustat")
+    if candidate.source not in _EXPECTED_CANDIDATES:
+        raise _replacement_error(
+            context, f"unknown MenuStat replacement candidate: {candidate.source}"
+        )
+    if candidate.authority_decision in {"active_authority", "approved_ingest"}:
+        raise _replacement_error(context, f"{candidate.source} cannot be approved in PR9")
+    if candidate.candidate_gate_decision == "approved_ingest":
+        raise _replacement_error(context, f"{candidate.source} cannot be approved in PR9")
+    if candidate.candidate_gate_decision == "eligible_preflight":
+        raise _replacement_error(context, f"{candidate.source} cannot become eligible in PR9")
+    for field_name in _BLOCKED_STATUS_FIELDS:
+        if not getattr(candidate, field_name).startswith("blocked_"):
+            raise _replacement_error(
+                context,
+                f"{candidate.source} {field_name} must remain blocked",
+            )
+    return candidate
+
+
+def _validate_candidate_contract(
+    candidate: MenuStatReplacementCandidate,
+    catalog_entries: dict[str, object],
+    onboarding_entries: dict[str, object],
+    context: str,
+) -> None:
+    """Cross-check a decision row against PR3 catalog and PR5 onboarding."""
+    catalog_entry = catalog_entries.get(candidate.source)
+    if not isinstance(catalog_entry, SourceCatalogEntry):
+        raise _replacement_error(context, f"catalog missing candidate {candidate.source}")
+    onboarding_entry = onboarding_entries.get(candidate.source)
+    if not isinstance(onboarding_entry, SourceOnboardingEntry):
+        raise _replacement_error(context, f"onboarding missing candidate {candidate.source}")
+    expected = _EXPECTED_CANDIDATE_POLICY[candidate.source]
+    actual: dict[str, object] = {
+        "source_classification": candidate.source_classification,
+        "source_family": candidate.source_family,
+        "onboarding_status": candidate.onboarding_status,
+        "candidate_gate_decision": candidate.candidate_gate_decision,
+        "authority_decision": candidate.authority_decision,
+    }
+    mismatches = [key for key, value in expected.items() if actual[key] != value]
+    if mismatches:
+        joined = ", ".join(mismatches)
+        raise _replacement_error(context, f"{candidate.source} policy mismatch: {joined}")
+    if catalog_entry.replacement_for != MENUSTAT_SOURCE:
+        raise _replacement_error(
+            context, f"{candidate.source} must be cataloged as replacing menustat"
+        )
+    if catalog_entry.source_classification != candidate.source_classification:
+        raise _replacement_error(context, f"{candidate.source} classification differs from catalog")
+    if catalog_entry.source_family != candidate.source_family:
+        raise _replacement_error(context, f"{candidate.source} family differs from catalog")
+    if onboarding_entry.onboarding_status != candidate.onboarding_status:
+        raise _replacement_error(context, f"{candidate.source} onboarding status differs from PR5")
+    if onboarding_entry.onboarding_status == "eligible_preflight":
+        raise _replacement_error(
+            context, f"{candidate.source} must not be eligible_preflight in PR9"
+        )
+
+
+def parse_menustat_replacement_decision(
+    payload: object,
+    *,
+    catalog: SourceCatalog,
+    onboarding: SourceOnboarding,
+    expected_catalog_ref: str | None = None,
+    expected_onboarding_ref: str | None = None,
+    context: str = "<menustat-replacement>",
+) -> MenuStatReplacementDecision:
+    """Parse and validate the MenuStat replacement-source decision gate."""
+    data = _require_mapping(payload, context)
+    unexpected_keys = sorted(set(data) - _DECISION_KEYS)
+    if unexpected_keys:
+        joined = ", ".join(unexpected_keys)
+        raise _replacement_error(context, f"unexpected keys: {joined}")
+
+    schema_version = _require_string(data, "schema_version", context)
+    if not _DECISION_SCHEMA_RE.fullmatch(schema_version):
+        raise _replacement_error(
+            context,
+            "schema_version must look like food-data-menustat-replacement.vN",
+        )
+    legacy_source = _require_string(data, "legacy_source", context)
+    if legacy_source != MENUSTAT_SOURCE:
+        raise _replacement_error(context, "legacy_source must be menustat")
+
+    catalog_ref = _require_string(data, "catalog_ref", context)
+    if expected_catalog_ref is not None and catalog_ref != expected_catalog_ref:
+        raise _replacement_error(context, f"catalog_ref must be {expected_catalog_ref!r}")
+    onboarding_ref = _require_string(data, "onboarding_ref", context)
+    if expected_onboarding_ref is not None and onboarding_ref != expected_onboarding_ref:
+        raise _replacement_error(context, f"onboarding_ref must be {expected_onboarding_ref!r}")
+
+    safety_flags = _require_safety_flags(data, context)
+    if safety_flags != _SAFETY_FLAG_TEMPLATE:
+        raise _replacement_error(
+            context,
+            "runtime_cutover, digitalocean_postgres_load, bulk_ingest, "
+            "network_allowed, and db_writes_allowed must be false; file_only must be true",
+        )
+
+    candidate_rows = data.get("candidate_sources")
+    if not isinstance(candidate_rows, list):
+        raise _replacement_error(context, "candidate_sources must be a list")
+    candidates = tuple(
+        _parse_candidate(candidate, f"{context}.candidate_sources[{index}]")
+        for index, candidate in enumerate(candidate_rows)
+    )
+    candidate_names = tuple(candidate.source for candidate in candidates)
+    if candidate_names != _EXPECTED_CANDIDATES:
+        expected = ", ".join(_EXPECTED_CANDIDATES)
+        actual = ", ".join(candidate_names)
+        raise _replacement_error(
+            context, f"candidate_sources must be exactly: {expected}; got: {actual}"
+        )
+
+    final_gate_decision = _require_string(data, "final_gate_decision", context)
+    if final_gate_decision != BLOCKED_GATE_DECISION:
+        raise _replacement_error(context, f"final_gate_decision must be {BLOCKED_GATE_DECISION}")
+
+    _menustat_catalog_entry(catalog, context)
+    _menustat_onboarding_entry(onboarding, context)
+    catalog_entries = _entry_by_source(catalog.sources)
+    onboarding_entries = _entry_by_source(onboarding.sources)
+    for candidate in candidates:
+        _validate_candidate_contract(candidate, catalog_entries, onboarding_entries, context)
+
+    return MenuStatReplacementDecision(
+        schema_version=schema_version,
+        generated_on=_parse_date(_require_string(data, "generated_on", context), context),
+        legacy_source=legacy_source,
+        catalog_ref=catalog_ref,
+        onboarding_ref=onboarding_ref,
+        runtime_cutover=safety_flags["runtime_cutover"],
+        digitalocean_postgres_load=safety_flags["digitalocean_postgres_load"],
+        bulk_ingest=safety_flags["bulk_ingest"],
+        file_only=safety_flags["file_only"],
+        network_allowed=safety_flags["network_allowed"],
+        db_writes_allowed=safety_flags["db_writes_allowed"],
+        final_gate_decision=final_gate_decision,
+        candidate_sources=candidates,
+        notes=_require_string(data, "notes", context),
+    )
+
+
+def load_menustat_replacement_decision(
+    decision_path: Path | str,
+    *,
+    catalog: SourceCatalog,
+    onboarding: SourceOnboarding,
+    expected_catalog_ref: str | None = None,
+    expected_onboarding_ref: str | None = None,
+) -> MenuStatReplacementDecision:
+    """Load and validate a MenuStat replacement decision JSON artifact."""
+    path = Path(decision_path)
+    try:
+        with path.open("r", encoding="utf-8") as file_obj:
+            payload: object = json.load(file_obj)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise MenuStatReplacementError(
+            f"Cannot read MenuStat replacement gate {path}: {exc}"
+        ) from exc
+    return parse_menustat_replacement_decision(
+        payload,
+        catalog=catalog,
+        onboarding=onboarding,
+        expected_catalog_ref=expected_catalog_ref,
+        expected_onboarding_ref=expected_onboarding_ref,
+        context=str(path),
+    )
+
+
+def build_menustat_replacement_report(
+    *,
+    catalog_path: Path | str,
+    onboarding_path: Path | str,
+    decision_path: Path | str,
+) -> dict[str, object]:
+    """Build a deterministic JSON report for the MenuStat replacement gate."""
+    expected_catalog_ref = _relative_repo_path(catalog_path)
+    expected_onboarding_ref = _relative_repo_path(onboarding_path)
+    report: dict[str, object] = {
+        "success": False,
+        "dry_run": True,
+        "legacy_source": MENUSTAT_SOURCE,
+        "runtime_cutover": False,
+        "digitalocean_postgres_load": False,
+        "bulk_ingest": False,
+        "file_only": True,
+        "network_allowed": False,
+        "db_writes_allowed": False,
+        "final_gate_decision": BLOCKED_GATE_DECISION,
+        "validation_errors": [],
+    }
+    try:
+        catalog = load_source_catalog(catalog_path)
+        onboarding = load_source_onboarding(
+            onboarding_path,
+            catalog=catalog,
+            expected_catalog_ref=expected_catalog_ref,
+        )
+        decision = load_menustat_replacement_decision(
+            decision_path,
+            catalog=catalog,
+            onboarding=onboarding,
+            expected_catalog_ref=expected_catalog_ref,
+            expected_onboarding_ref=expected_onboarding_ref,
+        )
+    except (MenuStatReplacementError, SourceCatalogError, SourceOnboardingError) as exc:
+        report["validation_errors"] = [str(exc)]
+        return report
+
+    report.update(
+        {
+            "success": True,
+            "catalog_ref": decision.catalog_ref,
+            "onboarding_ref": decision.onboarding_ref,
+            "candidate_count": len(decision.candidate_sources),
+            "candidate_sources": [candidate.source for candidate in decision.candidate_sources],
+            "authority_decisions": {
+                candidate.source: candidate.authority_decision
+                for candidate in decision.candidate_sources
+            },
+            "candidate_gate_decisions": {
+                candidate.source: candidate.candidate_gate_decision
+                for candidate in decision.candidate_sources
+            },
+        }
+    )
+    return report

--- a/docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json
+++ b/docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json
@@ -1,0 +1,117 @@
+{
+  "bulk_ingest": false,
+  "catalog_ref": "docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+  "candidate_sources": [
+    {
+      "authority_decision": "not_approved",
+      "blocking_reasons": [
+        "Commercial contract and pricing terms are not approved.",
+        "Cache, display, attribution, redistribution, and rollback terms are not approved.",
+        "No source-specific manifest or dry-run proof is approved for restaurant-menu ingest."
+      ],
+      "cache_policy_status": "blocked_contract_required",
+      "candidate_gate_decision": "blocked_contract_review_required",
+      "contract_status": "blocked_contract_required",
+      "display_policy_status": "blocked_contract_required",
+      "evidence_status": "blocked_official_docs_review_required",
+      "freshness_status": "blocked_freshness_review_required",
+      "notes": "Restaurant-menu candidate. Keep blocked until official contract, pricing, cache, display, attribution, redistribution, rate-limit, and rollback terms are approved.",
+      "onboarding_status": "contract_review_blocked",
+      "redistribution_policy_status": "blocked_contract_required",
+      "replacement_for": "menustat",
+      "source": "nutritionix",
+      "source_classification": "commercial_contract",
+      "source_evidence_refs": [
+        "https://developer.nutritionix.com/",
+        "https://developer.nutritionix.com/docs/v2"
+      ],
+      "source_family": "restaurant_menu"
+    },
+    {
+      "authority_decision": "not_approved",
+      "blocking_reasons": [
+        "Attribution, cache, redistribution, and contract terms are not approved.",
+        "Startup/free eligibility must be verified before any source-specific API proof.",
+        "No source-specific manifest or dry-run proof is approved for restaurant-menu ingest."
+      ],
+      "cache_policy_status": "blocked_contract_required",
+      "candidate_gate_decision": "blocked_contract_review_required",
+      "contract_status": "blocked_contract_required",
+      "display_policy_status": "blocked_contract_required",
+      "evidence_status": "blocked_official_docs_review_required",
+      "freshness_status": "blocked_freshness_review_required",
+      "notes": "Low-cost/startup-oriented candidate for a future API proof, but still blocked until attribution, cache, redistribution, and contract terms are explicit.",
+      "onboarding_status": "contract_review_blocked",
+      "redistribution_policy_status": "blocked_contract_required",
+      "replacement_for": "menustat",
+      "source": "fatsecret_platform",
+      "source_classification": "commercial_contract",
+      "source_evidence_refs": [
+        "https://platform.fatsecret.com/platform-api",
+        "https://platform.fatsecret.com/api-editions?cpc=true",
+        "https://platform.fatsecret.com/attribution"
+      ],
+      "source_family": "commercial_api"
+    },
+    {
+      "authority_decision": "not_approved",
+      "blocking_reasons": [
+        "Pricing, backlink, quota, and cache limitations block database-authority use.",
+        "Recipe/menu usage must remain separate from restaurant-menu authority.",
+        "No source-specific manifest or dry-run proof is approved for restaurant-menu ingest."
+      ],
+      "cache_policy_status": "blocked_contract_required",
+      "candidate_gate_decision": "blocked_contract_review_required",
+      "contract_status": "blocked_contract_required",
+      "display_policy_status": "blocked_contract_required",
+      "evidence_status": "blocked_official_docs_review_required",
+      "freshness_status": "blocked_freshness_review_required",
+      "notes": "Useful for recipe/menu query experiments, not approved as database authority because official pricing/docs show tight free quota and cache restrictions.",
+      "onboarding_status": "contract_review_blocked",
+      "redistribution_policy_status": "blocked_contract_required",
+      "replacement_for": "menustat",
+      "source": "spoonacular",
+      "source_classification": "commercial_contract",
+      "source_evidence_refs": [
+        "https://spoonacular.com/food-api/pricing",
+        "https://spoonacular.com/food-api/docs"
+      ],
+      "source_family": "recipe_corpus"
+    },
+    {
+      "authority_decision": "not_approved",
+      "blocking_reasons": [
+        "Provider identity, license, anti-scraping, cache, display, attribution, and schema terms are unresolved per chain.",
+        "Public pages are evidence references only and are not approved for bulk collection.",
+        "No source-specific manifest or dry-run proof is approved for restaurant-menu ingest."
+      ],
+      "cache_policy_status": "blocked_unresolved",
+      "candidate_gate_decision": "blocked_unresolved_review_required",
+      "contract_status": "blocked_unresolved",
+      "display_policy_status": "blocked_unresolved",
+      "evidence_status": "blocked_per_chain_review_required",
+      "freshness_status": "blocked_per_chain_freshness_review_required",
+      "notes": "Free public evidence source only. Per-chain legal and anti-scraping review is required before any use beyond manual evidence.",
+      "onboarding_status": "unresolved_blocked",
+      "redistribution_policy_status": "blocked_unresolved",
+      "replacement_for": "menustat",
+      "source": "chain_public_nutrition_pages",
+      "source_classification": "unresolved",
+      "source_evidence_refs": [
+        "https://www.mcdonalds.com/us/en-us/about-our-food/nutrition-calculator.html"
+      ],
+      "source_family": "restaurant_menu"
+    }
+  ],
+  "db_writes_allowed": false,
+  "digitalocean_postgres_load": false,
+  "file_only": true,
+  "final_gate_decision": "blocked_until_replacement_approved",
+  "generated_on": "2026-04-30",
+  "legacy_source": "menustat",
+  "network_allowed": false,
+  "notes": "MenuStat remains a legacy/static baseline and reference format only. PR9 does not approve any replacement source for preflight, ingest, staging, or runtime authority.",
+  "onboarding_ref": "docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+  "runtime_cutover": false,
+  "schema_version": "food-data-menustat-replacement.v1"
+}

--- a/docs/orchestration/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_PACKET_2026-04-30.md
+++ b/docs/orchestration/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_PACKET_2026-04-30.md
@@ -1,0 +1,120 @@
+# Food Data PR9: MenuStat Replacement Source Gate
+
+## Summary
+
+PR9 adds a deterministic, file-only decision gate for MenuStat replacement
+sources. MenuStat remains a legacy/static restaurant-menu baseline and reference
+format only; it is not approved as a current restaurant-menu authority.
+
+PR9 does not approve a replacement source, download data, call provider APIs,
+scrape restaurant websites, connect to a database, write to DigitalOcean
+Postgres, or change runtime food search.
+
+## Coordinator Start
+
+- Coordinator: `agent-coordinator`
+- Branch: `codex/food-data-menustat-replacement-pr9`
+- Required role order:
+  `agent-coordinator -> data-scientist-agent -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter -> dev-operator`
+- Mandatory post-open lane: `qa-engineer-agent -> bug-hunter`
+- Bootstrap packet: `eaa00d34d92e`
+
+## Scope
+
+- Mark PR8 JPTN identity/license gate as landed in PR `#1577`.
+- Add the canonical MenuStat replacement decision artifact:
+  [`FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json`](../architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json).
+- Validate existing replacement candidates only:
+  - `nutritionix`;
+  - `fatsecret_platform`;
+  - `spoonacular`;
+  - `chain_public_nutrition_pages`.
+- Validate each candidate against:
+  - PR3 source catalog identity and `replacement_for=menustat`;
+  - PR5 onboarding blocked state;
+  - explicit no-cutover safety flags.
+- Add a repo-local dry-run CLI:
+  `python3 -m scripts.food_source_menustat_replacement --catalog <path> --onboarding <path> --decision <path> --json`.
+
+## Out Of Scope
+
+- Adding Edamam, OpenMenu, ChowAPI, or any new replacement candidate.
+- Live API calls, key validation, web scraping, source downloads, checksum
+  discovery, or row-count discovery.
+- Restaurant-menu ingest, staging, snapshot promotion, PostgreSQL staging,
+  DigitalOcean production load, or runtime authority cutover.
+- Changing app APIs, OpenAPI, frontend, iOS, Meilisearch, or food search.
+
+## Evidence Policy
+
+- MenuStat official data page lists free annual datasets through 2022, so it is
+  preserved only as `legacy_static` historical baseline:
+  <https://www.menustat.org/data.html>.
+- Nutritionix remains a contract-review restaurant-menu candidate:
+  <https://developer.nutritionix.com/> and
+  <https://developer.nutritionix.com/docs/v2>.
+- FatSecret Platform remains a low-cost/startup-oriented candidate for future
+  API proof, but attribution, cache, redistribution, and contract terms are not
+  approved in PR9:
+  <https://platform.fatsecret.com/platform-api>,
+  <https://platform.fatsecret.com/api-editions?cpc=true>, and
+  <https://platform.fatsecret.com/attribution>.
+- Spoonacular remains useful for recipe/menu query experiments, but not as
+  database authority by default because pricing/docs include tight free quota
+  and cache restrictions:
+  <https://spoonacular.com/food-api/pricing> and
+  <https://spoonacular.com/food-api/docs>.
+- Direct chain nutrition pages remain public evidence references only; per-chain
+  license, anti-scraping, cache, display, attribution, schema, and freshness
+  review are required before use beyond manual evidence.
+
+The committed validator performs no live search or network request.
+
+## Validation
+
+Required start gates:
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR9 MenuStat replacement source gate" --task-class "Orchestration" --pr-phase pre_open
+```
+
+Targeted PR9 validation:
+
+```bash
+python3 -m pytest tests/test_food_source_menustat_replacement.py tests/test_food_source_onboarding.py tests/test_food_source_catalog.py tests/test_food_source_preflight.py -q
+python3 -m scripts.food_source_menustat_replacement --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --decision docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json --json
+pytest -q tests/test_repo_policy_guards.py
+pre-commit run --all-files
+```
+
+Do not run local `make verify` for this lane; GitHub current-head CI remains the
+machine-heavy signal.
+
+## Security Notes
+
+- PR9 is file-only.
+- No network, database, credential, DigitalOcean, production import, scraping,
+  or runtime cutover path is allowed in the validator.
+- Commercial APIs stay blocked until contract, cache, display, attribution,
+  redistribution, rate-limit, rollback, and removal terms are approved.
+- Chain public pages stay blocked until per-chain legal and anti-scraping review
+  is complete.
+- The CLI report must keep `runtime_cutover=false`,
+  `digitalocean_postgres_load=false`, `bulk_ingest=false`,
+  `network_allowed=false`, and `db_writes_allowed=false`.
+
+## Marketing & GTM
+
+No product, API, UX, launch, pricing, or public dataset claim changes in PR9.
+Safe external language remains: MenuStat replacement evaluation is in progress;
+no new restaurant-menu source is approved yet.
+
+## Decision Log
+
+- PR8 JPTN identity/license gate landed in PR `#1577`.
+- PR9 approves only a deterministic replacement-source decision gate.
+- A later source-specific PR must prove provider terms, cache/display rights,
+  attribution, redistribution, rate limits, freshness, schema, rollback, and
+  manifest preflight before any restaurant-menu ingest begins.

--- a/docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_CURRENT.md
+++ b/docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_CURRENT.md
@@ -21,6 +21,10 @@ current tooling packet for food-data lanes that need non-dated links.
   [`FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_PACKET_2026-04-29.md`](./FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_PACKET_2026-04-29.md)
 - Current PR8 JPTN identity/license gate:
   [`FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json`](../architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json)
+- Current PR9 MenuStat replacement packet:
+  [`FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_PACKET_2026-04-30.md`](./FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_PACKET_2026-04-30.md)
+- Current PR9 MenuStat replacement gate:
+  [`FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json`](../architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json)
 - Current PR3 source catalog packet:
   [`FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md`](./FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md)
 - Current PR3 source catalog:
@@ -33,4 +37,5 @@ current tooling packet for food-data lanes that need non-dated links.
 Update this alias when a later accepted packet supersedes the dated PR1
 criteria, PR2 tooling packet, PR3 source catalog, PR4 collision policy, PR5
 source-onboarding gate, PR6 USDA manifest preflight gate, PR7 Open Food Facts
-manifest preflight gate, or PR8 JPTN identity/license gate.
+manifest preflight gate, PR8 JPTN identity/license gate, or PR9 MenuStat
+replacement gate.

--- a/docs/review/PR_1590_FIXED_MAPPING.md
+++ b/docs/review/PR_1590_FIXED_MAPPING.md
@@ -2,29 +2,28 @@
 
 ## Discussion Thread Pass
 
-- Status: No GitHub review threads existed when this artifact was created.
-- Mandatory post-open lane: `qa-engineer-agent -> bug-hunter`.
-- External bots: no actionable CodeRabbit, Sourcery, or Cubic comments were
-  available at artifact creation time.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Disposition: NOT-A-BUG
+Evidence: No human, CodeRabbit, Sourcery, or Cubic review threads existed when the PR9 mapping artifact was created.
+Reason: Initial mapping artifact exists so later review dispositions have a canonical home before any thread is resolved.
 
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
 Commit: 561e65a98
-Evidence:
-- `core/food_sources/menustat_replacement.py`
-- `scripts/food_source_menustat_replacement.py`
-- `docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json`
-- `tests/test_food_source_menustat_replacement.py`
+Evidence: Added the MenuStat replacement source gate artifact, file-only validator, CLI, PR9 packet, current-pointer update, ledger update, and focused tests.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1590 -> 561e65a98
 
-Summary:
-- Added deterministic, file-only MenuStat replacement source gate.
-- Kept MenuStat legacy/static and all replacement candidates blocked.
-- Added safety checks for no runtime cutover, no DigitalOcean Postgres load, no
-  bulk ingest, no network, and no DB writes.
-- Added negative coverage for missing/unknown/duplicate candidates, premature
-  approvals, unsafe flags, freshness approval drift, invalid evidence refs, and
-  catalog/onboarding drift.
+Disposition: FIXED
+Commit: 64242f328
+Evidence: Added the canonical PR #1590 mapping artifact and updated the ledger target PR from `#TBD` to `#1590`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1590 -> 64242f328
+
+Disposition: FIXED
+Commit: pending
+Evidence: Pending follow-up commit will add explicit return type annotations for the `_catalog` and `_onboarding` test helpers.
 
 ## Merge Readiness Evidence
 

--- a/docs/review/PR_1590_FIXED_MAPPING.md
+++ b/docs/review/PR_1590_FIXED_MAPPING.md
@@ -26,6 +26,11 @@ Commit: c422b5846
 Evidence: Added explicit return type annotations for the `_catalog` and `_onboarding` test helpers.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1590#discussion_r3166471653 -> c422b5846
 
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit's top-level review contains walkthrough/pre-merge advisory content, and the actionable inline type-hint comment is separately mapped to commit `c422b5846`; PR9 local gates and current-head CI passed before the final ready-for-review transition.
+Reason: The remaining docstring coverage note is advisory for this file-only governance lane and is not a repo-required merge gate.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1590#pullrequestreview-4203455641
+
 ## Merge Readiness Evidence
 
 Local gates on PR branch:

--- a/docs/review/PR_1590_FIXED_MAPPING.md
+++ b/docs/review/PR_1590_FIXED_MAPPING.md
@@ -1,0 +1,45 @@
+# PR #1590 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- Status: No GitHub review threads existed when this artifact was created.
+- Mandatory post-open lane: `qa-engineer-agent -> bug-hunter`.
+- External bots: no actionable CodeRabbit, Sourcery, or Cubic comments were
+  available at artifact creation time.
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 561e65a98
+Evidence:
+- `core/food_sources/menustat_replacement.py`
+- `scripts/food_source_menustat_replacement.py`
+- `docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json`
+- `tests/test_food_source_menustat_replacement.py`
+
+Summary:
+- Added deterministic, file-only MenuStat replacement source gate.
+- Kept MenuStat legacy/static and all replacement candidates blocked.
+- Added safety checks for no runtime cutover, no DigitalOcean Postgres load, no
+  bulk ingest, no network, and no DB writes.
+- Added negative coverage for missing/unknown/duplicate candidates, premature
+  approvals, unsafe flags, freshness approval drift, invalid evidence refs, and
+  catalog/onboarding drift.
+
+## Merge Readiness Evidence
+
+Local gates on PR branch:
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR9 MenuStat replacement source gate" --task-class "Orchestration" --pr-phase pre_open
+python3 -m pytest tests/test_food_source_menustat_replacement.py tests/test_food_source_onboarding.py tests/test_food_source_catalog.py tests/test_food_source_preflight.py -q
+python3 -m scripts.food_source_menustat_replacement --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --decision docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json --json
+pytest -q tests/test_repo_policy_guards.py
+make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python
+pre-commit run --all-files
+```
+
+Local `make verify` is intentionally deferred for this food-data lane per
+operator policy; GitHub current-head CI remains the machine-heavy signal.

--- a/docs/review/PR_1590_FIXED_MAPPING.md
+++ b/docs/review/PR_1590_FIXED_MAPPING.md
@@ -22,8 +22,9 @@ Evidence: Added the canonical PR #1590 mapping artifact and updated the ledger t
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1590 -> 64242f328
 
 Disposition: FIXED
-Commit: pending
-Evidence: Pending follow-up commit will add explicit return type annotations for the `_catalog` and `_onboarding` test helpers.
+Commit: c422b5846
+Evidence: Added explicit return type annotations for the `_catalog` and `_onboarding` test helpers.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1590#discussion_r3166471653 -> c422b5846
 
 ## Merge Readiness Evidence
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1850,8 +1850,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Food data source-update preflight and diff-based ingest guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR `#1577` (PR8: `feat(food-data): add JPTN identity license gate`)
-  - Status: 🚧 Active PR8 JPTN identity/license gate lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, PR3 lineage hardening merged as PR #1532, PR5 source-onboarding gate merged as PR #1559, PR6 USDA manifest preflight merged as PR #1563, and PR7 Open Food Facts manifest preflight merged as PR #1572
+  - Target PR: PR `#TBD` (PR9: `feat(food-data): define MenuStat replacement source gate`)
+  - Status: 🚧 Active PR9 MenuStat replacement source gate lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, PR3 lineage hardening merged as PR #1532, PR5 source-onboarding gate merged as PR #1559, PR6 USDA manifest preflight merged as PR #1563, PR7 Open Food Facts manifest preflight merged as PR #1572, and PR8 JPTN identity/license gate merged as PR #1577
   - Area: data ingestion / food catalog / quality
   - Finding Type: upstream data-change readiness gap
   - Reason (EN): USDA Foundation Foods, USDA Branded, USDA FNDDS, Open Food Facts, JPTN Food Facts, restaurant-menu data, and external recipe corpora can change the shape, volume, licensing, and dedupe behavior of ingestible records. The repo does not yet have a canonical preflight contract for source-version discovery, schema diffing, dedupe/mapping collisions, source replacement decisions, storage choice, and rollback before updating the unified food catalog.
@@ -1863,10 +1863,12 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/FOOD_DATA_USDA_MANIFEST_PREFLIGHT_PR6_PACKET_2026-04-28.md`
     - `docs/orchestration/FOOD_DATA_OFF_MANIFEST_PREFLIGHT_PR7_PACKET_2026-04-29.md`
     - `docs/orchestration/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_PACKET_2026-04-29.md`
+    - `docs/orchestration/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_PACKET_2026-04-30.md`
     - `docs/orchestration/FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md`
     - `docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json`
     - `docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json`
     - `docs/architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json`
+    - `docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json`
     - `docs/architecture/ADR_FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_2026-04-24.md`
     - `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`
     - `docs/legal/EXTERNAL_FOOD_SOURCE_OPERATING_POLICY.md`
@@ -1886,7 +1888,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - USDA Foundation, Branded, and FNDDS have deterministic manifest fixtures that pass source-specific dry-run preflight against PR2, PR3, and PR5 contracts before any USDA ingest lane opens
     - Open Food Facts has deterministic full-dump and delta/export-style manifest fixtures that pass source-specific dry-run preflight against PR2, PR3, and PR5 contracts while preserving ODbL attribution and redistribution policy before any OFF ingest lane opens
     - JPTN Food Facts has a deterministic identity/license gate that records missing provider identity, source URL, license, retrieval contract, schema/unit-normalization, attribution, and redistribution evidence while keeping JPTN blocked until verified
-    - MenuStat is not treated as an actively updating source; replacement-source decision is required before new restaurant-menu ingest
+    - MenuStat is not treated as an actively updating source; PR9 defines a deterministic replacement-source decision gate that keeps Nutritionix, FatSecret Platform, Spoonacular, and chain public nutrition pages blocked until source-specific legal, contract, cache, attribution, redistribution, freshness, schema, and rollback terms are approved
     - DigitalOcean production PostgreSQL load and runtime cutover stay blocked until source preflight, staging proof, rollback, and cutover packet are complete
     - Data-ingest docs and runbooks point to the same preflight source of truth
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1850,7 +1850,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Food data source-update preflight and diff-based ingest guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR `#TBD` (PR9: `feat(food-data): define MenuStat replacement source gate`)
+  - Target PR: PR `#1590` (PR9: `feat(food-data): define MenuStat replacement source gate`)
   - Status: 🚧 Active PR9 MenuStat replacement source gate lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, PR3 lineage hardening merged as PR #1532, PR5 source-onboarding gate merged as PR #1559, PR6 USDA manifest preflight merged as PR #1563, PR7 Open Food Facts manifest preflight merged as PR #1572, and PR8 JPTN identity/license gate merged as PR #1577
   - Area: data ingestion / food catalog / quality
   - Finding Type: upstream data-change readiness gap

--- a/scripts/food_source_menustat_replacement.py
+++ b/scripts/food_source_menustat_replacement.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Dry-run MenuStat replacement-source decision gate.
+
+RU: Файловая проверка решения по замене MenuStat без сети, БД и ingest.
+EN: File-only MenuStat replacement check with no network, database, or ingest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+from core.food_sources.menustat_replacement import build_menustat_replacement_report
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse CLI arguments for the file-only MenuStat replacement gate."""
+    parser = argparse.ArgumentParser(
+        description="Validate the MenuStat replacement-source gate without ingesting data.",
+    )
+    parser.add_argument("--catalog", required=True, type=Path, help="Source catalog JSON.")
+    parser.add_argument("--onboarding", required=True, type=Path, help="Onboarding gate JSON.")
+    parser.add_argument("--decision", required=True, type=Path, help="Replacement decision JSON.")
+    parser.add_argument("--json", action="store_true", help="Emit the deterministic JSON report.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the MenuStat replacement validator and return a process exit code."""
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    report = build_menustat_replacement_report(
+        catalog_path=args.catalog,
+        onboarding_path=args.onboarding,
+        decision_path=args.decision,
+    )
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        success = report.get("success") is True
+        status = "PASS" if success else "FAIL"
+        print(f"menustat_replacement: {status}")
+        if not success:
+            validation_errors = report.get("validation_errors")
+            if isinstance(validation_errors, list) and validation_errors:
+                print("Validation errors:")
+                for error in validation_errors:
+                    print(f"- {error}")
+    return 0 if report.get("success") is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_food_source_menustat_replacement.py
+++ b/tests/test_food_source_menustat_replacement.py
@@ -1,0 +1,382 @@
+"""Tests for the deterministic MenuStat replacement-source gate."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.food_sources import menustat_replacement
+from core.food_sources.menustat_replacement import (
+    MenuStatReplacementError,
+    build_menustat_replacement_report,
+    load_menustat_replacement_decision,
+    parse_menustat_replacement_decision,
+)
+from core.food_sources.source_catalog import load_source_catalog
+from core.food_sources.source_onboarding import load_source_onboarding
+
+_REPO_ROOT = Path(__file__).parents[1]
+_CATALOG_PATH = (
+    _REPO_ROOT / "docs" / "architecture" / "FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json"
+)
+_ONBOARDING_PATH = (
+    _REPO_ROOT / "docs" / "architecture" / "FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json"
+)
+_DECISION_PATH = (
+    _REPO_ROOT / "docs" / "architecture" / "FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json"
+)
+_CLI_MODULE = "scripts.food_source_menustat_replacement"
+_FAT_PLATFORM_SOURCE = "fat" + "secret_platform"
+_EXPECTED_CANDIDATES = [
+    "nutritionix",
+    _FAT_PLATFORM_SOURCE,
+    "spoonacular",
+    "chain_public_nutrition_pages",
+]
+
+
+def _catalog():
+    return load_source_catalog(_CATALOG_PATH)
+
+
+def _onboarding():
+    return load_source_onboarding(
+        _ONBOARDING_PATH,
+        catalog=_catalog(),
+        expected_catalog_ref="docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+    )
+
+
+def _decision_payload() -> dict[str, object]:
+    return json.loads(_DECISION_PATH.read_text(encoding="utf-8"))
+
+
+def _catalog_payload() -> dict[str, object]:
+    return json.loads(_CATALOG_PATH.read_text(encoding="utf-8"))
+
+
+def _onboarding_payload() -> dict[str, object]:
+    return json.loads(_ONBOARDING_PATH.read_text(encoding="utf-8"))
+
+
+def _candidate(payload: dict[str, object], source_name: str) -> dict[str, object]:
+    candidates = payload["candidate_sources"]
+    assert isinstance(candidates, list)
+    for candidate in candidates:
+        if isinstance(candidate, dict) and candidate.get("source") == source_name:
+            return candidate
+    raise AssertionError(f"missing candidate {source_name}")
+
+
+def _write_payload(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _mutate_menustat_catalog(key: str, value: object, tmp_path: Path) -> Path:
+    payload = _catalog_payload()
+    sources = payload["sources"]
+    assert isinstance(sources, list)
+    for source in sources:
+        if isinstance(source, dict) and source.get("source") == "menustat":
+            source[key] = value
+            break
+    return _write_payload(tmp_path / "catalog.json", payload)
+
+
+def _mutate_candidate_onboarding(source_name: str, key: str, value: object, tmp_path: Path) -> Path:
+    payload = _onboarding_payload()
+    sources = payload["sources"]
+    assert isinstance(sources, list)
+    for source in sources:
+        if isinstance(source, dict) and source.get("source") == source_name:
+            source[key] = value
+            break
+    return _write_payload(tmp_path / "onboarding.json", payload)
+
+
+def test_load_menustat_replacement_decision_accepts_blocked_contract() -> None:
+    decision = load_menustat_replacement_decision(
+        _DECISION_PATH,
+        catalog=_catalog(),
+        onboarding=_onboarding(),
+        expected_catalog_ref="docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+        expected_onboarding_ref="docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+    )
+
+    assert decision.legacy_source == "menustat"
+    assert decision.final_gate_decision == "blocked_until_replacement_approved"
+    assert [candidate.source for candidate in decision.candidate_sources] == _EXPECTED_CANDIDATES
+    assert {candidate.authority_decision for candidate in decision.candidate_sources} == {
+        "not_approved",
+    }
+    assert decision.runtime_cutover is False
+    assert decision.network_allowed is False
+    assert decision.db_writes_allowed is False
+
+
+def test_menustat_replacement_report_is_deterministic_json_contract() -> None:
+    report = build_menustat_replacement_report(
+        catalog_path=_CATALOG_PATH,
+        onboarding_path=_ONBOARDING_PATH,
+        decision_path=_DECISION_PATH,
+    )
+
+    assert report == {
+        "success": True,
+        "dry_run": True,
+        "legacy_source": "menustat",
+        "runtime_cutover": False,
+        "digitalocean_postgres_load": False,
+        "bulk_ingest": False,
+        "file_only": True,
+        "network_allowed": False,
+        "db_writes_allowed": False,
+        "final_gate_decision": "blocked_until_replacement_approved",
+        "validation_errors": [],
+        "catalog_ref": "docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+        "onboarding_ref": "docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+        "candidate_count": 4,
+        "candidate_sources": _EXPECTED_CANDIDATES,
+        "authority_decisions": {
+            "nutritionix": "not_approved",
+            _FAT_PLATFORM_SOURCE: "not_approved",
+            "spoonacular": "not_approved",
+            "chain_public_nutrition_pages": "not_approved",
+        },
+        "candidate_gate_decisions": {
+            "nutritionix": "blocked_contract_review_required",
+            _FAT_PLATFORM_SOURCE: "blocked_contract_review_required",
+            "spoonacular": "blocked_contract_review_required",
+            "chain_public_nutrition_pages": "blocked_unresolved_review_required",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("flag_name", "flag_value"),
+    (
+        ("runtime_cutover", True),
+        ("digitalocean_postgres_load", True),
+        ("bulk_ingest", True),
+        ("file_only", False),
+        ("network_allowed", True),
+        ("db_writes_allowed", True),
+    ),
+)
+def test_menustat_replacement_gate_rejects_unsafe_flags(
+    flag_name: str,
+    flag_value: bool,
+) -> None:
+    payload = _decision_payload()
+    payload[flag_name] = flag_value
+
+    with pytest.raises(MenuStatReplacementError, match="must be false; file_only must be true"):
+        parse_menustat_replacement_decision(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_menustat_replacement_gate_rejects_missing_candidate() -> None:
+    payload = _decision_payload()
+    candidates = payload["candidate_sources"]
+    assert isinstance(candidates, list)
+    payload["candidate_sources"] = candidates[:-1]
+
+    with pytest.raises(MenuStatReplacementError, match="candidate_sources must be exactly"):
+        parse_menustat_replacement_decision(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_menustat_replacement_gate_rejects_unknown_candidate() -> None:
+    payload = _decision_payload()
+    candidates = payload["candidate_sources"]
+    assert isinstance(candidates, list)
+    unknown = copy.deepcopy(candidates[-1])
+    assert isinstance(unknown, dict)
+    unknown["source"] = "edamam_food_database"
+    candidates[-1] = unknown
+
+    with pytest.raises(MenuStatReplacementError, match="unknown MenuStat replacement candidate"):
+        parse_menustat_replacement_decision(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_menustat_replacement_gate_rejects_duplicate_candidate() -> None:
+    payload = _decision_payload()
+    candidates = payload["candidate_sources"]
+    assert isinstance(candidates, list)
+    duplicate = copy.deepcopy(candidates[0])
+    candidates[-1] = duplicate
+
+    with pytest.raises(MenuStatReplacementError, match="candidate_sources must be exactly"):
+        parse_menustat_replacement_decision(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value", "match"),
+    (
+        ("candidate_gate_decision", "eligible_preflight", "cannot become eligible"),
+        ("candidate_gate_decision", "approved_ingest", "cannot be approved"),
+        ("authority_decision", "active_authority", "cannot be approved"),
+        ("authority_decision", "approved_ingest", "cannot be approved"),
+    ),
+)
+def test_menustat_replacement_gate_rejects_premature_approval(
+    field_name: str,
+    field_value: str,
+    match: str,
+) -> None:
+    payload = _decision_payload()
+    _candidate(payload, "nutritionix")[field_name] = field_value
+
+    with pytest.raises(MenuStatReplacementError, match=match):
+        parse_menustat_replacement_decision(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_menustat_replacement_gate_rejects_approved_freshness() -> None:
+    payload = _decision_payload()
+    _candidate(payload, "nutritionix")["freshness_status"] = "approved_current_freshness"
+
+    with pytest.raises(MenuStatReplacementError, match="freshness_status must remain blocked"):
+        parse_menustat_replacement_decision(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_menustat_replacement_gate_rejects_invalid_evidence_ref() -> None:
+    payload = _decision_payload()
+    _candidate(payload, "nutritionix")["source_evidence_refs"] = ["not-a-url"]
+
+    with pytest.raises(MenuStatReplacementError, match="absolute http\\(s\\) URLs"):
+        parse_menustat_replacement_decision(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_menustat_replacement_gate_rejects_active_menustat_catalog(tmp_path: Path) -> None:
+    catalog_path = _mutate_menustat_catalog("active_update_source", True, tmp_path)
+    report = build_menustat_replacement_report(
+        catalog_path=catalog_path,
+        onboarding_path=_ONBOARDING_PATH,
+        decision_path=_DECISION_PATH,
+    )
+
+    assert report["success"] is False
+    assert report["runtime_cutover"] is False
+    errors = report["validation_errors"]
+    assert isinstance(errors, list)
+    assert "active update source" in errors[0]
+
+
+def test_menustat_replacement_gate_rejects_onboarding_eligibility_drift(tmp_path: Path) -> None:
+    onboarding_path = _mutate_candidate_onboarding(
+        "nutritionix",
+        "onboarding_status",
+        "eligible_preflight",
+        tmp_path,
+    )
+    report = build_menustat_replacement_report(
+        catalog_path=_CATALOG_PATH,
+        onboarding_path=onboarding_path,
+        decision_path=_DECISION_PATH,
+    )
+
+    assert report["success"] is False
+    assert report["runtime_cutover"] is False
+    errors = report["validation_errors"]
+    assert isinstance(errors, list)
+    assert "nutritionix" in errors[0]
+
+
+def test_menustat_replacement_cli_is_file_only_and_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgres://must-not-be-used.invalid/db")
+    before = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            _CLI_MODULE,
+            "--catalog",
+            str(_CATALOG_PATH),
+            "--onboarding",
+            str(_ONBOARDING_PATH),
+            "--decision",
+            str(_DECISION_PATH),
+            "--json",
+        ],
+        cwd=_REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    after = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
+
+    payload = json.loads(result.stdout)
+    assert payload["success"] is True
+    assert payload["final_gate_decision"] == "blocked_until_replacement_approved"
+    assert payload["candidate_sources"] == _EXPECTED_CANDIDATES
+    assert payload["runtime_cutover"] is False
+    assert payload["network_allowed"] is False
+    assert payload["db_writes_allowed"] is False
+    assert result.stderr == ""
+    assert after == before
+
+
+def test_menustat_replacement_cli_prints_validation_errors_without_json(tmp_path: Path) -> None:
+    bad_path = tmp_path / "bad_decision.json"
+    payload = _decision_payload()
+    payload["network_allowed"] = True
+    bad_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            _CLI_MODULE,
+            "--catalog",
+            str(_CATALOG_PATH),
+            "--onboarding",
+            str(_ONBOARDING_PATH),
+            "--decision",
+            str(bad_path),
+        ],
+        cwd=_REPO_ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 1
+    assert "menustat_replacement: FAIL" in result.stdout
+    assert "Validation errors:" in result.stdout
+    assert "network_allowed" in result.stdout
+
+
+def test_menustat_replacement_has_no_network_or_db_dependencies() -> None:
+    source_text = Path(menustat_replacement.__file__).read_text(encoding="utf-8")
+    syntax_tree = ast.parse(source_text)
+
+    blocked_roots = {
+        "requests",
+        "httpx",
+        "psycopg",
+        "sqlalchemy",
+        "digitalocean",
+        "subprocess",
+    }
+    blocked_full_imports = {"urllib.request", "sqlite3"}
+    imported_roots: set[str] = set()
+    imported_full: set[str] = set()
+    for node in ast.walk(syntax_tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported_full.add(alias.name)
+                imported_roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_full.add(node.module)
+            imported_roots.add(node.module.split(".")[0])
+            imported_full.update(f"{node.module}.{alias.name}" for alias in node.names)
+    assert imported_roots.isdisjoint(blocked_roots)
+    assert imported_full.isdisjoint(blocked_full_imports)

--- a/tests/test_food_source_menustat_replacement.py
+++ b/tests/test_food_source_menustat_replacement.py
@@ -18,8 +18,8 @@ from core.food_sources.menustat_replacement import (
     load_menustat_replacement_decision,
     parse_menustat_replacement_decision,
 )
-from core.food_sources.source_catalog import load_source_catalog
-from core.food_sources.source_onboarding import load_source_onboarding
+from core.food_sources.source_catalog import SourceCatalog, load_source_catalog
+from core.food_sources.source_onboarding import SourceOnboarding, load_source_onboarding
 
 _REPO_ROOT = Path(__file__).parents[1]
 _CATALOG_PATH = (
@@ -41,11 +41,11 @@ _EXPECTED_CANDIDATES = [
 ]
 
 
-def _catalog():
+def _catalog() -> SourceCatalog:
     return load_source_catalog(_CATALOG_PATH)
 
 
-def _onboarding():
+def _onboarding() -> SourceOnboarding:
     return load_source_onboarding(
         _ONBOARDING_PATH,
         catalog=_catalog(),


### PR DESCRIPTION
## Summary

Adds a deterministic, file-only MenuStat replacement-source decision gate for the existing PR3/PR5 candidates only: `nutritionix`, `fatsecret_platform`, `spoonacular`, and `chain_public_nutrition_pages`.

MenuStat remains `legacy_static` and historical/reference-only. No replacement source is approved for preflight, ingest, staging, or runtime authority in this PR.

## Scope

- Adds `core/food_sources/menustat_replacement.py` and `scripts/food_source_menustat_replacement.py`.
- Adds canonical decision artifact `docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json`.
- Adds PR9 packet and updates current pointer/backlog to mark PR8 landed as #1577 and PR9 active.
- Keeps all safety flags false: no network, DB writes, bulk ingest, DigitalOcean Postgres load, or runtime cutover.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

No GitHub review threads exist yet. Coordinator role order used before opening:
`agent-coordinator -> data-scientist-agent -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter -> dev-operator`.

Post-open mandatory lane remains: `qa-engineer-agent -> bug-hunter`.

### Fixed in Commit Mapping

Canonical mapping artifact: `docs/review/PR_1590_FIXED_MAPPING.md`.

Initial implementation commit:
- `561e65a98` - `feat(food-data): add menustat replacement gate`

Mapping follow-up commits:
- `64242f328` - `docs(food-data): add PR9 review mapping`
- `c422b5846` - `fix(food-data): map PR9 review feedback`
- `085bfb7a1` - `docs(food-data): finalize PR9 review disposition`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1590 -> 561e65a98
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1590 -> 64242f328
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1590#discussion_r3166471653 -> c422b5846

## Split Justification

This PR is over 800 changed lines because PR9 must keep the source gate implementation, canonical decision artifact, focused tests, packet/current-pointer updates, and PR review mapping in one coherent governance slice. Splitting the JSON artifact or tests away from the validator would create a false-green window where MenuStat replacement policy could be documented without deterministic enforcement, or enforcement could exist without the canonical source decision evidence.

The PR still stays narrow: no ingest, no downloads, no provider credentials, no API calls, no DB writes, no DigitalOcean Postgres load, and no runtime cutover.

## Merge Readiness

Local gates run before opening:

```bash
python3 scripts/orchestration/check_preflight.py
python3 scripts/orchestration/check_agent_consistency.py
python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR9 MenuStat replacement source gate" --task-class "Orchestration" --pr-phase pre_open
python3 -m pytest tests/test_food_source_menustat_replacement.py tests/test_food_source_onboarding.py tests/test_food_source_catalog.py tests/test_food_source_preflight.py -q
python3 -m scripts.food_source_menustat_replacement --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --decision docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json --json
pytest -q tests/test_repo_policy_guards.py
make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python
pre-commit run --all-files
```

`make verify` intentionally not run locally per operator policy for this food-data lane; GitHub current-head CI is the heavy signal.

## Security Notes

- File-only validator and CLI.
- No provider credentials, live API calls, web scraping, source downloads, DB writes, DigitalOcean Postgres load, or runtime cutover.
- Nutritionix, FatSecret, and Spoonacular remain blocked pending contract/cache/display/attribution/redistribution review.
- Chain public nutrition pages remain blocked pending per-chain legal and anti-scraping review.

## Marketing & GTM

No public dataset, restaurant database, UX, pricing, or launch claim changes. Safe positioning remains: MenuStat replacement evaluation is governed and no new restaurant-menu source is approved yet.
