### PR TITLE
fix(ios): add privacy manifest and align App Privacy disclosures

### DIFF
--- a/docs/orchestration/APPSTORE_RELEASE_READINESS_PR1_PRIVACY_PACKET_2026-04-30.md
+++ b/docs/orchestration/APPSTORE_RELEASE_READINESS_PR1_PRIVACY_PACKET_2026-04-30.md
@@ -1,0 +1,92 @@
+# App Store Release Readiness PR-1 Privacy Packet
+
+**Packet ID:** `appstore-release-readiness-pr1-privacy-2026-04-30`
+
+**Epic:** `epic/appstore-release-readiness-full-feature`
+
+**Branch:** `release/appstore-readiness-pr1-privacy-manifest`
+
+**PR title:** `fix(ios): add privacy manifest and align App Privacy disclosures`
+
+## Scope
+
+Close the first technical App Store readiness blocker:
+
+- add the iOS required-reason privacy manifest for `UserDefaults`
+- replace the previous `DATA_NOT_COLLECTED` App Privacy payload with collected-data
+  disclosures for current profile, AI query, and billing network flows
+- keep HealthKit validator behavior read-only without requiring the global
+  `DATA_NOT_COLLECTED` posture
+- add deterministic pytest contracts for privacy manifest and App Privacy drift
+
+## Out Of Scope
+
+- Release backend fail-fast and canonical production host selection
+- sensitive permission-string cleanup
+- screenshot scenario gating
+- AppIcon asset repair
+- HealthKit Swift 6 runtime cleanup
+- AI consent runtime flow
+- reviewer notes and metadata copy sync
+- protected App Store Connect uploads
+
+## Role Order
+
+1. `agent-coordinator`
+2. `ios-engineer-agent`
+3. `appstore-release-agent`
+4. `privacy-compliance-agent`
+5. `security-auditor`
+6. `qa-engineer-agent`
+7. `bug-hunter`
+
+Mandatory post-open review lane:
+
+```text
+qa-engineer-agent -> bug-hunter
+```
+
+## Evidence Plan
+
+Focused gates:
+
+```bash
+pytest -q tests/ios/test_privacy_manifest_contract.py tests/ios/test_app_privacy_details_contract.py
+pytest -q tests/test_ios_appstore_asset_validators.py
+plutil -lint ios/PulsePlate/PrivacyInfo.xcprivacy
+cd ios && bundle exec fastlane validate_metadata_package
+```
+
+Pre-push local gate:
+
+```bash
+pre-commit run --all-files
+```
+
+Operator CPU override for this lane: do not run additional local `make` gates
+before opening the PR. GitHub current-head CI is the heavy signal after push.
+
+`make ios-appstore-verify` is planned for PR-9 and is not expected to exist in
+this slice.
+
+## App Privacy Mapping
+
+| Runtime flow | Source | App Privacy category | Purpose | Protection |
+| --- | --- | --- | --- | --- |
+| Profile and nutrition context | `ios/PulsePlate/Services/ProDailyNutritionService.swift`, `ios/PulsePlate/Services/ProfileProvider.swift` | `HEALTH_AND_FITNESS` | `APP_FUNCTIONALITY` | `DATA_LINKED_TO_YOU` |
+| Free-form CBT/AI query | `ios/PulsePlate/Services/CBTInsightService.swift` | `USER_CONTENT` | `APP_FUNCTIONALITY` | `DATA_LINKED_TO_YOU` |
+| Receipt and activation data | `ios/PulsePlate/Services/SubscriptionBillingService.swift` | `PURCHASES` | `APP_FUNCTIONALITY` | `DATA_LINKED_TO_YOU` |
+
+No `DATA_USED_TO_TRACK_YOU` entry is allowed in this PR.
+
+## Decision Log
+
+1. `PrivacyInfo.xcprivacy` is added under `ios/PulsePlate/`, which is a
+   file-system synchronized Xcode root group and is not listed in target
+   membership exceptions.
+2. The App Privacy payload no longer uses the global `DATA_NOT_COLLECTED`
+   answer because current iOS runtime sends profile, AI query, and billing data
+   to backend endpoints.
+3. On-device HealthKit read-only posture remains guarded by purpose strings and
+   reviewer-copy validators, but PR-1 does not keep the old global
+   `DATA_NOT_COLLECTED` posture.

--- a/docs/orchestration/APPSTORE_RELEASE_READINESS_PR1_PRIVACY_PACKET_2026-04-30.md
+++ b/docs/orchestration/APPSTORE_RELEASE_READINESS_PR1_PRIVACY_PACKET_2026-04-30.md
@@ -73,9 +73,9 @@ this slice.
 
 | Runtime flow | Source | App Privacy category | Purpose | Protection |
 | --- | --- | --- | --- | --- |
-| Profile and nutrition context | `ios/PulsePlate/Services/ProDailyNutritionService.swift`, `ios/PulsePlate/Services/ProfileProvider.swift` | `HEALTH_AND_FITNESS` | `APP_FUNCTIONALITY` | `DATA_LINKED_TO_YOU` |
-| Free-form CBT/AI query | `ios/PulsePlate/Services/CBTInsightService.swift` | `USER_CONTENT` | `APP_FUNCTIONALITY` | `DATA_LINKED_TO_YOU` |
-| Receipt and activation data | `ios/PulsePlate/Services/SubscriptionBillingService.swift` | `PURCHASES` | `APP_FUNCTIONALITY` | `DATA_LINKED_TO_YOU` |
+| Profile and nutrition context | `ios/PulsePlate/Services/ProDailyNutritionService.swift`, `ios/PulsePlate/Services/ProfileProvider.swift` | `HEALTH` | `APP_FUNCTIONALITY` | `DATA_LINKED_TO_YOU` |
+| Free-form CBT/AI query | `ios/PulsePlate/Services/CBTInsightService.swift` | `OTHER_USER_CONTENT` | `APP_FUNCTIONALITY` | `DATA_LINKED_TO_YOU` |
+| Receipt and activation data | `ios/PulsePlate/Services/SubscriptionBillingService.swift` | `PURCHASE_HISTORY` | `APP_FUNCTIONALITY` | `DATA_LINKED_TO_YOU` |
 
 No `DATA_USED_TO_TRACK_YOU` entry is allowed in this PR.
 

--- a/docs/orchestration/APPSTORE_RELEASE_READINESS_TASK_PACKET_2026-04-29.md
+++ b/docs/orchestration/APPSTORE_RELEASE_READINESS_TASK_PACKET_2026-04-29.md
@@ -94,7 +94,7 @@ of truth, coordinator routing, fixed-mapping governance, or local gates.
 | PR | Branch | Primary outcome | Blocking proof |
 | --- | --- | --- | --- |
 | PR-0 | `release/appstore-readiness-pr0-bootstrap` | Epic, matrix, packet, ledger, root gates | docs/ledger validation and repo policy guards |
-| PR-1 | `release/appstore-readiness-pr1-privacy-truth` | Privacy manifest and App Privacy truth | privacy manifest and App Privacy contract tests |
+| PR-1 | `release/appstore-readiness-pr1-privacy-manifest` | Privacy manifest and App Privacy truth | privacy manifest and App Privacy contract tests |
 | PR-2 | `release/appstore-readiness-pr2-permission-truth` | Sensitive permission string cleanup | permission purpose-string guard |
 | PR-3 | `release/appstore-readiness-pr3-base-url` | Explicit HTTPS Release backend | Release plist/baseURL tests |
 | PR-4 | `release/appstore-readiness-pr4-asset-gating` | Screenshot submission policy | Swift and Python asset policy tests |

--- a/docs/release/APPSTORE_RELEASE_READINESS_EPIC.md
+++ b/docs/release/APPSTORE_RELEASE_READINESS_EPIC.md
@@ -82,7 +82,7 @@ then update this epic, the matrix, and the lane packet in the same PR.
    - No runtime, metadata, asset, or privacy payload changes.
 
 2. **PR-1: privacy manifest and App Privacy truth**
-   - Branch: `release/appstore-readiness-pr1-privacy-truth`
+   - Branch: `release/appstore-readiness-pr1-privacy-manifest`
    - Add `ios/PulsePlate/PrivacyInfo.xcprivacy`.
    - Replace `DATA_NOT_COLLECTED` with App Privacy answers matching profile,
      AI, billing, and diagnostics/telemetry truth.

--- a/docs/review/PR_1591_FIXED_MAPPING.md
+++ b/docs/review/PR_1591_FIXED_MAPPING.md
@@ -35,8 +35,8 @@ the heavy validation signal before ready-for-review and merge readiness.
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 No actionable human, CodeRabbit, Sourcery, or Cubic comments have been reviewed
 yet. New actionables must be added below with one of: `FIXED`, `NOT-A-BUG`, or
@@ -44,7 +44,7 @@ yet. New actionables must be added below with one of: `FIXED`, `NOT-A-BUG`, or
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments reviewed yet.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1591_FIXED_MAPPING.md
+++ b/docs/review/PR_1591_FIXED_MAPPING.md
@@ -44,7 +44,20 @@ yet. New actionables must be added below with one of: `FIXED`, `NOT-A-BUG`, or
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1591#pullrequestreview-4203449341 -> 2f9bdf4fc
+Disposition: FIXED
+Commit: 2f9bdf4fc
+Evidence: `tests/ios/test_app_privacy_details_contract.py` centralizes runtime-flow privacy probes in `AppPrivacyRuntimeFlow`; `tests/ios/test_privacy_manifest_contract.py` asserts the UserDefaults required-reason entry is present without requiring it to be the only accessed API type.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1591#pullrequestreview-4203457899 -> 2f9bdf4fc
+Disposition: FIXED
+Commit: 2f9bdf4fc
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md` now lists PR #1582 and PR #1591 / `release/appstore-readiness-pr1-privacy-manifest` in `Target PR`; `tests/ios/test_privacy_manifest_contract.py` now asserts `membership_exception_blocks` is non-empty before checking exclusions.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1591#discussion_r3166473693 -> 2f9bdf4fc
+Disposition: FIXED
+Commit: 2f9bdf4fc
+Evidence: `tests/ios/test_privacy_manifest_contract.py` asserts `membership_exception_blocks` is non-empty before `PrivacyInfo.xcprivacy` exclusion checks.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1591_FIXED_MAPPING.md
+++ b/docs/review/PR_1591_FIXED_MAPPING.md
@@ -16,6 +16,7 @@ Evidence:
 - `python3 scripts/orchestration/check_preflight.py` PASS
 - `python3 scripts/orchestration/check_agent_consistency.py` PASS
 - `pytest -q tests/ios/test_privacy_manifest_contract.py tests/ios/test_app_privacy_details_contract.py tests/test_ios_appstore_asset_validators.py` PASS, 43 tests
+- `pytest -q tests/ios/test_privacy_manifest_contract.py tests/ios/test_app_privacy_details_contract.py tests/test_ios_appstore_asset_validators.py` PASS, 44 tests after post-ready review fixes
 - `pytest -q tests/test_repo_policy_guards.py` PASS, 14 tests
 - `cd ios && bundle exec fastlane validate_metadata_package` PASS
 - `make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python` PASS
@@ -58,6 +59,21 @@ Evidence: `docs/roadmap/BACKLOG_LEDGER.md` now lists PR #1582 and PR #1591 / `re
 Disposition: FIXED
 Commit: 2f9bdf4fc
 Evidence: `tests/ios/test_privacy_manifest_contract.py` asserts `membership_exception_blocks` is non-empty before `PrivacyInfo.xcprivacy` exclusion checks.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1591#discussion_r3166747911 -> 4941c3c38
+Disposition: FIXED
+Commit: 4941c3c38
+Evidence: `ios/fastlane/app_privacy_details.json` now uses Fastlane/App Store Connect category identifiers `HEALTH`, `OTHER_USER_CONTENT`, and `PURCHASE_HISTORY`; `tests/ios/test_app_privacy_details_contract.py` locks the allowed Fastlane category ID set.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1591#pullrequestreview-4203813159 -> 4941c3c38
+Disposition: FIXED
+Commit: 4941c3c38
+Evidence: `tests/ios/test_app_privacy_details_contract.py` now asserts `data_protections` exists and is a list before checking `DATA_NOT_COLLECTED`, runtime-flow protections, and tracking protections.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1591#discussion_r3166780304 -> 4941c3c38
+Disposition: FIXED
+Commit: 4941c3c38
+Evidence: `tests/ios/test_app_privacy_details_contract.py` uses `_data_protections(...)` to fail closed when `data_protections` is missing or malformed.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1591_FIXED_MAPPING.md
+++ b/docs/review/PR_1591_FIXED_MAPPING.md
@@ -1,0 +1,55 @@
+# PR 1591 - Fixed in Commit Mapping
+
+## PR
+
+- PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1591>
+- Branch: `release/appstore-readiness-pr1-privacy-manifest`
+- Base: `main`
+- Implementation commit: `6e601deca`
+
+## Local Validation
+
+Disposition: FIXED
+Commit: `6e601deca`
+Evidence:
+
+- `python3 scripts/orchestration/check_preflight.py` PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS
+- `pytest -q tests/ios/test_privacy_manifest_contract.py tests/ios/test_app_privacy_details_contract.py tests/test_ios_appstore_asset_validators.py` PASS, 43 tests
+- `pytest -q tests/test_repo_policy_guards.py` PASS, 14 tests
+- `cd ios && bundle exec fastlane validate_metadata_package` PASS
+- `make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python` PASS
+- `pre-commit run --all-files` PASS
+- `plutil -lint ios/PulsePlate/PrivacyInfo.xcprivacy` PASS
+- `git diff --check` PASS
+- push hooks PASS, including `pip-audit`, backend changed tests, and full-repo Bandit
+
+## Operator CPU Override
+
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p0-app-store-release-readiness-closure`
+Reason: The operator explicitly paused additional local `make` gates for CPU
+load during draft opening. `make verify` was not run to completion locally and
+`make ios-test` was not run locally for this opening. GitHub current-head CI is
+the heavy validation signal before ready-for-review and merge readiness.
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+No actionable human, CodeRabbit, Sourcery, or Cubic comments have been reviewed
+yet. New actionables must be added below with one of: `FIXED`, `NOT-A-BUG`, or
+`DEFERRED`.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments reviewed yet.
+
+## Merge Readiness
+
+- [ ] PR is draft until current-head CI and post-open review settle.
+- [ ] Required current-head checks PASS on the latest commit.
+- [ ] CodeRabbit, Sourcery, and Cubic have no unresolved actionables.
+- [ ] No unresolved review threads.
+- [ ] Required wait window observed after latest bot/review activity.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -33,7 +33,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (App Store submission blocker)
   - Target PR: PR-TBD-APPSTORE-READINESS-TRAIN (`release/appstore-readiness-*`)
-  - Status: 📋 Planned / PR train bootstrap in progress
+  - Status: 🛠️ PR-0 merged in PR #1582; PR-1 active on branch `release/appstore-readiness-pr1-privacy-manifest`
   - Area: iOS / App Store / privacy / release governance
   - Finding Type: release-truth drift blocker
   - Reason (EN): The release shell must align iOS runtime, backend reachability, App Privacy, privacy manifest, permission strings, App Store assets, reviewer notes, and CI validators before public App Store submission. The fix is not to delete assets or reduce product scope; the train must preserve assets and classify each public submission surface as `SUBMIT_READY`, `IMPLEMENTATION_REQUIRED`, or `INTERNAL_REVIEW_ONLY`.
@@ -41,6 +41,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/release/APPSTORE_RELEASE_READINESS_EPIC.md`
     - `docs/release/APPSTORE_FEATURE_ASSET_MATRIX.md`
     - `docs/orchestration/APPSTORE_RELEASE_READINESS_TASK_PACKET_2026-04-29.md`
+    - `docs/orchestration/APPSTORE_RELEASE_READINESS_PR1_PRIVACY_PACKET_2026-04-30.md`
     - `docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md`
     - `ios/fastlane/app_privacy_details.json`
     - `ios/PulsePlate/Services/AppConfig.swift`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -32,7 +32,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P0: App Store release readiness closure for full-feature launch
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (App Store submission blocker)
-  - Target PR: PR-TBD-APPSTORE-READINESS-TRAIN (`release/appstore-readiness-*`)
+  - Target PR: PR #1582 -> PR-0 merged; PR #1591 / `release/appstore-readiness-pr1-privacy-manifest` -> PR-1 active; remaining train `release/appstore-readiness-*`
   - Status: 🛠️ PR-0 merged in PR #1582; PR-1 active on branch `release/appstore-readiness-pr1-privacy-manifest`
   - Area: iOS / App Store / privacy / release governance
   - Finding Type: release-truth drift blocker

--- a/ios/PulsePlate/PrivacyInfo.xcprivacy
+++ b/ios/PulsePlate/PrivacyInfo.xcprivacy
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ios/fastlane/app_privacy_details.json
+++ b/ios/fastlane/app_privacy_details.json
@@ -1,6 +1,6 @@
 [
   {
-    "category": "HEALTH_AND_FITNESS",
+    "category": "HEALTH",
     "purposes": [
       "APP_FUNCTIONALITY"
     ],
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "category": "PURCHASES",
+    "category": "PURCHASE_HISTORY",
     "purposes": [
       "APP_FUNCTIONALITY"
     ],
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "category": "USER_CONTENT",
+    "category": "OTHER_USER_CONTENT",
     "purposes": [
       "APP_FUNCTIONALITY"
     ],

--- a/ios/fastlane/app_privacy_details.json
+++ b/ios/fastlane/app_privacy_details.json
@@ -1,7 +1,29 @@
 [
   {
+    "category": "HEALTH_AND_FITNESS",
+    "purposes": [
+      "APP_FUNCTIONALITY"
+    ],
     "data_protections": [
-      "DATA_NOT_COLLECTED"
+      "DATA_LINKED_TO_YOU"
+    ]
+  },
+  {
+    "category": "PURCHASES",
+    "purposes": [
+      "APP_FUNCTIONALITY"
+    ],
+    "data_protections": [
+      "DATA_LINKED_TO_YOU"
+    ]
+  },
+  {
+    "category": "USER_CONTENT",
+    "purposes": [
+      "APP_FUNCTIONALITY"
+    ],
+    "data_protections": [
+      "DATA_LINKED_TO_YOU"
     ]
   }
 ]

--- a/ios/fastlane/verify/validate_healthkit_copy.rb
+++ b/ios/fastlane/verify/validate_healthkit_copy.rb
@@ -91,9 +91,6 @@ if privacy_json_path.file?
       end
     end
 
-    unless data_not_collected_healthkit
-      errors << "App privacy JSON must declare on-device HealthKit data as DATA_NOT_COLLECTED"
-    end
   rescue JSON::ParserError
     errors << "Invalid JSON in #{privacy_json_path}"
   end

--- a/tests/ios/test_app_privacy_details_contract.py
+++ b/tests/ios/test_app_privacy_details_contract.py
@@ -13,6 +13,39 @@ IOS_ROOT = REPO_ROOT / "ios/PulsePlate"
 
 APP_FUNCTIONALITY = ["APP_FUNCTIONALITY"]
 DATA_LINKED_TO_YOU = ["DATA_LINKED_TO_YOU"]
+FASTLANE_APP_PRIVACY_CATEGORIES = {
+    "ADVERTISING_DATA",
+    "AUDIO",
+    "BROWSING_HISTORY",
+    "COARSE_LOCATION",
+    "CONTACTS",
+    "CREDIT_AND_FRAUD",
+    "CUSTOMER_SUPPORT",
+    "DEVICE_ID",
+    "EMAIL_ADDRESS",
+    "EMAILS_OR_TEXT_MESSAGES",
+    "FITNESS",
+    "GAMEPLAY_CONTENT",
+    "HEALTH",
+    "NAME",
+    "OTHER_CONTACT_INFO",
+    "OTHER_DATA",
+    "OTHER_DIAGNOSTIC_DATA",
+    "OTHER_FINANCIAL_INFO",
+    "OTHER_USAGE_DATA",
+    "OTHER_USER_CONTENT",
+    "PAYMENT_INFORMATION",
+    "PERFORMANCE_DATA",
+    "PHONE_NUMBER",
+    "PHOTOS_OR_VIDEOS",
+    "PHYSICAL_ADDRESS",
+    "PRECISE_LOCATION",
+    "PRODUCT_INTERACTION",
+    "PURCHASE_HISTORY",
+    "SEARCH_HISTORY",
+    "SENSITIVE_INFO",
+    "USER_ID",
+}
 
 
 @dataclass(frozen=True)
@@ -26,7 +59,7 @@ class AppPrivacyRuntimeFlow:
 
 RUNTIME_FLOW_DISCLOSURES = (
     AppPrivacyRuntimeFlow(
-        category="HEALTH_AND_FITNESS",
+        category="HEALTH",
         source_paths=(
             "Services/ProDailyNutritionService.swift",
             "Services/ProfileProvider.swift",
@@ -44,14 +77,14 @@ RUNTIME_FLOW_DISCLOSURES = (
         data_protections=DATA_LINKED_TO_YOU,
     ),
     AppPrivacyRuntimeFlow(
-        category="USER_CONTENT",
+        category="OTHER_USER_CONTENT",
         source_paths=("Services/CBTInsightService.swift",),
         source_markers=("/api/v1/pro/cbt/insight", "query"),
         purposes=APP_FUNCTIONALITY,
         data_protections=DATA_LINKED_TO_YOU,
     ),
     AppPrivacyRuntimeFlow(
-        category="PURCHASES",
+        category="PURCHASE_HISTORY",
         source_paths=("Services/SubscriptionBillingService.swift",),
         source_markers=(
             "/api/v1/billing/apple/verify-receipt",
@@ -85,11 +118,27 @@ def _source_text(paths: tuple[str, ...]) -> str:
     return "\n".join((IOS_ROOT / path).read_text(encoding="utf-8") for path in paths)
 
 
+def _data_protections(entry: dict[str, Any]) -> list[str]:
+    assert "data_protections" in entry
+    data_protections = entry["data_protections"]
+    assert isinstance(data_protections, list)
+    assert all(isinstance(item, str) for item in data_protections)
+    return data_protections
+
+
 def test_app_privacy_no_longer_claims_nothing_collected() -> None:
     entries = _privacy_entries()
 
     assert entries
-    assert all("DATA_NOT_COLLECTED" not in entry.get("data_protections", []) for entry in entries)
+    assert all("DATA_NOT_COLLECTED" not in _data_protections(entry) for entry in entries)
+
+
+def test_app_privacy_uses_fastlane_category_identifiers() -> None:
+    entries = _privacy_entries()
+
+    assert entries
+    for entry in entries:
+        assert entry["category"] in FASTLANE_APP_PRIVACY_CATEGORIES
 
 
 def test_app_privacy_declares_profile_ai_and_billing_data_flows() -> None:
@@ -98,7 +147,7 @@ def test_app_privacy_declares_profile_ai_and_billing_data_flows() -> None:
     for flow in RUNTIME_FLOW_DISCLOSURES:
         assert flow.category in entries
         assert entries[flow.category]["purposes"] == flow.purposes
-        assert entries[flow.category]["data_protections"] == flow.data_protections
+        assert _data_protections(entries[flow.category]) == flow.data_protections
 
 
 def test_app_privacy_contract_tracks_current_ios_network_flows() -> None:
@@ -114,6 +163,4 @@ def test_app_privacy_contract_tracks_current_ios_network_flows() -> None:
 def test_app_privacy_does_not_enable_tracking_disclosures() -> None:
     entries = _privacy_entries()
 
-    assert all(
-        "DATA_USED_TO_TRACK_YOU" not in entry.get("data_protections", []) for entry in entries
-    )
+    assert all("DATA_USED_TO_TRACK_YOU" not in _data_protections(entry) for entry in entries)

--- a/tests/ios/test_app_privacy_details_contract.py
+++ b/tests/ios/test_app_privacy_details_contract.py
@@ -1,0 +1,96 @@
+"""Contracts for App Privacy truth against current iOS network flows."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APP_PRIVACY_DETAILS = REPO_ROOT / "ios/fastlane/app_privacy_details.json"
+IOS_ROOT = REPO_ROOT / "ios/PulsePlate"
+
+NETWORK_FLOW_CATEGORIES = {
+    "HEALTH_AND_FITNESS": {
+        "paths": [
+            "Services/ProDailyNutritionService.swift",
+            "Services/ProfileProvider.swift",
+        ],
+        "needles": [
+            "/api/v1/pro/nutrition/daily",
+            "sex",
+            "height_cm",
+            "weight_kg",
+            "activity",
+            "goal",
+            "lang",
+        ],
+    },
+    "USER_CONTENT": {
+        "paths": ["Services/CBTInsightService.swift"],
+        "needles": ["/api/v1/pro/cbt/insight", "query"],
+    },
+    "PURCHASES": {
+        "paths": ["Services/SubscriptionBillingService.swift"],
+        "needles": [
+            "/api/v1/billing/apple/verify-receipt",
+            "/api/v1/pro/payments/activate",
+            "/api/v1/pro/payments/activations/",
+        ],
+    },
+}
+
+
+def _privacy_entries() -> list[dict[str, Any]]:
+    with APP_PRIVACY_DETAILS.open(encoding="utf-8") as privacy_file:
+        entries = json.load(privacy_file)
+
+    assert isinstance(entries, list)
+    return entries
+
+
+def _entry_by_category() -> dict[str, dict[str, Any]]:
+    entries = _privacy_entries()
+    return {
+        entry["category"]: entry
+        for entry in entries
+        if isinstance(entry, dict) and isinstance(entry.get("category"), str)
+    }
+
+
+def _source_text(paths: list[str]) -> str:
+    return "\n".join((IOS_ROOT / path).read_text(encoding="utf-8") for path in paths)
+
+
+def test_app_privacy_no_longer_claims_nothing_collected() -> None:
+    entries = _privacy_entries()
+
+    assert entries
+    assert all("DATA_NOT_COLLECTED" not in entry.get("data_protections", []) for entry in entries)
+
+
+def test_app_privacy_declares_profile_ai_and_billing_data_flows() -> None:
+    entries = _entry_by_category()
+
+    for category in NETWORK_FLOW_CATEGORIES:
+        assert category in entries
+        assert entries[category]["purposes"] == ["APP_FUNCTIONALITY"]
+        assert entries[category]["data_protections"] == ["DATA_LINKED_TO_YOU"]
+
+
+def test_app_privacy_contract_tracks_current_ios_network_flows() -> None:
+    entries = _entry_by_category()
+
+    for category, flow in NETWORK_FLOW_CATEGORIES.items():
+        source = _source_text(flow["paths"])
+        for needle in flow["needles"]:
+            assert needle in source
+        assert category in entries
+
+
+def test_app_privacy_does_not_enable_tracking_disclosures() -> None:
+    entries = _privacy_entries()
+
+    assert all(
+        "DATA_USED_TO_TRACK_YOU" not in entry.get("data_protections", []) for entry in entries
+    )

--- a/tests/ios/test_app_privacy_details_contract.py
+++ b/tests/ios/test_app_privacy_details_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -10,13 +11,27 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 APP_PRIVACY_DETAILS = REPO_ROOT / "ios/fastlane/app_privacy_details.json"
 IOS_ROOT = REPO_ROOT / "ios/PulsePlate"
 
-NETWORK_FLOW_CATEGORIES = {
-    "HEALTH_AND_FITNESS": {
-        "paths": [
+APP_FUNCTIONALITY = ["APP_FUNCTIONALITY"]
+DATA_LINKED_TO_YOU = ["DATA_LINKED_TO_YOU"]
+
+
+@dataclass(frozen=True)
+class AppPrivacyRuntimeFlow:
+    category: str
+    source_paths: tuple[str, ...]
+    source_markers: tuple[str, ...]
+    purposes: list[str]
+    data_protections: list[str]
+
+
+RUNTIME_FLOW_DISCLOSURES = (
+    AppPrivacyRuntimeFlow(
+        category="HEALTH_AND_FITNESS",
+        source_paths=(
             "Services/ProDailyNutritionService.swift",
             "Services/ProfileProvider.swift",
-        ],
-        "needles": [
+        ),
+        source_markers=(
             "/api/v1/pro/nutrition/daily",
             "sex",
             "height_cm",
@@ -24,21 +39,29 @@ NETWORK_FLOW_CATEGORIES = {
             "activity",
             "goal",
             "lang",
-        ],
-    },
-    "USER_CONTENT": {
-        "paths": ["Services/CBTInsightService.swift"],
-        "needles": ["/api/v1/pro/cbt/insight", "query"],
-    },
-    "PURCHASES": {
-        "paths": ["Services/SubscriptionBillingService.swift"],
-        "needles": [
+        ),
+        purposes=APP_FUNCTIONALITY,
+        data_protections=DATA_LINKED_TO_YOU,
+    ),
+    AppPrivacyRuntimeFlow(
+        category="USER_CONTENT",
+        source_paths=("Services/CBTInsightService.swift",),
+        source_markers=("/api/v1/pro/cbt/insight", "query"),
+        purposes=APP_FUNCTIONALITY,
+        data_protections=DATA_LINKED_TO_YOU,
+    ),
+    AppPrivacyRuntimeFlow(
+        category="PURCHASES",
+        source_paths=("Services/SubscriptionBillingService.swift",),
+        source_markers=(
             "/api/v1/billing/apple/verify-receipt",
             "/api/v1/pro/payments/activate",
             "/api/v1/pro/payments/activations/",
-        ],
-    },
-}
+        ),
+        purposes=APP_FUNCTIONALITY,
+        data_protections=DATA_LINKED_TO_YOU,
+    ),
+)
 
 
 def _privacy_entries() -> list[dict[str, Any]]:
@@ -58,7 +81,7 @@ def _entry_by_category() -> dict[str, dict[str, Any]]:
     }
 
 
-def _source_text(paths: list[str]) -> str:
+def _source_text(paths: tuple[str, ...]) -> str:
     return "\n".join((IOS_ROOT / path).read_text(encoding="utf-8") for path in paths)
 
 
@@ -72,20 +95,20 @@ def test_app_privacy_no_longer_claims_nothing_collected() -> None:
 def test_app_privacy_declares_profile_ai_and_billing_data_flows() -> None:
     entries = _entry_by_category()
 
-    for category in NETWORK_FLOW_CATEGORIES:
-        assert category in entries
-        assert entries[category]["purposes"] == ["APP_FUNCTIONALITY"]
-        assert entries[category]["data_protections"] == ["DATA_LINKED_TO_YOU"]
+    for flow in RUNTIME_FLOW_DISCLOSURES:
+        assert flow.category in entries
+        assert entries[flow.category]["purposes"] == flow.purposes
+        assert entries[flow.category]["data_protections"] == flow.data_protections
 
 
 def test_app_privacy_contract_tracks_current_ios_network_flows() -> None:
     entries = _entry_by_category()
 
-    for category, flow in NETWORK_FLOW_CATEGORIES.items():
-        source = _source_text(flow["paths"])
-        for needle in flow["needles"]:
-            assert needle in source
-        assert category in entries
+    for flow in RUNTIME_FLOW_DISCLOSURES:
+        source = _source_text(flow.source_paths)
+        for marker in flow.source_markers:
+            assert marker in source
+        assert flow.category in entries
 
 
 def test_app_privacy_does_not_enable_tracking_disclosures() -> None:

--- a/tests/ios/test_privacy_manifest_contract.py
+++ b/tests/ios/test_privacy_manifest_contract.py
@@ -1,0 +1,56 @@
+"""Contracts for the iOS required-reason privacy manifest."""
+
+from __future__ import annotations
+
+import plistlib
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRIVACY_MANIFEST = REPO_ROOT / "ios/PulsePlate/PrivacyInfo.xcprivacy"
+XCODE_PROJECT = REPO_ROOT / "ios/PulsePlate.xcodeproj/project.pbxproj"
+
+
+def _read_manifest() -> dict[str, object]:
+    with PRIVACY_MANIFEST.open("rb") as manifest_file:
+        return plistlib.load(manifest_file)
+
+
+def test_privacy_manifest_exists_and_disables_tracking() -> None:
+    assert PRIVACY_MANIFEST.is_file()
+
+    manifest = _read_manifest()
+
+    assert manifest["NSPrivacyTracking"] is False
+
+
+def test_privacy_manifest_declares_user_defaults_required_reason() -> None:
+    manifest = _read_manifest()
+    accessed_api_types = manifest["NSPrivacyAccessedAPITypes"]
+
+    assert isinstance(accessed_api_types, list)
+    user_defaults_entries = [
+        entry
+        for entry in accessed_api_types
+        if entry.get("NSPrivacyAccessedAPIType") == "NSPrivacyAccessedAPICategoryUserDefaults"
+    ]
+
+    assert user_defaults_entries == [
+        {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
+            "NSPrivacyAccessedAPITypeReasons": ["CA92.1"],
+        }
+    ]
+
+
+def test_privacy_manifest_is_not_excluded_from_pulseplate_target() -> None:
+    project = XCODE_PROJECT.read_text(encoding="utf-8")
+    membership_exception_blocks = re.findall(
+        r"membershipExceptions = \((.*?)\);",
+        project,
+        flags=re.DOTALL,
+    )
+
+    assert "path = PulsePlate;" in project
+    assert "PBXFileSystemSynchronizedRootGroup" in project
+    assert all("PrivacyInfo.xcprivacy" not in block for block in membership_exception_blocks)

--- a/tests/ios/test_privacy_manifest_contract.py
+++ b/tests/ios/test_privacy_manifest_contract.py
@@ -27,20 +27,13 @@ def test_privacy_manifest_exists_and_disables_tracking() -> None:
 def test_privacy_manifest_declares_user_defaults_required_reason() -> None:
     manifest = _read_manifest()
     accessed_api_types = manifest["NSPrivacyAccessedAPITypes"]
+    expected_user_defaults_entry = {
+        "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
+        "NSPrivacyAccessedAPITypeReasons": ["CA92.1"],
+    }
 
     assert isinstance(accessed_api_types, list)
-    user_defaults_entries = [
-        entry
-        for entry in accessed_api_types
-        if entry.get("NSPrivacyAccessedAPIType") == "NSPrivacyAccessedAPICategoryUserDefaults"
-    ]
-
-    assert user_defaults_entries == [
-        {
-            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
-            "NSPrivacyAccessedAPITypeReasons": ["CA92.1"],
-        }
-    ]
+    assert expected_user_defaults_entry in accessed_api_types
 
 
 def test_privacy_manifest_is_not_excluded_from_pulseplate_target() -> None:
@@ -53,4 +46,5 @@ def test_privacy_manifest_is_not_excluded_from_pulseplate_target() -> None:
 
     assert "path = PulsePlate;" in project
     assert "PBXFileSystemSynchronizedRootGroup" in project
+    assert membership_exception_blocks
     assert all("PrivacyInfo.xcprivacy" not in block for block in membership_exception_blocks)

--- a/tests/test_ios_appstore_asset_validators.py
+++ b/tests/test_ios_appstore_asset_validators.py
@@ -745,7 +745,7 @@ def test_validate_healthkit_copy_uses_actual_privacy_posture_for_contradictions(
     assert "NSHealthUpdateUsageDescription must be absent for read-only HealthKit" in result.stderr
     assert (
         "App privacy JSON must declare on-device HealthKit data as DATA_NOT_COLLECTED"
-        in result.stderr
+        not in result.stderr
     )
     assert (
         f"Reviewer notes contradict read-only HealthKit posture: {review_notes}"


### PR DESCRIPTION
## Summary

PR-1 for `epic(ios-release): close App Store readiness for full-feature PulsePlate launch`.

This slice closes the first App Store privacy blocker:

- adds `ios/PulsePlate/PrivacyInfo.xcprivacy` with `NSPrivacyAccessedAPICategoryUserDefaults` reason `CA92.1`
- replaces the previous App Privacy `DATA_NOT_COLLECTED` payload with explicit collected-data categories for current profile, AI query, and billing network flows
- keeps HealthKit read-only validator coverage without forcing the old global no-collection posture
- adds deterministic contract tests for privacy manifest and App Privacy drift
- records the PR-1 coordinator packet and aligns the epic packet branch name with `release/appstore-readiness-pr1-privacy-manifest`

## Coordinator / Skills

Coordinator-first bootstrap was run before edits.

- Packet: `docs/orchestration/APPSTORE_RELEASE_READINESS_PR1_PRIVACY_PACKET_2026-04-30.md`
- Branch: `release/appstore-readiness-pr1-privacy-manifest`
- Skills used: `pulseplate-app-store-release`, `pulseplate-gates`, `pulseplate-pr-review`
- Role order: `agent-coordinator -> ios-engineer-agent -> appstore-release-agent -> privacy-compliance-agent -> security-auditor -> qa-engineer-agent -> bug-hunter`

## App Privacy Mapping

| Runtime flow | Source | App Privacy category | Purpose | Protection |
| --- | --- | --- | --- | --- |
| Profile and nutrition context | `ios/PulsePlate/Services/ProDailyNutritionService.swift`, `ios/PulsePlate/Services/ProfileProvider.swift` | `HEALTH` | `APP_FUNCTIONALITY` | `DATA_LINKED_TO_YOU` |
| Free-form CBT/AI query | `ios/PulsePlate/Services/CBTInsightService.swift` | `OTHER_USER_CONTENT` | `APP_FUNCTIONALITY` | `DATA_LINKED_TO_YOU` |
| Receipt and activation data | `ios/PulsePlate/Services/SubscriptionBillingService.swift` | `PURCHASE_HISTORY` | `APP_FUNCTIONALITY` | `DATA_LINKED_TO_YOU` |

## Validation

Passed locally:

```bash
python3 scripts/orchestration/check_preflight.py
python3 scripts/orchestration/check_agent_consistency.py
pytest -q tests/ios/test_privacy_manifest_contract.py tests/ios/test_app_privacy_details_contract.py tests/test_ios_appstore_asset_validators.py
pytest -q tests/test_repo_policy_guards.py
cd ios && bundle exec fastlane validate_metadata_package
make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python
pre-commit run --all-files
plutil -lint ios/PulsePlate/PrivacyInfo.xcprivacy
git diff --check
python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1591 --body "$(gh pr view 1591 --json body -q .body)"
```

Review-fix focused gates:

```bash
python3 -m black --check tests/ios/test_privacy_manifest_contract.py tests/ios/test_app_privacy_details_contract.py
pytest -q tests/ios/test_privacy_manifest_contract.py tests/ios/test_app_privacy_details_contract.py tests/test_ios_appstore_asset_validators.py
python3 -m json.tool ios/fastlane/app_privacy_details.json >/tmp/app_privacy_details_checked.json
cd ios && bundle exec fastlane validate_metadata_package
python3 scripts/orchestration/pr_review_context.py --pr 1591 --output /tmp/pulseplate_pr1591_review_context.json
python3 scripts/orchestration/pr_review_report.py --context /tmp/pulseplate_pr1591_review_context.json --format markdown
```

Push hooks passed:

```bash
fix end of files
trim trailing whitespace
check for merge conflicts
check for added large files
detect-secrets
black
ruff
pip-audit
backend tests (pytest, pre-push)
bandit (pre-push, full repo)
```

Not run to completion locally:

```bash
make verify
make ios-test
```

Operator CPU override: local heavy `make` gates are not run again for this opening. GitHub current-head CI is the heavy signal for this draft PR before ready-for-review / merge readiness.

## Split Justification

This PR is over the advisory 300-line review-risk threshold because it includes the PR-1 packet, canonical mapping artifact, and deterministic tests. It remains below the Tier 1 large-PR threshold and is a single release-truth invariant: privacy manifest plus App Privacy disclosure truth.

## Out Of Scope

- release backend fail-fast
- sensitive permission-string cleanup
- screenshot scenario gating
- AppIcon asset repair
- HealthKit Swift 6 runtime cleanup
- AI consent runtime flow
- reviewer notes and metadata copy sync
- protected App Store Connect upload

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1591#pullrequestreview-4203449341 -> 2f9bdf4fc
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1591#pullrequestreview-4203457899 -> 2f9bdf4fc
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1591#discussion_r3166473693 -> 2f9bdf4fc
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1591#discussion_r3166747911 -> 4941c3c38
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1591#pullrequestreview-4203813159 -> 4941c3c38
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1591#discussion_r3166780304 -> 4941c3c38

## Merge Readiness

- [ ] PR is non-draft only when truly ready for merge
- [ ] GitHub current-head CI is green on latest commit
- [x] Post-open `qa-engineer-agent -> bug-hunter` review pass is recorded
- [x] CodeRabbit/Sourcery/Cubic actionables reviewed and disposed in `docs/review/PR_1591_FIXED_MAPPING.md`
- [ ] No unresolved review threads
- [ ] Wait-window completed after latest bot/review activity

## Deferred / Follow-ups

- PR-2: sensitive permission-string cleanup
- PR-3: release backend fail-fast
- PR-4: App Store screenshot scenario gating
- PR-5: AppIcon marketing asset repair
- PR-6: HealthKit Swift 6 cleanup
- PR-7: AI/CBT consent and wellness-only disclosure
- PR-8: reviewer notes and metadata sync
- PR-9: release validators, including `make ios-appstore-verify`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated App Store release readiness documentation with privacy manifest specifications
  * Enhanced privacy disclosure configuration for iOS data categories (Health & Fitness, Purchases, User Content)

* **Tests**
  * Added privacy compliance validation tests for iOS privacy manifest and data protection declarations
  * Added tests to verify privacy data flows align with configured disclosures

* **Chores**
  * Added iOS privacy manifest configuration file
  * Updated privacy validation scripts to reflect new data protection requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

