### PR TITLE
feat(release): add reviewer packet hash contract

### DIFF
--- a/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
+++ b/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
@@ -99,7 +99,7 @@ changes.
 | PR | Branch | Primary outcome | Blocking proof |
 | --- | --- | --- | --- |
 | PR-0 | `release/release-control-plane-pr0-bootstrap` | Epic, packet, C4 release-risk context, ledger anchor | docs/ledger validation and repo policy guards |
-| PR-1 | `release/release-control-plane-pr1-reviewer-hash` | Reviewer-packet hash contract consuming App Store readiness artifacts | reviewer hash schema tests |
+| PR-1 | `release/release-control-plane-pr1-reviewer-hash` | Reviewer-packet hash contract consuming App Store readiness artifacts | reviewer hash schema tests and Fastlane artifact-name discovery |
 | PR-2 | `release/release-control-plane-pr2-rag-gate-export` | RAG/ML gate result export contract over the existing eval runner | gate-result schema tests |
 | PR-3 | `release/release-control-plane-pr3-release-manifest` | Release manifest generator and validator | manifest validator tests |
 | PR-4 | `release/release-control-plane-pr4-build-equivalence` | Review build equals production-candidate equivalence check | equivalence tests |
@@ -128,6 +128,36 @@ Hash and digest format contract:
 
 PR-0 defines the contract only. It does not generate, validate, or publish the
 packet.
+
+### PR-1 Reviewer Packet Hash Contract
+
+PR-1 defines the reviewer identity fields without changing App Store metadata,
+reviewer notes, Fastlane upload behavior, or protected App Store credentials.
+The machine-readable schema and field contract live in
+[`docs/release/REVIEWER_PACKET_HASH_CONTRACT.md`](../release/REVIEWER_PACKET_HASH_CONTRACT.md)
+and
+[`docs/release/REVIEWER_PACKET_HASH_CONTRACT.schema.json`](../release/REVIEWER_PACKET_HASH_CONTRACT.schema.json).
+
+Canonical upstream artifact names consumed from landed App Store readiness work:
+
+- `ios/fastlane/metadata/review_information/notes.txt`
+- `ios/fastlane/metadata/{en-US,ru-RU,es-ES}/name.txt`
+- `ios/fastlane/metadata/{en-US,ru-RU,es-ES}/subtitle.txt`
+- `ios/fastlane/metadata/{en-US,ru-RU,es-ES}/description.txt`
+- `ios/fastlane/metadata/{en-US,ru-RU,es-ES}/keywords.txt`
+- `ios/fastlane/metadata/{en-US,ru-RU,es-ES}/promotional_text.txt`
+- `ios/fastlane/metadata/{en-US,ru-RU,es-ES}/release_notes.txt`
+- `ios/fastlane/metadata/{en-US,ru-RU,es-ES}/privacy_url.txt`
+- `ios/fastlane/metadata/{en-US,ru-RU,es-ES}/support_url.txt`
+- `ios/fastlane/metadata/{en-US,ru-RU,es-ES}/marketing_url.txt`
+- `ios/fastlane/app_privacy_details.json` as upstream context only
+
+`reviewer_notes_hash` hashes only reviewer notes. `appstore_metadata_hash`
+hashes a canonical JSON manifest of localized metadata file hashes and excludes
+`review_information/**` plus App Privacy JSON. Text artifacts are decoded as
+UTF-8, line endings are normalized to LF, exactly one trailing LF is enforced,
+all other whitespace is preserved, and the resulting canonical UTF-8 bytes are
+hashed with SHA-256 lowercase hexadecimal.
 
 ## Bootstrap Commands
 
@@ -178,6 +208,8 @@ make verify
 Focused gates by future slice:
 
 - reviewer hash: Fastlane metadata/reviewer-note validators
+- reviewer packet hash contract:
+  `pytest -q tests/test_release_reviewer_packet_hashes.py`
 - RAG gate export: `pytest -q tests/test_rag_release_gates_runner.py`
 - release manifest: manifest schema and failure-mode tests
 - build equivalence: review/prod digest mismatch tests

--- a/docs/release/RELEASE_CONTROL_PLANE_EPIC.md
+++ b/docs/release/RELEASE_CONTROL_PLANE_EPIC.md
@@ -77,6 +77,9 @@ review governance.
    - Branch: `release/release-control-plane-pr1-reviewer-hash`
    - Define how reviewer notes, metadata, and App Store readiness artifacts are hashed after they land on `main`.
    - Consume App Store readiness outputs; do not own that PR train.
+   - Contract: [`REVIEWER_PACKET_HASH_CONTRACT.md`](REVIEWER_PACKET_HASH_CONTRACT.md)
+     and [`REVIEWER_PACKET_HASH_CONTRACT.schema.json`](REVIEWER_PACKET_HASH_CONTRACT.schema.json).
+   - Helper: `scripts/release/reviewer_packet_hashes.py`.
 
 3. **PR-2: RAG/ML gate result export**
    - Branch: `release/release-control-plane-pr2-rag-gate-export`
@@ -162,3 +165,4 @@ Blocked: diagnosis, treatment, therapy, crisis support, guaranteed outcomes.
 3. Reuse existing RAG gates and Docker provenance controls.
 4. Keep the release packet internal and machine-readable.
 5. Defer MLflow, Hugging Face cards, VEX/OPA, and protected uploads to later explicitly scoped slices.
+6. PR-1 hashes reviewer notes separately from localized App Store metadata and treats App Privacy JSON as upstream context only.

--- a/docs/release/REVIEWER_PACKET_HASH_CONTRACT.md
+++ b/docs/release/REVIEWER_PACKET_HASH_CONTRACT.md
@@ -1,0 +1,87 @@
+# Reviewer Packet Hash Contract
+
+**Schema version:** `release-reviewer-packet-hashes.v1`
+**Release-control-plane slice:** PR-1, `release/release-control-plane-pr1-reviewer-hash`
+**Schema:** [`REVIEWER_PACKET_HASH_CONTRACT.schema.json`](REVIEWER_PACKET_HASH_CONTRACT.schema.json)
+
+## Purpose
+
+This contract defines the reviewer identity portion of the internal release
+packet. It consumes landed App Store readiness artifacts from `main` as
+upstream evidence and does not own the App Store readiness PR train, Fastlane
+upload behavior, App Store Connect credentials, or reviewer copy content.
+
+## Upstream Artifacts
+
+The canonical upstream artifact names are:
+
+- `ios/fastlane/metadata/review_information/notes.txt`
+- `ios/fastlane/metadata/en-US/{name,subtitle,description,keywords,promotional_text,release_notes,privacy_url,support_url,marketing_url}.txt`
+- `ios/fastlane/metadata/ru-RU/{name,subtitle,description,keywords,promotional_text,release_notes,privacy_url,support_url,marketing_url}.txt`
+- `ios/fastlane/metadata/es-ES/{name,subtitle,description,keywords,promotional_text,release_notes,privacy_url,support_url,marketing_url}.txt`
+- `ios/fastlane/app_privacy_details.json` as upstream context only.
+
+`ios/fastlane/app_privacy_details.json` is included in `source_artifacts` as
+`app_privacy_context` when present, but it is not part of
+`appstore_metadata_hash` in PR-1. App Privacy identity can be promoted into the
+future release manifest only through a dedicated release-control-plane slice.
+
+## Hash Fields
+
+| Field | Source | Format |
+| --- | --- | --- |
+| `reviewer_notes_hash` | Canonical bytes for `ios/fastlane/metadata/review_information/notes.txt` | SHA-256 lowercase hex, no prefix |
+| `appstore_metadata_hash` | Canonical JSON manifest of per-file hashes for localized Fastlane metadata files | SHA-256 lowercase hex, no prefix |
+
+Every hash uses SHA-256 over canonical UTF-8 bytes and is emitted as lowercase
+64-character hexadecimal without a `sha256:` prefix.
+
+## Canonicalization
+
+Text artifacts are canonicalized before hashing:
+
+1. Decode bytes as UTF-8.
+2. Normalize `CRLF` and `CR` line endings to `LF`.
+3. Ensure exactly one trailing `LF`.
+4. Preserve all other whitespace and text.
+5. Encode as UTF-8 and hash the resulting bytes.
+
+`appstore_metadata_hash` is computed over a canonical JSON manifest containing
+the sorted metadata source entries. JSON is serialized with sorted keys,
+compact separators, UTF-8, and exactly one trailing `LF`.
+
+## Contract Payload
+
+The deterministic helper is
+`scripts/release/reviewer_packet_hashes.py`. It emits:
+
+```json
+{
+  "schema_version": "release-reviewer-packet-hashes.v1",
+  "hash_algorithm": "sha256",
+  "canonicalization": "utf8-lf-single-trailing-newline",
+  "reviewer_notes_hash": "<64 lowercase hex>",
+  "appstore_metadata_hash": "<64 lowercase hex>",
+  "source_artifacts": [
+    {
+      "kind": "reviewer_notes",
+      "path": "ios/fastlane/metadata/review_information/notes.txt",
+      "hash": "<64 lowercase hex>"
+    }
+  ]
+}
+```
+
+## Boundaries
+
+This PR-1 contract does not:
+
+- modify App Store metadata, reviewer notes, privacy payloads, screenshots, or
+  Fastlane upload lanes;
+- read App Store Connect credentials, signing material, reviewer credentials,
+  or protected GitHub environment secrets;
+- generate the final release manifest;
+- produce an `ALLOW` / `BLOCK` release decision.
+
+Those behaviors remain scoped to later release-control-plane slices and the
+separate App Store readiness train.

--- a/docs/release/REVIEWER_PACKET_HASH_CONTRACT.schema.json
+++ b/docs/release/REVIEWER_PACKET_HASH_CONTRACT.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.app/schemas/release-reviewer-packet-hashes.v1.json",
+  "title": "PulsePlate Release Reviewer Packet Hashes",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "hash_algorithm",
+    "canonicalization",
+    "reviewer_notes_hash",
+    "appstore_metadata_hash",
+    "source_artifacts"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "release-reviewer-packet-hashes.v1"
+    },
+    "hash_algorithm": {
+      "const": "sha256"
+    },
+    "canonicalization": {
+      "const": "utf8-lf-single-trailing-newline"
+    },
+    "reviewer_notes_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "appstore_metadata_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_artifacts": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "path",
+          "hash"
+        ],
+        "properties": {
+          "kind": {
+            "enum": [
+              "reviewer_notes",
+              "appstore_metadata",
+              "app_privacy_context"
+            ]
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "hash": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/review/PR_1592_FIXED_MAPPING.md
+++ b/docs/review/PR_1592_FIXED_MAPPING.md
@@ -1,0 +1,48 @@
+# PR 1592 Fixed in Commit Mapping
+
+**PR:** https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1592
+**Branch:** `release/release-control-plane-pr1-reviewer-hash`
+**Base:** `main`
+**Release-control-plane slice:** PR-1 reviewer-packet hash contract
+
+## Discussion Thread Pass
+
+No human, CodeRabbit, Sourcery, or Cubic actionable review threads were present
+when this canonical mapping artifact was created. This file must be updated
+before any review thread is resolved.
+
+## Fixed in Commit Mapping
+
+- Initial implementation commit: `49eb4162e`
+  - Disposition: FIXED
+  - Evidence:
+    - `docs/release/REVIEWER_PACKET_HASH_CONTRACT.md`
+    - `docs/release/REVIEWER_PACKET_HASH_CONTRACT.schema.json`
+    - `scripts/release/reviewer_packet_hashes.py`
+    - `tests/test_release_reviewer_packet_hashes.py`
+
+## Local Gate Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS
+- `pytest -q tests/test_release_reviewer_packet_hashes.py` PASS
+- `pytest -q tests/test_ios_appstore_asset_validators.py tests/test_ios_appstore_assets_workflow_contract.py` PASS
+- `pytest -q tests/test_repo_policy_guards.py` PASS
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` PASS
+- `pre-commit run --all-files` PASS
+- Pre-push hooks PASS: formatting, ruff, changed-file mypy, pip-audit,
+  backend pre-push tests, full-repo Bandit, docker build test
+
+## Merge Readiness
+
+Full local `make verify` was intentionally not run under operator-approved
+machine-heavy deferral to avoid CPU-heavy local execution. Before this PR can be
+marked ready, current-head GitHub CI parity and the strict merge-readiness
+wrapper must pass, and all review/bot actionables must have explicit
+dispositions in this artifact and in the PR body mirror.
+
+## Deferred / Follow-ups
+
+None for PR-1. Later release-control-plane slices own RAG/ML gate export,
+release manifest generation, build equivalence, and CI release decision
+integration.

--- a/docs/review/PR_1592_FIXED_MAPPING.md
+++ b/docs/review/PR_1592_FIXED_MAPPING.md
@@ -16,7 +16,25 @@ before any review thread is resolved.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1592#pullrequestreview-4203576058 -> 0259cf5b4
+Disposition: FIXED
+Commit: 0259cf5b4
+Evidence: `scripts/release/reviewer_packet_hashes.py` aggregates missing metadata files, reports UTF-8 decode context, and derives the digest from `HASH_ALGORITHM`; `tests/test_release_reviewer_packet_hashes.py` covers ordering and missing-file diagnostics.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1592#discussion_r3166579076 -> 0259cf5b4
+Disposition: FIXED
+Commit: 0259cf5b4
+Evidence: `scripts/release/reviewer_packet_hashes.py` includes artifact path context in UTF-8 decode failures; `tests/test_release_reviewer_packet_hashes.py` covers the diagnostic.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1592#discussion_r3166579122 -> 0259cf5b4
+Disposition: FIXED
+Commit: 0259cf5b4
+Evidence: `scripts/release/reviewer_packet_hashes.py` uses `hashlib.new(HASH_ALGORITHM, payload)` so the emitted algorithm and digest behavior stay aligned.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1592#discussion_r3166579154 -> 0259cf5b4
+Disposition: FIXED
+Commit: 0259cf5b4
+Evidence: `tests/test_release_reviewer_packet_hashes.py` covers deterministic `metadata_artifact_paths` ordering.
 
 ## Implementation Evidence
 

--- a/docs/review/PR_1592_FIXED_MAPPING.md
+++ b/docs/review/PR_1592_FIXED_MAPPING.md
@@ -7,19 +7,27 @@
 
 ## Discussion Thread Pass
 
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
 No human, CodeRabbit, Sourcery, or Cubic actionable review threads were present
 when this canonical mapping artifact was created. This file must be updated
 before any review thread is resolved.
 
 ## Fixed in Commit Mapping
 
-- Initial implementation commit: `49eb4162e`
-  - Disposition: FIXED
-  - Evidence:
-    - `docs/release/REVIEWER_PACKET_HASH_CONTRACT.md`
-    - `docs/release/REVIEWER_PACKET_HASH_CONTRACT.schema.json`
-    - `scripts/release/reviewer_packet_hashes.py`
-    - `tests/test_release_reviewer_packet_hashes.py`
+- No actionable review comments
+
+## Implementation Evidence
+
+Disposition: FIXED
+Commit: 49eb4162e
+Evidence:
+
+- `docs/release/REVIEWER_PACKET_HASH_CONTRACT.md`
+- `docs/release/REVIEWER_PACKET_HASH_CONTRACT.schema.json`
+- `scripts/release/reviewer_packet_hashes.py`
+- `tests/test_release_reviewer_packet_hashes.py`
 
 ## Local Gate Evidence
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -372,11 +372,13 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Target PR: PR-TBD-RELEASE-CONTROL-PLANE-PR0 -> PR-TBD-RELEASE-CONTROL-PLANE-PR5
   - Area: release / App Store / AI evals / supply-chain / orchestration
   - Finding Type: release evidence unification gap
-  - Status: Bootstrap lane starts in branch `release/release-control-plane-pr0-bootstrap`.
+  - Status: PR-0 merged; PR-1 active in branch `release/release-control-plane-pr1-reviewer-hash`.
   - Reason (EN): The App Store readiness PR train is owned separately, while the attached release-automation document also identifies a cross-cutting control-plane gap: build identity, reviewer packet identity, RAG/ML gate identity, supply-chain provenance, and the final release decision are not yet represented by one machine-readable release packet. This line complements PR `#1582` without editing its branch or worktree.
   - Links:
     - `docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md`
     - `docs/release/RELEASE_CONTROL_PLANE_EPIC.md`
+    - `docs/release/REVIEWER_PACKET_HASH_CONTRACT.md`
+    - `docs/release/REVIEWER_PACKET_HASH_CONTRACT.schema.json`
     - `docs/architecture/C4_RELEASE_CONTROL_PLANE_CONTEXT.md`
     - `docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md`
     - `scripts/evals/run_rag_release_gates.py`
@@ -384,7 +386,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md`
   - DoD:
     - PR-0 lands governance docs, C4 release-risk context, packet, and this ledger anchor without runtime/workflow changes.
-    - PR-1 defines reviewer-packet hash contract after App Store readiness artifacts land on `main`.
+    - PR-1 defines reviewer-packet hash contract after App Store readiness artifacts land on `main`, including `reviewer_notes_hash`, `appstore_metadata_hash`, canonical UTF-8 SHA-256 rules, and schema tests.
     - PR-2 exports a stable RAG/ML gate-result schema from the existing release-gate runner without creating a second eval source of truth.
     - PR-3 adds a release manifest generator and fail-closed validator.
     - PR-4 proves review-build and production-candidate equivalence by digest/hash checks.

--- a/scripts/release/__init__.py
+++ b/scripts/release/__init__.py
@@ -1,0 +1,1 @@
+"""Release automation helpers."""

--- a/scripts/release/reviewer_packet_hashes.py
+++ b/scripts/release/reviewer_packet_hashes.py
@@ -28,37 +28,52 @@ REQUIRED_METADATA_FILES = (
 )
 
 
-def canonical_utf8_bytes(raw: bytes) -> bytes:
+def canonical_utf8_bytes(raw: bytes, *, artifact_path: Path | None = None) -> bytes:
     """Return canonical UTF-8 bytes for reviewer packet text artifacts."""
 
-    text = raw.decode("utf-8")
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        artifact = artifact_path.as_posix() if artifact_path else "<unknown artifact>"
+        raise UnicodeDecodeError(
+            exc.encoding,
+            exc.object,
+            exc.start,
+            exc.end,
+            f"{exc.reason}; while decoding {artifact} as UTF-8",
+        ) from exc
     normalized = text.replace("\r\n", "\n").replace("\r", "\n").rstrip("\n")
     return f"{normalized}\n".encode("utf-8")
 
 
 def sha256_lower_hex(payload: bytes) -> str:
-    """Return lowercase SHA-256 hex without an algorithm prefix."""
+    """Return lowercase hex using the configured algorithm without a prefix."""
 
-    return hashlib.sha256(payload).hexdigest()
+    return hashlib.new(HASH_ALGORITHM, payload).hexdigest()
 
 
 def hash_text_artifact(path: Path) -> str:
     """Hash one UTF-8 text artifact using reviewer-packet canonicalization."""
 
-    return sha256_lower_hex(canonical_utf8_bytes(path.read_bytes()))
+    return sha256_lower_hex(canonical_utf8_bytes(path.read_bytes(), artifact_path=path))
 
 
 def metadata_artifact_paths(repo_root: Path) -> list[Path]:
     """Return canonical localized metadata file paths in deterministic order."""
 
     paths: list[Path] = []
+    missing_paths: list[Path] = []
     for locale in REQUIRED_LOCALES:
         for filename in REQUIRED_METADATA_FILES:
             relative_path = METADATA_ROOT / locale / filename
             absolute_path = repo_root / relative_path
             if not absolute_path.is_file():
-                raise FileNotFoundError(f"Missing App Store metadata artifact: {relative_path}")
+                missing_paths.append(relative_path)
+                continue
             paths.append(relative_path)
+    if missing_paths:
+        missing = ", ".join(path.as_posix() for path in missing_paths)
+        raise FileNotFoundError(f"Missing App Store metadata artifacts: {missing}")
     return sorted(paths, key=lambda path: path.as_posix())
 
 

--- a/scripts/release/reviewer_packet_hashes.py
+++ b/scripts/release/reviewer_packet_hashes.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Build deterministic App Store reviewer-packet identity hashes."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "release-reviewer-packet-hashes.v1"
+HASH_ALGORITHM = "sha256"
+REVIEWER_NOTES_PATH = Path("ios/fastlane/metadata/review_information/notes.txt")
+APP_PRIVACY_CONTEXT_PATH = Path("ios/fastlane/app_privacy_details.json")
+METADATA_ROOT = Path("ios/fastlane/metadata")
+REQUIRED_LOCALES = ("en-US", "ru-RU", "es-ES")
+REQUIRED_METADATA_FILES = (
+    "name.txt",
+    "subtitle.txt",
+    "description.txt",
+    "keywords.txt",
+    "promotional_text.txt",
+    "release_notes.txt",
+    "privacy_url.txt",
+    "support_url.txt",
+    "marketing_url.txt",
+)
+
+
+def canonical_utf8_bytes(raw: bytes) -> bytes:
+    """Return canonical UTF-8 bytes for reviewer packet text artifacts."""
+
+    text = raw.decode("utf-8")
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n").rstrip("\n")
+    return f"{normalized}\n".encode("utf-8")
+
+
+def sha256_lower_hex(payload: bytes) -> str:
+    """Return lowercase SHA-256 hex without an algorithm prefix."""
+
+    return hashlib.sha256(payload).hexdigest()
+
+
+def hash_text_artifact(path: Path) -> str:
+    """Hash one UTF-8 text artifact using reviewer-packet canonicalization."""
+
+    return sha256_lower_hex(canonical_utf8_bytes(path.read_bytes()))
+
+
+def metadata_artifact_paths(repo_root: Path) -> list[Path]:
+    """Return canonical localized metadata file paths in deterministic order."""
+
+    paths: list[Path] = []
+    for locale in REQUIRED_LOCALES:
+        for filename in REQUIRED_METADATA_FILES:
+            relative_path = METADATA_ROOT / locale / filename
+            absolute_path = repo_root / relative_path
+            if not absolute_path.is_file():
+                raise FileNotFoundError(f"Missing App Store metadata artifact: {relative_path}")
+            paths.append(relative_path)
+    return sorted(paths, key=lambda path: path.as_posix())
+
+
+def _source_entry(kind: str, relative_path: Path, artifact_hash: str) -> dict[str, str]:
+    return {
+        "kind": kind,
+        "path": relative_path.as_posix(),
+        "hash": artifact_hash,
+    }
+
+
+def _canonical_json_bytes(payload: Any) -> bytes:
+    serialized = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return f"{serialized}\n".encode("utf-8")
+
+
+def build_reviewer_packet_hash_contract(repo_root: Path) -> dict[str, Any]:
+    """Build the PR-1 reviewer-packet hash contract payload."""
+
+    resolved_root = repo_root.resolve()
+    reviewer_notes_path = resolved_root / REVIEWER_NOTES_PATH
+    if not reviewer_notes_path.is_file():
+        raise FileNotFoundError(f"Missing reviewer notes artifact: {REVIEWER_NOTES_PATH}")
+
+    reviewer_notes_hash = hash_text_artifact(reviewer_notes_path)
+    metadata_entries = [
+        _source_entry(
+            "appstore_metadata",
+            relative_path,
+            hash_text_artifact(resolved_root / relative_path),
+        )
+        for relative_path in metadata_artifact_paths(resolved_root)
+    ]
+    metadata_manifest = {
+        "canonicalization": "utf8-lf-single-trailing-newline",
+        "entries": metadata_entries,
+        "schema_version": SCHEMA_VERSION,
+    }
+    appstore_metadata_hash = sha256_lower_hex(_canonical_json_bytes(metadata_manifest))
+
+    source_artifacts: list[dict[str, str]] = [
+        _source_entry("reviewer_notes", REVIEWER_NOTES_PATH, reviewer_notes_hash),
+        *metadata_entries,
+    ]
+
+    app_privacy_path = resolved_root / APP_PRIVACY_CONTEXT_PATH
+    if app_privacy_path.is_file():
+        source_artifacts.append(
+            _source_entry(
+                "app_privacy_context",
+                APP_PRIVACY_CONTEXT_PATH,
+                hash_text_artifact(app_privacy_path),
+            )
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "hash_algorithm": HASH_ALGORITHM,
+        "canonicalization": "utf8-lf-single-trailing-newline",
+        "reviewer_notes_hash": reviewer_notes_hash,
+        "appstore_metadata_hash": appstore_metadata_hash,
+        "source_artifacts": source_artifacts,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root containing ios/fastlane artifacts.",
+    )
+    args = parser.parse_args()
+    payload = build_reviewer_packet_hash_contract(args.repo_root)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_reviewer_packet_hashes.py
+++ b/tests/test_release_reviewer_packet_hashes.py
@@ -37,6 +37,14 @@ def test_canonical_utf8_bytes_normalizes_line_endings_and_trailing_lf() -> None:
     assert reviewer_packet_hashes.canonical_utf8_bytes("wellness".encode("utf-8")) == b"wellness\n"
 
 
+def test_canonical_utf8_bytes_reports_artifact_path_on_decode_failure() -> None:
+    with pytest.raises(UnicodeDecodeError, match="bad.txt as UTF-8"):
+        reviewer_packet_hashes.canonical_utf8_bytes(
+            b"\xff",
+            artifact_path=Path("ios/fastlane/metadata/en-US/bad.txt"),
+        )
+
+
 def test_sha256_contract_is_lowercase_hex_without_prefix() -> None:
     digest = reviewer_packet_hashes.sha256_lower_hex(b"reviewer")
 
@@ -92,6 +100,27 @@ def test_metadata_hash_is_stable_for_discovery_order_and_changes_on_content(
 
     assert changed["appstore_metadata_hash"] != first["appstore_metadata_hash"]
     assert changed["reviewer_notes_hash"] == first["reviewer_notes_hash"]
+
+
+def test_metadata_artifact_paths_are_sorted_deterministically(tmp_path: Path) -> None:
+    _write_metadata_pack(tmp_path)
+
+    paths = reviewer_packet_hashes.metadata_artifact_paths(tmp_path)
+
+    assert paths == sorted(paths, key=lambda path: path.as_posix())
+
+
+def test_metadata_artifact_paths_reports_all_missing_files(tmp_path: Path) -> None:
+    _write_metadata_pack(tmp_path)
+    (tmp_path / "ios/fastlane/metadata/en-US/name.txt").unlink()
+    (tmp_path / "ios/fastlane/metadata/es-ES/support_url.txt").unlink()
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        reviewer_packet_hashes.metadata_artifact_paths(tmp_path)
+
+    message = str(exc_info.value)
+    assert "ios/fastlane/metadata/en-US/name.txt" in message
+    assert "ios/fastlane/metadata/es-ES/support_url.txt" in message
 
 
 def test_schema_file_matches_emitted_payload_shape(tmp_path: Path) -> None:

--- a/tests/test_release_reviewer_packet_hashes.py
+++ b/tests/test_release_reviewer_packet_hashes.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from scripts.release import reviewer_packet_hashes
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _write_metadata_pack(repo_root: Path) -> None:
+    notes_path = repo_root / "ios/fastlane/metadata/review_information/notes.txt"
+    notes_path.parent.mkdir(parents=True, exist_ok=True)
+    notes_path.write_text("Reviewer note\r\n", encoding="utf-8")
+
+    privacy_path = repo_root / "ios/fastlane/app_privacy_details.json"
+    privacy_path.parent.mkdir(parents=True, exist_ok=True)
+    privacy_path.write_text('[{"data_protections":["DATA_NOT_COLLECTED"]}]\n', encoding="utf-8")
+
+    for locale in reviewer_packet_hashes.REQUIRED_LOCALES:
+        locale_dir = repo_root / "ios/fastlane/metadata" / locale
+        locale_dir.mkdir(parents=True, exist_ok=True)
+        for filename in reviewer_packet_hashes.REQUIRED_METADATA_FILES:
+            (locale_dir / filename).write_text(
+                f"{locale}:{filename}\r\n",
+                encoding="utf-8",
+            )
+
+
+def test_canonical_utf8_bytes_normalizes_line_endings_and_trailing_lf() -> None:
+    assert reviewer_packet_hashes.canonical_utf8_bytes(b"a\r\nb\rc\n\n") == b"a\nb\nc\n"
+    assert reviewer_packet_hashes.canonical_utf8_bytes("wellness".encode("utf-8")) == b"wellness\n"
+
+
+def test_sha256_contract_is_lowercase_hex_without_prefix() -> None:
+    digest = reviewer_packet_hashes.sha256_lower_hex(b"reviewer")
+
+    assert digest == hashlib.sha256(b"reviewer").hexdigest()
+    assert HASH_RE.fullmatch(digest)
+    assert not digest.startswith("sha256:")
+
+
+def test_build_contract_emits_schema_hash_fields_and_current_artifact_names(
+    tmp_path: Path,
+) -> None:
+    _write_metadata_pack(tmp_path)
+
+    payload = reviewer_packet_hashes.build_reviewer_packet_hash_contract(tmp_path)
+    artifact_paths = {entry["path"] for entry in payload["source_artifacts"]}
+
+    assert payload["schema_version"] == "release-reviewer-packet-hashes.v1"
+    assert payload["hash_algorithm"] == "sha256"
+    assert payload["canonicalization"] == "utf8-lf-single-trailing-newline"
+    assert HASH_RE.fullmatch(payload["reviewer_notes_hash"])
+    assert HASH_RE.fullmatch(payload["appstore_metadata_hash"])
+    assert "ios/fastlane/metadata/review_information/notes.txt" in artifact_paths
+    assert "ios/fastlane/app_privacy_details.json" in artifact_paths
+    assert "ios/fastlane/metadata/en-US/name.txt" in artifact_paths
+    assert "ios/fastlane/metadata/ru-RU/release_notes.txt" in artifact_paths
+    assert "ios/fastlane/metadata/es-ES/support_url.txt" in artifact_paths
+
+
+def test_reviewer_notes_hash_is_independent_from_metadata_hash(tmp_path: Path) -> None:
+    _write_metadata_pack(tmp_path)
+    first = reviewer_packet_hashes.build_reviewer_packet_hash_contract(tmp_path)
+
+    notes_path = tmp_path / "ios/fastlane/metadata/review_information/notes.txt"
+    notes_path.write_text("Changed reviewer note\n", encoding="utf-8")
+    second = reviewer_packet_hashes.build_reviewer_packet_hash_contract(tmp_path)
+
+    assert second["reviewer_notes_hash"] != first["reviewer_notes_hash"]
+    assert second["appstore_metadata_hash"] == first["appstore_metadata_hash"]
+
+
+def test_metadata_hash_is_stable_for_discovery_order_and_changes_on_content(
+    tmp_path: Path,
+) -> None:
+    _write_metadata_pack(tmp_path)
+    first = reviewer_packet_hashes.build_reviewer_packet_hash_contract(tmp_path)
+    second = reviewer_packet_hashes.build_reviewer_packet_hash_contract(tmp_path)
+
+    assert second["appstore_metadata_hash"] == first["appstore_metadata_hash"]
+
+    metadata_path = tmp_path / "ios/fastlane/metadata/es-ES/keywords.txt"
+    metadata_path.write_text("nutrition,wellness,release\n", encoding="utf-8")
+    changed = reviewer_packet_hashes.build_reviewer_packet_hash_contract(tmp_path)
+
+    assert changed["appstore_metadata_hash"] != first["appstore_metadata_hash"]
+    assert changed["reviewer_notes_hash"] == first["reviewer_notes_hash"]
+
+
+def test_schema_file_matches_emitted_payload_shape(tmp_path: Path) -> None:
+    _write_metadata_pack(tmp_path)
+    payload = reviewer_packet_hashes.build_reviewer_packet_hash_contract(tmp_path)
+    schema = json.loads(
+        (REPO_ROOT / "docs/release/REVIEWER_PACKET_HASH_CONTRACT.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    required = set(schema["required"])
+    assert required <= set(payload)
+    assert payload["schema_version"] == schema["properties"]["schema_version"]["const"]
+    assert payload["hash_algorithm"] == schema["properties"]["hash_algorithm"]["const"]
+    assert payload["canonicalization"] == schema["properties"]["canonicalization"]["const"]
+    assert HASH_RE.fullmatch(payload["reviewer_notes_hash"])
+    assert HASH_RE.fullmatch(payload["appstore_metadata_hash"])
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "ios/fastlane/metadata/review_information/notes.txt",
+        "ios/fastlane/metadata/en-US/name.txt",
+        "ios/fastlane/metadata/ru-RU/description.txt",
+        "ios/fastlane/metadata/es-ES/release_notes.txt",
+    ],
+)
+def test_landed_appstore_readiness_artifacts_exist(relative_path: str) -> None:
+    assert (REPO_ROOT / relative_path).is_file()


### PR DESCRIPTION
## Summary
- Adds the PR-1 reviewer-packet hash contract for the release-control-plane line.
- Defines deterministic `reviewer_notes_hash` and `appstore_metadata_hash` over landed App Store readiness artifacts from `main`.
- Consumes App Store readiness outputs as upstream context without editing PR #1582, Fastlane upload behavior, reviewer copy, or App Store metadata content.

## Scope
- Contract docs: `docs/release/REVIEWER_PACKET_HASH_CONTRACT.md`
- Machine schema: `docs/release/REVIEWER_PACKET_HASH_CONTRACT.schema.json`
- Helper: `scripts/release/reviewer_packet_hashes.py`
- Tests: `tests/test_release_reviewer_packet_hashes.py`
- Packet/epic/ledger links for PR-1
- Canonical review mapping: `docs/review/PR_1592_FIXED_MAPPING.md`

## Coordinator / Role Order
`agent-coordinator -> architecture-specialist -> ml-engineer-agent -> data-scientist-agent -> security-auditor -> app-store-release-agent -> backend-engineer -> frontend-engineer -> dev-operator -> qa-engineer-agent -> bug-hunter`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Sourcery actionables were fixed and mapped in `docs/review/PR_1592_FIXED_MAPPING.md`. Resolved threads must stay represented there.

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1592_FIXED_MAPPING.md`

Implementation commits:
- Initial implementation: `49eb4162e`
- PR governance mapping: `3697d68b2`
- Phase2 mapping contract fix: `fbf5fa67f`
- Sourcery review fixes: `0259cf5b4`
- Sourcery mapping update: `ccd138c3a`

## Merge Readiness
Local narrow gates run before/during opening:
- `python3 scripts/orchestration/check_preflight.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `pytest -q tests/test_release_reviewer_packet_hashes.py` PASS
- `pytest -q tests/test_ios_appstore_asset_validators.py tests/test_ios_appstore_assets_workflow_contract.py` PASS
- `pytest -q tests/test_repo_policy_guards.py` PASS
- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` PASS
- `pre-commit run --all-files` PASS
- pre-push hooks PASS: formatting, ruff, changed-file mypy, pip-audit, backend pre-push tests, full-repo Bandit, docker build test where path-applicable

Operator-approved machine-heavy deferral: full local `make verify` was intentionally not run to avoid CPU-heavy local execution. Merge readiness must rely on the narrow local gates above plus GitHub current-head CI parity and strict merge-readiness governance before this PR is marked ready.

## Security Notes
- No App Store Connect credentials, signing material, reviewer credentials, protected upload secrets, or runtime secret surfaces are read or stored.
- Hashes are drift evidence only; they do not authorize an `ALLOW` release decision.
- App Privacy JSON is included as upstream context only and is not part of `appstore_metadata_hash` in PR-1.

## Marketing & GTM
No public App Store, ASO, Product Hunt, or wellness claims change in this PR. This is internal release-evidence infrastructure.
