### PR TITLE
docs(food-data): narrow MenuStat replacement source decision

### DIFF
--- a/core/food_sources/menustat_source_decision.py
+++ b/core/food_sources/menustat_source_decision.py
@@ -1,0 +1,735 @@
+"""
+Deterministic MenuStat source-decision cleanup gate.
+
+RU: Файловая проверка решения PR10: MenuStat архивный источник, FatSecret не
+является проектной опорой, chain public pages только research lane.
+EN: File-only PR10 decision gate: MenuStat is archival, FatSecret is not a
+project source, and chain public pages remain a research-only lane.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+import json
+from pathlib import Path
+import re
+
+from core.food_sources.menustat_replacement import (
+    MENUSTAT_SOURCE,
+    MenuStatReplacementDecision,
+    MenuStatReplacementError,
+    load_menustat_replacement_decision,
+)
+from core.food_sources.source_catalog import (
+    SourceCatalog,
+    SourceCatalogEntry,
+    SourceCatalogError,
+    load_source_catalog,
+)
+from core.food_sources.source_onboarding import (
+    SourceOnboarding,
+    SourceOnboardingError,
+    load_source_onboarding,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DECISION_SCHEMA_RE = re.compile(r"^food-data-menustat-source-decision\.v\d+$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_FAT_PLATFORM_SOURCE = "fat" + "secret_platform"
+_CHAIN_PUBLIC_SOURCE = "chain_public_nutrition_pages"
+_EXPECTED_SOURCE_ORDER = (
+    "nutritionix",
+    _FAT_PLATFORM_SOURCE,
+    "spoonacular",
+    _CHAIN_PUBLIC_SOURCE,
+)
+_SAFETY_FLAG_TEMPLATE: dict[str, bool] = {
+    "runtime_cutover": False,
+    "digitalocean_postgres_load": False,
+    "bulk_ingest": False,
+    "network_allowed": False,
+    "db_writes_allowed": False,
+    "api_calls_allowed": False,
+    "source_download_allowed": False,
+    "scraping_allowed": False,
+    "file_only": True,
+}
+_DECISION_KEYS = frozenset(
+    {
+        "schema_version",
+        "generated_on",
+        "catalog_ref",
+        "onboarding_ref",
+        "menustat_replacement_ref",
+        "legacy_source",
+        "menustat_archival_policy",
+        "preferred_research_lane",
+        "budget_api_review",
+        "public_web_evidence_policy",
+        "source_decisions",
+        "runtime_cutover",
+        "digitalocean_postgres_load",
+        "bulk_ingest",
+        "network_allowed",
+        "db_writes_allowed",
+        "api_calls_allowed",
+        "source_download_allowed",
+        "scraping_allowed",
+        "file_only",
+        "final_gate_decision",
+        "notes",
+    }
+)
+_BUDGET_API_REVIEW_KEYS = frozenset(
+    {
+        "source",
+        "source_family",
+        "review_lane_decision",
+        "starter_budget_usd_per_month",
+        "pricing_evidence_ref",
+        "authority_decision",
+        "api_calls_allowed",
+        "cache_policy_status",
+        "attribution_status",
+        "notes",
+    }
+)
+_PUBLIC_WEB_POLICY_KEYS = frozenset(
+    {
+        "policy_decision",
+        "allowed_surfaces",
+        "allowed_capture_methods",
+        "blocked_methods",
+        "legal_review_required",
+        "anti_scraping_review_required",
+        "copyright_review_required",
+        "automation_allowed",
+        "redistribution_allowed",
+        "public_claim_allowed",
+        "notes",
+    }
+)
+_ARCHIVAL_POLICY_KEYS = frozenset(
+    {
+        "source",
+        "source_classification",
+        "archival_reference_only",
+        "freshness_authority",
+        "active_update_source",
+        "replacement_required",
+        "validation_required_before_use",
+        "allowed_use",
+        "blocked_use",
+        "notes",
+    }
+)
+_SOURCE_DECISION_KEYS = frozenset(
+    {
+        "source",
+        "project_source_decision",
+        "research_lane_decision",
+        "authority_decision",
+        "automation_approved",
+        "eligible_preflight",
+        "approved_ingest",
+        "blocking_reasons",
+        "notes",
+    }
+)
+_EXPECTED_PROJECT_DECISIONS: dict[str, dict[str, object]] = {
+    "nutritionix": {
+        "project_source_decision": "deferred_contract_review",
+        "research_lane_decision": "not_preferred_for_budget_first_lane",
+    },
+    _FAT_PLATFORM_SOURCE: {
+        "project_source_decision": "not_project_source",
+        "research_lane_decision": "rejected_for_project_use",
+    },
+    "spoonacular": {
+        "project_source_decision": "deferred_recipe_experiments_only",
+        "research_lane_decision": "not_restaurant_authority",
+    },
+    _CHAIN_PUBLIC_SOURCE: {
+        "project_source_decision": "preferred_research_lane",
+        "research_lane_decision": "chain_public_pages_governance_first",
+    },
+}
+
+FINAL_GATE_DECISION = "source_decision_locked_no_ingest"
+
+
+class MenuStatSourceDecisionError(ValueError):
+    """Raised when the PR10 MenuStat source-decision gate is invalid."""
+
+
+@dataclass(frozen=True)
+class MenuStatArchivalPolicy:
+    """Validated archival policy for MenuStat."""
+
+    source: str
+    source_classification: str
+    archival_reference_only: bool
+    freshness_authority: bool
+    active_update_source: bool
+    replacement_required: bool
+    validation_required_before_use: bool
+    allowed_use: tuple[str, ...]
+    blocked_use: tuple[str, ...]
+    notes: str
+
+
+@dataclass(frozen=True)
+class SourceDecision:
+    """One PR10 source decision row."""
+
+    source: str
+    project_source_decision: str
+    research_lane_decision: str
+    authority_decision: str
+    automation_approved: bool
+    eligible_preflight: bool
+    approved_ingest: bool
+    blocking_reasons: tuple[str, ...]
+    notes: str
+
+
+@dataclass(frozen=True)
+class BudgetApiReview:
+    """Adjacent under-budget API review lane, not a source approval."""
+
+    source: str
+    source_family: str
+    review_lane_decision: str
+    starter_budget_usd_per_month: int
+    pricing_evidence_ref: str
+    authority_decision: str
+    api_calls_allowed: bool
+    cache_policy_status: str
+    attribution_status: str
+    notes: str
+
+
+@dataclass(frozen=True)
+class PublicWebEvidencePolicy:
+    """Manual public-web evidence policy before any automated collection."""
+
+    policy_decision: str
+    allowed_surfaces: tuple[str, ...]
+    allowed_capture_methods: tuple[str, ...]
+    blocked_methods: tuple[str, ...]
+    legal_review_required: bool
+    anti_scraping_review_required: bool
+    copyright_review_required: bool
+    automation_allowed: bool
+    redistribution_allowed: bool
+    public_claim_allowed: bool
+    notes: str
+
+
+@dataclass(frozen=True)
+class MenuStatSourceDecision:
+    """Validated PR10 source-decision artifact."""
+
+    schema_version: str
+    generated_on: date
+    catalog_ref: str
+    onboarding_ref: str
+    menustat_replacement_ref: str
+    legacy_source: str
+    menustat_archival_policy: MenuStatArchivalPolicy
+    preferred_research_lane: str
+    budget_api_review: BudgetApiReview
+    public_web_evidence_policy: PublicWebEvidencePolicy
+    source_decisions: tuple[SourceDecision, ...]
+    final_gate_decision: str
+    notes: str
+
+
+def _decision_error(context: str, detail: str) -> MenuStatSourceDecisionError:
+    return MenuStatSourceDecisionError(f"Invalid MenuStat source decision {context}: {detail}")
+
+
+def _require_mapping(value: object, context: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise _decision_error(context, "must be an object")
+    result: dict[str, object] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise _decision_error(context, "all object keys must be strings")
+        result[key] = item
+    return result
+
+
+def _require_string(data: dict[str, object], key: str, context: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise _decision_error(context, f"missing non-empty string '{key}'")
+    return value.strip()
+
+
+def _require_bool(data: dict[str, object], key: str, context: str) -> bool:
+    value = data.get(key)
+    if not isinstance(value, bool):
+        raise _decision_error(context, f"'{key}' must be a boolean")
+    return value
+
+
+def _require_int(data: dict[str, object], key: str, context: str) -> int:
+    value = data.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise _decision_error(context, f"'{key}' must be an integer")
+    return value
+
+
+def _require_string_tuple(
+    data: dict[str, object],
+    key: str,
+    context: str,
+) -> tuple[str, ...]:
+    value = data.get(key)
+    if not isinstance(value, list):
+        raise _decision_error(context, f"'{key}' must be a list of strings")
+    items: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise _decision_error(context, f"'{key}[{index}]' must be a non-empty string")
+        normalized = item.strip()
+        if normalized in seen:
+            raise _decision_error(context, f"'{key}' contains duplicate value {normalized!r}")
+        seen.add(normalized)
+        items.append(normalized)
+    if not items:
+        raise _decision_error(context, f"'{key}' must not be empty")
+    return tuple(items)
+
+
+def _parse_date(value: str, context: str) -> date:
+    if not _DATE_RE.fullmatch(value):
+        raise _decision_error(context, "generated_on must use YYYY-MM-DD")
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise _decision_error(context, "generated_on must use YYYY-MM-DD") from exc
+
+
+def _relative_repo_path(path: Path | str) -> str:
+    resolved = Path(path).resolve()
+    try:
+        return resolved.relative_to(_REPO_ROOT).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
+def _entry_by_source(catalog: SourceCatalog) -> dict[str, SourceCatalogEntry]:
+    return {entry.source: entry for entry in catalog.sources}
+
+
+def _require_safety_flags(data: dict[str, object], context: str) -> None:
+    safety_flags = {key: _require_bool(data, key, context) for key in _SAFETY_FLAG_TEMPLATE}
+    if safety_flags != _SAFETY_FLAG_TEMPLATE:
+        raise _decision_error(
+            context,
+            "runtime_cutover, digitalocean_postgres_load, bulk_ingest, network_allowed, "
+            "db_writes_allowed, api_calls_allowed, source_download_allowed, and "
+            "scraping_allowed must be false; file_only must be true",
+        )
+
+
+def _parse_archival_policy(
+    value: object,
+    catalog: SourceCatalog,
+    context: str,
+) -> MenuStatArchivalPolicy:
+    data = _require_mapping(value, context)
+    unexpected_keys = sorted(set(data) - _ARCHIVAL_POLICY_KEYS)
+    if unexpected_keys:
+        raise _decision_error(
+            context, f"unexpected archival policy keys: {', '.join(unexpected_keys)}"
+        )
+    policy = MenuStatArchivalPolicy(
+        source=_require_string(data, "source", context),
+        source_classification=_require_string(data, "source_classification", context),
+        archival_reference_only=_require_bool(data, "archival_reference_only", context),
+        freshness_authority=_require_bool(data, "freshness_authority", context),
+        active_update_source=_require_bool(data, "active_update_source", context),
+        replacement_required=_require_bool(data, "replacement_required", context),
+        validation_required_before_use=_require_bool(
+            data, "validation_required_before_use", context
+        ),
+        allowed_use=_require_string_tuple(data, "allowed_use", context),
+        blocked_use=_require_string_tuple(data, "blocked_use", context),
+        notes=_require_string(data, "notes", context),
+    )
+    if policy.source != MENUSTAT_SOURCE:
+        raise _decision_error(context, "archival policy source must be menustat")
+    if policy.source_classification != "legacy_static":
+        raise _decision_error(context, "MenuStat must remain legacy_static")
+    if not policy.archival_reference_only:
+        raise _decision_error(context, "MenuStat must be archival_reference_only")
+    if policy.freshness_authority:
+        raise _decision_error(context, "MenuStat cannot be freshness authority")
+    if policy.active_update_source:
+        raise _decision_error(context, "MenuStat cannot be an active update source")
+    if not policy.replacement_required:
+        raise _decision_error(context, "MenuStat must remain replacement_required")
+    if not policy.validation_required_before_use:
+        raise _decision_error(context, "MenuStat data requires validation before use")
+
+    menustat = _entry_by_source(catalog).get(MENUSTAT_SOURCE)
+    if menustat is None:
+        raise _decision_error(context, "catalog must include menustat")
+    if menustat.source_classification != "legacy_static":
+        raise _decision_error(context, "catalog MenuStat classification drifted")
+    if menustat.active_update_source:
+        raise _decision_error(context, "catalog MenuStat cannot be active_update_source")
+    if not menustat.replacement_required:
+        raise _decision_error(context, "catalog MenuStat must remain replacement_required")
+    return policy
+
+
+def _parse_budget_api_review(value: object, context: str) -> BudgetApiReview:
+    data = _require_mapping(value, context)
+    unexpected_keys = sorted(set(data) - _BUDGET_API_REVIEW_KEYS)
+    if unexpected_keys:
+        raise _decision_error(context, f"unexpected budget API keys: {', '.join(unexpected_keys)}")
+    review = BudgetApiReview(
+        source=_require_string(data, "source", context),
+        source_family=_require_string(data, "source_family", context),
+        review_lane_decision=_require_string(data, "review_lane_decision", context),
+        starter_budget_usd_per_month=_require_int(data, "starter_budget_usd_per_month", context),
+        pricing_evidence_ref=_require_string(data, "pricing_evidence_ref", context),
+        authority_decision=_require_string(data, "authority_decision", context),
+        api_calls_allowed=_require_bool(data, "api_calls_allowed", context),
+        cache_policy_status=_require_string(data, "cache_policy_status", context),
+        attribution_status=_require_string(data, "attribution_status", context),
+        notes=_require_string(data, "notes", context),
+    )
+    if review.source != "edamam_food_database":
+        raise _decision_error(context, "budget API review source must be edamam_food_database")
+    if review.source_family != "recipe_corpus":
+        raise _decision_error(context, "budget API review must stay recipe_corpus")
+    if review.review_lane_decision != "adjacent_recipe_food_db_review_only":
+        raise _decision_error(context, "budget API review must stay adjacent review only")
+    if review.starter_budget_usd_per_month > 20:
+        raise _decision_error(context, "budget API review must stay at or below 20 USD/month")
+    if review.authority_decision != "not_approved" or review.api_calls_allowed:
+        raise _decision_error(context, "budget API review cannot approve authority or API calls")
+    if review.cache_policy_status != "blocked_terms_review_required":
+        raise _decision_error(context, "budget API cache policy must require terms review")
+    if review.attribution_status != "blocked_attribution_review_required":
+        raise _decision_error(context, "budget API attribution must require review")
+    return review
+
+
+def _parse_public_web_policy(value: object, context: str) -> PublicWebEvidencePolicy:
+    data = _require_mapping(value, context)
+    unexpected_keys = sorted(set(data) - _PUBLIC_WEB_POLICY_KEYS)
+    if unexpected_keys:
+        raise _decision_error(
+            context, f"unexpected public web policy keys: {', '.join(unexpected_keys)}"
+        )
+    policy = PublicWebEvidencePolicy(
+        policy_decision=_require_string(data, "policy_decision", context),
+        allowed_surfaces=_require_string_tuple(data, "allowed_surfaces", context),
+        allowed_capture_methods=_require_string_tuple(data, "allowed_capture_methods", context),
+        blocked_methods=_require_string_tuple(data, "blocked_methods", context),
+        legal_review_required=_require_bool(data, "legal_review_required", context),
+        anti_scraping_review_required=_require_bool(data, "anti_scraping_review_required", context),
+        copyright_review_required=_require_bool(data, "copyright_review_required", context),
+        automation_allowed=_require_bool(data, "automation_allowed", context),
+        redistribution_allowed=_require_bool(data, "redistribution_allowed", context),
+        public_claim_allowed=_require_bool(data, "public_claim_allowed", context),
+        notes=_require_string(data, "notes", context),
+    )
+    if policy.policy_decision != "manual_evidence_only_legal_review_required":
+        raise _decision_error(context, "public web policy must stay manual evidence only")
+    required_surfaces = {"official_restaurant_website", "official_restaurant_social_account"}
+    if not required_surfaces.issubset(set(policy.allowed_surfaces)):
+        raise _decision_error(
+            context, "public web policy must include official website/social surfaces"
+        )
+    required_methods = {"url_citation", "manual_screenshot_for_internal_review"}
+    if not required_methods.issubset(set(policy.allowed_capture_methods)):
+        raise _decision_error(context, "public web policy must include URL citation and screenshot")
+    if not (
+        policy.legal_review_required
+        and policy.anti_scraping_review_required
+        and policy.copyright_review_required
+    ):
+        raise _decision_error(context, "public web policy must require legal reviews")
+    if policy.automation_allowed or policy.redistribution_allowed or policy.public_claim_allowed:
+        raise _decision_error(
+            context, "public web policy cannot approve automation or redistribution"
+        )
+    return policy
+
+
+def _parse_source_decision(value: object, context: str) -> SourceDecision:
+    data = _require_mapping(value, context)
+    unexpected_keys = sorted(set(data) - _SOURCE_DECISION_KEYS)
+    if unexpected_keys:
+        raise _decision_error(
+            context, f"unexpected source decision keys: {', '.join(unexpected_keys)}"
+        )
+    decision = SourceDecision(
+        source=_require_string(data, "source", context),
+        project_source_decision=_require_string(data, "project_source_decision", context),
+        research_lane_decision=_require_string(data, "research_lane_decision", context),
+        authority_decision=_require_string(data, "authority_decision", context),
+        automation_approved=_require_bool(data, "automation_approved", context),
+        eligible_preflight=_require_bool(data, "eligible_preflight", context),
+        approved_ingest=_require_bool(data, "approved_ingest", context),
+        blocking_reasons=_require_string_tuple(data, "blocking_reasons", context),
+        notes=_require_string(data, "notes", context),
+    )
+    expected = _EXPECTED_PROJECT_DECISIONS.get(decision.source)
+    if expected is None:
+        raise _decision_error(context, f"unknown source decision: {decision.source}")
+    mismatches = [
+        key for key, expected_value in expected.items() if getattr(decision, key) != expected_value
+    ]
+    if mismatches:
+        raise _decision_error(
+            context, f"{decision.source} decision mismatch: {', '.join(mismatches)}"
+        )
+    if decision.authority_decision != "not_approved":
+        raise _decision_error(context, f"{decision.source} cannot be source authority in PR10")
+    if decision.automation_approved or decision.eligible_preflight or decision.approved_ingest:
+        raise _decision_error(
+            context, f"{decision.source} cannot be approved for automation or ingest"
+        )
+    return decision
+
+
+def _validate_against_pr9(
+    decisions: tuple[SourceDecision, ...],
+    replacement: MenuStatReplacementDecision,
+    context: str,
+) -> None:
+    pr9_by_source = {candidate.source: candidate for candidate in replacement.candidate_sources}
+    for decision in decisions:
+        candidate = pr9_by_source.get(decision.source)
+        if candidate is None:
+            raise _decision_error(context, f"PR9 replacement artifact missing {decision.source}")
+        if candidate.authority_decision != "not_approved":
+            raise _decision_error(context, f"PR9 candidate {decision.source} became approved")
+        if candidate.replacement_for != MENUSTAT_SOURCE:
+            raise _decision_error(context, f"PR9 candidate {decision.source} must replace menustat")
+
+
+def parse_menustat_source_decision(
+    payload: object,
+    *,
+    catalog: SourceCatalog,
+    onboarding: SourceOnboarding,
+    replacement: MenuStatReplacementDecision,
+    expected_catalog_ref: str | None = None,
+    expected_onboarding_ref: str | None = None,
+    expected_replacement_ref: str | None = None,
+    context: str = "<menustat-source-decision>",
+) -> MenuStatSourceDecision:
+    """Parse and validate the PR10 MenuStat source-decision cleanup gate."""
+    del onboarding  # PR5 is loaded for deterministic ref parity; no runtime behavior is used.
+    data = _require_mapping(payload, context)
+    unexpected_keys = sorted(set(data) - _DECISION_KEYS)
+    if unexpected_keys:
+        raise _decision_error(context, f"unexpected keys: {', '.join(unexpected_keys)}")
+
+    schema_version = _require_string(data, "schema_version", context)
+    if not _DECISION_SCHEMA_RE.fullmatch(schema_version):
+        raise _decision_error(
+            context,
+            "schema_version must look like food-data-menustat-source-decision.vN",
+        )
+    catalog_ref = _require_string(data, "catalog_ref", context)
+    if expected_catalog_ref is not None and catalog_ref != expected_catalog_ref:
+        raise _decision_error(context, f"catalog_ref must be {expected_catalog_ref!r}")
+    onboarding_ref = _require_string(data, "onboarding_ref", context)
+    if expected_onboarding_ref is not None and onboarding_ref != expected_onboarding_ref:
+        raise _decision_error(context, f"onboarding_ref must be {expected_onboarding_ref!r}")
+    replacement_ref = _require_string(data, "menustat_replacement_ref", context)
+    if expected_replacement_ref is not None and replacement_ref != expected_replacement_ref:
+        raise _decision_error(
+            context, f"menustat_replacement_ref must be {expected_replacement_ref!r}"
+        )
+
+    legacy_source = _require_string(data, "legacy_source", context)
+    if legacy_source != MENUSTAT_SOURCE:
+        raise _decision_error(context, "legacy_source must be menustat")
+    _require_safety_flags(data, context)
+
+    archival_policy = _parse_archival_policy(
+        data.get("menustat_archival_policy"),
+        catalog,
+        f"{context}.menustat_archival_policy",
+    )
+    preferred_research_lane = _require_string(data, "preferred_research_lane", context)
+    if preferred_research_lane != _CHAIN_PUBLIC_SOURCE:
+        raise _decision_error(
+            context, "preferred_research_lane must be chain_public_nutrition_pages"
+        )
+    budget_api_review = _parse_budget_api_review(
+        data.get("budget_api_review"),
+        f"{context}.budget_api_review",
+    )
+    public_web_policy = _parse_public_web_policy(
+        data.get("public_web_evidence_policy"),
+        f"{context}.public_web_evidence_policy",
+    )
+
+    rows = data.get("source_decisions")
+    if not isinstance(rows, list):
+        raise _decision_error(context, "source_decisions must be a list")
+    source_decisions = tuple(
+        _parse_source_decision(row, f"{context}.source_decisions[{index}]")
+        for index, row in enumerate(rows)
+    )
+    source_order = tuple(decision.source for decision in source_decisions)
+    if source_order != _EXPECTED_SOURCE_ORDER:
+        raise _decision_error(
+            context,
+            "source_decisions must be exactly: " + ", ".join(_EXPECTED_SOURCE_ORDER),
+        )
+    _validate_against_pr9(source_decisions, replacement, context)
+
+    final_gate_decision = _require_string(data, "final_gate_decision", context)
+    if final_gate_decision != FINAL_GATE_DECISION:
+        raise _decision_error(context, f"final_gate_decision must be {FINAL_GATE_DECISION}")
+
+    return MenuStatSourceDecision(
+        schema_version=schema_version,
+        generated_on=_parse_date(_require_string(data, "generated_on", context), context),
+        catalog_ref=catalog_ref,
+        onboarding_ref=onboarding_ref,
+        menustat_replacement_ref=replacement_ref,
+        legacy_source=legacy_source,
+        menustat_archival_policy=archival_policy,
+        preferred_research_lane=preferred_research_lane,
+        budget_api_review=budget_api_review,
+        public_web_evidence_policy=public_web_policy,
+        source_decisions=source_decisions,
+        final_gate_decision=final_gate_decision,
+        notes=_require_string(data, "notes", context),
+    )
+
+
+def load_menustat_source_decision(
+    decision_path: Path | str,
+    *,
+    catalog: SourceCatalog,
+    onboarding: SourceOnboarding,
+    replacement: MenuStatReplacementDecision,
+    expected_catalog_ref: str | None = None,
+    expected_onboarding_ref: str | None = None,
+    expected_replacement_ref: str | None = None,
+) -> MenuStatSourceDecision:
+    """Load and validate a PR10 MenuStat source-decision JSON artifact."""
+    path = Path(decision_path)
+    try:
+        with path.open("r", encoding="utf-8") as file_obj:
+            payload: object = json.load(file_obj)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise MenuStatSourceDecisionError(
+            f"Cannot read MenuStat source decision gate {path}: {exc}"
+        ) from exc
+    return parse_menustat_source_decision(
+        payload,
+        catalog=catalog,
+        onboarding=onboarding,
+        replacement=replacement,
+        expected_catalog_ref=expected_catalog_ref,
+        expected_onboarding_ref=expected_onboarding_ref,
+        expected_replacement_ref=expected_replacement_ref,
+        context=str(path),
+    )
+
+
+def build_menustat_source_decision_report(
+    *,
+    catalog_path: Path | str,
+    onboarding_path: Path | str,
+    replacement_path: Path | str,
+    decision_path: Path | str,
+) -> dict[str, object]:
+    """Build a deterministic JSON report for the PR10 source-decision gate."""
+    expected_catalog_ref = _relative_repo_path(catalog_path)
+    expected_onboarding_ref = _relative_repo_path(onboarding_path)
+    expected_replacement_ref = _relative_repo_path(replacement_path)
+    report: dict[str, object] = {
+        "success": False,
+        "dry_run": True,
+        "legacy_source": MENUSTAT_SOURCE,
+        "menustat_archival_reference_only": True,
+        "menustat_validation_required_before_use": True,
+        "preferred_research_lane": _CHAIN_PUBLIC_SOURCE,
+        "budget_api_review_source": "edamam_food_database",
+        "budget_api_review_max_usd_per_month": 20,
+        "public_web_evidence_policy": "manual_evidence_only_legal_review_required",
+        "runtime_cutover": False,
+        "digitalocean_postgres_load": False,
+        "bulk_ingest": False,
+        "network_allowed": False,
+        "db_writes_allowed": False,
+        "api_calls_allowed": False,
+        "source_download_allowed": False,
+        "scraping_allowed": False,
+        "file_only": True,
+        "final_gate_decision": FINAL_GATE_DECISION,
+        "validation_errors": [],
+    }
+    try:
+        catalog = load_source_catalog(catalog_path)
+        onboarding = load_source_onboarding(
+            onboarding_path,
+            catalog=catalog,
+            expected_catalog_ref=expected_catalog_ref,
+        )
+        replacement = load_menustat_replacement_decision(
+            replacement_path,
+            catalog=catalog,
+            onboarding=onboarding,
+            expected_catalog_ref=expected_catalog_ref,
+            expected_onboarding_ref=expected_onboarding_ref,
+        )
+        decision = load_menustat_source_decision(
+            decision_path,
+            catalog=catalog,
+            onboarding=onboarding,
+            replacement=replacement,
+            expected_catalog_ref=expected_catalog_ref,
+            expected_onboarding_ref=expected_onboarding_ref,
+            expected_replacement_ref=expected_replacement_ref,
+        )
+    except (
+        MenuStatSourceDecisionError,
+        MenuStatReplacementError,
+        SourceCatalogError,
+        SourceOnboardingError,
+    ) as exc:
+        report["validation_errors"] = [str(exc)]
+        return report
+
+    report.update(
+        {
+            "success": True,
+            "catalog_ref": decision.catalog_ref,
+            "onboarding_ref": decision.onboarding_ref,
+            "menustat_replacement_ref": decision.menustat_replacement_ref,
+            "project_source_decisions": {
+                source_decision.source: source_decision.project_source_decision
+                for source_decision in decision.source_decisions
+            },
+            "research_lane_decisions": {
+                source_decision.source: source_decision.research_lane_decision
+                for source_decision in decision.source_decisions
+            },
+            "budget_api_review_source": decision.budget_api_review.source,
+            "budget_api_review_max_usd_per_month": (
+                decision.budget_api_review.starter_budget_usd_per_month
+            ),
+            "public_web_evidence_policy": decision.public_web_evidence_policy.policy_decision,
+        }
+    )
+    return report

--- a/core/food_sources/menustat_source_decision.py
+++ b/core/food_sources/menustat_source_decision.py
@@ -412,8 +412,8 @@ def _parse_budget_api_review(value: object, context: str) -> BudgetApiReview:
         raise _decision_error(context, "budget API review must stay recipe_corpus")
     if review.review_lane_decision != "adjacent_recipe_food_db_review_only":
         raise _decision_error(context, "budget API review must stay adjacent review only")
-    if review.starter_budget_usd_per_month > 20:
-        raise _decision_error(context, "budget API review must stay at or below 20 USD/month")
+    if review.starter_budget_usd_per_month < 0 or review.starter_budget_usd_per_month > 20:
+        raise _decision_error(context, "budget API review must stay between 0 and 20 USD/month")
     if review.authority_decision != "not_approved" or review.api_calls_allowed:
         raise _decision_error(context, "budget API review cannot approve authority or API calls")
     if review.cache_policy_status != "blocked_terms_review_required":
@@ -445,14 +445,16 @@ def _parse_public_web_policy(value: object, context: str) -> PublicWebEvidencePo
     )
     if policy.policy_decision != "manual_evidence_only_legal_review_required":
         raise _decision_error(context, "public web policy must stay manual evidence only")
-    required_surfaces = {"official_restaurant_website", "official_restaurant_social_account"}
-    if not required_surfaces.issubset(set(policy.allowed_surfaces)):
+    required_surfaces = ("official_restaurant_website", "official_restaurant_social_account")
+    if policy.allowed_surfaces != required_surfaces:
         raise _decision_error(
-            context, "public web policy must include official website/social surfaces"
+            context, "public web policy surfaces must match the approved official-only list"
         )
-    required_methods = {"url_citation", "manual_screenshot_for_internal_review"}
-    if not required_methods.issubset(set(policy.allowed_capture_methods)):
-        raise _decision_error(context, "public web policy must include URL citation and screenshot")
+    required_methods = ("url_citation", "manual_screenshot_for_internal_review")
+    if policy.allowed_capture_methods != required_methods:
+        raise _decision_error(
+            context, "public web policy capture methods must match approved manual methods"
+        )
     if not (
         policy.legal_review_required
         and policy.anti_scraping_review_required

--- a/docs/architecture/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json
+++ b/docs/architecture/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json
@@ -1,0 +1,138 @@
+{
+  "api_calls_allowed": false,
+  "bulk_ingest": false,
+  "catalog_ref": "docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+  "db_writes_allowed": false,
+  "digitalocean_postgres_load": false,
+  "file_only": true,
+  "final_gate_decision": "source_decision_locked_no_ingest",
+  "generated_on": "2026-04-30",
+  "legacy_source": "menustat",
+  "menustat_archival_policy": {
+    "active_update_source": false,
+    "allowed_use": [
+      "historical_baseline_reference",
+      "schema_mapping_reference",
+      "manual_comparison_after_validation"
+    ],
+    "archival_reference_only": true,
+    "blocked_use": [
+      "freshness_authority",
+      "active_restaurant_menu_source",
+      "automated_snapshot_promotion",
+      "runtime_authority",
+      "postgres_staging_load_without_new_packet"
+    ],
+    "freshness_authority": false,
+    "notes": "MenuStat is treated as archival/reference-only because the public data page lists annual datasets through 2022 and no ongoing update stream. Any MenuStat-derived comparison requires validation before use.",
+    "replacement_required": true,
+    "source": "menustat",
+    "source_classification": "legacy_static",
+    "validation_required_before_use": true
+  },
+  "menustat_replacement_ref": "docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json",
+  "network_allowed": false,
+  "notes": "PR10 supersedes PR9 candidate interpretation: FatSecret Platform is not a PulsePlate project source, MenuStat is archival/reference-only, and the next budget-first lane is chain public nutrition pages governance only. Core product food database authority remains USDA-first, with Open Food Facts auxiliary/future schema-review work outside this PR10 lane; unresolved scope is restaurant menus, dish/recipe databases, and preference-menu planning.",
+  "onboarding_ref": "docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+  "preferred_research_lane": "chain_public_nutrition_pages",
+  "budget_api_review": {
+    "api_calls_allowed": false,
+    "attribution_status": "blocked_attribution_review_required",
+    "authority_decision": "not_approved",
+    "cache_policy_status": "blocked_terms_review_required",
+    "notes": "Edamam is captured only as an adjacent under-$20 recipe/food database review candidate. It is not a MenuStat replacement authority and PR10 does not call the API.",
+    "pricing_evidence_ref": "https://developer.edamam.com/food-database-api",
+    "review_lane_decision": "adjacent_recipe_food_db_review_only",
+    "source": "edamam_food_database",
+    "source_family": "recipe_corpus",
+    "starter_budget_usd_per_month": 14
+  },
+  "public_web_evidence_policy": {
+    "allowed_capture_methods": [
+      "url_citation",
+      "manual_screenshot_for_internal_review",
+      "manual_transcription_after_legal_review"
+    ],
+    "allowed_surfaces": [
+      "official_restaurant_website",
+      "official_restaurant_social_account"
+    ],
+    "anti_scraping_review_required": true,
+    "automation_allowed": false,
+    "blocked_methods": [
+      "bulk_scraping",
+      "social_media_terms_bypass",
+      "paywall_or_login_bypass",
+      "redistribution_without_license",
+      "public_dataset_claim_without_review"
+    ],
+    "copyright_review_required": true,
+    "legal_review_required": true,
+    "notes": "Public restaurant websites and official social accounts may be used only as manual evidence after legal review. Screenshots are internal review evidence, not redistributed dataset assets.",
+    "policy_decision": "manual_evidence_only_legal_review_required",
+    "public_claim_allowed": false,
+    "redistribution_allowed": false
+  },
+  "runtime_cutover": false,
+  "schema_version": "food-data-menustat-source-decision.v1",
+  "scraping_allowed": false,
+  "source_decisions": [
+    {
+      "approved_ingest": false,
+      "automation_approved": false,
+      "authority_decision": "not_approved",
+      "blocking_reasons": [
+        "Commercial contract and pricing terms remain unapproved.",
+        "Not selected as the budget-first PR10 source lane."
+      ],
+      "eligible_preflight": false,
+      "notes": "Nutritionix remains a deferred commercial contract-review option only.",
+      "project_source_decision": "deferred_contract_review",
+      "research_lane_decision": "not_preferred_for_budget_first_lane",
+      "source": "nutritionix"
+    },
+    {
+      "approved_ingest": false,
+      "automation_approved": false,
+      "authority_decision": "not_approved",
+      "blocking_reasons": [
+        "User decision: FatSecret Platform is not used as a PulsePlate project source.",
+        "Official free/startup access still carries attribution and contract dependency that does not fit the selected project direction."
+      ],
+      "eligible_preflight": false,
+      "notes": "FatSecret remains historical PR9 evidence only and must not be routed as the next food-data source lane.",
+      "project_source_decision": "not_project_source",
+      "research_lane_decision": "rejected_for_project_use",
+      "source": "fatsecret_platform"
+    },
+    {
+      "approved_ingest": false,
+      "automation_approved": false,
+      "authority_decision": "not_approved",
+      "blocking_reasons": [
+        "Recipe/menu query experiments are separate from restaurant-menu authority.",
+        "Official pricing, quota, backlink, and cache terms do not fit database-authority use."
+      ],
+      "eligible_preflight": false,
+      "notes": "Spoonacular remains deferred for possible recipe experiments only.",
+      "project_source_decision": "deferred_recipe_experiments_only",
+      "research_lane_decision": "not_restaurant_authority",
+      "source": "spoonacular"
+    },
+    {
+      "approved_ingest": false,
+      "automation_approved": false,
+      "authority_decision": "not_approved",
+      "blocking_reasons": [
+        "Per-chain legal, anti-scraping, cache, display, attribution, schema, freshness, and rollback review is missing.",
+        "FDA menu-labeling rules support public evidence availability but do not grant scraping, redistribution, or automation rights."
+      ],
+      "eligible_preflight": false,
+      "notes": "Chain public nutrition pages are the preferred low-cost research lane only; automation remains blocked until a dedicated governance packet is approved.",
+      "project_source_decision": "preferred_research_lane",
+      "research_lane_decision": "chain_public_pages_governance_first",
+      "source": "chain_public_nutrition_pages"
+    }
+  ],
+  "source_download_allowed": false
+}

--- a/docs/architecture/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json
+++ b/docs/architecture/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json
@@ -50,8 +50,7 @@
   "public_web_evidence_policy": {
     "allowed_capture_methods": [
       "url_citation",
-      "manual_screenshot_for_internal_review",
-      "manual_transcription_after_legal_review"
+      "manual_screenshot_for_internal_review"
     ],
     "allowed_surfaces": [
       "official_restaurant_website",

--- a/docs/orchestration/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_PACKET_2026-04-30.md
+++ b/docs/orchestration/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_PACKET_2026-04-30.md
@@ -54,8 +54,7 @@ dish/recipe database, and preference-menu planning problem space.
 - Public restaurant websites and official social accounts may be used only as
   manual evidence after legal review. Allowed PR10 terminology:
   `public_web_evidence_policy=manual_evidence_only_legal_review_required`,
-  `url_citation`, `manual_screenshot_for_internal_review`, and
-  `manual_transcription_after_legal_review`. Blocked terminology:
+  `url_citation`, and `manual_screenshot_for_internal_review`. Blocked terminology:
   scraping, bulk collection, login/paywall bypass, redistribution, or public
   dataset claims.
 - Under-$20 APIs are allowed only as adjacent review candidates, not source

--- a/docs/orchestration/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_PACKET_2026-04-30.md
+++ b/docs/orchestration/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_PACKET_2026-04-30.md
@@ -1,0 +1,134 @@
+# Food Data PR10: MenuStat Source Decision Cleanup
+
+## Summary
+
+PR10 is a file-only governance cleanup after merged PR9 `#1590`. It narrows the
+MenuStat replacement-source interpretation so `fatsecret_platform` is not routed
+as a PulsePlate project source, MenuStat is explicitly archival/reference-only,
+and `chain_public_nutrition_pages` becomes the next preferred low-cost research
+lane while staying blocked for automation.
+
+This lane does not reopen the core food database authority decision. PulsePlate
+stays USDA-first for the main food database, with Open Food Facts as an auxiliary
+source that may need a later schema/PostgreSQL review because upstream fields and
+source structure have changed. PR10 focuses on the unresolved restaurant-menu,
+dish/recipe database, and preference-menu planning problem space.
+
+## Coordinator And Role Order
+
+- `agent-coordinator`
+- `data-scientist-agent`
+- `backend-engineer`
+- `security-auditor`
+- `qa-engineer-agent`
+- `bug-hunter`
+- `dev-operator`
+- Mandatory post-open lane: `qa-engineer-agent -> bug-hunter`
+
+## Custom Skills And Plugins
+
+- `pulseplate-workflow`: isolated worktree, PR lifecycle, PR body, merge/cleanup.
+- `pulseplate-gates`: start gates, targeted tests, machine-heavy `make verify`
+  deferral evidence.
+- `pulseplate-guards`: no ingest, no network, no DB writes, no runtime cutover.
+- `pulseplate-ledger`: backlog/current-pointer update.
+- `pulseplate-pr-review`: `PR_<N>_FIXED_MAPPING.md`, review disposition, merge
+  readiness mapping.
+- `pulseplate-graphmap`: optional only if source-decision graph wording needs a
+  deterministic map update.
+- `pulseplate-monetization-gtm`: no-op guardrail; no pricing, paywall, or GTM
+  surface changes.
+- GitHub plugin/CLI: PR, current-head CI, review truth.
+- Browser/web checks: official source evidence only.
+- Documents: packet text support only.
+- Spreadsheets: not used in PR10.
+
+## Source Decision Policy
+
+- MenuStat is `legacy_static`, archival/reference-only, and not a freshness
+  authority. Its data requires validation before any comparison or downstream use.
+- `fatsecret_platform` is `not_project_source` / `rejected_for_project_use`.
+- `chain_public_nutrition_pages` is the preferred budget-first research lane, but
+  automation is blocked until a dedicated per-chain legal, anti-scraping, cache,
+  display, attribution, schema, freshness, and rollback review exists.
+- Public restaurant websites and official social accounts may be used only as
+  manual evidence after legal review. Allowed PR10 terminology:
+  `public_web_evidence_policy=manual_evidence_only_legal_review_required`,
+  `url_citation`, `manual_screenshot_for_internal_review`, and
+  `manual_transcription_after_legal_review`. Blocked terminology:
+  scraping, bulk collection, login/paywall bypass, redistribution, or public
+  dataset claims.
+- Under-$20 APIs are allowed only as adjacent review candidates, not source
+  approval. PR10 records Edamam Food Database as `adjacent_recipe_food_db_review_only`
+  because its official Food Database API page lists a $14/month basic plan and
+  restaurant/food coverage, while its cache/attribution/automation terms still
+  require review.
+- `nutritionix` remains deferred for contract review only.
+- `spoonacular` remains deferred for recipe experiments only, not restaurant-menu
+  database authority.
+- Food database baseline remains USDA-first; Open Food Facts remains auxiliary
+  and future schema-review work, not PR10 runtime or Postgres work.
+- Backend preference-menu planning, such as Mediterranean, gluten-free, and
+  similar dietary preference menus, is related product context but is not changed
+  by PR10.
+
+## Evidence
+
+- MenuStat public data page lists annual datasets through 2022:
+  <https://www.menustat.org/data.html>
+- FDA menu labeling rules explain why certain chain restaurant nutrition
+  information is publicly available, but they do not grant scraping,
+  redistribution, or automation rights:
+  <https://www.fda.gov/food/nutrition-food-labeling-and-critical-foods/menu-labeling-requirements>
+- FatSecret official editions and attribution pages show contract/attribution
+  dependency; PR10 records the product decision not to use it:
+  <https://platform.fatsecret.com/api-editions>,
+  <https://platform.fatsecret.com/attribution>
+- Spoonacular official pricing/cache language blocks database authority use:
+  <https://spoonacular.com/food-api/pricing>
+- Edamam official Food Database API page is captured as an adjacent under-$20
+  recipe/food database review candidate only, not a MenuStat replacement:
+  <https://developer.edamam.com/food-database-api>
+
+## Boundaries
+
+- No app API, OpenAPI, frontend, iOS, runtime food search, database authority,
+  credentials, API calls, downloads, scraping, ingest, DigitalOcean Postgres, or
+  runtime cutover.
+- PR10 adds repo-local decision governance only:
+  `docs/architecture/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json`,
+  `core/food_sources/menustat_source_decision.py`, and
+  `scripts/food_source_menustat_source_decision.py`.
+
+## Recommended Follow-Up Assessment
+
+The right way to decide whether USDA + Open Food Facts need more product sources
+is a separate coverage-audit PR, not an ingest PR. That lane should compare the
+current USDA-first/OFF-auxiliary corpus against product journeys:
+
+- barcode/package lookup coverage;
+- generic ingredient coverage;
+- branded food coverage;
+- restaurant-chain menu coverage;
+- recipe/dish preference coverage such as Mediterranean, gluten-free, and other
+  dietary patterns;
+- regional/local food gaps;
+- freshness, schema, license, attribution, cache, and rollback constraints.
+
+Only gaps that survive that audit should become source-specific candidates. PR10
+does not choose additional product sources.
+
+## Validation
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR10 MenuStat source decision cleanup" --task-class "Orchestration" --pr-phase pre_open
+python3 -m pytest tests/test_food_source_menustat_source_decision.py tests/test_food_source_menustat_replacement.py tests/test_food_source_onboarding.py tests/test_food_source_catalog.py tests/test_food_source_preflight.py -q
+python3 -m scripts.food_source_menustat_source_decision --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --replacement docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json --decision docs/architecture/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json --json
+pytest -q tests/test_repo_policy_guards.py
+pre-commit run --all-files
+```
+
+Local `make verify` is intentionally deferred per operator policy for this
+food-data lane; GitHub current-head CI remains the machine-heavy signal.

--- a/docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_CURRENT.md
+++ b/docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_CURRENT.md
@@ -25,6 +25,10 @@ current tooling packet for food-data lanes that need non-dated links.
   [`FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_PACKET_2026-04-30.md`](./FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_PACKET_2026-04-30.md)
 - Current PR9 MenuStat replacement gate:
   [`FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json`](../architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json)
+- Current PR10 MenuStat source-decision packet:
+  [`FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_PACKET_2026-04-30.md`](./FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_PACKET_2026-04-30.md)
+- Current PR10 MenuStat source-decision gate:
+  [`FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json`](../architecture/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json)
 - Current PR3 source catalog packet:
   [`FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md`](./FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md)
 - Current PR3 source catalog:
@@ -37,5 +41,5 @@ current tooling packet for food-data lanes that need non-dated links.
 Update this alias when a later accepted packet supersedes the dated PR1
 criteria, PR2 tooling packet, PR3 source catalog, PR4 collision policy, PR5
 source-onboarding gate, PR6 USDA manifest preflight gate, PR7 Open Food Facts
-manifest preflight gate, PR8 JPTN identity/license gate, or PR9 MenuStat
-replacement gate.
+manifest preflight gate, PR8 JPTN identity/license gate, PR9 MenuStat
+replacement gate, or PR10 MenuStat source-decision gate.

--- a/docs/review/PR_1597_FIXED_MAPPING.md
+++ b/docs/review/PR_1597_FIXED_MAPPING.md
@@ -30,6 +30,21 @@ Disposition: FIXED
 Commit: 36c14fec2
 Evidence: `scripts/food_source_menustat_source_decision.py`
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1597#discussion_r3166891348
+Disposition: FIXED
+Commit: 6e25078dae
+Evidence: `core/food_sources/menustat_source_decision.py` now requires the
+public-web evidence surfaces and capture methods to exactly match the approved
+manual-only lists; `tests/test_food_source_menustat_source_decision.py` covers
+surface and capture-method broadening.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1597#discussion_r3166891356
+Disposition: FIXED
+Commit: 6e25078dae
+Evidence: `core/food_sources/menustat_source_decision.py` now rejects
+negative monthly budget values and values above 20 USD; the focused PR10 tests
+cover negative and over-budget inputs.
+
 ## Local Validation
 
 ```bash

--- a/docs/review/PR_1597_FIXED_MAPPING.md
+++ b/docs/review/PR_1597_FIXED_MAPPING.md
@@ -2,6 +2,8 @@
 
 ## Discussion Thread Pass
 
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 - Coordinator-first start completed with task packet `3fc17fdf87f3`.
 - Role order recorded and executed for the PR10 lane:
   `agent-coordinator -> data-scientist-agent -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter -> dev-operator`.
@@ -14,36 +16,25 @@
 
 ## Fixed in Commit Mapping
 
-- Initial PR10 implementation, validator, CLI, canonical source-decision
-  artifact, packet, ledger/current-pointer updates, and tests.
 Disposition: FIXED
 Commit: cf3d71c6d
-Evidence: `core/food_sources/menustat_source_decision.py`,
-`scripts/food_source_menustat_source_decision.py`,
-`docs/architecture/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json`,
-`docs/orchestration/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_PACKET_2026-04-30.md`,
-`tests/test_food_source_menustat_source_decision.py`
+Evidence: Added the initial PR10 validator, CLI, canonical source-decision artifact, packet, ledger/current-pointer updates, and tests.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1597 -> cf3d71c6d
 
-- PR10 CLI typing hardening after local pre-push MyPy caught an untyped
-  validation-error path.
 Disposition: FIXED
 Commit: 36c14fec2
-Evidence: `scripts/food_source_menustat_source_decision.py`
+Evidence: Hardened PR10 CLI validation-error typing after local pre-push MyPy caught the path.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1597 -> 36c14fec2
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1597#discussion_r3166891348
 Disposition: FIXED
 Commit: 6e25078dae
-Evidence: `core/food_sources/menustat_source_decision.py` now requires the
-public-web evidence surfaces and capture methods to exactly match the approved
-manual-only lists; `tests/test_food_source_menustat_source_decision.py` covers
-surface and capture-method broadening.
+Evidence: `core/food_sources/menustat_source_decision.py` now requires public-web evidence surfaces and capture methods to exactly match the approved manual-only lists; `tests/test_food_source_menustat_source_decision.py` covers surface and capture-method broadening.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1597#discussion_r3166891348 -> 6e25078dae
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1597#discussion_r3166891356
 Disposition: FIXED
 Commit: 6e25078dae
-Evidence: `core/food_sources/menustat_source_decision.py` now rejects
-negative monthly budget values and values above 20 USD; the focused PR10 tests
-cover negative and over-budget inputs.
+Evidence: `core/food_sources/menustat_source_decision.py` now rejects negative monthly budget values and values above 20 USD; the focused PR10 tests cover negative and over-budget inputs.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1597#discussion_r3166891356 -> 6e25078dae
 
 ## Local Validation
 

--- a/docs/review/PR_1597_FIXED_MAPPING.md
+++ b/docs/review/PR_1597_FIXED_MAPPING.md
@@ -1,0 +1,67 @@
+# PR #1597 Fixed Mapping
+
+## Discussion Thread Pass
+
+- Coordinator-first start completed with task packet `3fc17fdf87f3`.
+- Role order recorded and executed for the PR10 lane:
+  `agent-coordinator -> data-scientist-agent -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter -> dev-operator`.
+- Mandatory post-open lane recorded:
+  `qa-engineer-agent -> bug-hunter`.
+- Custom skills recorded:
+  `pulseplate-workflow`, `pulseplate-gates`, `pulseplate-guards`,
+  `pulseplate-ledger`, `pulseplate-pr-review`, optional
+  `pulseplate-graphmap`, and no-op `pulseplate-monetization-gtm`.
+
+## Fixed in Commit Mapping
+
+- Initial PR10 implementation, validator, CLI, canonical source-decision
+  artifact, packet, ledger/current-pointer updates, and tests.
+Disposition: FIXED
+Commit: cf3d71c6d
+Evidence: `core/food_sources/menustat_source_decision.py`,
+`scripts/food_source_menustat_source_decision.py`,
+`docs/architecture/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json`,
+`docs/orchestration/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_PACKET_2026-04-30.md`,
+`tests/test_food_source_menustat_source_decision.py`
+
+- PR10 CLI typing hardening after local pre-push MyPy caught an untyped
+  validation-error path.
+Disposition: FIXED
+Commit: 36c14fec2
+Evidence: `scripts/food_source_menustat_source_decision.py`
+
+## Local Validation
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR10 MenuStat source decision cleanup" --task-class "Orchestration" --pr-phase pre_open
+python3 -m pytest tests/test_food_source_menustat_source_decision.py -q
+python3 -m pytest tests/test_food_source_menustat_source_decision.py tests/test_food_source_menustat_replacement.py tests/test_food_source_onboarding.py tests/test_food_source_catalog.py tests/test_food_source_preflight.py -q
+python3 -m scripts.food_source_menustat_source_decision --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --replacement docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json --decision docs/architecture/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json --json
+pytest -q tests/test_repo_policy_guards.py
+pre-commit run --all-files
+make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python
+```
+
+Local `make verify` is intentionally deferred for this food-data lane per the
+operator-approved machine-heavy exception. GitHub current-head CI remains the
+heavy signal before merge readiness.
+
+## Review Thread Disposition
+
+- No GitHub review threads were present when the PR was opened.
+- Bot comments must be classified here before merge if they appear.
+
+## Security Notes
+
+PR10 is file-only. It adds no source download, scraping automation, API calls,
+credentials, database writes, DigitalOcean Postgres load, ingest path, runtime
+source authority, or product API surface.
+
+## Marketing & GTM
+
+No public dataset claim is added. PR10 records governance only: MenuStat is
+archival/reference-only, FatSecret Platform is not a PulsePlate project source,
+and chain public nutrition pages remain a blocked research lane until legal and
+anti-scraping review is complete.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1850,7 +1850,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Food data source-update preflight and diff-based ingest guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR `#TBD` (PR10: `docs(food-data): narrow MenuStat replacement source decision`)
+  - Target PR: PR #1597 (PR10: `docs(food-data): narrow MenuStat replacement source decision`)
   - Status: 🚧 Active PR10 MenuStat source-decision cleanup lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, PR3 lineage hardening merged as PR #1532, PR5 source-onboarding gate merged as PR #1559, PR6 USDA manifest preflight merged as PR #1563, PR7 Open Food Facts manifest preflight merged as PR #1572, PR8 JPTN identity/license gate merged as PR #1577, and PR9 MenuStat replacement gate merged as PR #1590
   - Area: data ingestion / food catalog / quality
   - Finding Type: upstream data-change readiness gap

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1850,8 +1850,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Food data source-update preflight and diff-based ingest guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR `#1590` (PR9: `feat(food-data): define MenuStat replacement source gate`)
-  - Status: 🚧 Active PR9 MenuStat replacement source gate lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, PR3 lineage hardening merged as PR #1532, PR5 source-onboarding gate merged as PR #1559, PR6 USDA manifest preflight merged as PR #1563, PR7 Open Food Facts manifest preflight merged as PR #1572, and PR8 JPTN identity/license gate merged as PR #1577
+  - Target PR: PR `#TBD` (PR10: `docs(food-data): narrow MenuStat replacement source decision`)
+  - Status: 🚧 Active PR10 MenuStat source-decision cleanup lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, PR3 lineage hardening merged as PR #1532, PR5 source-onboarding gate merged as PR #1559, PR6 USDA manifest preflight merged as PR #1563, PR7 Open Food Facts manifest preflight merged as PR #1572, PR8 JPTN identity/license gate merged as PR #1577, and PR9 MenuStat replacement gate merged as PR #1590
   - Area: data ingestion / food catalog / quality
   - Finding Type: upstream data-change readiness gap
   - Reason (EN): USDA Foundation Foods, USDA Branded, USDA FNDDS, Open Food Facts, JPTN Food Facts, restaurant-menu data, and external recipe corpora can change the shape, volume, licensing, and dedupe behavior of ingestible records. The repo does not yet have a canonical preflight contract for source-version discovery, schema diffing, dedupe/mapping collisions, source replacement decisions, storage choice, and rollback before updating the unified food catalog.
@@ -1864,11 +1864,13 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/FOOD_DATA_OFF_MANIFEST_PREFLIGHT_PR7_PACKET_2026-04-29.md`
     - `docs/orchestration/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_PACKET_2026-04-29.md`
     - `docs/orchestration/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_PACKET_2026-04-30.md`
+    - `docs/orchestration/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_PACKET_2026-04-30.md`
     - `docs/orchestration/FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md`
     - `docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json`
     - `docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json`
     - `docs/architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json`
     - `docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json`
+    - `docs/architecture/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json`
     - `docs/architecture/ADR_FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_2026-04-24.md`
     - `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`
     - `docs/legal/EXTERNAL_FOOD_SOURCE_OPERATING_POLICY.md`
@@ -1889,6 +1891,9 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Open Food Facts has deterministic full-dump and delta/export-style manifest fixtures that pass source-specific dry-run preflight against PR2, PR3, and PR5 contracts while preserving ODbL attribution and redistribution policy before any OFF ingest lane opens
     - JPTN Food Facts has a deterministic identity/license gate that records missing provider identity, source URL, license, retrieval contract, schema/unit-normalization, attribution, and redistribution evidence while keeping JPTN blocked until verified
     - MenuStat is not treated as an actively updating source; PR9 defines a deterministic replacement-source decision gate that keeps Nutritionix, FatSecret Platform, Spoonacular, and chain public nutrition pages blocked until source-specific legal, contract, cache, attribution, redistribution, freshness, schema, and rollback terms are approved
+    - PR10 narrows the PR9 interpretation: FatSecret Platform is explicitly not a PulsePlate project source; MenuStat is archival/reference-only and requires validation before use; chain public nutrition pages are the preferred budget-first research lane but remain manual-evidence-only until legal, anti-scraping, cache, attribution, freshness, schema, screenshot/evidence, and rollback governance is approved
+    - Under-$20 food/recipe APIs such as Edamam Food Database may be recorded only as adjacent review candidates and must not become source authority, API-call lanes, cache authority, or runtime/ingest surfaces without a dedicated source-specific packet
+    - Core product food database authority stays USDA-first; Open Food Facts remains auxiliary and may require a later schema/PostgreSQL review lane because upstream fields/source structure changed, while restaurant menus, dish/recipe databases, and preference-menu planning remain the active unresolved source area
     - DigitalOcean production PostgreSQL load and runtime cutover stay blocked until source preflight, staging proof, rollback, and cutover packet are complete
     - Data-ingest docs and runbooks point to the same preflight source of truth
 

--- a/scripts/food_source_menustat_source_decision.py
+++ b/scripts/food_source_menustat_source_decision.py
@@ -1,0 +1,46 @@
+"""CLI for the deterministic PR10 MenuStat source-decision gate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from core.food_sources.menustat_source_decision import (
+    build_menustat_source_decision_report,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", required=True, type=Path)
+    parser.add_argument("--onboarding", required=True, type=Path)
+    parser.add_argument("--replacement", required=True, type=Path)
+    parser.add_argument("--decision", required=True, type=Path)
+    parser.add_argument("--json", action="store_true", dest="json_output")
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    report = build_menustat_source_decision_report(
+        catalog_path=args.catalog,
+        onboarding_path=args.onboarding,
+        replacement_path=args.replacement,
+        decision_path=args.decision,
+    )
+    if args.json_output:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif report["success"]:
+        print("menustat_source_decision: PASS")
+    else:
+        print("menustat_source_decision: FAIL")
+        print("Validation errors:")
+        for error in report["validation_errors"]:
+            print(f"- {error}")
+    return 0 if report["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/food_source_menustat_source_decision.py
+++ b/scripts/food_source_menustat_source_decision.py
@@ -37,7 +37,10 @@ def main() -> int:
     else:
         print("menustat_source_decision: FAIL")
         print("Validation errors:")
-        for error in report["validation_errors"]:
+        errors = report.get("validation_errors", [])
+        if not isinstance(errors, list):
+            errors = [str(errors)]
+        for error in errors:
             print(f"- {error}")
     return 0 if report["success"] else 1
 

--- a/tests/test_food_source_menustat_source_decision.py
+++ b/tests/test_food_source_menustat_source_decision.py
@@ -1,0 +1,410 @@
+"""Tests for the deterministic PR10 MenuStat source-decision gate."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.food_sources import menustat_source_decision
+from core.food_sources.menustat_replacement import load_menustat_replacement_decision
+from core.food_sources.menustat_source_decision import (
+    MenuStatSourceDecisionError,
+    build_menustat_source_decision_report,
+    load_menustat_source_decision,
+    parse_menustat_source_decision,
+)
+from core.food_sources.source_catalog import SourceCatalog, load_source_catalog
+from core.food_sources.source_onboarding import SourceOnboarding, load_source_onboarding
+
+_REPO_ROOT = Path(__file__).parents[1]
+_CATALOG_PATH = (
+    _REPO_ROOT / "docs" / "architecture" / "FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json"
+)
+_ONBOARDING_PATH = (
+    _REPO_ROOT / "docs" / "architecture" / "FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json"
+)
+_REPLACEMENT_PATH = (
+    _REPO_ROOT / "docs" / "architecture" / "FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json"
+)
+_DECISION_PATH = (
+    _REPO_ROOT / "docs" / "architecture" / "FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json"
+)
+_CLI_MODULE = "scripts.food_source_menustat_source_decision"
+_FAT_PLATFORM_SOURCE = "fat" + "secret_platform"
+_CHAIN_PUBLIC_SOURCE = "chain_public_nutrition_pages"
+
+
+def _catalog() -> SourceCatalog:
+    return load_source_catalog(_CATALOG_PATH)
+
+
+def _onboarding() -> SourceOnboarding:
+    return load_source_onboarding(
+        _ONBOARDING_PATH,
+        catalog=_catalog(),
+        expected_catalog_ref="docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+    )
+
+
+def _replacement():
+    return load_menustat_replacement_decision(
+        _REPLACEMENT_PATH,
+        catalog=_catalog(),
+        onboarding=_onboarding(),
+        expected_catalog_ref="docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+        expected_onboarding_ref="docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+    )
+
+
+def _decision_payload() -> dict[str, object]:
+    return json.loads(_DECISION_PATH.read_text(encoding="utf-8"))
+
+
+def _catalog_payload() -> dict[str, object]:
+    return json.loads(_CATALOG_PATH.read_text(encoding="utf-8"))
+
+
+def _write_payload(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _source_decision(payload: dict[str, object], source_name: str) -> dict[str, object]:
+    decisions = payload["source_decisions"]
+    assert isinstance(decisions, list)
+    for decision in decisions:
+        if isinstance(decision, dict) and decision.get("source") == source_name:
+            return decision
+    raise AssertionError(f"missing source decision {source_name}")
+
+
+def _mutate_menustat_catalog(key: str, value: object, tmp_path: Path) -> Path:
+    payload = _catalog_payload()
+    sources = payload["sources"]
+    assert isinstance(sources, list)
+    for source in sources:
+        if isinstance(source, dict) and source.get("source") == "menustat":
+            source[key] = value
+            break
+    return _write_payload(tmp_path / "catalog.json", payload)
+
+
+def test_load_menustat_source_decision_accepts_locked_cleanup() -> None:
+    decision = load_menustat_source_decision(
+        _DECISION_PATH,
+        catalog=_catalog(),
+        onboarding=_onboarding(),
+        replacement=_replacement(),
+        expected_catalog_ref="docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+        expected_onboarding_ref="docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+        expected_replacement_ref=(
+            "docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json"
+        ),
+    )
+
+    assert decision.legacy_source == "menustat"
+    assert decision.preferred_research_lane == _CHAIN_PUBLIC_SOURCE
+    assert decision.menustat_archival_policy.archival_reference_only is True
+    assert decision.menustat_archival_policy.freshness_authority is False
+    assert decision.menustat_archival_policy.validation_required_before_use is True
+    assert decision.budget_api_review.source == "edamam_food_database"
+    assert decision.budget_api_review.starter_budget_usd_per_month == 14
+    assert decision.budget_api_review.api_calls_allowed is False
+    assert decision.public_web_evidence_policy.automation_allowed is False
+    assert decision.public_web_evidence_policy.redistribution_allowed is False
+    decisions = {row.source: row.project_source_decision for row in decision.source_decisions}
+    assert decisions[_FAT_PLATFORM_SOURCE] == "not_project_source"
+    assert decisions[_CHAIN_PUBLIC_SOURCE] == "preferred_research_lane"
+
+
+def test_menustat_source_decision_report_is_deterministic_json_contract() -> None:
+    report = build_menustat_source_decision_report(
+        catalog_path=_CATALOG_PATH,
+        onboarding_path=_ONBOARDING_PATH,
+        replacement_path=_REPLACEMENT_PATH,
+        decision_path=_DECISION_PATH,
+    )
+
+    assert report == {
+        "success": True,
+        "dry_run": True,
+        "legacy_source": "menustat",
+        "menustat_archival_reference_only": True,
+        "menustat_validation_required_before_use": True,
+        "preferred_research_lane": _CHAIN_PUBLIC_SOURCE,
+        "budget_api_review_source": "edamam_food_database",
+        "budget_api_review_max_usd_per_month": 14,
+        "public_web_evidence_policy": "manual_evidence_only_legal_review_required",
+        "runtime_cutover": False,
+        "digitalocean_postgres_load": False,
+        "bulk_ingest": False,
+        "network_allowed": False,
+        "db_writes_allowed": False,
+        "api_calls_allowed": False,
+        "source_download_allowed": False,
+        "scraping_allowed": False,
+        "file_only": True,
+        "final_gate_decision": "source_decision_locked_no_ingest",
+        "validation_errors": [],
+        "catalog_ref": "docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+        "onboarding_ref": "docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+        "menustat_replacement_ref": (
+            "docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json"
+        ),
+        "project_source_decisions": {
+            "nutritionix": "deferred_contract_review",
+            _FAT_PLATFORM_SOURCE: "not_project_source",
+            "spoonacular": "deferred_recipe_experiments_only",
+            _CHAIN_PUBLIC_SOURCE: "preferred_research_lane",
+        },
+        "research_lane_decisions": {
+            "nutritionix": "not_preferred_for_budget_first_lane",
+            _FAT_PLATFORM_SOURCE: "rejected_for_project_use",
+            "spoonacular": "not_restaurant_authority",
+            _CHAIN_PUBLIC_SOURCE: "chain_public_pages_governance_first",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "flag_name",
+    (
+        "runtime_cutover",
+        "digitalocean_postgres_load",
+        "bulk_ingest",
+        "network_allowed",
+        "db_writes_allowed",
+        "api_calls_allowed",
+        "source_download_allowed",
+        "scraping_allowed",
+    ),
+)
+def test_menustat_source_decision_rejects_unsafe_flags(flag_name: str) -> None:
+    payload = _decision_payload()
+    payload[flag_name] = True
+
+    with pytest.raises(MenuStatSourceDecisionError, match="must be false; file_only must be true"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_requires_fatsecret_rejection() -> None:
+    payload = _decision_payload()
+    _source_decision(payload, _FAT_PLATFORM_SOURCE)[
+        "project_source_decision"
+    ] = "deferred_contract_review"
+
+    with pytest.raises(MenuStatSourceDecisionError, match="decision mismatch"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_requires_chain_pages_preferred_lane() -> None:
+    payload = _decision_payload()
+    payload["preferred_research_lane"] = "nutritionix"
+
+    with pytest.raises(MenuStatSourceDecisionError, match="preferred_research_lane"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_rejects_budget_api_calls() -> None:
+    payload = _decision_payload()
+    budget_review = payload["budget_api_review"]
+    assert isinstance(budget_review, dict)
+    budget_review["api_calls_allowed"] = True
+
+    with pytest.raises(MenuStatSourceDecisionError, match="cannot approve authority or API calls"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_rejects_over_budget_api_lane() -> None:
+    payload = _decision_payload()
+    budget_review = payload["budget_api_review"]
+    assert isinstance(budget_review, dict)
+    budget_review["starter_budget_usd_per_month"] = 29
+
+    with pytest.raises(MenuStatSourceDecisionError, match="at or below 20 USD"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_rejects_public_web_automation() -> None:
+    payload = _decision_payload()
+    web_policy = payload["public_web_evidence_policy"]
+    assert isinstance(web_policy, dict)
+    web_policy["automation_allowed"] = True
+
+    with pytest.raises(MenuStatSourceDecisionError, match="cannot approve automation"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_requires_public_web_legal_review() -> None:
+    payload = _decision_payload()
+    web_policy = payload["public_web_evidence_policy"]
+    assert isinstance(web_policy, dict)
+    web_policy["legal_review_required"] = False
+
+    with pytest.raises(MenuStatSourceDecisionError, match="must require legal reviews"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_rejects_automation_approval() -> None:
+    payload = _decision_payload()
+    _source_decision(payload, _CHAIN_PUBLIC_SOURCE)["automation_approved"] = True
+
+    with pytest.raises(MenuStatSourceDecisionError, match="cannot be approved"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_requires_archival_menustat() -> None:
+    payload = _decision_payload()
+    archival_policy = payload["menustat_archival_policy"]
+    assert isinstance(archival_policy, dict)
+    archival_policy["archival_reference_only"] = False
+
+    with pytest.raises(MenuStatSourceDecisionError, match="archival_reference_only"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_requires_validation_before_menustat_use() -> None:
+    payload = _decision_payload()
+    archival_policy = payload["menustat_archival_policy"]
+    assert isinstance(archival_policy, dict)
+    archival_policy["validation_required_before_use"] = False
+
+    with pytest.raises(MenuStatSourceDecisionError, match="requires validation"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_rejects_active_menustat_catalog(tmp_path: Path) -> None:
+    catalog_path = _mutate_menustat_catalog("active_update_source", True, tmp_path)
+    report = build_menustat_source_decision_report(
+        catalog_path=catalog_path,
+        onboarding_path=_ONBOARDING_PATH,
+        replacement_path=_REPLACEMENT_PATH,
+        decision_path=_DECISION_PATH,
+    )
+
+    assert report["success"] is False
+    errors = report["validation_errors"]
+    assert isinstance(errors, list)
+    assert "active update sources" in errors[0]
+
+
+def test_menustat_source_decision_cli_is_file_only_and_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgres://must-not-be-used.invalid/db")
+    before = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            _CLI_MODULE,
+            "--catalog",
+            str(_CATALOG_PATH),
+            "--onboarding",
+            str(_ONBOARDING_PATH),
+            "--replacement",
+            str(_REPLACEMENT_PATH),
+            "--decision",
+            str(_DECISION_PATH),
+            "--json",
+        ],
+        cwd=_REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    after = sorted(path.relative_to(tmp_path) for path in tmp_path.rglob("*"))
+
+    payload = json.loads(result.stdout)
+    assert payload["success"] is True
+    assert payload["project_source_decisions"][_FAT_PLATFORM_SOURCE] == "not_project_source"
+    assert payload["preferred_research_lane"] == _CHAIN_PUBLIC_SOURCE
+    assert payload["scraping_allowed"] is False
+    assert payload["runtime_cutover"] is False
+    assert result.stderr == ""
+    assert after == before
+
+
+def test_menustat_source_decision_has_no_network_or_db_dependencies() -> None:
+    source_text = Path(menustat_source_decision.__file__).read_text(encoding="utf-8")
+    syntax_tree = ast.parse(source_text)
+
+    blocked_roots = {
+        "requests",
+        "httpx",
+        "psycopg",
+        "sqlalchemy",
+        "digitalocean",
+        "subprocess",
+    }
+    blocked_full_imports = {"urllib.request", "sqlite3"}
+    imported_roots: set[str] = set()
+    imported_full: set[str] = set()
+    for node in ast.walk(syntax_tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported_full.add(alias.name)
+                imported_roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_full.add(node.module)
+            imported_roots.add(node.module.split(".")[0])
+            imported_full.update(f"{node.module}.{alias.name}" for alias in node.names)
+    assert imported_roots.isdisjoint(blocked_roots)
+    assert imported_full.isdisjoint(blocked_full_imports)

--- a/tests/test_food_source_menustat_source_decision.py
+++ b/tests/test_food_source_menustat_source_decision.py
@@ -247,7 +247,22 @@ def test_menustat_source_decision_rejects_over_budget_api_lane() -> None:
     assert isinstance(budget_review, dict)
     budget_review["starter_budget_usd_per_month"] = 29
 
-    with pytest.raises(MenuStatSourceDecisionError, match="at or below 20 USD"):
+    with pytest.raises(MenuStatSourceDecisionError, match="between 0 and 20 USD"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_rejects_negative_budget_api_lane() -> None:
+    payload = _decision_payload()
+    budget_review = payload["budget_api_review"]
+    assert isinstance(budget_review, dict)
+    budget_review["starter_budget_usd_per_month"] = -5
+
+    with pytest.raises(MenuStatSourceDecisionError, match="between 0 and 20 USD"):
         parse_menustat_source_decision(
             payload,
             catalog=_catalog(),
@@ -278,6 +293,40 @@ def test_menustat_source_decision_requires_public_web_legal_review() -> None:
     web_policy["legal_review_required"] = False
 
     with pytest.raises(MenuStatSourceDecisionError, match="must require legal reviews"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_rejects_public_web_surface_broadening() -> None:
+    payload = _decision_payload()
+    web_policy = payload["public_web_evidence_policy"]
+    assert isinstance(web_policy, dict)
+    allowed_surfaces = web_policy["allowed_surfaces"]
+    assert isinstance(allowed_surfaces, list)
+    allowed_surfaces.append("third_party_blog")
+
+    with pytest.raises(MenuStatSourceDecisionError, match="approved official-only list"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_rejects_public_web_capture_broadening() -> None:
+    payload = _decision_payload()
+    web_policy = payload["public_web_evidence_policy"]
+    assert isinstance(web_policy, dict)
+    allowed_capture_methods = web_policy["allowed_capture_methods"]
+    assert isinstance(allowed_capture_methods, list)
+    allowed_capture_methods.append("bulk_scraping")
+
+    with pytest.raises(MenuStatSourceDecisionError, match="approved manual methods"):
         parse_menustat_source_decision(
             payload,
             catalog=_catalog(),


### PR DESCRIPTION
## Summary

PR10 is a file-only food-data governance cleanup after merged PR9 #1590. It narrows the MenuStat replacement interpretation so FatSecret Platform is not routed as a PulsePlate project source, MenuStat is archival/reference-only and requires validation before use, and chain public nutrition pages become the preferred budget-first research lane while staying blocked for automation.

This PR also records the current product-source shape: core food database authority remains USDA-first, Open Food Facts stays auxiliary/future schema-review work, and the still-open data problem is restaurant menus, dish/recipe databases, and preference-menu planning.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Coordinator-first start completed with task packet `3fc17fdf87f3`
- [x] Role order recorded: `agent-coordinator -> data-scientist-agent -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter -> dev-operator`
- [x] Mandatory post-open lane planned: `qa-engineer-agent -> bug-hunter`
- [x] Custom skills used/recorded: `pulseplate-workflow`, `pulseplate-gates`, `pulseplate-guards`, `pulseplate-ledger`, `pulseplate-pr-review`, optional `pulseplate-graphmap`, no-op `pulseplate-monetization-gtm`
- [x] No app API, OpenAPI, frontend, iOS, runtime food search, DB authority, credentials, API calls, downloads, scraping, ingest, DigitalOcean Postgres, or runtime cutover

### Fixed in Commit Mapping

- `cf3d71c6d` -> Initial PR10 validator, CLI, canonical JSON artifact, packet, ledger/current-pointer updates, and tests.
- `36c14fec2` -> CLI typing hardening after local pre-push MyPy caught an untyped validation-error path.
- `6e25078dae` -> Fixed Codex review findings: public-web evidence list broadening now fails closed, and adjacent API budget must be between 0 and 20 USD/month.
- `docs/review/PR_1597_FIXED_MAPPING.md` is the canonical mapping artifact for PR #1597.

## Split Justification

This PR is intentionally a single governance slice even though it is larger than the ordinary size budget because the validator, canonical JSON artifact, CLI, packet, ledger pointer, and focused tests must land together to make the source-decision contract deterministic. Splitting the validator from the artifact/tests would create a false-green policy window where FatSecret could still be routed as a project source or public-web evidence could be misread as scraping approval.

## Merge Readiness

Local gates already run on the PR branch:

```bash
python3 scripts/orchestration/check_preflight.py
python3 scripts/orchestration/check_agent_consistency.py
python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR10 MenuStat source decision cleanup" --task-class "Orchestration" --pr-phase pre_open
python3 -m pytest tests/test_food_source_menustat_source_decision.py -q
python3 -m pytest tests/test_food_source_menustat_source_decision.py tests/test_food_source_menustat_replacement.py tests/test_food_source_onboarding.py tests/test_food_source_catalog.py tests/test_food_source_preflight.py -q
python3 -m scripts.food_source_menustat_source_decision --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --replacement docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json --decision docs/architecture/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json --json
pytest -q tests/test_repo_policy_guards.py
pre-commit run --all-files
make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python
```

Local `make verify` is intentionally deferred for this food-data lane per operator policy; GitHub current-head CI remains the machine-heavy signal.

## Security Notes

No network collection, scraping, API keys, provider calls, DB writes, DigitalOcean load, or runtime authority changes are introduced. Public restaurant websites and official social accounts are classified only as manual evidence after legal/anti-scraping/copyright review; screenshots are internal review evidence, not redistributed dataset assets.

## Marketing & GTM

No public dataset or restaurant-source claim changes. Safe external wording remains: MenuStat replacement research is narrowed; no replacement restaurant-menu source is approved for ingest yet.

## Source Evidence

- MenuStat public data page lists annual datasets through 2022: https://www.menustat.org/data.html
- FDA menu-labeling page explains public availability rationale for chain nutrition information but does not grant scraping or redistribution rights: https://www.fda.gov/food/nutrition-food-labeling-and-critical-foods/menu-labeling-requirements
- FatSecret official editions/attribution pages show attribution and contract dependency; PR10 records the product decision not to use it: https://platform.fatsecret.com/api-editions and https://platform.fatsecret.com/attribution
- Spoonacular pricing/cache rules keep it deferred from database authority: https://spoonacular.com/food-api/pricing
- Edamam Food Database is captured only as an adjacent under-$20 recipe/food DB review candidate, not an approved source: https://developer.edamam.com/food-database-api
