### PR TITLE
feat(release): export RAG gate result contract

### DIFF
--- a/.github/workflows/rag-release-gates.yml
+++ b/.github/workflows/rag-release-gates.yml
@@ -71,6 +71,7 @@ jobs:
             artifacts/rag_eval/pr_smoke_${{ github.run_id }}/traces.jsonl
             artifacts/rag_eval/pr_smoke_${{ github.run_id }}/gate_report.md
             artifacts/rag_eval/pr_smoke_${{ github.run_id }}/metrics_summary.json
+            artifacts/rag_eval/pr_smoke_${{ github.run_id }}/rag_gate_result.json
             artifacts/rag_eval/pr_smoke_${{ github.run_id }}/latest_executed.ipynb
 
   rag-release-gates-weekly:
@@ -116,4 +117,5 @@ jobs:
             artifacts/rag_eval/weekly_${{ github.run_id }}/traces.jsonl
             artifacts/rag_eval/weekly_${{ github.run_id }}/gate_report.md
             artifacts/rag_eval/weekly_${{ github.run_id }}/metrics_summary.json
+            artifacts/rag_eval/weekly_${{ github.run_id }}/rag_gate_result.json
             artifacts/rag_eval/weekly_${{ github.run_id }}/latest_executed.ipynb

--- a/docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md
+++ b/docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md
@@ -275,10 +275,19 @@ PR / CI visibility:
 - upload only the safe artifact subset:
   - `gate_report.md`
   - `metrics_summary.json`
+  - `rag_gate_result.json`
   - `latest_executed.ipynb`
 - write a compact markdown summary to the CI check summary / PR check output
 - surface deterministic threshold rows in both the markdown report and the CI summary
 - include companion RAGAS metrics only as an informational block when explicitly provided
+
+### Release-control-plane export
+
+The runner also emits `rag_gate_result.json` for the release-control-plane
+ML identity contract. The schema and hash rules live in
+[`../release/RAG_GATE_RESULT_EXPORT_CONTRACT.md`](../release/RAG_GATE_RESULT_EXPORT_CONTRACT.md).
+This export is derived from the existing runner output and does not redefine
+threshold vocabulary, gate checks, `PASS` / `NO-GO`, or `--require-pass`.
 
 ### v2 persistence
 

--- a/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
+++ b/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
@@ -159,6 +159,24 @@ UTF-8, line endings are normalized to LF, exactly one trailing LF is enforced,
 all other whitespace is preserved, and the resulting canonical UTF-8 bytes are
 hashed with SHA-256 lowercase hexadecimal.
 
+### PR-2 RAG Gate Result Export Contract
+
+PR-2 defines the ML identity export without changing RAG thresholds, retrieval,
+generation, product runtime, backend APIs, or final release decision logic. The
+machine-readable schema and field contract live in
+[`docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.md`](../release/RAG_GATE_RESULT_EXPORT_CONTRACT.md)
+and
+[`docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json`](../release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json).
+
+The existing RAG release-gates runner emits
+`artifacts/rag_eval/<experiment_id>/rag_gate_result.json` beside the current
+artifact pack. The export contains `rag_gate_result_hash`,
+`eval_artifact_hash`, existing `PASS` / `NO-GO` eval decision fields, gate
+checks, threshold rows, strict violations, runtime warnings, dataset identity,
+sample size, git SHA, and retriever/generator modes. It reserves optional
+`mlflow_run_id` and `model_version` fields for future explicitly scoped ML
+identity integrations.
+
 ## Bootstrap Commands
 
 Run from synced root before each slice:

--- a/docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.md
+++ b/docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.md
@@ -1,0 +1,83 @@
+# RAG Gate Result Export Contract
+
+**Schema version:** `release-rag-gate-result.v1`
+**Release-control-plane slice:** PR-2, `release/release-control-plane-pr2-rag-gate-export`
+**Schema:** [`RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json`](RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json)
+
+## Purpose
+
+This contract defines the ML identity portion of the internal release packet.
+It is produced by the existing RAG release-gates runner and keeps
+`scripts/evals/run_rag_release_gates.py` as the only source of truth for RAG
+gate execution, thresholds, gate checks, and the `PASS` / `NO-GO` eval
+decision.
+
+PR-2 does not add the final `ALLOW` / `BLOCK` release decision. That remains
+scoped to the later release manifest and CI decision slices.
+
+## Output Artifact
+
+The runner writes `rag_gate_result.json` under the existing gitignored run
+directory:
+
+```text
+artifacts/rag_eval/<experiment_id>/rag_gate_result.json
+```
+
+The artifact is generated beside the existing `metrics_summary.json`,
+`gate_report.md`, `traces.jsonl`, flat trace export, and executed notebook.
+Generated paths inside the export are run-directory-relative and must not
+contain absolute local filesystem paths.
+
+## Hash Fields
+
+| Field | Source | Format |
+| --- | --- | --- |
+| `rag_gate_result_hash` | Canonical JSON export payload excluding this self-hash | SHA-256 lowercase hex, no prefix |
+| `eval_artifact_hash` | Canonical JSON manifest of safe eval artifact file hashes | SHA-256 lowercase hex, no prefix |
+
+JSON canonicalization uses sorted keys, compact separators, UTF-8 bytes, and
+exactly one trailing LF. Hash fields are lowercase 64-character SHA-256
+hexadecimal without a `sha256:` prefix.
+
+## Contract Payload
+
+The deterministic export includes:
+
+```json
+{
+  "schema_version": "release-rag-gate-result.v1",
+  "hash_algorithm": "sha256",
+  "canonicalization": "json-sorted-compact-utf8-single-trailing-newline",
+  "rag_gate_result_hash": "<64 lowercase hex>",
+  "eval_artifact_hash": "<64 lowercase hex>",
+  "release_decision": "PASS",
+  "gate_checks": {},
+  "threshold_results": [],
+  "strict_violations": [],
+  "runtime_warnings": [],
+  "dataset_path_used": "data/evals/pulseplate_rag_eval_sample.jsonl",
+  "dataset_fallback_used": false,
+  "sample_size": 4,
+  "git_sha": "<git sha>",
+  "retriever_mode": "local_tfidf",
+  "generator_mode": "extractive_stub",
+  "source_artifacts": []
+}
+```
+
+`mlflow_run_id` and `model_version` are reserved optional fields. The runner
+emits them only when a future explicitly scoped integration supplies non-empty
+values in the metrics summary.
+
+## Boundaries
+
+This PR-2 contract does not:
+
+- change RAG retrieval, generation, thresholds, calibration, or route behavior;
+- create a product dashboard or second eval source of truth;
+- upload artifacts outside the existing GitHub Actions artifact mechanism;
+- read secrets, provider credentials, App Store credentials, or protected
+  release environments;
+- generate the final release manifest;
+- produce the release-control-plane `ALLOW` / `BLOCK` decision.

--- a/docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json
+++ b/docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.app/schemas/release-rag-gate-result.v1.json",
+  "title": "PulsePlate Release RAG Gate Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "hash_algorithm",
+    "canonicalization",
+    "rag_gate_result_hash",
+    "eval_artifact_hash",
+    "release_decision",
+    "gate_checks",
+    "threshold_results",
+    "strict_violations",
+    "runtime_warnings",
+    "dataset_path_used",
+    "dataset_fallback_used",
+    "sample_size",
+    "git_sha",
+    "retriever_mode",
+    "generator_mode",
+    "small_fixture_metric_gates_advisory",
+    "source_artifacts"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "release-rag-gate-result.v1"
+    },
+    "hash_algorithm": {
+      "const": "sha256"
+    },
+    "canonicalization": {
+      "const": "json-sorted-compact-utf8-single-trailing-newline"
+    },
+    "rag_gate_result_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "eval_artifact_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "release_decision": {
+      "enum": [
+        "PASS",
+        "NO-GO"
+      ]
+    },
+    "gate_checks": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "threshold_results": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "strict_violations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "runtime_warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "dataset_path_used": {
+      "type": "string",
+      "minLength": 1
+    },
+    "dataset_fallback_used": {
+      "type": "boolean"
+    },
+    "sample_size": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "git_sha": {
+      "type": "string",
+      "minLength": 1
+    },
+    "retriever_mode": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generator_mode": {
+      "type": "string",
+      "minLength": 1
+    },
+    "small_fixture_metric_gates_advisory": {
+      "type": "boolean"
+    },
+    "small_fixture_raw_gate_checks": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "mlflow_run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "model_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "path",
+          "hash"
+        ],
+        "properties": {
+          "kind": {
+            "enum": [
+              "gate_report",
+              "latest_executed_notebook",
+              "metrics_summary",
+              "parquet_or_csv",
+              "traces_jsonl"
+            ]
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "hash": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json
+++ b/docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json
@@ -10,6 +10,8 @@
     "canonicalization",
     "rag_gate_result_hash",
     "eval_artifact_hash",
+    "experiment_id",
+    "timestamp",
     "release_decision",
     "gate_checks",
     "threshold_results",
@@ -41,6 +43,14 @@
     "eval_artifact_hash": {
       "type": "string",
       "pattern": "^[0-9a-f]{64}$"
+    },
+    "experiment_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "minLength": 1
     },
     "release_decision": {
       "enum": [

--- a/docs/release/RELEASE_CONTROL_PLANE_EPIC.md
+++ b/docs/release/RELEASE_CONTROL_PLANE_EPIC.md
@@ -85,6 +85,9 @@ review governance.
    - Branch: `release/release-control-plane-pr2-rag-gate-export`
    - Export a stable gate-result JSON contract from the existing RAG release-gate runner.
    - Do not introduce a second eval source of truth or product dashboard.
+   - Contract: [`RAG_GATE_RESULT_EXPORT_CONTRACT.md`](RAG_GATE_RESULT_EXPORT_CONTRACT.md)
+     and [`RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json`](RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json).
+   - Artifact: `artifacts/rag_eval/<experiment_id>/rag_gate_result.json`.
 
 4. **PR-3: release manifest generator and validator**
    - Branch: `release/release-control-plane-pr3-release-manifest`

--- a/docs/review/PR_1598_FIXED_MAPPING.md
+++ b/docs/review/PR_1598_FIXED_MAPPING.md
@@ -1,9 +1,9 @@
 # PR 1598 Fixed in Commit Mapping
 
-PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1598
-Branch: `release/release-control-plane-pr2-rag-gate-export`
-Base: `main`
-Head at PR open: `e31d43656`
+**PR:** https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1598
+**Branch:** `release/release-control-plane-pr2-rag-gate-export`
+**Base:** `main`
+**Release-control-plane slice:** PR-2 RAG/ML gate result export contract
 
 ## Scope
 
@@ -12,23 +12,35 @@ from the existing RAG release-gates runner. It does not create a second eval
 source of truth, change RAG thresholds/runtime behavior, or add final
 `ALLOW` / `BLOCK` release-decision CI enforcement.
 
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+No human, CodeRabbit, Sourcery, or Cubic actionable review threads were present
+when this canonical mapping artifact was created. This file must be updated
+before any review thread is resolved.
+
 ## Fixed in Commit Mapping
 
-- Initial implementation: `e31d43656`
-  - Disposition: FIXED
-  - Evidence:
-    - `scripts/evals/run_rag_release_gates.py` emits `rag_gate_result.json`
-      with `release-rag-gate-result.v1`, `rag_gate_result_hash`, and
-      `eval_artifact_hash`.
-    - `tests/test_rag_release_gates_runner.py` covers schema fields,
-      lowercase SHA-256 hash format, canonical ordering, hash changes on gate
-      result changes, hash changes on artifact changes, artifact writing, CLI
-      smoke output, and small-fixture raw gate preservation.
-    - `docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.md` and
-      `docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json` define the
-      contract.
+- No actionable review comments
 
-No GitHub review threads were resolved at PR open.
+## Implementation Evidence
+
+Disposition: FIXED
+Commit: e31d43656
+Evidence:
+
+- `scripts/evals/run_rag_release_gates.py` emits `rag_gate_result.json` with
+  `release-rag-gate-result.v1`, `rag_gate_result_hash`, and
+  `eval_artifact_hash`.
+- `tests/test_rag_release_gates_runner.py` covers schema fields, lowercase
+  SHA-256 hash format, canonical ordering, hash changes on gate result
+  changes, hash changes on artifact changes, artifact writing, CLI smoke
+  output, and small-fixture raw gate preservation.
+- `docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.md` and
+  `docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json` define the
+  contract.
 
 ## Local Gate Evidence
 
@@ -47,13 +59,6 @@ No GitHub review threads were resolved at PR open.
 Full `make verify` was intentionally not run under the operator-approved
 machine-heavy exception. Merge readiness requires current-head CI parity plus
 strict `check_merge_ready.py --require-auth`.
-
-## Discussion Thread Pass
-
-- [x] Canonical fixed-mapping artifact exists for PR `#1598`.
-- [x] No review threads were resolved without disposition evidence.
-- [x] External bot comments remain unresolved until classified as FIXED,
-  NOT-A-BUG, DEFERRED, or non-actionable with evidence.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1598_FIXED_MAPPING.md
+++ b/docs/review/PR_1598_FIXED_MAPPING.md
@@ -1,0 +1,63 @@
+# PR 1598 Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1598
+Branch: `release/release-control-plane-pr2-rag-gate-export`
+Base: `main`
+Head at PR open: `e31d43656`
+
+## Scope
+
+Release-control-plane PR-2 exports a stable RAG/ML gate-result JSON contract
+from the existing RAG release-gates runner. It does not create a second eval
+source of truth, change RAG thresholds/runtime behavior, or add final
+`ALLOW` / `BLOCK` release-decision CI enforcement.
+
+## Fixed in Commit Mapping
+
+- Initial implementation: `e31d43656`
+  - Disposition: FIXED
+  - Evidence:
+    - `scripts/evals/run_rag_release_gates.py` emits `rag_gate_result.json`
+      with `release-rag-gate-result.v1`, `rag_gate_result_hash`, and
+      `eval_artifact_hash`.
+    - `tests/test_rag_release_gates_runner.py` covers schema fields,
+      lowercase SHA-256 hash format, canonical ordering, hash changes on gate
+      result changes, hash changes on artifact changes, artifact writing, CLI
+      smoke output, and small-fixture raw gate preservation.
+    - `docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.md` and
+      `docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json` define the
+      contract.
+
+No GitHub review threads were resolved at PR open.
+
+## Local Gate Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS
+- `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-2: RAG/ML gate result export contract" --task-class Orchestration --pr-phase pre_open ...` PASS
+- `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-2 post-open review: RAG/ML gate result export contract" --task-class Orchestration --pr-phase post_open_review ...` PASS
+- `pytest -q tests/test_rag_release_gates_runner.py` PASS, 47 tests
+- `pytest -q tests/test_repo_policy_guards.py` PASS, 14 tests
+- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.md docs/roadmap/BACKLOG_LEDGER.md` PASS
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` PASS, 47 tests
+- `pre-commit run --all-files` PASS after Black formatting rerun
+- git commit hooks PASS
+- git pre-push hooks PASS
+
+Full `make verify` was intentionally not run under the operator-approved
+machine-heavy exception. Merge readiness requires current-head CI parity plus
+strict `check_merge_ready.py --require-auth`.
+
+## Discussion Thread Pass
+
+- [x] Canonical fixed-mapping artifact exists for PR `#1598`.
+- [x] No review threads were resolved without disposition evidence.
+- [x] External bot comments remain unresolved until classified as FIXED,
+  NOT-A-BUG, DEFERRED, or non-actionable with evidence.
+
+## Merge Readiness
+
+- [ ] Current-head CI complete and green for required/touched lanes.
+- [ ] CodeRabbit, Sourcery, and Cubic have no actionable unresolved findings.
+- [ ] `GH_TOKEN=$(gh auth token) GITHUB_TOKEN=$(gh auth token) python3 scripts/orchestration/check_merge_ready.py --pr-number 1598 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth` PASS.
+- [ ] Mandatory final review wait-window observed after latest review/bot activity.

--- a/docs/review/PR_1598_FIXED_MAPPING.md
+++ b/docs/review/PR_1598_FIXED_MAPPING.md
@@ -23,7 +23,10 @@ before any review thread is resolved.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1598#discussion_r3168261150 -> d5fc8c896
+Disposition: FIXED
+Commit: d5fc8c896
+Evidence: `docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json` now declares `experiment_id` and `timestamp`, matching the fields emitted by `scripts/evals/run_rag_release_gates.py`; `tests/test_rag_release_gates_runner.py` adds `test_rag_gate_result_schema_declares_all_emitted_fields`.
 
 ## Implementation Evidence
 
@@ -41,6 +44,8 @@ Evidence:
 - `docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.md` and
   `docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json` define the
   contract.
+- Review fix `d5fc8c896` aligns the published schema with the emitted export
+  fields and adds regression coverage.
 
 ## Local Gate Evidence
 
@@ -52,6 +57,8 @@ Evidence:
 - `pytest -q tests/test_repo_policy_guards.py` PASS, 14 tests
 - `python3 scripts/ci/check_docs_phase1_gates.py --files docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.md docs/roadmap/BACKLOG_LEDGER.md` PASS
 - `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` PASS, 47 tests
+- `pytest -q tests/test_rag_release_gates_runner.py` PASS after schema fix, 48 tests
+- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json` PASS
 - `pre-commit run --all-files` PASS after Black formatting rerun
 - git commit hooks PASS
 - git pre-push hooks PASS

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -379,6 +379,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/release/RELEASE_CONTROL_PLANE_EPIC.md`
     - `docs/release/REVIEWER_PACKET_HASH_CONTRACT.md`
     - `docs/release/REVIEWER_PACKET_HASH_CONTRACT.schema.json`
+    - `docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.md`
+    - `docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json`
     - `docs/architecture/C4_RELEASE_CONTROL_PLANE_CONTEXT.md`
     - `docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md`
     - `scripts/evals/run_rag_release_gates.py`
@@ -387,7 +389,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - DoD:
     - PR-0 lands governance docs, C4 release-risk context, packet, and this ledger anchor without runtime/workflow changes.
     - PR-1 defines reviewer-packet hash contract after App Store readiness artifacts land on `main`, including `reviewer_notes_hash`, `appstore_metadata_hash`, canonical UTF-8 SHA-256 rules, and schema tests.
-    - PR-2 exports a stable RAG/ML gate-result schema from the existing release-gate runner without creating a second eval source of truth.
+    - PR-2 exports a stable RAG/ML gate-result schema from the existing release-gate runner without creating a second eval source of truth, including `rag_gate_result_hash`, `eval_artifact_hash`, existing `PASS` / `NO-GO` eval decision fields, and safe artifact references.
     - PR-3 adds a release manifest generator and fail-closed validator.
     - PR-4 proves review-build and production-candidate equivalence by digest/hash checks.
     - PR-5 integrates focused CI gates for manifest, ML gate result, SBOM/provenance references, and `ALLOW` / `BLOCK` decision.

--- a/scripts/evals/run_rag_release_gates.py
+++ b/scripts/evals/run_rag_release_gates.py
@@ -42,6 +42,17 @@ DEFAULT_INPUT_PATH = REPO_ROOT / "data" / "evals" / "pulseplate_rag_eval_sample.
 DEFAULT_ARTIFACT_ROOT = REPO_ROOT / "artifacts" / "rag_eval"
 DEFAULT_NOTEBOOK_PATH = REPO_ROOT / "notebooks" / "pulseplate_rag_release_gates.ipynb"
 SAFE_EXPERIMENT_ID_RE = re.compile(r"[^A-Za-z0-9_-]+")
+RAG_GATE_RESULT_SCHEMA_VERSION = "release-rag-gate-result.v1"
+RAG_GATE_RESULT_HASH_ALGORITHM = "sha256"
+RAG_GATE_RESULT_CANONICALIZATION = "json-sorted-compact-utf8-single-trailing-newline"
+RAG_GATE_RESULT_FILENAME = "rag_gate_result.json"
+RAG_GATE_SOURCE_ARTIFACT_KEYS: tuple[str, ...] = (
+    "gate_report",
+    "latest_executed_notebook",
+    "metrics_summary",
+    "parquet_or_csv",
+    "traces_jsonl",
+)
 
 DEFAULT_SAMPLE_ROWS: list[dict[str, Any]] = [
     {
@@ -2049,6 +2060,25 @@ def _json_default(obj: Any) -> Any:
     return str(obj)
 
 
+def _canonical_json_bytes(payload: Any) -> bytes:
+    """Serialize JSON for release-control-plane hashing."""
+
+    serialized = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=_json_default,
+    )
+    return f"{serialized}\n".encode("utf-8")
+
+
+def _sha256_lower_hex(payload: bytes) -> str:
+    """Return lowercase SHA-256 hex without an algorithm prefix."""
+
+    return hashlib.new(RAG_GATE_RESULT_HASH_ALGORITHM, payload).hexdigest()
+
+
 def _write_jsonl(path: Path, traces: Sequence[dict[str, Any]]) -> None:
     """Write traces as JSONL."""
 
@@ -2120,6 +2150,119 @@ def _write_flat_export(run_dir: Path, traces: Sequence[dict[str, Any]]) -> str:
                 writer.writeheader()
                 writer.writerows(flat_rows)
         return str(csv_path)
+
+
+def _run_dir_relative_path(path: Path, *, run_dir: Path) -> str:
+    """Return a deterministic run-dir-relative artifact path."""
+
+    resolved_path = path.resolve()
+    resolved_run_dir = run_dir.resolve()
+    try:
+        return resolved_path.relative_to(resolved_run_dir).as_posix()
+    except ValueError:
+        return path.name
+
+
+def _artifact_manifest_entry(kind: str, path: Path, *, run_dir: Path) -> dict[str, str]:
+    """Build one safe eval artifact manifest entry."""
+
+    return {
+        "kind": kind,
+        "path": _run_dir_relative_path(path, run_dir=run_dir),
+        "hash": _sha256_lower_hex(path.read_bytes()),
+    }
+
+
+def build_eval_artifact_manifest(
+    artifacts: dict[str, str],
+    *,
+    run_dir: Path,
+) -> list[dict[str, str]]:
+    """Return deterministic safe-artifact entries for the RAG gate export."""
+
+    entries: list[dict[str, str]] = []
+    for kind in RAG_GATE_SOURCE_ARTIFACT_KEYS:
+        raw_path = artifacts.get(kind)
+        if raw_path is None:
+            continue
+        path = Path(raw_path)
+        if not path.is_file():
+            continue
+        entries.append(_artifact_manifest_entry(kind, path, run_dir=run_dir))
+    return entries
+
+
+def build_rag_gate_result_export(
+    metrics_summary: dict[str, Any],
+    artifacts: dict[str, str],
+    *,
+    run_dir: Path,
+) -> dict[str, Any]:
+    """Build the deterministic release-control-plane RAG gate result export."""
+
+    source_artifacts = build_eval_artifact_manifest(artifacts, run_dir=run_dir)
+    eval_artifact_hash = _sha256_lower_hex(
+        _canonical_json_bytes(
+            {
+                "artifacts": source_artifacts,
+                "canonicalization": RAG_GATE_RESULT_CANONICALIZATION,
+                "schema_version": RAG_GATE_RESULT_SCHEMA_VERSION,
+            }
+        )
+    )
+    export_payload: dict[str, Any] = {
+        "schema_version": RAG_GATE_RESULT_SCHEMA_VERSION,
+        "hash_algorithm": RAG_GATE_RESULT_HASH_ALGORITHM,
+        "canonicalization": RAG_GATE_RESULT_CANONICALIZATION,
+        "experiment_id": metrics_summary["experiment_id"],
+        "timestamp": metrics_summary["timestamp"],
+        "git_sha": metrics_summary["git_sha"],
+        "sample_size": metrics_summary["sample_size"],
+        "retriever_mode": metrics_summary["retriever_mode"],
+        "generator_mode": metrics_summary["generator_mode"],
+        "dataset_path_used": metrics_summary["dataset_path_used"],
+        "dataset_fallback_used": metrics_summary["dataset_fallback_used"],
+        "release_decision": metrics_summary["release_decision"],
+        "gate_checks": metrics_summary["gate_checks"],
+        "threshold_results": metrics_summary.get("threshold_results", []),
+        "strict_violations": metrics_summary.get("strict_violations", []),
+        "runtime_warnings": metrics_summary.get("runtime_warnings", []),
+        "small_fixture_metric_gates_advisory": metrics_summary.get(
+            "small_fixture_metric_gates_advisory",
+            False,
+        ),
+        "eval_artifact_hash": eval_artifact_hash,
+        "source_artifacts": source_artifacts,
+    }
+    if "small_fixture_raw_gate_checks" in metrics_summary:
+        export_payload["small_fixture_raw_gate_checks"] = metrics_summary[
+            "small_fixture_raw_gate_checks"
+        ]
+    for optional_key in ("mlflow_run_id", "model_version"):
+        optional_value = metrics_summary.get(optional_key)
+        if optional_value:
+            export_payload[optional_key] = optional_value
+
+    export_payload["rag_gate_result_hash"] = _sha256_lower_hex(
+        _canonical_json_bytes(export_payload)
+    )
+    return export_payload
+
+
+def write_rag_gate_result_export(
+    run_dir: Path,
+    metrics_summary: dict[str, Any],
+    artifacts: dict[str, str],
+) -> Path:
+    """Write the PR-2 RAG/ML gate-result export artifact."""
+
+    export_path = run_dir / RAG_GATE_RESULT_FILENAME
+    export_payload = build_rag_gate_result_export(metrics_summary, artifacts, run_dir=run_dir)
+    export_path.write_text(
+        json.dumps(export_payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return export_path
 
 
 def write_summary_notebook(
@@ -2219,13 +2362,17 @@ def write_artifacts(
         gate_report,
         template_notebook_path=template_notebook_path,
     )
-    return {
+    artifacts = {
         "traces_jsonl": str(traces_path),
         "parquet_or_csv": parquet_or_csv_status,
         "metrics_summary": str(metrics_path),
         "gate_report": str(report_path),
         "latest_executed_notebook": str(notebook_path),
     }
+    artifacts["rag_gate_result"] = str(
+        write_rag_gate_result_export(run_dir, metrics_summary, artifacts)
+    )
+    return artifacts
 
 
 def _write_github_step_summary(metrics_summary: dict[str, Any], artifacts: dict[str, str]) -> None:
@@ -2245,6 +2392,7 @@ def _write_github_step_summary(metrics_summary: dict[str, Any], artifacts: dict[
         "### Artifacts",
         f"- Gate report: `{artifacts['gate_report']}`",
         f"- Metrics summary: `{artifacts['metrics_summary']}`",
+        f"- RAG gate result: `{artifacts['rag_gate_result']}`",
         f"- Traces: `{artifacts['traces_jsonl']}`",
     ]
     threshold_results = metrics_summary.get("threshold_results", [])

--- a/tests/test_rag_release_gates_runner.py
+++ b/tests/test_rag_release_gates_runner.py
@@ -636,6 +636,7 @@ def test_runner_smoke_writes_expected_artifacts(tmp_path: Path) -> None:
     assert (run_dir / "traces.jsonl").is_file()
     assert (run_dir / "metrics_summary.json").is_file()
     assert (run_dir / "gate_report.md").is_file()
+    assert (run_dir / "rag_gate_result.json").is_file()
     assert (run_dir / "latest_executed.ipynb").is_file()
 
 
@@ -1525,6 +1526,129 @@ def test_threshold_results_ordering_and_escalation_corridor_are_deterministic(
     assert "`gate_c2_escalation_corridor` | `escalation_rate` | `0.25` | `0.1..0.25`" in gate_report
 
 
+def test_rag_gate_result_export_schema_and_hashes_are_deterministic(
+    tmp_path: Path,
+) -> None:
+    """The PR-2 export must be a stable release-control-plane artifact."""
+
+    run_dir = tmp_path / "artifacts" / "rag_eval" / "gate_result"
+    run_dir.mkdir(parents=True)
+    artifact_paths: dict[str, str] = {}
+    for name, content in {
+        "gate_report": "# report\n",
+        "latest_executed_notebook": "{}\n",
+        "metrics_summary": '{"ok": true}\n',
+        "parquet_or_csv": "trace_id\n",
+        "traces_jsonl": "{}\n",
+    }.items():
+        path = run_dir / f"{name}.txt"
+        path.write_text(content, encoding="utf-8")
+        artifact_paths[name] = str(path)
+    state = _make_release_gate_state(tmp_path, experiment_id="gate_result")
+    metrics_summary, _, _ = runner.build_metrics_summary(
+        state,
+        _passing_release_gate_traces(),
+        {"ece": 0.05},
+        dataset_fallback_used=False,
+        dataset_path_used="data/evals/pulseplate_rag_eval_sample.jsonl",
+    )
+
+    first = runner.build_rag_gate_result_export(metrics_summary, artifact_paths, run_dir=run_dir)
+    second = runner.build_rag_gate_result_export(
+        metrics_summary,
+        dict(reversed(list(artifact_paths.items()))),
+        run_dir=run_dir,
+    )
+
+    assert first == second
+    assert first["schema_version"] == "release-rag-gate-result.v1"
+    assert first["hash_algorithm"] == "sha256"
+    assert first["canonicalization"] == "json-sorted-compact-utf8-single-trailing-newline"
+    assert first["release_decision"] == "PASS"
+    assert len(first["rag_gate_result_hash"]) == 64
+    assert len(first["eval_artifact_hash"]) == 64
+    int(first["rag_gate_result_hash"], 16)
+    int(first["eval_artifact_hash"], 16)
+    assert all(not Path(entry["path"]).is_absolute() for entry in first["source_artifacts"])
+    assert first["small_fixture_raw_gate_checks"]
+
+
+def test_rag_gate_result_hash_changes_when_gate_result_changes(tmp_path: Path) -> None:
+    """The self-hash must bind the exported gate result, not just artifacts."""
+
+    run_dir = tmp_path / "artifacts" / "rag_eval" / "gate_change"
+    run_dir.mkdir(parents=True)
+    metrics_path = run_dir / "metrics_summary.json"
+    metrics_path.write_text("{}", encoding="utf-8")
+    artifacts = {"metrics_summary": str(metrics_path)}
+    state = _make_release_gate_state(tmp_path, experiment_id="gate_change")
+    metrics_summary, _, _ = runner.build_metrics_summary(
+        state,
+        _passing_release_gate_traces(),
+        {"ece": 0.05},
+        dataset_fallback_used=False,
+        dataset_path_used="data/evals/pulseplate_rag_eval_sample.jsonl",
+    )
+
+    passing = runner.build_rag_gate_result_export(metrics_summary, artifacts, run_dir=run_dir)
+    changed_metrics = {
+        **metrics_summary,
+        "release_decision": "NO-GO",
+        "gate_checks": {**metrics_summary["gate_checks"], "gate_c1_ece": False},
+    }
+    failing = runner.build_rag_gate_result_export(changed_metrics, artifacts, run_dir=run_dir)
+
+    assert passing["eval_artifact_hash"] == failing["eval_artifact_hash"]
+    assert passing["rag_gate_result_hash"] != failing["rag_gate_result_hash"]
+
+
+def test_eval_artifact_hash_changes_when_artifact_changes(tmp_path: Path) -> None:
+    """The eval artifact hash must bind the safe artifact manifest bytes."""
+
+    run_dir = tmp_path / "artifacts" / "rag_eval" / "artifact_change"
+    run_dir.mkdir(parents=True)
+    metrics_path = run_dir / "metrics_summary.json"
+    metrics_path.write_text("first\n", encoding="utf-8")
+    artifacts = {"metrics_summary": str(metrics_path)}
+    state = _make_release_gate_state(tmp_path, experiment_id="artifact_change")
+    metrics_summary, _, _ = runner.build_metrics_summary(
+        state,
+        _passing_release_gate_traces(),
+        {"ece": 0.05},
+        dataset_fallback_used=False,
+        dataset_path_used="data/evals/pulseplate_rag_eval_sample.jsonl",
+    )
+
+    first = runner.build_rag_gate_result_export(metrics_summary, artifacts, run_dir=run_dir)
+    metrics_path.write_text("second\n", encoding="utf-8")
+    second = runner.build_rag_gate_result_export(metrics_summary, artifacts, run_dir=run_dir)
+
+    assert first["eval_artifact_hash"] != second["eval_artifact_hash"]
+    assert first["rag_gate_result_hash"] != second["rag_gate_result_hash"]
+
+
+def test_write_artifacts_creates_rag_gate_result_export(tmp_path: Path) -> None:
+    """The canonical artifact pack must include the PR-2 export file."""
+
+    run_dir = tmp_path / "artifacts" / "rag_eval" / "write_export"
+    state = _make_release_gate_state(tmp_path, experiment_id="write_export")
+    metrics_summary, _, _ = runner.build_metrics_summary(
+        state,
+        _passing_release_gate_traces(),
+        {"ece": 0.05},
+        dataset_fallback_used=False,
+        dataset_path_used="data/evals/pulseplate_rag_eval_sample.jsonl",
+    )
+
+    artifacts = write_artifacts(run_dir, _passing_release_gate_traces(), metrics_summary)
+    export_path = Path(artifacts["rag_gate_result"])
+    payload = json.loads(export_path.read_text(encoding="utf-8"))
+
+    assert export_path == run_dir / "rag_gate_result.json"
+    assert payload["source_artifacts"]
+    assert payload["rag_gate_result_hash"]
+
+
 def test_step_summary_includes_threshold_results_and_optional_companion_metrics(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1552,6 +1676,7 @@ def test_step_summary_includes_threshold_results_and_optional_companion_metrics(
         {
             "gate_report": "artifacts/rag_eval/step_summary/gate_report.md",
             "metrics_summary": "artifacts/rag_eval/step_summary/metrics_summary.json",
+            "rag_gate_result": "artifacts/rag_eval/step_summary/rag_gate_result.json",
             "traces_jsonl": "artifacts/rag_eval/step_summary/traces.jsonl",
         },
     )
@@ -1559,6 +1684,9 @@ def test_step_summary_includes_threshold_results_and_optional_companion_metrics(
 
     assert "## PulsePlate RAG Release Gates" in summary_text
     assert "### Threshold results" in summary_text
+    assert (
+        "- RAG gate result: `artifacts/rag_eval/step_summary/rag_gate_result.json`" in summary_text
+    )
     assert (
         "`gate_c2_escalation_corridor` | `0.25` | `0.1..0.25` | `between_inclusive` | `True`"
         in summary_text

--- a/tests/test_rag_release_gates_runner.py
+++ b/tests/test_rag_release_gates_runner.py
@@ -1573,6 +1573,34 @@ def test_rag_gate_result_export_schema_and_hashes_are_deterministic(
     assert first["small_fixture_raw_gate_checks"]
 
 
+def test_rag_gate_result_schema_declares_all_emitted_fields(tmp_path: Path) -> None:
+    """The published schema must allow every key emitted by the runner."""
+
+    run_dir = tmp_path / "artifacts" / "rag_eval" / "schema_keys"
+    run_dir.mkdir(parents=True)
+    metrics_path = run_dir / "metrics_summary.json"
+    metrics_path.write_text("{}", encoding="utf-8")
+    state = _make_release_gate_state(tmp_path, experiment_id="schema_keys")
+    metrics_summary, _, _ = runner.build_metrics_summary(
+        state,
+        _passing_release_gate_traces(),
+        {"ece": 0.05},
+        dataset_fallback_used=False,
+        dataset_path_used="data/evals/pulseplate_rag_eval_sample.jsonl",
+    )
+    payload = runner.build_rag_gate_result_export(
+        metrics_summary,
+        {"metrics_summary": str(metrics_path)},
+        run_dir=run_dir,
+    )
+    schema = json.loads(
+        Path("docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json").read_text(encoding="utf-8")
+    )
+
+    assert set(payload).issubset(schema["properties"])
+    assert set(schema["required"]).issubset(payload)
+
+
 def test_rag_gate_result_hash_changes_when_gate_result_changes(tmp_path: Path) -> None:
     """The self-hash must bind the exported gate result, not just artifacts."""
 


### PR DESCRIPTION
## Summary

PR-2 for the release-control-plane line. This adds a deterministic `rag_gate_result.json` export produced by the existing `scripts/evals/run_rag_release_gates.py` runner.

The slice does not create a second eval source of truth, does not change RAG thresholds/runtime behavior, and does not add PR-5 `ALLOW` / `BLOCK` CI decision enforcement.

## Coordinator / Role Order

`agent-coordinator -> architecture-specialist -> ml-engineer-agent -> data-scientist-agent -> security-auditor -> app-store-release-agent -> backend-engineer -> frontend-engineer -> dev-operator -> qa-engineer-agent -> bug-hunter`

Packets:
- Pre-open: `artifacts/orchestration/task_packets/12fe2ab8739a.json` (local-only, gitignored)
- Post-open review: `artifacts/orchestration/task_packets/143647e92d65.json` (local-only, gitignored)

## Key Changes

- Emit `artifacts/rag_eval/<experiment_id>/rag_gate_result.json` from the existing RAG release-gates runner.
- Add `release-rag-gate-result.v1` docs/schema contract.
- Add deterministic `rag_gate_result_hash` and `eval_artifact_hash` fields using SHA-256 lowercase hex over canonical JSON bytes.
- Keep artifact paths run-dir-relative, not absolute local filesystem paths.
- Upload `rag_gate_result.json` in the existing RAG Release Gates workflow artifact set as visibility only.
- Update release-control-plane packet, epic, RAG eval docs, backlog ledger, and canonical fixed mapping.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

No review threads have been resolved without disposition evidence. External review bots are evidence helpers only; repo source of truth remains code, docs, tests, and fixed mapping.

### Fixed in Commit Mapping

- `docs/review/PR_1598_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1598#discussion_r3168261150 -> d5fc8c896

Implementation evidence:
- Initial implementation: `e31d43656`
- PR mapping artifact: `92f4f71a2`
- Phase2 mapping fix: `6d5e70ef3`
- Schema review fix: `d5fc8c896`
- Review mapping update: `fda105ccb`

## Merge Readiness

Local narrow gates already run before opening / after mapping:

- `python3 scripts/orchestration/check_preflight.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-2: RAG/ML gate result export contract" --task-class Orchestration --pr-phase pre_open ...` PASS
- `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-2 post-open review: RAG/ML gate result export contract" --task-class Orchestration --pr-phase post_open_review ...` PASS
- `pytest -q tests/test_rag_release_gates_runner.py` PASS, 48 tests after schema fix
- `pytest -q tests/test_repo_policy_guards.py` PASS, 14 tests
- `python3 scripts/ci/check_docs_phase1_gates.py --files ...` PASS
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json` PASS
- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` PASS, 47 tests before review fix
- `pre-commit run --all-files` PASS after Black formatting rerun
- git commit hooks PASS
- git pre-push hooks PASS

Full `make verify` intentionally not run under operator-approved machine-heavy exception to avoid CPU overload. Merge-ready claim will require current-head CI parity plus strict `check_merge_ready.py --require-auth`.

## Boundaries

- No backend API/OpenAPI changes.
- No App Store metadata/Fastlane content changes.
- No RAG threshold, retrieval, generation, calibration, or product runtime behavior changes.
- No final release-control-plane `ALLOW` / `BLOCK` decision logic in this PR.
