### PR TITLE
fix(ios): remove unused sensitive permission strings from release metadata

### DIFF
--- a/docs/orchestration/APPSTORE_RELEASE_READINESS_PR2_PERMISSION_PACKET_2026-04-30.md
+++ b/docs/orchestration/APPSTORE_RELEASE_READINESS_PR2_PERMISSION_PACKET_2026-04-30.md
@@ -1,0 +1,92 @@
+# App Store Release Readiness PR-2 Permission Packet
+
+**Packet ID:** `appstore-release-readiness-pr2-permission-purpose-strings-2026-04-30`
+
+**Epic:** `epic/appstore-release-readiness-full-feature`
+
+**Branch:** `release/appstore-readiness-pr2-permission-purpose-strings`
+
+**Title:** `fix(ios): remove unused sensitive permission strings from release metadata`
+
+## Coordinator Start
+
+Primary agent:
+
+1. `agent-coordinator`
+
+Declared role order:
+
+1. `agent-coordinator`
+2. `ios-engineer-agent`
+3. `appstore-release-agent`
+4. `privacy-compliance-agent`
+5. `security-auditor`
+6. `qa-engineer-agent`
+7. `bug-hunter`
+
+Bootstrap packet:
+
+- `artifacts/orchestration/task_packets/20ece0834a86.json`
+
+## Scope
+
+Remove sensitive iOS permission purpose strings that are not backed by current
+release runtime capability evidence. Preserve the read-only HealthKit consent
+copy.
+
+In scope:
+
+- `ios/PulsePlate/*/InfoPlist.strings`
+- `tests/ios/test_info_plist_permission_strings.py`
+- App Store readiness packet, epic, and ledger references
+
+Out of scope:
+
+- implementing camera, location, photo library, microphone, contacts, Face ID,
+  or ATT runtime features
+- changing HealthKit read/write posture
+- changing App Privacy payloads or screenshot assets
+
+## Release Truth
+
+Current runtime evidence supports:
+
+- HealthKit read-only access through `HealthKitManager`
+- `NSHealthShareUsageDescription`
+
+Current runtime evidence does not support release permission strings for:
+
+- camera
+- location
+- photo library
+- microphone
+- contacts
+- Face ID
+- App Tracking Transparency
+
+## Validation Plan
+
+Do not run full local `make verify` for this PR because the operator explicitly
+deferred heavy local validation.
+
+Required narrow local gates:
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+pytest -q tests/ios/test_info_plist_permission_strings.py tests/test_ios_appstore_asset_validators.py
+git diff --check
+pre-commit run --all-files
+```
+
+Heavy signal:
+
+- GitHub current-head CI for iOS unit/UI, lint, security, diff coverage, asset
+  validation, and merge readiness
+
+## Stop Conditions
+
+- A removed permission string is required by a release-enabled runtime feature.
+- ATT runtime is introduced in this slice.
+- HealthKit posture changes from read-only.
+- A validator needs full local `make verify` to prove correctness.

--- a/docs/orchestration/APPSTORE_RELEASE_READINESS_PR2_PERMISSION_PACKET_2026-04-30.md
+++ b/docs/orchestration/APPSTORE_RELEASE_READINESS_PR2_PERMISSION_PACKET_2026-04-30.md
@@ -81,8 +81,8 @@ pre-commit run --all-files
 
 Heavy signal:
 
-- GitHub current-head CI for iOS unit/UI, lint, security, diff coverage, asset
-  validation, and merge readiness
+- GitHub current-head CI for iOS unit tests, lint, security, diff coverage,
+  asset validation, and merge readiness
 
 ## Stop Conditions
 

--- a/docs/orchestration/APPSTORE_RELEASE_READINESS_TASK_PACKET_2026-04-29.md
+++ b/docs/orchestration/APPSTORE_RELEASE_READINESS_TASK_PACKET_2026-04-29.md
@@ -95,7 +95,7 @@ of truth, coordinator routing, fixed-mapping governance, or local gates.
 | --- | --- | --- | --- |
 | PR-0 | `release/appstore-readiness-pr0-bootstrap` | Epic, matrix, packet, ledger, root gates | docs/ledger validation and repo policy guards |
 | PR-1 | `release/appstore-readiness-pr1-privacy-manifest` | Privacy manifest and App Privacy truth | privacy manifest and App Privacy contract tests |
-| PR-2 | `release/appstore-readiness-pr2-permission-truth` | Sensitive permission string cleanup | permission purpose-string guard |
+| PR-2 | `release/appstore-readiness-pr2-permission-purpose-strings` | Sensitive permission string cleanup | permission purpose-string guard |
 | PR-3 | `release/appstore-readiness-pr3-base-url` | Explicit HTTPS Release backend | Release plist/baseURL tests |
 | PR-4 | `release/appstore-readiness-pr4-asset-gating` | Screenshot submission policy | Swift and Python asset policy tests |
 | PR-5 | `release/appstore-readiness-pr5-appicon` | AppIcon marketing asset validation | `actool` plus asset catalog test |

--- a/docs/release/APPSTORE_RELEASE_READINESS_EPIC.md
+++ b/docs/release/APPSTORE_RELEASE_READINESS_EPIC.md
@@ -89,7 +89,7 @@ then update this epic, the matrix, and the lane packet in the same PR.
    - Add deterministic contract tests.
 
 3. **PR-2: permission strings cleanup and capability truth**
-   - Branch: `release/appstore-readiness-pr2-permission-truth`
+   - Branch: `release/appstore-readiness-pr2-permission-purpose-strings`
    - Keep only release-used sensitive permission purpose strings.
    - Keep `NSHealthShareUsageDescription`; remove tracking and unused permission
      copy unless runtime evidence exists.

--- a/docs/review/PR_1600_FIXED_MAPPING.md
+++ b/docs/review/PR_1600_FIXED_MAPPING.md
@@ -28,10 +28,6 @@ Declared role order:
 6. `qa-engineer-agent`
 7. `bug-hunter`
 
-## Fixed in Commit Mapping
-
-- No actionable review comments
-
 ## Discussion Thread Pass
 
 - [x] Discussion-thread pass completed
@@ -45,6 +41,10 @@ proof before they are resolved:
 - `FIXED`: thread URL -> commit SHA made after the comment timestamp
 - `NOT-A-BUG`: thread URL plus evidence
 - `DEFERRED`: thread URL plus backlog link
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
 
 ## Local Validation
 
@@ -68,9 +68,7 @@ Pre-push hooks also passed.
 
 ## Merge Readiness
 
-Draft status is intentional until:
-
-- current-head PR CI is complete
-- CodeRabbit/Sourcery/Cubic have no actionable items
-- all review threads are dispositioned
-- strict merge readiness passes
+- [ ] current-head PR CI is complete
+- [ ] CodeRabbit/Sourcery/Cubic have no actionable items
+- [ ] all review threads are dispositioned
+- [ ] strict merge readiness passes

--- a/docs/review/PR_1600_FIXED_MAPPING.md
+++ b/docs/review/PR_1600_FIXED_MAPPING.md
@@ -1,0 +1,73 @@
+# PR 1600 Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1600
+
+Branch: `release/appstore-readiness-pr2-permission-purpose-strings`
+
+Title: `fix(ios): remove unused sensitive permission strings from release metadata`
+
+## Scope
+
+This PR is App Store readiness PR-2. It removes sensitive permission purpose
+strings that are not backed by current release runtime capability evidence and
+keeps the read-only HealthKit consent copy.
+
+## Coordinator Evidence
+
+Task packet:
+
+- `artifacts/orchestration/task_packets/20ece0834a86.json` (local, gitignored)
+
+Declared role order:
+
+1. `agent-coordinator`
+2. `ios-engineer-agent`
+3. `appstore-release-agent`
+4. `privacy-compliance-agent`
+5. `security-auditor`
+6. `qa-engineer-agent`
+7. `bug-hunter`
+
+## Fixed in Commit Mapping
+
+- Initial implementation -> `10c2d3528`
+
+## Discussion Thread Pass
+
+No review threads were present when the draft PR opened.
+
+Future actionable review threads must be listed here with disposition-specific
+proof before they are resolved:
+
+- `FIXED`: thread URL -> commit SHA made after the comment timestamp
+- `NOT-A-BUG`: thread URL plus evidence
+- `DEFERRED`: thread URL plus backlog link
+
+## Local Validation
+
+Full local `make verify` was intentionally not run per operator CPU-budget
+instruction. Current-head GitHub CI is the heavy validation signal for this
+lane.
+
+Narrow local gates run:
+
+```text
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+pytest -q tests/ios/test_info_plist_permission_strings.py tests/test_ios_appstore_asset_validators.py
+plutil -lint ios/PulsePlate/en.lproj/InfoPlist.strings ios/PulsePlate/es.lproj/InfoPlist.strings ios/PulsePlate/ru.lproj/InfoPlist.strings
+cd ios && bundle exec fastlane validate_metadata_package
+git diff --check
+pre-commit run --all-files
+```
+
+Pre-push hooks also passed.
+
+## Merge Readiness
+
+Draft status is intentional until:
+
+- current-head PR CI is complete
+- CodeRabbit/Sourcery/Cubic have no actionable items
+- all review threads are dispositioned
+- strict merge readiness passes

--- a/docs/review/PR_1600_FIXED_MAPPING.md
+++ b/docs/review/PR_1600_FIXED_MAPPING.md
@@ -46,6 +46,7 @@ proof before they are resolved:
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1600#discussion_r3168663349 -> 13e3d855e
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1600#discussion_r3168686984 -> 13e3d855e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1600#pullrequestreview-4206008955 -> 13e3d855e
 
 Disposition: FIXED
 Commit: 13e3d855e

--- a/docs/review/PR_1600_FIXED_MAPPING.md
+++ b/docs/review/PR_1600_FIXED_MAPPING.md
@@ -44,10 +44,6 @@ proof before they are resolved:
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1600#discussion_r3168663349 -> 13e3d855e
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1600#discussion_r3168686984 -> 13e3d855e
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1600#pullrequestreview-4206008955 -> 13e3d855e
-
 Disposition: FIXED
 Commit: 13e3d855e
 Evidence: `tests/ios/test_info_plist_permission_strings.py` now scans Xcode
@@ -56,6 +52,9 @@ Evidence: localized `InfoPlist.strings` files are discovered dynamically.
 Evidence: ATT checks stay fail-closed.
 Evidence: `docs/orchestration/APPSTORE_RELEASE_READINESS_PR2_PERMISSION_PACKET_2026-04-30.md`
 Evidence: current-head CI wording now says iOS unit tests rather than iOS unit/UI.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1600#discussion_r3168663349 -> 13e3d855e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1600#discussion_r3168686984 -> 13e3d855e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1600#pullrequestreview-4206008955 -> 13e3d855e
 
 ## Local Validation
 

--- a/docs/review/PR_1600_FIXED_MAPPING.md
+++ b/docs/review/PR_1600_FIXED_MAPPING.md
@@ -30,11 +30,14 @@ Declared role order:
 
 ## Fixed in Commit Mapping
 
-- Initial implementation -> `10c2d3528`
+- No actionable review comments
 
 ## Discussion Thread Pass
 
-No review threads were present when the draft PR opened.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+No actionable review threads were present when the draft PR opened.
 
 Future actionable review threads must be listed here with disposition-specific
 proof before they are resolved:

--- a/docs/review/PR_1600_FIXED_MAPPING.md
+++ b/docs/review/PR_1600_FIXED_MAPPING.md
@@ -33,7 +33,7 @@ Declared role order:
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-No actionable review threads were present when the draft PR opened.
+Actionable review threads were triaged after the PR moved to ready-for-review.
 
 Future actionable review threads must be listed here with disposition-specific
 proof before they are resolved:
@@ -44,7 +44,17 @@ proof before they are resolved:
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1600#discussion_r3168663349 -> 13e3d855e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1600#discussion_r3168686984 -> 13e3d855e
+
+Disposition: FIXED
+Commit: 13e3d855e
+Evidence: `tests/ios/test_info_plist_permission_strings.py` now scans Xcode
+Evidence: `INFOPLIST_KEY_*UsageDescription` build settings are covered.
+Evidence: localized `InfoPlist.strings` files are discovered dynamically.
+Evidence: ATT checks stay fail-closed.
+Evidence: `docs/orchestration/APPSTORE_RELEASE_READINESS_PR2_PERMISSION_PACKET_2026-04-30.md`
+Evidence: current-head CI wording now says iOS unit tests rather than iOS unit/UI.
 
 ## Local Validation
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -32,8 +32,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P0: App Store release readiness closure for full-feature launch
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (App Store submission blocker)
-  - Target PR: PR #1582 -> PR-0 merged; PR #1591 -> PR-1 merged; `release/appstore-readiness-pr2-permission-purpose-strings` -> PR-2 active; remaining train `release/appstore-readiness-*`
-  - Status: 🛠️ PR-0 merged in PR #1582; PR-1 merged in PR #1591; PR-2 active on branch `release/appstore-readiness-pr2-permission-purpose-strings`
+  - Target PR: PR #1582 -> PR-0 merged; PR #1591 -> PR-1 merged; PR #1600 / `release/appstore-readiness-pr2-permission-purpose-strings` -> PR-2 active; remaining train `release/appstore-readiness-*`
+  - Status: 🛠️ PR-0 merged in PR #1582; PR-1 merged in PR #1591; PR-2 active in draft PR #1600 on branch `release/appstore-readiness-pr2-permission-purpose-strings`
   - Area: iOS / App Store / privacy / release governance
   - Finding Type: release-truth drift blocker
   - Reason (EN): The release shell must align iOS runtime, backend reachability, App Privacy, privacy manifest, permission strings, App Store assets, reviewer notes, and CI validators before public App Store submission. The fix is not to delete assets or reduce product scope; the train must preserve assets and classify each public submission surface as `SUBMIT_READY`, `IMPLEMENTATION_REQUIRED`, or `INTERNAL_REVIEW_ONLY`.
@@ -43,6 +43,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/APPSTORE_RELEASE_READINESS_TASK_PACKET_2026-04-29.md`
     - `docs/orchestration/APPSTORE_RELEASE_READINESS_PR1_PRIVACY_PACKET_2026-04-30.md`
     - `docs/orchestration/APPSTORE_RELEASE_READINESS_PR2_PERMISSION_PACKET_2026-04-30.md`
+    - `docs/review/PR_1600_FIXED_MAPPING.md`
     - `docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md`
     - `ios/fastlane/app_privacy_details.json`
     - `ios/PulsePlate/Services/AppConfig.swift`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -32,8 +32,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P0: App Store release readiness closure for full-feature launch
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P0 (App Store submission blocker)
-  - Target PR: PR #1582 -> PR-0 merged; PR #1591 / `release/appstore-readiness-pr1-privacy-manifest` -> PR-1 active; remaining train `release/appstore-readiness-*`
-  - Status: 🛠️ PR-0 merged in PR #1582; PR-1 active on branch `release/appstore-readiness-pr1-privacy-manifest`
+  - Target PR: PR #1582 -> PR-0 merged; PR #1591 -> PR-1 merged; `release/appstore-readiness-pr2-permission-purpose-strings` -> PR-2 active; remaining train `release/appstore-readiness-*`
+  - Status: 🛠️ PR-0 merged in PR #1582; PR-1 merged in PR #1591; PR-2 active on branch `release/appstore-readiness-pr2-permission-purpose-strings`
   - Area: iOS / App Store / privacy / release governance
   - Finding Type: release-truth drift blocker
   - Reason (EN): The release shell must align iOS runtime, backend reachability, App Privacy, privacy manifest, permission strings, App Store assets, reviewer notes, and CI validators before public App Store submission. The fix is not to delete assets or reduce product scope; the train must preserve assets and classify each public submission surface as `SUBMIT_READY`, `IMPLEMENTATION_REQUIRED`, or `INTERNAL_REVIEW_ONLY`.
@@ -42,6 +42,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/release/APPSTORE_FEATURE_ASSET_MATRIX.md`
     - `docs/orchestration/APPSTORE_RELEASE_READINESS_TASK_PACKET_2026-04-29.md`
     - `docs/orchestration/APPSTORE_RELEASE_READINESS_PR1_PRIVACY_PACKET_2026-04-30.md`
+    - `docs/orchestration/APPSTORE_RELEASE_READINESS_PR2_PERMISSION_PACKET_2026-04-30.md`
     - `docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md`
     - `ios/fastlane/app_privacy_details.json`
     - `ios/PulsePlate/Services/AppConfig.swift`

--- a/ios/PulsePlate/en.lproj/InfoPlist.strings
+++ b/ios/PulsePlate/en.lproj/InfoPlist.strings
@@ -1,11 +1,4 @@
 /* English Info.plist Localization */
 "NSHealthShareUsageDescription" = "PulsePlate reads Health nutrition and body weight data to show wellness progress and planning with your consent.";
-"NSCameraUsageDescription" = "PulsePlate needs camera access to scan product barcodes for food identification.";
-"NSLocationWhenInUseUsageDescription" = "PulsePlate needs location access to find nearby stores and local products.";
-"NSPhotoLibraryUsageDescription" = "PulsePlate needs photo library access to save and share your meal plans.";
-"NSMicrophoneUsageDescription" = "PulsePlate needs microphone access for voice commands and audio notes.";
-"NSContactsUsageDescription" = "PulsePlate needs contacts access to share meal plans with family and friends.";
-"NSFaceIDUsageDescription" = "PulsePlate uses Face ID for secure authentication and quick access to your health information.";
-"NSUserTrackingUsageDescription" = "PulsePlate may use tracking data to personalize your nutritional experience and recommendations.";
 "CFBundleDisplayName" = "PulsePlate";
 "CFBundleName" = "PulsePlate";

--- a/ios/PulsePlate/es.lproj/InfoPlist.strings
+++ b/ios/PulsePlate/es.lproj/InfoPlist.strings
@@ -1,12 +1,5 @@
 /* Spanish Info.plist Localization */
 "NSHealthShareUsageDescription" = "PulsePlate lee nutrición y peso corporal de Health para mostrar progreso y planificación wellness con tu consentimiento.";
-"NSCameraUsageDescription" = "PulsePlate necesita acceso a la cámara para escanear códigos de barras de productos alimenticios.";
-"NSLocationWhenInUseUsageDescription" = "PulsePlate necesita acceso a la ubicación para encontrar tiendas cercanas y productos locales.";
-"NSPhotoLibraryUsageDescription" = "PulsePlate necesita acceso a la biblioteca de fotos para guardar y compartir tus planes de comidas.";
-"NSMicrophoneUsageDescription" = "PulsePlate necesita acceso al micrófono para comandos de voz y notas de audio.";
-"NSContactsUsageDescription" = "PulsePlate necesita acceso a los contactos para compartir planes de comidas con familiares y amigos.";
-"NSFaceIDUsageDescription" = "PulsePlate usa Face ID para autenticación segura y acceso rápido a tu información de salud.";
-"NSUserTrackingUsageDescription" = "PulsePlate puede usar datos de seguimiento para personalizar tu experiencia nutricional y recomendaciones.";
 "CFBundleDisplayName" = "PulsePlate";
 "CFBundleName" = "PulsePlate";
 "CFBundleShortVersionString" = "1.0";

--- a/ios/PulsePlate/ru.lproj/InfoPlist.strings
+++ b/ios/PulsePlate/ru.lproj/InfoPlist.strings
@@ -1,11 +1,4 @@
 /* Russian Info.plist Localization */
 "NSHealthShareUsageDescription" = "PulsePlate читает данные о питании и весе из Health, чтобы с вашего согласия показывать wellness-прогресс и планирование.";
-"NSCameraUsageDescription" = "PulsePlate использует камеру для сканирования штрих-кодов продуктов и их идентификации.";
-"NSLocationWhenInUseUsageDescription" = "PulsePlate использует геолокацию для поиска ближайших магазинов и местных продуктов.";
-"NSPhotoLibraryUsageDescription" = "PulsePlate использует фотоальбом для сохранения и обмена вашим прогрессом питания.";
-"NSMicrophoneUsageDescription" = "PulsePlate использует микрофон для голосовых команд и аудиозаметок.";
-"NSContactsUsageDescription" = "PulsePlate использует контакты для обмена планами питания с семьей и друзьями.";
-"NSFaceIDUsageDescription" = "PulsePlate использует Face ID для безопасной аутентификации и быстрого доступа к вашей информации о здоровье.";
-"NSUserTrackingUsageDescription" = "PulsePlate может использовать данные отслеживания для персонализации вашего опыта питания и рекомендаций.";
 "CFBundleDisplayName" = "PulsePlate";
 "CFBundleName" = "PulsePlate";

--- a/tests/ios/test_info_plist_permission_strings.py
+++ b/tests/ios/test_info_plist_permission_strings.py
@@ -1,0 +1,81 @@
+"""Contracts for iOS permission purpose strings and release capability truth."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IOS_APP_ROOT = REPO_ROOT / "ios/PulsePlate"
+INFO_PLIST_LOCALES = ("en.lproj", "es.lproj", "ru.lproj")
+
+PURPOSE_STRING_PATTERN = re.compile(r'"(?P<key>[^"]+)"\s*=\s*"(?P<value>(?:[^"\\]|\\.)*)";')
+
+ALLOWED_RELEASE_PURPOSE_STRINGS = {"NSHealthShareUsageDescription"}
+
+SENSITIVE_PURPOSE_STRINGS = {
+    "NSCameraUsageDescription": ("AVFoundation", "AVCapture"),
+    "NSLocationWhenInUseUsageDescription": ("CoreLocation", "CLLocation"),
+    "NSPhotoLibraryUsageDescription": ("Photos", "PHPhoto", "PhotosPicker"),
+    "NSMicrophoneUsageDescription": ("AVAudio", "SFSpeech", "NSSpeech"),
+    "NSContactsUsageDescription": ("Contacts", "CNContact"),
+    "NSFaceIDUsageDescription": ("LocalAuthentication", "LAContext"),
+    "NSUserTrackingUsageDescription": ("AppTrackingTransparency", "ATTrackingManager"),
+}
+
+
+def _parse_strings(path: Path) -> dict[str, str]:
+    entries: dict[str, str] = {}
+    for match in PURPOSE_STRING_PATTERN.finditer(path.read_text(encoding="utf-8")):
+        entries[match.group("key")] = match.group("value")
+    return entries
+
+
+def _swift_source_text() -> str:
+    swift_files = sorted(IOS_APP_ROOT.rglob("*.swift"))
+    assert swift_files, "Expected iOS Swift sources for permission runtime checks"
+    return "\n".join(path.read_text(encoding="utf-8") for path in swift_files)
+
+
+def test_release_localizations_keep_only_supported_sensitive_purpose_strings() -> None:
+    for locale in INFO_PLIST_LOCALES:
+        strings_path = IOS_APP_ROOT / locale / "InfoPlist.strings"
+        entries = _parse_strings(strings_path)
+        sensitive_keys = {
+            key for key in entries if key.startswith("NS") and key.endswith("UsageDescription")
+        }
+
+        assert sensitive_keys == ALLOWED_RELEASE_PURPOSE_STRINGS, (
+            f"{strings_path} must only declare release-backed sensitive purpose "
+            f"strings: {sorted(sensitive_keys)}"
+        )
+        assert entries[
+            "NSHealthShareUsageDescription"
+        ].strip(), f"{strings_path} must keep HealthKit read-only consent copy"
+
+
+def test_sensitive_purpose_strings_require_runtime_capability_evidence() -> None:
+    swift_text = _swift_source_text()
+
+    for locale in INFO_PLIST_LOCALES:
+        entries = _parse_strings(IOS_APP_ROOT / locale / "InfoPlist.strings")
+        for purpose_key, runtime_markers in SENSITIVE_PURPOSE_STRINGS.items():
+            if purpose_key not in entries:
+                continue
+
+            assert any(marker in swift_text for marker in runtime_markers), (
+                f"{purpose_key} is present in {locale} without matching runtime "
+                f"capability evidence: {runtime_markers}"
+            )
+
+
+def test_tracking_purpose_string_is_forbidden_without_att_runtime() -> None:
+    swift_text = _swift_source_text()
+    has_att_runtime = "AppTrackingTransparency" in swift_text or "ATTrackingManager" in swift_text
+
+    for locale in INFO_PLIST_LOCALES:
+        entries = _parse_strings(IOS_APP_ROOT / locale / "InfoPlist.strings")
+        assert "NSUserTrackingUsageDescription" not in entries or has_att_runtime, (
+            f"NSUserTrackingUsageDescription in {locale} requires ATT runtime "
+            "implementation and release review"
+        )

--- a/tests/ios/test_info_plist_permission_strings.py
+++ b/tests/ios/test_info_plist_permission_strings.py
@@ -7,13 +7,17 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 IOS_APP_ROOT = REPO_ROOT / "ios/PulsePlate"
-INFO_PLIST_LOCALES = ("en.lproj", "es.lproj", "ru.lproj")
+IOS_PROJECT_FILE = REPO_ROOT / "ios/PulsePlate.xcodeproj/project.pbxproj"
 
 PURPOSE_STRING_PATTERN = re.compile(r'"(?P<key>[^"]+)"\s*=\s*"(?P<value>(?:[^"\\]|\\.)*)";')
+INFOPLIST_BUILD_SETTING_PATTERN = re.compile(
+    r"INFOPLIST_KEY_(?P<key>NS[A-Za-z0-9]+UsageDescription)\s*="
+)
 
 ALLOWED_RELEASE_PURPOSE_STRINGS = {"NSHealthShareUsageDescription"}
 
 SENSITIVE_PURPOSE_STRINGS = {
+    "NSHealthShareUsageDescription": ("HealthKit", "HKHealthStore"),
     "NSCameraUsageDescription": ("AVFoundation", "AVCapture"),
     "NSLocationWhenInUseUsageDescription": ("CoreLocation", "CLLocation"),
     "NSPhotoLibraryUsageDescription": ("Photos", "PHPhoto", "PhotosPicker"),
@@ -24,11 +28,22 @@ SENSITIVE_PURPOSE_STRINGS = {
 }
 
 
+def _info_plist_strings_paths() -> tuple[Path, ...]:
+    paths = tuple(sorted(IOS_APP_ROOT.glob("*.lproj/InfoPlist.strings")))
+    assert paths, "Expected localized InfoPlist.strings under ios/PulsePlate/*.lproj"
+    return paths
+
+
 def _parse_strings(path: Path) -> dict[str, str]:
     entries: dict[str, str] = {}
     for match in PURPOSE_STRING_PATTERN.finditer(path.read_text(encoding="utf-8")):
         entries[match.group("key")] = match.group("value")
     return entries
+
+
+def _project_build_setting_purpose_keys() -> set[str]:
+    text = IOS_PROJECT_FILE.read_text(encoding="utf-8")
+    return {match.group("key") for match in INFOPLIST_BUILD_SETTING_PATTERN.finditer(text)}
 
 
 def _swift_source_text() -> str:
@@ -38,8 +53,7 @@ def _swift_source_text() -> str:
 
 
 def test_release_localizations_keep_only_supported_sensitive_purpose_strings() -> None:
-    for locale in INFO_PLIST_LOCALES:
-        strings_path = IOS_APP_ROOT / locale / "InfoPlist.strings"
+    for strings_path in _info_plist_strings_paths():
         entries = _parse_strings(strings_path)
         sensitive_keys = {
             key for key in entries if key.startswith("NS") and key.endswith("UsageDescription")
@@ -54,28 +68,54 @@ def test_release_localizations_keep_only_supported_sensitive_purpose_strings() -
         ].strip(), f"{strings_path} must keep HealthKit read-only consent copy"
 
 
+def test_built_info_plist_settings_keep_only_supported_sensitive_purpose_strings() -> None:
+    sensitive_keys = _project_build_setting_purpose_keys()
+
+    assert sensitive_keys == ALLOWED_RELEASE_PURPOSE_STRINGS, (
+        f"{IOS_PROJECT_FILE} must only inject release-backed sensitive purpose "
+        f"strings into the built Info.plist: {sorted(sensitive_keys)}"
+    )
+
+
 def test_sensitive_purpose_strings_require_runtime_capability_evidence() -> None:
     swift_text = _swift_source_text()
 
-    for locale in INFO_PLIST_LOCALES:
-        entries = _parse_strings(IOS_APP_ROOT / locale / "InfoPlist.strings")
+    for strings_path in _info_plist_strings_paths():
+        entries = _parse_strings(strings_path)
         for purpose_key, runtime_markers in SENSITIVE_PURPOSE_STRINGS.items():
             if purpose_key not in entries:
                 continue
 
             assert any(marker in swift_text for marker in runtime_markers), (
-                f"{purpose_key} is present in {locale} without matching runtime "
-                f"capability evidence: {runtime_markers}"
+                f"{purpose_key} is present in {strings_path.parent.name} without "
+                f"matching runtime capability evidence: {runtime_markers}"
             )
+
+    for purpose_key in _project_build_setting_purpose_keys():
+        runtime_markers = SENSITIVE_PURPOSE_STRINGS.get(purpose_key)
+        assert runtime_markers is not None, (
+            f"{purpose_key} is injected by {IOS_PROJECT_FILE} without a permission "
+            "runtime evidence contract"
+        )
+        assert any(marker in swift_text for marker in runtime_markers), (
+            f"{purpose_key} is injected by {IOS_PROJECT_FILE} without matching "
+            f"runtime capability evidence: {runtime_markers}"
+        )
 
 
 def test_tracking_purpose_string_is_forbidden_without_att_runtime() -> None:
     swift_text = _swift_source_text()
     has_att_runtime = "AppTrackingTransparency" in swift_text or "ATTrackingManager" in swift_text
 
-    for locale in INFO_PLIST_LOCALES:
-        entries = _parse_strings(IOS_APP_ROOT / locale / "InfoPlist.strings")
+    for strings_path in _info_plist_strings_paths():
+        entries = _parse_strings(strings_path)
         assert "NSUserTrackingUsageDescription" not in entries or has_att_runtime, (
-            f"NSUserTrackingUsageDescription in {locale} requires ATT runtime "
-            "implementation and release review"
+            f"NSUserTrackingUsageDescription in {strings_path.parent.name} requires "
+            "ATT runtime implementation and release review"
         )
+
+    project_keys = _project_build_setting_purpose_keys()
+    assert "NSUserTrackingUsageDescription" not in project_keys or has_att_runtime, (
+        f"NSUserTrackingUsageDescription in {IOS_PROJECT_FILE} requires ATT runtime "
+        "implementation and release review"
+    )


### PR DESCRIPTION
## Summary
- coordinator-first PR-2 slice for App Store readiness permission purpose-string truth
- removes unused sensitive purpose strings from localized iOS InfoPlist metadata
- keeps read-only HealthKit consent copy and adds a fail-closed pytest contract

## Coordinator / Role Order
Task packet: `artifacts/orchestration/task_packets/20ece0834a86.json` (local, gitignored)
Canonical packet: `docs/orchestration/APPSTORE_RELEASE_READINESS_PR2_PERMISSION_PACKET_2026-04-30.md`
Review mapping: `docs/review/PR_1600_FIXED_MAPPING.md`

Declared role order:
1. `agent-coordinator`
2. `ios-engineer-agent`
3. `appstore-release-agent`
4. `privacy-compliance-agent`
5. `security-auditor`
6. `qa-engineer-agent`
7. `bug-hunter`

Skills/plugins used: `pulseplate-app-store-release`, `pulseplate-guards`, `pulseplate-ledger`, `pulseplate-workflow`, `pulseplate-pr-review`, GitHub CLI/plugin, Build iOS Apps context.

## Validation
Local narrow gates only; full local `make verify` intentionally not run per operator CPU budget.

- `python3 scripts/orchestration/check_preflight.py` - PASS
- `python3 scripts/orchestration/check_agent_consistency.py` - PASS
- `pytest -q tests/ios/test_info_plist_permission_strings.py tests/test_ios_appstore_asset_validators.py` - PASS (`39 passed`)
- `plutil -lint ios/PulsePlate/en.lproj/InfoPlist.strings ios/PulsePlate/es.lproj/InfoPlist.strings ios/PulsePlate/ru.lproj/InfoPlist.strings` - PASS
- `cd ios && bundle exec fastlane validate_metadata_package` - PASS
- `git diff --check` - PASS
- `pre-commit run --all-files` - PASS
- pre-push hooks - PASS

## Main CI Note
Opened as draft because the operator explicitly overrode the next-PR start gate while monitoring `main` CI separately. Current-head PR CI is the heavy validation signal for this lane.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1600_FIXED_MAPPING.md`

## Merge Readiness
- Draft until current-head CI and post-open review governance are complete.
- Do not merge until CodeRabbit/Sourcery/Cubic/actionable comments are dispositioned and strict merge readiness passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed unused iOS permission purpose strings from app localizations across languages, preserving only the HealthKit read-only consent copy.

* **Tests**
  * Added validation tests enforcing that release localizations and build settings include only supported permission strings and require runtime evidence for any sensitive permission.

* **Documentation**
  * Added and updated orchestration, task, epic, review, and backlog docs for App Store release readiness PR-2, including updated branch/PR references and validation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->