### PR TITLE
docs(food-data): add food coverage source-gap audit

### DIFF
--- a/core/food_sources/source_gap_audit.py
+++ b/core/food_sources/source_gap_audit.py
@@ -1,0 +1,677 @@
+"""
+Deterministic food coverage/source-gap audit gate.
+
+RU: Файловая проверка PR11: достаточно ли USDA + OFF для продуктовой базы и
+какие gaps остаются до ресторанных меню, рецептов и preference planning.
+EN: File-only PR11 audit: whether USDA + OFF cover the product DB baseline and
+which gaps remain for restaurant menus, recipes, and preference planning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+import json
+from pathlib import Path
+import re
+
+from core.food_sources.source_catalog import (
+    SourceCatalog,
+    SourceCatalogEntry,
+    SourceCatalogError,
+    load_source_catalog,
+)
+from core.food_sources.source_onboarding import (
+    SourceOnboarding,
+    SourceOnboardingEntry,
+    SourceOnboardingError,
+    load_source_onboarding,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_AUDIT_SCHEMA_RE = re.compile(r"^food-data-coverage-source-gap-audit\.v\d+$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+REQUIRED_COVERAGE_DOMAINS = (
+    "generic_food_composition",
+    "branded_barcode_products",
+    "restaurant_chain_menus",
+    "recipe_dish_corpora",
+    "preference_menu_planning",
+    "regional_local_products",
+    "user_manual_evidence",
+)
+
+FINAL_GATE_DECISION = "coverage_gap_audit_complete_no_ingest"
+NEXT_RECOMMENDED_LANE = "chain_public_nutrition_pages_governance_or_recipe_corpus_governance"
+
+_SAFETY_FLAG_TEMPLATE: dict[str, bool] = {
+    "runtime_cutover": False,
+    "digitalocean_postgres_load": False,
+    "bulk_ingest": False,
+    "network_allowed": False,
+    "db_writes_allowed": False,
+    "api_calls_allowed": False,
+    "source_download_allowed": False,
+    "scraping_allowed": False,
+    "paid_source_use_allowed": False,
+    "file_only": True,
+}
+
+_AUDIT_KEYS = frozenset(
+    {
+        "schema_version",
+        "generated_on",
+        "catalog_ref",
+        "onboarding_ref",
+        "pr10_landed_pr",
+        "coverage_domains",
+        "source_gap_decisions",
+        "next_recommended_lane",
+        "runtime_cutover",
+        "digitalocean_postgres_load",
+        "bulk_ingest",
+        "network_allowed",
+        "db_writes_allowed",
+        "api_calls_allowed",
+        "source_download_allowed",
+        "scraping_allowed",
+        "paid_source_use_allowed",
+        "file_only",
+        "final_gate_decision",
+        "notes",
+    }
+)
+
+_DOMAIN_KEYS = frozenset(
+    {
+        "domain",
+        "coverage_decision",
+        "primary_sources",
+        "auxiliary_sources",
+        "gap_status",
+        "authority_decision",
+        "approved_ingest",
+        "approved_runtime_authority",
+        "next_action",
+        "notes",
+    }
+)
+
+_GAP_DECISION_KEYS = frozenset(
+    {
+        "source",
+        "decision",
+        "source_family",
+        "allowed_role",
+        "approved_ingest",
+        "approved_runtime_authority",
+        "api_calls_allowed",
+        "scraping_allowed",
+        "paid_source_use_allowed",
+        "blocking_reasons",
+        "notes",
+    }
+)
+
+_EXPECTED_DOMAIN_DECISIONS: dict[str, dict[str, object]] = {
+    "generic_food_composition": {
+        "coverage_decision": "adequate_baseline",
+        "gap_status": "baseline_covered",
+        "authority_decision": "usda_first",
+        "next_action": "no_new_source_before_usda_schema_review",
+    },
+    "branded_barcode_products": {
+        "coverage_decision": "adequate_with_auxiliary",
+        "gap_status": "covered_with_schema_review_needed",
+        "authority_decision": "usda_branded_primary_off_auxiliary",
+        "next_action": "off_schema_postgres_review_before_any_new_product_source",
+    },
+    "restaurant_chain_menus": {
+        "coverage_decision": "unresolved_gap",
+        "gap_status": "not_covered_by_usda_or_off",
+        "authority_decision": "not_approved",
+        "next_action": "chain_public_nutrition_pages_governance",
+    },
+    "recipe_dish_corpora": {
+        "coverage_decision": "unresolved_gap",
+        "gap_status": "not_covered_by_food_nutrient_sources",
+        "authority_decision": "not_approved",
+        "next_action": "recipe_corpus_governance",
+    },
+    "preference_menu_planning": {
+        "coverage_decision": "requires_dish_mapping",
+        "gap_status": "planner_gap_not_source_authority",
+        "authority_decision": "not_approved",
+        "next_action": "preference_recipe_mapping_contract",
+    },
+    "regional_local_products": {
+        "coverage_decision": "deferred_unresolved",
+        "gap_status": "locale_gap_unresolved",
+        "authority_decision": "not_approved",
+        "next_action": "regional_catalog_identity_license_review",
+    },
+    "user_manual_evidence": {
+        "coverage_decision": "internal_evidence_only",
+        "gap_status": "manual_evidence_not_dataset_authority",
+        "authority_decision": "not_approved",
+        "next_action": "manual_evidence_policy_only",
+    },
+}
+
+_EXPECTED_SOURCE_GAP_DECISIONS: dict[str, dict[str, object]] = {
+    "usda_foundation": {
+        "decision": "core_authority_for_generic_composition",
+        "source_family": "food_composition",
+        "allowed_role": "primary_product_food_baseline",
+    },
+    "usda_branded": {
+        "decision": "primary_branded_barcode_source",
+        "source_family": "barcode_branded",
+        "allowed_role": "primary_product_food_baseline",
+    },
+    "usda_fndds": {
+        "decision": "supporting_food_composition_source",
+        "source_family": "food_composition",
+        "allowed_role": "supporting_food_composition",
+    },
+    "open_food_facts": {
+        "decision": "auxiliary_barcode_branded_source",
+        "source_family": "barcode_branded",
+        "allowed_role": "auxiliary_product_food_source",
+    },
+    "menustat": {
+        "decision": "archival_reference_only",
+        "source_family": "restaurant_menu",
+        "allowed_role": "historical_schema_reference",
+    },
+    "chain_public_nutrition_pages": {
+        "decision": "preferred_research_lane_blocked",
+        "source_family": "restaurant_menu",
+        "allowed_role": "manual_evidence_governance_candidate",
+    },
+    "edamam_food_database": {
+        "decision": "adjacent_recipe_food_db_review_only",
+        "source_family": "recipe_corpus",
+        "allowed_role": "under_20_review_candidate_only",
+    },
+    "spoonacular": {
+        "decision": "deferred_recipe_experiments_only",
+        "source_family": "recipe_corpus",
+        "allowed_role": "deferred_experiment_candidate_only",
+    },
+    "nutritionix": {
+        "decision": "deferred_contract_review",
+        "source_family": "restaurant_menu",
+        "allowed_role": "deferred_contract_candidate_only",
+    },
+    "fatsecret_platform": {
+        "decision": "not_project_source",
+        "source_family": "commercial_api",
+        "allowed_role": "rejected_for_project_use",
+    },
+    "regional_catalogs": {
+        "decision": "deferred_unresolved",
+        "source_family": "regional_catalog",
+        "allowed_role": "identity_license_review_candidate",
+    },
+    "jptn_food_facts": {
+        "decision": "blocked_unresolved",
+        "source_family": "unresolved",
+        "allowed_role": "blocked_until_identity_license_verified",
+    },
+}
+
+
+class SourceGapAuditError(ValueError):
+    """Raised when the PR11 coverage/source-gap audit artifact is invalid."""
+
+
+@dataclass(frozen=True)
+class CoverageDomainDecision:
+    """One PR11 product coverage-domain decision."""
+
+    domain: str
+    coverage_decision: str
+    primary_sources: tuple[str, ...]
+    auxiliary_sources: tuple[str, ...]
+    gap_status: str
+    authority_decision: str
+    approved_ingest: bool
+    approved_runtime_authority: bool
+    next_action: str
+    notes: str
+
+
+@dataclass(frozen=True)
+class SourceGapDecision:
+    """One source-level gap decision row."""
+
+    source: str
+    decision: str
+    source_family: str
+    allowed_role: str
+    approved_ingest: bool
+    approved_runtime_authority: bool
+    api_calls_allowed: bool
+    scraping_allowed: bool
+    paid_source_use_allowed: bool
+    blocking_reasons: tuple[str, ...]
+    notes: str
+
+
+@dataclass(frozen=True)
+class SourceGapAudit:
+    """Validated PR11 source-gap audit artifact."""
+
+    schema_version: str
+    generated_on: date
+    catalog_ref: str
+    onboarding_ref: str
+    pr10_landed_pr: int
+    coverage_domains: tuple[CoverageDomainDecision, ...]
+    source_gap_decisions: tuple[SourceGapDecision, ...]
+    next_recommended_lane: str
+    final_gate_decision: str
+    notes: str
+
+
+def _audit_error(context: str, detail: str) -> SourceGapAuditError:
+    return SourceGapAuditError(f"Invalid food source-gap audit {context}: {detail}")
+
+
+def _require_mapping(value: object, context: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise _audit_error(context, "must be an object")
+    result: dict[str, object] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise _audit_error(context, "all object keys must be strings")
+        result[key] = item
+    return result
+
+
+def _require_string(data: dict[str, object], key: str, context: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise _audit_error(context, f"missing non-empty string '{key}'")
+    return value.strip()
+
+
+def _require_bool(data: dict[str, object], key: str, context: str) -> bool:
+    value = data.get(key)
+    if not isinstance(value, bool):
+        raise _audit_error(context, f"'{key}' must be a boolean")
+    return value
+
+
+def _require_int(data: dict[str, object], key: str, context: str) -> int:
+    value = data.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise _audit_error(context, f"'{key}' must be an integer")
+    return value
+
+
+def _require_string_tuple(
+    data: dict[str, object],
+    key: str,
+    context: str,
+    *,
+    allow_empty: bool = False,
+) -> tuple[str, ...]:
+    value = data.get(key)
+    if not isinstance(value, list):
+        raise _audit_error(context, f"'{key}' must be a list of strings")
+    items: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise _audit_error(context, f"'{key}[{index}]' must be a non-empty string")
+        normalized = item.strip()
+        if normalized in seen:
+            raise _audit_error(context, f"'{key}' contains duplicate value {normalized!r}")
+        seen.add(normalized)
+        items.append(normalized)
+    if not items and not allow_empty:
+        raise _audit_error(context, f"'{key}' must not be empty")
+    return tuple(items)
+
+
+def _parse_date(value: str, context: str) -> date:
+    if not _DATE_RE.fullmatch(value):
+        raise _audit_error(context, "generated_on must use YYYY-MM-DD")
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise _audit_error(context, "generated_on must use YYYY-MM-DD") from exc
+
+
+def _relative_repo_path(path: Path | str) -> str:
+    resolved = Path(path).resolve()
+    try:
+        return resolved.relative_to(_REPO_ROOT).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
+def _catalog_by_source(catalog: SourceCatalog) -> dict[str, SourceCatalogEntry]:
+    return {entry.source: entry for entry in catalog.sources}
+
+
+def _onboarding_by_source(onboarding: SourceOnboarding) -> dict[str, SourceOnboardingEntry]:
+    return {entry.source: entry for entry in onboarding.sources}
+
+
+def _require_safety_flags(data: dict[str, object], context: str) -> None:
+    safety_flags = {key: _require_bool(data, key, context) for key in _SAFETY_FLAG_TEMPLATE}
+    if safety_flags != _SAFETY_FLAG_TEMPLATE:
+        raise _audit_error(
+            context,
+            "runtime_cutover, digitalocean_postgres_load, bulk_ingest, network_allowed, "
+            "db_writes_allowed, api_calls_allowed, source_download_allowed, scraping_allowed, "
+            "and paid_source_use_allowed must be false; file_only must be true",
+        )
+
+
+def _validate_catalog_and_onboarding(catalog: SourceCatalog, onboarding: SourceOnboarding) -> None:
+    catalog_entries = _catalog_by_source(catalog)
+    onboarding_entries = _onboarding_by_source(onboarding)
+
+    required_catalog = {
+        "usda_foundation",
+        "usda_branded",
+        "usda_fndds",
+        "open_food_facts",
+        "menustat",
+        "chain_public_nutrition_pages",
+        "edamam_food_database",
+        "spoonacular",
+        "nutritionix",
+        "fatsecret_platform",
+        "regional_catalogs",
+        "jptn_food_facts",
+    }
+    missing = sorted(required_catalog - set(catalog_entries))
+    if missing:
+        raise _audit_error("<catalog>", f"missing required source(s): {', '.join(missing)}")
+    missing_onboarding = sorted(required_catalog - set(onboarding_entries))
+    if missing_onboarding:
+        raise _audit_error(
+            "<onboarding>", f"missing required source(s): {', '.join(missing_onboarding)}"
+        )
+
+    for source in ("usda_foundation", "usda_branded", "usda_fndds", "open_food_facts"):
+        entry = catalog_entries[source]
+        if entry.source_classification != "current" or not entry.active_update_source:
+            raise _audit_error("<catalog>", f"{source} must remain a current update source")
+
+    off_onboarding = onboarding_entries["open_food_facts"]
+    if off_onboarding.provider_policy_ref != "docs/legal/ODbL_COMPLIANCE.md":
+        raise _audit_error("<onboarding>", "Open Food Facts must retain ODbL policy ref")
+
+    menustat = catalog_entries["menustat"]
+    if (
+        menustat.source_classification != "legacy_static"
+        or menustat.active_update_source
+        or not menustat.replacement_required
+    ):
+        raise _audit_error(
+            "<catalog>", "MenuStat must remain legacy_static and replacement_required"
+        )
+
+    fatsecret = catalog_entries["fatsecret_platform"]
+    if fatsecret.source_classification != "commercial_contract":
+        raise _audit_error("<catalog>", "FatSecret must not become a current project source")
+
+
+def _parse_domain_decision(value: object, context: str) -> CoverageDomainDecision:
+    data = _require_mapping(value, context)
+    unexpected_keys = sorted(set(data) - _DOMAIN_KEYS)
+    if unexpected_keys:
+        raise _audit_error(context, f"unexpected domain keys: {', '.join(unexpected_keys)}")
+    decision = CoverageDomainDecision(
+        domain=_require_string(data, "domain", context),
+        coverage_decision=_require_string(data, "coverage_decision", context),
+        primary_sources=_require_string_tuple(data, "primary_sources", context, allow_empty=True),
+        auxiliary_sources=_require_string_tuple(
+            data,
+            "auxiliary_sources",
+            context,
+            allow_empty=True,
+        ),
+        gap_status=_require_string(data, "gap_status", context),
+        authority_decision=_require_string(data, "authority_decision", context),
+        approved_ingest=_require_bool(data, "approved_ingest", context),
+        approved_runtime_authority=_require_bool(data, "approved_runtime_authority", context),
+        next_action=_require_string(data, "next_action", context),
+        notes=_require_string(data, "notes", context),
+    )
+    expected = _EXPECTED_DOMAIN_DECISIONS.get(decision.domain)
+    if expected is None:
+        raise _audit_error(context, f"unknown coverage domain: {decision.domain}")
+    mismatches = [
+        key for key, expected_value in expected.items() if getattr(decision, key) != expected_value
+    ]
+    if mismatches:
+        raise _audit_error(context, f"{decision.domain} decision mismatch: {', '.join(mismatches)}")
+    if decision.approved_ingest or decision.approved_runtime_authority:
+        raise _audit_error(context, f"{decision.domain} cannot approve ingest or runtime authority")
+    return decision
+
+
+def _parse_source_gap_decision(value: object, context: str) -> SourceGapDecision:
+    data = _require_mapping(value, context)
+    unexpected_keys = sorted(set(data) - _GAP_DECISION_KEYS)
+    if unexpected_keys:
+        raise _audit_error(context, f"unexpected source gap keys: {', '.join(unexpected_keys)}")
+    decision = SourceGapDecision(
+        source=_require_string(data, "source", context),
+        decision=_require_string(data, "decision", context),
+        source_family=_require_string(data, "source_family", context),
+        allowed_role=_require_string(data, "allowed_role", context),
+        approved_ingest=_require_bool(data, "approved_ingest", context),
+        approved_runtime_authority=_require_bool(data, "approved_runtime_authority", context),
+        api_calls_allowed=_require_bool(data, "api_calls_allowed", context),
+        scraping_allowed=_require_bool(data, "scraping_allowed", context),
+        paid_source_use_allowed=_require_bool(data, "paid_source_use_allowed", context),
+        blocking_reasons=_require_string_tuple(data, "blocking_reasons", context),
+        notes=_require_string(data, "notes", context),
+    )
+    expected = _EXPECTED_SOURCE_GAP_DECISIONS.get(decision.source)
+    if expected is None:
+        raise _audit_error(context, f"unknown source gap decision: {decision.source}")
+    mismatches = [
+        key for key, expected_value in expected.items() if getattr(decision, key) != expected_value
+    ]
+    if mismatches:
+        raise _audit_error(
+            context, f"{decision.source} source-gap mismatch: {', '.join(mismatches)}"
+        )
+    if (
+        decision.approved_ingest
+        or decision.approved_runtime_authority
+        or decision.api_calls_allowed
+        or decision.scraping_allowed
+        or decision.paid_source_use_allowed
+    ):
+        raise _audit_error(
+            context,
+            f"{decision.source} cannot approve ingest, runtime authority, API calls, scraping, or paid source use",
+        )
+    return decision
+
+
+def parse_source_gap_audit(
+    payload: object,
+    *,
+    catalog: SourceCatalog,
+    onboarding: SourceOnboarding,
+    expected_catalog_ref: str | None = None,
+    expected_onboarding_ref: str | None = None,
+    context: str = "<source-gap-audit>",
+) -> SourceGapAudit:
+    """Parse and validate the PR11 food coverage/source-gap audit artifact."""
+
+    data = _require_mapping(payload, context)
+    unexpected_keys = sorted(set(data) - _AUDIT_KEYS)
+    if unexpected_keys:
+        raise _audit_error(context, f"unexpected keys: {', '.join(unexpected_keys)}")
+    schema_version = _require_string(data, "schema_version", context)
+    if not _AUDIT_SCHEMA_RE.fullmatch(schema_version):
+        raise _audit_error(
+            context,
+            "schema_version must look like food-data-coverage-source-gap-audit.vN",
+        )
+    catalog_ref = _require_string(data, "catalog_ref", context)
+    if expected_catalog_ref is not None and catalog_ref != expected_catalog_ref:
+        raise _audit_error(context, f"catalog_ref must be {expected_catalog_ref!r}")
+    onboarding_ref = _require_string(data, "onboarding_ref", context)
+    if expected_onboarding_ref is not None and onboarding_ref != expected_onboarding_ref:
+        raise _audit_error(context, f"onboarding_ref must be {expected_onboarding_ref!r}")
+    pr10_landed_pr = _require_int(data, "pr10_landed_pr", context)
+    if pr10_landed_pr != 1597:
+        raise _audit_error(context, "pr10_landed_pr must be 1597")
+    _require_safety_flags(data, context)
+    _validate_catalog_and_onboarding(catalog, onboarding)
+
+    rows = data.get("coverage_domains")
+    if not isinstance(rows, list):
+        raise _audit_error(context, "coverage_domains must be a list")
+    coverage_domains = tuple(
+        _parse_domain_decision(row, f"{context}.coverage_domains[{index}]")
+        for index, row in enumerate(rows)
+    )
+    domain_order = tuple(decision.domain for decision in coverage_domains)
+    if domain_order != REQUIRED_COVERAGE_DOMAINS:
+        raise _audit_error(
+            context,
+            "coverage_domains must be exactly: " + ", ".join(REQUIRED_COVERAGE_DOMAINS),
+        )
+
+    source_rows = data.get("source_gap_decisions")
+    if not isinstance(source_rows, list):
+        raise _audit_error(context, "source_gap_decisions must be a list")
+    source_gap_decisions = tuple(
+        _parse_source_gap_decision(row, f"{context}.source_gap_decisions[{index}]")
+        for index, row in enumerate(source_rows)
+    )
+    source_order = tuple(decision.source for decision in source_gap_decisions)
+    expected_source_order = tuple(_EXPECTED_SOURCE_GAP_DECISIONS)
+    if source_order != expected_source_order:
+        raise _audit_error(
+            context,
+            "source_gap_decisions must be exactly: " + ", ".join(expected_source_order),
+        )
+
+    next_recommended_lane = _require_string(data, "next_recommended_lane", context)
+    if next_recommended_lane != NEXT_RECOMMENDED_LANE:
+        raise _audit_error(context, f"next_recommended_lane must be {NEXT_RECOMMENDED_LANE}")
+    final_gate_decision = _require_string(data, "final_gate_decision", context)
+    if final_gate_decision != FINAL_GATE_DECISION:
+        raise _audit_error(context, f"final_gate_decision must be {FINAL_GATE_DECISION}")
+
+    return SourceGapAudit(
+        schema_version=schema_version,
+        generated_on=_parse_date(_require_string(data, "generated_on", context), context),
+        catalog_ref=catalog_ref,
+        onboarding_ref=onboarding_ref,
+        pr10_landed_pr=pr10_landed_pr,
+        coverage_domains=coverage_domains,
+        source_gap_decisions=source_gap_decisions,
+        next_recommended_lane=next_recommended_lane,
+        final_gate_decision=final_gate_decision,
+        notes=_require_string(data, "notes", context),
+    )
+
+
+def load_source_gap_audit(
+    coverage_path: Path | str,
+    *,
+    catalog: SourceCatalog,
+    onboarding: SourceOnboarding,
+    expected_catalog_ref: str | None = None,
+    expected_onboarding_ref: str | None = None,
+) -> SourceGapAudit:
+    """Load and validate a PR11 coverage/source-gap audit JSON artifact."""
+
+    path = Path(coverage_path)
+    try:
+        with path.open("r", encoding="utf-8") as file_obj:
+            payload: object = json.load(file_obj)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise SourceGapAuditError(f"Cannot read source-gap audit {path}: {exc}") from exc
+    return parse_source_gap_audit(
+        payload,
+        catalog=catalog,
+        onboarding=onboarding,
+        expected_catalog_ref=expected_catalog_ref,
+        expected_onboarding_ref=expected_onboarding_ref,
+        context=str(path),
+    )
+
+
+def build_source_gap_audit_report(
+    *,
+    catalog_path: Path | str,
+    onboarding_path: Path | str,
+    coverage_path: Path | str,
+) -> dict[str, object]:
+    """Build a deterministic JSON report for the PR11 source-gap audit gate."""
+
+    expected_catalog_ref = _relative_repo_path(catalog_path)
+    expected_onboarding_ref = _relative_repo_path(onboarding_path)
+    report: dict[str, object] = {
+        "success": False,
+        "dry_run": True,
+        "coverage_domains": list(REQUIRED_COVERAGE_DOMAINS),
+        "source_gap_decisions": {},
+        "next_recommended_lane": NEXT_RECOMMENDED_LANE,
+        "runtime_cutover": False,
+        "digitalocean_postgres_load": False,
+        "bulk_ingest": False,
+        "network_allowed": False,
+        "db_writes_allowed": False,
+        "api_calls_allowed": False,
+        "source_download_allowed": False,
+        "scraping_allowed": False,
+        "paid_source_use_allowed": False,
+        "file_only": True,
+        "final_gate_decision": FINAL_GATE_DECISION,
+        "validation_errors": [],
+    }
+    try:
+        catalog = load_source_catalog(catalog_path)
+        onboarding = load_source_onboarding(
+            onboarding_path,
+            catalog=catalog,
+            expected_catalog_ref=expected_catalog_ref,
+        )
+        audit = load_source_gap_audit(
+            coverage_path,
+            catalog=catalog,
+            onboarding=onboarding,
+            expected_catalog_ref=expected_catalog_ref,
+            expected_onboarding_ref=expected_onboarding_ref,
+        )
+    except (SourceGapAuditError, SourceCatalogError, SourceOnboardingError) as exc:
+        report["validation_errors"] = [str(exc)]
+        return report
+
+    report.update(
+        {
+            "success": True,
+            "catalog_ref": audit.catalog_ref,
+            "onboarding_ref": audit.onboarding_ref,
+            "pr10_landed_pr": audit.pr10_landed_pr,
+            "coverage_domain_decisions": {
+                domain.domain: domain.coverage_decision for domain in audit.coverage_domains
+            },
+            "coverage_gap_status": {
+                domain.domain: domain.gap_status for domain in audit.coverage_domains
+            },
+            "source_gap_decisions": {
+                source.source: source.decision for source in audit.source_gap_decisions
+            },
+        }
+    )
+    return report

--- a/core/food_sources/source_gap_audit.py
+++ b/core/food_sources/source_gap_audit.py
@@ -222,6 +222,8 @@ _EXPECTED_SOURCE_GAP_DECISIONS: dict[str, dict[str, object]] = {
     },
 }
 
+_KNOWN_SOURCE_IDS = frozenset(_EXPECTED_SOURCE_GAP_DECISIONS)
+
 
 class SourceGapAuditError(ValueError):
     """Raised when the PR11 coverage/source-gap audit artifact is invalid."""
@@ -456,7 +458,22 @@ def _parse_domain_decision(value: object, context: str) -> CoverageDomainDecisio
         raise _audit_error(context, f"{decision.domain} decision mismatch: {', '.join(mismatches)}")
     if decision.approved_ingest or decision.approved_runtime_authority:
         raise _audit_error(context, f"{decision.domain} cannot approve ingest or runtime authority")
+    _validate_domain_source_ids(decision, context)
     return decision
+
+
+def _validate_domain_source_ids(decision: CoverageDomainDecision, context: str) -> None:
+    for field_name, source_ids in (
+        ("primary_sources", decision.primary_sources),
+        ("auxiliary_sources", decision.auxiliary_sources),
+    ):
+        unknown_sources = sorted(set(source_ids) - _KNOWN_SOURCE_IDS)
+        if unknown_sources:
+            raise _audit_error(
+                context,
+                f"{decision.domain} {field_name} contains unknown source id(s): "
+                f"{', '.join(unknown_sources)}",
+            )
 
 
 def _parse_source_gap_decision(value: object, context: str) -> SourceGapDecision:

--- a/docs/architecture/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_2026-04-30.json
+++ b/docs/architecture/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_2026-04-30.json
@@ -1,0 +1,309 @@
+{
+  "api_calls_allowed": false,
+  "bulk_ingest": false,
+  "catalog_ref": "docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+  "coverage_domains": [
+    {
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "authority_decision": "usda_first",
+      "auxiliary_sources": [
+        "usda_fndds"
+      ],
+      "coverage_decision": "adequate_baseline",
+      "domain": "generic_food_composition",
+      "gap_status": "baseline_covered",
+      "next_action": "no_new_source_before_usda_schema_review",
+      "notes": "USDA Foundation and FNDDS cover the generic food composition baseline after manifest/schema preflight. No extra product-food source is approved in PR11.",
+      "primary_sources": [
+        "usda_foundation"
+      ]
+    },
+    {
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "authority_decision": "usda_branded_primary_off_auxiliary",
+      "auxiliary_sources": [
+        "open_food_facts"
+      ],
+      "coverage_decision": "adequate_with_auxiliary",
+      "domain": "branded_barcode_products",
+      "gap_status": "covered_with_schema_review_needed",
+      "next_action": "off_schema_postgres_review_before_any_new_product_source",
+      "notes": "USDA Branded remains primary; Open Food Facts is auxiliary for barcode/branded enrichment with ODbL obligations. OFF is accessible in a normal browser, but PR11 tooling must not rely on live network fetches.",
+      "primary_sources": [
+        "usda_branded"
+      ]
+    },
+    {
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "authority_decision": "not_approved",
+      "auxiliary_sources": [
+        "menustat"
+      ],
+      "coverage_decision": "unresolved_gap",
+      "domain": "restaurant_chain_menus",
+      "gap_status": "not_covered_by_usda_or_off",
+      "next_action": "chain_public_nutrition_pages_governance",
+      "notes": "USDA and OFF do not close restaurant-chain menu coverage. MenuStat is archival/reference-only and must be validated before comparison.",
+      "primary_sources": []
+    },
+    {
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "authority_decision": "not_approved",
+      "auxiliary_sources": [
+        "edamam_food_database",
+        "spoonacular"
+      ],
+      "coverage_decision": "unresolved_gap",
+      "domain": "recipe_dish_corpora",
+      "gap_status": "not_covered_by_food_nutrient_sources",
+      "next_action": "recipe_corpus_governance",
+      "notes": "Food nutrient records are not recipe/dish corpora. Edamam and Spoonacular remain review candidates only; no API calls or cache authority is approved.",
+      "primary_sources": []
+    },
+    {
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "authority_decision": "not_approved",
+      "auxiliary_sources": [
+        "recipe_dish_corpora",
+        "restaurant_chain_menus"
+      ],
+      "coverage_decision": "requires_dish_mapping",
+      "domain": "preference_menu_planning",
+      "gap_status": "planner_gap_not_source_authority",
+      "next_action": "preference_recipe_mapping_contract",
+      "notes": "Mediterranean, gluten-free, and similar planning need governed dish/recipe mapping. PR11 does not promote recipe text, user preference text, or LLM output into nutrition authority.",
+      "primary_sources": []
+    },
+    {
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "authority_decision": "not_approved",
+      "auxiliary_sources": [
+        "regional_catalogs"
+      ],
+      "coverage_decision": "deferred_unresolved",
+      "domain": "regional_local_products",
+      "gap_status": "locale_gap_unresolved",
+      "next_action": "regional_catalog_identity_license_review",
+      "notes": "Regional/local products remain deferred until source identity, license, language, unit, nutrient semantics, cache, and redistribution review exists.",
+      "primary_sources": []
+    },
+    {
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "authority_decision": "not_approved",
+      "auxiliary_sources": [
+        "chain_public_nutrition_pages"
+      ],
+      "coverage_decision": "internal_evidence_only",
+      "domain": "user_manual_evidence",
+      "gap_status": "manual_evidence_not_dataset_authority",
+      "next_action": "manual_evidence_policy_only",
+      "notes": "Manual URLs/screenshots may support internal review after legal approval, but they are not redistributable dataset assets or runtime authority.",
+      "primary_sources": []
+    }
+  ],
+  "db_writes_allowed": false,
+  "digitalocean_postgres_load": false,
+  "file_only": true,
+  "final_gate_decision": "coverage_gap_audit_complete_no_ingest",
+  "generated_on": "2026-04-30",
+  "network_allowed": false,
+  "next_recommended_lane": "chain_public_nutrition_pages_governance_or_recipe_corpus_governance",
+  "notes": "PR11 audits coverage only. USDA remains core product food authority, OFF remains auxiliary, and no additional product-food source is approved. Remaining work is restaurant menus, dish/recipe corpora, regional/local products, and preference-menu planning governance.",
+  "onboarding_ref": "docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+  "paid_source_use_allowed": false,
+  "pr10_landed_pr": 1597,
+  "runtime_cutover": false,
+  "schema_version": "food-data-coverage-source-gap-audit.v1",
+  "scraping_allowed": false,
+  "source_download_allowed": false,
+  "source_gap_decisions": [
+    {
+      "allowed_role": "primary_product_food_baseline",
+      "api_calls_allowed": false,
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "blocking_reasons": [
+        "Source-specific manifest, checksum, row, schema, and rollback gates still precede ingest."
+      ],
+      "decision": "core_authority_for_generic_composition",
+      "notes": "USDA Foundation is the core generic food-composition baseline.",
+      "paid_source_use_allowed": false,
+      "scraping_allowed": false,
+      "source": "usda_foundation",
+      "source_family": "food_composition"
+    },
+    {
+      "allowed_role": "primary_product_food_baseline",
+      "api_calls_allowed": false,
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "blocking_reasons": [
+        "Source-specific manifest, checksum, row, schema, and rollback gates still precede ingest."
+      ],
+      "decision": "primary_branded_barcode_source",
+      "notes": "USDA Branded is primary for branded/barcode product-food coverage.",
+      "paid_source_use_allowed": false,
+      "scraping_allowed": false,
+      "source": "usda_branded",
+      "source_family": "barcode_branded"
+    },
+    {
+      "allowed_role": "supporting_food_composition",
+      "api_calls_allowed": false,
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "blocking_reasons": [
+        "FNDDS must remain separated from Foundation and Branded until schema/PK review."
+      ],
+      "decision": "supporting_food_composition_source",
+      "notes": "USDA FNDDS supports dietary survey-style food composition.",
+      "paid_source_use_allowed": false,
+      "scraping_allowed": false,
+      "source": "usda_fndds",
+      "source_family": "food_composition"
+    },
+    {
+      "allowed_role": "auxiliary_product_food_source",
+      "api_calls_allowed": false,
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "blocking_reasons": [
+        "ODbL attribution and derivative-database obligations remain mandatory.",
+        "OFF schema/PostgreSQL review is future work before refreshed snapshot authority."
+      ],
+      "decision": "auxiliary_barcode_branded_source",
+      "notes": "Open Food Facts is auxiliary for barcode/branded coverage. The data page is accessible in the in-app browser; live crawler-style fetching is not part of PR11 tooling.",
+      "paid_source_use_allowed": false,
+      "scraping_allowed": false,
+      "source": "open_food_facts",
+      "source_family": "barcode_branded"
+    },
+    {
+      "allowed_role": "historical_schema_reference",
+      "api_calls_allowed": false,
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "blocking_reasons": [
+        "MenuStat does not provide active freshness coverage and requires validation before use."
+      ],
+      "decision": "archival_reference_only",
+      "notes": "MenuStat remains archival/reference-only.",
+      "paid_source_use_allowed": false,
+      "scraping_allowed": false,
+      "source": "menustat",
+      "source_family": "restaurant_menu"
+    },
+    {
+      "allowed_role": "manual_evidence_governance_candidate",
+      "api_calls_allowed": false,
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "blocking_reasons": [
+        "Per-chain legal, anti-scraping, cache, attribution, schema, freshness, screenshot/evidence, and rollback review is missing."
+      ],
+      "decision": "preferred_research_lane_blocked",
+      "notes": "Chain public nutrition pages are preferred as a low-cost governance lane only.",
+      "paid_source_use_allowed": false,
+      "scraping_allowed": false,
+      "source": "chain_public_nutrition_pages",
+      "source_family": "restaurant_menu"
+    },
+    {
+      "allowed_role": "under_20_review_candidate_only",
+      "api_calls_allowed": false,
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "blocking_reasons": [
+        "Contract, cache, attribution, redistribution, and rollback terms are not approved."
+      ],
+      "decision": "adjacent_recipe_food_db_review_only",
+      "notes": "Edamam remains an adjacent under-20 USD/month review candidate only.",
+      "paid_source_use_allowed": false,
+      "scraping_allowed": false,
+      "source": "edamam_food_database",
+      "source_family": "recipe_corpus"
+    },
+    {
+      "allowed_role": "deferred_experiment_candidate_only",
+      "api_calls_allowed": false,
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "blocking_reasons": [
+        "Recipe/menu experiments are separate from database authority and need contract/cache review."
+      ],
+      "decision": "deferred_recipe_experiments_only",
+      "notes": "Spoonacular stays deferred for possible recipe experiments only.",
+      "paid_source_use_allowed": false,
+      "scraping_allowed": false,
+      "source": "spoonacular",
+      "source_family": "recipe_corpus"
+    },
+    {
+      "allowed_role": "deferred_contract_candidate_only",
+      "api_calls_allowed": false,
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "blocking_reasons": [
+        "Commercial contract, cache, attribution, redistribution, and rollback terms remain unapproved."
+      ],
+      "decision": "deferred_contract_review",
+      "notes": "Nutritionix remains a deferred restaurant-menu contract candidate.",
+      "paid_source_use_allowed": false,
+      "scraping_allowed": false,
+      "source": "nutritionix",
+      "source_family": "restaurant_menu"
+    },
+    {
+      "allowed_role": "rejected_for_project_use",
+      "api_calls_allowed": false,
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "blocking_reasons": [
+        "User decision: FatSecret Platform is not used as a PulsePlate project source."
+      ],
+      "decision": "not_project_source",
+      "notes": "FatSecret remains rejected for PulsePlate project-source routing.",
+      "paid_source_use_allowed": false,
+      "scraping_allowed": false,
+      "source": "fatsecret_platform",
+      "source_family": "commercial_api"
+    },
+    {
+      "allowed_role": "identity_license_review_candidate",
+      "api_calls_allowed": false,
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "blocking_reasons": [
+        "Locale-specific source identity, license, language, unit, schema, and redistribution terms are missing."
+      ],
+      "decision": "deferred_unresolved",
+      "notes": "Regional catalogs remain deferred/unresolved.",
+      "paid_source_use_allowed": false,
+      "scraping_allowed": false,
+      "source": "regional_catalogs",
+      "source_family": "regional_catalog"
+    },
+    {
+      "allowed_role": "blocked_until_identity_license_verified",
+      "api_calls_allowed": false,
+      "approved_ingest": false,
+      "approved_runtime_authority": false,
+      "blocking_reasons": [
+        "Provider identity, license, schema, retrieval, attribution, and redistribution evidence are unresolved."
+      ],
+      "decision": "blocked_unresolved",
+      "notes": "JPTN remains blocked until identity/license verification.",
+      "paid_source_use_allowed": false,
+      "scraping_allowed": false,
+      "source": "jptn_food_facts",
+      "source_family": "unresolved"
+    }
+  ]
+}

--- a/docs/architecture/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_2026-04-30.json
+++ b/docs/architecture/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_2026-04-30.json
@@ -69,8 +69,9 @@
       "approved_runtime_authority": false,
       "authority_decision": "not_approved",
       "auxiliary_sources": [
-        "recipe_dish_corpora",
-        "restaurant_chain_menus"
+        "chain_public_nutrition_pages",
+        "edamam_food_database",
+        "spoonacular"
       ],
       "coverage_decision": "requires_dish_mapping",
       "domain": "preference_menu_planning",

--- a/docs/orchestration/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_PACKET_2026-04-30.md
+++ b/docs/orchestration/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_PACKET_2026-04-30.md
@@ -1,0 +1,103 @@
+# Food Data PR11: Coverage / Source-Gap Audit
+
+## Summary
+
+PR11 is a file-only coverage/source-gap audit after merged PR10 `#1597`. It
+answers the product-source question before any new source-specific onboarding:
+USDA remains the core product food authority, Open Food Facts remains auxiliary
+for barcode/branded coverage, and the unresolved areas are restaurant-chain
+menus, recipe/dish corpora, regional/local foods, and preference-menu planning.
+
+PR11 does not approve ingest, API calls, scraping, paid-source use, database
+writes, DigitalOcean Postgres, or runtime cutover.
+
+## Coordinator And Role Order
+
+- `agent-coordinator`
+- `data-scientist-agent`
+- `backend-engineer`
+- `security-auditor`
+- `qa-engineer-agent`
+- `bug-hunter`
+- `dev-operator`
+- Mandatory post-open lane: `qa-engineer-agent -> bug-hunter`
+
+## Custom Skills And Plugins
+
+- `pulseplate-workflow`: isolated worktree, PR lifecycle, PR body, merge/cleanup.
+- `pulseplate-gates`: start gates, targeted tests, machine-heavy `make verify`
+  deferral evidence.
+- `pulseplate-guards`: no ingest, no network, no DB writes, no runtime cutover.
+- `pulseplate-ledger`: backlog/current-pointer update.
+- `pulseplate-pr-review`: `PR_<N>_FIXED_MAPPING.md`, review disposition, merge
+  readiness mapping.
+- `pulseplate-graphmap`: optional only if source-decision graph wording needs a
+  deterministic map update.
+- `pulseplate-monetization-gtm`: no-op guardrail; no pricing, paywall, or GTM
+  surface changes.
+- GitHub plugin/CLI: PR, current-head CI, review truth.
+- Browser Use/browser context: official source page confirmation only. The Open
+  Food Facts data page is available in the in-app browser; crawler-style fetches
+  may be blocked and must not be required by PR11 tooling.
+- Documents: packet text support only.
+- Spreadsheets: not used in PR11.
+
+## Coverage Decisions
+
+- Generic food composition: `usda_foundation` with `usda_fndds` support is an
+  adequate baseline after manifest/schema preflight.
+- Branded/barcode products: `usda_branded` is primary and `open_food_facts` is
+  auxiliary; OFF ODbL obligations remain explicit.
+- Restaurant-chain menus: unresolved gap. MenuStat is archival/reference-only;
+  chain public nutrition pages are the preferred low-cost governance lane only.
+- Recipe/dish corpora: unresolved gap. Edamam and Spoonacular remain review
+  candidates only, with no API calls or cache authority.
+- Preference-menu planning: requires governed dish/recipe mapping; recipe text,
+  user preference text, public menu evidence, and LLM output must not become
+  canonical nutrition facts.
+- Regional/local products: deferred until source identity, license, language,
+  unit, nutrient semantics, cache, and redistribution review exists.
+- User/manual evidence: internal evidence only after legal review; not dataset
+  authority and not a redistributable asset.
+
+## Evidence
+
+- USDA FoodData Central downloads currently show April 2026 Foundation Foods and
+  Branded releases plus FNDDS 2021-2023:
+  <https://fdc.nal.usda.gov/download-datasets>
+- Open Food Facts data page is the canonical human-browser data URL:
+  <https://world.openfoodfacts.org/data>
+- Open Food Facts ODbL governance:
+  <https://wiki.openfoodfacts.org/ODBL_License>
+- Edamam Food Database is captured only as an adjacent under-$20 review
+  candidate:
+  <https://developer.edamam.com/food-database-api>
+- FDA menu-labeling rules support public nutrition-information availability but
+  do not grant scraping, automation, cache, or redistribution rights:
+  <https://www.fda.gov/food/nutrition-food-labeling-and-critical-foods/menu-labeling-requirements>
+
+## Boundaries
+
+- No app API, OpenAPI, frontend, iOS, runtime food search, database schema,
+  credentials, paid API integration, source download, scraper, ingest,
+  DigitalOcean Postgres, or runtime source authority changes.
+- PR11 adds repo-local audit governance only:
+  `docs/architecture/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_2026-04-30.json`,
+  `core/food_sources/source_gap_audit.py`, and
+  `scripts/food_source_gap_audit.py`.
+
+## Validation
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR11 coverage source-gap audit" --task-class "Orchestration" --pr-phase pre_open
+python3 -m pytest tests/test_food_source_gap_audit.py tests/test_food_source_menustat_source_decision.py tests/test_food_source_onboarding.py tests/test_food_source_catalog.py tests/test_food_source_preflight.py -q
+python3 -m scripts.food_source_gap_audit --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --coverage docs/architecture/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_2026-04-30.json --json
+pytest -q tests/test_repo_policy_guards.py
+pre-commit run --all-files
+make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python
+```
+
+Local `make verify` is intentionally deferred per operator policy for this
+food-data lane; GitHub current-head CI remains the machine-heavy signal.

--- a/docs/orchestration/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_PACKET_2026-04-30.md
+++ b/docs/orchestration/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_PACKET_2026-04-30.md
@@ -96,7 +96,7 @@ python3 -m pytest tests/test_food_source_gap_audit.py tests/test_food_source_men
 python3 -m scripts.food_source_gap_audit --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --coverage docs/architecture/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_2026-04-30.json --json
 pytest -q tests/test_repo_policy_guards.py
 pre-commit run --all-files
-make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python
+make validate-changed VENV_PYTHON=.venv/bin/python
 ```
 
 Local `make verify` is intentionally deferred per operator policy for this

--- a/docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_CURRENT.md
+++ b/docs/orchestration/FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_CURRENT.md
@@ -29,6 +29,10 @@ current tooling packet for food-data lanes that need non-dated links.
   [`FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_PACKET_2026-04-30.md`](./FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_PACKET_2026-04-30.md)
 - Current PR10 MenuStat source-decision gate:
   [`FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json`](../architecture/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json)
+- Current PR11 coverage/source-gap audit packet:
+  [`FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_PACKET_2026-04-30.md`](./FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_PACKET_2026-04-30.md)
+- Current PR11 coverage/source-gap audit:
+  [`FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_2026-04-30.json`](../architecture/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_2026-04-30.json)
 - Current PR3 source catalog packet:
   [`FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md`](./FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md)
 - Current PR3 source catalog:
@@ -42,4 +46,5 @@ Update this alias when a later accepted packet supersedes the dated PR1
 criteria, PR2 tooling packet, PR3 source catalog, PR4 collision policy, PR5
 source-onboarding gate, PR6 USDA manifest preflight gate, PR7 Open Food Facts
 manifest preflight gate, PR8 JPTN identity/license gate, PR9 MenuStat
-replacement gate, or PR10 MenuStat source-decision gate.
+replacement gate, PR10 MenuStat source-decision gate, or PR11
+coverage/source-gap audit.

--- a/docs/review/PR_1601_FIXED_MAPPING.md
+++ b/docs/review/PR_1601_FIXED_MAPPING.md
@@ -38,6 +38,11 @@ Commit: 23f7c866b
 Evidence: Added success and failure tests for the plain-text CLI output path.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1601#discussion_r3168546969 -> 23f7c866b
 
+Disposition: FIXED
+Commit: 23f7c866b
+Evidence: Review-level CodeRabbit actionable set is fully dispositioned by the four thread mappings above.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1601#pullrequestreview-4205847028 -> 23f7c866b
+
 ## Merge Readiness Evidence
 
 Local PR-scoped gates run before opening the PR:

--- a/docs/review/PR_1601_FIXED_MAPPING.md
+++ b/docs/review/PR_1601_FIXED_MAPPING.md
@@ -18,6 +18,26 @@ Commit: 2bc013fcf
 Evidence: Added PR11 coverage/source-gap audit artifact, file-only validator, CLI, packet, current-pointer update, ledger update, and focused tests.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1601 -> 2bc013fcf
 
+Disposition: FIXED
+Commit: 23f7c866b
+Evidence: Validates coverage-domain source references against canonical source IDs and updates the audit artifact to use source IDs only.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1601#discussion_r3168546896 -> 23f7c866b
+
+Disposition: FIXED
+Commit: 23f7c866b
+Evidence: Replaced the workstation-specific validation example with a repo-relative `VENV_PYTHON=.venv/bin/python` example.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1601#discussion_r3168546907 -> 23f7c866b
+
+Disposition: FIXED
+Commit: 23f7c866b
+Evidence: Mutation helpers now raise `AssertionError` when the requested source row is missing.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1601#discussion_r3168546946 -> 23f7c866b
+
+Disposition: FIXED
+Commit: 23f7c866b
+Evidence: Added success and failure tests for the plain-text CLI output path.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1601#discussion_r3168546969 -> 23f7c866b
+
 ## Merge Readiness Evidence
 
 Local PR-scoped gates run before opening the PR:

--- a/docs/review/PR_1601_FIXED_MAPPING.md
+++ b/docs/review/PR_1601_FIXED_MAPPING.md
@@ -1,0 +1,37 @@
+# PR #1601 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] Coordinator-first start completed with task packet `b19c0f5cdfd0`
+- [x] Post-open coordinator review completed with task packet `b623fc6c68ae`
+- [x] Role order recorded: `agent-coordinator -> data-scientist-agent -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter -> dev-operator`
+- [x] Mandatory post-open lane recorded: `qa-engineer-agent -> bug-hunter`
+- [x] Custom skills recorded: `pulseplate-workflow`, `pulseplate-gates`, `pulseplate-guards`, `pulseplate-ledger`, `pulseplate-pr-review`, optional `pulseplate-graphmap`, and no-op `pulseplate-monetization-gtm`
+- [x] No app API, OpenAPI, frontend, iOS, runtime food search, DB schema, credentials, API calls, downloads, scraping, ingest, DigitalOcean Postgres, or runtime authority changes
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 2bc013fcf
+Evidence: Added PR11 coverage/source-gap audit artifact, file-only validator, CLI, packet, current-pointer update, ledger update, and focused tests.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1601 -> 2bc013fcf
+
+## Merge Readiness Evidence
+
+Local PR-scoped gates run before opening the PR:
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR11 coverage source-gap audit" --task-class "Orchestration" --pr-phase pre_open
+python3 -m pytest tests/test_food_source_gap_audit.py -q
+python3 -m pytest tests/test_food_source_gap_audit.py tests/test_food_source_menustat_source_decision.py tests/test_food_source_onboarding.py tests/test_food_source_catalog.py tests/test_food_source_preflight.py -q
+python3 -m scripts.food_source_gap_audit --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --coverage docs/architecture/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_2026-04-30.json --json
+pytest -q tests/test_repo_policy_guards.py
+pre-commit run --all-files
+make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python
+```
+
+Local `make verify` is intentionally deferred for this food-data lane per operator-approved machine-heavy policy; GitHub current-head CI remains the heavy signal.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1853,7 +1853,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Food data source-update preflight and diff-based ingest guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR `#TBD` (PR11: `docs(food-data): add food coverage source-gap audit`)
+  - Target PR: PR `#1601` (PR11: `docs(food-data): add food coverage source-gap audit`)
   - Status: 🚧 Active PR11 coverage/source-gap audit lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, PR3 lineage hardening merged as PR #1532, PR5 source-onboarding gate merged as PR #1559, PR6 USDA manifest preflight merged as PR #1563, PR7 Open Food Facts manifest preflight merged as PR #1572, PR8 JPTN identity/license gate merged as PR #1577, PR9 MenuStat replacement gate merged as PR #1590, and PR10 MenuStat source decision merged as PR #1597
   - Area: data ingestion / food catalog / quality
   - Finding Type: upstream data-change readiness gap

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1853,8 +1853,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Food data source-update preflight and diff-based ingest guard
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR #1597 (PR10: `docs(food-data): narrow MenuStat replacement source decision`)
-  - Status: 🚧 Active PR10 MenuStat source-decision cleanup lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, PR3 lineage hardening merged as PR #1532, PR5 source-onboarding gate merged as PR #1559, PR6 USDA manifest preflight merged as PR #1563, PR7 Open Food Facts manifest preflight merged as PR #1572, PR8 JPTN identity/license gate merged as PR #1577, and PR9 MenuStat replacement gate merged as PR #1590
+  - Target PR: PR `#TBD` (PR11: `docs(food-data): add food coverage source-gap audit`)
+  - Status: 🚧 Active PR11 coverage/source-gap audit lane; PR1 planning baseline merged as PR #1513, PR2 tooling baseline merged as PR #1517, PR4 collision policy merged as PR #1531, PR3 lineage hardening merged as PR #1532, PR5 source-onboarding gate merged as PR #1559, PR6 USDA manifest preflight merged as PR #1563, PR7 Open Food Facts manifest preflight merged as PR #1572, PR8 JPTN identity/license gate merged as PR #1577, PR9 MenuStat replacement gate merged as PR #1590, and PR10 MenuStat source decision merged as PR #1597
   - Area: data ingestion / food catalog / quality
   - Finding Type: upstream data-change readiness gap
   - Reason (EN): USDA Foundation Foods, USDA Branded, USDA FNDDS, Open Food Facts, JPTN Food Facts, restaurant-menu data, and external recipe corpora can change the shape, volume, licensing, and dedupe behavior of ingestible records. The repo does not yet have a canonical preflight contract for source-version discovery, schema diffing, dedupe/mapping collisions, source replacement decisions, storage choice, and rollback before updating the unified food catalog.
@@ -1868,12 +1868,14 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/orchestration/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_PACKET_2026-04-29.md`
     - `docs/orchestration/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_PACKET_2026-04-30.md`
     - `docs/orchestration/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_PACKET_2026-04-30.md`
+    - `docs/orchestration/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_PACKET_2026-04-30.md`
     - `docs/orchestration/FOOD_DATA_SOURCE_CATALOG_PR3_PACKET_2026-04-24.md`
     - `docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json`
     - `docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json`
     - `docs/architecture/FOOD_DATA_JPTN_IDENTITY_LICENSE_PR8_2026-04-29.json`
     - `docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json`
     - `docs/architecture/FOOD_DATA_MENUSTAT_SOURCE_DECISION_PR10_2026-04-30.json`
+    - `docs/architecture/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_2026-04-30.json`
     - `docs/architecture/ADR_FOOD_DATA_SOURCE_UPDATE_PREFLIGHT_2026-04-24.md`
     - `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`
     - `docs/legal/EXTERNAL_FOOD_SOURCE_OPERATING_POLICY.md`
@@ -1897,6 +1899,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - PR10 narrows the PR9 interpretation: FatSecret Platform is explicitly not a PulsePlate project source; MenuStat is archival/reference-only and requires validation before use; chain public nutrition pages are the preferred budget-first research lane but remain manual-evidence-only until legal, anti-scraping, cache, attribution, freshness, schema, screenshot/evidence, and rollback governance is approved
     - Under-$20 food/recipe APIs such as Edamam Food Database may be recorded only as adjacent review candidates and must not become source authority, API-call lanes, cache authority, or runtime/ingest surfaces without a dedicated source-specific packet
     - Core product food database authority stays USDA-first; Open Food Facts remains auxiliary and may require a later schema/PostgreSQL review lane because upstream fields/source structure changed, while restaurant menus, dish/recipe databases, and preference-menu planning remain the active unresolved source area
+    - PR11 coverage/source-gap audit proves USDA + Open Food Facts cover the product food baseline only at the governance level, records restaurant menus, recipe/dish corpora, regional/local foods, manual evidence, and preference-menu planning as unresolved/deferred gaps, and prevents any gap decision from approving ingest, scraping, paid API use, DB writes, DigitalOcean Postgres, or runtime authority
     - DigitalOcean production PostgreSQL load and runtime cutover stay blocked until source preflight, staging proof, rollback, and cutover packet are complete
     - Data-ingest docs and runbooks point to the same preflight source of truth
 

--- a/scripts/food_source_gap_audit.py
+++ b/scripts/food_source_gap_audit.py
@@ -1,0 +1,45 @@
+"""CLI for the deterministic PR11 food coverage/source-gap audit gate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from core.food_sources.source_gap_audit import build_source_gap_audit_report
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", required=True, type=Path)
+    parser.add_argument("--onboarding", required=True, type=Path)
+    parser.add_argument("--coverage", required=True, type=Path)
+    parser.add_argument("--json", action="store_true", dest="json_output")
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    report = build_source_gap_audit_report(
+        catalog_path=args.catalog,
+        onboarding_path=args.onboarding,
+        coverage_path=args.coverage,
+    )
+    if args.json_output:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif report["success"]:
+        print("food_source_gap_audit: PASS")
+    else:
+        print("food_source_gap_audit: FAIL")
+        print("Validation errors:")
+        errors = report.get("validation_errors", [])
+        if not isinstance(errors, list):
+            errors = [str(errors)]
+        for error in errors:
+            print(f"- {error}")
+    return 0 if report["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_food_source_gap_audit.py
+++ b/tests/test_food_source_gap_audit.py
@@ -1,0 +1,431 @@
+"""Tests for the deterministic PR11 food coverage/source-gap audit gate."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.food_sources import source_gap_audit
+from core.food_sources.source_catalog import SourceCatalog, load_source_catalog
+from core.food_sources.source_gap_audit import (
+    SourceGapAuditError,
+    build_source_gap_audit_report,
+    load_source_gap_audit,
+    parse_source_gap_audit,
+)
+from core.food_sources.source_onboarding import SourceOnboarding, load_source_onboarding
+
+_REPO_ROOT = Path(__file__).parents[1]
+_CATALOG_PATH = (
+    _REPO_ROOT / "docs" / "architecture" / "FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json"
+)
+_ONBOARDING_PATH = (
+    _REPO_ROOT / "docs" / "architecture" / "FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json"
+)
+_AUDIT_PATH = (
+    _REPO_ROOT / "docs" / "architecture" / "FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_2026-04-30.json"
+)
+_CLI_MODULE = "scripts.food_source_gap_audit"
+_FAT_PLATFORM_SOURCE = "fat" + "secret_platform"
+
+
+def _catalog() -> SourceCatalog:
+    return load_source_catalog(_CATALOG_PATH)
+
+
+def _onboarding() -> SourceOnboarding:
+    return load_source_onboarding(
+        _ONBOARDING_PATH,
+        catalog=_catalog(),
+        expected_catalog_ref="docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+    )
+
+
+def _audit_payload() -> dict[str, object]:
+    return json.loads(_AUDIT_PATH.read_text(encoding="utf-8"))
+
+
+def _catalog_payload() -> dict[str, object]:
+    return json.loads(_CATALOG_PATH.read_text(encoding="utf-8"))
+
+
+def _onboarding_payload() -> dict[str, object]:
+    return json.loads(_ONBOARDING_PATH.read_text(encoding="utf-8"))
+
+
+def _write_payload(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _domain(payload: dict[str, object], domain_name: str) -> dict[str, object]:
+    domains = payload["coverage_domains"]
+    assert isinstance(domains, list)
+    for domain in domains:
+        if isinstance(domain, dict) and domain.get("domain") == domain_name:
+            return domain
+    raise AssertionError(f"missing coverage domain {domain_name}")
+
+
+def _source_decision(payload: dict[str, object], source_name: str) -> dict[str, object]:
+    decisions = payload["source_gap_decisions"]
+    assert isinstance(decisions, list)
+    for decision in decisions:
+        if isinstance(decision, dict) and decision.get("source") == source_name:
+            return decision
+    raise AssertionError(f"missing source decision {source_name}")
+
+
+def _mutate_catalog_source(source_name: str, key: str, value: object, tmp_path: Path) -> Path:
+    payload = _catalog_payload()
+    sources = payload["sources"]
+    assert isinstance(sources, list)
+    for source in sources:
+        if isinstance(source, dict) and source.get("source") == source_name:
+            source[key] = value
+            break
+    return _write_payload(tmp_path / "catalog.json", payload)
+
+
+def _mutate_onboarding_source(source_name: str, key: str, value: object, tmp_path: Path) -> Path:
+    payload = _onboarding_payload()
+    sources = payload["sources"]
+    assert isinstance(sources, list)
+    for source in sources:
+        if isinstance(source, dict) and source.get("source") == source_name:
+            source[key] = value
+            break
+    return _write_payload(tmp_path / "onboarding.json", payload)
+
+
+def test_load_source_gap_audit_accepts_canonical_artifact() -> None:
+    audit = load_source_gap_audit(
+        _AUDIT_PATH,
+        catalog=_catalog(),
+        onboarding=_onboarding(),
+        expected_catalog_ref="docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+        expected_onboarding_ref="docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+    )
+
+    assert audit.pr10_landed_pr == 1597
+    assert audit.next_recommended_lane == (
+        "chain_public_nutrition_pages_governance_or_recipe_corpus_governance"
+    )
+    assert [domain.domain for domain in audit.coverage_domains] == [
+        "generic_food_composition",
+        "branded_barcode_products",
+        "restaurant_chain_menus",
+        "recipe_dish_corpora",
+        "preference_menu_planning",
+        "regional_local_products",
+        "user_manual_evidence",
+    ]
+    source_decisions = {row.source: row.decision for row in audit.source_gap_decisions}
+    assert source_decisions["open_food_facts"] == "auxiliary_barcode_branded_source"
+    assert source_decisions[_FAT_PLATFORM_SOURCE] == "not_project_source"
+
+
+def test_source_gap_audit_report_is_deterministic_json_contract() -> None:
+    report = build_source_gap_audit_report(
+        catalog_path=_CATALOG_PATH,
+        onboarding_path=_ONBOARDING_PATH,
+        coverage_path=_AUDIT_PATH,
+    )
+
+    assert report == {
+        "success": True,
+        "dry_run": True,
+        "coverage_domains": [
+            "generic_food_composition",
+            "branded_barcode_products",
+            "restaurant_chain_menus",
+            "recipe_dish_corpora",
+            "preference_menu_planning",
+            "regional_local_products",
+            "user_manual_evidence",
+        ],
+        "source_gap_decisions": {
+            "usda_foundation": "core_authority_for_generic_composition",
+            "usda_branded": "primary_branded_barcode_source",
+            "usda_fndds": "supporting_food_composition_source",
+            "open_food_facts": "auxiliary_barcode_branded_source",
+            "menustat": "archival_reference_only",
+            "chain_public_nutrition_pages": "preferred_research_lane_blocked",
+            "edamam_food_database": "adjacent_recipe_food_db_review_only",
+            "spoonacular": "deferred_recipe_experiments_only",
+            "nutritionix": "deferred_contract_review",
+            _FAT_PLATFORM_SOURCE: "not_project_source",
+            "regional_catalogs": "deferred_unresolved",
+            "jptn_food_facts": "blocked_unresolved",
+        },
+        "next_recommended_lane": (
+            "chain_public_nutrition_pages_governance_or_recipe_corpus_governance"
+        ),
+        "runtime_cutover": False,
+        "digitalocean_postgres_load": False,
+        "bulk_ingest": False,
+        "network_allowed": False,
+        "db_writes_allowed": False,
+        "api_calls_allowed": False,
+        "source_download_allowed": False,
+        "scraping_allowed": False,
+        "paid_source_use_allowed": False,
+        "file_only": True,
+        "final_gate_decision": "coverage_gap_audit_complete_no_ingest",
+        "validation_errors": [],
+        "catalog_ref": "docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+        "onboarding_ref": "docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+        "pr10_landed_pr": 1597,
+        "coverage_domain_decisions": {
+            "generic_food_composition": "adequate_baseline",
+            "branded_barcode_products": "adequate_with_auxiliary",
+            "restaurant_chain_menus": "unresolved_gap",
+            "recipe_dish_corpora": "unresolved_gap",
+            "preference_menu_planning": "requires_dish_mapping",
+            "regional_local_products": "deferred_unresolved",
+            "user_manual_evidence": "internal_evidence_only",
+        },
+        "coverage_gap_status": {
+            "generic_food_composition": "baseline_covered",
+            "branded_barcode_products": "covered_with_schema_review_needed",
+            "restaurant_chain_menus": "not_covered_by_usda_or_off",
+            "recipe_dish_corpora": "not_covered_by_food_nutrient_sources",
+            "preference_menu_planning": "planner_gap_not_source_authority",
+            "regional_local_products": "locale_gap_unresolved",
+            "user_manual_evidence": "manual_evidence_not_dataset_authority",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "flag_name",
+    (
+        "runtime_cutover",
+        "digitalocean_postgres_load",
+        "bulk_ingest",
+        "network_allowed",
+        "db_writes_allowed",
+        "api_calls_allowed",
+        "source_download_allowed",
+        "scraping_allowed",
+        "paid_source_use_allowed",
+    ),
+)
+def test_source_gap_audit_rejects_unsafe_flags(flag_name: str) -> None:
+    payload = _audit_payload()
+    payload[flag_name] = True
+
+    with pytest.raises(SourceGapAuditError, match="must be false; file_only must be true"):
+        parse_source_gap_audit(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_source_gap_audit_rejects_missing_domain() -> None:
+    payload = _audit_payload()
+    domains = payload["coverage_domains"]
+    assert isinstance(domains, list)
+    domains.pop()
+
+    with pytest.raises(SourceGapAuditError, match="coverage_domains must be exactly"):
+        parse_source_gap_audit(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_source_gap_audit_rejects_duplicate_domain() -> None:
+    payload = _audit_payload()
+    domains = payload["coverage_domains"]
+    assert isinstance(domains, list)
+    domains[-1] = copy.deepcopy(domains[0])
+
+    with pytest.raises(SourceGapAuditError, match="coverage_domains must be exactly"):
+        parse_source_gap_audit(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_source_gap_audit_rejects_unknown_domain() -> None:
+    payload = _audit_payload()
+    _domain(payload, "restaurant_chain_menus")["domain"] = "social_media_restaurant_feeds"
+
+    with pytest.raises(SourceGapAuditError, match="unknown coverage domain"):
+        parse_source_gap_audit(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_source_gap_audit_rejects_domain_ingest_approval() -> None:
+    payload = _audit_payload()
+    _domain(payload, "restaurant_chain_menus")["approved_ingest"] = True
+
+    with pytest.raises(SourceGapAuditError, match="cannot approve ingest"):
+        parse_source_gap_audit(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_source_gap_audit_rejects_off_as_primary_authority() -> None:
+    payload = _audit_payload()
+    _domain(payload, "branded_barcode_products")["authority_decision"] = "off_primary"
+
+    with pytest.raises(SourceGapAuditError, match="branded_barcode_products decision mismatch"):
+        parse_source_gap_audit(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_source_gap_audit_rejects_source_gap_approval() -> None:
+    payload = _audit_payload()
+    _source_decision(payload, "chain_public_nutrition_pages")["scraping_allowed"] = True
+
+    with pytest.raises(SourceGapAuditError, match="cannot approve ingest"):
+        parse_source_gap_audit(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_source_gap_audit_rejects_fatsecret_project_source() -> None:
+    payload = _audit_payload()
+    _source_decision(payload, _FAT_PLATFORM_SOURCE)["decision"] = "deferred_contract_review"
+
+    with pytest.raises(SourceGapAuditError, match="fatsecret_platform source-gap mismatch"):
+        parse_source_gap_audit(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_source_gap_audit_rejects_edamam_api_calls() -> None:
+    payload = _audit_payload()
+    _source_decision(payload, "edamam_food_database")["api_calls_allowed"] = True
+
+    with pytest.raises(SourceGapAuditError, match="edamam_food_database cannot approve"):
+        parse_source_gap_audit(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_source_gap_audit_rejects_jptn_or_regional_eligibility() -> None:
+    payload = _audit_payload()
+    _source_decision(payload, "jptn_food_facts")["decision"] = "auxiliary_barcode_branded_source"
+
+    with pytest.raises(SourceGapAuditError, match="jptn_food_facts source-gap mismatch"):
+        parse_source_gap_audit(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_source_gap_audit_rejects_menustat_current_catalog(tmp_path: Path) -> None:
+    catalog_path = _mutate_catalog_source("menustat", "source_classification", "current", tmp_path)
+    report = build_source_gap_audit_report(
+        catalog_path=catalog_path,
+        onboarding_path=_ONBOARDING_PATH,
+        coverage_path=_AUDIT_PATH,
+    )
+
+    assert report["success"] is False
+    errors = report["validation_errors"]
+    assert isinstance(errors, list)
+    assert any("current sources must be active update sources" in str(error) for error in errors)
+
+
+def test_source_gap_audit_rejects_off_missing_odbl_ref(tmp_path: Path) -> None:
+    onboarding_path = _mutate_onboarding_source(
+        "open_food_facts",
+        "provider_policy_ref",
+        None,
+        tmp_path,
+    )
+    report = build_source_gap_audit_report(
+        catalog_path=_CATALOG_PATH,
+        onboarding_path=onboarding_path,
+        coverage_path=_AUDIT_PATH,
+    )
+
+    assert report["success"] is False
+    errors = report["validation_errors"]
+    assert isinstance(errors, list)
+    assert any("policy mismatch for open_food_facts" in str(error) for error in errors)
+
+
+def test_source_gap_audit_rejects_missing_source_decision() -> None:
+    payload = _audit_payload()
+    decisions = payload["source_gap_decisions"]
+    assert isinstance(decisions, list)
+    decisions.pop()
+
+    with pytest.raises(SourceGapAuditError, match="source_gap_decisions must be exactly"):
+        parse_source_gap_audit(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_source_gap_audit_rejects_unknown_source_decision() -> None:
+    payload = _audit_payload()
+    _source_decision(payload, "nutritionix")["source"] = "unknown_restaurant_api"
+
+    with pytest.raises(SourceGapAuditError, match="unknown source gap decision"):
+        parse_source_gap_audit(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_source_gap_audit_cli_is_file_only_and_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://invalid.invalid/pulseplate")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            _CLI_MODULE,
+            "--catalog",
+            str(_CATALOG_PATH),
+            "--onboarding",
+            str(_ONBOARDING_PATH),
+            "--coverage",
+            str(_AUDIT_PATH),
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    report = json.loads(result.stdout)
+
+    assert result.stderr == ""
+    assert report["success"] is True
+    assert report["network_allowed"] is False
+    assert report["db_writes_allowed"] is False
+    assert report["api_calls_allowed"] is False
+    assert report["scraping_allowed"] is False
+
+
+def test_source_gap_audit_cli_returns_nonzero_for_invalid_artifact(tmp_path: Path) -> None:
+    payload = _audit_payload()
+    payload["runtime_cutover"] = True
+    audit_path = _write_payload(tmp_path / "audit.json", payload)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            _CLI_MODULE,
+            "--catalog",
+            str(_CATALOG_PATH),
+            "--onboarding",
+            str(_ONBOARDING_PATH),
+            "--coverage",
+            str(audit_path),
+            "--json",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    report = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert report["success"] is False
+    assert report["validation_errors"]
+
+
+def test_source_gap_audit_core_has_no_network_or_db_imports() -> None:
+    tree = ast.parse(Path(source_gap_audit.__file__).read_text(encoding="utf-8"))
+    forbidden = {
+        "requests",
+        "httpx",
+        "psycopg",
+        "sqlalchemy",
+        "digitalocean",
+        "sqlite3",
+        "subprocess",
+    }
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module.split(".")[0])
+
+    assert forbidden.isdisjoint(imports)
+    assert "urllib" not in imports

--- a/tests/test_food_source_gap_audit.py
+++ b/tests/test_food_source_gap_audit.py
@@ -90,6 +90,8 @@ def _mutate_catalog_source(source_name: str, key: str, value: object, tmp_path: 
         if isinstance(source, dict) and source.get("source") == source_name:
             source[key] = value
             break
+    else:
+        raise AssertionError(f"missing catalog source {source_name}")
     return _write_payload(tmp_path / "catalog.json", payload)
 
 
@@ -101,6 +103,8 @@ def _mutate_onboarding_source(source_name: str, key: str, value: object, tmp_pat
         if isinstance(source, dict) and source.get("source") == source_name:
             source[key] = value
             break
+    else:
+        raise AssertionError(f"missing onboarding source {source_name}")
     return _write_payload(tmp_path / "onboarding.json", payload)
 
 
@@ -352,6 +356,14 @@ def test_source_gap_audit_rejects_unknown_source_decision() -> None:
         parse_source_gap_audit(payload, catalog=_catalog(), onboarding=_onboarding())
 
 
+def test_source_gap_audit_rejects_unknown_domain_source_id() -> None:
+    payload = _audit_payload()
+    _domain(payload, "generic_food_composition")["primary_sources"] = ["not_a_source"]
+
+    with pytest.raises(SourceGapAuditError, match="primary_sources contains unknown source"):
+        parse_source_gap_audit(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
 def test_source_gap_audit_cli_is_file_only_and_json(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DATABASE_URL", "postgresql://invalid.invalid/pulseplate")
     result = subprocess.run(
@@ -381,6 +393,29 @@ def test_source_gap_audit_cli_is_file_only_and_json(monkeypatch: pytest.MonkeyPa
     assert report["scraping_allowed"] is False
 
 
+def test_source_gap_audit_cli_plain_text_success() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            _CLI_MODULE,
+            "--catalog",
+            str(_CATALOG_PATH),
+            "--onboarding",
+            str(_ONBOARDING_PATH),
+            "--coverage",
+            str(_AUDIT_PATH),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert "food_source_gap_audit: PASS" in result.stdout
+
+
 def test_source_gap_audit_cli_returns_nonzero_for_invalid_artifact(tmp_path: Path) -> None:
     payload = _audit_payload()
     payload["runtime_cutover"] = True
@@ -407,6 +442,35 @@ def test_source_gap_audit_cli_returns_nonzero_for_invalid_artifact(tmp_path: Pat
     assert result.returncode == 1
     assert report["success"] is False
     assert report["validation_errors"]
+
+
+def test_source_gap_audit_cli_plain_text_failure(tmp_path: Path) -> None:
+    payload = _audit_payload()
+    payload["network_allowed"] = True
+    audit_path = _write_payload(tmp_path / "audit.json", payload)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            _CLI_MODULE,
+            "--catalog",
+            str(_CATALOG_PATH),
+            "--onboarding",
+            str(_ONBOARDING_PATH),
+            "--coverage",
+            str(audit_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert result.stderr == ""
+    assert "food_source_gap_audit: FAIL" in result.stdout
+    assert "Validation errors:" in result.stdout
+    assert "network_allowed" in result.stdout
+    assert "must be false" in result.stdout
 
 
 def test_source_gap_audit_core_has_no_network_or_db_imports() -> None:


### PR DESCRIPTION
## Summary

PR11 is a file-only food-data coverage/source-gap audit after merged PR10 #1597. It records that USDA remains the core product-food authority, Open Food Facts remains auxiliary for barcode/branded coverage, and unresolved gaps remain for restaurant menus, recipe/dish corpora, regional/local foods, manual evidence, and preference-menu planning.

This PR does not approve ingest, API calls, scraping, paid-source use, source downloads, DB writes, DigitalOcean Postgres, or runtime cutover.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Coordinator-first start completed with task packet `b19c0f5cdfd0`
- [x] Role order recorded: `agent-coordinator -> data-scientist-agent -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter -> dev-operator`
- [x] Mandatory post-open lane planned: `qa-engineer-agent -> bug-hunter`
- [x] Custom skills used/recorded: `pulseplate-workflow`, `pulseplate-gates`, `pulseplate-guards`, `pulseplate-ledger`, `pulseplate-pr-review`, optional `pulseplate-graphmap`, no-op `pulseplate-monetization-gtm`
- [x] No app API, OpenAPI, frontend, iOS, runtime food search, DB schema, credentials, API calls, downloads, scraping, ingest, DigitalOcean Postgres, or runtime authority changes

### Fixed in Commit Mapping

- `2bc013fcf` -> Initial PR11 coverage/source-gap audit artifact, validator, CLI, packet, ledger/current-pointer updates, and tests.
- `docs/review/PR_1601_FIXED_MAPPING.md` records the canonical PR #1601 mapping and post-open coordinator packet.
- CodeRabbit actionables fixed in `23f7c866b`:
  - `discussion_r3168546896` -> domain `primary_sources`/`auxiliary_sources` now validate source IDs.
  - `discussion_r3168546907` -> packet validation command no longer hardcodes the workstation venv path.
  - `discussion_r3168546946` -> mutation helpers fail fast on missing source rows.
  - `discussion_r3168546969` -> plain-text CLI success/failure branches are covered.
  - `pullrequestreview-4205847028` -> parent CodeRabbit review mapped to the same fix commit.

## Split Justification

This PR is intentionally a single governance slice because the coverage artifact, file-only validator, CLI, packet, ledger pointer, and focused tests must land together to prevent a false-green source decision. Splitting these pieces would leave the food line without a deterministic answer on whether USDA + Open Food Facts are enough and which gaps are still blocked.

## Merge Readiness

Local gates already run on the PR branch:

```bash
python3 scripts/orchestration/check_preflight.py
python3 scripts/orchestration/check_agent_consistency.py
python3 scripts/orchestration/task_bootstrap.py --goal "Food Data PR11 coverage source-gap audit" --task-class "Orchestration" --pr-phase pre_open
python3 -m pytest tests/test_food_source_gap_audit.py -q
python3 -m pytest tests/test_food_source_gap_audit.py tests/test_food_source_menustat_source_decision.py tests/test_food_source_onboarding.py tests/test_food_source_catalog.py tests/test_food_source_preflight.py -q
python3 -m scripts.food_source_gap_audit --catalog docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json --onboarding docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json --coverage docs/architecture/FOOD_DATA_COVERAGE_SOURCE_GAP_PR11_2026-04-30.json --json
pytest -q tests/test_repo_policy_guards.py
pre-commit run --all-files
make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python
```

Local `make verify` is intentionally deferred for this food-data lane per operator policy; GitHub current-head CI remains the machine-heavy signal.

## Security Notes

No network collection, scraping, API keys, provider calls, paid-source use, source downloads, DB writes, DigitalOcean load, or runtime authority changes are introduced. Open Food Facts remains auxiliary with ODbL obligations; public restaurant/menu pages and screenshots are internal evidence only after legal/anti-scraping review.

## Marketing & GTM

No public dataset coverage claim changes. Safe wording remains: USDA + Open Food Facts cover the governed product-food baseline; restaurant menu and recipe/dish coverage are still under source-governance review.

## Source Evidence

- USDA FoodData Central downloads show April 2026 Foundation/Branded releases and FNDDS 2021-2023: https://fdc.nal.usda.gov/download-datasets
- Open Food Facts data page is accessible in the in-app browser and remains the canonical data URL: https://world.openfoodfacts.org/data
- Open Food Facts ODbL governance: https://wiki.openfoodfacts.org/ODBL_License
- Edamam Food Database is captured only as an adjacent under-$20 review candidate, not an approved source: https://developer.edamam.com/food-database-api
- FDA menu labeling is public-evidence context, not scraping or redistribution permission: https://www.fda.gov/food/nutrition-food-labeling-and-critical-foods/menu-labeling-requirements
