### PR TITLE
test(food-data): restore main coverage floor

### DIFF
--- a/docs/review/PR_1610_FIXED_MAPPING.md
+++ b/docs/review/PR_1610_FIXED_MAPPING.md
@@ -21,18 +21,14 @@ Actionable CodeRabbit comments were fixed after the first review pass.
 
 ## Fixed in Commit Mapping
 
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: `tests/test_food_source_menustat_replacement.py`, `tests/test_food_source_menustat_source_decision.py`, and `docs/review/PR_1610_FIXED_MAPPING.md` address CodeRabbit review findings.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#discussion_r3169352494 -> a9a52367e
-Disposition: FIXED
-Evidence: `docs/review/PR_1610_FIXED_MAPPING.md` uses the required `## Merge Readiness` checklist section.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#discussion_r3169352504 -> a9a52367e
-Disposition: FIXED
-Evidence: `tests/test_food_source_menustat_replacement.py` annotates the parametrized helper callable.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#issuecomment-4354114129 -> a9a52367e
-Disposition: FIXED
-Evidence: `tests/test_food_source_menustat_source_decision.py` annotates newly added helper and parametrized signatures.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#pullrequestreview-4206770024 -> a9a52367e
-Disposition: FIXED
-Evidence: `tests/test_food_source_menustat_replacement.py` and `tests/test_food_source_menustat_source_decision.py` annotate CodeRabbit-reported helper signatures.
 
 ## Local Verification
 

--- a/docs/review/PR_1610_FIXED_MAPPING.md
+++ b/docs/review/PR_1610_FIXED_MAPPING.md
@@ -12,12 +12,16 @@
 - Post-open packet: `artifacts/orchestration/task_packets/3a0658144b75.json` (local artifact, not committed)
 - Role order: `agent-coordinator -> qa-engineer-agent -> backend-engineer -> architecture-specialist -> security-auditor -> cursor-specialist-agent -> bug-hunter -> agent-coordinator`
 
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+No actionable review comments were present when this artifact was created.
+
 ## Fixed in Commit Mapping
 
-- No actionable review threads are present at PR open.
-
-Disposition: NOT-A-BUG
-Evidence: PR opened with no actionable review threads; hotfix commit `635af78ae` restores coverage by adding deterministic tests only.
+- No actionable review comments
 
 ## Local Verification
 

--- a/docs/review/PR_1610_FIXED_MAPPING.md
+++ b/docs/review/PR_1610_FIXED_MAPPING.md
@@ -1,0 +1,40 @@
+# PR 1610 Fixed in Commit Mapping
+
+## PR
+
+- PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610
+- Branch: `codex/hotfix-main-coverage-floor`
+- Scope: restore main coverage floor after PR #1603 merge without lowering gates.
+
+## Coordinator Evidence
+
+- Pre-open packet: `artifacts/orchestration/task_packets/74c728fad218.json` (local artifact, not committed)
+- Post-open packet: `artifacts/orchestration/task_packets/3a0658144b75.json` (local artifact, not committed)
+- Role order: `agent-coordinator -> qa-engineer-agent -> backend-engineer -> architecture-specialist -> security-auditor -> cursor-specialist-agent -> bug-hunter -> agent-coordinator`
+
+## Fixed in Commit Mapping
+
+- No actionable review threads are present at PR open.
+
+Disposition: NOT-A-BUG
+Evidence: PR opened with no actionable review threads; hotfix commit `635af78ae` restores coverage by adding deterministic tests only.
+
+## Local Verification
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `. .venv/bin/activate && pytest tests/test_food_source_menustat_replacement.py tests/test_food_source_menustat_source_decision.py -q`
+- `. .venv/bin/activate && python -X faulthandler -m pytest -n 4 --dist=loadscope -m "not slow" --durations=25 --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 --junitxml=tests/results.xml -o junit_family=legacy tests`
+- `make validate-changed`
+- `pre-commit run --all-files`
+- pre-push hooks
+
+## Local Verification Deferral
+
+Full local `make verify` was intentionally not run per operator instruction to avoid the CPU-heavy full bundle. The broken `test-main` coverage gate was validated directly with the CI-equivalent coverage command.
+
+## Merge Readiness Notes
+
+- Do not merge while PR current-head checks are pending.
+- Do not merge while CodeRabbit, Sourcery, Cubic, or human review has actionable unresolved comments.
+- After merge, watch `main` CI for the merge commit and confirm the `test-main` matrix passes.

--- a/docs/review/PR_1610_FIXED_MAPPING.md
+++ b/docs/review/PR_1610_FIXED_MAPPING.md
@@ -30,6 +30,9 @@ Evidence: `tests/test_food_source_menustat_replacement.py` annotates the paramet
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#issuecomment-4354114129 -> a9a52367e
 Disposition: FIXED
 Evidence: `tests/test_food_source_menustat_source_decision.py` annotates newly added helper and parametrized signatures.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#pullrequestreview-4206770024 -> a9a52367e
+Disposition: FIXED
+Evidence: `tests/test_food_source_menustat_replacement.py` and `tests/test_food_source_menustat_source_decision.py` annotate CodeRabbit-reported helper signatures.
 
 ## Local Verification
 

--- a/docs/review/PR_1610_FIXED_MAPPING.md
+++ b/docs/review/PR_1610_FIXED_MAPPING.md
@@ -17,11 +17,19 @@
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-No actionable review comments were present when this artifact was created.
+Actionable CodeRabbit comments were fixed after the first review pass.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#discussion_r3169352494 -> PENDING_COMMIT
+  - Disposition: FIXED
+  - Evidence: `docs/review/PR_1610_FIXED_MAPPING.md` uses the required `## Merge Readiness` checklist section.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#discussion_r3169352504 -> PENDING_COMMIT
+  - Disposition: FIXED
+  - Evidence: `tests/test_food_source_menustat_replacement.py` annotates the parametrized helper callable.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#issuecomment-4354114129 -> PENDING_COMMIT
+  - Disposition: FIXED
+  - Evidence: `tests/test_food_source_menustat_source_decision.py` annotates newly added helper and parametrized signatures.
 
 ## Local Verification
 
@@ -37,8 +45,8 @@ No actionable review comments were present when this artifact was created.
 
 Full local `make verify` was intentionally not run per operator instruction to avoid the CPU-heavy full bundle. The broken `test-main` coverage gate was validated directly with the CI-equivalent coverage command.
 
-## Merge Readiness Notes
+## Merge Readiness
 
-- Do not merge while PR current-head checks are pending.
-- Do not merge while CodeRabbit, Sourcery, Cubic, or human review has actionable unresolved comments.
-- After merge, watch `main` CI for the merge commit and confirm the `test-main` matrix passes.
+- [ ] Required checks PASS on current head.
+- [ ] No unresolved actionable review comments/threads.
+- [ ] Post-merge `main` CI observed and `test-main` matrix passes.

--- a/docs/review/PR_1610_FIXED_MAPPING.md
+++ b/docs/review/PR_1610_FIXED_MAPPING.md
@@ -21,13 +21,13 @@ Actionable CodeRabbit comments were fixed after the first review pass.
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#discussion_r3169352494 -> PENDING_COMMIT
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#discussion_r3169352494 -> a9a52367e
   - Disposition: FIXED
   - Evidence: `docs/review/PR_1610_FIXED_MAPPING.md` uses the required `## Merge Readiness` checklist section.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#discussion_r3169352504 -> PENDING_COMMIT
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#discussion_r3169352504 -> a9a52367e
   - Disposition: FIXED
   - Evidence: `tests/test_food_source_menustat_replacement.py` annotates the parametrized helper callable.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#issuecomment-4354114129 -> PENDING_COMMIT
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#issuecomment-4354114129 -> a9a52367e
   - Disposition: FIXED
   - Evidence: `tests/test_food_source_menustat_source_decision.py` annotates newly added helper and parametrized signatures.
 

--- a/docs/review/PR_1610_FIXED_MAPPING.md
+++ b/docs/review/PR_1610_FIXED_MAPPING.md
@@ -22,14 +22,14 @@ Actionable CodeRabbit comments were fixed after the first review pass.
 ## Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#discussion_r3169352494 -> a9a52367e
-  - Disposition: FIXED
-  - Evidence: `docs/review/PR_1610_FIXED_MAPPING.md` uses the required `## Merge Readiness` checklist section.
+Disposition: FIXED
+Evidence: `docs/review/PR_1610_FIXED_MAPPING.md` uses the required `## Merge Readiness` checklist section.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#discussion_r3169352504 -> a9a52367e
-  - Disposition: FIXED
-  - Evidence: `tests/test_food_source_menustat_replacement.py` annotates the parametrized helper callable.
+Disposition: FIXED
+Evidence: `tests/test_food_source_menustat_replacement.py` annotates the parametrized helper callable.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#issuecomment-4354114129 -> a9a52367e
-  - Disposition: FIXED
-  - Evidence: `tests/test_food_source_menustat_source_decision.py` annotates newly added helper and parametrized signatures.
+Disposition: FIXED
+Evidence: `tests/test_food_source_menustat_source_decision.py` annotates newly added helper and parametrized signatures.
 
 ## Local Verification
 

--- a/tests/test_food_source_menustat_replacement.py
+++ b/tests/test_food_source_menustat_replacement.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import copy
+from dataclasses import replace
 import json
 import subprocess
 import sys
@@ -72,6 +73,44 @@ def _candidate(payload: dict[str, object], source_name: str) -> dict[str, object
         if isinstance(candidate, dict) and candidate.get("source") == source_name:
             return candidate
     raise AssertionError(f"missing candidate {source_name}")
+
+
+def _catalog_without(source_name: str) -> SourceCatalog:
+    catalog = _catalog()
+    return replace(
+        catalog,
+        sources=tuple(entry for entry in catalog.sources if entry.source != source_name),
+    )
+
+
+def _catalog_with_replaced(source_name: str, **changes: object) -> SourceCatalog:
+    catalog = _catalog()
+    return replace(
+        catalog,
+        sources=tuple(
+            replace(entry, **changes) if entry.source == source_name else entry
+            for entry in catalog.sources
+        ),
+    )
+
+
+def _onboarding_without(source_name: str) -> SourceOnboarding:
+    onboarding = _onboarding()
+    return replace(
+        onboarding,
+        sources=tuple(entry for entry in onboarding.sources if entry.source != source_name),
+    )
+
+
+def _onboarding_with_replaced(source_name: str, **changes: object) -> SourceOnboarding:
+    onboarding = _onboarding()
+    return replace(
+        onboarding,
+        sources=tuple(
+            replace(entry, **changes) if entry.source == source_name else entry
+            for entry in onboarding.sources
+        ),
+    )
 
 
 def _write_payload(path: Path, payload: dict[str, object]) -> Path:
@@ -179,6 +218,227 @@ def test_menustat_replacement_gate_rejects_unsafe_flags(
 
     with pytest.raises(MenuStatReplacementError, match="must be false; file_only must be true"):
         parse_menustat_replacement_decision(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    (
+        (None, "must be an object"),
+        ({1: "bad-key"}, "all object keys must be strings"),
+    ),
+)
+def test_menustat_replacement_requires_mapping_payload(
+    payload: object,
+    match: str,
+) -> None:
+    with pytest.raises(MenuStatReplacementError, match=match):
+        parse_menustat_replacement_decision(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+@pytest.mark.parametrize(
+    ("callable_obj", "match"),
+    (
+        (
+            lambda: menustat_replacement._require_string({}, "name", "helper"),
+            "missing non-empty string",
+        ),
+        (
+            lambda: menustat_replacement._require_bool({"flag": "yes"}, "flag", "helper"),
+            "must be a boolean",
+        ),
+        (
+            lambda: menustat_replacement._require_string_tuple(
+                {"items": "bad"},
+                "items",
+                "helper",
+            ),
+            "list of strings",
+        ),
+        (
+            lambda: menustat_replacement._require_string_tuple(
+                {"items": [""]},
+                "items",
+                "helper",
+            ),
+            "non-empty string",
+        ),
+        (
+            lambda: menustat_replacement._parse_date("20260430", "helper"),
+            "YYYY-MM-DD",
+        ),
+    ),
+)
+def test_menustat_replacement_helper_failures_are_stable(
+    callable_obj,
+    match: str,
+) -> None:
+    with pytest.raises(MenuStatReplacementError, match=match):
+        callable_obj()
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value", "match"),
+    (
+        ("schema_version", "invalid", "schema_version must look"),
+        ("generated_on", "2026-02-31", "generated_on must use YYYY-MM-DD"),
+        ("legacy_source", "nutritionix", "legacy_source must be menustat"),
+        ("catalog_ref", "wrong.json", "catalog_ref must be"),
+        ("onboarding_ref", "wrong.json", "onboarding_ref must be"),
+        ("candidate_sources", "not-a-list", "candidate_sources must be a list"),
+        ("final_gate_decision", "approved_ingest", "final_gate_decision must be"),
+    ),
+)
+def test_menustat_replacement_rejects_top_level_contract_drift(
+    field_name: str,
+    field_value: object,
+    match: str,
+) -> None:
+    payload = _decision_payload()
+    payload[field_name] = field_value
+
+    with pytest.raises(MenuStatReplacementError, match=match):
+        parse_menustat_replacement_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            expected_catalog_ref="docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+            expected_onboarding_ref="docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+        )
+
+
+def test_menustat_replacement_rejects_unexpected_top_level_key() -> None:
+    payload = _decision_payload()
+    payload["unexpected"] = "value"
+
+    with pytest.raises(MenuStatReplacementError, match="unexpected keys"):
+        parse_menustat_replacement_decision(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+def test_menustat_replacement_load_reports_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{", encoding="utf-8")
+
+    with pytest.raises(MenuStatReplacementError, match="Cannot read MenuStat replacement gate"):
+        load_menustat_replacement_decision(path, catalog=_catalog(), onboarding=_onboarding())
+
+
+@pytest.mark.parametrize(
+    ("candidate_change", "match"),
+    (
+        ({"unexpected": "value"}, "unexpected candidate keys"),
+        ({"replacement_for": "usda"}, "must replace menustat"),
+        ({"authority_decision": "active_authority"}, "cannot be approved"),
+        ({"authority_decision": "approved_ingest"}, "cannot be approved"),
+        ({"candidate_gate_decision": "approved_ingest"}, "cannot be approved"),
+        ({"candidate_gate_decision": "eligible_preflight"}, "cannot become eligible"),
+        ({"evidence_status": "approved"}, "evidence_status must remain blocked"),
+        ({"contract_status": "approved"}, "contract_status must remain blocked"),
+        ({"source_evidence_refs": ["not-a-url"]}, "absolute http"),
+        ({"blocking_reasons": []}, "must not be empty"),
+        ({"blocking_reasons": ["contract", "contract"]}, "duplicate value"),
+    ),
+)
+def test_menustat_replacement_rejects_candidate_contract_drift(
+    candidate_change: dict[str, object],
+    match: str,
+) -> None:
+    payload = _decision_payload()
+    candidate = _candidate(payload, "nutritionix")
+    candidate.update(candidate_change)
+
+    with pytest.raises(MenuStatReplacementError, match=match):
+        parse_menustat_replacement_decision(payload, catalog=_catalog(), onboarding=_onboarding())
+
+
+@pytest.mark.parametrize(
+    ("catalog", "match"),
+    (
+        (_catalog_without("menustat"), "catalog must include menustat"),
+        (
+            _catalog_with_replaced("menustat", source_classification="public_dataset"),
+            "legacy_static",
+        ),
+        (_catalog_with_replaced("menustat", status="approved_active_source"), "legacy_baseline"),
+        (_catalog_with_replaced("menustat", active_update_source=True), "active update source"),
+        (_catalog_with_replaced("menustat", replacement_required=False), "replacement_required"),
+    ),
+)
+def test_menustat_replacement_rejects_menustat_catalog_drift(
+    catalog: SourceCatalog,
+    match: str,
+) -> None:
+    with pytest.raises(MenuStatReplacementError, match=match):
+        parse_menustat_replacement_decision(
+            _decision_payload(),
+            catalog=catalog,
+            onboarding=_onboarding(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("onboarding", "match"),
+    (
+        (_onboarding_without("menustat"), "onboarding must include menustat"),
+        (
+            _onboarding_with_replaced("menustat", onboarding_status="eligible_preflight"),
+            "legacy_baseline_blocked",
+        ),
+        (
+            _onboarding_with_replaced("menustat", ingestion_path="direct_api_pull"),
+            "legacy_snapshot_review_only",
+        ),
+    ),
+)
+def test_menustat_replacement_rejects_menustat_onboarding_drift(
+    onboarding: SourceOnboarding,
+    match: str,
+) -> None:
+    with pytest.raises(MenuStatReplacementError, match=match):
+        parse_menustat_replacement_decision(
+            _decision_payload(),
+            catalog=_catalog(),
+            onboarding=onboarding,
+        )
+
+
+@pytest.mark.parametrize(
+    ("catalog", "onboarding", "match"),
+    (
+        (_catalog_without("nutritionix"), _onboarding(), "catalog missing candidate"),
+        (_catalog(), _onboarding_without("nutritionix"), "onboarding missing candidate"),
+        (
+            _catalog_with_replaced("nutritionix", replacement_for="usda"),
+            _onboarding(),
+            "cataloged as replacing menustat",
+        ),
+        (
+            _catalog_with_replaced("nutritionix", source_classification="public_dataset"),
+            _onboarding(),
+            "classification differs from catalog",
+        ),
+        (
+            _catalog_with_replaced("nutritionix", source_family="recipe_corpus"),
+            _onboarding(),
+            "family differs from catalog",
+        ),
+        (
+            _catalog(),
+            _onboarding_with_replaced("nutritionix", onboarding_status="eligible_preflight"),
+            "onboarding status differs from PR5",
+        ),
+    ),
+)
+def test_menustat_replacement_rejects_candidate_catalog_or_onboarding_drift(
+    catalog: SourceCatalog,
+    onboarding: SourceOnboarding,
+    match: str,
+) -> None:
+    with pytest.raises(MenuStatReplacementError, match=match):
+        parse_menustat_replacement_decision(
+            _decision_payload(),
+            catalog=catalog,
+            onboarding=onboarding,
+        )
 
 
 def test_menustat_replacement_gate_rejects_missing_candidate() -> None:

--- a/tests/test_food_source_menustat_replacement.py
+++ b/tests/test_food_source_menustat_replacement.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+from collections.abc import Callable
 import copy
 from dataclasses import replace
 import json
@@ -269,7 +270,7 @@ def test_menustat_replacement_requires_mapping_payload(
     ),
 )
 def test_menustat_replacement_helper_failures_are_stable(
-    callable_obj,
+    callable_obj: Callable[[], object],
     match: str,
 ) -> None:
     with pytest.raises(MenuStatReplacementError, match=match):

--- a/tests/test_food_source_menustat_source_decision.py
+++ b/tests/test_food_source_menustat_source_decision.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+from collections.abc import Callable
 import copy
 from dataclasses import replace
 import json
@@ -13,7 +14,10 @@ from pathlib import Path
 import pytest
 
 from core.food_sources import menustat_source_decision
-from core.food_sources.menustat_replacement import load_menustat_replacement_decision
+from core.food_sources.menustat_replacement import (
+    MenuStatReplacementDecision,
+    load_menustat_replacement_decision,
+)
 from core.food_sources.menustat_source_decision import (
     MenuStatSourceDecisionError,
     build_menustat_source_decision_report,
@@ -53,7 +57,7 @@ def _onboarding() -> SourceOnboarding:
     )
 
 
-def _replacement():
+def _replacement() -> MenuStatReplacementDecision:
     return load_menustat_replacement_decision(
         _REPLACEMENT_PATH,
         catalog=_catalog(),
@@ -85,7 +89,7 @@ def _source_decision(payload: dict[str, object], source_name: str) -> dict[str, 
     raise AssertionError(f"missing source decision {source_name}")
 
 
-def _replacement_without(source_name: str):
+def _replacement_without(source_name: str) -> MenuStatReplacementDecision:
     replacement = _replacement()
     return replace(
         replacement,
@@ -97,7 +101,10 @@ def _replacement_without(source_name: str):
     )
 
 
-def _replacement_with_candidate(source_name: str, **changes: object):
+def _replacement_with_candidate(
+    source_name: str,
+    **changes: object,
+) -> MenuStatReplacementDecision:
     replacement = _replacement()
     return replace(
         replacement,
@@ -279,7 +286,7 @@ def test_menustat_source_decision_requires_mapping_payload(
     ),
 )
 def test_menustat_source_decision_helper_failures_are_stable(
-    callable_obj,
+    callable_obj: Callable[[], object],
     match: str,
 ) -> None:
     with pytest.raises(MenuStatSourceDecisionError, match=match):
@@ -532,7 +539,7 @@ def test_menustat_source_decision_rejects_source_decision_drift(
     ),
 )
 def test_menustat_source_decision_rejects_pr9_replacement_drift(
-    replacement,
+    replacement: MenuStatReplacementDecision,
     match: str,
 ) -> None:
     with pytest.raises(MenuStatSourceDecisionError, match=match):

--- a/tests/test_food_source_menustat_source_decision.py
+++ b/tests/test_food_source_menustat_source_decision.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import copy
+from dataclasses import replace
 import json
 import subprocess
 import sys
@@ -84,6 +85,29 @@ def _source_decision(payload: dict[str, object], source_name: str) -> dict[str, 
     raise AssertionError(f"missing source decision {source_name}")
 
 
+def _replacement_without(source_name: str):
+    replacement = _replacement()
+    return replace(
+        replacement,
+        candidate_sources=tuple(
+            candidate
+            for candidate in replacement.candidate_sources
+            if candidate.source != source_name
+        ),
+    )
+
+
+def _replacement_with_candidate(source_name: str, **changes: object):
+    replacement = _replacement()
+    return replace(
+        replacement,
+        candidate_sources=tuple(
+            replace(candidate, **changes) if candidate.source == source_name else candidate
+            for candidate in replacement.candidate_sources
+        ),
+    )
+
+
 def _mutate_menustat_catalog(key: str, value: object, tmp_path: Path) -> Path:
     payload = _catalog_payload()
     sources = payload["sources"]
@@ -93,6 +117,25 @@ def _mutate_menustat_catalog(key: str, value: object, tmp_path: Path) -> Path:
             source[key] = value
             break
     return _write_payload(tmp_path / "catalog.json", payload)
+
+
+def _catalog_without(source_name: str) -> SourceCatalog:
+    catalog = _catalog()
+    return replace(
+        catalog,
+        sources=tuple(entry for entry in catalog.sources if entry.source != source_name),
+    )
+
+
+def _catalog_with_replaced(source_name: str, **changes: object) -> SourceCatalog:
+    catalog = _catalog()
+    return replace(
+        catalog,
+        sources=tuple(
+            replace(entry, **changes) if entry.source == source_name else entry
+            for entry in catalog.sources
+        ),
+    )
 
 
 def test_load_menustat_source_decision_accepts_locked_cleanup() -> None:
@@ -195,6 +238,309 @@ def test_menustat_source_decision_rejects_unsafe_flags(flag_name: str) -> None:
             catalog=_catalog(),
             onboarding=_onboarding(),
             replacement=_replacement(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    (
+        (None, "must be an object"),
+        ({1: "bad-key"}, "all object keys must be strings"),
+    ),
+)
+def test_menustat_source_decision_requires_mapping_payload(
+    payload: object,
+    match: str,
+) -> None:
+    with pytest.raises(MenuStatSourceDecisionError, match=match):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("callable_obj", "match"),
+    (
+        (
+            lambda: menustat_source_decision._require_string({}, "name", "helper"),
+            "missing non-empty string",
+        ),
+        (
+            lambda: menustat_source_decision._require_bool({"flag": "yes"}, "flag", "helper"),
+            "must be a boolean",
+        ),
+        (
+            lambda: menustat_source_decision._parse_date("20260430", "helper"),
+            "YYYY-MM-DD",
+        ),
+    ),
+)
+def test_menustat_source_decision_helper_failures_are_stable(
+    callable_obj,
+    match: str,
+) -> None:
+    with pytest.raises(MenuStatSourceDecisionError, match=match):
+        callable_obj()
+
+
+@pytest.mark.parametrize(
+    ("catalog", "match"),
+    (
+        (_catalog_without("menustat"), "catalog must include menustat"),
+        (
+            _catalog_with_replaced("menustat", source_classification="public_dataset"),
+            "classification",
+        ),
+        (_catalog_with_replaced("menustat", active_update_source=True), "active_update_source"),
+        (_catalog_with_replaced("menustat", replacement_required=False), "replacement_required"),
+    ),
+)
+def test_menustat_source_decision_rejects_catalog_archival_drift(
+    catalog: SourceCatalog,
+    match: str,
+) -> None:
+    with pytest.raises(MenuStatSourceDecisionError, match=match):
+        parse_menustat_source_decision(
+            _decision_payload(),
+            catalog=catalog,
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value", "match"),
+    (
+        ("schema_version", "invalid", "schema_version must look"),
+        ("generated_on", "2026-02-31", "generated_on must use YYYY-MM-DD"),
+        ("catalog_ref", "wrong.json", "catalog_ref must be"),
+        ("onboarding_ref", "wrong.json", "onboarding_ref must be"),
+        ("menustat_replacement_ref", "wrong.json", "menustat_replacement_ref must be"),
+        ("legacy_source", "nutritionix", "legacy_source must be menustat"),
+        ("source_decisions", "not-a-list", "source_decisions must be a list"),
+        ("final_gate_decision", "approved_ingest", "final_gate_decision must be"),
+    ),
+)
+def test_menustat_source_decision_rejects_top_level_contract_drift(
+    field_name: str,
+    field_value: object,
+    match: str,
+) -> None:
+    payload = _decision_payload()
+    payload[field_name] = field_value
+
+    with pytest.raises(MenuStatSourceDecisionError, match=match):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+            expected_catalog_ref="docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+            expected_onboarding_ref="docs/architecture/FOOD_DATA_SOURCE_ONBOARDING_PR5_2026-04-28.json",
+            expected_replacement_ref=(
+                "docs/architecture/FOOD_DATA_MENUSTAT_REPLACEMENT_PR9_2026-04-30.json"
+            ),
+        )
+
+
+def test_menustat_source_decision_rejects_unexpected_top_level_key() -> None:
+    payload = _decision_payload()
+    payload["unexpected"] = "value"
+
+    with pytest.raises(MenuStatSourceDecisionError, match="unexpected keys"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_rejects_source_decision_order_drift() -> None:
+    payload = _decision_payload()
+    rows = payload["source_decisions"]
+    assert isinstance(rows, list)
+    payload["source_decisions"] = list(reversed(rows))
+
+    with pytest.raises(MenuStatSourceDecisionError, match="source_decisions must be exactly"):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+def test_menustat_source_decision_load_reports_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{", encoding="utf-8")
+
+    with pytest.raises(MenuStatSourceDecisionError, match="Cannot read MenuStat source decision"):
+        load_menustat_source_decision(
+            path,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("policy_change", "match"),
+    (
+        ({"unexpected": "value"}, "unexpected archival policy keys"),
+        ({"source": "nutritionix"}, "archival policy source must be menustat"),
+        ({"source_classification": "public_dataset"}, "legacy_static"),
+        ({"archival_reference_only": False}, "archival_reference_only"),
+        ({"freshness_authority": True}, "freshness authority"),
+        ({"active_update_source": True}, "active update source"),
+        ({"replacement_required": False}, "replacement_required"),
+        ({"validation_required_before_use": False}, "requires validation"),
+        ({"allowed_use": []}, "must not be empty"),
+        ({"blocked_use": ["bulk_ingest", "bulk_ingest"]}, "duplicate value"),
+    ),
+)
+def test_menustat_source_decision_rejects_archival_policy_drift(
+    policy_change: dict[str, object],
+    match: str,
+) -> None:
+    payload = _decision_payload()
+    policy = payload["menustat_archival_policy"]
+    assert isinstance(policy, dict)
+    policy.update(policy_change)
+
+    with pytest.raises(MenuStatSourceDecisionError, match=match):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("review_change", "match"),
+    (
+        ({"unexpected": "value"}, "unexpected budget API keys"),
+        ({"source": "nutritionix"}, "budget API review source"),
+        ({"source_family": "restaurant_menu"}, "recipe_corpus"),
+        ({"review_lane_decision": "approved"}, "adjacent review only"),
+        ({"starter_budget_usd_per_month": "14"}, "must be an integer"),
+        ({"starter_budget_usd_per_month": 21}, "between 0 and 20"),
+        ({"authority_decision": "approved"}, "cannot approve authority"),
+        ({"api_calls_allowed": True}, "cannot approve authority"),
+        ({"cache_policy_status": "approved"}, "cache policy"),
+        ({"attribution_status": "approved"}, "attribution"),
+    ),
+)
+def test_menustat_source_decision_rejects_budget_api_drift(
+    review_change: dict[str, object],
+    match: str,
+) -> None:
+    payload = _decision_payload()
+    review = payload["budget_api_review"]
+    assert isinstance(review, dict)
+    review.update(review_change)
+
+    with pytest.raises(MenuStatSourceDecisionError, match=match):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("policy_change", "match"),
+    (
+        ({"unexpected": "value"}, "unexpected public web policy keys"),
+        ({"policy_decision": "automation_allowed"}, "manual evidence only"),
+        ({"allowed_surfaces": ["official_restaurant_website"]}, "surfaces must match"),
+        ({"allowed_capture_methods": ["url_citation"]}, "capture methods"),
+        ({"legal_review_required": False}, "must require legal reviews"),
+        ({"anti_scraping_review_required": False}, "must require legal reviews"),
+        ({"copyright_review_required": False}, "must require legal reviews"),
+        ({"automation_allowed": True}, "cannot approve automation"),
+        ({"redistribution_allowed": True}, "cannot approve automation"),
+        ({"public_claim_allowed": True}, "cannot approve automation"),
+    ),
+)
+def test_menustat_source_decision_rejects_public_web_policy_drift(
+    policy_change: dict[str, object],
+    match: str,
+) -> None:
+    payload = _decision_payload()
+    policy = payload["public_web_evidence_policy"]
+    assert isinstance(policy, dict)
+    policy.update(policy_change)
+
+    with pytest.raises(MenuStatSourceDecisionError, match=match):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("decision_change", "match"),
+    (
+        ({"unexpected": "value"}, "unexpected source decision keys"),
+        ({"source": "edamam_food_database"}, "unknown source decision"),
+        ({"research_lane_decision": "approved"}, "decision mismatch"),
+        ({"authority_decision": "approved"}, "cannot be source authority"),
+        ({"automation_approved": True}, "cannot be approved for automation"),
+        ({"eligible_preflight": True}, "cannot be approved for automation"),
+        ({"approved_ingest": True}, "cannot be approved for automation"),
+        ({"blocking_reasons": "not-a-list"}, "must be a list of strings"),
+        ({"blocking_reasons": ["", "contract"]}, "must be a non-empty string"),
+    ),
+)
+def test_menustat_source_decision_rejects_source_decision_drift(
+    decision_change: dict[str, object],
+    match: str,
+) -> None:
+    payload = _decision_payload()
+    decision = _source_decision(payload, "nutritionix")
+    decision.update(decision_change)
+
+    with pytest.raises(MenuStatSourceDecisionError, match=match):
+        parse_menustat_source_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=_replacement(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("replacement", "match"),
+    (
+        (_replacement_without("nutritionix"), "PR9 replacement artifact missing"),
+        (
+            _replacement_with_candidate("nutritionix", authority_decision="approved"),
+            "PR9 candidate nutritionix became approved",
+        ),
+        (
+            _replacement_with_candidate("nutritionix", replacement_for="usda"),
+            "PR9 candidate nutritionix must replace menustat",
+        ),
+    ),
+)
+def test_menustat_source_decision_rejects_pr9_replacement_drift(
+    replacement,
+    match: str,
+) -> None:
+    with pytest.raises(MenuStatSourceDecisionError, match=match):
+        parse_menustat_source_decision(
+            _decision_payload(),
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            replacement=replacement,
         )
 
 


### PR DESCRIPTION
## Summary
- restores the main coverage floor after merge commit `f626435b3` produced `test-main (3.11, 60)` coverage failure at 96.70%
- adds deterministic fail-closed tests for existing food-source governance validators
- keeps production code, CI thresholds, and PR #1603 docs unchanged

## Coordinator / Role Order
- Coordinator packet: `artifacts/orchestration/task_packets/74c728fad218.json` (local artifact, not committed)
- Post-open packet: `artifacts/orchestration/task_packets/3a0658144b75.json` (local artifact, not committed)
- Role order used: agent-coordinator -> qa-engineer-agent -> backend-engineer -> architecture-specialist -> security-auditor -> cursor-specialist-agent -> bug-hunter -> agent-coordinator
- Skills used: `pulseplate-agent-product`, `pulseplate-pr-review`, `code-review-expert`, `ci-fix`

## Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pytest tests/test_food_source_menustat_replacement.py tests/test_food_source_menustat_source_decision.py -q`
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pytest tests/test_food_source_menustat_replacement.py tests/test_food_source_menustat_source_decision.py -q` after CodeRabbit fixes
- `. .venv/bin/activate && python -X faulthandler -m pytest -n 4 --dist=loadscope -m "not slow" --durations=25 --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=97 --junitxml=tests/results.xml -o junit_family=legacy tests` -> 11415 passed, 25 skipped, coverage 97.02%
- `make validate-changed` -> passed; selector reported no production Python files changed
- `pre-commit run --all-files`
- pre-push hooks passed

## Local Verification Deferral
Full local `make verify` was intentionally not run per operator instruction to avoid the CPU-heavy full bundle. The broken coverage gate was checked directly with the CI-equivalent coverage command above.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

Disposition: FIXED
Commit: see mapping entries below
Evidence: `tests/test_food_source_menustat_replacement.py`, `tests/test_food_source_menustat_source_decision.py`, and `docs/review/PR_1610_FIXED_MAPPING.md` address CodeRabbit review findings.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#discussion_r3169352494 -> a9a52367e
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#discussion_r3169352504 -> a9a52367e
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#issuecomment-4354114129 -> a9a52367e
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1610#pullrequestreview-4206770024 -> a9a52367e

## Merge Readiness (Mandatory)

- [x] PR is non-draft only when truly ready for merge
- [x] All required checks are green on latest commit (no pending/rerun required)
- [x] No unresolved review threads
- [x] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [x] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups

- [x] Ledger item(s): None
- [x] GitHub issue(s): None

## Security Notes
- No secrets, auth, quota, or network behavior changed.
- Tests assert existing fail-closed source-governance behavior.

## Decision Log
| Decision | Outcome |
| --- | --- |
| Rollback PR #1603 | No |
| Lower coverage threshold | No |
| Production code changes | No |
| Hotfix surface | Focused tests only |
| Post-merge success target | `main` CI test-main matrix green |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded validation coverage for food source decision parsing, including error handling stability and data consistency checks across system components.

* **Documentation**
  * Added PR verification documentation for quality assurance tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

