### PR TITLE
test(ci): restore main coverage floor

### DIFF
--- a/docs/review/PR_1612_FIXED_MAPPING.md
+++ b/docs/review/PR_1612_FIXED_MAPPING.md
@@ -26,13 +26,18 @@
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-- Status: PR opened for CodeRabbit / bot / human review.
-- Review threads resolved by this artifact: none yet.
-- Actionable review comments: none yet.
+- Status: CodeRabbit / bot / human review pass completed for current findings.
+- Review threads resolved by this artifact: CodeRabbit findings listed below.
+- Actionable review comments: fixed.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 597e7b197
+Evidence: `tests/test_legacy_app_scheduler_non_pytest_path.py` now pins both `app` and `app_module` alias surfaces in scheduler sync-mode tests and asserts the running-loop scheduling branch without allowing the cleanup fallback path.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1612#discussion_r3169886929 -> 597e7b197
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1612#pullrequestreview-4207410376 -> 597e7b197
 
 ## Merge Readiness
 

--- a/docs/review/PR_1612_FIXED_MAPPING.md
+++ b/docs/review/PR_1612_FIXED_MAPPING.md
@@ -23,11 +23,16 @@
 
 ## Discussion Thread Pass
 
-No review threads yet.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+- Status: PR opened for CodeRabbit / bot / human review.
+- Review threads resolved by this artifact: none yet.
+- Actionable review comments: none yet.
 
 ## Fixed in Commit Mapping
 
-No review threads yet.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1612_FIXED_MAPPING.md
+++ b/docs/review/PR_1612_FIXED_MAPPING.md
@@ -1,0 +1,36 @@
+# PR #1612 Fixed Mapping
+
+## PR
+
+- URL: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1612
+- Branch: `codex/hotfix-main-coverage-floor-2`
+- Title: `test(ci): restore main coverage floor`
+
+## Scope
+
+- Coordinator-owned hotfix continuation after `main` coverage stayed below 97%.
+- Adds focused deterministic tests only.
+- Does not lower coverage thresholds, weaken CI, revert prior PRs, or change runtime behavior.
+
+## Local Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS.
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pytest tests/test_utils_pack_facades_coverage.py tests/test_food_source_menustat_replacement.py tests/test_legacy_app_scheduler_non_pytest_path.py -q` PASS.
+- `pre-commit run --all-files` PASS.
+- Pre-push hooks PASS.
+- CI-equivalent coverage probe reached total coverage `97.01%`; the local run had one worktree-environment failure because `make openapi` requires a checkout-local `.venv` in the temp worktree. GitHub current-head CI remains authoritative for that job.
+
+## Discussion Thread Pass
+
+No review threads yet.
+
+## Fixed in Commit Mapping
+
+No review threads yet.
+
+## Merge Readiness
+
+- [ ] Current-head PR CI is green.
+- [ ] CodeRabbit/Sourcery/Cubic actionables are mapped or explicitly classified.
+- [ ] `check_merge_ready.py --require-auth` passes before merge.

--- a/docs/review/PR_1612_FIXED_MAPPING.md
+++ b/docs/review/PR_1612_FIXED_MAPPING.md
@@ -35,9 +35,13 @@
 Disposition: FIXED
 Commit: 597e7b197
 Evidence: `tests/test_legacy_app_scheduler_non_pytest_path.py` now pins both `app` and `app_module` alias surfaces in scheduler sync-mode tests and asserts the running-loop scheduling branch without allowing the cleanup fallback path.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1612#discussion_r3169886929 -> 597e7b197
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1612#pullrequestreview-4207410376 -> 597e7b197
+
+Disposition: FIXED
+Commit: 91e7f2238
+Evidence: `tests/test_legacy_app_scheduler_non_pytest_path.py` covers scheduler sync-mode package/app-module fallback branches with `monkeypatch.setattr()` on the imported `app` package and no `sys.modules` mutation.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1612#discussion_r3169876414 -> 91e7f2238
 
 ## Merge Readiness
 

--- a/tests/test_food_source_menustat_replacement.py
+++ b/tests/test_food_source_menustat_replacement.py
@@ -442,6 +442,44 @@ def test_menustat_replacement_rejects_candidate_catalog_or_onboarding_drift(
         )
 
 
+def test_menustat_replacement_rejects_candidate_policy_mismatch() -> None:
+    payload = _decision_payload()
+    candidate = _candidate(payload, "nutritionix")
+    candidate["source_family"] = "recipe_corpus"
+
+    with pytest.raises(MenuStatReplacementError, match="policy mismatch: source_family"):
+        parse_menustat_replacement_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+        )
+
+
+def test_menustat_replacement_rejects_candidate_eligible_preflight_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _decision_payload()
+    candidate = _candidate(payload, "nutritionix")
+    candidate["onboarding_status"] = "eligible_preflight"
+    expected_policy = dict(menustat_replacement._EXPECTED_CANDIDATE_POLICY["nutritionix"])
+    expected_policy["onboarding_status"] = "eligible_preflight"
+    monkeypatch.setitem(
+        menustat_replacement._EXPECTED_CANDIDATE_POLICY,
+        "nutritionix",
+        expected_policy,
+    )
+
+    with pytest.raises(MenuStatReplacementError, match="must not be eligible_preflight"):
+        parse_menustat_replacement_decision(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding_with_replaced(
+                "nutritionix",
+                onboarding_status="eligible_preflight",
+            ),
+        )
+
+
 def test_menustat_replacement_gate_rejects_missing_candidate() -> None:
     payload = _decision_payload()
     candidates = payload["candidate_sources"]

--- a/tests/test_legacy_app_scheduler_non_pytest_path.py
+++ b/tests/test_legacy_app_scheduler_non_pytest_path.py
@@ -68,7 +68,9 @@ def test_scheduler_pytest_sync_prefers_package_ref_for_app_module_alias(
 
     package_app._scheduler_start_background_updates = starter
     package_app._scheduler_stop_background_updates = stopper
-    monkeypatch.setitem(importlib.import_module("sys").modules, "app", alias_app)
+    sys_modules = importlib.import_module("sys").modules
+    monkeypatch.setitem(sys_modules, "app", alias_app)
+    monkeypatch.setitem(sys_modules, "app_module", alias_app)
     monkeypatch.setattr(legacy_app, "_APP_PACKAGE_REF", package_app, raising=False)
 
     legacy_app.start_background_updates(update_interval_hours=6)
@@ -98,7 +100,9 @@ def test_scheduler_pytest_sync_skips_noncallable_candidates(
     app_module._scheduler_stop_background_updates = object()
     pkg.app_module = app_module
 
-    monkeypatch.setitem(importlib.import_module("sys").modules, "app", pkg)
+    sys_modules = importlib.import_module("sys").modules
+    monkeypatch.setitem(sys_modules, "app", pkg)
+    monkeypatch.setitem(sys_modules, "app_module", app_module)
     monkeypatch.setattr(legacy_app, "_scheduler_start_background_updates", starter, raising=False)
     monkeypatch.setattr(legacy_app, "_scheduler_stop_background_updates", stopper, raising=False)
 
@@ -113,24 +117,33 @@ def test_stop_background_updates_schedules_stopper_on_running_loop(
 ) -> None:
     """Cover non-pytest stop path when an event loop is already running."""
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
-    scheduled: list[Any] = []
+    scheduled: list[str] = []
+    loop_probe = {"called": False}
 
     async def stopper() -> None:
         scheduled.append("ran")
 
     class FakeLoop:
         def create_task(self, coro: Any) -> None:
-            scheduled.append(coro)
+            scheduled.append("scheduled")
             coro.close()
 
     class FakeAsyncio:
         @staticmethod
         def get_running_loop() -> FakeLoop:
+            loop_probe["called"] = True
             return FakeLoop()
 
     monkeypatch.setattr(legacy_app, "resolve_stop_callable", lambda *args: stopper, raising=True)
     monkeypatch.setattr(legacy_app, "asyncio", FakeAsyncio, raising=True)
+    monkeypatch.setattr(
+        legacy_app,
+        "safe_stop_with_cleanup",
+        lambda _stopper: pytest.fail("expected running-loop scheduling path"),
+        raising=True,
+    )
 
     legacy_app.stop_background_updates()
 
-    assert len(scheduled) == 1
+    assert loop_probe["called"] is True
+    assert scheduled == ["scheduled"]

--- a/tests/test_legacy_app_scheduler_non_pytest_path.py
+++ b/tests/test_legacy_app_scheduler_non_pytest_path.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import importlib
 import os
+from types import ModuleType
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -47,3 +49,88 @@ def test_scheduler_path_without_pytest_current_test(monkeypatch: pytest.MonkeyPa
     # Verify resolvers were called (they are called in normal mode, not in pytest sync mode)
     assert mock_resolve_starter.called, "resolve_scheduler_starter should be called in normal mode"
     assert mock_resolve_stopper.called, "resolve_stop_callable should be called in normal mode"
+
+
+def test_scheduler_pytest_sync_prefers_package_ref_for_app_module_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover scheduler sync-mode fallback when sys.modules['app'] is the alias module."""
+    alias_app = ModuleType("app")
+    package_app = ModuleType("app_package")
+    package_app.__path__ = []  # mark as package-like for legacy_app fallback logic
+    called: list[Any] = []
+
+    def starter(update_interval_hours: int) -> None:
+        called.append(("start", update_interval_hours))
+
+    def stopper() -> None:
+        called.append(("stop", None))
+
+    package_app._scheduler_start_background_updates = starter
+    package_app._scheduler_stop_background_updates = stopper
+    monkeypatch.setitem(importlib.import_module("sys").modules, "app", alias_app)
+    monkeypatch.setattr(legacy_app, "_APP_PACKAGE_REF", package_app, raising=False)
+
+    legacy_app.start_background_updates(update_interval_hours=6)
+    legacy_app.stop_background_updates()
+
+    assert called == [("start", 6), 6, ("stop", None), "stop"]
+
+
+def test_scheduler_pytest_sync_skips_noncallable_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover sync-mode candidate iteration before falling back to module globals."""
+    called: list[Any] = []
+
+    def starter(update_interval_hours: int) -> None:
+        called.append(("start", update_interval_hours))
+
+    def stopper() -> None:
+        called.append(("stop", None))
+
+    pkg = ModuleType("app")
+    pkg.__path__ = []
+    pkg._scheduler_start_background_updates = object()
+    pkg._scheduler_stop_background_updates = object()
+    app_module = ModuleType("app_module")
+    app_module._scheduler_start_background_updates = object()
+    app_module._scheduler_stop_background_updates = object()
+    pkg.app_module = app_module
+
+    monkeypatch.setitem(importlib.import_module("sys").modules, "app", pkg)
+    monkeypatch.setattr(legacy_app, "_scheduler_start_background_updates", starter, raising=False)
+    monkeypatch.setattr(legacy_app, "_scheduler_stop_background_updates", stopper, raising=False)
+
+    legacy_app.start_background_updates(update_interval_hours=3)
+    legacy_app.stop_background_updates()
+
+    assert called == [("start", 3), 3, ("stop", None), "stop"]
+
+
+def test_stop_background_updates_schedules_stopper_on_running_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover non-pytest stop path when an event loop is already running."""
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    scheduled: list[Any] = []
+
+    async def stopper() -> None:
+        scheduled.append("ran")
+
+    class FakeLoop:
+        def create_task(self, coro: Any) -> None:
+            scheduled.append(coro)
+            coro.close()
+
+    class FakeAsyncio:
+        @staticmethod
+        def get_running_loop() -> FakeLoop:
+            return FakeLoop()
+
+    monkeypatch.setattr(legacy_app, "resolve_stop_callable", lambda *args: stopper, raising=True)
+    monkeypatch.setattr(legacy_app, "asyncio", FakeAsyncio, raising=True)
+
+    legacy_app.stop_background_updates()
+
+    assert len(scheduled) == 1

--- a/tests/test_legacy_app_scheduler_non_pytest_path.py
+++ b/tests/test_legacy_app_scheduler_non_pytest_path.py
@@ -54,10 +54,8 @@ def test_scheduler_path_without_pytest_current_test(monkeypatch: pytest.MonkeyPa
 def test_scheduler_pytest_sync_prefers_package_ref_for_app_module_alias(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cover scheduler sync-mode fallback when sys.modules['app'] is the alias module."""
-    alias_app = ModuleType("app")
-    package_app = ModuleType("app_package")
-    package_app.__path__ = []  # mark as package-like for legacy_app fallback logic
+    """Cover scheduler sync-mode package callable resolution without module registry edits."""
+    package_app = importlib.import_module("app")
     called: list[Any] = []
 
     def starter(update_interval_hours: int) -> None:
@@ -66,12 +64,8 @@ def test_scheduler_pytest_sync_prefers_package_ref_for_app_module_alias(
     def stopper() -> None:
         called.append(("stop", None))
 
-    package_app._scheduler_start_background_updates = starter
-    package_app._scheduler_stop_background_updates = stopper
-    sys_modules = importlib.import_module("sys").modules
-    monkeypatch.setitem(sys_modules, "app", alias_app)
-    monkeypatch.setitem(sys_modules, "app_module", alias_app)
-    monkeypatch.setattr(legacy_app, "_APP_PACKAGE_REF", package_app, raising=False)
+    monkeypatch.setattr(package_app, "_scheduler_start_background_updates", starter, raising=False)
+    monkeypatch.setattr(package_app, "_scheduler_stop_background_updates", stopper, raising=False)
 
     legacy_app.start_background_updates(update_interval_hours=6)
     legacy_app.stop_background_updates()
@@ -91,18 +85,13 @@ def test_scheduler_pytest_sync_skips_noncallable_candidates(
     def stopper() -> None:
         called.append(("stop", None))
 
-    pkg = ModuleType("app")
-    pkg.__path__ = []
-    pkg._scheduler_start_background_updates = object()
-    pkg._scheduler_stop_background_updates = object()
+    pkg = importlib.import_module("app")
     app_module = ModuleType("app_module")
     app_module._scheduler_start_background_updates = object()
     app_module._scheduler_stop_background_updates = object()
-    pkg.app_module = app_module
-
-    sys_modules = importlib.import_module("sys").modules
-    monkeypatch.setitem(sys_modules, "app", pkg)
-    monkeypatch.setitem(sys_modules, "app_module", app_module)
+    monkeypatch.setattr(pkg, "_scheduler_start_background_updates", object(), raising=False)
+    monkeypatch.setattr(pkg, "_scheduler_stop_background_updates", object(), raising=False)
+    monkeypatch.setattr(pkg, "app_module", app_module, raising=False)
     monkeypatch.setattr(legacy_app, "_scheduler_start_background_updates", starter, raising=False)
     monkeypatch.setattr(legacy_app, "_scheduler_stop_background_updates", stopper, raising=False)
 

--- a/tests/test_utils_pack_facades_coverage.py
+++ b/tests/test_utils_pack_facades_coverage.py
@@ -22,6 +22,7 @@ class TestCoreUtilsFacades:
         assert safe_float("-123.45") == -123.45
         assert safe_float(42) == 42.0
         assert safe_float(3.14) == 3.14
+        assert safe_float(object(), default=7.5) == 7.5
 
     def test_safe_float_invalid_inputs(self) -> None:
         """Test safe_float with invalid inputs returns default."""
@@ -41,7 +42,9 @@ class TestCoreUtilsFacades:
         assert safe_int("0") == 0
         assert safe_int("-123") == -123
         assert safe_int(42) == 42
+        assert safe_int(42.9) == 42
         assert safe_int("123.45") == 123  # truncates float string
+        assert safe_int(object(), default=7) == 7
 
     def test_safe_int_invalid_inputs(self) -> None:
         """Test safe_int with invalid inputs returns default."""


### PR DESCRIPTION
## Summary
- Coordinator-owned continuation hotfix after main coverage remained below 97% on current-head CI.
- Adds focused deterministic tests only for existing scheduler fallback, utility conversion, and MenuStat governance validator branches.
- Does not lower thresholds, weaken CI, revert prior PRs, or change runtime behavior.

## Coordinator / Role Order
1. agent-coordinator: locked hotfix scope and no-threshold-lowering rule.
2. qa-engineer-agent: targeted coverage gap selection and deterministic tests.
3. backend-engineer: confirmed tests cover existing behavior only.
4. architecture-specialist: kept changes narrow; no coverage hacks or runtime drift.
5. security-auditor: no secret/env/auth weakening.
6. cursor-specialist-agent: PR governance and evidence tracking.
7. bug-hunter: checked false-green risks from cancelled main runs.
8. agent-coordinator: final synthesis and merge-readiness tracking.

## Local Evidence
- python3 scripts/orchestration/check_preflight.py: PASS
- python3 scripts/orchestration/check_agent_consistency.py: PASS
- pytest tests/test_utils_pack_facades_coverage.py tests/test_food_source_menustat_replacement.py tests/test_legacy_app_scheduler_non_pytest_path.py -q: PASS
- pre-commit run --all-files: PASS
- pre-push hooks: PASS
- CI-equivalent coverage probe from the hotfix worktree reached total coverage 97.01%; local run had one environment-only failure because make openapi requires a worktree-local .venv in /tmp. GitHub CI is the authoritative current-head signal for that job.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

CodeRabbit actionable comments fixed and mapped.

### Fixed in Commit Mapping
Canonical artifact: docs/review/PR_1612_FIXED_MAPPING.md

Disposition: FIXED
Commit: 597e7b197
Evidence: tests/test_legacy_app_scheduler_non_pytest_path.py pins app/app_module aliases and asserts running-loop scheduling without fallback cleanup.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1612#discussion_r3169886929 -> 597e7b197
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1612#pullrequestreview-4207410376 -> 597e7b197

Disposition: FIXED
Commit: 91e7f2238
Evidence: tests/test_legacy_app_scheduler_non_pytest_path.py now covers scheduler sync-mode package/app-module fallback branches with monkeypatch.setattr() on the imported app package and no sys.modules mutation.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1612#discussion_r3169876414 -> 91e7f2238

## Merge Readiness
- [ ] Current-head PR CI is green.
- [x] CodeRabbit/Sourcery/Cubic actionables are mapped or explicitly classified.
- [x] docs/review/PR_1612_FIXED_MAPPING.md exists and mirrors this PR body.
- [ ] check_merge_ready.py --require-auth passes before merge.

## Security Notes
No production security behavior changed. No auth, secret, quota, or network exposure changes.

## Marketing & GTM
No user-facing product or GTM change; this is CI reliability work to restore main health.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for validation scenarios: policy-field mismatches, disallowed candidate eligibility states, scheduler start/stop resolution and ordering (including behavior when an event loop is already running), and utility conversion/ default-return edge cases.

* **Documentation**
  * Added review documentation summarizing verification status, scope limits, local testing notes, and mapping of fixes to validated tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->