### PR TITLE
fix(docs): mark release-note blocker examples

### DIFF
--- a/docs/release/APPSTORE_RELEASE_NOTES_TEMPLATE.md
+++ b/docs/release/APPSTORE_RELEASE_NOTES_TEMPLATE.md
@@ -169,7 +169,7 @@ in App Store Metadata".
 | 1 | Diagnosis | Claiming the app diagnoses health conditions | "Diagnose nutritional deficiencies" |
 | 2 | Treatment | Claiming the app treats any medical condition | "Treats obesity with personalized plans" |
 | 3 | Therapy | Claiming the app provides therapy or CBT treatment | "CBT therapy sessions included" |
-| 4 | Cure | Claiming the app cures any condition | "Cure your metabolic issues" |
+| 4 | Cure | Claiming the app cures any condition | "Cure your metabolic issues" <!-- pulseplate-allow:blocker-example --> |
 | 5 | Guaranteed weight loss | Asserting definite weight-loss outcomes | "Lose 5 kg in 2 weeks" |
 | 6 | Guaranteed health outcome | Asserting definite health improvements | "Guaranteed to lower your BMI" |
 | 7 | Doctor/medical-device framing | Positioning the app as medical advice or device | "Your pocket nutritionist doctor" |
@@ -181,7 +181,7 @@ in App Store Metadata".
 
 Instead of forbidden patterns, use wellness-only language:
 
-- "Track your wellness journey" (not "diagnose your health")
+- "Track your wellness journey" (not "diagnose your health") <!-- pulseplate-allow:blocker-example -->
 - "Explore nutrition insights" (not "treat nutritional deficiencies")
 - "Understand your body composition" (not "cure metabolic issues")
 - "See current pricing in the app" (not "$4.99/month")

--- a/docs/review/PR_1623_FIXED_MAPPING.md
+++ b/docs/review/PR_1623_FIXED_MAPPING.md
@@ -16,10 +16,13 @@ therefore continued to scan those lines and failed on two matches:
 - Line 172: `"Cure your metabolic issues"` (matched `cures? your`)
 - Line 184: `"diagnose your health"` (matched `diagnoses? your`)
 
+## Discussion Thread Pass
+
+No actionable review comments.
+
 ## Fixed in Commit Mapping
 
-- `docs/release/APPSTORE_RELEASE_NOTES_TEMPLATE.md:172` -> bd618b56d
-- `docs/release/APPSTORE_RELEASE_NOTES_TEMPLATE.md:184` -> bd618b56d
+No actionable review comments
 
 ## Validation
 

--- a/docs/review/PR_1623_FIXED_MAPPING.md
+++ b/docs/review/PR_1623_FIXED_MAPPING.md
@@ -23,7 +23,17 @@ therefore continued to scan those lines and failed on two matches:
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1623#discussion_r3176619302 -> 58e686106
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1623#discussion_r3176621079 -> 58e686106
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1623#discussion_r3176621082 -> 58e686106
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1623#pullrequestreview-4214926544 -> 58e686106
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1623#pullrequestreview-4214930647 -> 58e686106
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1623#pullrequestreview-4214942234 -> 58e686106
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1623#pullrequestreview-4214943653 -> 58e686106
+
+Disposition: FIXED
+Commit: 58e686106
+Evidence: docs/review/PR_1623_FIXED_MAPPING.md — artifact format corrected (checkboxes + canonical marker)
 
 ## Validation
 

--- a/docs/review/PR_1623_FIXED_MAPPING.md
+++ b/docs/review/PR_1623_FIXED_MAPPING.md
@@ -18,11 +18,12 @@ therefore continued to scan those lines and failed on two matches:
 
 ## Discussion Thread Pass
 
-No actionable review comments.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-No actionable review comments
+- No actionable review comments
 
 ## Validation
 

--- a/docs/review/PR_1623_FIXED_MAPPING.md
+++ b/docs/review/PR_1623_FIXED_MAPPING.md
@@ -1,0 +1,32 @@
+# PR #1623 Fixed in Commit Mapping
+
+## Summary
+
+Hotfix for `tests/guards/test_wellness_language_blockers_guard.py` failure after PR #1621.
+The fix adds `pulseplate-allow:blocker-example` inline marker to the exact intentional
+forbidden-claim example lines in `APPSTORE_RELEASE_NOTES_TEMPLATE.md`.
+
+## Root Cause
+
+The wellness language blocker guard only skips lines containing the inline marker
+`pulseplate-allow:blocker-example`. PR #1621 placed the marker in an HTML comment
+above the forbidden-examples section, not on the individual example lines. The guard
+therefore continued to scan those lines and failed on two matches:
+
+- Line 172: `"Cure your metabolic issues"` (matched `cures? your`)
+- Line 184: `"diagnose your health"` (matched `diagnoses? your`)
+
+## Fixed in Commit Mapping
+
+- `docs/release/APPSTORE_RELEASE_NOTES_TEMPLATE.md:172` -> bd618b56d
+- `docs/release/APPSTORE_RELEASE_NOTES_TEMPLATE.md:184` -> bd618b56d
+
+## Validation
+
+- `pytest -q tests/guards/test_wellness_language_blockers_guard.py` — PASS (3/3)
+- `pre-commit run --all-files` — PASS (all hooks)
+- Bug-hunter scan: no remaining unmarked blocker patterns in `docs/`
+
+## Review Thread Disposition
+
+No actionable review comments at time of artifact creation.


### PR DESCRIPTION
## Summary

Fix red `main` by adding the repo-approved wellness blocker example marker to intentional forbidden-claim examples in `APPSTORE_RELEASE_NOTES_TEMPLATE.md`.

## Root Cause

`tests/guards/test_wellness_language_blockers_guard.py` skips only lines containing `pulseplate-allow:blocker-example`.

PR #1621 added release-notes policy examples containing forbidden medical-claim phrases, but the marker was placed above the section rather than on the exact example lines. The guard therefore still scanned the examples and failed.

Failing examples:
- `docs/release/APPSTORE_RELEASE_NOTES_TEMPLATE.md:172`
- `docs/release/APPSTORE_RELEASE_NOTES_TEMPLATE.md:184`

## Scope

- Mark intentional blocker examples inline.
- Keep wellness-language guard strict.

## Non-goals

- No guard weakening.
- No allowlist expansion.
- No skip/xfail.
- No runtime changes.
- No iOS changes.
- No backend/frontend changes.
- No OpenAPI changes.
- No App Store metadata changes.

## Validation

- [x] `pytest -q tests/guards/test_wellness_language_blockers_guard.py` — PASS (3/3)
- [x] `pre-commit run --all-files` — PASS (all hooks)
- [x] `git diff --check` — clean
- [x] Bug-hunter scan: no remaining unmarked blocker patterns in `docs/`

## Security Notes

This preserves the wellness-only posture. The guard remains strict; only intentional policy examples are marked inline. No allowlist expansion. No guard regex change.

## Decision Log

1. Use inline marker because these are intentional forbidden-claim examples in a policy document.
2. Do not modify guard regex because it correctly detected unmarked examples.
3. Do not use allowlist because local inline marker is more precise.

## Deferred / Follow-ups

None. This is a self-contained hotfix.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: docs/review/PR_1623_FIXED_MAPPING.md

## Merge Readiness

- [ ] CI green
- [ ] Guard green
- [ ] Review mapping artifact created
- [ ] No actionable bot comments remain
- [ ] Mandatory wait-window elapsed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Adjusted placement/numbering for the "Cure" row in the release notes template.
  * Added an inline allowance example to a wellness-safe alternative and clarified wellness-language exception handling.
  * Documented a hotfix to validation checks, corrected example mappings for wellness statements, and recorded successful validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->