### PR TITLE
fix(docs): mark blocker examples in PR 1623 mapping artifact

### DIFF
--- a/docs/review/PR_1623_FIXED_MAPPING.md
+++ b/docs/review/PR_1623_FIXED_MAPPING.md
@@ -13,8 +13,8 @@ The wellness language blocker guard only skips lines containing the inline marke
 above the forbidden-examples section, not on the individual example lines. The guard
 therefore continued to scan those lines and failed on two matches:
 
-- Line 172: `"Cure your metabolic issues"` (matched `cures? your`)
-- Line 184: `"diagnose your health"` (matched `diagnoses? your`)
+- Line 172: `"Cure your metabolic issues"` (matched `cures? your`) <!-- pulseplate-allow:blocker-example -->
+- Line 184: `"diagnose your health"` (matched `diagnoses? your`) <!-- pulseplate-allow:blocker-example -->
 
 ## Discussion Thread Pass
 

--- a/docs/review/PR_1624_FIXED_MAPPING.md
+++ b/docs/review/PR_1624_FIXED_MAPPING.md
@@ -1,0 +1,19 @@
+# PR #1624 Fixed in Commit Mapping
+
+## Summary
+
+Follow-up to PR #1623. Adds inline `pulseplate-allow:blocker-example` markers to quoted
+forbidden-claim phrases in the PR #1623 mapping artifact Root Cause section.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Validation
+
+- `pytest -q tests/guards/test_wellness_language_blockers_guard.py` — PASS (3/3)


### PR DESCRIPTION
## Summary

Follow-up to PR #1623. The mapping artifact `docs/review/PR_1623_FIXED_MAPPING.md` contains quoted forbidden-claim phrases in its Root Cause section that trigger the wellness language blocker guard. This adds the inline `pulseplate-allow:blocker-example` marker to those 2 lines.

## Scope

- 2-line inline marker addition in `docs/review/PR_1623_FIXED_MAPPING.md`
- No guard weakening, no allowlist expansion, no runtime changes

## Validation

- [x] `pytest -q tests/guards/test_wellness_language_blockers_guard.py` — PASS (3/3)

## Deferred / Follow-ups

None.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: docs/review/PR_1624_FIXED_MAPPING.md (will create after PR number known)

## Merge Readiness

- [ ] CI green
- [ ] Guard green
- [ ] No actionable bot comments remain

## Summary by Sourcery

Документация:
- Аннотировать два приведённых в кавычках примера запрещённых фраз в документе исправленного отображения PR 1623 с помощью встроенного маркера разрешения для примеров блокировки, чтобы предотвратить ложные срабатывания защитного механизма блокировщика языка, связанного с благополучием.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Annotate two quoted forbidden-phrase examples in the PR 1623 fixed mapping document with an inline blocker-example allow marker to prevent false positives from the wellness language blocker guard.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds inline `pulseplate-allow:blocker-example` markers to two quoted examples in `docs/review/PR_1623_FIXED_MAPPING.md` and adds `docs/review/PR_1624_FIXED_MAPPING.md`. Stops false positives from the wellness blocker; no guard or runtime changes.

<sup>Written for commit f802dadd2c9f7becbefe273258236316d015f91f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed release notes template examples to include the required inline marker for consistent validation.
  * Added a new PR review document summarizing the change, checklist pass, commit mapping, and validation (pytest) result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->