### PR TITLE
fix(ios): handle AI consent required state

### DIFF
--- a/docs/review/PR_1629_FIXED_MAPPING.md
+++ b/docs/review/PR_1629_FIXED_MAPPING.md
@@ -7,6 +7,7 @@ PR #1629 fixes the iOS build failure by handling `.consentRequired` in `AIInsigh
 ## Scope
 
 - `ios/PulsePlate/Views/AIInsightView.swift`
+- `ios/PulsePlateTests/AIWellnessConsentTests.swift`
 - `tests/ios/test_ai_insight_state_exhaustiveness_guard.py`
 
 ## Discussion Thread Pass

--- a/docs/review/PR_1629_FIXED_MAPPING.md
+++ b/docs/review/PR_1629_FIXED_MAPPING.md
@@ -9,10 +9,14 @@ PR #1629 fixes the iOS build failure by handling `.consentRequired` in `AIInsigh
 - `ios/PulsePlate/Views/AIInsightView.swift`
 - `tests/ios/test_ai_insight_state_exhaustiveness_guard.py`
 
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
 ## Fixed in Commit Mapping
 
-- AIInsightView `.consentRequired` case added to `switch vm.state` -> `f8438bb3634e2276f28defd44f3c3e4d592fc1be`
-- State exhaustiveness guard test created -> `f8438bb3634e2276f28defd44f3c3e4d592fc1be`
+No actionable review comments.
 
 ## Validation
 
@@ -24,7 +28,3 @@ PR #1629 fixes the iOS build failure by handling `.consentRequired` in `AIInsigh
 - `python3 scripts/orchestration/check_agent_consistency.py` — PASS
 - `pre-commit run --all-files` — PASS
 - `git diff --check` — PASS
-
-## Review Thread Disposition
-
-Populate after CodeRabbit, Sourcery, and Cubic reviews complete.

--- a/docs/review/PR_1629_FIXED_MAPPING.md
+++ b/docs/review/PR_1629_FIXED_MAPPING.md
@@ -17,7 +17,15 @@ PR #1629 fixes the iOS build failure by handling `.consentRequired` in `AIInsigh
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1629#discussion_r3177030442 -> 4454d3e36
+  Disposition: FIXED
+  Commit: 4454d3e36
+  Evidence: docs/review/PR_1629_FIXED_MAPPING.md (mapping format corrected to canonical `- No actionable review comments`)
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1629#discussion_r3177030443 -> c609d3b80
+  Disposition: FIXED
+  Commit: c609d3b80
+  Evidence: docs/review/PR_1629_FIXED_MAPPING.md:12 (`## Discussion Thread Pass` section added)
 
 ## Validation
 

--- a/docs/review/PR_1629_FIXED_MAPPING.md
+++ b/docs/review/PR_1629_FIXED_MAPPING.md
@@ -16,7 +16,7 @@ PR #1629 fixes the iOS build failure by handling `.consentRequired` in `AIInsigh
 
 ## Fixed in Commit Mapping
 
-No actionable review comments.
+- No actionable review comments
 
 ## Validation
 

--- a/docs/review/PR_1629_FIXED_MAPPING.md
+++ b/docs/review/PR_1629_FIXED_MAPPING.md
@@ -20,7 +20,7 @@ PR #1629 fixes the iOS build failure by handling `.consentRequired` in `AIInsigh
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1629#discussion_r3177030442 -> 4454d3e36
   Disposition: FIXED
   Commit: 4454d3e36
-  Evidence: docs/review/PR_1629_FIXED_MAPPING.md (mapping format corrected to canonical `- No actionable review comments`)
+  Evidence: docs/review/PR_1629_FIXED_MAPPING.md (mapping format corrected to canonical N/A marker)
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1629#discussion_r3177030443 -> c609d3b80
   Disposition: FIXED

--- a/docs/review/PR_1629_FIXED_MAPPING.md
+++ b/docs/review/PR_1629_FIXED_MAPPING.md
@@ -1,0 +1,30 @@
+# PR #1629 Fixed in Commit Mapping
+
+## Summary
+
+PR #1629 fixes the iOS build failure by handling `.consentRequired` in `AIInsightView.swift`.
+
+## Scope
+
+- `ios/PulsePlate/Views/AIInsightView.swift`
+- `tests/ios/test_ai_insight_state_exhaustiveness_guard.py`
+
+## Fixed in Commit Mapping
+
+- AIInsightView `.consentRequired` case added to `switch vm.state` -> `f8438bb3634e2276f28defd44f3c3e4d592fc1be`
+- State exhaustiveness guard test created -> `f8438bb3634e2276f28defd44f3c3e4d592fc1be`
+
+## Validation
+
+- `pytest -q tests/ios/test_ai_insight_state_exhaustiveness_guard.py` — PASS
+- `pytest -q tests/ios/test_ai_wellness_consent_guard.py` — PASS
+- `pytest -q tests/ios/` — PASS (32 tests)
+- `pytest -q tests/guards/test_wellness_language_blockers_guard.py` — PASS
+- `python3 scripts/orchestration/check_preflight.py` — PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` — PASS
+- `pre-commit run --all-files` — PASS
+- `git diff --check` — PASS
+
+## Review Thread Disposition
+
+Populate after CodeRabbit, Sourcery, and Cubic reviews complete.

--- a/docs/review/PR_1629_FIXED_MAPPING.md
+++ b/docs/review/PR_1629_FIXED_MAPPING.md
@@ -27,6 +27,14 @@ PR #1629 fixes the iOS build failure by handling `.consentRequired` in `AIInsigh
   Commit: c609d3b80
   Evidence: docs/review/PR_1629_FIXED_MAPPING.md:12 (`## Discussion Thread Pass` section added)
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1629#pullrequestreview-4215353001
+  Disposition: NOT-A-BUG
+  Evidence: CodeRabbit summary review with nitpick suggestions; inline threads resolved above. Localization deferral is intentional (hotfix scope).
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1629#pullrequestreview-4215355555
+  Disposition: NOT-A-BUG
+  Evidence: Cubic summary review pointing to inline threads already resolved above (artifact format issues fixed in 4454d3e36 and c609d3b80).
+
 ## Validation
 
 - `pytest -q tests/ios/test_ai_insight_state_exhaustiveness_guard.py` — PASS

--- a/ios/PulsePlate/Views/AIInsightView.swift
+++ b/ios/PulsePlate/Views/AIInsightView.swift
@@ -129,6 +129,25 @@ struct AIInsightView: View {
         case .idle:
             EmptyView()
 
+        case .consentRequired:
+            GlassCard {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("AI wellness consent required")
+                        .font(.headline)
+                        .foregroundStyle(Color.textPrimary)
+
+                    Text("Review the wellness-only AI disclosure before generating an insight.")
+                        .font(.subheadline)
+                        .foregroundStyle(Color.textSecondary)
+
+                    Button("Review disclosure") {
+                        showConsentSheet = true
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
         case .loading:
             GlassCard {
                 VStack(alignment: .leading, spacing: 12) {

--- a/ios/PulsePlateTests/AIWellnessConsentTests.swift
+++ b/ios/PulsePlateTests/AIWellnessConsentTests.swift
@@ -137,13 +137,13 @@ final class AIWellnessConsentTests: XCTestCase {
     private func makeResponse() -> CBTInsightResponseDTO {
         CBTInsightResponseDTO(
             insight: "Test insight",
+            ragUsed: false,
+            sources: [],
             confidence: 0.9,
             uncertainty: 0.1,
-            ragUsed: false,
-            mode: "auto_safe",
-            quotaState: "consumed",
             warnings: [],
-            sources: []
+            mode: "auto_safe",
+            quotaState: "consumed"
         )
     }
 

--- a/tests/ios/test_ai_insight_state_exhaustiveness_guard.py
+++ b/tests/ios/test_ai_insight_state_exhaustiveness_guard.py
@@ -1,0 +1,39 @@
+"""Guard: AIInsightView must handle all AIInsightState cases explicitly.
+
+The switch over vm.state in AIInsightView.swift must handle every enum case
+without using ``default:`` or ``@unknown default`` to hide missing branches.
+
+Evidence anchors:
+- ios/PulsePlate/Views/AIInsightView.swift
+- ios/PulsePlate/ViewModels/AIInsightViewModel.swift (AIInsightState enum)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AI_VIEW = REPO_ROOT / "ios" / "PulsePlate" / "Views" / "AIInsightView.swift"
+
+
+def test_ai_insight_view_handles_consent_required_state() -> None:
+    """AIInsightView must contain an explicit case .consentRequired branch."""
+    text = AI_VIEW.read_text(encoding="utf-8")
+    assert (
+        "case .consentRequired" in text
+    ), "AIInsightView.swift must handle .consentRequired in switch vm.state"
+    assert "switch vm.state" in text, "AIInsightView.swift must contain switch vm.state"
+
+
+def test_ai_insight_view_does_not_hide_state_exhaustiveness_with_default() -> None:
+    """switch vm.state must not use default: or @unknown default for internal enum."""
+    text = AI_VIEW.read_text(encoding="utf-8")
+    switch_start = text.index("switch vm.state")
+    # Read enough of the switch block to cover all cases
+    switch_block = text[switch_start : switch_start + 1500]
+    assert (
+        "default:" not in switch_block
+    ), "switch vm.state must not use default: to hide enum exhaustiveness"
+    assert (
+        "@unknown default" not in switch_block
+    ), "switch vm.state must not use @unknown default for internal enum"


### PR DESCRIPTION
## Summary

Fix red `main` by handling the new `.consentRequired` AI insight state in `AIInsightView.swift`.

## Root Cause

The AI wellness consent lane (PR #1628) added `.consentRequired` to `AIInsightViewModel.State`, but `AIInsightView.swift` still had a non-exhaustive `switch vm.state`. Xcode build-for-testing fails with:

```
ios/PulsePlate/Views/AIInsightView.swift:128:9
error: switch must be exhaustive
note: add missing case: '.consentRequired'
```

## Changes

- **`ios/PulsePlate/Views/AIInsightView.swift`**: Add explicit `case .consentRequired:` to `switch vm.state` in `resultSection`. Renders a `GlassCard` with consent-required message and a "Review disclosure" button that opens the existing `AIWellnessDisclosureSheet`. No `default:` used — all enum cases handled explicitly.
- **`tests/ios/test_ai_insight_state_exhaustiveness_guard.py`**: New guard test asserting `.consentRequired` is handled and no `default:`/`@unknown default` hides enum exhaustiveness.

## Scope

- `ios/PulsePlate/Views/AIInsightView.swift`
- `tests/ios/test_ai_insight_state_exhaustiveness_guard.py`

## Non-goals

- No backend changes
- No OpenAPI changes
- No Fastlane metadata changes
- No reviewer-pack work
- No validation-gates work
- No HealthKit changes
- No AppIcon changes
- No security/trivy changes
- No consent bypass
- No consent storage semantics changes

## Validation

- [x] `pytest -q tests/ios/test_ai_insight_state_exhaustiveness_guard.py` — PASS
- [x] `pytest -q tests/ios/test_ai_wellness_consent_guard.py` — PASS
- [x] `pytest -q tests/ios/` — PASS (32 tests)
- [x] `pytest -q tests/guards/test_wellness_language_blockers_guard.py` — PASS
- [x] `python3 scripts/orchestration/check_preflight.py` — PASS
- [x] `python3 scripts/orchestration/check_agent_consistency.py` — PASS
- [x] `pre-commit run --all-files` — PASS
- [x] `git diff --check` — PASS
- [ ] CI green (pending)
- [ ] iOS build-for-testing green (pending CI)

## Security Notes

The fix preserves fail-closed AI consent behavior. `.consentRequired` remains a blocked state — no AI request is sent, and the user must explicitly review and accept the wellness-only disclosure before the request proceeds. The manual "Review disclosure" button is a redundant safety net alongside the `.onChange` auto-trigger.

## Decision Log

1. Handle `.consentRequired` explicitly — no `default:` to hide enum exhaustiveness.
2. Use inline English string literals (localization deferred to follow-up).
3. Include manual "Review disclosure" button for edge-case resilience.
4. Do not change consent persistence or backend contracts.
5. Keep reviewer-pack and validation-gates work in separate PRs.

## Agent Pass Summary

| Agent | Scope | Result |
|-------|-------|--------|
| coordinator | scope control, no mixing with PR-8/PR-9 | PASS |
| ios-engineer | Swift compile fix in AIInsightView.swift | PASS |
| qa-engineer | guard test for state exhaustiveness | PASS |
| security-auditor | consent gate not bypassed, AI request blocked | PASS |
| appstore-release | wellness-only disclosure, no medical/therapy/crisis claims | PASS |
| bug-hunter | no other switch over AIInsightState missing .consentRequired | PASS |
| cursor-specialist | branch hygiene, validation, PR body | PASS |

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: docs/review/PR_1629_FIXED_MAPPING.md

## Merge Readiness

- [ ] CI green
- [ ] iOS build-for-testing green
- [x] Review mapping artifact created
- [ ] No actionable bot comments remain
- [ ] Mandatory wait-window elapsed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a consent disclosure prompt in the AI Insight interface with a "Review disclosure" button to view the AI wellness-only information.

* **Tests**
  * Added tests requiring the AI Insight view to explicitly handle the new consent state and enforce exhaustive state handling (no hidden fallbacks).

* **Documentation**
  * Added review notes documenting the fix, validation checklist, and test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->