### PR TITLE
fix(security): remove Trivy suppression for CVE-2026-33845

### DIFF
--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -178,52 +178,6 @@ ignore if {
 	input.InstalledVersion == "3.7.9-2+deb12u5"
 }
 
-# anchor:cve-2026-33845-gnutls-suppression
-# CVE-2026-33845 (GnuTLS) - no fixed release for observed Debian package at triage time
-# Review-by: 2026-05-27 (manual removal)
-# Rationale: Trivy code-scanning alert #589 reports libgnutls30 fixed-version unknown
-#   for `3.7.9-2+deb12u5` in the production image. No repository-level
-#   remediation path exists until Debian publishes a fixed package line or
-#   Trivy metadata reports a Fixed Version.
-# Monitor: https://security-tracker.debian.org/tracker/CVE-2026-33845
-# Documented in: docs/security/CVE-2026-33845-gnutls.md
-# Removal condition: Remove when Debian publishes fixed libgnutls30 package / Trivy metadata gains fixed version for this package context
-
-cve_2026_33845_libgnutls30_version := "3.7.9-2+deb12u5"
-
-cve_2026_33845_image_reference_match if {
-	startswith(input.Image, "ghcr.io/katsiarynakavaleuskaya/pulseplate")
-}
-
-cve_2026_33845_image_reference_match if {
-	startswith(input.Image, "katsiarynakavaleuskaya/pulseplate")
-}
-
-cve_2026_33845_image_reference_match if {
-	# Fallback: Trivy sometimes omits the Image field in certain scan contexts;
-	# suppression still requires exact CVE + package + version + pkgID prefix match.
-	not input.Image
-}
-
-cve_2026_33845_distro_match if {
-	input.Distro == "debian"
-}
-
-cve_2026_33845_distro_match if {
-	# Fallback: Trivy sometimes omits the Distro field;
-	# suppression still requires exact CVE + package + version + pkgID prefix match.
-	not input.Distro
-}
-
-ignore if {
-	input.VulnerabilityID == "CVE-2026-33845"
-	input.PkgName == "libgnutls30"
-	input.InstalledVersion == cve_2026_33845_libgnutls30_version
-	cve_2026_33845_image_reference_match
-	cve_2026_33845_distro_match
-	startswith(input.PkgID, sprintf("libgnutls30@%s", [cve_2026_33845_libgnutls30_version]))
-}
-
 # CVE-2026-3184 (util-linux family) - upstream unfixed in Debian bookworm
 # Review-by: 2026-05-27 (manual removal)
 # Rationale: Unfixed distro CVE; access control bypass via hostname canonicalization; LOW severity


### PR DESCRIPTION
### Motivation
- Restore CI/code-scanning visibility for a documented HIGH-severity GnuTLS issue by removing a repository-level Trivy suppression that was hiding `CVE-2026-33845` for `libgnutls30@3.7.9-2+deb12u5`.

### Description
- Removed the `CVE-2026-33845` ignore-policy block from `trivy/ignore-policy.rego`, leaving no other behavioral changes in the repo and keeping remediation (package/base-image upgrade) as a separate follow-up.

### Testing
- Verified the change by inspecting `trivy/ignore-policy.rego` with `rg`, `sed`, and `nl` to confirm the suppression predicates were removed and committed the file (`git commit` succeeded). 
- No full test-suite or `make verify` run was performed in this PR; CI will surface downstream test results and package-remediation follow-ups will be tracked separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f670c55c1c8333a72b3cdc6903ac2c)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Trivy ignore rule for `CVE-2026-33845` so CI/code scanning reports the high-severity GnuTLS issue again. This deletes the suppression in `trivy/ignore-policy.rego` for `libgnutls30@3.7.9-2+deb12u5`; remediation will follow separately.

<sup>Written for commit e0e17eadf939f5417e6579eb323e9fe06eaf2b48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed suppression for CVE-2026-33845 in libgnutls30, enabling security vulnerability alerts for this issue to be detected and reported in scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->