### PR TITLE
fix(tests): remove sys path mutation from evals conftest

### DIFF
--- a/docs/review/PR_1641_FIXED_MAPPING.md
+++ b/docs/review/PR_1641_FIXED_MAPPING.md
@@ -35,6 +35,16 @@ forbids this pattern in test files. The mutation was redundant because
   Commit: 3fab25392
   Evidence: docs/review/PR_1641_FIXED_MAPPING.md (Discussion Thread Pass section added)
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1641#pullrequestreview-4215974470
+  Disposition: NOT-A-BUG
+  Evidence: CodeRabbit review summary — no actionable items
+  Reason: Review summary approving the change, no code modifications needed
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1641#pullrequestreview-4215975347
+  Disposition: NOT-A-BUG
+  Evidence: Cubic review summary — inline comments addressed in commit 3fab25392
+  Reason: Summary references inline comments already mapped above as FIXED
+
 ## Validation
 
 - `pytest -q tests/test_import_hygiene_guard.py` — PASS
@@ -48,5 +58,5 @@ forbids this pattern in test files. The mutation was redundant because
 - [x] CI green
 - [x] import hygiene guard green
 - [x] review mapping artifact created
-- [ ] no actionable bot comments remain
+- [x] no actionable bot comments remain
 - [ ] mandatory wait-window elapsed

--- a/docs/review/PR_1641_FIXED_MAPPING.md
+++ b/docs/review/PR_1641_FIXED_MAPPING.md
@@ -1,0 +1,36 @@
+# PR #1641 Fixed in Commit Mapping
+
+## Summary
+
+PR #1641 fixes the import hygiene guard failure on `main` by removing
+`sys.path.insert` from `tests/evals/conftest.py` and removing the stale
+allowlist entry from `tests/test_repo_policy_guards.py`.
+
+## Root Cause
+
+`tests/evals/conftest.py` mutated `sys.path` to make `scripts.evals.*`
+importable. The import hygiene guard (`tests/test_import_hygiene_guard.py`)
+forbids this pattern in test files. The mutation was redundant because
+`pyproject.toml` already sets `pythonpath = "."`.
+
+## Scope
+
+- `tests/evals/conftest.py`
+- `tests/test_repo_policy_guards.py`
+
+## Fixed in Commit Mapping
+
+Pending bot review comments. Will be populated after CodeRabbit, Sourcery,
+and Cubic reviews complete.
+
+## Validation
+
+- `pytest -q tests/test_import_hygiene_guard.py` — PASS
+- `pytest -q tests/test_repo_policy_guards.py` — PASS
+- `pytest -q tests/evals/` — PASS (53 tests)
+- `make validate-min` — PASS
+- `pre-commit run --all-files` — PASS
+
+## Review Thread Disposition
+
+Populate after bot reviews complete.

--- a/docs/review/PR_1641_FIXED_MAPPING.md
+++ b/docs/review/PR_1641_FIXED_MAPPING.md
@@ -27,12 +27,12 @@ forbids this pattern in test files. The mutation was redundant because
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1641#discussion_r3177732677
   Disposition: FIXED
-  Commit: PENDING
+  Commit: 3fab25392
   Evidence: docs/review/PR_1641_FIXED_MAPPING.md (artifact updated with canonical format)
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1641#discussion_r3177732679
   Disposition: FIXED
-  Commit: PENDING
+  Commit: 3fab25392
   Evidence: docs/review/PR_1641_FIXED_MAPPING.md (Discussion Thread Pass section added)
 
 ## Validation

--- a/docs/review/PR_1641_FIXED_MAPPING.md
+++ b/docs/review/PR_1641_FIXED_MAPPING.md
@@ -18,10 +18,22 @@ forbids this pattern in test files. The mutation was redundant because
 - `tests/evals/conftest.py`
 - `tests/test_repo_policy_guards.py`
 
-## Fixed in Commit Mapping
+## Discussion Thread Pass
 
-Pending bot review comments. Will be populated after CodeRabbit, Sourcery,
-and Cubic reviews complete.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+### Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1641#discussion_r3177732677
+  Disposition: FIXED
+  Commit: PENDING
+  Evidence: docs/review/PR_1641_FIXED_MAPPING.md (artifact updated with canonical format)
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1641#discussion_r3177732679
+  Disposition: FIXED
+  Commit: PENDING
+  Evidence: docs/review/PR_1641_FIXED_MAPPING.md (Discussion Thread Pass section added)
 
 ## Validation
 
@@ -31,6 +43,10 @@ and Cubic reviews complete.
 - `make validate-min` — PASS
 - `pre-commit run --all-files` — PASS
 
-## Review Thread Disposition
+## Merge Readiness
 
-Populate after bot reviews complete.
+- [x] CI green
+- [x] import hygiene guard green
+- [x] review mapping artifact created
+- [ ] no actionable bot comments remain
+- [ ] mandatory wait-window elapsed

--- a/tests/evals/conftest.py
+++ b/tests/evals/conftest.py
@@ -1,16 +1,10 @@
-"""Shared conftest for tests/evals/.
+"""Shared pytest configuration for tests/evals/.
 
-RU: Путь к корню репо для импорта scripts/evals/*.
-EN: Adds repo root to sys.path so scripts.evals.* is importable.
+RU: Импорты evals используют стандартный путь через pyproject.toml pythonpath.
+EN: Evals tests use standard package imports from the repository root,
+    as provided by the test runner (pyproject.toml: pythonpath = ".").
 
-conftest.py is in the import-hygiene allowlist for sys.path.insert.
+Import hygiene policy forbids mutating sys.path from test files.
 """
 
 from __future__ import annotations
-
-import sys
-from pathlib import Path
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_repo_policy_guards.py
+++ b/tests/test_repo_policy_guards.py
@@ -44,7 +44,6 @@ ALLOWED_TEST_FILES_FOR_DYNAMIC_IMPORT = {
 ALLOWED_TEST_FILES_FOR_SYS_PATH_INSERT = {
     "tests/test_test_pro_access_coverage.py",
     "tests/conftest.py",
-    "tests/evals/conftest.py",  # repo root path for scripts.evals.* imports
     "tests/test_repo_policy_guards.py",  # this file (checks for the pattern)
     "tests/test_import_hygiene_guard.py",  # guard test
 }


### PR DESCRIPTION
## Summary

Fix red `main` by removing `sys.path.insert` from `tests/evals/conftest.py`.

**Type:** P0 / main red hotfix / test import hygiene

## Root Cause

`tests/test_import_hygiene_guard.py::test_no_sys_path_insert_in_tests` scans all test files and rejects `sys.path.insert` outside the explicit exception list.

`tests/evals/conftest.py` (introduced in PR #1632) added repo-root path mutation for `scripts.evals.*` imports, but this violates the import hygiene policy. The `sys.path.insert` was redundant because `pyproject.toml` already sets `pythonpath = "."`, which makes `scripts.evals.*` importable via Python 3 implicit namespace packages.

## Scope

- `tests/evals/conftest.py` — removed `sys.path.insert`, replaced with neutral docstring
- `tests/test_repo_policy_guards.py` — removed stale allowlist entry (tightening, not loosening)

## Split Justification

2-file minimal hotfix. Well under any LoC threshold.

## Non-goals

- No guard weakening
- No new exceptions
- No allowlist additions
- No runtime changes
- No backend/frontend/iOS changes
- No OpenAPI changes

## Validation

- [x] `pytest -q tests/test_import_hygiene_guard.py` — PASS
- [x] `pytest -q tests/test_repo_policy_guards.py` — PASS
- [x] `pytest -q tests/evals/` — PASS (53 tests, standard imports work)
- [x] `make validate-min` — PASS
- [x] `pre-commit run --all-files` — PASS

## Security Notes

The guard is tightened, not weakened. The allowlist entry in `test_repo_policy_guards.py` is removed because `tests/evals/conftest.py` no longer uses `sys.path.insert`.

## Decision Log

1. Remove `sys.path.insert` from conftest (redundant with `pythonpath = "."`)
2. Remove stale allowlist entry from `test_repo_policy_guards.py`
3. Do not add `tests/evals/conftest.py` to guard exceptions in `test_import_hygiene_guard.py`
4. Keep eval imports standard and repo-root based via implicit namespace packages

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: docs/review/PR_1641_FIXED_MAPPING.md

## Merge Readiness

- [x] CI green
- [x] import hygiene guard green
- [x] review mapping artifact created
- [ ] no actionable bot comments remain
- [ ] mandatory wait-window elapsed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on import-hygiene policy and a validation checklist confirming test/tooling passing.

* **Chores**
  * Removed redundant test environment path mutation from test setup.
  * Tightened test validation rules to enforce stricter import patterns and disallow the prior exception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->