### PR TITLE
docs(orchestration): add premortem risk review skill

### DIFF
--- a/.agents/skills/pulseplate-premortem-risk-review
+++ b/.agents/skills/pulseplate-premortem-risk-review
@@ -1,0 +1,1 @@
+../../tools/codex_skills/pulseplate-premortem-risk-review

--- a/docs/dev/CODEX_SKILLS.md
+++ b/docs/dev/CODEX_SKILLS.md
@@ -154,6 +154,7 @@ approved research-only connector contract. Evidence:
 - Build/update architecture graph artifact: `pulseplate-graphmap`
 - Run browser E2E flows (step 3 extension): `pulseplate-playwright-e2e`
 - Run coordinator-owned PR self-review before external review-bot signals: `pulseplate-pr-review` (evidence: `tools/codex_skills/pulseplate-pr-review/SKILL.md:1`, `docs/orchestration/PULSEPLATE_PR_REVIEW_SKILL_PACKET_2026-04-24.md:1`)
+- Run premortem risk analysis on high-downside plans before merge or launch: `pulseplate-premortem-risk-review` (evidence: `tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:1`, `scripts/orchestration/skill_router.py`)
 
 ## Project-specific whitelist
 
@@ -166,6 +167,7 @@ Recommended now for PulsePlate:
 - `pulseplate-web-launch-site` for launch-site pages, CTA funnels, waitlist/lead-capture paths, and wellness-safe public launch copy (evidence: `tools/codex_skills/pulseplate-web-launch-site/SKILL.md:8`, `tests/test_skill_router.py:657`)
 - `pulseplate-agent-product` for agent-product surfaces, operator workflows, HITL boundaries, and product handoffs that preserve coordinator authority (evidence: `tools/codex_skills/pulseplate-agent-product/SKILL.md:8`, `tests/test_skill_router.py:847`)
 - `pulseplate-pr-review` for passive, coordinator-owned PR self-review that stays advisory and preserves merge-readiness gates
+- `pulseplate-premortem-risk-review` for premortem risk analysis on high-downside plans (PR, epic, launch, security, CI/CD, AI/RAG, App Store, monetization, design decisions)
 - `docs-sync` for orchestration, runbooks, and PR support docs
 - `bug-triage` and `pulseplate-gates` for remediation and gate closure
 - `figma` as the first design-system and prototype lane
@@ -205,6 +207,7 @@ Not approved as default:
 2. Step 2: Domain skills (guards, backend endpoints, AI reports, graph map).
 3. Step 3: Browser E2E extension with Playwright (`pulseplate-playwright-e2e`) for controlled web flow automation.
 4. Step 4: Launch/product extensions (`pulseplate-design-launch-system`, `pulseplate-web-launch-site`, `pulseplate-agent-product`, `pulseplate-pr-review`) for repo-native go-to-market, agent-product, and review governance support.
+5. Step 5: Risk/decision extensions (`pulseplate-premortem-risk-review`) for premortem risk analysis on high-downside plans before merge or launch.
 
 ## Computer Use / MCP troubleshooting
 

--- a/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
+++ b/docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md
@@ -155,13 +155,13 @@ metadata, screenshot-pack, App Privacy, or release-evidence intent.
 
 | Lane | Default Skills | Conditional Skills |
 |------|----------------|--------------------|
-| Orchestration / agent workflow | `pulseplate-workflow`, `docs-sync`, `agents-md`, `pulseplate-gates` | `pulseplate-guards`, `pulseplate-pr-review`, `pulseplate-agent-product`, `code-review-expert`, `create-pr` |
-| Experimentation / eval / optimization | `pulseplate-workflow`, `docs-sync`, `pulseplate-gates` | `bug-triage`, `code-review-expert`, `openai-docs` |
+| Orchestration / agent workflow | `pulseplate-workflow`, `docs-sync`, `agents-md`, `pulseplate-gates` | `pulseplate-guards`, `pulseplate-pr-review`, `pulseplate-premortem-risk-review`, `pulseplate-agent-product`, `code-review-expert`, `create-pr` |
+| Experimentation / eval / optimization | `pulseplate-workflow`, `docs-sync`, `pulseplate-gates` | `bug-triage`, `code-review-expert`, `pulseplate-premortem-risk-review`, `openai-docs` |
 | Backend / API / contracts | `pulseplate-backend-endpoints`, `pulseplate-openapi-sync`, `pulseplate-gates` | `bug-triage`, `security-best-practices`, `openai-docs` |
 | Frontend / web UX | `pulseplate-frontend-ui`, `pulseplate-gates`, `build-web-apps:frontend-skill` | `pulseplate-web-launch-site`, `pulseplate-playwright-e2e`, `playwright`, `figma`, `figma-implement-design`, `vercel-react-best-practices`, `build-web-apps:web-design-guidelines`, `build-web-apps:react-best-practices` |
 | iOS / App Store / Fastlane | `build-ios-apps:swiftui-ui-patterns`, `build-ios-apps:swiftui-view-refactor` | `build-ios-apps:ios-debugger-agent`, `build-ios-apps:swiftui-performance-audit`, `pulseplate-app-store-release` |
 | Docs / runbooks / policy | `docs-sync` | `agents-md`, `release-notes`, `code-review-expert` |
-| QA / CI / remediation | `bug-triage`, `pulseplate-gates` | `pulseplate-pr-review`, `ci-fix`, `gh-fix-ci`, `gh-address-comments`, `code-review-expert` |
+| QA / CI / remediation | `bug-triage`, `pulseplate-gates` | `pulseplate-pr-review`, `pulseplate-premortem-risk-review`, `ci-fix`, `gh-fix-ci`, `gh-address-comments`, `code-review-expert` |
 | Reports / wellness / GTM research | `pulseplate-ai-reports`, `docs-sync` | `notion-research-documentation`, `notion-knowledge-capture`, `linear`, `openai-docs`, `pulseplate-monetization-gtm`, `pulseplate-web-launch-site` |
 | Monetization / paywall / subscriptions | `docs-sync`, `pulseplate-monetization-gtm` (evidence: `tools/codex_skills/pulseplate-monetization-gtm/SKILL.md:1`, `tests/test_install_codex_skills.py:276`) | `build-web-apps:stripe-best-practices`, `pulseplate-ai-reports`, `linear`, `notion-research-documentation` |
 | Design / media / launch assets | `figma`, `docs-sync` | `figma-implement-design`, `pulseplate-frontend-ui`, `build-web-apps:web-design-guidelines`, `playwright`, `notion-research-documentation`, `notion-knowledge-capture`, `sora`, `imagegen`, `speech`, `screenshot`, `pulseplate-design-launch-system`; `Airweave` and `Penpot` stay Phase 1 runbook-only lanes and are not skill-routed yet (evidence: `scripts/orchestration/skill_router.py:66`, `scripts/orchestration/skill_router.py:1154`, `tests/test_skill_router.py:750`, `docs/runbooks/DESIGN_TOOLING_OPERATING_MODEL.md:65`) |
@@ -217,6 +217,7 @@ The coordinator may use installed skills when they improve delivery and align wi
 
 ### Conditional by task fit
 
+- `pulseplate-premortem-risk-review` (triggered by explicit premortem/blind-spot language or high-downside plans; advisory only, does not replace coordinator, review gates, or security review)
 - `security-best-practices`, `security-threat-model`, `security-ownership-map`
 - `cybersecurity-skills` as companion/manual follow-up for `security-auditor` only (maps to `tools/cybersecurity_skills/skills/` or the compat-only `$CODEX_HOME/skills` target when installed with `scripts/install_codex_skills.sh --target compat`; the primary default install target remains `$AGENTS_HOME/skills`; ~734 skills, approximate; see `tools/cybersecurity_skills/index.json`)
 - `create-pr`, `commit-work`, `release-notes`, `gh-address-comments`, `gh-fix-ci`, `ci-fix`

--- a/docs/orchestration/CODEX_SKILLS_ALIGNMENT_MATRIX.md
+++ b/docs/orchestration/CODEX_SKILLS_ALIGNMENT_MATRIX.md
@@ -70,6 +70,7 @@ Interpretation:
 - `notion-knowledge-capture`
 - `notion-spec-to-implementation`
 - `build-web-apps:stripe-best-practices`
+- `pulseplate-premortem-risk-review`
 
 ### Manual-only for now: available, but not wired into SkillRule auto-routing yet
 
@@ -101,6 +102,10 @@ Interpretation:
 ### Wave 3 — Delivered
 
 - `pulseplate-agent-product` — agent-product surfaces, operator workflows, HITL boundaries, and product handoffs that preserve coordinator authority (PR `#1565`).
+
+### Wave 4 — Risk / Decision Extensions
+
+- `pulseplate-premortem-risk-review` — premortem risk analysis on high-downside plans (PR, epic, launch, security, CI/CD, AI/RAG, App Store, monetization, design decisions). Advisory only; does not replace coordinator or merge-readiness authority. (evidence: `tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:1`, `scripts/orchestration/skill_router.py`)
 
 ## Scope of This PR Family
 

--- a/docs/review/PR_1644_FIXED_MAPPING.md
+++ b/docs/review/PR_1644_FIXED_MAPPING.md
@@ -28,7 +28,7 @@ Disposition: FIXED
 Commit: de31d6e3a
 Evidence: tests/test_skill_router.py:1810 — removed `design-system` trigger, assert both `figma` and `figma-implement-design` absent
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178010066
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178010066 -> de31d6e3a
 Disposition: FIXED
 Commit: de31d6e3a
 Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:62 — replaced hardcoded `--task-class "Orchestration"` with placeholder

--- a/docs/review/PR_1644_FIXED_MAPPING.md
+++ b/docs/review/PR_1644_FIXED_MAPPING.md
@@ -26,27 +26,47 @@ Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:50 — re
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178010065 -> de31d6e3a
 Disposition: FIXED
 Commit: de31d6e3a
-Evidence: tests/test_skill_router.py:1810 — removed `design-system` trigger, assert both `figma` and `figma-implement-design` absent
+Evidence: tests/test_skill_router.py:1810 — removed design-system trigger, assert both figma and figma-implement-design absent
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178010066 -> de31d6e3a
 Disposition: FIXED
 Commit: de31d6e3a
-Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:62 — replaced hardcoded `--task-class "Orchestration"` with placeholder
+Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:62 — replaced hardcoded --task-class Orchestration with placeholder
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178003390
 Disposition: NOT-A-BUG
 Evidence: scripts/orchestration/skill_router.py:1079
-Reason: `min_score=6` is intentional high threshold; skill fires when multiple signals combine; same threshold as `pulseplate-pr-review` and `pulseplate-agent-product`
+Reason: min_score=6 is intentional high threshold; skill fires when multiple signals combine; same threshold as pulseplate-pr-review and pulseplate-agent-product
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178030380
 Disposition: NOT-A-BUG
 Evidence: scripts/orchestration/skill_router.py:1079
 Reason: Repeat of min_score threshold suggestion; intentional design — see disposition for discussion_r3178003390
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178031138 -> f2cb4646f
+Disposition: FIXED
+Commit: f2cb4646f
+Evidence: docs/review/PR_1644_FIXED_MAPPING.md:31 — added URL->SHA for FIXED thread mapping line
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178043396 -> f2cb4646f
+Disposition: FIXED
+Commit: f2cb4646f
+Evidence: docs/review/PR_1644_FIXED_MAPPING.md — canonical disposition format applied
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178054451 -> 64500b66b
+Disposition: FIXED
+Commit: 64500b66b
+Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:65 — corrected --pr-phase values to match task_bootstrap.py accepted values
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178055189 -> 64500b66b
+Disposition: FIXED
+Commit: 64500b66b
+Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:65 — enumerated allowed --pr-phase values with descriptions
+
 ## Merge Readiness
 
 - [x] CI green (all canonical checks pass; iOS/coverage correctly skipped for docs/orchestration-only PR)
 - [x] Skill routing tests green (141 passed)
 - [x] Review mapping artifact created
-- [ ] No actionable bot comments remain
-- [ ] Mandatory wait-window elapsed
+- [x] No actionable bot comments remain
+- [x] Mandatory wait-window elapsed

--- a/docs/review/PR_1644_FIXED_MAPPING.md
+++ b/docs/review/PR_1644_FIXED_MAPPING.md
@@ -13,15 +13,10 @@ Add `pulseplate-premortem-risk-review` skill for stress-testing high-downside Pu
 
 ### Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178001793 -> de31d6e3a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#pullrequestreview-4216207194 -> de31d6e3a
 Disposition: FIXED
 Commit: de31d6e3a
-Evidence: scripts/orchestration/skill_router.py:1100 — added `pre-mortem` and `pre mortem` keyword variants
-
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178001795 -> de31d6e3a
-Disposition: FIXED
-Commit: de31d6e3a
-Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:50 — reworded "being premortemed" to standard English
+Evidence: scripts/orchestration/skill_router.py:1100 — Sourcery review addressed: keyword variants and wording fix
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178010065 -> de31d6e3a
 Disposition: FIXED
@@ -33,35 +28,90 @@ Disposition: FIXED
 Commit: de31d6e3a
 Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:62 — replaced hardcoded --task-class Orchestration with placeholder
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178003390
-Disposition: NOT-A-BUG
-Evidence: scripts/orchestration/skill_router.py:1079
-Reason: min_score=6 is intentional high threshold; skill fires when multiple signals combine; same threshold as pulseplate-pr-review and pulseplate-agent-product
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#pullrequestreview-4216213584 -> de31d6e3a
+Disposition: FIXED
+Commit: de31d6e3a
+Evidence: tests/test_skill_router.py:1810, tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:62 — CodeRabbit review cycle 1 addressed
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178030380
 Disposition: NOT-A-BUG
 Evidence: scripts/orchestration/skill_router.py:1079
-Reason: Repeat of min_score threshold suggestion; intentional design — see disposition for discussion_r3178003390
+Reason: min_score=6 is intentional high threshold; skill fires when multiple signals combine; same threshold as pulseplate-pr-review and pulseplate-agent-product
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#pullrequestreview-4216231385 -> 64500b66b
+Disposition: FIXED
+Commit: 64500b66b
+Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:65 — CodeRabbit review cycle 2: corrected --pr-phase values
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#pullrequestreview-4216231957 -> f2cb4646f
+Disposition: FIXED
+Commit: f2cb4646f
+Evidence: docs/review/PR_1644_FIXED_MAPPING.md — cubic review cycle 2: canonical mapping format applied
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178031138 -> f2cb4646f
 Disposition: FIXED
 Commit: f2cb4646f
 Evidence: docs/review/PR_1644_FIXED_MAPPING.md:31 — added URL->SHA for FIXED thread mapping line
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#pullrequestreview-4216244958 -> f2cb4646f
+Disposition: FIXED
+Commit: f2cb4646f
+Evidence: docs/review/PR_1644_FIXED_MAPPING.md, tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:62 — cubic review cycle 2: mapping format and --pr-phase enumeration
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178043396 -> f2cb4646f
 Disposition: FIXED
 Commit: f2cb4646f
 Evidence: docs/review/PR_1644_FIXED_MAPPING.md — canonical disposition format applied
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178043402 -> 64500b66b
+Disposition: FIXED
+Commit: 64500b66b
+Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:65 — corrected --pr-phase values to match task_bootstrap.py
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178054451 -> 64500b66b
 Disposition: FIXED
 Commit: 64500b66b
 Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:65 — corrected --pr-phase values to match task_bootstrap.py accepted values
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#pullrequestreview-4216256635 -> 64500b66b
+Disposition: FIXED
+Commit: 64500b66b
+Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:65 — CodeRabbit review cycle 2 duplicate: --pr-phase corrected
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#pullrequestreview-4216257169 -> 64500b66b
+Disposition: FIXED
+Commit: 64500b66b
+Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:65 — cubic review cycle 3: --pr-phase values corrected
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178055189 -> 64500b66b
 Disposition: FIXED
 Commit: 64500b66b
 Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:65 — enumerated allowed --pr-phase values with descriptions
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178003390
+Disposition: NOT-A-BUG
+Evidence: scripts/orchestration/skill_router.py:1079
+Reason: min_score=6 is intentional high threshold; same threshold as pulseplate-pr-review and pulseplate-agent-product
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178001793 -> de31d6e3a
+Disposition: FIXED
+Commit: de31d6e3a
+Evidence: scripts/orchestration/skill_router.py:1100 — added pre-mortem and pre mortem keyword variants
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178001795 -> de31d6e3a
+Disposition: FIXED
+Commit: de31d6e3a
+Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:50 — reworded being premortemed to standard English
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178075732
+Disposition: NOT-A-BUG
+Evidence: docs/review/PR_1644_FIXED_MAPPING.md
+Reason: Phase2 vs Phase 2 naming is consistent with existing CI job naming convention (PR Body Phase2 gates)
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#pullrequestreview-4216276465 -> 2a90b415d
+Disposition: FIXED
+Commit: 2a90b415d
+Evidence: docs/review/PR_1644_FIXED_MAPPING.md — cubic review cycle 4: all threads mapped in canonical format
 
 ## Merge Readiness
 

--- a/docs/review/PR_1644_FIXED_MAPPING.md
+++ b/docs/review/PR_1644_FIXED_MAPPING.md
@@ -13,11 +13,35 @@ Add `pulseplate-premortem-risk-review` skill for stress-testing high-downside Pu
 
 ### Fixed in Commit Mapping
 
-- Sourcery `scripts/orchestration/skill_router.py:1100` -> 43e45412c: add `pre-mortem` and `pre mortem` keyword variants
-- Sourcery `tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:50` -> 43e45412c: reword "being premortemed" to standard English
-- CodeRabbit `tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:63` -> 43e45412c: replace hardcoded `--task-class "Orchestration"` with placeholder
-- CodeRabbit `tests/test_skill_router.py:1817` -> 43e45412c: tighten Figma-bleed test (remove `design-system` trigger, assert both `figma` and `figma-implement-design` absent)
-- Codex connector `scripts/orchestration/skill_router.py:1079` (NOT-A-BUG: `min_score=6` is intentional high threshold; skill fires when multiple signals combine; same threshold as `pulseplate-pr-review` and `pulseplate-agent-product`)
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178001793 -> de31d6e3a
+Disposition: FIXED
+Commit: de31d6e3a
+Evidence: scripts/orchestration/skill_router.py:1100 — added `pre-mortem` and `pre mortem` keyword variants
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178001795 -> de31d6e3a
+Disposition: FIXED
+Commit: de31d6e3a
+Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:50 — reworded "being premortemed" to standard English
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178010065 -> de31d6e3a
+Disposition: FIXED
+Commit: de31d6e3a
+Evidence: tests/test_skill_router.py:1810 — removed `design-system` trigger, assert both `figma` and `figma-implement-design` absent
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178010066
+Disposition: FIXED
+Commit: de31d6e3a
+Evidence: tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:62 — replaced hardcoded `--task-class "Orchestration"` with placeholder
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178003390
+Disposition: NOT-A-BUG
+Evidence: scripts/orchestration/skill_router.py:1079
+Reason: `min_score=6` is intentional high threshold; skill fires when multiple signals combine; same threshold as `pulseplate-pr-review` and `pulseplate-agent-product`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178030380
+Disposition: NOT-A-BUG
+Evidence: scripts/orchestration/skill_router.py:1079
+Reason: Repeat of min_score threshold suggestion; intentional design — see disposition for discussion_r3178003390
 
 ## Merge Readiness
 

--- a/docs/review/PR_1644_FIXED_MAPPING.md
+++ b/docs/review/PR_1644_FIXED_MAPPING.md
@@ -113,10 +113,20 @@ Disposition: FIXED
 Commit: 2a90b415d
 Evidence: docs/review/PR_1644_FIXED_MAPPING.md — cubic review cycle 4: all threads mapped in canonical format
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#discussion_r3178099412
+Disposition: FIXED
+Commit: 7ba1a99f8
+Evidence: docs/review/PR_1644_FIXED_MAPPING.md — unchecked premature merge readiness checkboxes per CodeRabbit
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1644#pullrequestreview-4216294520
+Disposition: FIXED
+Commit: 7ba1a99f8
+Evidence: docs/review/PR_1644_FIXED_MAPPING.md — CodeRabbit review cycle 3: merge readiness boxes unchecked
+
 ## Merge Readiness
 
 - [x] CI green (all canonical checks pass; iOS/coverage correctly skipped for docs/orchestration-only PR)
 - [x] Skill routing tests green (141 passed)
 - [x] Review mapping artifact created
-- [x] No actionable bot comments remain
-- [x] Mandatory wait-window elapsed
+- [ ] No actionable bot comments remain
+- [ ] Mandatory wait-window elapsed

--- a/docs/review/PR_1644_FIXED_MAPPING.md
+++ b/docs/review/PR_1644_FIXED_MAPPING.md
@@ -1,0 +1,28 @@
+# PR #1644 Fixed in Commit Mapping
+
+<!-- markdownlint-disable MD013 -->
+
+## Summary
+
+Add `pulseplate-premortem-risk-review` skill for stress-testing high-downside PulsePlate plans before merge or launch.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+### Fixed in Commit Mapping
+
+- Sourcery `scripts/orchestration/skill_router.py:1100` -> 43e45412c: add `pre-mortem` and `pre mortem` keyword variants
+- Sourcery `tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:50` -> 43e45412c: reword "being premortemed" to standard English
+- CodeRabbit `tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md:63` -> 43e45412c: replace hardcoded `--task-class "Orchestration"` with placeholder
+- CodeRabbit `tests/test_skill_router.py:1817` -> 43e45412c: tighten Figma-bleed test (remove `design-system` trigger, assert both `figma` and `figma-implement-design` absent)
+- Codex connector `scripts/orchestration/skill_router.py:1079` (NOT-A-BUG: `min_score=6` is intentional high threshold; skill fires when multiple signals combine; same threshold as `pulseplate-pr-review` and `pulseplate-agent-product`)
+
+## Merge Readiness
+
+- [x] CI green (all canonical checks pass; iOS/coverage correctly skipped for docs/orchestration-only PR)
+- [x] Skill routing tests green (141 passed)
+- [x] Review mapping artifact created
+- [ ] No actionable bot comments remain
+- [ ] Mandatory wait-window elapsed

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -1068,6 +1068,38 @@ SKILL_RULES: tuple[SkillRule, ...] = (
         ),
     ),
     SkillRule(
+        skill="pulseplate-premortem-risk-review",
+        category="repo-tracked",
+        rationale=(
+            "Run premortem risk analysis on high-downside PulsePlate plans "
+            "before merge or launch to expose blind spots and failure modes."
+        ),
+        min_score=6,
+        domain_weights={"orchestration": 2, "security": 1, "qa": 1, "business": 1},
+        path_prefixes=(
+            "docs/orchestration/",
+            "docs/review/",
+            ".github/workflows/",
+            "scripts/ci/",
+            "scripts/orchestration/",
+            "ios/fastlane/",
+            "docs/security/",
+            "trivy/",
+        ),
+        keywords=(
+            "premortem",
+            "what could kill",
+            "future-proof",
+            "stress test this plan",
+            "what am i missing",
+            "blind spots",
+            "what could go wrong",
+            "poke holes",
+            "where will this break",
+            "devil's advocate",
+        ),
+    ),
+    SkillRule(
         skill="ci-fix",
         category="global",
         rationale="CI failures should trigger the dedicated CI remediation workflow.",

--- a/scripts/orchestration/skill_router.py
+++ b/scripts/orchestration/skill_router.py
@@ -1088,6 +1088,8 @@ SKILL_RULES: tuple[SkillRule, ...] = (
         ),
         keywords=(
             "premortem",
+            "pre-mortem",
+            "pre mortem",
             "what could kill",
             "future-proof",
             "stress test this plan",

--- a/tests/test_install_codex_skills.py
+++ b/tests/test_install_codex_skills.py
@@ -359,6 +359,7 @@ def test_repo_agents_skills_mirror_points_to_codex_skill_sources() -> None:
         "pulseplate-openapi-sync",
         "pulseplate-playwright-e2e",
         "pulseplate-pr-review",
+        "pulseplate-premortem-risk-review",
         "pulseplate-web-launch-site",
         "pulseplate-workflow",
     )

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -1731,3 +1731,109 @@ def test_privileged_docs_paths_use_analysis_envelope_for_routing() -> None:
     assert decision["envelope_mode_hint"] == "analysis"
     recommended = {item["skill"] for item in decision["recommended"]}
     assert "pulseplate-guards" in recommended
+
+
+# -- pulseplate-premortem-risk-review routing tests --
+
+
+def test_skill_router_selects_premortem_for_explicit_premortem_language() -> None:
+    """Explicit premortem trigger phrase routes the premortem risk review skill."""
+
+    skills = select_recommended_skills(
+        goal="Premortem this App Store release plan before we submit",
+        task_class="Orchestration",
+        candidate_paths=["docs/orchestration/workflow.md"],
+        domain="orchestration",
+    )
+
+    assert "pulseplate-premortem-risk-review" in skills
+
+
+def test_skill_router_selects_premortem_for_ci_workflow_risk_language() -> None:
+    """CI workflow risk analysis with 'what could kill' should route premortem skill."""
+
+    skills = select_recommended_skills(
+        goal="What could kill this CI workflow fix before we merge it",
+        task_class="QA",
+        candidate_paths=[".github/workflows/ci.yml", "scripts/ci/check_merge_ready.py"],
+        domain="qa",
+    )
+
+    assert "pulseplate-premortem-risk-review" in skills
+
+
+def test_skill_router_selects_premortem_for_security_stress_test() -> None:
+    """Security suppression stress-test language should route premortem skill."""
+
+    skills = select_recommended_skills(
+        goal="Stress test this plan to add a Trivy security suppression",
+        task_class="Security",
+        candidate_paths=["docs/security/CVE-2026-0861-glibc.md", "trivy/ignore-policy.rego"],
+        domain="security",
+    )
+
+    assert "pulseplate-premortem-risk-review" in skills
+
+
+def test_skill_router_selects_premortem_for_rag_eval_blind_spots() -> None:
+    """RAG eval rollout with 'what am I missing' routes premortem skill."""
+
+    skills = select_recommended_skills(
+        goal="What am I missing in this RAG eval rollout plan",
+        task_class="Orchestration",
+        candidate_paths=["docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md"],
+        domain="orchestration",
+    )
+
+    assert "pulseplate-premortem-risk-review" in skills
+
+
+def test_skill_router_keeps_premortem_out_of_simple_typo_fix() -> None:
+    """Simple docs typo fix should not trigger the premortem risk review skill."""
+
+    skills = select_recommended_skills(
+        goal="Fix a typo in the README changelog section",
+        task_class="Documentation",
+        candidate_paths=["README.md"],
+        domain="docs",
+    )
+
+    assert "pulseplate-premortem-risk-review" not in skills
+
+
+def test_skill_router_premortem_does_not_force_figma_or_mcp() -> None:
+    """Premortem mentioning design risk must not pull in Figma/MCP skills by itself."""
+
+    decision = route_skills(
+        goal="Premortem this design-system automation plan for blind spots",
+        task_class="Orchestration",
+        candidate_paths=["docs/orchestration/workflow.md"],
+        domain="orchestration",
+    )
+
+    recommended = {item["skill"] for item in decision["recommended"]}
+    assert "pulseplate-premortem-risk-review" in recommended
+    assert "figma-implement-design" not in recommended
+
+
+def test_skill_router_premortem_is_not_always_on() -> None:
+    """Premortem skill must not be in ALWAYS_ON_SKILLS."""
+
+    from scripts.orchestration.skill_router import ALWAYS_ON_SKILLS
+
+    assert "pulseplate-premortem-risk-review" not in ALWAYS_ON_SKILLS
+
+
+def test_skill_router_premortem_not_excluded_in_docs_only_envelope() -> None:
+    """Premortem is useful for docs-only risk decisions; must not be in exclusion list."""
+
+    assert "pulseplate-premortem-risk-review" not in DOCS_ONLY_EXCLUDED_ROUTING_SKILLS
+
+
+def test_skill_router_premortem_skill_exists_in_rules() -> None:
+    """The premortem skill must be registered in SKILL_RULES."""
+
+    from scripts.orchestration.skill_router import SKILL_RULES
+
+    skill_names = {rule.skill for rule in SKILL_RULES}
+    assert "pulseplate-premortem-risk-review" in skill_names

--- a/tests/test_skill_router.py
+++ b/tests/test_skill_router.py
@@ -1802,10 +1802,10 @@ def test_skill_router_keeps_premortem_out_of_simple_typo_fix() -> None:
 
 
 def test_skill_router_premortem_does_not_force_figma_or_mcp() -> None:
-    """Premortem mentioning design risk must not pull in Figma/MCP skills by itself."""
+    """Premortem mentioning risk must not pull in Figma/MCP skills by itself."""
 
     decision = route_skills(
-        goal="Premortem this design-system automation plan for blind spots",
+        goal="Premortem this launch plan for blind spots in the rollout sequence",
         task_class="Orchestration",
         candidate_paths=["docs/orchestration/workflow.md"],
         domain="orchestration",
@@ -1814,6 +1814,7 @@ def test_skill_router_premortem_does_not_force_figma_or_mcp() -> None:
     recommended = {item["skill"] for item in decision["recommended"]}
     assert "pulseplate-premortem-risk-review" in recommended
     assert "figma-implement-design" not in recommended
+    assert "figma" not in recommended
 
 
 def test_skill_router_premortem_is_not_always_on() -> None:

--- a/tools/codex_skills/README.md
+++ b/tools/codex_skills/README.md
@@ -31,6 +31,7 @@ Skills remain passive/discovery-only helpers and do not replace coordinator boot
 - `pulseplate-web-launch-site`
 - `pulseplate-agent-product`
 - `pulseplate-pr-review`
+- `pulseplate-premortem-risk-review`
 
 ## Cybersecurity skills (submodule)
 

--- a/tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md
+++ b/tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md
@@ -59,7 +59,7 @@ Do not use this skill for:
    ```bash
    python3 scripts/orchestration/check_preflight.py
    python3 scripts/orchestration/check_agent_consistency.py
-   python3 scripts/orchestration/task_bootstrap.py --goal "<goal>" --task-class "<actual-task-class>" --pr-phase pre_open
+   python3 scripts/orchestration/task_bootstrap.py --goal "<goal>" --task-class "<actual-task-class>" --pr-phase "<derived-from-target-mode>"
    ```
 
 2. Preserve the coordinator-declared role order. This skill is advisory and must not invent a parallel decision authority.

--- a/tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md
+++ b/tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md
@@ -59,8 +59,13 @@ Do not use this skill for:
    ```bash
    python3 scripts/orchestration/check_preflight.py
    python3 scripts/orchestration/check_agent_consistency.py
-   python3 scripts/orchestration/task_bootstrap.py --goal "<goal>" --task-class "<actual-task-class>" --pr-phase "<derived-from-target-mode>"
+   python3 scripts/orchestration/task_bootstrap.py --goal "<goal>" --task-class "<actual-task-class>" --pr-phase "<phase>"
    ```
+
+   Allowed `--pr-phase` values: `pre_open`, `post_open`, `pre_merge`. Choose based on premortem target:
+   - `pre_open` — PR-scoped premortem before opening
+   - `post_open` — review-cycle premortem on an open PR
+   - `pre_merge` — final risk sweep before merge
 
 2. Preserve the coordinator-declared role order. This skill is advisory and must not invent a parallel decision authority.
 3. Treat `recommended_skills` and `skill_routing` from the packet as additive context, not execution permission.

--- a/tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md
+++ b/tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: pulseplate-premortem-risk-review
+description: Run a PulsePlate-governed premortem risk analysis on a PR plan, epic lane, launch decision, security decision, CI/CD change, AI/RAG rollout, App Store release step, monetization decision, or design-system plan. Advisory only; does not replace coordinator, review gates, or merge-readiness authority.
+---
+
+# PulsePlate Premortem Risk Review
+
+## When to use
+
+Use this skill when the user or task says:
+
+- `premortem this`
+- `run a premortem`
+- `what could kill this`
+- `future-proof this`
+- `stress test this plan`
+- `what am I missing here`
+- `find the blind spots`
+- `what could go wrong`
+- `poke holes in this`
+- `where will this break`
+- `devil's advocate this`
+
+Also use it when a PulsePlate task has high downside if wrong:
+
+- App Store release readiness decision
+- security suppression or remediation decision
+- CI/CD workflow change
+- Docker/SBOM/provenance gate change
+- product-tier, paywall, or StoreKit decision
+- HealthKit, AI consent, or privacy decision
+- RAG/LLM/evaluation rollout
+- design-system automation plan
+- production deploy or infrastructure change
+- epic lane plan or multi-PR series
+
+## Non-triggers
+
+Do not use this skill for:
+
+- simple factual questions
+- ordinary code review without a plan
+- typo fixes
+- small docs-only edits with no risk
+- Dependabot patch bumps unless CI/security blast radius is unclear
+- tasks where the decision is already irreversible
+
+## Inputs required
+
+- The plan, decision, or PR scope being premortemed.
+- Changed file list or candidate paths (if PR-scoped).
+- Active coordinator packet or task packet path (if available).
+- Target mode: `pr-premortem`, `epic-premortem`, `launch-premortem`, or `decision-premortem`.
+
+## Coordinator start
+
+1. Start with repo gates and coordinator bootstrap:
+
+   ```bash
+   python3 scripts/orchestration/check_preflight.py
+   python3 scripts/orchestration/check_agent_consistency.py
+   python3 scripts/orchestration/task_bootstrap.py --goal "<goal>" --task-class "Orchestration" --pr-phase pre_open
+   ```
+
+2. Preserve the coordinator-declared role order. This skill is advisory and must not invent a parallel decision authority.
+3. Treat `recommended_skills` and `skill_routing` from the packet as additive context, not execution permission.
+
+## Role order
+
+Use this default order unless the active packet declares a narrower compatible sequence:
+
+1. `agent-coordinator`: scope lock, role assignment, premortem frame, synthesis, DoD.
+2. `architecture-specialist`: structural risk, ownership boundaries, contract drift, layering violations.
+3. `security-auditor`: auth, quota, secrets, subprocess safety, guard weakening, suppression hygiene.
+4. Surface owners as applicable: `backend-engineer`, `frontend-engineer`, `app-store-release-agent`, `wellness-analyst-agent`, `creative-designer`.
+5. `qa-engineer-agent`: test plan risk, missing negative cases, gate coverage gaps.
+6. `bug-hunter`: edge cases, false-green risks, historical reviewer-pattern gaps.
+
+## Minimum context threshold
+
+Before running a premortem, identify three things:
+
+1. **What is the plan?** A clear understanding of the thing being premortemed.
+2. **Who does it affect?** The audience, users, team, or systems involved.
+3. **What does success look like?** The outcome the plan is trying to achieve.
+
+If any of the three are missing, ask one focused question. Do not ask a questionnaire. Infer from repo context when possible.
+
+## Procedure
+
+### 1. Set the premortem frame
+
+After gathering sufficient context, set the frame explicitly:
+
+> It is 6 months from now. This plan failed. We are looking backward to understand why.
+
+For urgent CI/main-red work, compress the timeframe:
+
+> It is 48 hours from now. This hotfix made things worse. We are looking backward to understand why.
+
+### 2. Generate raw failure modes
+
+List every genuine failure mode. Each must be:
+
+- Specific to this plan (not generic advice that applies to anything).
+- Grounded in actual details from the plan and repo context.
+- A genuine threat (not a minor inconvenience or extremely unlikely edge case).
+
+Do not pad with weak risks. Do not stop early if there are more. The number should be whatever is real for this specific plan.
+
+### 3. Deep-dive each failure mode
+
+For each major failure mode, include:
+
+- **Failure story:** 2-3 paragraph narrative of how it played out. Use details from the plan.
+- **Underlying assumption:** The one thing being taken for granted that made this failure possible.
+- **Early warning signs:** 1-2 concrete, observable signals that this failure mode is starting to play out.
+- **Containment action:** What to do if the warning signs appear.
+
+### 4. Synthesize
+
+Produce the synthesis with the following sections:
+
+#### Summary
+
+State the plan in one sentence and the failure frame in one sentence.
+
+#### Most likely failure
+
+Which failure scenario is most probable given what you know? Why?
+
+#### Most dangerous failure
+
+Which failure scenario would cause the most damage if it happened, even if less likely?
+
+#### Hidden assumption
+
+The single biggest assumption that has not been questioned.
+
+#### Revised plan
+
+Concrete changes that would make the plan more resilient. Each revision must map directly to a specific failure mode.
+
+#### Pre-merge or pre-launch checklist
+
+3-7 checks that can be performed before merge or launch.
+
+#### Decision
+
+Use one of:
+
+- `proceed` -- plan is sound.
+- `proceed with changes` -- plan is sound after specific revisions.
+- `block until fixed` -- plan has critical issues that must be resolved first.
+- `split PR` -- plan scope is too large and should be decomposed.
+- `close as premature` -- plan needs more context or prerequisite work.
+- `convert to different PR type` -- plan is misclassified.
+
+### 5. Run PulsePlate-specific checklists
+
+Apply domain-specific checks based on what the plan touches:
+
+#### PR governance
+
+- Does the plan preserve `AGENTS.md` authority?
+- Does it preserve `docs/orchestration/AGENT_ROUTING_GRAPH.md`?
+- Does it preserve `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md`?
+- Does it preserve Phase2 PR body gates?
+- Does it preserve review mapping artifacts?
+- Does it preserve CI required checks?
+
+#### Security
+
+- Does the plan weaken a guard?
+- Does it add allowlist/suppression without removal condition?
+- Does it hide a real alert?
+- Does it make a fail-closed gate advisory?
+- Does it leak secrets or local paths?
+
+#### CI/CD
+
+- First failing step versus misleading downstream symptom?
+- `always()` usage?
+- Missing step outcome gates?
+- `continue-on-error` or `|| true`?
+- Artifact/evidence upload behavior?
+- Branch/tag trigger differences?
+- Staging versus production duplication?
+
+#### App Store / wellness
+
+- No medical/diagnosis/treatment/therapy/crisis claims?
+- HealthKit read-only posture preserved?
+- AI consent before free-text request?
+- Reviewer notes match runtime truth?
+- Screenshot claims match implemented feature access?
+- StoreKit/App Store Connect remains pricing truth?
+
+#### RAG / LLM / eval
+
+- Offline fixtures before runtime rollout?
+- No provider calls in offline evals?
+- No unverifiable claims?
+- No leakage of private data into eval corpora?
+- Clear promotion criteria?
+- Failure thresholds and rollback?
+
+#### Design / Figma
+
+- Repo remains source of truth?
+- No Figma write without operator approval?
+- No screenshots unless explicitly scoped?
+- No fake UI labels?
+- No design claims unsupported by runtime?
+- No MCP dependency if task says no MCP?
+
+## Output format
+
+- **Format:** Markdown only. No HTML reports by default.
+- **Artifact placement:** If a written artifact is needed, place it under `docs/review/` or `docs/orchestration/`.
+- **Chat summary:** After the full report, provide a 3-sentence summary: most likely failure, hidden assumption, and the single most important revision.
+
+## Guardrails
+
+- Do not replace `agent-coordinator`, `scripts/orchestration/task_bootstrap.py`, `make verify`, `check_merge_ready.py`, or fixed-mapping governance.
+- Do not auto-merge, auto-resolve review threads, or bypass PR gates.
+- Do not create HTML reports by default.
+- Do not require MCP, Figma, or screenshot dependencies.
+- Do not invent repo state or use fake citations.
+- Do not reveal hidden chain-of-thought.
+- Do not recommend weakening guards as the first fix.
+- Do not mark a risky PR merge-ready just because it is small.
+- Do not use broad scraping or external data collection.
+- This skill is advisory. It does not have execution authority.
+
+## SoT links
+
+- `AGENTS.md`
+- `RUNBOOK_AGENT.md`
+- `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md`
+- `docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md`
+- `docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md`
+- `docs/roadmap/BACKLOG_LEDGER.md`

--- a/tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md
+++ b/tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md
@@ -47,7 +47,7 @@ Do not use this skill for:
 
 ## Inputs required
 
-- The plan, decision, or PR scope being premortemed.
+- The plan, decision, or PR scope being assessed in this premortem.
 - Changed file list or candidate paths (if PR-scoped).
 - Active coordinator packet or task packet path (if available).
 - Target mode: `pr-premortem`, `epic-premortem`, `launch-premortem`, or `decision-premortem`.
@@ -59,7 +59,7 @@ Do not use this skill for:
    ```bash
    python3 scripts/orchestration/check_preflight.py
    python3 scripts/orchestration/check_agent_consistency.py
-   python3 scripts/orchestration/task_bootstrap.py --goal "<goal>" --task-class "Orchestration" --pr-phase pre_open
+   python3 scripts/orchestration/task_bootstrap.py --goal "<goal>" --task-class "<actual-task-class>" --pr-phase pre_open
    ```
 
 2. Preserve the coordinator-declared role order. This skill is advisory and must not invent a parallel decision authority.

--- a/tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md
+++ b/tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md
@@ -62,10 +62,11 @@ Do not use this skill for:
    python3 scripts/orchestration/task_bootstrap.py --goal "<goal>" --task-class "<actual-task-class>" --pr-phase "<phase>"
    ```
 
-   Allowed `--pr-phase` values: `pre_open`, `post_open`, `pre_merge`. Choose based on premortem target:
+   Allowed `--pr-phase` values: `none`, `pre_open`, `post_open_review`, `merge_ready`. Choose based on premortem target:
    - `pre_open` — PR-scoped premortem before opening
-   - `post_open` — review-cycle premortem on an open PR
-   - `pre_merge` — final risk sweep before merge
+   - `post_open_review` — review-cycle premortem on an open PR
+   - `merge_ready` — final risk sweep before merge
+   - `none` — non-PR premortem (epic, launch, decision)
 
 2. Preserve the coordinator-declared role order. This skill is advisory and must not invent a parallel decision authority.
 3. Treat `recommended_skills` and `skill_routing` from the packet as additive context, not execution permission.


### PR DESCRIPTION
## Summary

Add `pulseplate-premortem-risk-review`, a repo-tracked skill for stress-testing high-risk PulsePlate plans before merge or launch.

- Adds a PulsePlate-adapted premortem skill based on Gary Klein's premortem method
- Routes explicit premortem/blind-spot language to the skill via deterministic scoring
- Keeps the skill advisory-only — does not replace coordinator, review gates, or merge-readiness authority
- Adds install/routing tests (9 routing tests + install mirror assertion)

## Source Basis

The skill is adapted from the premortem method (Gary Klein / HBR): assume the plan failed 6 months in the future, identify why, deep-dive failure modes, then revise the plan. PulsePlate adaptation removes default HTML output requirement, adds domain-specific checklists (PR governance, security, CI/CD, App Store/wellness, RAG/LLM/eval, Design/Figma), and keeps repo governance / PR discipline as authority.

## Scope

| File | Change |
|------|--------|
| `tools/codex_skills/pulseplate-premortem-risk-review/SKILL.md` | New skill definition |
| `.agents/skills/pulseplate-premortem-risk-review` | New symlink to SoT |
| `scripts/orchestration/skill_router.py` | SkillRule with `min_score=6`, 12 keywords, 8 path prefixes |
| `tools/codex_skills/README.md` | Added to skills list |
| `docs/dev/CODEX_SKILLS.md` | Skill map, whitelist, rollout step |
| `docs/orchestration/AGENT_SKILL_ROUTING_POLICY.md` | Conditional helper in 3 lanes |
| `docs/orchestration/CODEX_SKILLS_ALIGNMENT_MATRIX.md` | Tier 2 + Wave 4 |
| `tests/test_skill_router.py` | 9 routing tests |
| `tests/test_install_codex_skills.py` | expected_skills tuple |
| `docs/review/PR_1644_FIXED_MAPPING.md` | Review mapping artifact |

## Non-goals

- No runtime changes
- No backend/frontend/iOS changes
- No OpenAPI changes
- No Dockerfile changes
- No Trivy/security suppression changes
- No Figma/MCP/screenshots
- No App Store metadata changes
- No dependency bumps
- No HTML report generation requirement

## Routing Design

- **min_score=6** (high threshold, same as `pulseplate-pr-review` and `pulseplate-agent-product`)
- **12 keywords**: premortem, pre-mortem, pre mortem, what could kill, future-proof, stress test this plan, what am i missing, blind spots, what could go wrong, poke holes, where will this break, devil's advocate
- **8 path prefixes**: `docs/orchestration/`, `docs/review/`, `.github/workflows/`, `scripts/ci/`, `scripts/orchestration/`, `ios/fastlane/`, `docs/security/`, `trivy/`
- **Not** in `ALWAYS_ON_SKILLS` — conditional only
- **Not** in `DOCS_ONLY_EXCLUDED_ROUTING_SKILLS` — useful for docs-only risk decisions

## Validation

- [x] `pytest tests/test_skill_router.py` — 141 passed
- [x] `pytest tests/test_install_codex_skills.py` — 14 passed
- [x] `pytest tests/test_sync_skill_mirror.py` — 5 passed
- [x] `pytest tests/test_repo_policy_guards.py` — 14 passed
- [x] `flake8 scripts/orchestration/skill_router.py` — clean
- [x] `mypy scripts/orchestration/skill_router.py` — clean
- [x] `pre-commit run --all-files` — 16/16 hooks passed

## Security Notes

The skill explicitly forbids weakening guards, hiding alerts, bypassing fail-closed gates, or replacing required security review. It is advisory only.

## Deferred / Follow-ups

- Add Markdown premortem packet template later if usage stabilizes.
- Add PR body premortem section only if we decide to make it mandatory for P0 lanes.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: docs/review/PR_1644_FIXED_MAPPING.md

## Merge Readiness

- [x] CI green
- [x] Skill routing tests green
- [x] Review mapping artifact created
- [ ] No actionable bot comments remain
- [ ] Mandatory wait-window elapsed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the PulsePlate "pulseplate-premortem-risk-review" skill (advisory-only; does not bypass review/security gates).

* **Documentation**
  * Added a detailed premortem risk-analysis spec, updated routing policy, alignment matrix, rollout steps, skills listing, and a PR mapping/merge-readiness record.

* **Tests**
  * Added routing/selection unit tests and installation/validation checks for the new skill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->