### PR TITLE
fix(deps): align ruff emergency manifest and lock to 0.15.12

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -494,7 +494,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "8dd39e27e184590c790cbecd95f65e0ceaf61b46",
+        "hashed_secret": "9d99ddcde81d214a71fbade9b758ef72213c835d",
         "is_verified": false,
         "line_number": 118
       },
@@ -1662,5 +1662,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-01T15:53:59Z"
+  "generated_at": "2026-05-03T11:05:09Z"
 }

--- a/docs/review/PR_1645_FIXED_MAPPING.md
+++ b/docs/review/PR_1645_FIXED_MAPPING.md
@@ -7,7 +7,7 @@
 
 ## Fixed in Commit Mapping
 
-No actionable review comments (fresh PR, minimal deps-only fix).
+No actionable review comments
 
 ## Summary
 

--- a/docs/review/PR_1645_FIXED_MAPPING.md
+++ b/docs/review/PR_1645_FIXED_MAPPING.md
@@ -1,0 +1,15 @@
+# PR #1645 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+No actionable review comments (fresh PR, minimal deps-only fix).
+
+## Summary
+
+Fix for red `main` caused by PR #1638 (dependabot ruff 0.15.11 -> 0.15.12)
+leaving emergency manifest and requirements-lock.txt out of sync.

--- a/docs/review/PR_1645_FIXED_MAPPING.md
+++ b/docs/review/PR_1645_FIXED_MAPPING.md
@@ -11,6 +11,26 @@
   Disposition: FIXED
   Evidence: docs/review/PR_1645_FIXED_MAPPING.md:10 — list marker added in commit f61a953c7
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1645#discussion_r3178028607 -> 4758aa13c
+  Disposition: FIXED
+  Evidence: docs/review/PR_1645_FIXED_MAPPING.md:11-12 — Disposition/Evidence metadata added in commit 4758aa13c
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1645#pullrequestreview-4216219420
+  Disposition: NOT-A-BUG
+  Evidence: Sourcery found no issues ("changes look great").
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1645#pullrequestreview-4216219997
+  Disposition: NOT-A-BUG
+  Evidence: Cubic found no issues (initial review pass).
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1645#pullrequestreview-4216222471
+  Disposition: FIXED
+  Evidence: Issue about mapping format addressed in commit f61a953c7.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1645#pullrequestreview-4216229890
+  Disposition: FIXED
+  Evidence: Issue about Disposition metadata addressed in commit 4758aa13c.
+
 ## Summary
 
 Fix for red `main` caused by PR #1638 (dependabot ruff 0.15.11 -> 0.15.12)

--- a/docs/review/PR_1645_FIXED_MAPPING.md
+++ b/docs/review/PR_1645_FIXED_MAPPING.md
@@ -8,6 +8,8 @@
 ## Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1645#discussion_r3178019403 -> f61a953c7
+  Disposition: FIXED
+  Evidence: docs/review/PR_1645_FIXED_MAPPING.md:10 — list marker added in commit f61a953c7
 
 ## Summary
 

--- a/docs/review/PR_1645_FIXED_MAPPING.md
+++ b/docs/review/PR_1645_FIXED_MAPPING.md
@@ -7,7 +7,7 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1645#discussion_r3178019403 -> f61a953c7
 
 ## Summary
 

--- a/docs/review/PR_1645_FIXED_MAPPING.md
+++ b/docs/review/PR_1645_FIXED_MAPPING.md
@@ -7,7 +7,7 @@
 
 ## Fixed in Commit Mapping
 
-No actionable review comments
+- No actionable review comments
 
 ## Summary
 

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -161,6 +161,8 @@ requests==2.33.0
     # via
     #   -r requirements.in
     #   opentelemetry-exporter-otlp-proto-http
+ruff==0.15.12
+    # via -r requirements-dev.in
 six==1.17.0
     # via python-dateutil
 slowapi==0.1.9

--- a/scripts/ci/emergency_python_wheels.json
+++ b/scripts/ci/emergency_python_wheels.json
@@ -112,10 +112,10 @@
     },
     {
       "package": "ruff",
-      "version": "0.15.11",
-      "filename": "ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-      "url": "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-      "sha256": "1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431"
+      "version": "0.15.12",
+      "filename": "ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+      "sha256": "83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0"
     },
     {
       "package": "types-pyyaml",


### PR DESCRIPTION
## Summary
- PR #1638 (dependabot ruff bump 0.15.11 → 0.15.12) updated `requirements-dev.in` and `requirements-dev.txt` but did not update the emergency wheel manifest or restore ruff in `requirements-lock.txt`.
- This caused `test_repo_ruff_emergency_fallback_matches_dev_requirement_surfaces` to fail on `main`, making all `test-main` CI jobs red.
- This PR aligns all four dependency surfaces to `ruff==0.15.12`.

## Changes
- `scripts/ci/emergency_python_wheels.json`: ruff version, filename, url, sha256 updated from 0.15.11 to 0.15.12
- `requirements-lock.txt`: restored `ruff==0.15.12` entry (dependabot incorrectly removed it)
- `.secrets.baseline`: updated fingerprint for the changed sha256 hash

## Root Cause
Dependabot PR #1638 was merged without post-merge local validation (`pytest -q tests/test_repo_policy_guards.py` and `make test-fast`), violating the Dependabot merge protocol in AGENTS.md.

## Local Verification
```
pytest -q tests/test_install_locked_python_requirements.py -- PASS (all 71 tests)
pytest -q tests/test_repo_policy_guards.py -- PASS (all 14 tests)
make test-fast -- PASS
pre-commit run --all-files -- PASS (all 16 hooks)
```

## Deferred / Follow-ups
- None. This is a minimal scope-fix for main CI health.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: docs/review/PR_1645_FIXED_MAPPING.md
- No actionable review comments (fresh PR)

## Merge Readiness
- [x] Local gates green (`make test-fast`, `pre-commit run --all-files`)
- [x] Scope minimal (4 files, deps-only fix)
- [ ] CI current-head green (pending)
- [ ] Wait-window elapsed after latest activity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Updated ruff to 0.15.12.

* **Chores**
  * Updated dependency lock and emergency artifact records to match the new ruff release.
  * Refreshed security baseline timestamp.

* **Documentation**
  * Added a maintenance note documenting the commit-mapping fix and completed review status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->