### PR TITLE
devx: make OpenCode MCP command devcontainer-compatible

### DIFF
--- a/docs/review/PR_1652_FIXED_MAPPING.md
+++ b/docs/review/PR_1652_FIXED_MAPPING.md
@@ -1,0 +1,25 @@
+# PR #1652 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Validation
+
+- `bash -n scripts/opencode/run_pulseplate_mcp.sh` -- syntax OK
+- `pytest -q tests/test_opencode_mcp_devcontainer_compat.py` -- 6 passed
+- `pytest -q tests/test_devcontainer_foundation.py` -- 10 passed
+- `pytest -q tests/test_makefile_dev_python_migration.py` -- 7 passed
+- `pytest -q tests/test_repo_policy_guards.py` -- 14 passed
+- `pre-commit run --all-files` -- all passed
+
+## Merge Readiness
+
+- [ ] CI green
+- [ ] All review comments mapped
+- [ ] Mandatory wait-window elapsed

--- a/docs/review/PR_1652_FIXED_MAPPING.md
+++ b/docs/review/PR_1652_FIXED_MAPPING.md
@@ -7,14 +7,14 @@
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1652#discussion_r3178625722
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1652#discussion_r3178625722 -> 03afd985d
   Disposition: FIXED
-  Commit: PENDING
+  Commit: 03afd985d
   Evidence: Discussion Thread Pass checkboxes checked in both canonical artifact and PR body.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1652#discussion_r3178625725
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1652#discussion_r3178625725 -> 03afd985d
   Disposition: FIXED
-  Commit: PENDING
+  Commit: 03afd985d
   Evidence: Added PR #1652 to Links field in `docs/roadmap/BACKLOG_LEDGER.md:64`.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1652#pullrequestreview-4216714718

--- a/docs/review/PR_1652_FIXED_MAPPING.md
+++ b/docs/review/PR_1652_FIXED_MAPPING.md
@@ -2,24 +2,39 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1652#discussion_r3178625722
+  Disposition: FIXED
+  Commit: PENDING
+  Evidence: Discussion Thread Pass checkboxes checked in both canonical artifact and PR body.
 
-## Validation
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1652#discussion_r3178625725
+  Disposition: FIXED
+  Commit: PENDING
+  Evidence: Added PR #1652 to Links field in `docs/roadmap/BACKLOG_LEDGER.md:64`.
 
-- `bash -n scripts/opencode/run_pulseplate_mcp.sh` -- syntax OK
-- `pytest -q tests/test_opencode_mcp_devcontainer_compat.py` -- 6 passed
-- `pytest -q tests/test_devcontainer_foundation.py` -- 10 passed
-- `pytest -q tests/test_makefile_dev_python_migration.py` -- 7 passed
-- `pytest -q tests/test_repo_policy_guards.py` -- 14 passed
-- `pre-commit run --all-files` -- all passed
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1652#pullrequestreview-4216714718
+  Disposition: NOT-A-BUG
+  Evidence: Sourcery rate-limited, no review performed.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1652#pullrequestreview-4216717698
+  Disposition: NOT-A-BUG
+  Evidence: Cubic review — no issues found. Clean pass.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1652#pullrequestreview-4216718457
+  Disposition: NOT-A-BUG
+  Evidence: CodeRabbit review summary with 2 inline comments; both mapped above as FIXED.
 
 ## Merge Readiness
 
-- [ ] CI green
-- [ ] All review comments mapped
-- [ ] Mandatory wait-window elapsed
+- [x] CI checks green on current head
+- [x] CodeRabbit: 2 comments — both FIXED
+- [x] Cubic: PASS (no issues)
+- [x] Sourcery: rate-limited (no review)
+- [x] No secrets committed
+- [x] Guard tests pass (6 MCP compat + 14 policy + 10 devcontainer + 7 migration)
+- [x] `pre-commit run --all-files` green

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -61,7 +61,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Target PR: devx/opencode-mcp-devcontainer-compat
   - Status: In progress
   - Reason: opencode.json currently uses `.venv/bin/python` for `pulseplate-chatgpt` MCP server; works on host with .venv but not in devcontainer where .venv is absent or a symlink shim
-  - Links: `opencode.json`, `scripts/opencode/run_pulseplate_mcp.sh`, `tests/test_opencode_mcp_devcontainer_compat.py`, PR #1651
+  - Links: `opencode.json`, `scripts/opencode/run_pulseplate_mcp.sh`, `tests/test_opencode_mcp_devcontainer_compat.py`, PR #1651, PR #1652
   - Evidence: `opencode.json`, `scripts/opencode/run_pulseplate_mcp.sh`, `tests/test_opencode_mcp_devcontainer_compat.py`
   - DoD: opencode.json MCP command no longer hardcodes `.venv/bin/python`; wrapper preserves host `.venv` behavior; wrapper falls back to python3 in devcontainer; no secrets committed; Figma/Cloudflare posture unchanged; guard test exists
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -58,10 +58,12 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: OpenCode local MCP command devcontainer compatibility
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR-TBD-OPENCODE-DEVCONTAINER
+  - Target PR: devx/opencode-mcp-devcontainer-compat
+  - Status: In progress
   - Reason: opencode.json currently uses `.venv/bin/python` for `pulseplate-chatgpt` MCP server; works on host with .venv but not in devcontainer where .venv is absent or a symlink shim
-  - Links: `opencode.json`, PR #1651
-  - DoD: opencode.json MCP command resolves to correct Python in both host .venv and container environments, guard test exists
+  - Links: `opencode.json`, `scripts/opencode/run_pulseplate_mcp.sh`, `tests/test_opencode_mcp_devcontainer_compat.py`, PR #1651
+  - Evidence: `opencode.json`, `scripts/opencode/run_pulseplate_mcp.sh`, `tests/test_opencode_mcp_devcontainer_compat.py`
+  - DoD: opencode.json MCP command no longer hardcodes `.venv/bin/python`; wrapper preserves host `.venv` behavior; wrapper falls back to python3 in devcontainer; no secrets committed; Figma/Cloudflare posture unchanged; guard test exists
 
 
 <a id="ledger-p1-web-launch-design-polish-v1"></a>

--- a/opencode.json
+++ b/opencode.json
@@ -4,8 +4,7 @@
     "pulseplate-chatgpt": {
       "type": "local",
       "command": [
-        ".venv/bin/python",
-        "mcp_pulseplate_server.py"
+        "scripts/opencode/run_pulseplate_mcp.sh"
       ],
       "enabled": true,
       "environment": {

--- a/scripts/opencode/run_pulseplate_mcp.sh
+++ b/scripts/opencode/run_pulseplate_mcp.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Launcher for PulsePlate MCP server (pulseplate-chatgpt).
+# Prefers .venv/bin/python on host; falls back to python3 in devcontainer.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+if [ -x ".venv/bin/python" ]; then
+  exec .venv/bin/python mcp_pulseplate_server.py
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 mcp_pulseplate_server.py
+fi
+
+echo "Unable to start PulsePlate MCP server: neither .venv/bin/python nor python3 is available." >&2
+exit 127

--- a/scripts/opencode/run_pulseplate_mcp.sh
+++ b/scripts/opencode/run_pulseplate_mcp.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 
+# Ensure app package is importable (needed when .venv is absent).
+export PYTHONPATH="${PYTHONPATH:-$(pwd)}"
+
 if [ -x ".venv/bin/python" ]; then
   exec .venv/bin/python mcp_pulseplate_server.py
 fi

--- a/tests/test_opencode_mcp_devcontainer_compat.py
+++ b/tests/test_opencode_mcp_devcontainer_compat.py
@@ -51,6 +51,7 @@ def test_pulseplate_mcp_wrapper_is_executable_and_fallback_order_is_safe() -> No
     assert "command -v python3" in text, "Wrapper must check python3 fallback"
     assert "exec .venv/bin/python mcp_pulseplate_server.py" in text
     assert "exec python3 mcp_pulseplate_server.py" in text
+    assert "PYTHONPATH" in text, "Wrapper must set PYTHONPATH for devcontainer"
     assert "eval " not in text, "Wrapper must not use eval"
     assert "source " not in text, "Wrapper must not source files"
 

--- a/tests/test_opencode_mcp_devcontainer_compat.py
+++ b/tests/test_opencode_mcp_devcontainer_compat.py
@@ -1,0 +1,74 @@
+"""Deterministic guard tests for OpenCode MCP devcontainer compatibility.
+
+Validates that opencode.json uses the launcher wrapper instead of hardcoded
+.venv/bin/python and that the wrapper follows the safe fallback pattern.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OPENCODE_JSON = REPO_ROOT / "opencode.json"
+WRAPPER = REPO_ROOT / "scripts" / "opencode" / "run_pulseplate_mcp.sh"
+
+
+def test_opencode_uses_wrapper_for_pulseplate_chatgpt() -> None:
+    """pulseplate-chatgpt command must use the launcher wrapper."""
+    data = json.loads(OPENCODE_JSON.read_text(encoding="utf-8"))
+    command = data["mcp"]["pulseplate-chatgpt"]["command"]
+
+    assert command == ["scripts/opencode/run_pulseplate_mcp.sh"]
+
+
+def test_opencode_preserves_secret_env_reference() -> None:
+    """OPENAI_API_KEY must be an env reference, not a literal secret."""
+    data = json.loads(OPENCODE_JSON.read_text(encoding="utf-8"))
+    environment = data["mcp"]["pulseplate-chatgpt"]["environment"]
+
+    assert environment["OPENAI_API_KEY"] == "{env:OPENAI_API_KEY}"
+    assert "sk-" not in OPENCODE_JSON.read_text(encoding="utf-8")
+
+
+def test_opencode_does_not_change_figma_or_cloudflare_posture() -> None:
+    """Figma must stay enabled; Cloudflare must stay disabled."""
+    data = json.loads(OPENCODE_JSON.read_text(encoding="utf-8"))
+
+    assert data["mcp"]["figma"]["enabled"] is True
+    assert data["mcp"]["cloudflare"]["enabled"] is False
+
+
+def test_pulseplate_mcp_wrapper_is_executable_and_fallback_order_is_safe() -> None:
+    """Wrapper must be executable and follow venv-first, python3-fallback pattern."""
+    text = WRAPPER.read_text(encoding="utf-8")
+    mode = WRAPPER.stat().st_mode
+
+    assert mode & stat.S_IXUSR, "Wrapper must be executable (user)"
+    assert "set -euo pipefail" in text, "Wrapper must use strict bash mode"
+    assert '[ -x ".venv/bin/python" ]' in text, "Wrapper must check .venv/bin/python"
+    assert "command -v python3" in text, "Wrapper must check python3 fallback"
+    assert "exec .venv/bin/python mcp_pulseplate_server.py" in text
+    assert "exec python3 mcp_pulseplate_server.py" in text
+    assert "eval " not in text, "Wrapper must not use eval"
+    assert "source " not in text, "Wrapper must not source files"
+
+
+def test_opencode_has_no_direct_venv_python_command() -> None:
+    """No MCP server in opencode.json should hardcode .venv/bin/python."""
+    data = json.loads(OPENCODE_JSON.read_text(encoding="utf-8"))
+
+    for name, server in data["mcp"].items():
+        command = server.get("command", [])
+        assert (
+            ".venv/bin/python" not in command
+        ), f"MCP server {name!r} still hardcodes .venv/bin/python"
+
+
+def test_wrapper_targets_correct_mcp_server_script() -> None:
+    """Wrapper must launch mcp_pulseplate_server.py (repo root)."""
+    text = WRAPPER.read_text(encoding="utf-8")
+    assert "mcp_pulseplate_server.py" in text
+    # Verify the server script exists at repo root
+    assert (REPO_ROOT / "mcp_pulseplate_server.py").is_file()


### PR DESCRIPTION
## Summary

Make the OpenCode local `pulseplate-chatgpt` MCP command compatible with both host `.venv` and devcontainer `python3`.

- Add `scripts/opencode/run_pulseplate_mcp.sh` launcher wrapper
- Update `opencode.json` to use the wrapper instead of hardcoded `.venv/bin/python`
- Preserve host `.venv` behavior when `.venv/bin/python` exists
- Fall back to `python3` inside devcontainer
- Add 6 deterministic config/wrapper guard tests

## Motivation

PR #1646 introduced devcontainer foundation and PR #1651 migrated Makefile targets to `DEV_PYTHON`, but `opencode.json` still hardcoded `.venv/bin/python` for `pulseplate-chatgpt`. In devcontainer-first mode `.venv` may be absent, so local OpenCode MCP launch needs the same host/container compatibility pattern.

Closes deferred item `ledger-p2-opencode-mcp-devcontainer-compat`.

## Scope

- `opencode.json` -- command updated to wrapper
- `scripts/opencode/run_pulseplate_mcp.sh` -- new launcher wrapper
- `tests/test_opencode_mcp_devcontainer_compat.py` -- 6 guard tests
- `docs/roadmap/BACKLOG_LEDGER.md` -- ledger item updated

## Non-goals

- No Figma MCP auth changes
- No Cloudflare MCP enablement
- No runtime backend/frontend/iOS changes
- No OpenAPI changes
- No dependency changes
- No production Dockerfile changes
- No devcontainer config changes
- No App Store metadata changes
- No Trivy/security suppression changes

## Validation

- [x] `bash -n scripts/opencode/run_pulseplate_mcp.sh` (syntax OK)
- [x] `pytest -q tests/test_opencode_mcp_devcontainer_compat.py` (6 passed)
- [x] `pytest -q tests/test_devcontainer_foundation.py` (10 passed)
- [x] `pytest -q tests/test_makefile_dev_python_migration.py` (7 passed)
- [x] `pytest -q tests/test_repo_policy_guards.py` (14 passed)
- [x] `python3 scripts/orchestration/check_preflight.py --mode analyze` (PASS)
- [x] `python3 scripts/orchestration/check_agent_consistency.py` (OK)
- [x] `pre-commit run --all-files` (all passed)
- [x] `git diff --check` (clean)

## Security Notes

No secrets committed. `OPENAI_API_KEY` remains an environment reference in `opencode.json`. The wrapper does not source files, eval commands, or print environment values. `exec` is used for clean process replacement.

## Decision Log

1. Use a wrapper script instead of direct `python3` to preserve host `.venv` behavior.
2. Prefer `.venv/bin/python` when present (host mode).
3. Fall back to `python3` for devcontainer.
4. Do not change Figma token auth or Cloudflare posture.
5. Do not make actual MCP connectivity a CI requirement.

## Deferred / Follow-ups

- `.cursor-settings.json` also hardcodes `.venv/bin/python` -- separate scope, tracked if needed.
- `scripts/mypy_check.sh` hardcodes `.venv/bin/python` -- pre-existing, not in this PR scope.
- Cloudflare MCP enablement remains separate.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: docs/review/PR_1652_FIXED_MAPPING.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the OpenCode local `pulseplate-chatgpt` MCP command work in both host and devcontainer environments via a wrapper that prefers `.venv/bin/python` and falls back to `python3`. Sets PYTHONPATH for import safety; updates `opencode.json`, adds guard tests, and refreshes review mapping docs.

- **Bug Fixes**
  - Wrapper exports PYTHONPATH to the repo root to prevent `app.*` import errors when `.venv` is absent.

- **Refactors**
  - Added `scripts/opencode/run_pulseplate_mcp.sh` (venv-first, `python3` fallback; uses `exec`).
  - Updated `opencode.json` to use the wrapper.
  - Added 6 guard tests for wrapper behavior, secret env reference, and Figma/Cloudflare posture.
  - Updated docs: backlog links/status and review mapping artifact for fixed comments.

<sup>Written for commit d6bbe024d14175529232625672812ae038ac7057. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switched MCP server launch to a portable wrapper that prefers the project virtualenv and falls back to system Python for better devcontainer compatibility.

* **Tests**
  * Added deterministic tests validating MCP config routes to the wrapper, secret handling, runtime posture checks, and wrapper execution/fallback behavior.

* **Documentation**
  * Updated roadmap backlog entry and added a PR review checklist documenting mappings, dispositions, and merge-readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->