### PR TITLE
ci(devx): add devcontainer smoke workflow

### DIFF
--- a/.github/workflows/devcontainer-smoke.yml
+++ b/.github/workflows/devcontainer-smoke.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   devcontainer-smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/devcontainer-smoke.yml
+++ b/.github/workflows/devcontainer-smoke.yml
@@ -1,0 +1,54 @@
+# ---------------------------------------------------------------------------
+# PulsePlate Devcontainer Smoke — lightweight tooling-layer CI guard
+# ---------------------------------------------------------------------------
+# Builds the devcontainer image and verifies core developer tools exist.
+# Does NOT install application dependencies, does NOT require secrets,
+# and does NOT run backend/frontend tests.
+# ---------------------------------------------------------------------------
+
+name: Devcontainer Smoke
+
+on:
+  pull_request:
+    paths:
+      - ".devcontainer/**"
+      - ".github/workflows/devcontainer-smoke.yml"
+      - "Makefile"
+      - "scripts/devcontainer/**"
+      - "scripts/opencode/**"
+      - "opencode.json"
+      - "tests/test_devcontainer_foundation.py"
+      - "tests/test_makefile_dev_python_migration.py"
+      - "tests/test_opencode_mcp_devcontainer_compat.py"
+      - "tests/test_devcontainer_smoke_workflow.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  devcontainer-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build devcontainer tooling image
+        run: |
+          set -euo pipefail
+          docker build \
+            -f .devcontainer/Dockerfile \
+            -t pulseplate-devcontainer-smoke:ci \
+            .
+
+      - name: Run devcontainer tooling smoke
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -e PULSEPLATE_IN_CONTAINER=1 \
+            -e PYTHONPATH=/workspaces/PulsePlate \
+            -v "$PWD:/workspaces/PulsePlate" \
+            -w /workspaces/PulsePlate \
+            pulseplate-devcontainer-smoke:ci \
+            bash scripts/devcontainer/smoke.sh

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ pre-commit run --all-files
 Generic developer targets use `DEV_PYTHON`, which resolves to `.venv/bin/python`
 when present or `python3` inside containers.
 
+**CI:** A lightweight Devcontainer Smoke workflow verifies the tooling image and
+base developer tools on PRs that touch `.devcontainer/` or related scripts.  It
+does not run `make devcontainer-bootstrap` or require secrets.
+
 **Legacy fallback (host-native .venv):**
 
 ```bash

--- a/docs/review/PR_1653_FIXED_MAPPING.md
+++ b/docs/review/PR_1653_FIXED_MAPPING.md
@@ -1,0 +1,35 @@
+# PR #1653 Fixed in Commit Mapping
+
+## Summary
+
+PR #1653 adds a lightweight CI smoke workflow for the Docker devcontainer tooling layer.
+
+## Scope
+
+- `.github/workflows/devcontainer-smoke.yml` — path-scoped workflow
+- `scripts/devcontainer/smoke.sh` — tooling smoke script
+- `tests/test_devcontainer_smoke_workflow.py` — 9 contract tests
+- `README.md` — short CI note in devcontainer section
+- `docs/roadmap/BACKLOG_LEDGER.md` — updated ledger entry
+
+## Fixed in Commit Mapping
+
+- Devcontainer smoke workflow + script -> fda935d8c
+- Workflow contract tests -> 568ca93cc
+- README devcontainer CI note -> 187121a32
+- Backlog ledger update -> 92726fb9f
+
+## Validation
+
+- `bash -n scripts/devcontainer/smoke.sh` — PASS
+- `pytest -q tests/test_devcontainer_smoke_workflow.py` — 9/9 PASS
+- `pytest -q tests/test_devcontainer_foundation.py` — 10/10 PASS
+- `pytest -q tests/test_makefile_dev_python_migration.py` — 7/7 PASS
+- `pytest -q tests/test_opencode_mcp_devcontainer_compat.py` — 6/6 PASS
+- `pre-commit run --all-files` — all hooks PASS
+- `python3 scripts/orchestration/check_preflight.py` — PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` — PASS
+
+## Review Thread Disposition
+
+Populate after CodeRabbit, Sourcery, and Cubic reviews complete.

--- a/docs/review/PR_1653_FIXED_MAPPING.md
+++ b/docs/review/PR_1653_FIXED_MAPPING.md
@@ -20,21 +20,20 @@ PR #1653 adds a lightweight CI smoke workflow for the Docker devcontainer toolin
 ## Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1653#discussion_r3178673149
-  Disposition: NOT-A-BUG
-  Evidence: `tests/test_devcontainer_smoke_workflow.py:91` -- separate test
-  `test_devcontainer_smoke_does_not_build_production_dockerfile` already scans
-  all non-comment lines for any Dockerfile reference that is not
-  `.devcontainer/Dockerfile`. No `.devcontainer/Dockerfile.prod` exists in repo.
-  Substring match is sufficient for this contract guard.
+Disposition: NOT-A-BUG
+Evidence: `tests/test_devcontainer_smoke_workflow.py:91` separate guard test covers exact Dockerfile path exclusion; no `.devcontainer/Dockerfile.prod` exists in repo.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1653#pullrequestreview-4216754988
-  Disposition: NOT-A-BUG (Cubic review-level summary; inline comment mapped above)
+Disposition: NOT-A-BUG
+Reason: Cubic review-level summary; inline comment mapped above.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1653#pullrequestreview-4216755573
-  Disposition: NOT-A-BUG (CodeRabbit review-level summary; no actionable inline comments)
+Disposition: NOT-A-BUG
+Reason: CodeRabbit review-level summary; no actionable inline comments.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1653#pullrequestreview-4216752472
-  Disposition: NOT-A-BUG (Sourcery review-level summary; no actionable inline comments)
+Disposition: NOT-A-BUG
+Reason: Sourcery review-level summary; no actionable inline comments.
 
 ## Validation
 

--- a/docs/review/PR_1653_FIXED_MAPPING.md
+++ b/docs/review/PR_1653_FIXED_MAPPING.md
@@ -6,29 +6,26 @@ PR #1653 adds a lightweight CI smoke workflow for the Docker devcontainer toolin
 
 ## Scope
 
-- `.github/workflows/devcontainer-smoke.yml` — path-scoped workflow
-- `scripts/devcontainer/smoke.sh` — tooling smoke script
-- `tests/test_devcontainer_smoke_workflow.py` — 9 contract tests
-- `README.md` — short CI note in devcontainer section
-- `docs/roadmap/BACKLOG_LEDGER.md` — updated ledger entry
+- `.github/workflows/devcontainer-smoke.yml` -- path-scoped workflow
+- `scripts/devcontainer/smoke.sh` -- tooling smoke script
+- `tests/test_devcontainer_smoke_workflow.py` -- 9 contract tests
+- `README.md` -- short CI note in devcontainer section
+- `docs/roadmap/BACKLOG_LEDGER.md` -- updated ledger entry
 
 ## Fixed in Commit Mapping
 
-- Devcontainer smoke workflow + script -> fda935d8c
-- Workflow contract tests -> 568ca93cc
-- README devcontainer CI note -> 187121a32
-- Backlog ledger update -> 92726fb9f
+- No actionable review comments
 
 ## Validation
 
-- `bash -n scripts/devcontainer/smoke.sh` — PASS
-- `pytest -q tests/test_devcontainer_smoke_workflow.py` — 9/9 PASS
-- `pytest -q tests/test_devcontainer_foundation.py` — 10/10 PASS
-- `pytest -q tests/test_makefile_dev_python_migration.py` — 7/7 PASS
-- `pytest -q tests/test_opencode_mcp_devcontainer_compat.py` — 6/6 PASS
-- `pre-commit run --all-files` — all hooks PASS
-- `python3 scripts/orchestration/check_preflight.py` — PASS
-- `python3 scripts/orchestration/check_agent_consistency.py` — PASS
+- `bash -n scripts/devcontainer/smoke.sh` -- PASS
+- `pytest -q tests/test_devcontainer_smoke_workflow.py` -- 9/9 PASS
+- `pytest -q tests/test_devcontainer_foundation.py` -- 10/10 PASS
+- `pytest -q tests/test_makefile_dev_python_migration.py` -- 7/7 PASS
+- `pytest -q tests/test_opencode_mcp_devcontainer_compat.py` -- 6/6 PASS
+- `pre-commit run --all-files` -- all hooks PASS
+- `python3 scripts/orchestration/check_preflight.py` -- PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` -- PASS
 
 ## Review Thread Disposition
 

--- a/docs/review/PR_1653_FIXED_MAPPING.md
+++ b/docs/review/PR_1653_FIXED_MAPPING.md
@@ -19,7 +19,22 @@ PR #1653 adds a lightweight CI smoke workflow for the Docker devcontainer toolin
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1653#discussion_r3178673149
+  Disposition: NOT-A-BUG
+  Evidence: `tests/test_devcontainer_smoke_workflow.py:91` -- separate test
+  `test_devcontainer_smoke_does_not_build_production_dockerfile` already scans
+  all non-comment lines for any Dockerfile reference that is not
+  `.devcontainer/Dockerfile`. No `.devcontainer/Dockerfile.prod` exists in repo.
+  Substring match is sufficient for this contract guard.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1653#pullrequestreview-4216754988
+  Disposition: NOT-A-BUG (Cubic review-level summary; inline comment mapped above)
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1653#pullrequestreview-4216755573
+  Disposition: NOT-A-BUG (CodeRabbit review-level summary; no actionable inline comments)
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1653#pullrequestreview-4216752472
+  Disposition: NOT-A-BUG (Sourcery review-level summary; no actionable inline comments)
 
 ## Validation
 
@@ -34,4 +49,4 @@ PR #1653 adds a lightweight CI smoke workflow for the Docker devcontainer toolin
 
 ## Review Thread Disposition
 
-Populate after CodeRabbit, Sourcery, and Cubic reviews complete.
+All bot reviews mapped. 1 Cubic inline (NOT-A-BUG), 3 review summaries (NOT-A-BUG).

--- a/docs/review/PR_1653_FIXED_MAPPING.md
+++ b/docs/review/PR_1653_FIXED_MAPPING.md
@@ -12,6 +12,11 @@ PR #1653 adds a lightweight CI smoke workflow for the Docker devcontainer toolin
 - `README.md` -- short CI note in devcontainer section
 - `docs/roadmap/BACKLOG_LEDGER.md` -- updated ledger entry
 
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
 ## Fixed in Commit Mapping
 
 - No actionable review comments

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -40,9 +40,12 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P2: Add CI devcontainer smoke job
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P2
-  - Target PR: PR-TBD-DEVCONTAINER-CI-SMOKE
-  - Reason: deferred from devcontainer foundation PR to keep blast radius low; path-scoped `.github/workflows/devcontainer-smoke.yml` job that builds and runs `make dc-smoke` on `.devcontainer/**` changes
-  - DoD: CI job exists, path-scoped, builds devcontainer image, runs `dc-smoke`, does not block unrelated PRs
+  - Status: In progress
+  - Branch: devx/devcontainer-ci-smoke
+  - Target PR: devx/devcontainer-ci-smoke
+  - Reason: deferred from devcontainer foundation PR to keep blast radius low; path-scoped `.github/workflows/devcontainer-smoke.yml` job that builds devcontainer image and runs `scripts/devcontainer/smoke.sh` on `.devcontainer/**` changes
+  - DoD: CI job exists, path-scoped, builds devcontainer image, runs smoke script, no secrets required, no dependency bootstrap, workflow contract tests pass, does not block unrelated PRs
+  - Evidence: `.github/workflows/devcontainer-smoke.yml`, `scripts/devcontainer/smoke.sh`, `tests/test_devcontainer_smoke_workflow.py`
 
 <a id="ledger-p2-makefile-dev-python-migration"></a>
 - [x] P2: Migrate Makefile generic targets from VENV_PYTHON to DEV_PYTHON

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -42,7 +42,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Priority: P2
   - Status: In progress
   - Branch: devx/devcontainer-ci-smoke
-  - Target PR: devx/devcontainer-ci-smoke
+  - Target PR: #1653
   - Reason: deferred from devcontainer foundation PR to keep blast radius low; path-scoped `.github/workflows/devcontainer-smoke.yml` job that builds devcontainer image and runs `scripts/devcontainer/smoke.sh` on `.devcontainer/**` changes
   - DoD: CI job exists, path-scoped, builds devcontainer image, runs smoke script, no secrets required, no dependency bootstrap, workflow contract tests pass, does not block unrelated PRs
   - Evidence: `.github/workflows/devcontainer-smoke.yml`, `scripts/devcontainer/smoke.sh`, `tests/test_devcontainer_smoke_workflow.py`

--- a/scripts/devcontainer/smoke.sh
+++ b/scripts/devcontainer/smoke.sh
@@ -10,6 +10,9 @@ set -euo pipefail
 
 echo "== PulsePlate devcontainer tooling smoke =="
 
+# --- Git safe.directory (CI bind-mount UID may differ from container user) ---
+git config --global --add safe.directory /workspaces/PulsePlate 2>/dev/null || true
+
 # --- Workdir assumption ---
 if [ "$(pwd)" != "/workspaces/PulsePlate" ]; then
   echo "FAIL: expected workdir /workspaces/PulsePlate, got $(pwd)" >&2

--- a/scripts/devcontainer/smoke.sh
+++ b/scripts/devcontainer/smoke.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# PulsePlate devcontainer tooling smoke
+# ---------------------------------------------------------------------------
+# Lightweight check that the devcontainer image provides the expected
+# developer tooling baseline.  Does NOT install application dependencies,
+# does NOT require secrets or package proxy, and does NOT run backend tests.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+echo "== PulsePlate devcontainer tooling smoke =="
+
+# --- Workdir assumption ---
+if [ "$(pwd)" != "/workspaces/PulsePlate" ]; then
+  echo "FAIL: expected workdir /workspaces/PulsePlate, got $(pwd)" >&2
+  exit 1
+fi
+
+# --- Python 3.13 baseline ---
+python3 --version
+python3 - <<'PY'
+import sys
+major, minor = sys.version_info[:2]
+if (major, minor) != (3, 13):
+    raise SystemExit(f"Expected Python 3.13, got {major}.{minor}")
+print("Python baseline OK")
+PY
+
+# --- Core CLI tools ---
+make --version | head -1
+git --version
+jq --version
+curl --version | head -1
+sqlite3 --version
+psql --version
+
+# --- OpenCode wrapper syntax (if present) ---
+if [ -f scripts/opencode/run_pulseplate_mcp.sh ]; then
+  bash -n scripts/opencode/run_pulseplate_mcp.sh
+  echo "OpenCode wrapper syntax OK"
+fi
+
+echo "Devcontainer tooling smoke passed."

--- a/tests/test_devcontainer_smoke_workflow.py
+++ b/tests/test_devcontainer_smoke_workflow.py
@@ -80,12 +80,12 @@ def test_devcontainer_smoke_builds_devcontainer_dockerfile() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
     assert "docker build" in text, "Workflow must contain docker build command"
-    assert "-f .devcontainer/Dockerfile" in text, (
-        "Workflow must build from .devcontainer/Dockerfile"
-    )
-    assert "pulseplate-devcontainer-smoke:ci" in text, (
-        "Workflow must tag image as pulseplate-devcontainer-smoke:ci"
-    )
+    assert (
+        "-f .devcontainer/Dockerfile" in text
+    ), "Workflow must build from .devcontainer/Dockerfile"
+    assert (
+        "pulseplate-devcontainer-smoke:ci" in text
+    ), "Workflow must tag image as pulseplate-devcontainer-smoke:ci"
 
 
 def test_devcontainer_smoke_does_not_build_production_dockerfile() -> None:
@@ -99,9 +99,9 @@ def test_devcontainer_smoke_does_not_build_production_dockerfile() -> None:
         if stripped.startswith("#"):
             continue
         if "Dockerfile" in stripped and ".devcontainer/Dockerfile" not in stripped:
-            assert False, (
-                f"Workflow references a Dockerfile that is not .devcontainer/Dockerfile: {stripped}"
-            )
+            assert (
+                False
+            ), f"Workflow references a Dockerfile that is not .devcontainer/Dockerfile: {stripped}"
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +156,6 @@ def test_devcontainer_smoke_script_checks_workdir() -> None:
     """Smoke script must verify the expected working directory."""
     text = SMOKE_SCRIPT.read_text(encoding="utf-8")
 
-    assert "/workspaces/PulsePlate" in text, (
-        "Smoke script must check /workspaces/PulsePlate workdir"
-    )
+    assert (
+        "/workspaces/PulsePlate" in text
+    ), "Smoke script must check /workspaces/PulsePlate workdir"

--- a/tests/test_devcontainer_smoke_workflow.py
+++ b/tests/test_devcontainer_smoke_workflow.py
@@ -1,0 +1,161 @@
+"""Guard tests for the devcontainer CI smoke workflow.
+
+These tests verify that:
+- Workflow and smoke script files exist
+- Workflow is path-scoped and supports manual dispatch
+- Workflow does not use secrets, package proxy, or dependency bootstrap
+- Workflow builds the devcontainer Dockerfile (not production)
+- Smoke script checks tooling baseline without installing dependencies
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "devcontainer-smoke.yml"
+SMOKE_SCRIPT = REPO_ROOT / "scripts" / "devcontainer" / "smoke.sh"
+
+
+# ---------------------------------------------------------------------------
+# File existence
+# ---------------------------------------------------------------------------
+
+
+def test_devcontainer_smoke_workflow_exists() -> None:
+    """Both the workflow and the smoke script must be present."""
+    assert WORKFLOW.is_file(), "Missing .github/workflows/devcontainer-smoke.yml"
+    assert SMOKE_SCRIPT.is_file(), "Missing scripts/devcontainer/smoke.sh"
+
+
+# ---------------------------------------------------------------------------
+# Workflow triggers: path-scoped + manual
+# ---------------------------------------------------------------------------
+
+
+def test_devcontainer_smoke_workflow_is_path_scoped_and_manual() -> None:
+    """Workflow must trigger on PR path changes and support manual dispatch."""
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    triggers = data[True] if True in data else data.get("on", {})
+
+    assert "workflow_dispatch" in triggers, "Workflow must support workflow_dispatch"
+    assert "pull_request" in triggers, "Workflow must trigger on pull_request"
+
+    paths = triggers["pull_request"].get("paths", [])
+    assert ".devcontainer/**" in paths, "Workflow must be scoped to .devcontainer/**"
+    assert "scripts/devcontainer/**" in paths, "Workflow must be scoped to scripts/devcontainer/**"
+    assert "opencode.json" in paths, "Workflow must be scoped to opencode.json"
+
+
+# ---------------------------------------------------------------------------
+# Security: no secrets, no bootstrap, no error masking
+# ---------------------------------------------------------------------------
+
+
+def test_devcontainer_smoke_workflow_does_not_use_secrets_or_bootstrap() -> None:
+    """Workflow must not reference secrets, package proxy, or dependency bootstrap."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    forbidden = [
+        "secrets.",
+        "PULSEPLATE_PYTHON_INDEX_URL",
+        "make devcontainer-bootstrap",
+        "continue-on-error: true",
+        "|| true",
+    ]
+
+    for token in forbidden:
+        assert token not in text, f"Workflow must not contain '{token}'"
+
+
+# ---------------------------------------------------------------------------
+# Docker: builds devcontainer Dockerfile, not production
+# ---------------------------------------------------------------------------
+
+
+def test_devcontainer_smoke_builds_devcontainer_dockerfile() -> None:
+    """Workflow must build the devcontainer Dockerfile image."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "docker build" in text, "Workflow must contain docker build command"
+    assert "-f .devcontainer/Dockerfile" in text, (
+        "Workflow must build from .devcontainer/Dockerfile"
+    )
+    assert "pulseplate-devcontainer-smoke:ci" in text, (
+        "Workflow must tag image as pulseplate-devcontainer-smoke:ci"
+    )
+
+
+def test_devcontainer_smoke_does_not_build_production_dockerfile() -> None:
+    """Workflow must not reference the production Dockerfile."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    # The only Dockerfile reference should be .devcontainer/Dockerfile
+    lines = text.splitlines()
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if "Dockerfile" in stripped and ".devcontainer/Dockerfile" not in stripped:
+            assert False, (
+                f"Workflow references a Dockerfile that is not .devcontainer/Dockerfile: {stripped}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Smoke script: tooling checks without dependency install
+# ---------------------------------------------------------------------------
+
+
+def test_devcontainer_smoke_script_checks_tooling_without_installing_deps() -> None:
+    """Smoke script must verify tooling baseline without installing dependencies."""
+    text = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    required = [
+        "python3 --version",
+        "make --version",
+        "git --version",
+        "jq --version",
+        "curl --version",
+        "sqlite3 --version",
+        "psql --version",
+        "bash -n scripts/opencode/run_pulseplate_mcp.sh",
+    ]
+
+    for token in required:
+        assert token in text, f"Smoke script must contain '{token}'"
+
+    forbidden = [
+        "pip install",
+        "npm install",
+        "npm ci",
+        "make devcontainer-bootstrap",
+    ]
+
+    for token in forbidden:
+        assert token not in text, f"Smoke script must not contain '{token}'"
+
+
+def test_devcontainer_smoke_script_uses_strict_mode() -> None:
+    """Smoke script must use set -euo pipefail for safe execution."""
+    text = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "set -euo pipefail" in text, "Smoke script must use 'set -euo pipefail'"
+
+
+def test_devcontainer_smoke_script_checks_python_313() -> None:
+    """Smoke script must validate Python 3.13 baseline."""
+    text = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "(3, 13)" in text, "Smoke script must check for Python 3.13"
+
+
+def test_devcontainer_smoke_script_checks_workdir() -> None:
+    """Smoke script must verify the expected working directory."""
+    text = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "/workspaces/PulsePlate" in text, (
+        "Smoke script must check /workspaces/PulsePlate workdir"
+    )


### PR DESCRIPTION
## Summary

Add a lightweight CI smoke workflow for the Docker devcontainer foundation.

- Build `.devcontainer/Dockerfile` as `pulseplate-devcontainer-smoke:ci`
- Run tooling smoke inside container via `scripts/devcontainer/smoke.sh`
- Verify Python 3.13 baseline and core developer tools (make, git, jq, curl, sqlite3, psql)
- Check OpenCode wrapper shell syntax if present
- Add 9 deterministic workflow contract tests
- Keep dependency bootstrap out of CI (no secrets, no package proxy)

## Motivation

PR #1646 added the devcontainer foundation, PR #1651 moved generic Makefile targets to `DEV_PYTHON`, and PR #1652 made OpenCode MCP launch devcontainer-compatible. This PR adds a lightweight CI guard so future changes do not silently break the devcontainer tooling layer.

## Scope

- `.github/workflows/devcontainer-smoke.yml` — path-scoped workflow
- `scripts/devcontainer/smoke.sh` — tooling smoke script
- `tests/test_devcontainer_smoke_workflow.py` — 9 contract tests
- `README.md` — short CI note in devcontainer section
- `docs/roadmap/BACKLOG_LEDGER.md` — updated ledger entry

## Non-goals

- No full dependency bootstrap in CI
- No `make devcontainer-bootstrap` in CI
- No secrets required
- No package proxy usage
- No backend/frontend/iOS runtime changes
- No production Dockerfile changes
- No dependency pin changes
- No OpenAPI changes
- No Figma/MCP auth changes
- No App Store metadata changes
- No Trivy/security suppression changes

## Validation

- [x] `bash -n scripts/devcontainer/smoke.sh`
- [x] `pytest -q tests/test_devcontainer_smoke_workflow.py` (9/9 pass)
- [x] `pytest -q tests/test_devcontainer_foundation.py` (10/10 pass)
- [x] `pytest -q tests/test_makefile_dev_python_migration.py` (7/7 pass)
- [x] `pytest -q tests/test_opencode_mcp_devcontainer_compat.py` (6/6 pass)
- [x] `python3 scripts/orchestration/check_preflight.py`
- [x] `python3 scripts/orchestration/check_agent_consistency.py`
- [x] `pre-commit run --all-files` (all hooks green)
- [x] `git diff --check` (clean)

## Security Notes

The workflow requires no secrets and does not run dependency bootstrap. It does not expose package proxy values, does not use `continue-on-error`, and does not bypass failures with `|| true`.

## Decision Log

1. Add lightweight tooling smoke before full dependency bootstrap.
2. Keep package proxy / dependency install out of CI smoke.
3. Use path-scoped PR trigger to avoid unnecessary Docker jobs.
4. Preserve production Dockerfile and runtime behavior.
5. Use direct `docker build`+`docker run` instead of `docker compose` for CI simplicity.
6. Skip optional Makefile `dc-ci-smoke` target — workflow-only for now.

## Deferred / Follow-ups

- Full devcontainer bootstrap smoke after secret/package-proxy strategy is approved (`BACKLOG_LEDGER.md`)
- Optional local `make dc-ci-smoke` target if useful after workflow stabilizes

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: docs/review/PR_1653_FIXED_MAPPING.md

## Merge Readiness

- [ ] CI green
- [ ] Devcontainer smoke workflow green
- [ ] Workflow contract tests green
- [ ] Review mapping artifact created
- [ ] No actionable bot comments remain
- [ ] Mandatory wait-window elapsed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lightweight CI smoke workflow for the devcontainer to catch tooling regressions early. It builds the image and verifies core tools without installing dependencies or using secrets.

- **New Features**
  - Adds `.github/workflows/devcontainer-smoke.yml` to build `.devcontainer/Dockerfile` as `pulseplate-devcontainer-smoke:ci` and run `scripts/devcontainer/smoke.sh`.
  - Verifies Python 3.13 and core CLIs (make, git, jq, curl, sqlite3, psql); checks OpenCode wrapper syntax if present.
  - Path-scoped PR trigger for `.devcontainer/` and related scripts; supports `workflow_dispatch`.
  - Adds 9 contract tests; updates README, backlog ledger, and review mapping artifact.

- **Bug Fixes**
  - Sets `git` safe.directory in the smoke script to handle host/container UID mismatches.
  - Increases workflow timeout to 20 minutes for cold-cache builds.
  - Updates review mapping artifact for Phase2 gate: adds “Discussion Thread Pass,” uses single-line dispositions for validator compliance, maps bot review comments as NOT-A-BUG, and resolves the Cubic inline thread.

<sup>Written for commit 903e5cb7edb036bcaacf3ebc8589a1a1256048ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lightweight CI "devcontainer smoke" workflow that validates devcontainer tooling on relevant PRs and supports manual runs.

* **Documentation**
  * Updated README, review notes, and roadmap/backlog to describe the new validation workflow and its implementation status.

* **Tests**
  * Added guard tests for path-scoped/manual triggers, no-secret/bootstrap usage, and devcontainer image build behavior.

* **Chores**
  * Added a portable smoke-check script to verify CLI/tool versions, Python 3.13, strict shell mode, and workspace sanity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->