### PR TITLE
fix(devcontainer): remove stale Yarn APT source before apt-get update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,13 @@ FROM mcr.microsoft.com/devcontainers/python:1-3.13-bookworm
 
 USER root
 
-RUN apt-get update \
+# Remove Yarn APT source shipped by Microsoft base image — the GPG key
+# (62D54FD4003F6525) is periodically expired/rotated upstream and breaks
+# apt-get update in CI.  Yarn is not needed for backend development;
+# Node.js is provided by the devcontainer Node feature instead.
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+    && rm -f /usr/share/keyrings/yarn-keyring.gpg \
+    && apt-get update \
     && apt-get install -y --no-install-recommends \
         make \
         jq \

--- a/docs/review/PR_1654_FIXED_MAPPING.md
+++ b/docs/review/PR_1654_FIXED_MAPPING.md
@@ -1,0 +1,24 @@
+# PR #1654 Fixed in Commit Mapping
+
+## Summary
+
+Fix devcontainer-smoke CI by removing stale Yarn APT source from base image.
+
+## Scope
+
+- `.devcontainer/Dockerfile` only
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Validation
+
+- `pytest -q tests/test_devcontainer_foundation.py` -- 10/10 PASS
+- `pytest -q tests/test_devcontainer_smoke_workflow.py` -- 9/9 PASS
+- `pre-commit run --all-files` -- all hooks PASS


### PR DESCRIPTION
## Summary

Remove the Yarn APT source from the Microsoft devcontainer base image before
`apt-get update` to fix the devcontainer-smoke CI workflow.

## Motivation

PR #1653 added a devcontainer-smoke workflow that builds `.devcontainer/Dockerfile`.
The first CI run failed because the Microsoft `python:1-3.13-bookworm` base image
ships a Yarn APT repository whose GPG key (`62D54FD4003F6525`) is expired/rotated
upstream, causing `apt-get update` to fail with:

```
E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
```

## Fix

Remove `yarn.list` and `yarn-keyring.gpg` before `apt-get update`. Yarn is not
needed for backend development; Node.js is provided by the devcontainer Node
feature in `devcontainer.json`.

## Scope

- `.devcontainer/Dockerfile` only

## Non-goals

- No changes to production Dockerfile
- No dependency changes
- No runtime code changes

## Validation

- [x] `pytest -q tests/test_devcontainer_foundation.py` (10/10 pass)
- [x] `pytest -q tests/test_devcontainer_smoke_workflow.py` (9/9 pass)
- [x] `pre-commit run --all-files` (all hooks green)
- [x] `python3 scripts/orchestration/check_preflight.py` (PASS)

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: docs/review/PR_1654_FIXED_MAPPING.md

## Merge Readiness

- [ ] CI green (including devcontainer-smoke)
- [ ] No actionable bot comments remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved development environment setup issue affecting development container initialization

* **Documentation**
  * Added documentation confirming the development environment fix

<!-- end of auto-generated comment: release notes by coderabbit.ai -->