### PR TITLE
fix(ci): remove unsafe pip lock drift from dev install

### DIFF
--- a/docs/review/PR_1655_FIXED_MAPPING.md
+++ b/docs/review/PR_1655_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+# PR 1655 Fixed Mapping
+
+## Summary
+
+Nightly CI dependency-lock unblock for unsafe `pip==26.1` drift in `requirements-dev.txt`.
+
+## Review Thread Dispositions
+
+No review threads yet.
+
+## Fixed in Commit Mapping
+
+Pending review comments.
+
+## Merge Readiness Evidence
+
+Pending current-head CI and local validation.

--- a/docs/review/PR_1655_FIXED_MAPPING.md
+++ b/docs/review/PR_1655_FIXED_MAPPING.md
@@ -4,14 +4,15 @@
 
 Nightly CI dependency-lock unblock for unsafe `pip==26.1` drift in `requirements-dev.txt`.
 
-## Review Thread Dispositions
+## Discussion Thread Pass
 
-No review threads yet.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
-## Fixed in Commit Mapping
+### Fixed in Commit Mapping
 
-Pending review comments.
+No actionable review comments.
 
-## Merge Readiness Evidence
+## Merge Readiness
 
-Pending current-head CI and local validation.
+Pending current-head CI green and mandatory wait-window.

--- a/docs/review/PR_1655_FIXED_MAPPING.md
+++ b/docs/review/PR_1655_FIXED_MAPPING.md
@@ -11,7 +11,7 @@ Nightly CI dependency-lock unblock for unsafe `pip==26.1` drift in `requirements
 
 ### Fixed in Commit Mapping
 
-No actionable review comments.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/security/GHSA-58qw-9mgm-455v-pip.md
+++ b/docs/security/GHSA-58qw-9mgm-455v-pip.md
@@ -19,14 +19,16 @@ and records a deterministic blocked-version guard.
 
 ## Repo Evidence
 
-- `requirements-dev.txt:258` shows the unsafe package block now starts at
+- `requirements-dev.txt:249` shows the unsafe package block now starts at
   `setuptools==78.1.1`; the prior `pip==26.0` entry is absent.
-- `requirements-lock.txt:545` shows the unsafe package block now starts at
+- `requirements-lock.txt:211` shows the unsafe package block now starts at
   `setuptools==78.1.1`; the prior `pip==26.0.1` entry is absent.
 - `tests/fixtures/dependency_security_schema.json:15` blocks `pip<=26.0.1`
   in pinned requirement surfaces.
 - GitHub Dependabot alert `#118` maps `pip` in `requirements-dev.txt` to
   `GHSA-58qw-9mgm-455v`.
+- `tests/test_dependency_security_guard.py` includes
+  `test_repo_managed_lock_surfaces_do_not_pin_pip` to prevent future drift.
 - GitHub Dependabot alert `#119` maps `pip` in `requirements-lock.txt` to
   `GHSA-58qw-9mgm-455v`.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -247,10 +247,6 @@ yamllint==1.38.0
     # via -r requirements-dev.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1
-    # via
-    #   pip-api
-    #   pip-tools
 setuptools==78.1.1
     # via
     #   -c requirements.txt

--- a/tests/test_dependency_security_guard.py
+++ b/tests/test_dependency_security_guard.py
@@ -579,3 +579,33 @@ def test_blocked_version_enforcement_with_fake_surface(tmp_path: Path) -> None:
     assert violations == [
         ("some-pkg", "2.0.3", ">=2.0.0,<2.1.0")
     ], "Blocked version match should be detected."
+
+
+def test_repo_managed_lock_surfaces_do_not_pin_pip() -> None:
+    """Guard: repo-managed lock surfaces must not pin pip as an unsafe package.
+
+    pip-compile --allow-unsafe may reintroduce pip==... entries; the repo
+    security policy (GHSA-58qw-9mgm-455v-pip.md) requires these entries to
+    be absent.  This guard prevents future drift regardless of the specific
+    pip version.
+    """
+    pinned_surfaces = [
+        surface for surface in REQUIREMENT_SURFACES if not _is_constraint_style(surface)
+    ]
+
+    offenders: list[str] = []
+    for surface in pinned_surfaces:
+        if not surface.exists():
+            continue
+        pins = _pinned_versions_per_package(surface).get(
+            _normalized_package_name("pip"),
+        )
+        if pins:
+            versions = ", ".join(str(v) for v in sorted(pins))
+            offenders.append(f"{surface.name}: pip=={versions}")
+
+    assert not offenders, (
+        "Repo-managed lock surfaces must not pin pip as an unsafe package. "
+        "Remove pip==... entries instead of repinning pip. "
+        "See docs/security/GHSA-58qw-9mgm-455v-pip.md. Offenders: " + "; ".join(offenders)
+    )


### PR DESCRIPTION
## Summary

Fixes Nightly Tests locked-install failure caused by unsafe `pip==26.1` lock drift in `requirements-dev.txt`.

The approved private index currently provides only `pip` 26.0 and 26.0.1, so the locked dev install fails before tests start. This PR restores the existing security policy: repo-managed lock surfaces must not pin `pip==...` as an unsafe requirement. The normal dev tooling packages (`pip-api`, `pip-audit`, `pip-requirements-parser`, `pip-tools`) remain in place.

**Nightly failure:** https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/25302753929/job/74172547344

## Scope

- Remove unsafe `pip==26.1` pin from `requirements-dev.txt`
- Add deterministic regression guard `test_repo_managed_lock_surfaces_do_not_pin_pip` preventing pinned `pip==...` drift in repo-managed lock surfaces
- Sync `docs/security/GHSA-58qw-9mgm-455v-pip.md` evidence references

## Non-goals

- No runtime changes
- No frontend changes
- No iOS changes
- No OpenAPI changes
- No billing changes
- No App Store changes
- No Docker/deploy changes
- No public-index bypass
- No emergency wheel for pip
- No repinning pip to 26.0 / 26.0.1 / another version

## Validation

- [x] `rg -n "^pip==" requirements*.txt constraints.txt` returns no matches
- [x] `python3 -m pytest -q tests/test_dependency_security_guard.py` — 37 passed, 15 skipped
- [x] `test_repo_managed_lock_surfaces_do_not_pin_pip` — PASSED
- [x] `python3 scripts/orchestration/check_preflight.py` — PASS
- [x] `python3 scripts/orchestration/check_agent_consistency.py` — OK
- [x] `pre-commit run --all-files` — all passed
- [x] `git diff --check` — clean
- [x] `make lint` — no issues
- [x] `make typecheck` — no issues (344 source files)
- [x] `make test-fast` — 144 passed, 0 failed
- [x] CI current-head: all checks green (lint, test-pr, security, diff-coverage, Phase2, scope guard, OpenAPI sync)

## Security Notes

This PR keeps the existing pip advisory strategy: do not repin pip to a nonexistent safe release; remove unsafe pip lock entries from repo-managed requirement surfaces. It adds a regression guard to prevent future `pip==...` drift.

## Decision Log

1. `pip==26.1` is removed instead of repinned.
2. `pip-api`, `pip-audit`, `pip-requirements-parser`, and `pip-tools` remain normal dev dependencies.
3. Repo-managed lock surfaces must not pin `pip==...`.
4. The fix is CI/dependency-lock only and does not touch runtime surfaces.

## Deferred / Follow-ups

- Broader dependency operating-model work remains separate.
- Private index mirror retirement work remains separate.
- No change to current Evaluation Science PR.
- Existing backlog item: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-pip-unsafe-pin-alerts-118-119`

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: docs/review/PR_1655_FIXED_MAPPING.md
- No actionable review comments

## Merge Readiness

- [x] Required CI green on current head (run 25303968551 — all pass)
- [x] `mergeStateStatus: CLEAN`
- [x] Review mapping artifact created
- [x] CodeRabbit / Sourcery / Cubic have no actionables
- [x] `check_pr_merge_readiness.py` — passed
- [x] `check_review_threads_disposition.py` — OK
- [x] Mandatory wait-window elapsed (first CI green: run 25303801637; final: 25303968551)
- [x] Final strict merge-readiness check passed