### PR TITLE
feat(evals): emit validity sidecar for judgment replay

### DIFF
--- a/docs/evals/PULSEPLATE_EVAL_VALIDITY_CONTRACT.md
+++ b/docs/evals/PULSEPLATE_EVAL_VALIDITY_CONTRACT.md
@@ -123,9 +123,42 @@ RAG release-gate PASS/NO-GO decision.
 
 ## Judgment Lane Integration
 
-Current state: standalone. The judgment eval
-(`core/judgment_eval.py`) uses promote/defer/discard decisions. Future PR
-may map judgment outcomes to validity `EvalOutcomeRecord` format.
+Current state: **sidecar integrated** (PR-3).
+
+The FitChef judgment replay eval runner (`scripts/orchestration/judgment_eval.py`)
+now emits optional validity sidecar artifacts alongside the canonical decision
+artifact:
+
+- `judgment_validity_items.jsonl` -- one `EvalOutcomeRecord` per evaluated case.
+- `judgment_validity_report.json` -- the validity report built from those outcomes.
+
+### Decision-to-outcome mapping
+
+| Judgment decision | `passed` | `score` | Rationale |
+|-------------------|----------|---------|-----------|
+| `promote` | `True` | `1.0` | Fully supported, safe to surface. |
+| `defer` | `True` | `0.5` | Safe but under-supported; not a failure. |
+| `discard` | `False` | `0.0` | Failed safety or evidence checks. |
+
+The `decision` field in each `EvalOutcomeRecord` carries the original judgment
+string (`"promote"` / `"defer"` / `"discard"`), not a pass/fail label.
+
+Slice tags include `"judgment"`, the `boundary_class` value, and `"hard_fail"`
+when hard-fail reasons are present.
+
+### Limitations
+
+Current judgment replay datasets contain only canonical items. The validity
+report honestly shows `invariance_score=0.0`, `mutation_drop.overall=0.0`,
+and `item_instability_index=0.0` for canonical-only data. Full
+invariance/mutation coverage requires explicit variant families in future
+judgment replay datasets.
+
+### Invariant
+
+Judgment validity sidecar artifacts are informational measurement artifacts.
+They do not override claim taxonomy, claim-to-evidence records, uncertainty
+split, or canonical promote/defer/discard decisions.
 
 ## Security / Privacy Boundary
 
@@ -141,7 +174,8 @@ may map judgment outcomes to validity `EvalOutcomeRecord` format.
    fixtures, tests, docs.
 2. **PR-2 (current, #1648)**: RAG release-gate validity sidecar --
    item-level artifacts emitted via adapter.
-3. **PR-3 (deferred)**: Integration with judgment eval outcome export.
+3. **PR-3 (current)**: Judgment replay validity sidecar -- item-level
+   artifacts emitted via adapter, CLI wiring with graceful degradation.
 4. **PR-4+ (deferred)**: Psychometrics / IRT, adaptive evals, hybrid
    adjudication, tool-use reliability.
 

--- a/docs/orchestration/JUDGMENT_ADJUDICATION_SUBLANE_PROTOCOL.md
+++ b/docs/orchestration/JUDGMENT_ADJUDICATION_SUBLANE_PROTOCOL.md
@@ -184,3 +184,11 @@ coordinator packet wiring remains gated for enablement after offline eval and th
 hidden pilot.
 
 Public heavy-runtime exposure is out of scope until the hidden pilot and offline evals prove value.
+
+### Offline validity sidecars
+
+Offline judgment validity sidecars (PR-3 of the evaluation-validity epic) may
+measure stability of adjudication outcomes across replay datasets. They do not
+change this sub-lane protocol. The coordinator remains the decision authority
+and promote/defer/discard remains canonical. See
+`docs/evals/PULSEPLATE_EVAL_VALIDITY_CONTRACT.md` for sidecar details.

--- a/docs/review/PR_1656_FIXED_MAPPING.md
+++ b/docs/review/PR_1656_FIXED_MAPPING.md
@@ -26,6 +26,11 @@ Disposition: FIXED
 Commit: 19e20cb83
 Evidence: tests/test_judgment_eval.py:153 -- JSONL assertion now filters blank lines
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#discussion_r3180620838 -> e29632d42
+Disposition: FIXED
+Commit: e29632d42
+Evidence: scripts/orchestration/judgment_eval.py:115 -- import reverted to inside try block for graceful degradation
+
 ## Merge Readiness Evidence
 
 Pending current-head CI and local validation.

--- a/docs/review/PR_1656_FIXED_MAPPING.md
+++ b/docs/review/PR_1656_FIXED_MAPPING.md
@@ -31,8 +31,6 @@ Disposition: FIXED
 Commit: e29632d42
 Evidence: scripts/orchestration/judgment_eval.py:115 -- import reverted to inside try block for graceful degradation
 
-### Review-level dispositions (parent reviews)
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#pullrequestreview-4217785400
 Disposition: NOT-A-BUG
 Evidence: CodeRabbit summary review; inline actionables mapped above as discussion threads

--- a/docs/review/PR_1656_FIXED_MAPPING.md
+++ b/docs/review/PR_1656_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+# PR 1656 Fixed Mapping
+
+## Summary
+
+Judgment replay/eval validity sidecar PR (PR-3 of evaluation validity epic).
+
+## Review Thread Dispositions
+
+No review threads yet.
+
+## Fixed in Commit Mapping
+
+Pending review comments.
+
+## Merge Readiness Evidence
+
+Pending current-head CI and local validation.

--- a/docs/review/PR_1656_FIXED_MAPPING.md
+++ b/docs/review/PR_1656_FIXED_MAPPING.md
@@ -11,7 +11,20 @@ Judgment replay/eval validity sidecar PR (PR-3 of evaluation validity epic).
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#discussion_r3179676207 -> 19e20cb83
+Disposition: FIXED
+Commit: 19e20cb83
+Evidence: scripts/orchestration/judgment_eval.py:130 -- stderr warning replaces silent pass
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#discussion_r3179687480 -> 19e20cb83
+Disposition: FIXED
+Commit: 19e20cb83
+Evidence: scripts/orchestration/judgment_eval.py:130 -- same fix as Cubic finding above
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#discussion_r3179687490 -> 19e20cb83
+Disposition: FIXED
+Commit: 19e20cb83
+Evidence: tests/test_judgment_eval.py:153 -- JSONL assertion now filters blank lines
 
 ## Merge Readiness Evidence
 

--- a/docs/review/PR_1656_FIXED_MAPPING.md
+++ b/docs/review/PR_1656_FIXED_MAPPING.md
@@ -31,6 +31,23 @@ Disposition: FIXED
 Commit: e29632d42
 Evidence: scripts/orchestration/judgment_eval.py:115 -- import reverted to inside try block for graceful degradation
 
+### Review-level dispositions (parent reviews)
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#pullrequestreview-4217785400
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit summary review; inline actionables mapped above as discussion threads
+Reason: Parent review comment is summary only; actionable items are inline threads already mapped
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#pullrequestreview-4217801842
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit follow-up review acknowledging fixes in 19e20cb83
+Reason: Follow-up review confirming fixes applied; no new actionables
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#pullrequestreview-4218901013 -> e29632d42
+Disposition: FIXED
+Commit: e29632d42
+Evidence: scripts/orchestration/judgment_eval.py:115 -- sidecar import reverted to inside try block
+
 ## Merge Readiness Evidence
 
 Pending current-head CI and local validation.

--- a/docs/review/PR_1656_FIXED_MAPPING.md
+++ b/docs/review/PR_1656_FIXED_MAPPING.md
@@ -4,13 +4,14 @@
 
 Judgment replay/eval validity sidecar PR (PR-3 of evaluation validity epic).
 
-## Review Thread Dispositions
+## Discussion Thread Pass
 
-No review threads yet.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-Pending review comments.
+- No actionable review comments
 
 ## Merge Readiness Evidence
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2128,6 +2128,33 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Tests prove sidecar generation and no threshold/decision drift
     - Docs explain sidecar semantics and limitations
     - No runtime/API/frontend/iOS/billing/OpenAPI/App Store/Claude/Opus/MCP changes
+<a id="ledger-p1-judgment-validity-sidecar"></a>
+- [ ] P1: Judgment replay validity sidecar integration
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD (`evals/judgment-validity-sidecar`)
+  - Status: In progress
+  - Area: evals / judgment / adjudication / measurement science
+  - Finding Type: validity-artifact integration gap
+  - Reason (EN): PR #1632 added the evaluation-validity substrate and PR #1648 integrated RAG release-gate sidecars. The next rollout step in `PULSEPLATE_EVAL_VALIDITY_CONTRACT.md` is judgment eval outcome export, so judgment replay/adjudication should emit item-level validity-compatible sidecars while preserving existing promote/defer/discard semantics.
+  - Links:
+    - `docs/evals/PULSEPLATE_EVAL_VALIDITY_CONTRACT.md`
+    - `docs/orchestration/JUDGMENT_ADJUDICATION_SUBLANE_PROTOCOL.md`
+    - `core/judgment_eval.py`
+    - `scripts/evals/judgment_validity.py`
+    - `scripts/evals/eval_validity_contract.py`
+    - `scripts/orchestration/judgment_eval.py`
+    - `tests/evals/test_judgment_validity_sidecar.py`
+    - `tests/test_judgment_eval.py`
+  - DoD:
+    - Judgment replay/eval can emit validity-compatible item-level sidecar JSONL
+    - Judgment replay/eval can emit validity report sidecar JSON
+    - Existing claim taxonomy remains canonical
+    - Existing claim-to-evidence semantics remain canonical
+    - Existing promote/defer/discard decision logic is unchanged
+    - Tests prove sidecar generation and no decision drift
+    - Docs explain sidecar semantics and limitations
+    - No runtime/API/frontend/iOS/billing/OpenAPI/App Store/Claude/Opus/MCP changes
 <a id="ledger-p1-knowledge-promotion-from-validated-rag"></a>
 - [ ] P1: Knowledge contracts and promotion from validated RAG evidence
   - Owner: @katsiaryna_kavaleuskaya

--- a/scripts/evals/judgment_validity.py
+++ b/scripts/evals/judgment_validity.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Judgment replay validity sidecar adapter.
+
+RU: Адаптер для преобразования FitChef judgment replay результатов в
+    validity-совместимые EvalOutcomeRecord и генерации validity sidecar
+    артефактов.
+EN: Adapter to convert FitChef judgment replay results into validity-compatible
+    EvalOutcomeRecord rows and generate validity sidecar artifacts.
+
+This module is a bridge between the FitChef judgment replay eval runner
+(``scripts/orchestration/judgment_eval.py``) and the evaluation-validity
+substrate (``scripts/evals/eval_validity_contract.py``).
+
+Hard rules:
+- No network calls.
+- No model invocations.
+- No changes to promote/defer/discard logic.
+- No changes to claim taxonomy.
+- No changes to claim-to-evidence semantics.
+- Sidecar artifacts are informational sibling artifacts.
+- Canonical-only rows must not be misrepresented as invariance/mutation coverage.
+
+Judgment validity sidecar artifacts are informational measurement artifacts.
+They do not override claim taxonomy, claim-to-evidence records, uncertainty
+split, or canonical promote/defer/discard decisions.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+from scripts.evals.eval_validity_contract import (
+    EvalOutcomeRecord,
+    build_validity_report,
+    validate_eval_outcome_record,
+)
+
+# ---------------------------------------------------------------------------
+# Constants (judgment decision -> validity score mapping)
+# ---------------------------------------------------------------------------
+
+# Deterministic mapping from judgment decisions to validity scores.
+#
+# - promote (1.0): fully supported, safe to surface.
+# - defer (0.5): safe but under-supported; not a failure, but not fully promoted.
+#   passed=True because defer means content is safe (per judgment protocol).
+# - discard (0.0): failed safety or evidence checks.
+JUDGMENT_DECISION_SCORES: dict[str, float] = {
+    "promote": 1.0,
+    "defer": 0.5,
+    "discard": 0.0,
+}
+
+# Decisions that map to passed=True in validity sidecar.
+# Defer is treated as passed because the judgment protocol defines defer as
+# "safe but still under-supported" -- content is not harmful, just incomplete.
+_PASSED_DECISIONS: frozenset[str] = frozenset({"promote", "defer"})
+
+JUDGMENT_VALIDITY_ITEMS_FILENAME = "judgment_validity_items.jsonl"
+JUDGMENT_VALIDITY_REPORT_FILENAME = "judgment_validity_report.json"
+
+
+# ---------------------------------------------------------------------------
+# Result -> EvalOutcomeRecord mapping
+# ---------------------------------------------------------------------------
+
+
+def result_to_eval_outcome(
+    result: dict[str, Any],
+    pack_meta: dict[str, Any] | None = None,
+) -> EvalOutcomeRecord:
+    """Convert a single FitChef judgment replay result to an ``EvalOutcomeRecord``.
+
+    The mapping preserves existing promote/defer/discard semantics:
+
+    - ``promote`` -> passed=True, score=1.0
+    - ``defer``   -> passed=True, score=0.5
+    - ``discard`` -> passed=False, score=0.0
+
+    Since current judgment replay datasets contain only canonical items (no
+    invariance or mutation variants), all rows are mapped as
+    ``variant_family="canonical"`` and ``transform_type="none"``.
+
+    The ``decision`` field carries the original judgment decision string
+    (``"promote"`` / ``"defer"`` / ``"discard"``), not a pass/fail label.
+
+    Parameters
+    ----------
+    result:
+        A FitChef replay result dict (``FitChefReplayResultRecord``-shaped).
+    pack_meta:
+        Optional pack-level metadata (unused in current implementation but
+        reserved for future variant-family support).
+    """
+    case_id = str(result.get("case_id", "unknown"))
+    decision = str(result.get("decision", "")).strip().lower()
+    boundary_class = str(result.get("boundary_class", "unknown"))
+    hard_fail_reasons: list[str] = result.get("hard_fail_reasons") or []
+
+    score = JUDGMENT_DECISION_SCORES.get(decision, 0.0)
+    passed = decision in _PASSED_DECISIONS
+
+    slice_tags: list[str] = ["judgment", boundary_class]
+    if hard_fail_reasons:
+        slice_tags.append("hard_fail")
+
+    raw: dict[str, Any] = {
+        "canonical_id": case_id,
+        "variant_id": case_id,
+        "variant_family": "canonical",
+        "transform_type": "none",
+        "passed": passed,
+        "score": score,
+        "decision": decision,
+        "slice_tags": slice_tags,
+    }
+    return validate_eval_outcome_record(raw)
+
+
+def results_to_eval_outcomes(
+    results: Sequence[dict[str, Any]],
+    pack_meta: dict[str, Any] | None = None,
+) -> list[EvalOutcomeRecord]:
+    """Convert a sequence of FitChef judgment replay results to ``EvalOutcomeRecord`` rows.
+
+    Deterministic: insertion order is preserved.
+    """
+    return [result_to_eval_outcome(r, pack_meta) for r in results]
+
+
+# ---------------------------------------------------------------------------
+# Sidecar artifact writing
+# ---------------------------------------------------------------------------
+
+
+def write_judgment_validity_sidecar(
+    run_dir: Path,
+    results: Sequence[dict[str, Any]],
+    pack_meta: dict[str, Any] | None = None,
+) -> dict[str, str]:
+    """Write judgment validity sidecar artifacts into the run directory.
+
+    Emits two files:
+
+    - ``judgment_validity_items.jsonl`` -- one ``EvalOutcomeRecord`` per result.
+    - ``judgment_validity_report.json`` -- the validity report built from those
+      outcomes.
+
+    Returns a dict mapping artifact kind to file path (string).
+
+    The sidecar files are informational measurement artifacts.  They do NOT
+    override the claim taxonomy, claim-to-evidence records, uncertainty split,
+    or the canonical promote/defer/discard decisions.
+    """
+    outcomes = results_to_eval_outcomes(results, pack_meta)
+    report = build_validity_report(outcomes)
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write item-level outcomes.
+    items_path = run_dir / JUDGMENT_VALIDITY_ITEMS_FILENAME
+    with open(items_path, "w", encoding="utf-8") as fh:
+        for rec in outcomes:
+            fh.write(json.dumps(rec, ensure_ascii=False, sort_keys=True) + "\n")
+
+    # Write validity report.
+    report_path = run_dir / JUDGMENT_VALIDITY_REPORT_FILENAME
+    with open(report_path, "w", encoding="utf-8") as fh:
+        json.dump(report, fh, indent=2, sort_keys=True, ensure_ascii=False)
+        fh.write("\n")
+
+    return {
+        "validity_items": str(items_path),
+        "validity_report": str(report_path),
+    }

--- a/scripts/evals/judgment_validity.py
+++ b/scripts/evals/judgment_validity.py
@@ -97,7 +97,8 @@ def result_to_eval_outcome(
     case_id = str(result.get("case_id", "unknown"))
     decision = str(result.get("decision", "")).strip().lower()
     boundary_class = str(result.get("boundary_class", "unknown"))
-    hard_fail_reasons: list[str] = result.get("hard_fail_reasons") or []
+    _raw_hfr = result.get("hard_fail_reasons")
+    hard_fail_reasons: list[str] = _raw_hfr if isinstance(_raw_hfr, list) else []
 
     score = JUDGMENT_DECISION_SCORES.get(decision, 0.0)
     passed = decision in _PASSED_DECISIONS
@@ -161,13 +162,13 @@ def write_judgment_validity_sidecar(
 
     # Write item-level outcomes.
     items_path = run_dir / JUDGMENT_VALIDITY_ITEMS_FILENAME
-    with open(items_path, "w", encoding="utf-8") as fh:
+    with items_path.open("w", encoding="utf-8") as fh:
         for rec in outcomes:
             fh.write(json.dumps(rec, ensure_ascii=False, sort_keys=True) + "\n")
 
     # Write validity report.
     report_path = run_dir / JUDGMENT_VALIDITY_REPORT_FILENAME
-    with open(report_path, "w", encoding="utf-8") as fh:
+    with report_path.open("w", encoding="utf-8") as fh:
         json.dump(report, fh, indent=2, sort_keys=True, ensure_ascii=False)
         fh.write("\n")
 

--- a/scripts/evals/judgment_validity.py
+++ b/scripts/evals/judgment_validity.py
@@ -94,6 +94,7 @@ def result_to_eval_outcome(
         Optional pack-level metadata (unused in current implementation but
         reserved for future variant-family support).
     """
+    del pack_meta  # reserved for future variant-family support
     case_id = str(result.get("case_id", "unknown"))
     decision = str(result.get("decision", "")).strip().lower()
     boundary_class = str(result.get("boundary_class", "unknown"))

--- a/scripts/orchestration/judgment_eval.py
+++ b/scripts/orchestration/judgment_eval.py
@@ -108,6 +108,30 @@ def main(argv: list[str] | None = None) -> int:
         print(str(exc), file=sys.stderr)
         return 1
 
+    # Validity sidecar (informational -- does not change promote/defer/discard).
+    # Follows the same graceful-degradation pattern as the RAG release-gate
+    # validity sidecar in run_rag_release_gates.py (PR #1648).
+    try:
+        from scripts.evals.judgment_validity import write_judgment_validity_sidecar
+
+        pack_meta = {
+            "bundle_id": artifact.get("bundle_id", ""),
+            "schema_version": artifact.get("schema_version", ""),
+            "mode": artifact.get("mode", ""),
+            "scenario_family": artifact.get("scenario_family", ""),
+        }
+        sidecar_paths = write_judgment_validity_sidecar(
+            run_dir=output_path.parent,
+            results=results,
+            pack_meta=pack_meta,
+        )
+        for kind, path in sorted(sidecar_paths.items()):
+            print(f"validity_{kind}: {path}", file=sys.stderr)
+    except Exception:  # noqa: BLE001 -- sidecar failure must not break eval
+        # Sidecar is informational only; graceful degradation is the correct
+        # behavior (same pattern as RAG sidecar in run_rag_release_gates.py).
+        pass  # nosec B110 sidecar metrics are non-critical; silent degradation is intentional (remove-by: 2026-11-01, ref: PR-1648)
+
     print(output_path)
     return 0
 

--- a/scripts/orchestration/judgment_eval.py
+++ b/scripts/orchestration/judgment_eval.py
@@ -18,7 +18,6 @@ if str(RUNNER_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(RUNNER_REPO_ROOT))
 
 from scripts.orchestration.context_pack import REPO_ROOT
-from scripts.evals.judgment_validity import write_judgment_validity_sidecar
 from scripts.orchestration.judgment_eval_contract import (
     evaluate_fitchef_replay_pack,
     validate_fitchef_replay_pack,
@@ -113,13 +112,15 @@ def main(argv: list[str] | None = None) -> int:
     # Follows the same graceful-degradation pattern as the RAG release-gate
     # validity sidecar in run_rag_release_gates.py (PR #1648).
     try:
+        from scripts.evals.judgment_validity import write_judgment_validity_sidecar
+
         sidecar_paths = write_judgment_validity_sidecar(
             run_dir=output_path.parent,
             results=results,
         )
         for kind, path in sorted(sidecar_paths.items()):
             print(f"{kind}: {path}", file=sys.stderr)
-    except Exception as exc:  # noqa: BLE001 -- sidecar write failure must not break eval
+    except Exception as exc:  # noqa: BLE001 -- sidecar failure must not break eval
         # Sidecar is informational only; graceful degradation is the correct
         # behavior (same pattern as RAG sidecar in run_rag_release_gates.py).
         print(f"warning: validity sidecar emission failed: {exc}", file=sys.stderr)

--- a/scripts/orchestration/judgment_eval.py
+++ b/scripts/orchestration/judgment_eval.py
@@ -18,6 +18,7 @@ if str(RUNNER_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(RUNNER_REPO_ROOT))
 
 from scripts.orchestration.context_pack import REPO_ROOT
+from scripts.evals.judgment_validity import write_judgment_validity_sidecar
 from scripts.orchestration.judgment_eval_contract import (
     evaluate_fitchef_replay_pack,
     validate_fitchef_replay_pack,
@@ -112,22 +113,13 @@ def main(argv: list[str] | None = None) -> int:
     # Follows the same graceful-degradation pattern as the RAG release-gate
     # validity sidecar in run_rag_release_gates.py (PR #1648).
     try:
-        from scripts.evals.judgment_validity import write_judgment_validity_sidecar
-
-        pack_meta = {
-            "bundle_id": artifact.get("bundle_id", ""),
-            "schema_version": artifact.get("schema_version", ""),
-            "mode": artifact.get("mode", ""),
-            "scenario_family": artifact.get("scenario_family", ""),
-        }
         sidecar_paths = write_judgment_validity_sidecar(
             run_dir=output_path.parent,
             results=results,
-            pack_meta=pack_meta,
         )
         for kind, path in sorted(sidecar_paths.items()):
             print(f"{kind}: {path}", file=sys.stderr)
-    except Exception as exc:  # noqa: BLE001 -- sidecar failure must not break eval
+    except Exception as exc:  # noqa: BLE001 -- sidecar write failure must not break eval
         # Sidecar is informational only; graceful degradation is the correct
         # behavior (same pattern as RAG sidecar in run_rag_release_gates.py).
         print(f"warning: validity sidecar emission failed: {exc}", file=sys.stderr)

--- a/scripts/orchestration/judgment_eval.py
+++ b/scripts/orchestration/judgment_eval.py
@@ -126,11 +126,11 @@ def main(argv: list[str] | None = None) -> int:
             pack_meta=pack_meta,
         )
         for kind, path in sorted(sidecar_paths.items()):
-            print(f"validity_{kind}: {path}", file=sys.stderr)
+            print(f"{kind}: {path}", file=sys.stderr)
     except Exception:  # noqa: BLE001 -- sidecar failure must not break eval
         # Sidecar is informational only; graceful degradation is the correct
         # behavior (same pattern as RAG sidecar in run_rag_release_gates.py).
-        pass  # nosec B110 sidecar metrics are non-critical; silent degradation is intentional (remove-by: 2026-11-01, ref: PR-1648)
+        pass  # nosec B110: sidecar metrics are non-critical; silent degradation is intentional (remove-by: 2026-11-01, ref: PR-1656)
 
     print(output_path)
     return 0

--- a/scripts/orchestration/judgment_eval.py
+++ b/scripts/orchestration/judgment_eval.py
@@ -127,10 +127,10 @@ def main(argv: list[str] | None = None) -> int:
         )
         for kind, path in sorted(sidecar_paths.items()):
             print(f"{kind}: {path}", file=sys.stderr)
-    except Exception:  # noqa: BLE001 -- sidecar failure must not break eval
+    except Exception as exc:  # noqa: BLE001 -- sidecar failure must not break eval
         # Sidecar is informational only; graceful degradation is the correct
         # behavior (same pattern as RAG sidecar in run_rag_release_gates.py).
-        pass  # nosec B110: sidecar metrics are non-critical; silent degradation is intentional (remove-by: 2026-11-01, ref: PR-1656)
+        print(f"warning: validity sidecar emission failed: {exc}", file=sys.stderr)
 
     print(output_path)
     return 0

--- a/tests/evals/test_judgment_validity_sidecar.py
+++ b/tests/evals/test_judgment_validity_sidecar.py
@@ -313,6 +313,18 @@ class TestEdgeCases:
 
         assert "hard_fail" not in rec["slice_tags"]
 
+    def test_hard_fail_reasons_non_list_treated_as_empty(self) -> None:
+        """Non-list values (e.g. string) must not trigger hard_fail tag."""
+        result: dict[str, object] = {
+            "case_id": "str_hfr",
+            "decision": "promote",
+            "boundary_class": "wellness_coaching",
+            "hard_fail_reasons": "unexpected_string_value",
+        }
+        rec = result_to_eval_outcome(result)
+
+        assert "hard_fail" not in rec["slice_tags"]
+
 
 class TestValidationBoundary:
     """Verify that malformed inputs propagate validator errors correctly."""

--- a/tests/evals/test_judgment_validity_sidecar.py
+++ b/tests/evals/test_judgment_validity_sidecar.py
@@ -314,6 +314,45 @@ class TestEdgeCases:
         assert "hard_fail" not in rec["slice_tags"]
 
 
+class TestValidationBoundary:
+    """Verify that malformed inputs propagate validator errors correctly."""
+
+    def test_non_bool_passed_raises(self) -> None:
+        """If score mapping produced a non-bool passed, validator must reject."""
+        import scripts.evals.eval_validity_contract as evc
+
+        raw: dict[str, object] = {
+            "canonical_id": "bad",
+            "variant_id": "bad",
+            "variant_family": "canonical",
+            "transform_type": "none",
+            "passed": "yes",  # non-bool
+            "score": 1.0,
+            "decision": "promote",
+            "slice_tags": ["judgment"],
+        }
+        with pytest.raises(ValueError, match="passed"):
+            evc.validate_eval_outcome_record(raw)
+
+    def test_non_finite_score_raises(self) -> None:
+        import math
+
+        import scripts.evals.eval_validity_contract as evc
+
+        raw: dict[str, object] = {
+            "canonical_id": "bad",
+            "variant_id": "bad",
+            "variant_family": "canonical",
+            "transform_type": "none",
+            "passed": True,
+            "score": math.inf,
+            "decision": "promote",
+            "slice_tags": ["judgment"],
+        }
+        with pytest.raises(ValueError, match="score"):
+            evc.validate_eval_outcome_record(raw)
+
+
 class TestNoNetworkImports:
     """Guard: sidecar adapter must not import networking libraries."""
 

--- a/tests/evals/test_judgment_validity_sidecar.py
+++ b/tests/evals/test_judgment_validity_sidecar.py
@@ -276,14 +276,51 @@ class TestWriteJudgmentValiditySidecar:
 # ---------------------------------------------------------------------------
 
 
+class TestEdgeCases:
+    """Edge-case coverage for missing or unusual result keys."""
+
+    def test_missing_case_id_defaults_to_unknown(self) -> None:
+        result: dict[str, object] = {
+            "decision": "promote",
+            "boundary_class": "wellness_coaching",
+            "hard_fail_reasons": [],
+        }
+        rec = result_to_eval_outcome(result)
+
+        assert rec["canonical_id"] == "unknown"
+        assert rec["variant_id"] == "unknown"
+
+    def test_missing_decision_defaults_to_empty(self) -> None:
+        result: dict[str, object] = {
+            "case_id": "no_decision",
+            "boundary_class": "wellness_coaching",
+            "hard_fail_reasons": [],
+        }
+        rec = result_to_eval_outcome(result)
+
+        assert rec["decision"] == ""
+        assert rec["passed"] is False
+        assert rec["score"] == 0.0
+
+    def test_hard_fail_reasons_none_treated_as_empty(self) -> None:
+        result: dict[str, object] = {
+            "case_id": "null_hfr",
+            "decision": "promote",
+            "boundary_class": "wellness_coaching",
+            "hard_fail_reasons": None,
+        }
+        rec = result_to_eval_outcome(result)
+
+        assert "hard_fail" not in rec["slice_tags"]
+
+
 class TestNoNetworkImports:
     """Guard: sidecar adapter must not import networking libraries."""
 
     def test_no_network_imports_in_module_source(self) -> None:
-        source_path = (
-            Path(__file__).resolve().parents[2] / "scripts" / "evals" / "judgment_validity.py"
-        )
-        source = source_path.read_text(encoding="utf-8")
+        import scripts.evals.judgment_validity as jv_mod
+
+        source = Path(jv_mod.__file__).read_text(encoding="utf-8")
 
         for forbidden in ("import urllib", "import requests", "import httpx", "import aiohttp"):
             assert (

--- a/tests/evals/test_judgment_validity_sidecar.py
+++ b/tests/evals/test_judgment_validity_sidecar.py
@@ -1,0 +1,291 @@
+"""Tests for the judgment replay validity sidecar adapter.
+
+Verifies that FitChef judgment replay results are correctly mapped to
+validity-compatible EvalOutcomeRecord rows and that sidecar artifacts
+are written deterministically.
+
+Hard rules:
+- No network calls / no model calls.
+- Sidecar does not change promote/defer/discard decisions.
+- Sidecar is informational / measurement-validity layer only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.evals.judgment_validity import (
+    JUDGMENT_DECISION_SCORES,
+    JUDGMENT_VALIDITY_ITEMS_FILENAME,
+    JUDGMENT_VALIDITY_REPORT_FILENAME,
+    result_to_eval_outcome,
+    results_to_eval_outcomes,
+    write_judgment_validity_sidecar,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+_PROMOTE_RESULT: dict[str, object] = {
+    "case_id": "case_promote_001",
+    "decision": "promote",
+    "boundary_class": "wellness_coaching",
+    "hard_fail_reasons": [],
+    "scores": {"personalization_relevance": 4, "emotional_attunement": 4},
+}
+
+_DEFER_RESULT: dict[str, object] = {
+    "case_id": "case_defer_002",
+    "decision": "defer",
+    "boundary_class": "wellness_coaching",
+    "hard_fail_reasons": [],
+    "scores": {"personalization_relevance": 3, "emotional_attunement": 3},
+}
+
+_DISCARD_RESULT: dict[str, object] = {
+    "case_id": "case_discard_003",
+    "decision": "discard",
+    "boundary_class": "high_distress_boundary",
+    "hard_fail_reasons": ["forbidden_pattern:skip_the_next_meal"],
+    "scores": {"personalization_relevance": 1, "emotional_attunement": 1},
+}
+
+_ALL_RESULTS: list[dict[str, object]] = [
+    _PROMOTE_RESULT,
+    _DEFER_RESULT,
+    _DISCARD_RESULT,
+]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: result_to_eval_outcome mapping
+# ---------------------------------------------------------------------------
+
+
+class TestResultToEvalOutcome:
+    """Verify deterministic mapping from judgment decisions to EvalOutcomeRecord."""
+
+    def test_promote_result(self) -> None:
+        rec = result_to_eval_outcome(_PROMOTE_RESULT)
+
+        assert rec["canonical_id"] == "case_promote_001"
+        assert rec["variant_id"] == "case_promote_001"
+        assert rec["variant_family"] == "canonical"
+        assert rec["transform_type"] == "none"
+        assert rec["passed"] is True
+        assert rec["score"] == 1.0
+        assert rec["decision"] == "promote"
+
+    def test_defer_result(self) -> None:
+        rec = result_to_eval_outcome(_DEFER_RESULT)
+
+        assert rec["canonical_id"] == "case_defer_002"
+        assert rec["passed"] is True
+        assert rec["score"] == 0.5
+        assert rec["decision"] == "defer"
+
+    def test_discard_result(self) -> None:
+        rec = result_to_eval_outcome(_DISCARD_RESULT)
+
+        assert rec["canonical_id"] == "case_discard_003"
+        assert rec["passed"] is False
+        assert rec["score"] == 0.0
+        assert rec["decision"] == "discard"
+
+    def test_slice_tags_include_boundary_class(self) -> None:
+        rec = result_to_eval_outcome(_PROMOTE_RESULT)
+
+        assert "judgment" in rec["slice_tags"]
+        assert "wellness_coaching" in rec["slice_tags"]
+
+    def test_slice_tags_include_hard_fail_when_present(self) -> None:
+        rec = result_to_eval_outcome(_DISCARD_RESULT)
+
+        assert "hard_fail" in rec["slice_tags"]
+        assert "high_distress_boundary" in rec["slice_tags"]
+
+    def test_slice_tags_exclude_hard_fail_when_empty(self) -> None:
+        rec = result_to_eval_outcome(_PROMOTE_RESULT)
+
+        assert "hard_fail" not in rec["slice_tags"]
+
+    def test_decision_score_constants_cover_all_judgments(self) -> None:
+        """Verify the score mapping covers all canonical judgment decisions."""
+        assert set(JUDGMENT_DECISION_SCORES.keys()) == {"promote", "defer", "discard"}
+
+    def test_unknown_decision_defaults_to_zero_score(self) -> None:
+        """Unknown decisions default to score=0.0 and passed=False."""
+        result: dict[str, object] = {
+            "case_id": "unknown_decision",
+            "decision": "unknown_value",
+            "boundary_class": "wellness_coaching",
+            "hard_fail_reasons": [],
+        }
+        rec = result_to_eval_outcome(result)
+
+        assert rec["score"] == 0.0
+        assert rec["passed"] is False
+        assert rec["decision"] == "unknown_value"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: batch conversion
+# ---------------------------------------------------------------------------
+
+
+class TestResultsToEvalOutcomes:
+    """Verify batch conversion preserves order and count."""
+
+    def test_batch_preserves_insertion_order(self) -> None:
+        outcomes = results_to_eval_outcomes(_ALL_RESULTS)
+
+        assert len(outcomes) == 3
+        assert outcomes[0]["canonical_id"] == "case_promote_001"
+        assert outcomes[1]["canonical_id"] == "case_defer_002"
+        assert outcomes[2]["canonical_id"] == "case_discard_003"
+
+    def test_empty_results_returns_empty_list(self) -> None:
+        outcomes = results_to_eval_outcomes([])
+
+        assert outcomes == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: sidecar writing
+# ---------------------------------------------------------------------------
+
+
+class TestWriteJudgmentValiditySidecar:
+    """Verify sidecar file creation, content validity, and determinism."""
+
+    def test_creates_expected_files(self, tmp_path: Path) -> None:
+        paths = write_judgment_validity_sidecar(tmp_path, _ALL_RESULTS)
+
+        items_path = tmp_path / JUDGMENT_VALIDITY_ITEMS_FILENAME
+        report_path = tmp_path / JUDGMENT_VALIDITY_REPORT_FILENAME
+
+        assert items_path.exists()
+        assert report_path.exists()
+        assert paths["validity_items"] == str(items_path)
+        assert paths["validity_report"] == str(report_path)
+
+    def test_jsonl_lines_are_valid_records(self, tmp_path: Path) -> None:
+        write_judgment_validity_sidecar(tmp_path, _ALL_RESULTS)
+
+        items_path = tmp_path / JUDGMENT_VALIDITY_ITEMS_FILENAME
+        lines = items_path.read_text(encoding="utf-8").strip().split("\n")
+
+        assert len(lines) == 3
+        for line in lines:
+            rec = json.loads(line)
+            assert "canonical_id" in rec
+            assert "variant_id" in rec
+            assert "variant_family" in rec
+            assert "passed" in rec
+            assert "score" in rec
+            assert "decision" in rec
+            assert "slice_tags" in rec
+            assert isinstance(rec["passed"], bool)
+            assert isinstance(rec["score"], (int, float))
+
+    def test_report_has_expected_keys(self, tmp_path: Path) -> None:
+        write_judgment_validity_sidecar(tmp_path, _ALL_RESULTS)
+
+        report_path = tmp_path / JUDGMENT_VALIDITY_REPORT_FILENAME
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+
+        expected_keys = {
+            "schema_version",
+            "invariance_score",
+            "mutation_drop",
+            "worst_case_error_rate",
+            "item_instability_index",
+            "slice_support",
+            "unstable_items",
+            "slice_breakdown",
+        }
+        assert expected_keys.issubset(set(report.keys()))
+        assert report["schema_version"] == "1.0"
+
+    def test_report_canonical_only_metrics(self, tmp_path: Path) -> None:
+        """Canonical-only rows must not be misrepresented as invariance coverage."""
+        write_judgment_validity_sidecar(tmp_path, _ALL_RESULTS)
+
+        report_path = tmp_path / JUDGMENT_VALIDITY_REPORT_FILENAME
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+
+        # With only canonical rows, invariance_score is 0.0 and
+        # mutation_drop.overall is 0.0 -- honest about missing coverage.
+        assert report["invariance_score"] == 0.0
+        assert report["mutation_drop"]["overall"] == 0.0
+        assert report["item_instability_index"] == 0.0
+
+    def test_sidecar_determinism(self, tmp_path: Path) -> None:
+        """Two runs with the same input must produce byte-identical output."""
+        dir_a = tmp_path / "run_a"
+        dir_b = tmp_path / "run_b"
+
+        write_judgment_validity_sidecar(dir_a, _ALL_RESULTS)
+        write_judgment_validity_sidecar(dir_b, _ALL_RESULTS)
+
+        items_a = (dir_a / JUDGMENT_VALIDITY_ITEMS_FILENAME).read_bytes()
+        items_b = (dir_b / JUDGMENT_VALIDITY_ITEMS_FILENAME).read_bytes()
+        assert items_a == items_b
+
+        report_a = (dir_a / JUDGMENT_VALIDITY_REPORT_FILENAME).read_bytes()
+        report_b = (dir_b / JUDGMENT_VALIDITY_REPORT_FILENAME).read_bytes()
+        assert report_a == report_b
+
+    def test_empty_results_produces_clean_output(self, tmp_path: Path) -> None:
+        """Empty results list should produce empty JSONL and a report with zeros."""
+        write_judgment_validity_sidecar(tmp_path, [])
+
+        items_path = tmp_path / JUDGMENT_VALIDITY_ITEMS_FILENAME
+        report_path = tmp_path / JUDGMENT_VALIDITY_REPORT_FILENAME
+
+        assert items_path.read_text(encoding="utf-8") == ""
+
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        assert report["schema_version"] == "1.0"
+        assert report["worst_case_error_rate"] == 0.0
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        nested_dir = tmp_path / "deep" / "nested" / "dir"
+        paths = write_judgment_validity_sidecar(nested_dir, _ALL_RESULTS)
+
+        assert Path(paths["validity_items"]).exists()
+        assert Path(paths["validity_report"]).exists()
+
+    def test_slice_support_reflects_tags(self, tmp_path: Path) -> None:
+        write_judgment_validity_sidecar(tmp_path, _ALL_RESULTS)
+
+        report_path = tmp_path / JUDGMENT_VALIDITY_REPORT_FILENAME
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+
+        slice_support = report["slice_support"]
+        assert "judgment" in slice_support
+        assert slice_support["judgment"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Guard tests
+# ---------------------------------------------------------------------------
+
+
+class TestNoNetworkImports:
+    """Guard: sidecar adapter must not import networking libraries."""
+
+    def test_no_network_imports_in_module_source(self) -> None:
+        source_path = (
+            Path(__file__).resolve().parents[2] / "scripts" / "evals" / "judgment_validity.py"
+        )
+        source = source_path.read_text(encoding="utf-8")
+
+        for forbidden in ("import urllib", "import requests", "import httpx", "import aiohttp"):
+            assert (
+                forbidden not in source
+            ), f"Forbidden network import found in judgment_validity.py: {forbidden}"

--- a/tests/test_judgment_eval.py
+++ b/tests/test_judgment_eval.py
@@ -124,3 +124,71 @@ def test_main_returns_clean_error_on_write_failure(
     stderr = capsys.readouterr().err
     assert "disk full" in stderr
     assert "Traceback" not in stderr
+
+
+def test_main_emits_validity_sidecar_alongside_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CLI should emit validity sidecar files next to the main artifact."""
+
+    artifact_dir = tmp_path / "artifacts" / "orchestration" / "judgment" / "evals"
+    input_path = tmp_path / "bundle.json"
+    input_path.write_text(
+        json.dumps(_load_fixture("replay_cases.json"), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(judgment_eval, "RESULT_ARTIFACT_DIR", artifact_dir)
+
+    exit_code = judgment_eval.main(["--input", str(input_path)])
+
+    assert exit_code == 0
+    items_path = artifact_dir / "judgment_validity_items.jsonl"
+    report_path = artifact_dir / "judgment_validity_report.json"
+    assert items_path.exists(), "Sidecar JSONL not created"
+    assert report_path.exists(), "Sidecar report not created"
+
+    # Verify JSONL has at least one line per evaluated case.
+    lines = items_path.read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) >= 1
+
+    # Verify report is valid JSON with expected keys.
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["schema_version"] == "1.0"
+    assert "invariance_score" in report
+
+
+def test_main_succeeds_when_sidecar_import_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CLI must still succeed even if the validity sidecar adapter cannot be imported."""
+
+    artifact_dir = tmp_path / "artifacts" / "orchestration" / "judgment" / "evals"
+    input_path = tmp_path / "bundle.json"
+    input_path.write_text(
+        json.dumps(_load_fixture("replay_cases.json"), ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(judgment_eval, "RESULT_ARTIFACT_DIR", artifact_dir)
+
+    # Poison the import so the sidecar try/except catches it.
+    import scripts.evals.judgment_validity as jv_mod
+
+    original_fn = jv_mod.write_judgment_validity_sidecar
+
+    def _explode(*_a: object, **_kw: object) -> None:
+        raise RuntimeError("sidecar boom")
+
+    monkeypatch.setattr(jv_mod, "write_judgment_validity_sidecar", _explode)
+
+    exit_code = judgment_eval.main(["--input", str(input_path)])
+
+    assert exit_code == 0
+    output_path = Path(capsys.readouterr().out.strip())
+    assert output_path.exists(), "Main artifact must exist despite sidecar failure"
+
+    # Restore for other tests.
+    monkeypatch.setattr(jv_mod, "write_judgment_validity_sidecar", original_fn)

--- a/tests/test_judgment_eval.py
+++ b/tests/test_judgment_eval.py
@@ -149,8 +149,8 @@ def test_main_emits_validity_sidecar_alongside_artifact(
     assert items_path.exists(), "Sidecar JSONL not created"
     assert report_path.exists(), "Sidecar report not created"
 
-    # Verify JSONL has at least one line per evaluated case.
-    lines = items_path.read_text(encoding="utf-8").strip().split("\n")
+    # Verify JSONL has at least one non-empty line per evaluated case.
+    lines = [ln for ln in items_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
     assert len(lines) >= 1
 
     # Verify report is valid JSON with expected keys.
@@ -184,5 +184,8 @@ def test_main_succeeds_when_sidecar_raises(
     exit_code = judgment_eval.main(["--input", str(input_path)])
 
     assert exit_code == 0
-    output_path = Path(capsys.readouterr().out.strip())
+    captured = capsys.readouterr()
+    output_path = Path(captured.out.strip())
     assert output_path.exists(), "Main artifact must exist despite sidecar failure"
+    assert "warning: validity sidecar emission failed" in captured.err
+    assert "sidecar boom" in captured.err

--- a/tests/test_judgment_eval.py
+++ b/tests/test_judgment_eval.py
@@ -174,12 +174,10 @@ def test_main_succeeds_when_sidecar_raises(
     )
     monkeypatch.setattr(judgment_eval, "RESULT_ARTIFACT_DIR", artifact_dir)
 
-    import scripts.evals.judgment_validity as jv_mod
-
     def _explode(*_a: object, **_kw: object) -> None:
         raise RuntimeError("sidecar boom")
 
-    monkeypatch.setattr(jv_mod, "write_judgment_validity_sidecar", _explode)
+    monkeypatch.setattr(judgment_eval, "write_judgment_validity_sidecar", _explode)
 
     exit_code = judgment_eval.main(["--input", str(input_path)])
 

--- a/tests/test_judgment_eval.py
+++ b/tests/test_judgment_eval.py
@@ -159,12 +159,12 @@ def test_main_emits_validity_sidecar_alongside_artifact(
     assert "invariance_score" in report
 
 
-def test_main_succeeds_when_sidecar_import_fails(
+def test_main_succeeds_when_sidecar_raises(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """CLI must still succeed even if the validity sidecar adapter cannot be imported."""
+    """CLI must still succeed even if the validity sidecar adapter raises at runtime."""
 
     artifact_dir = tmp_path / "artifacts" / "orchestration" / "judgment" / "evals"
     input_path = tmp_path / "bundle.json"
@@ -174,10 +174,7 @@ def test_main_succeeds_when_sidecar_import_fails(
     )
     monkeypatch.setattr(judgment_eval, "RESULT_ARTIFACT_DIR", artifact_dir)
 
-    # Poison the import so the sidecar try/except catches it.
     import scripts.evals.judgment_validity as jv_mod
-
-    original_fn = jv_mod.write_judgment_validity_sidecar
 
     def _explode(*_a: object, **_kw: object) -> None:
         raise RuntimeError("sidecar boom")
@@ -189,6 +186,3 @@ def test_main_succeeds_when_sidecar_import_fails(
     assert exit_code == 0
     output_path = Path(capsys.readouterr().out.strip())
     assert output_path.exists(), "Main artifact must exist despite sidecar failure"
-
-    # Restore for other tests.
-    monkeypatch.setattr(jv_mod, "write_judgment_validity_sidecar", original_fn)

--- a/tests/test_judgment_eval.py
+++ b/tests/test_judgment_eval.py
@@ -174,10 +174,12 @@ def test_main_succeeds_when_sidecar_raises(
     )
     monkeypatch.setattr(judgment_eval, "RESULT_ARTIFACT_DIR", artifact_dir)
 
+    import scripts.evals.judgment_validity as jv_mod
+
     def _explode(*_a: object, **_kw: object) -> None:
         raise RuntimeError("sidecar boom")
 
-    monkeypatch.setattr(judgment_eval, "write_judgment_validity_sidecar", _explode)
+    monkeypatch.setattr(jv_mod, "write_judgment_validity_sidecar", _explode)
 
     exit_code = judgment_eval.main(["--input", str(input_path)])
 


### PR DESCRIPTION
## Summary

Adds optional validity sidecar artifacts to the existing judgment replay/eval lane.

This PR connects the evaluation-validity substrate from PR #1632 to judgment adjudication by emitting item-level validity-compatible outcomes and a validity report sidecar.

The existing claim taxonomy, claim-to-evidence semantics, uncertainty split, and promote/defer/discard decisions remain canonical and unchanged.

## Scope

- Add judgment validity sidecar adapter (`scripts/evals/judgment_validity.py`)
- Wire sidecar emission into CLI runner (`scripts/orchestration/judgment_eval.py`)
- Emit validity-compatible item-level JSONL sidecar
- Emit validity report JSON sidecar
- Preserve existing judgment taxonomy and promote/defer/discard logic
- Add 26 deterministic tests
- Update docs/evals, judgment protocol note, and backlog

## Non-goals

- No Claude / Opus runtime integration
- No production API / frontend / iOS / billing / OpenAPI / App Store changes
- No judgment taxonomy or promote/defer/discard logic changes
- No semantic cache, RAG rewrite, psychometrics, IRT, or LLM-generated fixtures

## Validation

- [x] `python3 scripts/orchestration/check_preflight.py`
- [x] `python3 scripts/orchestration/check_agent_consistency.py`
- [x] `pytest -q tests/evals/` (all pass)
- [x] `pytest -q tests/test_judgment_eval.py` (all pass)
- [x] `pre-commit run --all-files` (all hooks pass)
- [x] Pre-push hooks: mypy, pip-audit, bandit full, docker build, backend tests

## Deferred / Follow-ups

- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-judgment-validity-sidecar`

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_1656_FIXED_MAPPING.md`

Inline thread dispositions:
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#discussion_r3179676207 -> 19e20cb83
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#discussion_r3179687480 -> 19e20cb83
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#discussion_r3179687490 -> 19e20cb83
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#discussion_r3180620838 -> e29632d42

Review-level dispositions:
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#pullrequestreview-4217785400 (NOT-A-BUG: summary review, actionables mapped as inline threads)
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#pullrequestreview-4217801842 (NOT-A-BUG: follow-up confirming fixes)
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1656#pullrequestreview-4218901013 -> e29632d42

## Merge Readiness

- [x] Required CI green on current head
- [x] `make verify` passed locally or raw failure output documented
- [x] Review mapping artifact created
- [x] CodeRabbit / Sourcery / Cubic have no actionables
- [x] Mandatory wait-window elapsed
- [x] Final strict merge-readiness check passed