### PR TITLE
docs(roadmap): close ledger-p1-eval-item-metadata-registry after PR #1660 merge

### DIFF
--- a/docs/review/PR_1661_FIXED_MAPPING.md
+++ b/docs/review/PR_1661_FIXED_MAPPING.md
@@ -17,14 +17,14 @@ Disposition: NOT-A-BUG
 Evidence: docs/roadmap/BACKLOG_LEDGER.md:10730-10734
 Reason: Sourcery suggested date format normalization. The ledger uses mixed formats by convention across 10k+ lines; normalizing one entry would be inconsistent. No action needed.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1661#pullrequestreview-4221698549 -> PENDING_SHA
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1661#pullrequestreview-4221698549 -> 376a70686
 Disposition: FIXED
-Commit: PENDING_SHA
+Commit: 376a70686
 Evidence: docs/review/PR_1661_FIXED_MAPPING.md — evidence section updated to list both changed files
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1661#discussion_r3182954354 -> PENDING_SHA
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1661#discussion_r3182954354 -> 376a70686
 Disposition: FIXED
-Commit: PENDING_SHA
+Commit: 376a70686
 Evidence: docs/review/PR_1661_FIXED_MAPPING.md:19 — corrected to "only `.md` files changed"
 
 ## Merge Readiness Evidence

--- a/docs/review/PR_1661_FIXED_MAPPING.md
+++ b/docs/review/PR_1661_FIXED_MAPPING.md
@@ -12,7 +12,7 @@ after PR #1660 merge (`b4335d405`, 2026-05-04).
 
 ## Fixed in Commit Mapping
 
-No actionable review comments (docs-only ledger closure).
+- No actionable review comments
 
 ## Merge Readiness Evidence
 

--- a/docs/review/PR_1661_FIXED_MAPPING.md
+++ b/docs/review/PR_1661_FIXED_MAPPING.md
@@ -12,10 +12,23 @@ after PR #1660 merge (`b4335d405`, 2026-05-04).
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1661#pullrequestreview-4221683829
+Disposition: NOT-A-BUG
+Evidence: docs/roadmap/BACKLOG_LEDGER.md:10730-10734
+Reason: Sourcery suggested date format normalization. The ledger uses mixed formats by convention across 10k+ lines; normalizing one entry would be inconsistent. No action needed.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1661#pullrequestreview-4221698549 -> PENDING_SHA
+Disposition: FIXED
+Commit: PENDING_SHA
+Evidence: docs/review/PR_1661_FIXED_MAPPING.md — evidence section updated to list both changed files
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1661#discussion_r3182954354 -> PENDING_SHA
+Disposition: FIXED
+Commit: PENDING_SHA
+Evidence: docs/review/PR_1661_FIXED_MAPPING.md:19 — corrected to "only `.md` files changed"
 
 ## Merge Readiness Evidence
 
-- Docs-only PR: only `docs/roadmap/BACKLOG_LEDGER.md` changed
+- Docs-only PR: only `.md` files changed (`docs/roadmap/BACKLOG_LEDGER.md` + `docs/review/PR_1661_FIXED_MAPPING.md`)
 - `pre-commit run --all-files`: PASS
 - Docs-only enforcement: `git diff --name-only origin/main...HEAD` shows only `.md` files

--- a/docs/review/PR_1661_FIXED_MAPPING.md
+++ b/docs/review/PR_1661_FIXED_MAPPING.md
@@ -1,0 +1,21 @@
+# PR 1661 Fixed Mapping
+
+## Summary
+
+Docs-only PR closing backlog ledger item `ledger-p1-eval-item-metadata-registry`
+after PR #1660 merge (`b4335d405`, 2026-05-04).
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+No actionable review comments (docs-only ledger closure).
+
+## Merge Readiness Evidence
+
+- Docs-only PR: only `docs/roadmap/BACKLOG_LEDGER.md` changed
+- `pre-commit run --all-files`: PASS
+- Docs-only enforcement: `git diff --name-only origin/main...HEAD` shows only `.md` files

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -10727,11 +10727,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - No runtime/API/frontend/iOS/billing/OpenAPI/App Store changes
 
 <a id="ledger-p1-eval-item-metadata-registry"></a>
-- [ ] P1: Evaluation item metadata registry for psychometric readiness
+- [x] P1: Evaluation item metadata registry for psychometric readiness
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR #1660 (`evals/item-metadata-registry`)
-  - Status: Opened on 4 May 2026
+  - Target PR: PR #1660 (merged `b4335d405`, 2026-05-04)
+  - Status: **CLOSED** — merged 4 May 2026
   - Area: evals / measurement science / psychometric readiness
   - Finding Type: item-metadata gap
   - Reason: The Evaluation Science foundation now has item-level outcomes, RAG/judgment sidecars, invariance/mutation fixtures, and canonical-fail negative controls, but still lacks a registry that maps canonical_id values to stable item metadata such as lane, domain, skill dimension, difficulty band, expected decision, expected score band, fixture coverage, and anchor-item status. This registry is required before honest IRT, item weighting, adaptive evals, or psychometric modeling.
@@ -10751,6 +10751,6 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - No IRT or psychometric scoring is implemented
     - No runtime/API/frontend/iOS/billing/OpenAPI/App Store/Claude/Opus/MCP changes are included
 
-**Last updated:** 2026-05-04 (evaluation item metadata registry PR)
+**Last updated:** 2026-05-04 (evaluation item metadata registry merged, ledger closed)
 **Maintainer:** @katsiaryna_kavaleuskaya
 <!-- markdownlint-enable MD013 -->


### PR DESCRIPTION
## Summary

Closes backlog ledger item `ledger-p1-eval-item-metadata-registry` after
PR #1660 was merged (`b4335d405`, 2026-05-04).

This is a **docs-only PR** — only `docs/roadmap/BACKLOG_LEDGER.md` and
`docs/review/PR_1661_FIXED_MAPPING.md` are changed.

## Changes

- `docs/roadmap/BACKLOG_LEDGER.md`: checkbox checked, status set to CLOSED,
  Target PR updated with merge commit SHA and date.
- `docs/review/PR_1661_FIXED_MAPPING.md`: canonical review mapping artifact.

## Deferred / Follow-ups

None. This PR closes an existing ledger item; no new deferred work.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: docs/review/PR_1661_FIXED_MAPPING.md
- No actionable review comments (docs-only ledger closure)

## Merge Readiness

- [x] Docs-only PR (no runtime/CI/code changes)
- [x] `pre-commit run --all-files` passes
- [x] Only `.md` files in diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Marked the evaluation-item metadata registry as completed and closed in the project roadmap ledger; updated the ledger's last-updated timestamp to reflect closure.
  * Added a review note confirming the mapping fix, completion of checklist and discussion-thread checks, and merge-readiness evidence showing only documentation changed and that pre-commit checks passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->