### PR TITLE
feat(evals): add evaluation item statistics baseline

### DIFF
--- a/docs/evals/PULSEPLATE_EVAL_VALIDITY_CONTRACT.md
+++ b/docs/evals/PULSEPLATE_EVAL_VALIDITY_CONTRACT.md
@@ -213,7 +213,9 @@ split, or canonical promote/defer/discard decisions.
     deterministic curated variant fixtures for robustness measurement.
 5. **PR-4b (current)**: RAG release-gate invariance and mutation fixture families --
     deterministic curated variant fixtures for RAG validity robustness measurement.
-6. **PR-5+ (deferred)**: Psychometrics / IRT, adaptive evals, hybrid
+6. **PR-6 (current)**: Item statistics baseline -- descriptive per-item
+    statistics combining registry metadata with fixture outcomes.
+7. **PR-7+ (deferred)**: Psychometrics / IRT, adaptive evals, hybrid
     adjudication, tool-use reliability.
 
 ### RAG Release-Gate Invariance and Mutation Fixtures (PR-4b)
@@ -300,6 +302,68 @@ Each registry row is an `EvalItemMetadataRecord` with these fields:
 - Item weighting based on registry metadata.
 - Adaptive item selection using registry anchors.
 
+## Evaluation Item Statistics Baseline
+
+The item statistics baseline (`scripts/evals/eval_item_statistics.py`) is a
+**descriptive measurement layer** over curated fixture outcomes and item metadata
+registry rows.  It is not IRT, not psychometric calibration, not an adaptive
+item selector, and not a release-gate decision source.
+
+### Script paths
+
+- Core module: `scripts/evals/eval_item_statistics.py`
+- CLI runner: `scripts/evals/run_eval_item_statistics.py`
+- Tests: `tests/evals/test_eval_item_statistics.py`
+- Output artifact: `artifacts/evals/item_statistics_report.json` (gitignored)
+
+### Per-item fields
+
+Each `EvalItemStatisticsRecord` contains:
+
+- `canonical_id`, `lane`, `domain`, `skill_dimension` -- from registry.
+- `difficulty_band`, `expected_decision`, `expected_score_band` -- from registry.
+- `variant_count` -- total outcome rows for this canonical item.
+- `canonical_score`, `canonical_passed` -- from the canonical-family outcome row.
+- `invariance_count`, `invariance_agreement_count`, `invariance_agreement_rate`
+  -- invariance stability measurement.
+- `mutation_count`, `mutation_mean_drop` -- mutation sensitivity measurement.
+- `worst_variant_score` -- minimum score across all variants.
+- `pass_rate` -- fraction of passed=True across all variants.
+- `decision_set` -- sorted unique decisions across all variants.
+- `instability_flag` -- True if more than one unique decision exists.
+- `anchor_item` -- from registry metadata.
+
+### Report envelope
+
+```json
+{
+  "schema_version": "1.0",
+  "item_count": 10,
+  "lane_counts": {"judgment": 5, "rag": 5},
+  "anchor_item_count": 2,
+  "unstable_item_count": 6,
+  "items": [...]
+}
+```
+
+### Limitations
+
+- All statistics are descriptive proportions computed from curated fixtures.
+  They are not calibrated psychometric parameters.
+- Difficulty bands are heuristic labels, not IRT difficulty estimates.
+- `invariance_agreement_rate` and `pass_rate` are simple proportions, not
+  reliability coefficients.
+- The statistics layer does not override EvalOutcomeRecord data, validity
+  metrics, RAG release-gate PASS/NO-GO decisions, or judgment
+  promote/defer/discard decisions.
+
+### Future follow-up
+
+- IRT / item information modeling requires empirical run history across
+  multiple evaluation sessions, not only curated fixtures.
+- Item weighting based on combined registry metadata and item statistics.
+- Adaptive item selection using anchor items and instability flags.
+
 ## Deferred Follow-ups
 
 - Hybrid adjudication framework.
@@ -320,4 +384,6 @@ Each registry row is an `EvalItemMetadataRecord` with these fields:
 4. TypedDict chosen over dataclass for record schemas (repo convention).
 5. Tests placed in `tests/evals/` following existing eval-test convention.
 6. Opus/Claude used only as operator coding model, never integrated into
-   runtime or orchestration identity.
+    runtime or orchestration identity.
+7. Item statistics baseline is a descriptive layer, not psychometric
+    calibration.  Future IRT requires empirical run data.

--- a/docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md
+++ b/docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md
@@ -472,6 +472,16 @@ threshold_results, gate thresholds, or the PASS/NO-GO decision.
 
 See: `scripts/evals/eval_item_registry.py`
 
+### Item Statistics Baseline
+
+The evaluation item statistics baseline (`scripts/evals/eval_item_statistics.py`)
+computes descriptive per-item statistics by combining registry metadata with
+fixture outcomes.  Item statistics are an **informational sidecar only**.  They
+do not modify `threshold_results`, gate thresholds, or the PASS/NO-GO decision.
+
+See: `docs/evals/PULSEPLATE_EVAL_VALIDITY_CONTRACT.md` (section "Evaluation
+Item Statistics Baseline")
+
 ### Future follow-ups
 
 - Add per-gate slice breakdown to validity report.

--- a/docs/orchestration/JUDGMENT_ADJUDICATION_SUBLANE_PROTOCOL.md
+++ b/docs/orchestration/JUDGMENT_ADJUDICATION_SUBLANE_PROTOCOL.md
@@ -208,3 +208,9 @@ registry (`data/evals/eval_item_metadata_registry.jsonl`).  The registry
 records lane, domain, skill dimension, difficulty band, expected decision,
 and variant family coverage for each judgment canonical item.  It does not
 change decision logic, claim taxonomy, or the sub-lane protocol.
+
+The evaluation item statistics baseline (`scripts/evals/eval_item_statistics.py`)
+computes descriptive per-item statistics by combining registry metadata with
+fixture outcomes.  Item statistics do not alter promote/defer/discard decisions,
+claim taxonomy, or the judgment adjudication sub-lane protocol.  The judgment
+taxonomy remains canonical and is not overridden by descriptive statistics.

--- a/docs/review/PR_1662_FIXED_MAPPING.md
+++ b/docs/review/PR_1662_FIXED_MAPPING.md
@@ -9,36 +9,35 @@
 
 ## Fixed in Commit Mapping
 
-### CodeRabbit Review (Round 1) — Commits 134b4651e to 698fb2041
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1662#discussion_r3183911263 -> 698fb2041
-  - Disposition: FIXED
-  - Evidence: `scripts/evals/eval_item_statistics.py:119-126` — canonical row cardinality validated (exactly 1 required, ValueError on 0 or >1)
-  - Test: `test_multiple_canonical_rows_raises`, `test_missing_canonical_row_raises`
+Disposition: FIXED
+Commit: 698fb2041
+Evidence: scripts/evals/eval_item_statistics.py:119-126 — exactly 1 canonical row required, ValueError on 0 or >1
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1662#discussion_r3183911268 -> 698fb2041
-  - Disposition: FIXED
-  - Evidence: `tests/evals/test_eval_item_statistics.py:464-467` — `assert result.returncode == 0` + `assert output_file.exists()` added to first CLI test
-
-### CodeRabbit Review (Round 2) — Commit 6d59716db
+Disposition: FIXED
+Commit: 698fb2041
+Evidence: tests/evals/test_eval_item_statistics.py:464-467 — assert result.returncode == 0 added to first CLI test
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1662#discussion_r3184060104 -> 6d59716db
-  - Disposition: FIXED
-  - Evidence: `tests/evals/test_eval_item_statistics.py:21` — `from typing import Any, cast`; line 539 — `return cast(EvalOutcomeRecord, base)` replaces bare `# type: ignore[return-value]`
+Disposition: FIXED
+Commit: 6d59716db
+Evidence: tests/evals/test_eval_item_statistics.py:21 — cast import; line 539 — return cast(EvalOutcomeRecord, base)
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1662#discussion_r3184060111 -> 6d59716db
-  - Disposition: FIXED
-  - Evidence: `tests/evals/test_eval_item_statistics.py:48-52` — `_GUARDED_MODULES` now filters by `.exists()` per repo policy (`tests/AGENTS.md`)
+Disposition: FIXED
+Commit: 6d59716db
+Evidence: tests/evals/test_eval_item_statistics.py:48-52 — _GUARDED_MODULES filters by .exists() per repo policy
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1662#discussion_r3184060114 -> 6d59716db
-  - Disposition: FIXED
-  - Evidence: `tests/evals/test_eval_item_statistics.py:507-517` — recursive `_collect_all_keys()` traverses nested dicts/lists for timestamp key detection
-
-### CodeRabbit Review — NOT-A-BUG
+Disposition: FIXED
+Commit: 6d59716db
+Evidence: tests/evals/test_eval_item_statistics.py:507-517 — _collect_all_keys() recursive traversal
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1662#discussion_r3183911259
-  - Disposition: NOT-A-BUG
-  - Evidence: `docs/roadmap/BACKLOG_LEDGER.md:10758` — entry already reads `Target PR: PR #1662 (\`evals/item-statistics-baseline\`)`. CodeRabbit comment was against an earlier push. Checkbox `- [ ]` is intentionally unchecked (will be checked in post-merge docs-only PR).
+Disposition: NOT-A-BUG
+Evidence: docs/roadmap/BACKLOG_LEDGER.md:10758 — entry already reads Target PR: PR #1662
+Reason: CodeRabbit comment was against earlier push; ledger was updated before the comment was filed
 
 ## Merge Readiness
 

--- a/docs/review/PR_1662_FIXED_MAPPING.md
+++ b/docs/review/PR_1662_FIXED_MAPPING.md
@@ -9,11 +9,40 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+### CodeRabbit Review (Round 1) — Commits 134b4651e to 698fb2041
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1662#discussion_r3183911263 -> 698fb2041
+  - Disposition: FIXED
+  - Evidence: `scripts/evals/eval_item_statistics.py:119-126` — canonical row cardinality validated (exactly 1 required, ValueError on 0 or >1)
+  - Test: `test_multiple_canonical_rows_raises`, `test_missing_canonical_row_raises`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1662#discussion_r3183911268 -> 698fb2041
+  - Disposition: FIXED
+  - Evidence: `tests/evals/test_eval_item_statistics.py:464-467` — `assert result.returncode == 0` + `assert output_file.exists()` added to first CLI test
+
+### CodeRabbit Review (Round 2) — Commit 6d59716db
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1662#discussion_r3184060104 -> 6d59716db
+  - Disposition: FIXED
+  - Evidence: `tests/evals/test_eval_item_statistics.py:21` — `from typing import Any, cast`; line 539 — `return cast(EvalOutcomeRecord, base)` replaces bare `# type: ignore[return-value]`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1662#discussion_r3184060111 -> 6d59716db
+  - Disposition: FIXED
+  - Evidence: `tests/evals/test_eval_item_statistics.py:48-52` — `_GUARDED_MODULES` now filters by `.exists()` per repo policy (`tests/AGENTS.md`)
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1662#discussion_r3184060114 -> 6d59716db
+  - Disposition: FIXED
+  - Evidence: `tests/evals/test_eval_item_statistics.py:507-517` — recursive `_collect_all_keys()` traverses nested dicts/lists for timestamp key detection
+
+### CodeRabbit Review — NOT-A-BUG
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1662#discussion_r3183911259
+  - Disposition: NOT-A-BUG
+  - Evidence: `docs/roadmap/BACKLOG_LEDGER.md:10758` — entry already reads `Target PR: PR #1662 (\`evals/item-statistics-baseline\`)`. CodeRabbit comment was against an earlier push. Checkbox `- [ ]` is intentionally unchecked (will be checked in post-merge docs-only PR).
 
 ## Merge Readiness
 
-- [ ] CI green
+- [ ] CI green (current-head)
 - [ ] No unresolved review threads
 - [ ] CodeRabbit / Sourcery / Cubic: no actionables
 - [ ] Canonical artifact current

--- a/docs/review/PR_1662_FIXED_MAPPING.md
+++ b/docs/review/PR_1662_FIXED_MAPPING.md
@@ -39,6 +39,16 @@ Disposition: NOT-A-BUG
 Evidence: docs/roadmap/BACKLOG_LEDGER.md:10758 — entry already reads Target PR: PR #1662
 Reason: CodeRabbit comment was against earlier push; ledger was updated before the comment was filed
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1662#pullrequestreview-4222799521
+Disposition: FIXED
+Evidence: All individual threads from this review are mapped above (r3183911259, r3183911263, r3183911268)
+Commit: 698fb2041
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1662#pullrequestreview-4222972363
+Disposition: FIXED
+Evidence: All individual threads from this review are mapped above (r3184060104, r3184060111, r3184060114)
+Commit: 6d59716db
+
 ## Merge Readiness
 
 - [ ] CI green (current-head)

--- a/docs/review/PR_1662_FIXED_MAPPING.md
+++ b/docs/review/PR_1662_FIXED_MAPPING.md
@@ -1,0 +1,22 @@
+# PR #1662 — Fixed in Commit Mapping
+
+<!-- markdownlint-disable MD013 -->
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+No actionable review comments at time of PR opening.
+
+This artifact will be updated as review threads are created and resolved.
+
+## Merge Readiness
+
+- [ ] CI green
+- [ ] No unresolved review threads
+- [ ] CodeRabbit / Sourcery / Cubic: no actionables
+- [ ] Canonical artifact current
+- [ ] Wait-window elapsed after latest activity

--- a/docs/review/PR_1662_FIXED_MAPPING.md
+++ b/docs/review/PR_1662_FIXED_MAPPING.md
@@ -9,9 +9,7 @@
 
 ## Fixed in Commit Mapping
 
-No actionable review comments at time of PR opening.
-
-This artifact will be updated as review threads are created and resolved.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1662_PREMORTEM.md
+++ b/docs/review/PR_1662_PREMORTEM.md
@@ -54,9 +54,33 @@ It is 6 months from now. The item statistics PR merged and created false confide
 
 **Mitigation:** Required wording includes "not IRT, not psychometric calibration, not an adaptive item selector, and not a release-gate decision source." Limitations section explicitly states stats are simple proportions.
 
+### 8. (Round 2) FileNotFoundError on Module Rename (FM-B)
+
+**Story:** `_GUARDED_MODULES` was a hard-coded list of two Path objects. If either file was renamed, parametrized AST tests crashed with `FileNotFoundError` instead of a policy-style skip.
+
+**Mitigation:** Added `.exists()` filter per repo policy (`tests/AGENTS.md`). Commit: 6d59716db.
+
+### 9. (Round 2) Bare `# type: ignore` Without Justification (FM-C)
+
+**Story:** `_make_outcome()` returned `dict[str, Any]` as `EvalOutcomeRecord` with bare `# type: ignore[return-value]`. Repo policy forbids this without justification.
+
+**Mitigation:** Replaced with `cast(EvalOutcomeRecord, base)`. Commit: 6d59716db.
+
+### 10. (Round 2) Shallow Timestamp Key Check (FM-D)
+
+**Story:** `test_item_statistics_cli_output_has_no_timestamp` only checked top-level `report.keys()`. Nested `generated_at` or `timestamp` keys would pass undetected.
+
+**Mitigation:** Recursive `_collect_all_keys()` helper now traverses all nested dicts and lists. Commit: 6d59716db.
+
+### 11. (Round 2) Missing CLI returncode Assert (FM-E)
+
+**Story:** Second CLI test (`TestCliOutputHasNoTimestamp`) didn't check `returncode == 0`. Silent CLI failure would produce misleading test results.
+
+**Mitigation:** Added `assert result.returncode == 0` and `assert output_file.exists()`. Commit: 6d59716db.
+
 ## Decision
 
-**proceed** — plan is sound as designed. All 7 failure modes have concrete mitigations implemented in code and tests.
+**proceed** — plan is sound as designed. All 11 failure modes (7 original + 4 from round 2) have concrete mitigations implemented in code and tests.
 
 ## Most Likely Failure
 

--- a/docs/review/PR_1662_PREMORTEM.md
+++ b/docs/review/PR_1662_PREMORTEM.md
@@ -1,0 +1,71 @@
+# PR #1662 — Premortem Risk Review
+
+<!-- markdownlint-disable MD013 -->
+
+## Frame
+
+It is 6 months from now. The item statistics PR merged and created false confidence that PulsePlate has psychometric calibration.
+
+## Failure Modes
+
+### 1. Fake IRT Claims
+
+**Story:** A contributor sees `difficulty_band`, `anchor_item`, `invariance_agreement_rate` and assumes these are calibrated psychometric parameters. They build an "adaptive eval" on top of these descriptive stats, claiming IRT-level item discrimination without empirical calibration.
+
+**Underlying assumption:** Field names look psychometric, so they must be psychometric.
+
+**Warning signs:** Someone refers to `difficulty_band` as "item difficulty parameter" or cites `invariance_agreement_rate` as a "reliability coefficient" in a PR.
+
+**Mitigation:** Explicit doc wording ("heuristic label, not calibrated IRT estimate"); AST guard test rejects IRT vocabulary in source code.
+
+### 2. Descriptive Stats Misread as Calibrated
+
+**Story:** `pass_rate` and `invariance_agreement_rate` are presented in a product context as "psychometric quality measures" when they are simple proportions from 10 curated fixture items.
+
+**Mitigation:** Report `schema_version` and doc section explicitly state "descriptive measurement layer, not psychometric calibration."
+
+### 3. Registry/Fixture Drift
+
+**Story:** New fixture items are added in a future PR without updating the registry, causing the statistics builder to raise `ValueError` on coverage mismatch.
+
+**Mitigation:** Bidirectional coverage test (`test_item_statistics_covers_all_registry_items` + `test_item_statistics_has_no_orphan_items`).
+
+### 4. Stats Overriding PASS/NO-GO
+
+**Story:** Someone imports `build_item_statistics` from the RAG gate runner and uses instability flags to override the PASS/NO-GO decision.
+
+**Mitigation:** AST guard tests (tests 12 + 13) verify no imports of gate/judgment decision modules. Stats module does not export any decision function.
+
+### 5. Non-Deterministic Output
+
+**Story:** Floating point ordering or dict ordering causes different report JSON across Python versions or platforms.
+
+**Mitigation:** Determinism test runs computation twice and compares JSON byte-for-byte. Sorting by `(lane, canonical_id)`. Sorted keys in `json.dump`.
+
+### 6. Provider/Network Contamination
+
+**Story:** Accidental import of httpx/requests in the statistics module leaks network capabilities into an offline-only tool.
+
+**Mitigation:** AST scan test (test 1) rejects network library imports at source level.
+
+### 7. Docs Overclaiming Production Robustness
+
+**Story:** Docs say "item statistics prove psychometric readiness" when they only prove curated fixture coverage for 10 items.
+
+**Mitigation:** Required wording includes "not IRT, not psychometric calibration, not an adaptive item selector, and not a release-gate decision source." Limitations section explicitly states stats are simple proportions.
+
+## Decision
+
+**proceed** — plan is sound as designed. All 7 failure modes have concrete mitigations implemented in code and tests.
+
+## Most Likely Failure
+
+Registry/fixture drift (FM-3) — most likely because future PRs add items to fixtures without updating the registry. Bidirectional coverage tests catch this at test time.
+
+## Hidden Assumption
+
+The 10-item fixture set is representative enough to make descriptive statistics meaningful. In reality, 10 items per lane is a minimal foundation; the statistics become more informative with larger, more diverse item pools.
+
+## Single Most Important Revision
+
+None required — the current implementation has sufficient guardrails. The most impactful future improvement would be expanding the fixture set beyond 10 items to make the statistics more representative before building IRT on top.

--- a/docs/review/PR_1662_PREMORTEM.md
+++ b/docs/review/PR_1662_PREMORTEM.md
@@ -16,7 +16,7 @@ It is 6 months from now. The item statistics PR merged and created false confide
 
 **Warning signs:** Someone refers to `difficulty_band` as "item difficulty parameter" or cites `invariance_agreement_rate` as a "reliability coefficient" in a PR.
 
-**Mitigation:** Explicit doc wording ("heuristic label, not calibrated IRT estimate"); AST guard test rejects IRT vocabulary in source code.
+**Mitigation:** Explicit doc wording ("heuristic label, not calibrated IRT estimate"); AST guard test rejects IRT vocabulary in both source files (stats module + CLI runner); report output guard test rejects IRT-claiming field names in output schema.
 
 ### 2. Descriptive Stats Misread as Calibrated
 
@@ -34,7 +34,7 @@ It is 6 months from now. The item statistics PR merged and created false confide
 
 **Story:** Someone imports `build_item_statistics` from the RAG gate runner and uses instability flags to override the PASS/NO-GO decision.
 
-**Mitigation:** AST guard tests (tests 12 + 13) verify no imports of gate/judgment decision modules. Stats module does not export any decision function.
+**Mitigation:** AST guard tests (tests 12 + 13) verify no imports of gate/judgment decision modules in both source files (stats module + CLI runner). Decision-function vocabulary guard (test 14) rejects gate/decision function names in source. Stats module does not export any decision function.
 
 ### 5. Non-Deterministic Output
 
@@ -46,7 +46,7 @@ It is 6 months from now. The item statistics PR merged and created false confide
 
 **Story:** Accidental import of httpx/requests in the statistics module leaks network capabilities into an offline-only tool.
 
-**Mitigation:** AST scan test (test 1) rejects network library imports at source level.
+**Mitigation:** AST scan test (test 1) rejects network library imports at source level in both source files (stats module + CLI runner).
 
 ### 7. Docs Overclaiming Production Robustness
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -10755,7 +10755,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Evaluation item statistics baseline for empirical-readiness
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD (`evals/item-statistics-baseline`)
+  - Target PR: PR #1662 (`evals/item-statistics-baseline`)
   - Area: evals / measurement science / psychometric readiness
   - Finding Type: item-statistics gap
   - Reason: Evaluation item metadata registry is present, but the project still lacks deterministic descriptive item statistics that combine registry metadata with curated fixture outcomes. This layer is required before honest item weighting, IRT, adaptive evals, or empirical calibration.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -10751,6 +10751,28 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - No IRT or psychometric scoring is implemented
     - No runtime/API/frontend/iOS/billing/OpenAPI/App Store/Claude/Opus/MCP changes are included
 
-**Last updated:** 2026-05-04 (evaluation item metadata registry merged, ledger closed)
+<a id="ledger-p1-eval-item-statistics-baseline"></a>
+- [ ] P1: Evaluation item statistics baseline for empirical-readiness
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD (`evals/item-statistics-baseline`)
+  - Area: evals / measurement science / psychometric readiness
+  - Finding Type: item-statistics gap
+  - Reason: Evaluation item metadata registry is present, but the project still lacks deterministic descriptive item statistics that combine registry metadata with curated fixture outcomes. This layer is required before honest item weighting, IRT, adaptive evals, or empirical calibration.
+  - Links:
+    - `docs/evals/PULSEPLATE_EVAL_VALIDITY_CONTRACT.md`
+    - `scripts/evals/eval_item_statistics.py`
+    - `scripts/evals/run_eval_item_statistics.py`
+    - `data/evals/eval_item_metadata_registry.jsonl`
+    - `tests/evals/test_eval_item_statistics.py`
+  - DoD:
+    - Descriptive item statistics are generated deterministically from registry + fixture outcomes
+    - Report includes per-item pass_rate, invariance agreement, mutation drop, worst variant score, decision set, and instability flag
+    - RAG PASS/NO-GO logic remains unchanged
+    - Judgment promote/defer/discard logic remains unchanged
+    - No IRT or psychometric scoring is implemented
+    - No runtime/API/frontend/iOS/billing/OpenAPI/App Store/Claude/Opus/MCP changes are included
+
+**Last updated:** 2026-05-04 (evaluation item statistics baseline ledger entry added)
 **Maintainer:** @katsiaryna_kavaleuskaya
 <!-- markdownlint-enable MD013 -->

--- a/scripts/evals/eval_item_statistics.py
+++ b/scripts/evals/eval_item_statistics.py
@@ -112,15 +112,18 @@ def _compute_item_stats(
     registry_record: EvalItemMetadataRecord,
 ) -> EvalItemStatisticsRecord:
     """Compute descriptive statistics for one canonical item group."""
-    # Find the canonical row
-    canonical_row: EvalOutcomeRecord | None = None
-    for rec in outcomes:
-        if rec["variant_family"] == "canonical":
-            canonical_row = rec
-            break
+    if not outcomes:
+        raise ValueError(f"Empty outcomes list for canonical_id={canonical_id!r}")
 
-    if canonical_row is None:
+    # Find the canonical row (must be exactly one)
+    canonical_rows = [r for r in outcomes if r["variant_family"] == "canonical"]
+    if len(canonical_rows) == 0:
         raise ValueError(f"No canonical row found for canonical_id={canonical_id!r}")
+    if len(canonical_rows) > 1:
+        raise ValueError(
+            f"Multiple canonical rows ({len(canonical_rows)}) for " f"canonical_id={canonical_id!r}"
+        )
+    canonical_row = canonical_rows[0]
 
     canonical_score = canonical_row["score"]
     canonical_passed = canonical_row["passed"]
@@ -195,10 +198,13 @@ def build_item_statistics(
     for rec in outcomes:
         by_cid.setdefault(rec["canonical_id"], []).append(rec)
 
-    # Index registry
+    # Index registry (reject duplicates)
     registry_index: dict[str, EvalItemMetadataRecord] = {}
     for reg in registry_records:
-        registry_index[reg["canonical_id"]] = reg
+        cid = reg["canonical_id"]
+        if cid in registry_index:
+            raise ValueError(f"Duplicate canonical_id in registry: {cid!r}")
+        registry_index[cid] = reg
 
     # Validate coverage
     outcome_cids = set(by_cid.keys())

--- a/scripts/evals/eval_item_statistics.py
+++ b/scripts/evals/eval_item_statistics.py
@@ -35,6 +35,13 @@ from scripts.evals.eval_validity_contract import (
 )
 
 # ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DECIMAL_PLACES = 6
+"""Rounding precision for all computed rates and means."""
+
+# ---------------------------------------------------------------------------
 # Item statistics record schema
 # ---------------------------------------------------------------------------
 
@@ -126,7 +133,9 @@ def _compute_item_stats(
         1 for r in invariance_rows if r["decision"] == canonical_decision
     )
     invariance_agreement_rate = (
-        round(invariance_agreement_count / invariance_count, 6) if invariance_count > 0 else 0.0
+        round(invariance_agreement_count / invariance_count, _DECIMAL_PLACES)
+        if invariance_count > 0
+        else 0.0
     )
 
     # Mutation stats
@@ -134,7 +143,7 @@ def _compute_item_stats(
     mutation_count = len(mutation_rows)
     if mutation_count > 0:
         drops = [canonical_score - r["score"] for r in mutation_rows]
-        mutation_mean_drop = round(statistics.mean(drops), 6)
+        mutation_mean_drop = round(statistics.mean(drops), _DECIMAL_PLACES)
     else:
         mutation_mean_drop = 0.0
 
@@ -143,7 +152,7 @@ def _compute_item_stats(
     all_scores = [r["score"] for r in outcomes]
     worst_variant_score = min(all_scores)
     pass_count = sum(1 for r in outcomes if r["passed"])
-    pass_rate = round(pass_count / variant_count, 6)
+    pass_rate = round(pass_count / variant_count, _DECIMAL_PLACES)
     decision_set = sorted(set(r["decision"] for r in outcomes))
     instability_flag = len(decision_set) > 1
 
@@ -198,18 +207,18 @@ def build_item_statistics(
     missing_from_registry = outcome_cids - registry_cids
     if missing_from_registry:
         raise ValueError(
-            f"Outcome canonical_ids missing from registry: " f"{sorted(missing_from_registry)}"
+            f"Outcome canonical_ids missing from registry: {sorted(missing_from_registry)}"
         )
 
     orphan_registry = registry_cids - outcome_cids
     if orphan_registry:
         raise ValueError(
-            f"Orphan registry canonical_ids not in outcomes: " f"{sorted(orphan_registry)}"
+            f"Orphan registry canonical_ids not in outcomes: {sorted(orphan_registry)}"
         )
 
-    # Compute stats per item, sorted by (lane, canonical_id) for determinism
+    # Compute stats per item, then sort by (lane, canonical_id) for determinism
     items: list[EvalItemStatisticsRecord] = []
-    for cid in sorted(registry_cids):
+    for cid in registry_cids:
         item_stats = _compute_item_stats(cid, by_cid[cid], registry_index[cid])
         items.append(item_stats)
 

--- a/scripts/evals/eval_item_statistics.py
+++ b/scripts/evals/eval_item_statistics.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Evaluation item statistics baseline.
+
+RU: Описательная статистика eval-элементов для психометрической готовности.
+EN: Descriptive item-level statistics layer over curated fixture outcomes
+    and the item metadata registry.  Combines registry metadata with
+    fixture outcomes to produce per-item descriptive statistics.
+
+This module is a **descriptive measurement layer**, not IRT, not
+psychometric calibration, not an adaptive item selector, and not a
+release-gate decision source.
+
+Hard rules:
+- No IRT, Rasch, 2PL, 3PL.
+- No scientific computing libraries (stdlib-only).
+- No network calls, no provider metadata.
+- No mutation of EvalOutcomeRecord or EvalItemMetadataRecord schemas.
+- No mutation of RAG PASS/NO-GO or judgment promote/defer/discard logic.
+- Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from pathlib import Path
+from typing import Any, Sequence, TypedDict
+
+from scripts.evals.eval_item_registry import (
+    EvalItemMetadataRecord,
+)
+from scripts.evals.eval_validity_contract import (
+    EvalOutcomeRecord,
+    validate_eval_outcome_record,
+)
+
+# ---------------------------------------------------------------------------
+# Item statistics record schema
+# ---------------------------------------------------------------------------
+
+
+class EvalItemStatisticsRecord(TypedDict):
+    """Descriptive statistics for one canonical eval item.
+
+    RU: Описательная статистика для одного канонического eval-элемента.
+    EN: Combines registry metadata with fixture outcome data to produce
+        per-item descriptive statistics.  These are NOT IRT estimates,
+        NOT calibrated difficulty parameters, and NOT psychometric scores.
+    """
+
+    canonical_id: str
+    lane: str
+    domain: str
+    skill_dimension: str
+    difficulty_band: str
+    expected_decision: str
+    expected_score_band: str
+    variant_count: int
+    canonical_score: float
+    canonical_passed: bool
+    invariance_count: int
+    invariance_agreement_count: int
+    invariance_agreement_rate: float
+    mutation_count: int
+    mutation_mean_drop: float
+    worst_variant_score: float
+    pass_rate: float
+    decision_set: list[str]
+    instability_flag: bool
+    anchor_item: bool
+
+
+# ---------------------------------------------------------------------------
+# Loading helpers
+# ---------------------------------------------------------------------------
+
+
+def load_fixture_outcomes(path: Path) -> list[EvalOutcomeRecord]:
+    """Load and validate EvalOutcomeRecord rows from a JSONL file.
+
+    Raises ``ValueError`` on first malformed line.
+    """
+    outcomes: list[EvalOutcomeRecord] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                raw = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_no}: invalid JSON: {exc}") from exc
+            outcomes.append(validate_eval_outcome_record(raw))
+    return outcomes
+
+
+# ---------------------------------------------------------------------------
+# Statistics computation
+# ---------------------------------------------------------------------------
+
+
+def _compute_item_stats(
+    canonical_id: str,
+    outcomes: list[EvalOutcomeRecord],
+    registry_record: EvalItemMetadataRecord,
+) -> EvalItemStatisticsRecord:
+    """Compute descriptive statistics for one canonical item group."""
+    # Find the canonical row
+    canonical_row: EvalOutcomeRecord | None = None
+    for rec in outcomes:
+        if rec["variant_family"] == "canonical":
+            canonical_row = rec
+            break
+
+    if canonical_row is None:
+        raise ValueError(f"No canonical row found for canonical_id={canonical_id!r}")
+
+    canonical_score = canonical_row["score"]
+    canonical_passed = canonical_row["passed"]
+    canonical_decision = canonical_row["decision"]
+
+    # Invariance stats
+    invariance_rows = [r for r in outcomes if r["variant_family"] == "invariance"]
+    invariance_count = len(invariance_rows)
+    invariance_agreement_count = sum(
+        1 for r in invariance_rows if r["decision"] == canonical_decision
+    )
+    invariance_agreement_rate = (
+        round(invariance_agreement_count / invariance_count, 6) if invariance_count > 0 else 0.0
+    )
+
+    # Mutation stats
+    mutation_rows = [r for r in outcomes if r["variant_family"] == "mutation"]
+    mutation_count = len(mutation_rows)
+    if mutation_count > 0:
+        drops = [canonical_score - r["score"] for r in mutation_rows]
+        mutation_mean_drop = round(statistics.mean(drops), 6)
+    else:
+        mutation_mean_drop = 0.0
+
+    # Aggregate stats
+    variant_count = len(outcomes)
+    all_scores = [r["score"] for r in outcomes]
+    worst_variant_score = min(all_scores)
+    pass_count = sum(1 for r in outcomes if r["passed"])
+    pass_rate = round(pass_count / variant_count, 6)
+    decision_set = sorted(set(r["decision"] for r in outcomes))
+    instability_flag = len(decision_set) > 1
+
+    return EvalItemStatisticsRecord(
+        canonical_id=canonical_id,
+        lane=registry_record["lane"],
+        domain=registry_record["domain"],
+        skill_dimension=registry_record["skill_dimension"],
+        difficulty_band=registry_record["difficulty_band"],
+        expected_decision=registry_record["expected_decision"],
+        expected_score_band=registry_record["expected_score_band"],
+        variant_count=variant_count,
+        canonical_score=canonical_score,
+        canonical_passed=canonical_passed,
+        invariance_count=invariance_count,
+        invariance_agreement_count=invariance_agreement_count,
+        invariance_agreement_rate=invariance_agreement_rate,
+        mutation_count=mutation_count,
+        mutation_mean_drop=mutation_mean_drop,
+        worst_variant_score=worst_variant_score,
+        pass_rate=pass_rate,
+        decision_set=decision_set,
+        instability_flag=instability_flag,
+        anchor_item=registry_record["anchor_item"],
+    )
+
+
+def build_item_statistics(
+    outcomes: Sequence[EvalOutcomeRecord],
+    registry_records: Sequence[EvalItemMetadataRecord],
+) -> list[EvalItemStatisticsRecord]:
+    """Build per-item statistics from outcomes and registry records.
+
+    Raises ``ValueError`` on coverage mismatch (orphan stats or missing
+    registry items).  Results are sorted by ``(lane, canonical_id)``
+    for deterministic output.
+    """
+    # Group outcomes by canonical_id
+    by_cid: dict[str, list[EvalOutcomeRecord]] = {}
+    for rec in outcomes:
+        by_cid.setdefault(rec["canonical_id"], []).append(rec)
+
+    # Index registry
+    registry_index: dict[str, EvalItemMetadataRecord] = {}
+    for reg in registry_records:
+        registry_index[reg["canonical_id"]] = reg
+
+    # Validate coverage
+    outcome_cids = set(by_cid.keys())
+    registry_cids = set(registry_index.keys())
+
+    missing_from_registry = outcome_cids - registry_cids
+    if missing_from_registry:
+        raise ValueError(
+            f"Outcome canonical_ids missing from registry: " f"{sorted(missing_from_registry)}"
+        )
+
+    orphan_registry = registry_cids - outcome_cids
+    if orphan_registry:
+        raise ValueError(
+            f"Orphan registry canonical_ids not in outcomes: " f"{sorted(orphan_registry)}"
+        )
+
+    # Compute stats per item, sorted by (lane, canonical_id) for determinism
+    items: list[EvalItemStatisticsRecord] = []
+    for cid in sorted(registry_cids):
+        item_stats = _compute_item_stats(cid, by_cid[cid], registry_index[cid])
+        items.append(item_stats)
+
+    items.sort(key=lambda x: (x["lane"], x["canonical_id"]))
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Report builder
+# ---------------------------------------------------------------------------
+
+
+def build_item_statistics_report(
+    items: Sequence[EvalItemStatisticsRecord],
+) -> dict[str, Any]:
+    """Build the item statistics report envelope.
+
+    The report is deterministic: identical input always produces identical
+    output (sorted keys, stable ordering, no timestamps).
+    """
+    lane_counts: dict[str, int] = {}
+    anchor_count = 0
+    unstable_count = 0
+
+    for item in items:
+        lane = item["lane"]
+        lane_counts[lane] = lane_counts.get(lane, 0) + 1
+        if item["anchor_item"]:
+            anchor_count += 1
+        if item["instability_flag"]:
+            unstable_count += 1
+
+    return {
+        "schema_version": "1.0",
+        "item_count": len(items),
+        "lane_counts": dict(sorted(lane_counts.items())),
+        "anchor_item_count": anchor_count,
+        "unstable_item_count": unstable_count,
+        "items": list(items),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Writer
+# ---------------------------------------------------------------------------
+
+
+def write_item_statistics_report(
+    report: dict[str, Any],
+    output_path: Path,
+) -> None:
+    """Write item statistics report as deterministic JSON.
+
+    Creates parent directories if needed.  No timestamps in output.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as fh:
+        json.dump(report, fh, indent=2, sort_keys=True, ensure_ascii=False)
+        fh.write("\n")

--- a/scripts/evals/run_eval_item_statistics.py
+++ b/scripts/evals/run_eval_item_statistics.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""CLI runner for evaluation item statistics baseline.
+
+RU: CLI для генерации описательной статистики eval-элементов.
+EN: Computes descriptive item-level statistics from the item metadata
+    registry and curated fixture outcomes.
+
+No network calls.  No model invocations.  Pure offline computation.
+No IRT.  No psychometric scoring.  No adaptive item selection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.evals.eval_item_registry import load_eval_item_registry  # noqa: E402
+from scripts.evals.eval_item_statistics import (  # noqa: E402
+    build_item_statistics,
+    build_item_statistics_report,
+    load_fixture_outcomes,
+    write_item_statistics_report,
+)
+
+DEFAULT_REGISTRY_PATH = REPO_ROOT / "data" / "evals" / "eval_item_metadata_registry.jsonl"
+DEFAULT_FIXTURES = [
+    REPO_ROOT / "data" / "evals" / "pulseplate_judgment_eval_validity_variants.jsonl",
+    REPO_ROOT / "data" / "evals" / "pulseplate_rag_release_gate_validity_variants.jsonl",
+]
+DEFAULT_OUTPUT_PATH = REPO_ROOT / "artifacts" / "evals" / "item_statistics_report.json"
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the item statistics CLI."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compute descriptive item-level statistics from the item "
+            "metadata registry and curated fixture outcomes."
+        ),
+    )
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=DEFAULT_REGISTRY_PATH,
+        help="Path to the item metadata registry JSONL file.",
+    )
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        action="append",
+        default=None,
+        dest="fixtures",
+        help=(
+            "Path to an EvalOutcomeRecord JSONL fixture file.  Can be "
+            "repeated.  Defaults to judgment + RAG variant fixtures."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help="Path to write the JSON item statistics report.",
+    )
+    args = parser.parse_args(argv)
+
+    fixture_paths: list[Path] = args.fixtures if args.fixtures else list(DEFAULT_FIXTURES)
+
+    # Load registry
+    registry_records = load_eval_item_registry(args.registry)
+
+    # Load all fixture outcomes
+    all_outcomes = []
+    for fp in fixture_paths:
+        all_outcomes.extend(load_fixture_outcomes(fp))
+
+    # Build statistics
+    items = build_item_statistics(all_outcomes, registry_records)
+    report = build_item_statistics_report(items)
+
+    # Write report
+    write_item_statistics_report(report, args.output)
+
+    # Print compact summary
+    print(f"Item statistics report written to {args.output}")
+    print(f"  item_count:         {report['item_count']}")
+    print(f"  lane_counts:        {report['lane_counts']}")
+    print(f"  anchor_item_count:  {report['anchor_item_count']}")
+    print(f"  unstable_items:     {report['unstable_item_count']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evals/run_eval_item_statistics.py
+++ b/scripts/evals/run_eval_item_statistics.py
@@ -26,6 +26,7 @@ from scripts.evals.eval_item_statistics import (  # noqa: E402
     load_fixture_outcomes,
     write_item_statistics_report,
 )
+from scripts.evals.eval_validity_contract import EvalOutcomeRecord  # noqa: E402
 
 DEFAULT_REGISTRY_PATH = REPO_ROOT / "data" / "evals" / "eval_item_metadata_registry.jsonl"
 DEFAULT_FIXTURES = [
@@ -74,7 +75,7 @@ def main(argv: list[str] | None = None) -> None:
     registry_records = load_eval_item_registry(args.registry)
 
     # Load all fixture outcomes
-    all_outcomes = []
+    all_outcomes: list[EvalOutcomeRecord] = []
     for fp in fixture_paths:
         all_outcomes.extend(load_fixture_outcomes(fp))
 

--- a/tests/evals/test_eval_item_statistics.py
+++ b/tests/evals/test_eval_item_statistics.py
@@ -41,7 +41,11 @@ _JUDGMENT_FIXTURE = (
 )
 _RAG_FIXTURE = _REPO_ROOT / "data" / "evals" / "pulseplate_rag_release_gate_validity_variants.jsonl"
 _STATISTICS_MODULE = _REPO_ROOT / "scripts" / "evals" / "eval_item_statistics.py"
-_CLI_SCRIPT = _REPO_ROOT / "scripts" / "evals" / "run_eval_item_statistics.py"
+_CLI_MODULE = _REPO_ROOT / "scripts" / "evals" / "run_eval_item_statistics.py"
+_CLI_SCRIPT = _CLI_MODULE  # alias for subprocess tests
+
+# Both source files must be guarded by AST scans (FM-1, FM-4, FM-6)
+_GUARDED_MODULES = [_STATISTICS_MODULE, _CLI_MODULE]
 
 
 # ---------------------------------------------------------------------------
@@ -96,25 +100,27 @@ def _is_forbidden_module(module_name: str) -> bool:
 
 
 class TestNoNetworkImports:
-    def test_item_statistics_module_has_no_network_imports(self) -> None:
-        source = _STATISTICS_MODULE.read_text(encoding="utf-8")
+    @pytest.mark.parametrize("module_path", _GUARDED_MODULES, ids=lambda p: p.name)
+    def test_guarded_modules_have_no_network_imports(self, module_path: Path) -> None:
+        """FM-6: Neither the stats module nor the CLI runner may import network libs."""
+        source = module_path.read_text(encoding="utf-8")
         tree = ast.parse(source)
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 for alias in node.names:
                     assert not _is_forbidden_module(
                         alias.name
-                    ), f"eval_item_statistics.py imports network lib: {alias.name}"
+                    ), f"{module_path.name} imports network lib: {alias.name}"
             elif isinstance(node, ast.ImportFrom):
                 if node.module is not None:
                     assert not _is_forbidden_module(
                         node.module
-                    ), f"eval_item_statistics.py imports from network lib: {node.module}"
+                    ), f"{module_path.name} imports from network lib: {node.module}"
                     for alias in node.names:
                         qualified = f"{node.module}.{alias.name}"
                         assert not _is_forbidden_module(
                             qualified
-                        ), f"eval_item_statistics.py imports from network lib: {qualified}"
+                        ), f"{module_path.name} imports from network lib: {qualified}"
 
 
 # ---------------------------------------------------------------------------
@@ -143,13 +149,15 @@ _IRT_PATTERNS = frozenset(
 
 
 class TestNoIrtImports:
-    def test_item_statistics_module_has_no_irt_imports(self) -> None:
-        source = _STATISTICS_MODULE.read_text(encoding="utf-8")
+    @pytest.mark.parametrize("module_path", _GUARDED_MODULES, ids=lambda p: p.name)
+    def test_guarded_modules_have_no_irt_patterns(self, module_path: Path) -> None:
+        """FM-1: Neither the stats module nor the CLI runner may contain IRT vocabulary."""
+        source = module_path.read_text(encoding="utf-8")
         source_lower = source.lower()
         for pattern in _IRT_PATTERNS:
             assert (
                 pattern.lower() not in source_lower
-            ), f"eval_item_statistics.py contains IRT/forbidden pattern: {pattern!r}"
+            ), f"{module_path.name} contains IRT/forbidden pattern: {pattern!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -296,28 +304,34 @@ class TestExpectedDecisionMatchesRegistry:
 # ---------------------------------------------------------------------------
 
 
+_FORBIDDEN_RAG_MODULES = frozenset(
+    {
+        "scripts.evals.run_rag_release_gates",
+        "scripts.evals.rag_release_gate_validity",
+    }
+)
+
+
 class TestNoRagDecisionImports:
-    def test_item_statistics_does_not_change_rag_threshold_or_decision_logic(
+    @pytest.mark.parametrize("module_path", _GUARDED_MODULES, ids=lambda p: p.name)
+    def test_guarded_modules_do_not_import_rag_gate_modules(
         self,
+        module_path: Path,
     ) -> None:
-        source = _STATISTICS_MODULE.read_text(encoding="utf-8")
+        """FM-4: Neither the stats module nor the CLI may import RAG gate modules."""
+        source = module_path.read_text(encoding="utf-8")
         tree = ast.parse(source)
-        _forbidden_rag_modules = {
-            "scripts.evals.run_rag_release_gates",
-            "scripts.evals.rag_release_gate_validity",
-        }
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 for alias in node.names:
-                    assert alias.name not in _forbidden_rag_modules, (
-                        f"eval_item_statistics.py must not import RAG gate " f"module: {alias.name}"
-                    )
+                    assert (
+                        alias.name not in _FORBIDDEN_RAG_MODULES
+                    ), f"{module_path.name} must not import RAG gate module: {alias.name}"
             elif isinstance(node, ast.ImportFrom):
                 if node.module is not None:
-                    assert node.module not in _forbidden_rag_modules, (
-                        f"eval_item_statistics.py must not import from RAG "
-                        f"gate module: {node.module}"
-                    )
+                    assert (
+                        node.module not in _FORBIDDEN_RAG_MODULES
+                    ), f"{module_path.name} must not import from RAG gate module: {node.module}"
 
 
 # ---------------------------------------------------------------------------
@@ -325,30 +339,105 @@ class TestNoRagDecisionImports:
 # ---------------------------------------------------------------------------
 
 
+_FORBIDDEN_JUDGMENT_MODULES = frozenset(
+    {
+        "scripts.evals.judgment_validity",
+        "scripts.orchestration.judgment_eval",
+    }
+)
+
+
 class TestNoJudgmentDecisionImports:
-    def test_item_statistics_does_not_change_judgment_decision_logic(self) -> None:
-        source = _STATISTICS_MODULE.read_text(encoding="utf-8")
+    @pytest.mark.parametrize("module_path", _GUARDED_MODULES, ids=lambda p: p.name)
+    def test_guarded_modules_do_not_import_judgment_modules(
+        self,
+        module_path: Path,
+    ) -> None:
+        """FM-4: Neither the stats module nor the CLI may import judgment modules."""
+        source = module_path.read_text(encoding="utf-8")
         tree = ast.parse(source)
-        _forbidden_judgment_modules = {
-            "scripts.evals.judgment_validity",
-            "scripts.orchestration.judgment_eval",
-        }
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 for alias in node.names:
-                    assert alias.name not in _forbidden_judgment_modules, (
-                        f"eval_item_statistics.py must not import judgment " f"module: {alias.name}"
-                    )
+                    assert (
+                        alias.name not in _FORBIDDEN_JUDGMENT_MODULES
+                    ), f"{module_path.name} must not import judgment module: {alias.name}"
             elif isinstance(node, ast.ImportFrom):
                 if node.module is not None:
-                    assert node.module not in _forbidden_judgment_modules, (
-                        f"eval_item_statistics.py must not import from "
-                        f"judgment module: {node.module}"
-                    )
+                    assert (
+                        node.module not in _FORBIDDEN_JUDGMENT_MODULES
+                    ), f"{module_path.name} must not import from judgment module: {node.module}"
 
 
 # ---------------------------------------------------------------------------
-# 14. CLI writes report
+# 14. No decision-function vocabulary in source (FM-4 reinforcement)
+# ---------------------------------------------------------------------------
+
+_DECISION_FUNCTION_PATTERNS = frozenset(
+    {
+        "pass_no_go",
+        "evaluate_pass",
+        "evaluate_no_go",
+        "promote_item",
+        "defer_item",
+        "discard_item",
+        "gate_decision",
+        "release_decision",
+    }
+)
+
+
+class TestNoDecisionFunctionVocabulary:
+    @pytest.mark.parametrize("module_path", _GUARDED_MODULES, ids=lambda p: p.name)
+    def test_guarded_modules_have_no_decision_function_vocabulary(
+        self,
+        module_path: Path,
+    ) -> None:
+        """FM-4: Stats modules must not define or call decision functions."""
+        source = module_path.read_text(encoding="utf-8")
+        source_lower = source.lower()
+        for pattern in _DECISION_FUNCTION_PATTERNS:
+            assert (
+                pattern not in source_lower
+            ), f"{module_path.name} contains decision-function vocabulary: {pattern!r}"
+
+
+# ---------------------------------------------------------------------------
+# 15. Report output has no IRT-claiming keys (FM-1 reinforcement)
+# ---------------------------------------------------------------------------
+
+_IRT_REPORT_KEYS = frozenset(
+    {
+        "irt_difficulty",
+        "irt_discrimination",
+        "irt_information",
+        "theta_estimate",
+        "item_information",
+        "test_information",
+        "rasch_difficulty",
+        "reliability_coefficient",
+        "calibrated_difficulty",
+    }
+)
+
+
+class TestReportHasNoIrtKeys:
+    def test_item_statistics_report_has_no_irt_keys(self) -> None:
+        """FM-1: Report output must not contain IRT-claiming field names."""
+        report = _build_full_report()
+        for item in report["items"]:
+            item_keys = set(item.keys())
+            irt_found = item_keys & _IRT_REPORT_KEYS
+            assert (
+                not irt_found
+            ), f"Item {item.get('canonical_id', '?')!r} has IRT-claiming keys: {irt_found}"
+        top_keys = set(report.keys())
+        irt_top = top_keys & _IRT_REPORT_KEYS
+        assert not irt_top, f"Report envelope has IRT-claiming keys: {irt_top}"
+
+
+# ---------------------------------------------------------------------------
+# 16. CLI writes report
 # ---------------------------------------------------------------------------
 
 
@@ -387,7 +476,7 @@ class TestCliWritesReport:
 
 
 # ---------------------------------------------------------------------------
-# 15. CLI output has no timestamp
+# 17. CLI output has no timestamp
 # ---------------------------------------------------------------------------
 
 

--- a/tests/evals/test_eval_item_statistics.py
+++ b/tests/evals/test_eval_item_statistics.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import ast
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -26,8 +27,8 @@ from scripts.evals.eval_item_statistics import (
     build_item_statistics,
     build_item_statistics_report,
     load_fixture_outcomes,
-    write_item_statistics_report,
 )
+from scripts.evals.eval_validity_contract import EvalOutcomeRecord
 
 # ---------------------------------------------------------------------------
 # Paths (relative to repo root, resolved from this file)
@@ -48,9 +49,9 @@ _CLI_SCRIPT = _REPO_ROOT / "scripts" / "evals" / "run_eval_item_statistics.py"
 # ---------------------------------------------------------------------------
 
 
-def _load_all_outcomes() -> list[dict[str, Any]]:
+def _load_all_outcomes() -> list[EvalOutcomeRecord]:
     """Load outcomes from both judgment and RAG fixtures."""
-    outcomes: list[dict[str, Any]] = []
+    outcomes: list[EvalOutcomeRecord] = []
     outcomes.extend(load_fixture_outcomes(_JUDGMENT_FIXTURE))
     outcomes.extend(load_fixture_outcomes(_RAG_FIXTURE))
     return outcomes
@@ -419,7 +420,5 @@ class TestCliOutputHasNoTimestamp:
         assert not found, f"Report contains timestamp key(s): {found}"
 
         # Also verify no ISO-format timestamps in raw content
-        import re
-
         iso_pattern = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
         assert not iso_pattern.search(content), "Report contains ISO timestamp string"

--- a/tests/evals/test_eval_item_statistics.py
+++ b/tests/evals/test_eval_item_statistics.py
@@ -1,0 +1,425 @@
+"""Tests for the evaluation item statistics baseline.
+
+RU: Тесты для описательной статистики eval-элементов.
+EN: Deterministic, offline tests that validate the item statistics
+    baseline covers all registry items, has no orphan items, produces
+    deterministic output, and contains no forbidden imports.
+
+This test file does NOT implement IRT, psychometric scoring, or
+adaptive item selection.  It validates descriptive statistics only.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.evals.eval_item_registry import load_eval_item_registry
+from scripts.evals.eval_item_statistics import (
+    EvalItemStatisticsRecord,
+    build_item_statistics,
+    build_item_statistics_report,
+    load_fixture_outcomes,
+    write_item_statistics_report,
+)
+
+# ---------------------------------------------------------------------------
+# Paths (relative to repo root, resolved from this file)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_REGISTRY_PATH = _REPO_ROOT / "data" / "evals" / "eval_item_metadata_registry.jsonl"
+_JUDGMENT_FIXTURE = (
+    _REPO_ROOT / "data" / "evals" / "pulseplate_judgment_eval_validity_variants.jsonl"
+)
+_RAG_FIXTURE = _REPO_ROOT / "data" / "evals" / "pulseplate_rag_release_gate_validity_variants.jsonl"
+_STATISTICS_MODULE = _REPO_ROOT / "scripts" / "evals" / "eval_item_statistics.py"
+_CLI_SCRIPT = _REPO_ROOT / "scripts" / "evals" / "run_eval_item_statistics.py"
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_all_outcomes() -> list[dict[str, Any]]:
+    """Load outcomes from both judgment and RAG fixtures."""
+    outcomes: list[dict[str, Any]] = []
+    outcomes.extend(load_fixture_outcomes(_JUDGMENT_FIXTURE))
+    outcomes.extend(load_fixture_outcomes(_RAG_FIXTURE))
+    return outcomes
+
+
+def _build_full_stats() -> list[EvalItemStatisticsRecord]:
+    """Build item statistics from real registry + fixtures."""
+    registry = load_eval_item_registry(_REGISTRY_PATH)
+    outcomes = _load_all_outcomes()
+    return build_item_statistics(outcomes, registry)
+
+
+def _build_full_report() -> dict[str, Any]:
+    """Build the full item statistics report from real data."""
+    items = _build_full_stats()
+    return build_item_statistics_report(items)
+
+
+# ---------------------------------------------------------------------------
+# 1. No network imports
+# ---------------------------------------------------------------------------
+
+_NETWORK_MODULES = frozenset(
+    {
+        "requests",
+        "httpx",
+        "aiohttp",
+        "urllib3",
+        "urllib.request",
+        "socket",
+        "http.client",
+    }
+)
+
+
+def _is_forbidden_module(module_name: str) -> bool:
+    """Check if a module name matches or is a submodule of a forbidden network lib."""
+    return any(
+        module_name == forbidden or module_name.startswith(f"{forbidden}.")
+        for forbidden in _NETWORK_MODULES
+    )
+
+
+class TestNoNetworkImports:
+    def test_item_statistics_module_has_no_network_imports(self) -> None:
+        source = _STATISTICS_MODULE.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert not _is_forbidden_module(
+                        alias.name
+                    ), f"eval_item_statistics.py imports network lib: {alias.name}"
+            elif isinstance(node, ast.ImportFrom):
+                if node.module is not None:
+                    assert not _is_forbidden_module(
+                        node.module
+                    ), f"eval_item_statistics.py imports from network lib: {node.module}"
+                    for alias in node.names:
+                        qualified = f"{node.module}.{alias.name}"
+                        assert not _is_forbidden_module(
+                            qualified
+                        ), f"eval_item_statistics.py imports from network lib: {qualified}"
+
+
+# ---------------------------------------------------------------------------
+# 2. No IRT imports
+# ---------------------------------------------------------------------------
+
+_IRT_PATTERNS = frozenset(
+    {
+        "item_response_theory",
+        "irt_difficulty",
+        "irt_discrimination",
+        "irt_information",
+        "rasch_model",
+        "2pl_model",
+        "3pl_model",
+        "theta_estimate",
+        "item_information_function",
+        "test_information_function",
+        "scipy.optimize",
+        "scipy.stats",
+        "numpy",
+        "pandas",
+        "sklearn",
+    }
+)
+
+
+class TestNoIrtImports:
+    def test_item_statistics_module_has_no_irt_imports(self) -> None:
+        source = _STATISTICS_MODULE.read_text(encoding="utf-8")
+        source_lower = source.lower()
+        for pattern in _IRT_PATTERNS:
+            assert (
+                pattern.lower() not in source_lower
+            ), f"eval_item_statistics.py contains IRT/forbidden pattern: {pattern!r}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Loads registry and fixtures
+# ---------------------------------------------------------------------------
+
+
+class TestLoadsRegistryAndFixtures:
+    def test_item_statistics_loads_registry_and_fixtures(self) -> None:
+        items = _build_full_stats()
+        assert len(items) > 0, "Item statistics list must not be empty"
+        for item in items:
+            assert isinstance(item["canonical_id"], str)
+            assert isinstance(item["variant_count"], int)
+            assert item["variant_count"] > 0
+
+
+# ---------------------------------------------------------------------------
+# 4. Covers all registry items
+# ---------------------------------------------------------------------------
+
+
+class TestCoversAllRegistryItems:
+    def test_item_statistics_covers_all_registry_items(self) -> None:
+        registry = load_eval_item_registry(_REGISTRY_PATH)
+        items = _build_full_stats()
+        stats_ids = {item["canonical_id"] for item in items}
+        registry_ids = {rec["canonical_id"] for rec in registry}
+        missing = registry_ids - stats_ids
+        assert not missing, f"Registry items missing from statistics: {sorted(missing)}"
+
+
+# ---------------------------------------------------------------------------
+# 5. No orphan items
+# ---------------------------------------------------------------------------
+
+
+class TestNoOrphanItems:
+    def test_item_statistics_has_no_orphan_items(self) -> None:
+        registry = load_eval_item_registry(_REGISTRY_PATH)
+        items = _build_full_stats()
+        stats_ids = {item["canonical_id"] for item in items}
+        registry_ids = {rec["canonical_id"] for rec in registry}
+        orphans = stats_ids - registry_ids
+        assert not orphans, f"Orphan statistics items not in registry: {sorted(orphans)}"
+
+
+# ---------------------------------------------------------------------------
+# 6. Deterministic report
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministicReport:
+    def test_item_statistics_report_is_deterministic(self) -> None:
+        report_1 = _build_full_report()
+        report_2 = _build_full_report()
+        json_1 = json.dumps(report_1, sort_keys=True, ensure_ascii=False)
+        json_2 = json.dumps(report_2, sort_keys=True, ensure_ascii=False)
+        assert json_1 == json_2, "Item statistics report is not deterministic"
+
+
+# ---------------------------------------------------------------------------
+# 7. Lane counts include rag and judgment
+# ---------------------------------------------------------------------------
+
+
+class TestLaneCounts:
+    def test_item_statistics_lane_counts_include_rag_and_judgment(self) -> None:
+        report = _build_full_report()
+        lane_counts = report["lane_counts"]
+        assert "rag" in lane_counts, "lane_counts missing 'rag'"
+        assert "judgment" in lane_counts, "lane_counts missing 'judgment'"
+        assert lane_counts["rag"] > 0, "rag lane_count must be > 0"
+        assert lane_counts["judgment"] > 0, "judgment lane_count must be > 0"
+
+
+# ---------------------------------------------------------------------------
+# 8. Anchor item count is nonzero
+# ---------------------------------------------------------------------------
+
+
+class TestAnchorItemCount:
+    def test_item_statistics_anchor_item_count_is_nonzero(self) -> None:
+        report = _build_full_report()
+        assert report["anchor_item_count"] > 0, "anchor_item_count must be > 0"
+
+
+# ---------------------------------------------------------------------------
+# 9. Invariance counts are nonzero
+# ---------------------------------------------------------------------------
+
+
+class TestInvarianceCounts:
+    def test_item_statistics_invariance_counts_are_nonzero(self) -> None:
+        items = _build_full_stats()
+        total_invariance = sum(item["invariance_count"] for item in items)
+        assert total_invariance > 0, "Total invariance_count across all items must be > 0"
+
+        total_agreement = sum(item["invariance_agreement_count"] for item in items)
+        assert total_agreement > 0, "Total invariance_agreement_count must be > 0"
+
+
+# ---------------------------------------------------------------------------
+# 10. Mutation counts are nonzero
+# ---------------------------------------------------------------------------
+
+
+class TestMutationCounts:
+    def test_item_statistics_mutation_counts_are_nonzero(self) -> None:
+        items = _build_full_stats()
+        total_mutation = sum(item["mutation_count"] for item in items)
+        assert total_mutation > 0, "Total mutation_count across all items must be > 0"
+
+
+# ---------------------------------------------------------------------------
+# 11. Expected decision matches registry
+# ---------------------------------------------------------------------------
+
+
+class TestExpectedDecisionMatchesRegistry:
+    def test_item_statistics_expected_decision_matches_registry(self) -> None:
+        registry = load_eval_item_registry(_REGISTRY_PATH)
+        items = _build_full_stats()
+        registry_index = {rec["canonical_id"]: rec for rec in registry}
+
+        for item in items:
+            cid = item["canonical_id"]
+            reg = registry_index.get(cid)
+            assert reg is not None, f"Item {cid!r} has no registry entry"
+            assert item["expected_decision"] == reg["expected_decision"], (
+                f"Item {cid!r} expected_decision mismatch: "
+                f"stats={item['expected_decision']!r} vs "
+                f"registry={reg['expected_decision']!r}"
+            )
+            assert item["expected_score_band"] == reg["expected_score_band"], (
+                f"Item {cid!r} expected_score_band mismatch: "
+                f"stats={item['expected_score_band']!r} vs "
+                f"registry={reg['expected_score_band']!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 12. Does not change RAG threshold or decision logic
+# ---------------------------------------------------------------------------
+
+
+class TestNoRagDecisionImports:
+    def test_item_statistics_does_not_change_rag_threshold_or_decision_logic(
+        self,
+    ) -> None:
+        source = _STATISTICS_MODULE.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        _forbidden_rag_modules = {
+            "scripts.evals.run_rag_release_gates",
+            "scripts.evals.rag_release_gate_validity",
+        }
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert alias.name not in _forbidden_rag_modules, (
+                        f"eval_item_statistics.py must not import RAG gate " f"module: {alias.name}"
+                    )
+            elif isinstance(node, ast.ImportFrom):
+                if node.module is not None:
+                    assert node.module not in _forbidden_rag_modules, (
+                        f"eval_item_statistics.py must not import from RAG "
+                        f"gate module: {node.module}"
+                    )
+
+
+# ---------------------------------------------------------------------------
+# 13. Does not change judgment decision logic
+# ---------------------------------------------------------------------------
+
+
+class TestNoJudgmentDecisionImports:
+    def test_item_statistics_does_not_change_judgment_decision_logic(self) -> None:
+        source = _STATISTICS_MODULE.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        _forbidden_judgment_modules = {
+            "scripts.evals.judgment_validity",
+            "scripts.orchestration.judgment_eval",
+        }
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert alias.name not in _forbidden_judgment_modules, (
+                        f"eval_item_statistics.py must not import judgment " f"module: {alias.name}"
+                    )
+            elif isinstance(node, ast.ImportFrom):
+                if node.module is not None:
+                    assert node.module not in _forbidden_judgment_modules, (
+                        f"eval_item_statistics.py must not import from "
+                        f"judgment module: {node.module}"
+                    )
+
+
+# ---------------------------------------------------------------------------
+# 14. CLI writes report
+# ---------------------------------------------------------------------------
+
+
+class TestCliWritesReport:
+    def test_item_statistics_cli_writes_report(self, tmp_path: Path) -> None:
+        output_file = tmp_path / "test_report.json"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(_CLI_SCRIPT),
+                "--registry",
+                str(_REGISTRY_PATH),
+                "--fixture",
+                str(_JUDGMENT_FIXTURE),
+                "--fixture",
+                str(_RAG_FIXTURE),
+                "--output",
+                str(output_file),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert (
+            result.returncode == 0
+        ), f"CLI failed with:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        assert output_file.exists(), "CLI did not create output file"
+
+        report = json.loads(output_file.read_text(encoding="utf-8"))
+        assert report["schema_version"] == "1.0"
+        assert report["item_count"] > 0
+        assert "lane_counts" in report
+        assert "items" in report
+        assert isinstance(report["items"], list)
+        assert len(report["items"]) == report["item_count"]
+
+
+# ---------------------------------------------------------------------------
+# 15. CLI output has no timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestCliOutputHasNoTimestamp:
+    def test_item_statistics_cli_output_has_no_timestamp(self, tmp_path: Path) -> None:
+        output_file = tmp_path / "test_report_ts.json"
+        subprocess.run(
+            [
+                sys.executable,
+                str(_CLI_SCRIPT),
+                "--registry",
+                str(_REGISTRY_PATH),
+                "--fixture",
+                str(_JUDGMENT_FIXTURE),
+                "--fixture",
+                str(_RAG_FIXTURE),
+                "--output",
+                str(output_file),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        content = output_file.read_text(encoding="utf-8")
+
+        # Check no timestamp-like keys in JSON
+        report = json.loads(content)
+        _timestamp_keys = {"timestamp", "created_at", "updated_at", "generated_at", "date"}
+        found = _timestamp_keys & set(report.keys())
+        assert not found, f"Report contains timestamp key(s): {found}"
+
+        # Also verify no ISO-format timestamps in raw content
+        import re
+
+        iso_pattern = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+        assert not iso_pattern.search(content), "Report contains ISO timestamp string"

--- a/tests/evals/test_eval_item_statistics.py
+++ b/tests/evals/test_eval_item_statistics.py
@@ -511,3 +511,95 @@ class TestCliOutputHasNoTimestamp:
         # Also verify no ISO-format timestamps in raw content
         iso_pattern = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
         assert not iso_pattern.search(content), "Report contains ISO timestamp string"
+
+
+# ---------------------------------------------------------------------------
+# 18. Edge cases: data integrity guards
+# ---------------------------------------------------------------------------
+
+
+def _make_outcome(
+    canonical_id: str = "test_001",
+    variant_family: str = "canonical",
+    **overrides: Any,
+) -> EvalOutcomeRecord:
+    """Factory for minimal EvalOutcomeRecord dicts used in edge-case tests."""
+    base: dict[str, Any] = {
+        "canonical_id": canonical_id,
+        "variant_id": f"{canonical_id}_{variant_family}",
+        "variant_family": variant_family,
+        "transform_type": "none",
+        "passed": True,
+        "score": 1.0,
+        "decision": "pass",
+    }
+    base.update(overrides)
+    return base  # type: ignore[return-value]
+
+
+def _make_registry(
+    canonical_id: str = "test_001",
+    lane: str = "judgment",
+) -> dict[str, Any]:
+    """Factory for minimal EvalItemMetadataRecord dicts."""
+    return {
+        "canonical_id": canonical_id,
+        "lane": lane,
+        "domain": "test",
+        "skill_dimension": "test",
+        "difficulty_band": "medium",
+        "expected_decision": "pass",
+        "expected_score_band": "high",
+        "anchor_item": False,
+    }
+
+
+class TestEdgeCaseDataIntegrity:
+    def test_multiple_canonical_rows_raises(self) -> None:
+        """BUG-2: Multiple canonical rows for same item must raise."""
+        outcomes = [
+            _make_outcome("x", "canonical"),
+            _make_outcome("x", "canonical", variant_id="x_canonical_2"),
+        ]
+        registry = [_make_registry("x")]
+        with pytest.raises(ValueError, match="Multiple canonical rows"):
+            build_item_statistics(outcomes, registry)
+
+    def test_duplicate_registry_canonical_id_raises(self) -> None:
+        """BUG-3: Duplicate canonical_id in registry must raise."""
+        outcomes = [_make_outcome("x", "canonical")]
+        registry = [_make_registry("x"), _make_registry("x")]
+        with pytest.raises(ValueError, match="Duplicate canonical_id in registry"):
+            build_item_statistics(outcomes, registry)
+
+    def test_missing_canonical_row_raises(self) -> None:
+        """Only invariance/mutation rows, no canonical row => must raise."""
+        outcomes = [_make_outcome("x", "invariance")]
+        registry = [_make_registry("x")]
+        with pytest.raises(ValueError, match="No canonical row found"):
+            build_item_statistics(outcomes, registry)
+
+    def test_orphan_outcome_raises(self) -> None:
+        """Outcome canonical_id not in registry => must raise."""
+        outcomes = [_make_outcome("orphan", "canonical")]
+        registry = [_make_registry("other")]
+        with pytest.raises(ValueError, match="missing from registry"):
+            build_item_statistics(outcomes, registry)
+
+    def test_orphan_registry_raises(self) -> None:
+        """Registry canonical_id not in outcomes => must raise."""
+        outcomes = [_make_outcome("x", "canonical")]
+        registry = [_make_registry("x"), _make_registry("extra")]
+        with pytest.raises(ValueError, match="Orphan registry"):
+            build_item_statistics(outcomes, registry)
+
+    def test_zero_mutation_produces_zero_mean_drop(self) -> None:
+        """Items with no mutation rows should have mutation_mean_drop=0.0."""
+        outcomes = [
+            _make_outcome("x", "canonical"),
+            _make_outcome("x", "invariance", variant_id="x_inv"),
+        ]
+        registry = [_make_registry("x")]
+        items = build_item_statistics(outcomes, registry)
+        assert items[0]["mutation_count"] == 0
+        assert items[0]["mutation_mean_drop"] == 0.0

--- a/tests/evals/test_eval_item_statistics.py
+++ b/tests/evals/test_eval_item_statistics.py
@@ -17,7 +17,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -45,7 +45,10 @@ _CLI_MODULE = _REPO_ROOT / "scripts" / "evals" / "run_eval_item_statistics.py"
 _CLI_SCRIPT = _CLI_MODULE  # alias for subprocess tests
 
 # Both source files must be guarded by AST scans (FM-1, FM-4, FM-6)
-_GUARDED_MODULES = [_STATISTICS_MODULE, _CLI_MODULE]
+# Filter by .exists() per repo policy (tests/AGENTS.md: AST scan path lists).
+_GUARDED_MODULES = [
+    module_path for module_path in (_STATISTICS_MODULE, _CLI_MODULE) if module_path.exists()
+]
 
 
 # ---------------------------------------------------------------------------
@@ -483,7 +486,7 @@ class TestCliWritesReport:
 class TestCliOutputHasNoTimestamp:
     def test_item_statistics_cli_output_has_no_timestamp(self, tmp_path: Path) -> None:
         output_file = tmp_path / "test_report_ts.json"
-        subprocess.run(
+        result = subprocess.run(
             [
                 sys.executable,
                 str(_CLI_SCRIPT),
@@ -500,14 +503,124 @@ class TestCliOutputHasNoTimestamp:
             text=True,
             timeout=30,
         )
+        assert (
+            result.returncode == 0
+        ), f"CLI failed with:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        assert output_file.exists(), "CLI did not create output file"
         content = output_file.read_text(encoding="utf-8")
 
-        # Check no timestamp-like keys in JSON
+        # Check no timestamp-like keys in JSON (recursively)
         report = json.loads(content)
         _timestamp_keys = {"timestamp", "created_at", "updated_at", "generated_at", "date"}
-        found = _timestamp_keys & set(report.keys())
+
+        def _collect_all_keys(obj: Any) -> set[str]:
+            """Recursively collect all dict keys from a JSON-like structure."""
+            keys: set[str] = set()
+            if isinstance(obj, dict):
+                keys.update(obj.keys())
+                for v in obj.values():
+                    keys.update(_collect_all_keys(v))
+            elif isinstance(obj, list):
+                for item in obj:
+                    keys.update(_collect_all_keys(item))
+            return keys
+
+        all_keys = _collect_all_keys(report)
+        found = _timestamp_keys & all_keys
         assert not found, f"Report contains timestamp key(s): {found}"
 
         # Also verify no ISO-format timestamps in raw content
         iso_pattern = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
         assert not iso_pattern.search(content), "Report contains ISO timestamp string"
+
+
+# ---------------------------------------------------------------------------
+# 18. Edge cases: data integrity guards
+# ---------------------------------------------------------------------------
+
+
+def _make_outcome(
+    canonical_id: str = "test_001",
+    variant_family: str = "canonical",
+    **overrides: Any,
+) -> EvalOutcomeRecord:
+    """Factory for minimal EvalOutcomeRecord dicts used in edge-case tests."""
+    base: dict[str, Any] = {
+        "canonical_id": canonical_id,
+        "variant_id": f"{canonical_id}_{variant_family}",
+        "variant_family": variant_family,
+        "transform_type": "none",
+        "passed": True,
+        "score": 1.0,
+        "decision": "pass",
+    }
+    base.update(overrides)
+    return cast(EvalOutcomeRecord, base)
+
+
+def _make_registry(
+    canonical_id: str = "test_001",
+    lane: str = "judgment",
+) -> dict[str, Any]:
+    """Factory for minimal EvalItemMetadataRecord dicts."""
+    return {
+        "canonical_id": canonical_id,
+        "lane": lane,
+        "domain": "test",
+        "skill_dimension": "test",
+        "difficulty_band": "medium",
+        "expected_decision": "pass",
+        "expected_score_band": "high",
+        "anchor_item": False,
+    }
+
+
+class TestEdgeCaseDataIntegrity:
+    def test_multiple_canonical_rows_raises(self) -> None:
+        """BUG-2: Multiple canonical rows for same item must raise."""
+        outcomes = [
+            _make_outcome("x", "canonical"),
+            _make_outcome("x", "canonical", variant_id="x_canonical_2"),
+        ]
+        registry = [_make_registry("x")]
+        with pytest.raises(ValueError, match="Multiple canonical rows"):
+            build_item_statistics(outcomes, registry)
+
+    def test_duplicate_registry_canonical_id_raises(self) -> None:
+        """BUG-3: Duplicate canonical_id in registry must raise."""
+        outcomes = [_make_outcome("x", "canonical")]
+        registry = [_make_registry("x"), _make_registry("x")]
+        with pytest.raises(ValueError, match="Duplicate canonical_id in registry"):
+            build_item_statistics(outcomes, registry)
+
+    def test_missing_canonical_row_raises(self) -> None:
+        """Only invariance/mutation rows, no canonical row => must raise."""
+        outcomes = [_make_outcome("x", "invariance")]
+        registry = [_make_registry("x")]
+        with pytest.raises(ValueError, match="No canonical row found"):
+            build_item_statistics(outcomes, registry)
+
+    def test_orphan_outcome_raises(self) -> None:
+        """Outcome canonical_id not in registry => must raise."""
+        outcomes = [_make_outcome("orphan", "canonical")]
+        registry = [_make_registry("other")]
+        with pytest.raises(ValueError, match="missing from registry"):
+            build_item_statistics(outcomes, registry)
+
+    def test_orphan_registry_raises(self) -> None:
+        """Registry canonical_id not in outcomes => must raise."""
+        outcomes = [_make_outcome("x", "canonical")]
+        registry = [_make_registry("x"), _make_registry("extra")]
+        with pytest.raises(ValueError, match="Orphan registry"):
+            build_item_statistics(outcomes, registry)
+
+    def test_zero_mutation_produces_zero_mean_drop(self) -> None:
+        """Items with no mutation rows should have mutation_mean_drop=0.0."""
+        outcomes = [
+            _make_outcome("x", "canonical"),
+            _make_outcome("x", "invariance", variant_id="x_inv"),
+        ]
+        registry = [_make_registry("x")]
+        items = build_item_statistics(outcomes, registry)
+        assert items[0]["mutation_count"] == 0
+        assert items[0]["mutation_mean_drop"] == 0.0


### PR DESCRIPTION
## Summary

- Add deterministic item-level statistics baseline that combines the eval item metadata registry with curated fixture outcomes
- Compute per-item descriptive statistics (pass rate, invariance agreement, mutation sensitivity, instability flags) for both RAG and judgment eval lanes
- Provide CLI runner for generating statistics reports as gitignored artifacts

## Scope

**IN:**
- `scripts/evals/eval_item_statistics.py` — core statistics module (TypedDict schema + computation)
- `scripts/evals/run_eval_item_statistics.py` — CLI runner with `--registry`, `--fixture`, `--output`
- `tests/evals/test_eval_item_statistics.py` — 15 deterministic tests
- Doc updates to eval validity contract, RAG release gates, judgment adjudication protocol
- Backlog ledger entry

**OUT (explicitly excluded):**
- No IRT, Rasch, 2PL, 3PL, psychometric scoring
- No scipy, numpy, pandas (stdlib-only)
- No network calls, no provider metadata
- No runtime/API/frontend/iOS/billing/OpenAPI/App Store changes
- No Claude/Opus/MCP integration
- No changes to RAG PASS/NO-GO or judgment promote/defer/discard logic

## Non-goals

- This PR does not implement psychometric calibration
- This PR does not implement adaptive item selection
- This PR does not modify any release-gate decisions
- Difficulty bands remain heuristic labels, not calibrated IRT parameters

## Validation

- `pytest -q tests/evals/test_eval_item_statistics.py` — 15/15 pass
- `pytest -q tests/evals/` — all eval tests pass
- `make lint` — clean
- `make test-fast` — pass
- Pre-push hooks: mypy, bandit, pip-audit, backend tests, docker build — all pass

## Pre-mortem Mitigations

| Risk | Mitigation |
|------|-----------|
| Stats misread as IRT | Explicit "not IRT" wording in all docs; AST guard test |
| Registry/fixture drift | Bidirectional coverage test (no orphans, no missing) |
| Stats overriding PASS/NO-GO | No imports of gate/decision modules; AST guard test |
| Non-deterministic output | Sorted keys, sorted items, no timestamps; idempotency test |
| Provider/network contamination | AST scan for forbidden imports; forbidden-string scan |

## Security Notes

- No secrets, URLs, API keys, or provider metadata in any new file
- No network library imports (enforced by AST scan test)
- All fixtures are synthetic and curated
- No PII or real user data

## Decision Log

1. Item statistics are descriptive, not psychometric — IRT requires empirical run data
2. TypedDict schema follows existing eval contract convention
3. CLI runner follows existing `run_eval_validity.py` pattern
4. Report output to `artifacts/evals/` (gitignored)
5. Sorted by `(lane, canonical_id)` for deterministic output

## Deferred / Follow-ups

- [P1: Evaluation item statistics baseline](docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-eval-item-statistics-baseline)
- Future: IRT / item information modeling (requires empirical run data)
- Future: Item weighting using statistics + registry metadata
- Future: Adaptive item selection using anchor items and instability flags

## Split Justification

This PR is a single cohesive feature (item statistics baseline) that cannot be meaningfully split:
- `eval_item_statistics.py` (core module) + `run_eval_item_statistics.py` (CLI) + `test_eval_item_statistics.py` (tests) form one atomic deliverable
- The 6 doc files are required governance artifacts (review mapping, premortem, backlog ledger, eval contract updates)
- Splitting code from tests or docs from code would create incomplete, unverifiable PRs
- 9 files total, well within the 15-file guideline; LoC is high due to comprehensive test suite (15 tests with guard AST scans)

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: docs/review/PR_1662_FIXED_MAPPING.md
- No actionable review comments

## Merge Readiness

- [ ] CI green (pending)
- [ ] No unresolved review threads
- [ ] CodeRabbit / Sourcery / Cubic: no actionables
- [ ] Canonical artifact current
- [ ] Wait-window elapsed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic, stdlib‑only evaluation item statistics baseline that merges the eval item metadata registry with curated fixture outcomes for RAG and judgment lanes. Informational only—no IRT and no changes to PASS/NO‑GO or promote/defer/discard decisions.

- **New Features**
  - Computes per‑item fields: pass_rate, invariance_agreement_rate, mutation_mean_drop, worst_variant_score, decision_set, instability_flag.
  - Deterministic and offline (sorted by lane and ID). Writes to artifacts/evals/item_statistics_report.json.
  - CLI `scripts/evals/run_eval_item_statistics.py` (`--registry`, `--fixture`, `--output`); core `scripts/evals/eval_item_statistics.py`; tests in `tests/evals/test_eval_item_statistics.py` for determinism, coverage, no network/IRT/decision coupling, and CLI output.
  - Docs updated with an item statistics section; RAG/judgment sidecar notes; review premortem; fixed‑mapping artifact and backlog ledger updated.

- **Bug Fixes**
  - Updated `docs/review/PR_1662_FIXED_MAPPING.md` to match Phase2 gate validator format and added review‑level URLs required by the merge‑readiness gate.
  - Minor cleanups: extracted `_DECIMAL_PLACES`, removed redundant pre‑sort, fixed a return type annotation, merged f‑strings.
  - Hardened tests: recursive timestamp scan, `.exists()` filter for AST guards, CLI return‑code assert, `cast` instead of bare ignore; re‑applied Black and resolved test merge conflicts.

<sup>Written for commit b55e575e2541222154a84c1928cb084b6315757b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an evaluation item statistics baseline and an offline CLI to generate deterministic per-item statistics reports and console summaries.

* **Documentation**
  * Updated validity contract, release gates, adjudication protocol, roadmap, and review docs to describe the baseline, its scope/limitations, and clarify these statistics are informational only and do not change decision logic or thresholds.

* **Tests**
  * Added comprehensive deterministic tests for correctness, full registry coverage, edge cases, and guards against network/IRT/decision‑logic usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
