### PR TITLE
fix(makefile): remove command-injection vector in COMPOSE_PROJECT_NAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,13 @@ PIP ?= $(VENV_PYTHON) -m pip
 DEV_PYTHON ?= $(if $(wildcard $(VENV_PYTHON)),$(VENV_PYTHON),python3)
 
 # Dev Container compose settings (worktree-safe project name)
-COMPOSE_PROJECT_NAME ?= pulseplate
+COMPOSE_PROJECT_NAME_SUFFIX := $(strip $(shell pwd -P | cksum | cut -d' ' -f1))
+ifneq ($(origin COMPOSE_PROJECT_NAME), undefined)
+else ifeq ($(COMPOSE_PROJECT_NAME_SUFFIX),)
+  $(error failed to compute stable COMPOSE_PROJECT_NAME suffix; set COMPOSE_PROJECT_NAME explicitly)
+endif
+COMPOSE_PROJECT_NAME ?= pulseplate-$(COMPOSE_PROJECT_NAME_SUFFIX)
+export COMPOSE_PROJECT_NAME
 DEVCONTAINER_COMPOSE ?= .devcontainer/docker-compose.devcontainer.yml
 
 # Цвета для вывода
@@ -139,6 +145,10 @@ validate-changed: ## Run tests inferred from changed Python files
 	@echo "$(YELLOW)🧪 Running diff-based validation for changed Python files...$(NC)"
 	VENV_PYTHON="$(DEV_PYTHON)" BRANCH_DIFF_MODE=1 bash scripts/run-backend-tests-pre-commit.sh
 	@echo "$(GREEN)✅ Diff-based validation completed$(NC)"
+
+pr-regression-scan: ## Run temporary PR regression scan (focused + full/main-suite fallback + current-head check)
+	@bash scripts/ci/pr_regression_scan.sh "$${PR_NUMBER:-}" "$${REPO_NAME:-}"
+
 
 ## Coverage in terminal + XML (uses .coveragerc)
 cov: ## Run coverage with pytest (term + XML)
@@ -560,16 +570,16 @@ devcontainer-bootstrap: ensure-python-proxy ## Install deps + hooks inside dev c
 	@echo "$(GREEN)Devcontainer bootstrap complete$(NC)"
 
 dc-up: ## Start dev container (build + detach)
-	COMPOSE_PROJECT_NAME="$(COMPOSE_PROJECT_NAME)" docker compose -f "$(DEVCONTAINER_COMPOSE)" up -d --build
+	docker compose -f "$(DEVCONTAINER_COMPOSE)" up -d --build
 
 dc-shell: ## Open shell inside dev container
-	COMPOSE_PROJECT_NAME="$(COMPOSE_PROJECT_NAME)" docker compose -f "$(DEVCONTAINER_COMPOSE)" exec devcontainer bash
+	docker compose -f "$(DEVCONTAINER_COMPOSE)" exec devcontainer bash
 
 dc-down: ## Stop dev container
-	COMPOSE_PROJECT_NAME="$(COMPOSE_PROJECT_NAME)" docker compose -f "$(DEVCONTAINER_COMPOSE)" down
+	docker compose -f "$(DEVCONTAINER_COMPOSE)" down
 
 dc-smoke: ## Verify tooling inside dev container
-	COMPOSE_PROJECT_NAME="$(COMPOSE_PROJECT_NAME)" docker compose -f "$(DEVCONTAINER_COMPOSE)" run --rm devcontainer \
+	docker compose -f "$(DEVCONTAINER_COMPOSE)" run --rm devcontainer \
 		bash -lc "python3 --version && node --version && make --version"
 
-.PHONY: all help venv venv-sync setup-automation dev test test-fast validate-min validate-changed cov cov-check cov-html lint fmt fmt-check security pre-commit quick-check auto-push safe-push feature sync-main status clean check-all fix-all ci smoke-auto smoke-8000 smoke-8001 docker-build docker-build-dev docker-run docker-run-dev docker-stop docker-clean docker-logs docker-shell bandit-full diff-cov typecheck verify verify-env openapi frontend-install openapi-check ios-test ios-snapshot ios-appstore-validate ios-appstore-upload ios-appstore-upload-privacy ios-appstore-verify icon-silhouette-lock icon-silhouette-check icon-core-validate design-guard tokens-build tokens-check design-validate design-execute design-verify design-list devcontainer-bootstrap dc-up dc-shell dc-down dc-smoke
+.PHONY: all help venv venv-sync setup-automation dev test test-fast validate-min validate-changed pr-regression-scan cov cov-check cov-html lint fmt fmt-check security pre-commit quick-check auto-push safe-push feature sync-main status clean check-all fix-all ci smoke-auto smoke-8000 smoke-8001 docker-build docker-build-dev docker-run docker-run-dev docker-stop docker-clean docker-logs docker-shell bandit-full diff-cov typecheck verify verify-env openapi frontend-install openapi-check ios-test ios-snapshot ios-appstore-validate ios-appstore-upload ios-appstore-upload-privacy ios-appstore-verify icon-silhouette-lock icon-silhouette-check icon-core-validate design-guard tokens-build tokens-check design-validate design-execute design-verify design-list devcontainer-bootstrap dc-up dc-shell dc-down dc-smoke

--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,12 @@ DEV_PYTHON ?= $(if $(wildcard $(VENV_PYTHON)),$(VENV_PYTHON),python3)
 
 # Dev Container compose settings (worktree-safe project name)
 COMPOSE_PROJECT_NAME_SUFFIX := $(strip $(shell pwd -P | cksum | cut -d' ' -f1))
-ifneq ($(origin COMPOSE_PROJECT_NAME), undefined)
-else ifeq ($(COMPOSE_PROJECT_NAME_SUFFIX),)
+ifeq ($(origin COMPOSE_PROJECT_NAME), undefined)
+ifeq ($(COMPOSE_PROJECT_NAME_SUFFIX),)
   $(error failed to compute stable COMPOSE_PROJECT_NAME suffix; set COMPOSE_PROJECT_NAME explicitly)
 endif
 COMPOSE_PROJECT_NAME ?= pulseplate-$(COMPOSE_PROJECT_NAME_SUFFIX)
+endif
 export COMPOSE_PROJECT_NAME
 DEVCONTAINER_COMPOSE ?= .devcontainer/docker-compose.devcontainer.yml
 

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ validate-changed: ## Run tests inferred from changed Python files
 	@echo "$(GREEN)✅ Diff-based validation completed$(NC)"
 
 pr-regression-scan: ## Run temporary PR regression scan (focused + full/main-suite fallback + current-head check)
-	@bash scripts/ci/pr_regression_scan.sh "$${PR_NUMBER:-}" "$${REPO_NAME:-}"
+	@bash scripts/ci/pr_regression_scan.sh "$${PR_NUMBER:-}" "$${REPO:-$${REPO_NAME:-}}"
 
 
 ## Coverage in terminal + XML (uses .coveragerc)

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ PIP ?= $(VENV_PYTHON) -m pip
 DEV_PYTHON ?= $(if $(wildcard $(VENV_PYTHON)),$(VENV_PYTHON),python3)
 
 # Dev Container compose settings (worktree-safe project name)
-COMPOSE_PROJECT_NAME ?= pulseplate-$(shell basename "$(CURDIR)" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/-$$//')
+COMPOSE_PROJECT_NAME ?= pulseplate
 DEVCONTAINER_COMPOSE ?= .devcontainer/docker-compose.devcontainer.yml
 
 # Цвета для вывода

--- a/docs/review/PR_1664_FIXED_MAPPING.md
+++ b/docs/review/PR_1664_FIXED_MAPPING.md
@@ -9,8 +9,8 @@
 
 Disposition: FIXED
 Commit: see mapping entries below
-Evidence: Makefile:78, tests/test_makefile_dev_python_migration.py:189, scripts/ci/pr_regression_scan.sh:1
+Evidence: Makefile:73, tests/test_makefile_dev_python_migration.py:34-90
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3184251643 -> 0989cb7ac
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223167834 -> 0989cb7ac
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223199248 -> 0989cb7ac
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3184251643 -> 3aba1852f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223167834 -> 3aba1852f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223199248 -> 3aba1852f

--- a/docs/review/PR_1664_FIXED_MAPPING.md
+++ b/docs/review/PR_1664_FIXED_MAPPING.md
@@ -8,8 +8,8 @@
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
-Commit: e19535182
-Evidence: docs/review/PR_1664_FIXED_MAPPING.md lines in Fixed in Commit Mapping section (current HEAD)
+Commit: see mapping entries below
+Evidence: Makefile:74
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3184251643 -> e19535182
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223167834 -> e19535182

--- a/docs/review/PR_1664_FIXED_MAPPING.md
+++ b/docs/review/PR_1664_FIXED_MAPPING.md
@@ -1,0 +1,16 @@
+# PR 1664 - Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: e19535182
+Evidence: docs/review/PR_1664_FIXED_MAPPING.md lines in Fixed in Commit Mapping section (current HEAD)
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3184251643 -> e19535182
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223167834 -> e19535182
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223199248 -> e19535182

--- a/docs/review/PR_1664_FIXED_MAPPING.md
+++ b/docs/review/PR_1664_FIXED_MAPPING.md
@@ -14,3 +14,14 @@ Evidence: Makefile:73, tests/test_makefile_dev_python_migration.py:34-90
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3184251643 -> 3aba1852f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223167834 -> 3aba1852f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223199248 -> 3aba1852f
+
+Disposition: FIXED
+Commit: 1f15132ce
+Evidence: scripts/ci/pr_regression_scan.sh:45, tests/test_makefile_dev_python_migration.py:334, tests/test_pr_regression_scan.py:75
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4225106857 -> 1f15132ce
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3185891116 -> 1f15132ce
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3185891122 -> 1f15132ce
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4225164107 -> 1f15132ce
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3185937509 -> 1f15132ce
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3185937511 -> 1f15132ce

--- a/docs/review/PR_1664_FIXED_MAPPING.md
+++ b/docs/review/PR_1664_FIXED_MAPPING.md
@@ -9,8 +9,8 @@
 
 Disposition: FIXED
 Commit: see mapping entries below
-Evidence: Makefile:74
+Evidence: Makefile:78, tests/test_makefile_dev_python_migration.py:189, scripts/ci/pr_regression_scan.sh:1
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3184251643 -> e19535182
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223167834 -> e19535182
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223199248 -> e19535182
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3184251643 -> 0989cb7ac
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223167834 -> 0989cb7ac
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223199248 -> 0989cb7ac

--- a/docs/review/PR_1664_FIXED_MAPPING.md
+++ b/docs/review/PR_1664_FIXED_MAPPING.md
@@ -16,7 +16,7 @@ Evidence: Makefile:73, tests/test_makefile_dev_python_migration.py:34-90
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223199248 -> 3aba1852f
 
 Disposition: FIXED
-Commit: 1f15132ce
+Commit: see mapping entries below
 Evidence: scripts/ci/pr_regression_scan.sh:45, tests/test_makefile_dev_python_migration.py:334, tests/test_pr_regression_scan.py:75
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4225106857 -> 1f15132ce

--- a/scripts/ci/pr_regression_scan.sh
+++ b/scripts/ci/pr_regression_scan.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 #   scripts/ci/pr_regression_scan.sh [PR_NUMBER] [REPO]
 # Defaults:
 #   PR_NUMBER: from $PR_NUMBER env var
-#   REPO: GITHUB_REPOSITORY or Katsiarynakavaleuskaya/PulsePlate
+#   REPO: CLI arg, REPO env, GITHUB_REPOSITORY, or Katsiarynakavaleuskaya/PulsePlate
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -26,7 +26,7 @@ Usage:
 
 Environment variables:
   PR_NUMBER (default: from arg or environment)
-  GITHUB_REPOSITORY / REPO (default: Katsiarynakavaleuskaya/PulsePlate)
+  REPO (default: from CLI arg, REPO env, GITHUB_REPOSITORY, or Katsiarynakavaleuskaya/PulsePlate)
   SKIP_CURRENT_HEAD_CHECK (default: 0)
   RUN_MAIN_SUITE (default: 1)  # run sharded main-suite baseline
   PYTHON_VERSION (default: 3.13)
@@ -42,7 +42,7 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
 fi
 
 PR_NUMBER="${1:-${PR_NUMBER:-${GH_PR_NUMBER:-}}}"
-REPO="${2:-${GITHUB_REPOSITORY:-Katsiarynakavaleuskaya/PulsePlate}}"
+REPO="${2:-${REPO:-${GITHUB_REPOSITORY:-Katsiarynakavaleuskaya/PulsePlate}}}"
 PYTHON_VERSION="${PYTHON_VERSION:-3.13}"
 RUN_MAIN_SUITE="${RUN_MAIN_SUITE:-1}"
 MAIN_SHARD_COUNT="${MAIN_SHARD_COUNT:-2}"

--- a/scripts/ci/pr_regression_scan.sh
+++ b/scripts/ci/pr_regression_scan.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Temporary PR regression scanner for high-signal, PR-local pre-merge checks.
+# This wrapper intentionally runs:
+# - pre-flight and agent consistency checks
+# - focused local gates (validate-min, validate-changed, pre-commit, lint, typecheck)
+# - optional main-suite sharded fallback scan (close to CI test breadth)
+# - optional current-head PR check parity (requires GH auth)
+# - optional strict merge-readiness check (requires GH auth)
+#
+# Usage:
+#   scripts/ci/pr_regression_scan.sh [PR_NUMBER] [REPO]
+# Defaults:
+#   PR_NUMBER: from $PR_NUMBER env var
+#   REPO: GITHUB_REPOSITORY or Katsiarynakavaleuskaya/PulsePlate
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "$REPO_ROOT"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  pr_regression_scan.sh [PR_NUMBER] [REPO]
+
+Environment variables:
+  PR_NUMBER (default: from arg or environment)
+  GITHUB_REPOSITORY / REPO (default: Katsiarynakavaleuskaya/PulsePlate)
+  SKIP_CURRENT_HEAD_CHECK (default: 0)
+  RUN_MAIN_SUITE (default: 1)  # run sharded main-suite baseline
+  PYTHON_VERSION (default: 3.13)
+  MAIN_SHARD_COUNT (default: 2)
+  MAIN_MAX_PARALLEL (default: 2)
+  CI (if set, passed through for parity compatibility)
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+PR_NUMBER="${1:-${PR_NUMBER:-${GH_PR_NUMBER:-}}}"
+REPO="${2:-${GITHUB_REPOSITORY:-Katsiarynakavaleuskaya/PulsePlate}}"
+PYTHON_VERSION="${PYTHON_VERSION:-3.13}"
+RUN_MAIN_SUITE="${RUN_MAIN_SUITE:-1}"
+MAIN_SHARD_COUNT="${MAIN_SHARD_COUNT:-2}"
+MAIN_MAX_PARALLEL="${MAIN_MAX_PARALLEL:-2}"
+SKIP_CURRENT_HEAD_CHECK="${SKIP_CURRENT_HEAD_CHECK:-0}"
+
+if [[ "${2:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+FAILED=0
+
+run_step() {
+  local name="$1"
+  shift
+  printf '\n=== [START] %s ===\n' "$name"
+  set +e
+  "$@"
+  local status=$?
+  set -e
+  if [[ $status -ne 0 ]]; then
+    printf '[FAIL] %s (exit=%s)\n' "$name" "$status"
+    FAILED=1
+    return 0
+  fi
+  printf '[PASS] %s\n' "$name"
+}
+
+run_step "check_preflight" python3 scripts/orchestration/check_preflight.py
+run_step "check_agent_consistency" python3 scripts/orchestration/check_agent_consistency.py
+run_step "make validate-min" make validate-min
+run_step "make validate-changed" make validate-changed
+run_step "pre-commit run --all-files" pre-commit run --all-files
+run_step "make lint" make lint
+run_step "make typecheck" make typecheck
+
+if [[ "$RUN_MAIN_SUITE" == "1" ]]; then
+  run_step "scripts/ci/run_main_test_shards.py" \
+    python3 scripts/ci/run_main_test_shards.py \
+      --python-version "${PYTHON_VERSION}" \
+      --shard-count "${MAIN_SHARD_COUNT}" \
+      --max-parallel "${MAIN_MAX_PARALLEL}"
+else
+  echo "[SKIP] scripts/ci/run_main_test_shards.py (RUN_MAIN_SUITE=${RUN_MAIN_SUITE})"
+fi
+
+if [[ "$SKIP_CURRENT_HEAD_CHECK" != "1" ]]; then
+  if [[ -n "${GH_TOKEN:-}" || -n "${GITHUB_TOKEN:-}" ]]; then
+    if [[ -n "${PR_NUMBER:-}" ]]; then
+      run_step "scripts/ci/check_current_head_pr_checks.py" \
+        python3 scripts/ci/check_current_head_pr_checks.py \
+          --pr-number "${PR_NUMBER}" \
+          --repo "${REPO}"
+    else
+      echo "[SKIP] scripts/ci/check_current_head_pr_checks.py (PR number not provided)"
+    fi
+  else
+    echo "[SKIP] scripts/ci/check_current_head_pr_checks.py (GH_TOKEN / GITHUB_TOKEN not set)"
+  fi
+else
+  echo "[SKIP] scripts/ci/check_current_head_pr_checks.py (SKIP_CURRENT_HEAD_CHECK=${SKIP_CURRENT_HEAD_CHECK})"
+fi
+
+if [[ -n "${GH_TOKEN:-}" || -n "${GITHUB_TOKEN:-}" ]]; then
+  if [[ -n "${PR_NUMBER:-}" ]]; then
+    run_step "scripts/ci/check_merge_ready.py" \
+        python3 scripts/orchestration/check_merge_ready.py \
+        --require-auth \
+        --pr-number "${PR_NUMBER}" \
+        --repo "${REPO}"
+  else
+    echo "[SKIP] scripts/ci/check_merge_ready.py (PR number not provided)"
+  fi
+else
+  echo "[SKIP] scripts/ci/check_merge_ready.py (GH_TOKEN / GITHUB_TOKEN not set)"
+fi
+
+if [[ $FAILED -ne 0 ]]; then
+  printf "\nRegression scan summary: failed"
+  echo "Run output above contains details for each step."
+  exit 1
+fi
+
+printf "\nRegression scan summary: passed"

--- a/tests/test_makefile_dev_python_migration.py
+++ b/tests/test_makefile_dev_python_migration.py
@@ -11,7 +11,11 @@ Ensures that:
 from __future__ import annotations
 
 import re
+import subprocess
+import os
+from shutil import which
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MAKEFILE = REPO_ROOT / "Makefile"
@@ -19,6 +23,38 @@ MAKEFILE = REPO_ROOT / "Makefile"
 
 def _makefile_text() -> str:
     return MAKEFILE.read_text(encoding="utf-8")
+
+
+def _make_binary(name: str) -> str:
+    binary = which(name)
+    assert binary is not None, f"Required executable '{name}' must be on PATH"
+    return binary
+
+
+def _make_compose_project_name(cwd: Path) -> str:
+    """Evaluate COMPOSE_PROJECT_NAME in a temporary make invocation from a worktree."""
+    make_binary = _make_binary("make")
+    with TemporaryDirectory() as probe_dir:
+        probe_makefile = Path(probe_dir) / "probe.mk"
+        probe_makefile.write_text(
+            f"""include {MAKEFILE}\n\n.PHONY: print-compose\nprint-compose:\n\t@printf '%s\\n' \"$(COMPOSE_PROJECT_NAME)\"\n""",
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            [
+                make_binary,
+                "-s",
+                "-f",
+                str(probe_makefile),
+                "-C",
+                str(cwd),
+                "print-compose",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    return result.stdout.strip()
 
 
 # ---------------------------------------------------------------------------
@@ -153,3 +189,130 @@ def test_openapi_target_uses_dev_python() -> None:
 
     body = match.group("body")
     assert "$(DEV_PYTHON)" in body, "openapi target must use DEV_PYTHON"
+
+
+def test_compose_project_name_is_safe_and_deterministic() -> None:
+    """Dev-container project names must use safe shell eval + deterministic worktree uniqueness."""
+    text = _makefile_text()
+
+    assert (
+        "COMPOSE_PROJECT_NAME_SUFFIX" in text
+    ), "Makefile should define COMPOSE_PROJECT_NAME_SUFFIX"
+    pattern = re.compile(r"^COMPOSE_PROJECT_NAME\s+\?=\s*(.+)$", re.MULTILINE)
+    match = pattern.search(text)
+    assert match, "COMPOSE_PROJECT_NAME must be defined"
+
+    assignment = match.group(1)
+    assert (
+        "COMPOSE_PROJECT_NAME_SUFFIX" in assignment
+    ), "COMPOSE_PROJECT_NAME default must use suffix helper variable"
+    assert "$(CURDIR)" not in assignment, "COMPOSE_PROJECT_NAME must not interpolate CURDIR"
+    assert re.fullmatch(
+        r"pulseplate-\$\((?:(?!\)).)*COMPOSE_PROJECT_NAME_SUFFIX(?:(?!\)).)*\)", assignment
+    ), "COMPOSE_PROJECT_NAME default must be derived from COMPOSE_PROJECT_NAME_SUFFIX"
+    assert assignment != "pulseplate", "COMPOSE_PROJECT_NAME must not be globally static"
+
+
+def test_compose_project_name_default_override_semantics() -> None:
+    """Preserve Make override semantics for COMPOSE_PROJECT_NAME."""
+    text = _makefile_text()
+    match = re.search(r"^COMPOSE_PROJECT_NAME\s+\?=", text, re.MULTILINE)
+    assert match is not None, "COMPOSE_PROJECT_NAME must use conditional assignment"
+    assert (
+        match.group(0).strip().startswith("COMPOSE_PROJECT_NAME ?=")
+    ), "Makefile must use '?=' assignment for environment override support"
+
+
+def test_devcontainer_dc_targets_are_intact() -> None:
+    """Devcontainer targets must still pass compose project name by environment."""
+    text = _makefile_text()
+    assert "export COMPOSE_PROJECT_NAME" in text
+
+    for target_name, expected_fragment in [
+        (
+            "dc-up",
+            'docker compose -f "$(DEVCONTAINER_COMPOSE)" up -d --build',
+        ),
+        (
+            "dc-shell",
+            'docker compose -f "$(DEVCONTAINER_COMPOSE)" exec devcontainer bash',
+        ),
+        (
+            "dc-down",
+            'docker compose -f "$(DEVCONTAINER_COMPOSE)" down',
+        ),
+        (
+            "dc-smoke",
+            'docker compose -f "$(DEVCONTAINER_COMPOSE)" run --rm devcontainer',
+        ),
+    ]:
+        assert (
+            expected_fragment in text
+        ), f"{target_name} must remain intact and forward COMPOSE_PROJECT_NAME"
+
+
+def test_compose_project_name_varies_between_worktrees() -> None:
+    """Different worktrees should evaluate to different compose project names."""
+    with TemporaryDirectory() as first_dir, TemporaryDirectory() as second_dir:
+        first = _make_compose_project_name(Path(first_dir))
+        second = _make_compose_project_name(Path(second_dir))
+
+        assert first != second
+        assert re.fullmatch(r"pulseplate-[0-9]+", first) is not None
+        assert re.fullmatch(r"pulseplate-[0-9]+", second) is not None
+
+
+def test_compose_project_name_stable_per_worktree() -> None:
+    """A single worktree should keep the same deterministic project name across runs."""
+    with TemporaryDirectory() as worktree:
+        name_one = _make_compose_project_name(Path(worktree))
+        name_two = _make_compose_project_name(Path(worktree))
+        assert name_one == name_two
+
+
+def test_compose_project_name_safe_with_special_directory_chars() -> None:
+    """Special directory characters must not alter command-evaluation semantics."""
+    with TemporaryDirectory() as root:
+        worktree = Path(root) / "sp ec;ial $() `chars` dir"
+        worktree.mkdir(parents=True, exist_ok=True)
+        value = _make_compose_project_name(worktree)
+        assert re.fullmatch(r"pulseplate-[0-9]+", value) is not None
+
+
+def test_compose_project_name_does_not_execute_path_text() -> None:
+    """A malicious-looking directory name should not execute shell payloads."""
+    with TemporaryDirectory() as root:
+        root_path = Path(root)
+        injection_marker = root_path / "injection_marker"
+        worktree = root_path / f"pwn_$(touch {injection_marker.name})"
+        worktree.mkdir(parents=True, exist_ok=True)
+        value = _make_compose_project_name(worktree)
+        assert re.fullmatch(r"pulseplate-[0-9]+", value) is not None
+        assert not injection_marker.exists()
+
+
+def test_dc_targets_dont_execute_injected_override() -> None:
+    """User overrides for COMPOSE_PROJECT_NAME must remain data, never shell code."""
+    make_binary = _make_binary("make")
+    with TemporaryDirectory() as root:
+        root_path = Path(root)
+        marker = root_path / "injection_marker"
+        env = os.environ.copy()
+        env["COMPOSE_PROJECT_NAME"] = f"pwn_$(touch {marker})"
+
+        result = subprocess.run(
+            [
+                make_binary,
+                "-s",
+                "-n",
+                "-C",
+                str(REPO_ROOT),
+                "dc-up",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        assert "touch" not in result.stdout

--- a/tests/test_makefile_dev_python_migration.py
+++ b/tests/test_makefile_dev_python_migration.py
@@ -231,6 +231,17 @@ def test_compose_project_name_is_safe_and_deterministic() -> None:
     assert (
         "COMPOSE_PROJECT_NAME_SUFFIX" in text
     ), "Makefile should define COMPOSE_PROJECT_NAME_SUFFIX"
+    suffix_match = re.search(
+        r"^COMPOSE_PROJECT_NAME_SUFFIX\s*:=\s*\$\(strip \$\(shell (?P<body>.+)\)\)$",
+        text,
+        re.MULTILINE,
+    )
+    assert suffix_match, "Makefile should define COMPOSE_PROJECT_NAME_SUFFIX via shell"
+    suffix_body = suffix_match.group("body")
+    assert suffix_body == "pwd -P | cksum | cut -d' ' -f1"
+    assert "$(CURDIR)" not in suffix_body
+    assert "basename" not in suffix_body
+
     pattern = re.compile(r"^COMPOSE_PROJECT_NAME\s+\?=\s*(.+)$", re.MULTILINE)
     match = pattern.search(text)
     assert match, "COMPOSE_PROJECT_NAME must be defined"
@@ -323,12 +334,19 @@ def test_compose_project_name_does_not_execute_path_text() -> None:
     """A malicious-looking directory name should not execute shell payloads."""
     with TemporaryDirectory() as root:
         root_path = Path(root)
-        injection_marker = root_path / "injection_marker"
-        worktree = root_path / f"pwn_$(touch {injection_marker.name})"
+        payload_name = "injection_marker"
+        worktree = root_path / f"pwn_$(touch {payload_name})"
         worktree.mkdir(parents=True, exist_ok=True)
+        injection_marker = worktree / payload_name
         value = _make_compose_project_name(worktree)
         assert re.fullmatch(r"pulseplate-[0-9]+", value) is not None
         assert not injection_marker.exists()
+
+
+def test_pr_regression_scan_make_target_forwards_repo_env() -> None:
+    """Make wrapper should forward the documented REPO env contract."""
+    text = _makefile_text()
+    assert '"$${REPO:-$${REPO_NAME:-}}"' in text
 
 
 def test_dc_targets_dont_execute_injected_override() -> None:

--- a/tests/test_makefile_dev_python_migration.py
+++ b/tests/test_makefile_dev_python_migration.py
@@ -53,7 +53,11 @@ def _expected_compose_project_name(cwd: Path) -> str:
     return f"pulseplate-{result.stdout.strip()}"
 
 
-def _make_compose_project_name(cwd: Path) -> str:
+def _make_compose_project_name(
+    cwd: Path,
+    *,
+    compose_project_name: str | None = None,
+) -> str:
     """Evaluate COMPOSE_PROJECT_NAME in a temporary make invocation from a worktree."""
     make_binary = _make_binary("make")
     probe_makefile = cwd / "probe.mk"
@@ -72,6 +76,10 @@ def _make_compose_project_name(cwd: Path) -> str:
         ),
         encoding="utf-8",
     )
+    env = _clean_make_env()
+    if compose_project_name is not None:
+        env["COMPOSE_PROJECT_NAME"] = compose_project_name
+
     result = subprocess.run(
         [
             make_binary,
@@ -85,8 +93,43 @@ def _make_compose_project_name(cwd: Path) -> str:
         capture_output=True,
         text=True,
         check=True,
-        env=_clean_make_env(),
+        env=env,
     )
+    return result.stdout.strip()
+
+
+def _make_compose_project_name_from_repo_root() -> str:
+    """Evaluate COMPOSE_PROJECT_NAME from the real repo root without writing there."""
+    make_binary = _make_binary("make")
+    with TemporaryDirectory() as probe_dir:
+        probe_makefile = Path(probe_dir) / "probe.mk"
+        probe_makefile.write_text(
+            "\n".join(
+                [
+                    f"include {MAKEFILE}",
+                    "",
+                    ".PHONY: print-compose",
+                    "print-compose:",
+                    "\t@printf '%s\\n' \"$(COMPOSE_PROJECT_NAME)\"",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            [
+                make_binary,
+                "-s",
+                "-f",
+                str(probe_makefile),
+                "-C",
+                str(REPO_ROOT),
+                "print-compose",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=_clean_make_env(),
+        )
     return result.stdout.strip()
 
 
@@ -313,12 +356,46 @@ def test_compose_project_name_varies_between_worktrees() -> None:
         assert expected_first != expected_second
 
 
+def test_compose_project_name_varies_between_sibling_worktrees() -> None:
+    """Sibling worktrees should not collide in Docker Compose project naming."""
+    with TemporaryDirectory() as root:
+        first_worktree = Path(root) / "checkout-a"
+        second_worktree = Path(root) / "checkout-b"
+        first_worktree.mkdir()
+        second_worktree.mkdir()
+
+        first = _make_compose_project_name(first_worktree)
+        second = _make_compose_project_name(second_worktree)
+
+        assert re.fullmatch(r"pulseplate-[0-9]+", first) is not None
+        assert re.fullmatch(r"pulseplate-[0-9]+", second) is not None
+        assert first != second
+
+
+def test_compose_project_name_works_from_repo_root_checkout() -> None:
+    """The actual repo root checkout should evaluate to the same safe slug shape."""
+    value = _make_compose_project_name_from_repo_root()
+
+    assert value == _expected_compose_project_name(REPO_ROOT)
+    assert re.fullmatch(r"pulseplate-[0-9]+", value) is not None
+
+
 def test_compose_project_name_stable_per_worktree() -> None:
     """A single worktree should keep the same deterministic project name across runs."""
     with TemporaryDirectory() as worktree:
         name_one = _make_compose_project_name(Path(worktree))
         name_two = _make_compose_project_name(Path(worktree))
         assert name_one == name_two
+
+
+def test_compose_project_name_env_override_wins_for_exported_shell_env() -> None:
+    """A pre-exported project name should bypass the default worktree slug."""
+    with TemporaryDirectory() as worktree:
+        name = _make_compose_project_name(
+            Path(worktree),
+            compose_project_name="custom",
+        )
+        assert name == "custom"
 
 
 def test_compose_project_name_safe_with_special_directory_chars() -> None:

--- a/tests/test_makefile_dev_python_migration.py
+++ b/tests/test_makefile_dev_python_migration.py
@@ -31,29 +31,62 @@ def _make_binary(name: str) -> str:
     return binary
 
 
+def _clean_make_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("COMPOSE_PROJECT_NAME", None)
+    env.pop("COMPOSE_PROJECT_NAME_SUFFIX", None)
+    return env
+
+
+def _expected_compose_project_name(cwd: Path) -> str:
+    """Compute the Makefile's default compose project name formula for a worktree."""
+    shell = _make_binary("sh")
+    result = subprocess.run(
+        ["sh", "-lc", "pwd -P | cksum | cut -d' ' -f1"],
+        executable=shell,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+        env=_clean_make_env(),
+    )
+    return f"pulseplate-{result.stdout.strip()}"
+
+
 def _make_compose_project_name(cwd: Path) -> str:
     """Evaluate COMPOSE_PROJECT_NAME in a temporary make invocation from a worktree."""
     make_binary = _make_binary("make")
-    with TemporaryDirectory() as probe_dir:
-        probe_makefile = Path(probe_dir) / "probe.mk"
-        probe_makefile.write_text(
-            f"""include {MAKEFILE}\n\n.PHONY: print-compose\nprint-compose:\n\t@printf '%s\\n' \"$(COMPOSE_PROJECT_NAME)\"\n""",
-            encoding="utf-8",
-        )
-        result = subprocess.run(
+    probe_makefile = cwd / "probe.mk"
+    worktree_makefile = cwd / "Makefile"
+    if not worktree_makefile.exists():
+        worktree_makefile.symlink_to(MAKEFILE)
+    probe_makefile.write_text(
+        "\n".join(
             [
-                make_binary,
-                "-s",
-                "-f",
-                str(probe_makefile),
-                "-C",
-                str(cwd),
-                "print-compose",
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+                "include Makefile",
+                "",
+                ".PHONY: print-compose",
+                "print-compose:",
+                "\t@printf '%s\\n' \"$(COMPOSE_PROJECT_NAME)\"",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [
+            make_binary,
+            "-s",
+            "-f",
+            str(probe_makefile),
+            "-C",
+            str(cwd),
+            "print-compose",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=_clean_make_env(),
+    )
     return result.stdout.strip()
 
 
@@ -254,12 +287,19 @@ def test_devcontainer_dc_targets_are_intact() -> None:
 def test_compose_project_name_varies_between_worktrees() -> None:
     """Different worktrees should evaluate to different compose project names."""
     with TemporaryDirectory() as first_dir, TemporaryDirectory() as second_dir:
-        first = _make_compose_project_name(Path(first_dir))
-        second = _make_compose_project_name(Path(second_dir))
+        first_worktree = Path(first_dir)
+        second_worktree = Path(second_dir)
 
-        assert first != second
+        first = _make_compose_project_name(first_worktree)
+        second = _make_compose_project_name(second_worktree)
+        expected_first = _expected_compose_project_name(first_worktree)
+        expected_second = _expected_compose_project_name(second_worktree)
+
+        assert first == expected_first
+        assert second == expected_second
         assert re.fullmatch(r"pulseplate-[0-9]+", first) is not None
         assert re.fullmatch(r"pulseplate-[0-9]+", second) is not None
+        assert expected_first != expected_second
 
 
 def test_compose_project_name_stable_per_worktree() -> None:

--- a/tests/test_pr_regression_scan.py
+++ b/tests/test_pr_regression_scan.py
@@ -1,0 +1,204 @@
+"""Focused tests for the temporary PR regression scanner wrapper."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from shutil import which
+from tempfile import TemporaryDirectory
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAN_SCRIPT = REPO_ROOT / "scripts" / "ci" / "pr_regression_scan.sh"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_scan_with_stubbed_tools(
+    *,
+    args: list[str],
+    repo_env: str | None = None,
+    github_repository: str | None = None,
+) -> str:
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        log_path = tmp_path / "calls.log"
+
+        _write_executable(
+            tmp_path / "python3",
+            "\n".join(
+                [
+                    "#!/bin/bash",
+                    'printf "python3 %s\\n" "$*" >> "$PR_SCAN_TEST_LOG"',
+                    "exit 0",
+                ]
+            ),
+        )
+        _write_executable(
+            tmp_path / "make",
+            "\n".join(
+                [
+                    "#!/bin/bash",
+                    'printf "make %s\\n" "$*" >> "$PR_SCAN_TEST_LOG"',
+                    "exit 0",
+                ]
+            ),
+        )
+        _write_executable(
+            tmp_path / "pre-commit",
+            "\n".join(
+                [
+                    "#!/bin/bash",
+                    'printf "pre-commit %s\\n" "$*" >> "$PR_SCAN_TEST_LOG"',
+                    "exit 0",
+                ]
+            ),
+        )
+
+        env = os.environ.copy()
+        env["PATH"] = f"{tmp_path}{os.pathsep}{env['PATH']}"
+        env["PR_SCAN_TEST_LOG"] = str(log_path)
+        env["GH_TOKEN"] = "dummy-token"
+        env["RUN_MAIN_SUITE"] = "0"
+        if repo_env is None:
+            env.pop("REPO", None)
+        else:
+            env["REPO"] = repo_env
+        if github_repository is None:
+            env.pop("GITHUB_REPOSITORY", None)
+        else:
+            env["GITHUB_REPOSITORY"] = github_repository
+
+        subprocess.run(
+            ["bash", str(SCAN_SCRIPT), *args],
+            cwd=REPO_ROOT,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return log_path.read_text(encoding="utf-8")
+
+
+def test_pr_regression_scan_honors_repo_env_override() -> None:
+    """REPO env should feed GitHub current-head and merge-readiness checks."""
+    calls = _run_scan_with_stubbed_tools(repo_env="custom/Repo", args=["1664"])
+
+    assert (
+        "python3 scripts/ci/check_current_head_pr_checks.py " "--pr-number 1664 --repo custom/Repo"
+    ) in calls
+    assert (
+        "python3 scripts/orchestration/check_merge_ready.py "
+        "--require-auth --pr-number 1664 --repo custom/Repo"
+    ) in calls
+
+
+def test_pr_regression_scan_cli_repo_arg_overrides_repo_env() -> None:
+    """Explicit CLI repo argument should have highest precedence."""
+    calls = _run_scan_with_stubbed_tools(
+        repo_env="env/Repo",
+        args=["1664", "cli/Repo"],
+    )
+
+    assert "--repo cli/Repo" in calls
+    assert "--repo env/Repo" not in calls
+
+
+def test_pr_regression_scan_uses_github_repository_fallback() -> None:
+    """GITHUB_REPOSITORY should be used when CLI and REPO env are absent."""
+    calls = _run_scan_with_stubbed_tools(
+        args=["1664"],
+        github_repository="github/Repo",
+    )
+
+    assert "--repo github/Repo" in calls
+
+
+def test_pr_regression_scan_uses_default_repo_fallback() -> None:
+    """Hardcoded repo fallback should remain explicit and deterministic."""
+    calls = _run_scan_with_stubbed_tools(args=["1664"])
+
+    assert "--repo Katsiarynakavaleuskaya/PulsePlate" in calls
+
+
+def test_make_pr_regression_scan_forwards_repo_before_repo_name() -> None:
+    """Make wrapper should pass REPO before legacy REPO_NAME fallback."""
+    make_binary = which("make")
+    assert make_binary is not None, "Required executable 'make' must be on PATH"
+
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        log_path = tmp_path / "bash.log"
+        _write_executable(
+            tmp_path / "bash",
+            "\n".join(
+                [
+                    "#!/bin/bash",
+                    'printf "%s\\n" "$*" >> "$PR_SCAN_TEST_LOG"',
+                    "exit 0",
+                ]
+            ),
+        )
+
+        env = os.environ.copy()
+        env["PATH"] = f"{tmp_path}{os.pathsep}{env['PATH']}"
+        env["PR_SCAN_TEST_LOG"] = str(log_path)
+        env["PR_NUMBER"] = "1664"
+        env["REPO"] = "repo/Env"
+        env["REPO_NAME"] = "legacy/RepoName"
+
+        subprocess.run(
+            [make_binary, "-s", "-C", str(REPO_ROOT), "pr-regression-scan"],
+            cwd=REPO_ROOT,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        assert "scripts/ci/pr_regression_scan.sh 1664 repo/Env" in log_path.read_text(
+            encoding="utf-8"
+        )
+
+
+def test_make_pr_regression_scan_preserves_repo_name_fallback() -> None:
+    """Legacy REPO_NAME should still work when REPO is unset."""
+    make_binary = which("make")
+    assert make_binary is not None, "Required executable 'make' must be on PATH"
+
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        log_path = tmp_path / "bash.log"
+        _write_executable(
+            tmp_path / "bash",
+            "\n".join(
+                [
+                    "#!/bin/bash",
+                    'printf "%s\\n" "$*" >> "$PR_SCAN_TEST_LOG"',
+                    "exit 0",
+                ]
+            ),
+        )
+
+        env = os.environ.copy()
+        env["PATH"] = f"{tmp_path}{os.pathsep}{env['PATH']}"
+        env["PR_SCAN_TEST_LOG"] = str(log_path)
+        env["PR_NUMBER"] = "1664"
+        env.pop("REPO", None)
+        env["REPO_NAME"] = "legacy/RepoName"
+
+        subprocess.run(
+            [make_binary, "-s", "-C", str(REPO_ROOT), "pr-regression-scan"],
+            cwd=REPO_ROOT,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        assert "scripts/ci/pr_regression_scan.sh 1664 legacy/RepoName" in log_path.read_text(
+            encoding="utf-8"
+        )

--- a/tests/test_pr_regression_scan.py
+++ b/tests/test_pr_regression_scan.py
@@ -63,6 +63,7 @@ def _run_scan_with_stubbed_tools(
         env["PR_SCAN_TEST_LOG"] = str(log_path)
         env["GH_TOKEN"] = "dummy-token"
         env["RUN_MAIN_SUITE"] = "0"
+        env["SKIP_CURRENT_HEAD_CHECK"] = "0"
         if repo_env is None:
             env.pop("REPO", None)
         else:


### PR DESCRIPTION
### Motivation
- Remove a local command-injection vector in the Makefile where `COMPOSE_PROJECT_NAME` was computed via `$(shell basename "$(CURDIR)" | ...)`, which allowed shell command substitution from a malicious worktree path during Make evaluation.

### Description
- Replace the shell-derived slug with a deterministic, per-checkout safe default by changing the Makefile line to `COMPOSE_PROJECT_NAME ?= pulseplate-$(shell pwd -P | cksum | cut -d' ' -f1)`, preserving existing devcontainer targets and allowing overrides via environment/CLI.

### Testing
- Local validation completed with an active virtualenv:
  - `pre-commit run --all-files`
  - `make validate-changed`
  - `.venv/bin/python -m pytest tests/test_makefile_dev_python_migration.py`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8fb6ed6ac8333860c92089d51914d)

## Summary by Sourcery

Исправления ошибок:
- Удалён вектор внедрения команд за счёт отказа от вычисления `COMPOSE_PROJECT_NAME` на основе оцениваемого оболочкой пути рабочей директории в `Makefile`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove a command-injection vector by no longer computing COMPOSE_PROJECT_NAME from a shell-evaluated worktree path in the Makefile.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix a command-injection in the Makefile by deriving `COMPOSE_PROJECT_NAME` from `pwd -P | cksum`, exporting it, and removing inline var passing in devcontainer targets. This blocks path-based execution, keeps per-checkout isolation, and preserves env/CLI overrides; added guardrails and tests for edge cases.

- New Features
  - Added `pr-regression-scan` target and `scripts/ci/pr_regression_scan.sh` for focused local checks with optional sharded main suite, current-head parity, and merge-readiness.
  - Set repo precedence for the scanner: CLI arg > `REPO` env > `GITHUB_REPOSITORY` > default; Make target forwards `REPO` with `REPO_NAME` fallback. Tests cover this.

<sup>Written for commit 9ae291b9f6ee3550c3ccd2f5b597f4d2900d416b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Compose project name is now computed deterministically per workspace, exported, and used by dev-container targets.
* **New Features**
  * Added a PR regression scan utility with optional PR/repo inputs, gated checks, and a Make target to run it.
* **Tests**
  * Expanded tests for deterministic/safe compose naming, dev-target forwarding, and the regression-scan wrapper behavior.
* **Documentation**
  * Added a review record documenting mapping and resolutions for a prior PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] New Cubic and CodeRabbit actionables mapped after fix commit

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3184251643 -> 3aba1852f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223167834 -> 3aba1852f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4223199248 -> 3aba1852f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4225106857 -> 1f15132ce
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3185891116 -> 1f15132ce
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3185891122 -> 1f15132ce
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#pullrequestreview-4225164107 -> 1f15132ce
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3185937509 -> 1f15132ce
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1664#discussion_r3185937511 -> 1f15132ce

## Merge Readiness
- [x] Coordinator + task bootstrap: run and packet created (`7d86e76510a7`).
- [x] Required role order used: `agent-coordinator` -> `architecture-specialist` -> `security-auditor` -> `dev-operator` / `qa-engineer-agent` -> `bug-hunter` -> `pulseplate-premortem-risk-review`.
- [x] Local focused tests passed: `.venv/bin/python -m pytest -q tests/test_makefile_dev_python_migration.py tests/test_pr_regression_scan.py` (25 passed, including premortem edge cases for repo-root checkout, sibling worktree uniqueness, pre-exported `COMPOSE_PROJECT_NAME`, and scanner env isolation).
- [x] Local narrow gates passed: `make validate-changed`, `pre-commit run --all-files`.
- [x] Regression scanner passed in CPU-safe mode: `RUN_MAIN_SUITE=0 SKIP_CURRENT_HEAD_CHECK=1 scripts/ci/pr_regression_scan.sh 1664`.
- [x] Full local `make verify` operator-deferred as machine-heavy after prior local hang around 82%; current-head GitHub CI parity used as the heavy signal.
- [x] Premortem risk review completed: decision `proceed with changes`; code changes added for repo-root checkout evaluation, sibling worktree uniqueness, pre-exported `COMPOSE_PROJECT_NAME`, and scanner env isolation before readiness.
- [x] Final pushed head verified: `9ae291b9f` (premortem code fixes pushed after `61c8a2d80`).
- [x] Current-head CI parity passed: `gh pr checks 1664 --watch=false`.
- [x] Strict merge-governance passed: `GH_TOKEN=$(gh auth token) GITHUB_TOKEN=$(gh auth token) python3 scripts/orchestration/check_merge_ready.py --require-auth --pr-number 1664 --repo Katsiarynakavaleuskaya/PulsePlate`.

## Deferred / Follow-ups
- No new follow-ups for this hotfix.

