### PR TITLE
fix(security): prevent symlink traversal in judgment validity sidecar

### DIFF
--- a/docs/review/PR_1666_FIXED_MAPPING.md
+++ b/docs/review/PR_1666_FIXED_MAPPING.md
@@ -20,7 +20,6 @@
 Disposition: FIXED
 Commit: 13b837d6dd0903bd628c1cdde848bec5a7c2245c
 Evidence: `_safe_write_text()` now fails closed when `os.O_NOFOLLOW` is unavailable; sidecar symlink tests cover both items/report targets and assert the outside target remains unchanged. Focused pytest passed with `28 passed`.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#discussion_r3184241197 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#discussion_r3184257890 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#pullrequestreview-4223185713 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c
@@ -28,7 +27,7 @@ Evidence: `_safe_write_text()` now fails closed when `os.O_NOFOLLOW` is unavaila
 
 Disposition: NOT-A-BUG
 Evidence: Non-actionable service/rate-limit or coverage summary comments; no code change requested.
-
+Reason: These comments report review quota, generated summaries, or Codecov coverage status rather than actionable code defects.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#issuecomment-4374159015
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#issuecomment-4374159985
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#issuecomment-4374195204

--- a/docs/review/PR_1666_FIXED_MAPPING.md
+++ b/docs/review/PR_1666_FIXED_MAPPING.md
@@ -1,0 +1,45 @@
+# PR #1666 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Reviewed current actionable CodeRabbit, Cubic, Sourcery, Codex, and coverage comments for PR #1666.
+- [x] Fixed valid security/test findings before mapping them.
+- [x] Kept scope limited to judgment-validity sidecar write safety, focused tests, and governance.
+
+## Review Evidence
+
+- PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666
+- Fix commit: `13b837d6dd0903bd628c1cdde848bec5a7c2245c`
+- Focused test: `.venv/bin/python -m pytest -q tests/evals/test_judgment_validity_sidecar.py` -> `28 passed`
+- Local full `make verify`: deferred by operator-approved machine-heavy exception; full-suite parity is expected from GitHub sharded CI after push.
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: `13b837d6dd0903bd628c1cdde848bec5a7c2245c`
+Evidence: `_safe_write_text()` now fails closed when `os.O_NOFOLLOW` is unavailable; sidecar symlink tests cover both items/report targets and assert the outside target remains unchanged. Focused pytest passed with `28 passed`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#discussion_r3184241197 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#discussion_r3184257890 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c
+
+Disposition: NOT-A-BUG
+Evidence: Non-actionable service/rate-limit or coverage summary comments; no code change requested.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#issuecomment-4374159015
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#issuecomment-4374159985
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#issuecomment-4374195204
+
+## Merge Readiness
+
+- [x] Coordinator-first startup: `check_preflight.py`, `check_agent_consistency.py`, and `task_bootstrap.py` ran before edits.
+- [x] Focused sidecar tests passed locally.
+- [x] `pre-commit run --all-files`
+- [x] `make validate-changed`
+- [ ] PR body Phase2 gates.
+- [ ] Strict merge-readiness wrapper with auth.
+- [ ] Current-head GitHub CI parity after push.
+- [ ] CodeRabbit, Cubic, and Sourcery have no actionable open comments.
+
+## Deferred / Follow-ups
+
+- Full local `make verify` is intentionally deferred for this PR by operator instruction because full-suite execution is sharded on GitHub and can overload the local machine. Required substitute: focused local tests, `pre-commit run --all-files`, `make validate-changed`, current-head GitHub CI parity, and strict merge-readiness wrapper.

--- a/docs/review/PR_1666_FIXED_MAPPING.md
+++ b/docs/review/PR_1666_FIXED_MAPPING.md
@@ -25,6 +25,13 @@ Evidence: `_safe_write_text()` now fails closed when `os.O_NOFOLLOW` is unavaila
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#pullrequestreview-4223185713 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#pullrequestreview-4223206641 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c
 
+Disposition: FIXED
+Commit: a07f74c03e8ccc4bb83934c0d2539409b53f93a4
+Evidence: Merge-readiness checkboxes in this artifact remain unchecked until the final merge cycle; the gate label now uses `Phase 2`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#discussion_r3188473577 -> a07f74c03e8ccc4bb83934c0d2539409b53f93a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#discussion_r3188473596 -> a07f74c03e8ccc4bb83934c0d2539409b53f93a4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#pullrequestreview-4228033431 -> a07f74c03e8ccc4bb83934c0d2539409b53f93a4
+
 Disposition: NOT-A-BUG
 Evidence: Non-actionable service/rate-limit or coverage summary comments; no code change requested.
 Reason: These comments report review quota, generated summaries, or Codecov coverage status rather than actionable code defects.

--- a/docs/review/PR_1666_FIXED_MAPPING.md
+++ b/docs/review/PR_1666_FIXED_MAPPING.md
@@ -34,11 +34,11 @@ Reason: These comments report review quota, generated summaries, or Codecov cove
 
 ## Merge Readiness
 
-- [x] Coordinator-first startup: `check_preflight.py`, `check_agent_consistency.py`, and `task_bootstrap.py` ran before edits.
-- [x] Focused sidecar tests passed locally.
-- [x] `pre-commit run --all-files`
-- [x] `make validate-changed`
-- [ ] PR body Phase2 gates.
+- [ ] Coordinator-first startup: `check_preflight.py`, `check_agent_consistency.py`, and `task_bootstrap.py` ran before edits.
+- [ ] Focused sidecar tests passed locally.
+- [ ] `pre-commit run --all-files`
+- [ ] `make validate-changed`
+- [ ] PR body Phase 2 gates.
 - [ ] Strict merge-readiness wrapper with auth.
 - [ ] Current-head GitHub CI parity after push.
 - [ ] CodeRabbit, Cubic, and Sourcery have no actionable open comments.

--- a/docs/review/PR_1666_FIXED_MAPPING.md
+++ b/docs/review/PR_1666_FIXED_MAPPING.md
@@ -5,6 +5,8 @@
 - [x] Reviewed current actionable CodeRabbit, Cubic, Sourcery, Codex, and coverage comments for PR #1666.
 - [x] Fixed valid security/test findings before mapping them.
 - [x] Kept scope limited to judgment-validity sidecar write safety, focused tests, and governance.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Review Evidence
 
@@ -16,11 +18,13 @@
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
-Commit: `13b837d6dd0903bd628c1cdde848bec5a7c2245c`
+Commit: 13b837d6dd0903bd628c1cdde848bec5a7c2245c
 Evidence: `_safe_write_text()` now fails closed when `os.O_NOFOLLOW` is unavailable; sidecar symlink tests cover both items/report targets and assert the outside target remains unchanged. Focused pytest passed with `28 passed`.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#discussion_r3184241197 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#discussion_r3184257890 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#pullrequestreview-4223185713 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#pullrequestreview-4223206641 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c
 
 Disposition: NOT-A-BUG
 Evidence: Non-actionable service/rate-limit or coverage summary comments; no code change requested.

--- a/scripts/evals/judgment_validity.py
+++ b/scripts/evals/judgment_validity.py
@@ -65,9 +65,11 @@ JUDGMENT_VALIDITY_REPORT_FILENAME = "judgment_validity_report.json"
 
 def _safe_write_text(path: Path, content: str) -> None:
     """Write text without following symlinks."""
+    no_follow = getattr(os, "O_NOFOLLOW", None)
+    if no_follow is None:
+        raise OSError("Symlink-safe writes are not supported on this platform")
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
+    flags |= no_follow
     fd = os.open(path, flags, 0o600)
     with os.fdopen(fd, "w", encoding="utf-8") as fh:
         fh.write(content)

--- a/scripts/evals/judgment_validity.py
+++ b/scripts/evals/judgment_validity.py
@@ -28,6 +28,7 @@ split, or canonical promote/defer/discard decisions.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -60,6 +61,16 @@ _PASSED_DECISIONS: frozenset[str] = frozenset({"promote", "defer"})
 
 JUDGMENT_VALIDITY_ITEMS_FILENAME = "judgment_validity_items.jsonl"
 JUDGMENT_VALIDITY_REPORT_FILENAME = "judgment_validity_report.json"
+
+
+def _safe_write_text(path: Path, content: str) -> None:
+    """Write text without following symlinks."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(path, flags, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(content)
 
 
 # ---------------------------------------------------------------------------
@@ -163,15 +174,15 @@ def write_judgment_validity_sidecar(
 
     # Write item-level outcomes.
     items_path = run_dir / JUDGMENT_VALIDITY_ITEMS_FILENAME
-    with items_path.open("w", encoding="utf-8") as fh:
-        for rec in outcomes:
-            fh.write(json.dumps(rec, ensure_ascii=False, sort_keys=True) + "\n")
+    items_content = "".join(
+        json.dumps(rec, ensure_ascii=False, sort_keys=True) + "\n" for rec in outcomes
+    )
+    _safe_write_text(items_path, items_content)
 
     # Write validity report.
     report_path = run_dir / JUDGMENT_VALIDITY_REPORT_FILENAME
-    with report_path.open("w", encoding="utf-8") as fh:
-        json.dump(report, fh, indent=2, sort_keys=True, ensure_ascii=False)
-        fh.write("\n")
+    report_content = json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+    _safe_write_text(report_path, report_content)
 
     return {
         "validity_items": str(items_path),

--- a/tests/evals/test_judgment_validity_sidecar.py
+++ b/tests/evals/test_judgment_validity_sidecar.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import pytest
 
+import scripts.evals.judgment_validity as judgment_validity
 from scripts.evals.judgment_validity import (
     JUDGMENT_DECISION_SCORES,
     JUDGMENT_VALIDITY_ITEMS_FILENAME,
@@ -276,6 +277,24 @@ class TestWriteJudgmentValiditySidecar:
         (tmp_path / JUDGMENT_VALIDITY_ITEMS_FILENAME).symlink_to(outside)
 
         with pytest.raises(OSError):
+            write_judgment_validity_sidecar(tmp_path, _ALL_RESULTS)
+        assert outside.read_text(encoding="utf-8") == "safe"
+
+    def test_rejects_preexisting_symlink_report_sidecar_target(self, tmp_path: Path) -> None:
+        outside = tmp_path / "outside_report.txt"
+        outside.write_text("safe", encoding="utf-8")
+        (tmp_path / JUDGMENT_VALIDITY_REPORT_FILENAME).symlink_to(outside)
+
+        with pytest.raises(OSError):
+            write_judgment_validity_sidecar(tmp_path, _ALL_RESULTS)
+        assert outside.read_text(encoding="utf-8") == "safe"
+
+    def test_fails_closed_without_no_follow_support(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delattr(judgment_validity.os, "O_NOFOLLOW", raising=False)
+
+        with pytest.raises(OSError, match="Symlink-safe writes are not supported on this platform"):
             write_judgment_validity_sidecar(tmp_path, _ALL_RESULTS)
 
 

--- a/tests/evals/test_judgment_validity_sidecar.py
+++ b/tests/evals/test_judgment_validity_sidecar.py
@@ -270,6 +270,14 @@ class TestWriteJudgmentValiditySidecar:
         assert "judgment" in slice_support
         assert slice_support["judgment"] == 3
 
+    def test_rejects_preexisting_symlink_sidecar_target(self, tmp_path: Path) -> None:
+        outside = tmp_path / "outside.txt"
+        outside.write_text("safe", encoding="utf-8")
+        (tmp_path / JUDGMENT_VALIDITY_ITEMS_FILENAME).symlink_to(outside)
+
+        with pytest.raises(OSError):
+            write_judgment_validity_sidecar(tmp_path, _ALL_RESULTS)
+
 
 # ---------------------------------------------------------------------------
 # Guard tests


### PR DESCRIPTION
### Motivation
- A sidecar writer used predictable filenames and `Path.open("w")`, which follows existing symlinks and allowed pre-planted symlinks in the artifact directory to redirect/truncate files outside the intended artifact tree.
- This PR hardens offline eval/dev-CI tooling to prevent symlink-follow writes while preserving existing sidecar semantics.

### Description
- Added a `_safe_write_text` helper in `scripts/evals/judgment_validity.py` that uses `os.open(..., O_NOFOLLOW)` and writes via the returned file descriptor to avoid following symlinks.
- The helper now fails closed when `os.O_NOFOLLOW` is unavailable instead of silently falling back to unsafe writes.
- Replaced `Path.open("w")` usage for `judgment_validity_items.jsonl` and `judgment_validity_report.json` with the safe writer.
- Added symmetric regression tests for item/report sidecar symlink targets and outside-target preservation.
- Only the write primitive was changed; mapping, report-building, artifact paths, and output format remain intact.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Reviewed current CodeRabbit, Cubic, Sourcery, Codex, and coverage comments.
- [x] Fixed valid actionable findings before mapping.
- [x] Kept scope limited to eval sidecar write safety, focused tests, and governance.

### Fixed in Commit Mapping
Canonical artifact: `docs/review/PR_1666_FIXED_MAPPING.md`

Disposition: FIXED  
Commit: 13b837d6dd0903bd628c1cdde848bec5a7c2245c  
Evidence: `_safe_write_text()` now fails closed when `os.O_NOFOLLOW` is unavailable; focused sidecar pytest passed with `28 passed`.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#discussion_r3184241197 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#discussion_r3184257890 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#pullrequestreview-4223185713 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#pullrequestreview-4223206641 -> 13b837d6dd0903bd628c1cdde848bec5a7c2245c

Disposition: NOT-A-BUG  
Evidence: Non-actionable service/rate-limit or coverage summary comments; no code change requested.  
Reason: These comments report review quota, generated summaries, or Codecov coverage status rather than actionable code defects.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#issuecomment-4374159015
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#issuecomment-4374159985
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1666#issuecomment-4374195204

## Merge Readiness
- [x] `python3 scripts/orchestration/check_preflight.py`
- [x] `python3 scripts/orchestration/check_agent_consistency.py`
- [x] `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review`
- [x] `.venv/bin/python -m pytest -q tests/evals/test_judgment_validity_sidecar.py` -> `28 passed`
- [x] `pre-commit run --all-files`
- [x] `make validate-changed`
- [x] `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1666`
- [x] `python3 scripts/orchestration/check_merge_ready.py --require-auth --pr-number 1666 --repo Katsiarynakavaleuskaya/PulsePlate` passed locally on head `ad321368d705d308215b18009f5d12afb31751fa`; final pass will be rerun after current-head CI closes.
- [ ] Current-head GitHub CI parity after latest PR body edit/recheck
- [ ] CodeRabbit, Cubic, and Sourcery no-actionables after latest head

## Deferred / Follow-ups
- Full local `make verify` is intentionally deferred by operator-approved machine-heavy exception because full-suite execution is sharded on GitHub and can overload the local machine.
- Substitute evidence required before merge: focused local tests, `pre-commit run --all-files`, `make validate-changed`, current-head GitHub CI parity, and strict merge-readiness wrapper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security for judgment validity sidecar file operations by implementing symlink-safe file writes with restricted file permissions and platform-level protections.

* **Tests**
  * Added integration tests to verify rejection of symlink-based attacks and proper error handling on platforms without required security features.

* **Documentation**
  * Added resolution mapping documentation recording test verification results and PR status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->