### PR TITLE
fix(evals): enforce fail-closed schema validation for eval validity records

### DIFF
--- a/docs/review/PR_1667_FIXED_MAPPING.md
+++ b/docs/review/PR_1667_FIXED_MAPPING.md
@@ -36,6 +36,12 @@ Disposition: NOT-A-BUG
 Evidence: CodeRabbit returned a rate-limit/service notice only; no actionable code finding was present.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#issuecomment-4374170474
 
+Disposition: FIXED
+Commit: 71574a5dfb6635aa4985cdaaa40aa6542f702601
+Evidence: tests/evals/test_eval_validity_contract.py now covers `slice_tags` lists with non-string members for both eval variant and outcome records; local validation passed with focused pytest, pre-commit, and make validate-changed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3188888265 -> 71574a5dfb6635aa4985cdaaa40aa6542f702601
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#pullrequestreview-4228567555 -> 71574a5dfb6635aa4985cdaaa40aa6542f702601
+
 ## Merge Readiness
 
 Local gates run:

--- a/docs/review/PR_1667_FIXED_MAPPING.md
+++ b/docs/review/PR_1667_FIXED_MAPPING.md
@@ -3,6 +3,8 @@
 ## Discussion Thread Pass
 
 Status: COMPLETE
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 PR phase: post_open_review remediation
 Scope lock: eval validity schema validation, focused tests, governance, and merge-readiness only.
 
@@ -19,8 +21,7 @@ Role order executed:
 
 Disposition: FIXED
 Commit: b6e1ae03d6906c117791c7dbfd90e62889f7db96
-Evidence: scripts/evals/eval_validity_contract.py now returns defensive shallow copies from `_require_list_of_str` and `_require_dict` only after strict type validation; tests/evals/test_eval_validity_contract.py covers variant/outcome slice tag aliasing, variant input payload aliasing, malformed slice tag strings, and malformed string fields.
-Validation: `.venv/bin/python -m pytest -q tests/evals/test_eval_validity_contract.py`; `pre-commit run --all-files`; `make validate-changed`.
+Evidence: scripts/evals/eval_validity_contract.py now returns defensive shallow copies from `_require_list_of_str` and `_require_dict` only after strict type validation; tests/evals/test_eval_validity_contract.py covers variant/outcome slice tag aliasing, variant input payload aliasing, malformed slice tag strings, and malformed string fields; local validation passed with focused pytest, pre-commit, and make validate-changed.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3184245561 -> b6e1ae03d6906c117791c7dbfd90e62889f7db96
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3184245567 -> b6e1ae03d6906c117791c7dbfd90e62889f7db96
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3184277278 -> b6e1ae03d6906c117791c7dbfd90e62889f7db96

--- a/docs/review/PR_1667_FIXED_MAPPING.md
+++ b/docs/review/PR_1667_FIXED_MAPPING.md
@@ -1,0 +1,58 @@
+# PR 1667 Fixed Mapping
+
+## Discussion Thread Pass
+
+Status: COMPLETE
+PR phase: post_open_review remediation
+Scope lock: eval validity schema validation, focused tests, governance, and merge-readiness only.
+
+Role order executed:
+1. agent-coordinator: locked scope, phase, agents, validation plan, and DoD.
+2. architecture-specialist: confirmed no runtime/API/client/DB scope drift.
+3. security-auditor: confirmed fail-closed validation remains strict and no coercion was reintroduced.
+4. backend-engineer: implemented shallow defensive copies after strict validation.
+5. qa-engineer-agent: added focused aliasing and malformed-field regression tests.
+6. bug-hunter: checked false-green paths from first-field-only invalid payload tests and mutable aliases.
+7. pulseplate-premortem-risk-review: reviewed the 48-hour failure frame that downstream metrics remain nondeterministic through mutable aliasing.
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: b6e1ae03d6906c117791c7dbfd90e62889f7db96
+Evidence: scripts/evals/eval_validity_contract.py now returns defensive shallow copies from `_require_list_of_str` and `_require_dict` only after strict type validation; tests/evals/test_eval_validity_contract.py covers variant/outcome slice tag aliasing, variant input payload aliasing, malformed slice tag strings, and malformed string fields.
+Validation: `.venv/bin/python -m pytest -q tests/evals/test_eval_validity_contract.py`; `pre-commit run --all-files`; `make validate-changed`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3184245561 -> b6e1ae03d6906c117791c7dbfd90e62889f7db96
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3184245567 -> b6e1ae03d6906c117791c7dbfd90e62889f7db96
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3184277278 -> b6e1ae03d6906c117791c7dbfd90e62889f7db96
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3184277291 -> b6e1ae03d6906c117791c7dbfd90e62889f7db96
+
+Disposition: NOT-A-BUG
+Evidence: Sourcery returned a weekly rate-limit notice only; no code finding or requested change was present.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#pullrequestreview-4223179802
+
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit returned a rate-limit/service notice only; no actionable code finding was present.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#issuecomment-4374170474
+
+## Merge Readiness
+
+Local gates run:
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `python3 scripts/orchestration/task_bootstrap.py --goal "Bring PR #1667 fail-closed eval validity record validation to merge readiness" --task-class "Security/Eval tooling" --pr-phase post_open_review --path scripts/evals/eval_validity_contract.py --path tests/evals/test_eval_validity_contract.py --path docs/review/PR_1667_FIXED_MAPPING.md --requested-agent agent-coordinator --requested-agent architecture-specialist --requested-agent security-auditor --requested-agent backend-engineer --requested-agent qa-engineer-agent --requested-agent bug-hunter`
+- PASS: `.venv/bin/python -m pytest -q tests/evals/test_eval_validity_contract.py`
+- PASS: `pre-commit run --all-files`
+- PASS: `make validate-changed`
+
+Full local `make verify` exception: operator-approved machine-heavy exception. Full-suite parity is expected from current-head GitHub sharded CI plus strict merge-readiness gates.
+
+Pending before merge:
+- Current-head GitHub checks must pass with no required pending jobs.
+- CodeRabbit, Cubic, and Sourcery must have no actionable open items.
+- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1667` must pass.
+- `python3 scripts/orchestration/check_merge_ready.py --require-auth --pr-number 1667 --repo Katsiarynakavaleuskaya/PulsePlate` must pass.
+
+## Deferred / Follow-ups
+
+- No in-scope deferred code fixes.
+- Nested deep-copy / immutable schema formalization is intentionally out of scope for this PR; this PR implements the required shallow defensive-copy contract without widening eval contract behavior.

--- a/docs/review/PR_1667_FIXED_MAPPING.md
+++ b/docs/review/PR_1667_FIXED_MAPPING.md
@@ -26,6 +26,7 @@ Evidence: scripts/evals/eval_validity_contract.py now returns defensive shallow 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3184245567 -> b6e1ae03d6906c117791c7dbfd90e62889f7db96
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3184277278 -> b6e1ae03d6906c117791c7dbfd90e62889f7db96
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3184277291 -> b6e1ae03d6906c117791c7dbfd90e62889f7db96
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#pullrequestreview-4223228686 -> b6e1ae03d6906c117791c7dbfd90e62889f7db96
 
 Disposition: NOT-A-BUG
 Evidence: Sourcery returned a weekly rate-limit notice only; no code finding or requested change was present.

--- a/scripts/evals/eval_validity_contract.py
+++ b/scripts/evals/eval_validity_contract.py
@@ -84,6 +84,26 @@ _OUTCOME_RECORD_REQUIRED_KEYS: frozenset[str] = frozenset(
 )
 
 
+def _require_str(value: Any, *, field: str, record_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{record_name}.{field} must be str, got {type(value).__name__}")
+    return value
+
+
+def _require_list_of_str(value: Any, *, field: str, record_name: str) -> list[str]:
+    if not isinstance(value, list):
+        raise ValueError(f"{record_name}.{field} must be list[str], got {type(value).__name__}")
+    if not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{record_name}.{field} must contain only str values")
+    return value
+
+
+def _require_dict(value: Any, *, field: str, record_name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{record_name}.{field} must be dict, got {type(value).__name__}")
+    return value
+
+
 def validate_eval_variant_record(
     raw: dict[str, Any],
 ) -> EvalVariantRecord:
@@ -105,13 +125,13 @@ def validate_eval_variant_record(
             f"expected one of {EXPECTED_RELATIONS}"
         )
     return EvalVariantRecord(
-        canonical_id=str(raw["canonical_id"]),
-        variant_id=str(raw["variant_id"]),
+        canonical_id=_require_str(raw["canonical_id"], field="canonical_id", record_name="EvalVariantRecord"),
+        variant_id=_require_str(raw["variant_id"], field="variant_id", record_name="EvalVariantRecord"),
         variant_family=raw["variant_family"],
-        transform_type=str(raw["transform_type"]),
+        transform_type=_require_str(raw["transform_type"], field="transform_type", record_name="EvalVariantRecord"),
         expected_relation=raw["expected_relation"],
-        slice_tags=list(raw["slice_tags"]),
-        input_payload=dict(raw["input_payload"]),
+        slice_tags=_require_list_of_str(raw["slice_tags"], field="slice_tags", record_name="EvalVariantRecord"),
+        input_payload=_require_dict(raw["input_payload"], field="input_payload", record_name="EvalVariantRecord"),
     )
 
 
@@ -141,14 +161,14 @@ def validate_eval_outcome_record(
     if not math.isfinite(score):
         raise ValueError(f"EvalOutcomeRecord.score must be finite, got {score!r}")
     return EvalOutcomeRecord(
-        canonical_id=str(raw["canonical_id"]),
-        variant_id=str(raw["variant_id"]),
+        canonical_id=_require_str(raw["canonical_id"], field="canonical_id", record_name="EvalOutcomeRecord"),
+        variant_id=_require_str(raw["variant_id"], field="variant_id", record_name="EvalOutcomeRecord"),
         variant_family=raw["variant_family"],
-        transform_type=str(raw["transform_type"]),
-        passed=bool(passed),
+        transform_type=_require_str(raw["transform_type"], field="transform_type", record_name="EvalOutcomeRecord"),
+        passed=passed,
         score=float(score),
-        decision=str(raw["decision"]),
-        slice_tags=list(raw["slice_tags"]),
+        decision=_require_str(raw["decision"], field="decision", record_name="EvalOutcomeRecord"),
+        slice_tags=_require_list_of_str(raw["slice_tags"], field="slice_tags", record_name="EvalOutcomeRecord"),
     )
 
 

--- a/scripts/evals/eval_validity_contract.py
+++ b/scripts/evals/eval_validity_contract.py
@@ -95,13 +95,13 @@ def _require_list_of_str(value: Any, *, field: str, record_name: str) -> list[st
         raise ValueError(f"{record_name}.{field} must be list[str], got {type(value).__name__}")
     if not all(isinstance(item, str) for item in value):
         raise ValueError(f"{record_name}.{field} must contain only str values")
-    return value
+    return list(value)
 
 
 def _require_dict(value: Any, *, field: str, record_name: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError(f"{record_name}.{field} must be dict, got {type(value).__name__}")
-    return value
+    return dict(value)
 
 
 def validate_eval_variant_record(
@@ -125,13 +125,23 @@ def validate_eval_variant_record(
             f"expected one of {EXPECTED_RELATIONS}"
         )
     return EvalVariantRecord(
-        canonical_id=_require_str(raw["canonical_id"], field="canonical_id", record_name="EvalVariantRecord"),
-        variant_id=_require_str(raw["variant_id"], field="variant_id", record_name="EvalVariantRecord"),
+        canonical_id=_require_str(
+            raw["canonical_id"], field="canonical_id", record_name="EvalVariantRecord"
+        ),
+        variant_id=_require_str(
+            raw["variant_id"], field="variant_id", record_name="EvalVariantRecord"
+        ),
         variant_family=raw["variant_family"],
-        transform_type=_require_str(raw["transform_type"], field="transform_type", record_name="EvalVariantRecord"),
+        transform_type=_require_str(
+            raw["transform_type"], field="transform_type", record_name="EvalVariantRecord"
+        ),
         expected_relation=raw["expected_relation"],
-        slice_tags=_require_list_of_str(raw["slice_tags"], field="slice_tags", record_name="EvalVariantRecord"),
-        input_payload=_require_dict(raw["input_payload"], field="input_payload", record_name="EvalVariantRecord"),
+        slice_tags=_require_list_of_str(
+            raw["slice_tags"], field="slice_tags", record_name="EvalVariantRecord"
+        ),
+        input_payload=_require_dict(
+            raw["input_payload"], field="input_payload", record_name="EvalVariantRecord"
+        ),
     )
 
 
@@ -161,14 +171,22 @@ def validate_eval_outcome_record(
     if not math.isfinite(score):
         raise ValueError(f"EvalOutcomeRecord.score must be finite, got {score!r}")
     return EvalOutcomeRecord(
-        canonical_id=_require_str(raw["canonical_id"], field="canonical_id", record_name="EvalOutcomeRecord"),
-        variant_id=_require_str(raw["variant_id"], field="variant_id", record_name="EvalOutcomeRecord"),
+        canonical_id=_require_str(
+            raw["canonical_id"], field="canonical_id", record_name="EvalOutcomeRecord"
+        ),
+        variant_id=_require_str(
+            raw["variant_id"], field="variant_id", record_name="EvalOutcomeRecord"
+        ),
         variant_family=raw["variant_family"],
-        transform_type=_require_str(raw["transform_type"], field="transform_type", record_name="EvalOutcomeRecord"),
+        transform_type=_require_str(
+            raw["transform_type"], field="transform_type", record_name="EvalOutcomeRecord"
+        ),
         passed=passed,
         score=float(score),
         decision=_require_str(raw["decision"], field="decision", record_name="EvalOutcomeRecord"),
-        slice_tags=_require_list_of_str(raw["slice_tags"], field="slice_tags", record_name="EvalOutcomeRecord"),
+        slice_tags=_require_list_of_str(
+            raw["slice_tags"], field="slice_tags", record_name="EvalOutcomeRecord"
+        ),
     )
 
 

--- a/tests/evals/test_eval_validity_contract.py
+++ b/tests/evals/test_eval_validity_contract.py
@@ -144,6 +144,16 @@ class TestValidateEvalVariantRecord:
         with pytest.raises(ValueError, match="Invalid expected_relation"):
             validate_eval_variant_record(raw)
 
+    def test_rejects_non_string_identifiers_and_transform_type(self) -> None:
+        raw = _make_variant_raw(canonical_id=["item_001"], variant_id={"id": "v"}, transform_type=123)
+        with pytest.raises(ValueError, match="EvalVariantRecord.canonical_id must be str"):
+            validate_eval_variant_record(raw)
+
+    def test_rejects_invalid_slice_tags_and_input_payload_types(self) -> None:
+        raw = _make_variant_raw(slice_tags="rag", input_payload=["x"])
+        with pytest.raises(ValueError, match="EvalVariantRecord.slice_tags must be list\[str\]"):
+            validate_eval_variant_record(raw)
+
 
 # ---------------------------------------------------------------------------
 # Outcome record validation
@@ -197,6 +207,16 @@ class TestValidateEvalOutcomeRecord:
     def test_rejects_neg_infinity_score(self) -> None:
         raw = _make_outcome_raw(score=float("-inf"))
         with pytest.raises(ValueError, match="must be finite"):
+            validate_eval_outcome_record(raw)
+
+    def test_rejects_non_string_fields(self) -> None:
+        raw = _make_outcome_raw(canonical_id=["item_001"], transform_type={"kind": "none"}, decision=["pass"])
+        with pytest.raises(ValueError, match="EvalOutcomeRecord.canonical_id must be str"):
+            validate_eval_outcome_record(raw)
+
+    def test_rejects_invalid_slice_tags_type_with_value_error(self) -> None:
+        raw = _make_outcome_raw(slice_tags="rag")
+        with pytest.raises(ValueError, match="EvalOutcomeRecord.slice_tags must be list\[str\]"):
             validate_eval_outcome_record(raw)
 
 

--- a/tests/evals/test_eval_validity_contract.py
+++ b/tests/evals/test_eval_validity_contract.py
@@ -128,6 +128,24 @@ class TestValidateEvalVariantRecord:
         assert rec["canonical_id"] == "item_001"
         assert rec["variant_family"] == "canonical"
 
+    def test_slice_tags_are_defensive_copy(self) -> None:
+        raw = _make_variant_raw(slice_tags=["rag"])
+        rec = validate_eval_variant_record(raw)
+
+        raw["slice_tags"].append("mutated")
+
+        assert rec["slice_tags"] == ["rag"]
+
+    def test_input_payload_is_defensive_copy(self) -> None:
+        payload = {"query": "test"}
+        raw = _make_variant_raw(input_payload=payload)
+        rec = validate_eval_variant_record(raw)
+
+        payload["query"] = "changed"
+        payload["extra"] = "mutated"
+
+        assert rec["input_payload"] == {"query": "test"}
+
     def test_rejects_invalid_family(self) -> None:
         raw = _make_variant_raw(variant_family="bogus")
         with pytest.raises(ValueError, match="Invalid variant_family"):
@@ -144,14 +162,29 @@ class TestValidateEvalVariantRecord:
         with pytest.raises(ValueError, match="Invalid expected_relation"):
             validate_eval_variant_record(raw)
 
-    def test_rejects_non_string_identifiers_and_transform_type(self) -> None:
-        raw = _make_variant_raw(canonical_id=["item_001"], variant_id={"id": "v"}, transform_type=123)
-        with pytest.raises(ValueError, match="EvalVariantRecord.canonical_id must be str"):
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("canonical_id", ["item_001"]),
+            ("variant_id", {"id": "v"}),
+            ("transform_type", 123),
+        ],
+    )
+    def test_rejects_non_string_identifiers_and_transform_type(
+        self, field: str, value: object
+    ) -> None:
+        raw = _make_variant_raw(**{field: value})
+        with pytest.raises(ValueError, match=rf"EvalVariantRecord.{field} must be str"):
             validate_eval_variant_record(raw)
 
-    def test_rejects_invalid_slice_tags_and_input_payload_types(self) -> None:
-        raw = _make_variant_raw(slice_tags="rag", input_payload=["x"])
-        with pytest.raises(ValueError, match="EvalVariantRecord.slice_tags must be list\[str\]"):
+    def test_rejects_invalid_slice_tags_type_with_value_error(self) -> None:
+        raw = _make_variant_raw(slice_tags="rag")
+        with pytest.raises(ValueError, match=r"EvalVariantRecord.slice_tags must be list\[str\]"):
+            validate_eval_variant_record(raw)
+
+    def test_rejects_invalid_input_payload_type(self) -> None:
+        raw = _make_variant_raw(input_payload=["x"])
+        with pytest.raises(ValueError, match="EvalVariantRecord.input_payload must be dict"):
             validate_eval_variant_record(raw)
 
 
@@ -167,6 +200,14 @@ class TestValidateEvalOutcomeRecord:
         rec = validate_eval_outcome_record(raw)
         assert rec["passed"] is True
         assert rec["score"] == 1.0
+
+    def test_slice_tags_are_defensive_copy(self) -> None:
+        raw = _make_outcome_raw(slice_tags=["rag"])
+        rec = validate_eval_outcome_record(raw)
+
+        raw["slice_tags"].append("mutated")
+
+        assert rec["slice_tags"] == ["rag"]
 
     def test_rejects_invalid_family(self) -> None:
         raw = _make_outcome_raw(variant_family="bogus")
@@ -209,14 +250,23 @@ class TestValidateEvalOutcomeRecord:
         with pytest.raises(ValueError, match="must be finite"):
             validate_eval_outcome_record(raw)
 
-    def test_rejects_non_string_fields(self) -> None:
-        raw = _make_outcome_raw(canonical_id=["item_001"], transform_type={"kind": "none"}, decision=["pass"])
-        with pytest.raises(ValueError, match="EvalOutcomeRecord.canonical_id must be str"):
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("canonical_id", ["item_001"]),
+            ("variant_id", {"id": "v"}),
+            ("transform_type", {"kind": "none"}),
+            ("decision", ["pass"]),
+        ],
+    )
+    def test_rejects_non_string_fields(self, field: str, value: object) -> None:
+        raw = _make_outcome_raw(**{field: value})
+        with pytest.raises(ValueError, match=rf"EvalOutcomeRecord.{field} must be str"):
             validate_eval_outcome_record(raw)
 
     def test_rejects_invalid_slice_tags_type_with_value_error(self) -> None:
         raw = _make_outcome_raw(slice_tags="rag")
-        with pytest.raises(ValueError, match="EvalOutcomeRecord.slice_tags must be list\[str\]"):
+        with pytest.raises(ValueError, match=r"EvalOutcomeRecord.slice_tags must be list\[str\]"):
             validate_eval_outcome_record(raw)
 
 

--- a/tests/evals/test_eval_validity_contract.py
+++ b/tests/evals/test_eval_validity_contract.py
@@ -182,6 +182,13 @@ class TestValidateEvalVariantRecord:
         with pytest.raises(ValueError, match=r"EvalVariantRecord.slice_tags must be list\[str\]"):
             validate_eval_variant_record(raw)
 
+    def test_rejects_slice_tags_with_non_string_elements(self) -> None:
+        raw = _make_variant_raw(slice_tags=["rag", 1])
+        with pytest.raises(
+            ValueError, match="EvalVariantRecord.slice_tags must contain only str values"
+        ):
+            validate_eval_variant_record(raw)
+
     def test_rejects_invalid_input_payload_type(self) -> None:
         raw = _make_variant_raw(input_payload=["x"])
         with pytest.raises(ValueError, match="EvalVariantRecord.input_payload must be dict"):
@@ -267,6 +274,13 @@ class TestValidateEvalOutcomeRecord:
     def test_rejects_invalid_slice_tags_type_with_value_error(self) -> None:
         raw = _make_outcome_raw(slice_tags="rag")
         with pytest.raises(ValueError, match=r"EvalOutcomeRecord.slice_tags must be list\[str\]"):
+            validate_eval_outcome_record(raw)
+
+    def test_rejects_slice_tags_with_non_string_elements(self) -> None:
+        raw = _make_outcome_raw(slice_tags=["rag", 1])
+        with pytest.raises(
+            ValueError, match="EvalOutcomeRecord.slice_tags must contain only str values"
+        ):
             validate_eval_outcome_record(raw)
 
 


### PR DESCRIPTION
### Motivation
- Aardvark detected that eval record validators silently coerced malformed fields, allowing corrupted JSONL artifacts to affect offline validity metrics.
- Post-open review then found a second integrity issue: strict helpers validated containers but returned caller-owned mutable `list`/`dict` instances.
- The PR keeps eval validity validation fail-closed and prevents already-validated records from being mutated through raw payload aliases.

### Description
- Use strict validation helpers in `scripts/evals/eval_validity_contract.py` for `str`, `list[str]`, and `dict` fields without reintroducing coercion.
- Return shallow defensive copies from `_require_list_of_str` and `_require_dict` after strict type validation.
- Preserve existing output shape, deterministic formatting, `passed` bool validation, and finite non-bool numeric `score` validation.
- Add focused regression tests for mutable aliasing and malformed field failures in `tests/evals/test_eval_validity_contract.py`.

### Testing
- PASS: `python3 scripts/orchestration/check_preflight.py`
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
- PASS: `python3 scripts/orchestration/task_bootstrap.py --goal "Bring PR #1667 fail-closed eval validity record validation to merge readiness" --task-class "Security/Eval tooling" --pr-phase post_open_review --path scripts/evals/eval_validity_contract.py --path tests/evals/test_eval_validity_contract.py --path docs/review/PR_1667_FIXED_MAPPING.md --requested-agent agent-coordinator --requested-agent architecture-specialist --requested-agent security-auditor --requested-agent backend-engineer --requested-agent qa-engineer-agent --requested-agent bug-hunter`
- PASS: `.venv/bin/python -m pytest -q tests/evals/test_eval_validity_contract.py`
- PASS: `pre-commit run --all-files`
- PASS: `make validate-changed`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- Completed review-thread pass for Codex review, Cubic, Sourcery, and CodeRabbit activity on PR #1667.
- Actionable mutable-aliasing findings were fixed in code and tests.
- Sourcery and CodeRabbit rate-limit/service notices are non-actionable and mapped as `NOT-A-BUG` in the canonical artifact.

### Fixed in Commit Mapping
Canonical artifact: `docs/review/PR_1667_FIXED_MAPPING.md`

- `FIXED`: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3184245561 -> `b6e1ae03d6906c117791c7dbfd90e62889f7db96`
- `FIXED`: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3184245567 -> `b6e1ae03d6906c117791c7dbfd90e62889f7db96`
- `FIXED`: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3184277278 -> `b6e1ae03d6906c117791c7dbfd90e62889f7db96`
- `FIXED`: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3184277291 -> `b6e1ae03d6906c117791c7dbfd90e62889f7db96`
- `FIXED`: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#pullrequestreview-4223228686 -> `b6e1ae03d6906c117791c7dbfd90e62889f7db96`
- `NOT-A-BUG`: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#pullrequestreview-4223179802
- `NOT-A-BUG`: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#issuecomment-4374170474
- `FIXED`: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#discussion_r3188888265 -> `71574a5dfb6635aa4985cdaaa40aa6542f702601`
- `FIXED`: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1667#pullrequestreview-4228567555 -> `71574a5dfb6635aa4985cdaaa40aa6542f702601`

## Merge Readiness
- Local narrow gates passed for the touched eval contract surface.
- Full local `make verify` is operator-deferred under the repo machine-heavy exception because this repo uses GitHub sharded CI for full-suite parity and local full verify can overload the workstation.
- Current-head GitHub CI, strict merge-readiness, and no-actionable review status remain required before merge.

## Deferred / Follow-ups
- No in-scope deferred code fixes.
- Nested deep-copy or fully immutable eval schema formalization is intentionally out of scope for this PR; the required contract here is shallow defensive copy after strict validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8fc7939d883339bc85b35451085af)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced stricter runtime type validation for key record fields and return clear errors for invalid types; ensured validated records are defensively copied to prevent aliasing and regressions.

* **Tests**
  * Added deterministic tests covering defensive-copy behavior and many validation-error cases for malformed or wrong-typed fields.

* **Documentation**
  * Added review remediation notes, merge-readiness checks, dispositions, and a deferred follow-up on deep-copy/schema formalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->