### PR TITLE
test(guards): add regression guards for dev tooling and eval artifact safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1166,6 +1166,10 @@ Rules:
 - LLM-generated fixtures are forbidden in deterministic foundation PRs.
 - Item-level artifacts are required before psychometrics, IRT, adaptive evals, or mechanistic evaluation.
 - External coding models such as Opus may be used by the operator, but MUST NOT be integrated into repo runtime, provider routing, `.claude/`, or orchestration identity.
+- Eval artifact sidecars with predictable filenames must use symlink-safe,
+  fail-closed writes. Eval JSONL validators must reject malformed fields with
+  `ValueError`, avoid coercive casts for accepted schema fields, and
+  defensively copy mutable validated containers.
 
 See: `docs/evals/PULSEPLATE_EVAL_VALIDITY_CONTRACT.md`
 

--- a/docs/DEPENDENCY_MANAGEMENT.md
+++ b/docs/DEPENDENCY_MANAGEMENT.md
@@ -118,6 +118,25 @@ If you need vector/ML runtime tooling on a machine without CUDA support, use the
 pip-sync requirements-rag-vector-cpu.txt
 ```
 
+### Security coverage registry for optional RAG/vector profiles
+
+Optional RAG/vector dependency profiles are high-risk supply-chain surfaces even
+when they are local-only or excluded from default runtime installs. The current
+security coverage registry is:
+
+- `requirements-rag-vector.in`
+- `requirements-rag-vector.txt`
+- `requirements-rag-vector-cpu.in`
+- `requirements-rag-vector-cpu.txt`
+
+Every file in this registry must be covered consistently by Python dependency
+submission path filters and CI risk-profile routing. Every compiled lockfile in
+this registry must also be covered by the shared Safety audit helper and the
+pip-audit helper. The guard
+`tests/guards/test_security_devtooling_regression_guards.py` fails if a future
+`requirements-rag-vector*` profile is added without updating all security
+surfaces.
+
 Canonical contract for shared CI/Docker/bootstrap paths:
 
 - `PULSEPLATE_PYTHON_INDEX_URL` is mandatory and must point to the approved private package proxy.

--- a/docs/review/PR_1669_FIXED_MAPPING.md
+++ b/docs/review/PR_1669_FIXED_MAPPING.md
@@ -4,23 +4,13 @@ PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1669
 Branch: `test/security-devtooling-regression-guards`
 Title: `test(guards): add regression guards for dev tooling and eval artifact safety`
 
-## Summary
-
-Preventive guard PR for the security/dev-tooling regression classes found across
-PR #1664, PR #1665, PR #1666, and PR #1667.
-
-Scope is guard/tests/docs only:
-
-- Makefile compose project-name shell-safety regression guard.
-- Optional RAG/vector dependency-profile security coverage guard.
-- Eval sidecar symlink-safe fail-closed write guard.
-- Eval validity strict validation and defensive-copy guard.
-- Diff-scoped docs local `/Users/...` path leakage guard.
-- Minimal AGENTS/dependency policy documentation.
-
 ## Discussion Thread Pass
 
-No external review threads existed at PR open time.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+No external review threads existed at PR open time. Later CodeRabbit, Cubic, or
+Sourcery actionables must be added here before any thread resolution.
 
 Role order used:
 
@@ -44,7 +34,7 @@ In-scope premortem fixes applied:
 - Eval validator guard against coercive casts and mutable aliasing regressions.
 - Diff-scoped docs path leakage guard to avoid historical `/Users/...` false positives.
 
-## Fixed in Commit Mapping
+## Review Evidence
 
 ### Preventive guard implementation
 
@@ -56,25 +46,26 @@ Evidence:
 - `AGENTS.md` and `scripts/AGENTS.md` document eval/dev-tooling regression policy.
 - `docs/DEPENDENCY_MANAGEMENT.md` documents the optional RAG/vector profile security coverage registry.
 
-Thread mapping:
-
-- Pre-open preventive PR; no review thread URL to map.
-
 ### Local gate false-positive correction
 
 Disposition: FIXED
 Commit: 2194a3a3a
 Evidence:
 
-- `make validate-changed` exposed that the new docs leakage guard blocked the
-  intentional placeholder `/Users/...` in policy text.
-- `tests/guards/test_security_devtooling_regression_guards.py` now uses a
-  local absolute path regex that allows the placeholder while still rejecting
-  real `/Users/<name>/...` paths.
+- `make validate-changed` exposed that the new docs leakage guard blocked the intentional placeholder `/Users/...` in policy text.
+- `tests/guards/test_security_devtooling_regression_guards.py` now uses a local absolute path regex that allows the placeholder while still rejecting real `/Users/<name>/...` paths.
 
-Thread mapping:
+### Mapping artifact update
 
-- Local pre-push gate finding; no review thread URL to map.
+Disposition: FIXED
+Commit: 9045512ee
+Evidence:
+
+- `docs/review/PR_1669_FIXED_MAPPING.md` records the PR-numbered governance artifact and local gate evidence.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
 
 ## Merge Readiness
 
@@ -85,7 +76,7 @@ Local gates run before opening PR:
 - `. .venv/bin/activate && python -m pytest -q tests/guards/test_security_devtooling_regression_guards.py tests/test_makefile_dev_python_migration.py tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py tests/test_ci_risk_profile.py tests/evals/test_judgment_validity_sidecar.py tests/evals/test_eval_validity_contract.py` -> PASS
 - `pre-commit run --all-files` -> PASS after black reformatted `tests/guards/test_security_devtooling_regression_guards.py` and the hook was rerun cleanly
 - `make validate-changed` -> PASS; after commit it ran `tests/guards/test_security_devtooling_regression_guards.py` and reported `10 passed`
-- Push pre-push hooks -> PASS, including `pip-audit`, backend pre-push pytest, full-repo Bandit, and docker build test
+- Push pre-push hooks -> PASS, including `pip-audit`, backend pre-push pytest, full-repo Bandit, and docker build test where path filters attached it
 
 Full local `make verify` was not run by operator-approved machine-heavy exception
 for guard/CI tooling PRs. Heavy-suite parity must come from current-head GitHub

--- a/docs/review/PR_1669_FIXED_MAPPING.md
+++ b/docs/review/PR_1669_FIXED_MAPPING.md
@@ -9,8 +9,8 @@ Title: `test(guards): add regression guards for dev tooling and eval artifact sa
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-No external review threads existed at PR open time. Later CodeRabbit, Cubic, or
-Sourcery actionables must be added here before any thread resolution.
+Sourcery high-level review feedback was reviewed and mapped below. CodeRabbit
+reported no actionable comments, and Cubic reported no issues.
 
 Role order used:
 
@@ -33,6 +33,9 @@ In-scope premortem fixes applied:
 - Source-level invariant that predictable judgment sidecars use `_safe_write_text()`.
 - Eval validator guard against coercive casts and mutable aliasing regressions.
 - Diff-scoped docs path leakage guard to avoid historical `/Users/...` false positives.
+- Sourcery feedback hardened the guard implementation itself: source checks now
+  use AST-backed function extraction instead of brittle string slicing, and docs
+  diff base selection is configurable with local fallbacks.
 
 ## Review Evidence
 
@@ -63,9 +66,21 @@ Evidence:
 
 - `docs/review/PR_1669_FIXED_MAPPING.md` records the PR-numbered governance artifact and local gate evidence.
 
+### Sourcery guard robustness review
+
+Disposition: FIXED
+Commit: f8f7c5796
+Evidence:
+
+- `tests/guards/test_security_devtooling_regression_guards.py` now extracts guarded writer functions through `ast.FunctionDef` line spans instead of `str.index`.
+- `tests/guards/test_security_devtooling_regression_guards.py` now supports `PULSEPLATE_DOCS_LEAKAGE_GUARD_BASE` and falls back across available local git refs before diffing docs changes.
+
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: f8f7c5796
+Evidence: `tests/guards/test_security_devtooling_regression_guards.py` replaces brittle source slicing and hard-coded docs diff base behavior in response to Sourcery review feedback.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1669#pullrequestreview-4230017026 -> f8f7c5796
 
 ## Merge Readiness
 
@@ -76,6 +91,9 @@ Local gates run before opening PR:
 - `. .venv/bin/activate && python -m pytest -q tests/guards/test_security_devtooling_regression_guards.py tests/test_makefile_dev_python_migration.py tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py tests/test_ci_risk_profile.py tests/evals/test_judgment_validity_sidecar.py tests/evals/test_eval_validity_contract.py` -> PASS
 - `pre-commit run --all-files` -> PASS after black reformatted `tests/guards/test_security_devtooling_regression_guards.py` and the hook was rerun cleanly
 - `make validate-changed` -> PASS; after commit it ran `tests/guards/test_security_devtooling_regression_guards.py` and reported `10 passed`
+- `. .venv/bin/activate && python -m pytest -q tests/guards/test_security_devtooling_regression_guards.py` -> PASS after Sourcery robustness fix; reported `10 passed`
+- `pre-commit run --all-files` -> PASS after Sourcery robustness fix
+- `make validate-changed` -> PASS after Sourcery robustness fix; reported `10 passed`
 - Push pre-push hooks -> PASS, including `pip-audit`, backend pre-push pytest, full-repo Bandit, and docker build test where path filters attached it
 
 Full local `make verify` was not run by operator-approved machine-heavy exception

--- a/docs/review/PR_1669_FIXED_MAPPING.md
+++ b/docs/review/PR_1669_FIXED_MAPPING.md
@@ -81,6 +81,7 @@ Disposition: FIXED
 Commit: f8f7c5796
 Evidence: `tests/guards/test_security_devtooling_regression_guards.py` replaces brittle source slicing and hard-coded docs diff base behavior in response to Sourcery review feedback.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1669#pullrequestreview-4230017026 -> f8f7c5796
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1669#discussion_r3190144728 -> f8f7c5796
 
 ## Merge Readiness
 

--- a/docs/review/PR_1669_FIXED_MAPPING.md
+++ b/docs/review/PR_1669_FIXED_MAPPING.md
@@ -53,7 +53,7 @@ Commit: 2194a3a3a
 Evidence:
 
 - `make validate-changed` exposed that the new docs leakage guard blocked the intentional placeholder `/Users/...` in policy text.
-- `tests/guards/test_security_devtooling_regression_guards.py` now uses a local absolute path regex that allows the placeholder while still rejecting real `/Users/<name>/...` paths.
+- `tests/guards/test_security_devtooling_regression_guards.py` now uses a local absolute path regex that allows the placeholder while still rejecting real machine-local absolute paths.
 
 ### Mapping artifact update
 

--- a/docs/review/PR_1669_FIXED_MAPPING.md
+++ b/docs/review/PR_1669_FIXED_MAPPING.md
@@ -60,6 +60,22 @@ Thread mapping:
 
 - Pre-open preventive PR; no review thread URL to map.
 
+### Local gate false-positive correction
+
+Disposition: FIXED
+Commit: 2194a3a3a
+Evidence:
+
+- `make validate-changed` exposed that the new docs leakage guard blocked the
+  intentional placeholder `/Users/...` in policy text.
+- `tests/guards/test_security_devtooling_regression_guards.py` now uses a
+  local absolute path regex that allows the placeholder while still rejecting
+  real `/Users/<name>/...` paths.
+
+Thread mapping:
+
+- Local pre-push gate finding; no review thread URL to map.
+
 ## Merge Readiness
 
 Local gates run before opening PR:

--- a/docs/review/PR_1669_FIXED_MAPPING.md
+++ b/docs/review/PR_1669_FIXED_MAPPING.md
@@ -1,0 +1,91 @@
+# PR #1669 Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1669
+Branch: `test/security-devtooling-regression-guards`
+Title: `test(guards): add regression guards for dev tooling and eval artifact safety`
+
+## Summary
+
+Preventive guard PR for the security/dev-tooling regression classes found across
+PR #1664, PR #1665, PR #1666, and PR #1667.
+
+Scope is guard/tests/docs only:
+
+- Makefile compose project-name shell-safety regression guard.
+- Optional RAG/vector dependency-profile security coverage guard.
+- Eval sidecar symlink-safe fail-closed write guard.
+- Eval validity strict validation and defensive-copy guard.
+- Diff-scoped docs local `/Users/...` path leakage guard.
+- Minimal AGENTS/dependency policy documentation.
+
+## Discussion Thread Pass
+
+No external review threads existed at PR open time.
+
+Role order used:
+
+1. `agent-coordinator`
+2. `architecture-specialist`
+3. `security-auditor`
+4. `dev-operator`
+5. `qa-engineer-agent`
+6. `bug-hunter`
+
+Premortem frame applied before code freeze:
+
+> It is 48 hours after PR-5 merged. Another Codex security finding appears for
+> the same class of issue. Why did our new guard layer fail?
+
+In-scope premortem fixes applied:
+
+- Dynamic malicious-worktree Makefile probe instead of text-only shell guard.
+- Registry-backed optional RAG/vector dependency assertions across security surfaces.
+- Source-level invariant that predictable judgment sidecars use `_safe_write_text()`.
+- Eval validator guard against coercive casts and mutable aliasing regressions.
+- Diff-scoped docs path leakage guard to avoid historical `/Users/...` false positives.
+
+## Fixed in Commit Mapping
+
+### Preventive guard implementation
+
+Disposition: FIXED
+Commit: c0cdf1ba2
+Evidence:
+
+- `tests/guards/test_security_devtooling_regression_guards.py` adds focused preventive guards.
+- `AGENTS.md` and `scripts/AGENTS.md` document eval/dev-tooling regression policy.
+- `docs/DEPENDENCY_MANAGEMENT.md` documents the optional RAG/vector profile security coverage registry.
+
+Thread mapping:
+
+- Pre-open preventive PR; no review thread URL to map.
+
+## Merge Readiness
+
+Local gates run before opening PR:
+
+- `python3 scripts/orchestration/check_preflight.py` -> PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS
+- `. .venv/bin/activate && python -m pytest -q tests/guards/test_security_devtooling_regression_guards.py tests/test_makefile_dev_python_migration.py tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py tests/test_ci_risk_profile.py tests/evals/test_judgment_validity_sidecar.py tests/evals/test_eval_validity_contract.py` -> PASS
+- `pre-commit run --all-files` -> PASS after black reformatted `tests/guards/test_security_devtooling_regression_guards.py` and the hook was rerun cleanly
+- `make validate-changed` -> PASS; after commit it ran `tests/guards/test_security_devtooling_regression_guards.py` and reported `10 passed`
+- Push pre-push hooks -> PASS, including `pip-audit`, backend pre-push pytest, full-repo Bandit, and docker build test
+
+Full local `make verify` was not run by operator-approved machine-heavy exception
+for guard/CI tooling PRs. Heavy-suite parity must come from current-head GitHub
+sharded CI plus strict merge-readiness wrapper before merge.
+
+Pending before merge readiness claim:
+
+- Current-head GitHub CI complete and passing.
+- CodeRabbit/Cubic/Sourcery no-actionables confirmed.
+- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1669` passes.
+- `python3 scripts/orchestration/check_merge_ready.py --require-auth --pr-number 1669 --repo Katsiarynakavaleuskaya/PulsePlate` passes.
+
+## Deferred / Follow-ups
+
+No deferred code changes in this PR.
+
+If future optional dependency profiles expand beyond `requirements-rag-vector*`,
+the security profile registry can be generalized in a separate coordinator-owned
+guard lane instead of widening this PR.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -56,3 +56,16 @@ First-class repo wrappers:
 ## Evaluation validity
 
 For evaluation-validity work, follow `docs/evals/PULSEPLATE_EVAL_VALIDITY_CONTRACT.md`.
+Eval artifact sidecars with predictable filenames must use symlink-safe,
+fail-closed writers. Eval JSONL validators must reject malformed fields with
+`ValueError`, must not coerce raw values into accepted schema fields, and must
+defensively copy validated mutable containers.
+
+## Security/dev-tooling regression guards
+
+When touching Makefile devcontainer project-name generation, dependency audit
+helpers, dependency-submission filters, CI risk routing, or eval artifact
+writers, update the focused guards in
+`tests/guards/test_security_devtooling_regression_guards.py`. Optional
+RAG/vector dependency profiles must be covered consistently by Safety,
+pip-audit, Python dependency submission, and CI risk-profile routing.

--- a/tests/guards/test_security_devtooling_regression_guards.py
+++ b/tests/guards/test_security_devtooling_regression_guards.py
@@ -1,0 +1,307 @@
+"""Regression guards for security/dev-tooling hotfix classes.
+
+These tests protect the narrow issue classes closed by PRs #1664-#1667:
+
+- Makefile compose project-name shell safety
+- optional RAG/vector dependency-profile security coverage
+- eval sidecar symlink-safe writes
+- eval validity strict validation and defensive copies
+- new docs/review local absolute path leakage
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Any
+
+import yaml
+
+from scripts.ci import ci_risk_profile
+from scripts.ci import run_safety_audit
+from scripts.evals import eval_validity_contract
+from scripts.evals import judgment_validity
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAKEFILE = REPO_ROOT / "Makefile"
+PYTHON_DEPENDENCY_SUBMISSION = REPO_ROOT / ".github/workflows/python-dependency-submission.yml"
+PIP_AUDIT_HELPER = REPO_ROOT / "scripts/ci_pip_audit.sh"
+
+SECURITY_DEPENDENCY_PROFILE_FILES: tuple[str, ...] = (
+    "requirements-rag-vector.in",
+    "requirements-rag-vector.txt",
+    "requirements-rag-vector-cpu.in",
+    "requirements-rag-vector-cpu.txt",
+)
+SECURITY_DEPENDENCY_LOCKFILES: tuple[str, ...] = tuple(
+    name for name in SECURITY_DEPENDENCY_PROFILE_FILES if name.endswith(".txt")
+)
+
+
+def _binary(name: str) -> str:
+    binary = shutil.which(name)
+    assert binary is not None, f"Required executable is unavailable on PATH: {name}"
+    return binary
+
+
+def _makefile_text() -> str:
+    return MAKEFILE.read_text(encoding="utf-8")
+
+
+def _workflow_path_filters() -> dict[str, set[str]]:
+    workflow = yaml.safe_load(PYTHON_DEPENDENCY_SUBMISSION.read_text(encoding="utf-8"))
+    events = workflow.get("on", workflow.get(True))
+    assert isinstance(events, dict), "workflow events must be a mapping"
+    filters: dict[str, set[str]] = {}
+    for event in ("push", "pull_request"):
+        event_block = events[event]
+        assert isinstance(event_block, dict), f"{event} block must be a mapping"
+        filters[event] = set(event_block["paths"])
+    return filters
+
+
+def _make_print_compose_project_name(cwd: Path, env: dict[str, str]) -> str:
+    probe_makefile = cwd / "probe.mk"
+    (cwd / "Makefile").symlink_to(MAKEFILE)
+    probe_makefile.write_text(
+        "\n".join(
+            [
+                "include Makefile",
+                "",
+                ".PHONY: print-compose",
+                "print-compose:",
+                "\t@printf '%s\\n' \"$(COMPOSE_PROJECT_NAME)\"",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [
+            _binary("make"),
+            "-s",
+            "-f",
+            str(probe_makefile),
+            "-C",
+            str(cwd),
+            "print-compose",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result.stdout.strip()
+
+
+def test_makefile_compose_project_name_uses_internal_pwd_not_curdir_interpolation() -> None:
+    text = _makefile_text()
+
+    assert "$(CURDIR)" not in "\n".join(
+        line for line in text.splitlines() if "COMPOSE_PROJECT_NAME" in line
+    )
+    assert "COMPOSE_PROJECT_NAME_SUFFIX := $(strip $(shell pwd -P | cksum | cut -d' ' -f1))" in text
+    assert "COMPOSE_PROJECT_NAME ?= pulseplate-$(COMPOSE_PROJECT_NAME_SUFFIX)" in text
+    assert "ifeq ($(origin COMPOSE_PROJECT_NAME), undefined)" in text
+
+
+def test_makefile_compose_project_name_does_not_execute_malicious_worktree_text(
+    tmp_path: Path,
+) -> None:
+    malicious_dir = tmp_path / "wt;touch SHOULD_NOT_EXIST;$(touch SHOULD_NOT_EXIST_2)"
+    malicious_dir.mkdir()
+    marker = malicious_dir / "SHOULD_NOT_EXIST"
+    marker_2 = malicious_dir / "SHOULD_NOT_EXIST_2"
+    env = os.environ.copy()
+    env.pop("COMPOSE_PROJECT_NAME", None)
+    env.pop("COMPOSE_PROJECT_NAME_SUFFIX", None)
+
+    project_name = _make_print_compose_project_name(malicious_dir, env)
+
+    assert project_name.startswith("pulseplate-")
+    assert project_name != "pulseplate"
+    assert not marker.exists()
+    assert not marker_2.exists()
+
+
+def test_makefile_compose_project_name_override_is_preserved(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env["COMPOSE_PROJECT_NAME"] = "custom"
+    env.pop("COMPOSE_PROJECT_NAME_SUFFIX", None)
+
+    assert _make_print_compose_project_name(tmp_path, env) == "custom"
+
+
+def test_optional_rag_vector_dependency_profiles_have_canonical_security_registry() -> None:
+    discovered = {
+        path.name
+        for pattern in ("requirements-rag-vector*.in", "requirements-rag-vector*.txt")
+        for path in REPO_ROOT.glob(pattern)
+    }
+
+    assert discovered == set(SECURITY_DEPENDENCY_PROFILE_FILES)
+
+
+def test_dependency_profiles_are_covered_by_all_security_surfaces() -> None:
+    safety_manifests = set(run_safety_audit.OPTIONAL_MANIFESTS)
+    pip_audit_text = PIP_AUDIT_HELPER.read_text(encoding="utf-8")
+    workflow_filters = _workflow_path_filters()
+    risk_profile_files = set(ci_risk_profile.BACKEND_SHARED_EXACT)
+
+    for lockfile in SECURITY_DEPENDENCY_LOCKFILES:
+        assert lockfile in safety_manifests
+        assert lockfile in pip_audit_text
+
+    for profile_file in SECURITY_DEPENDENCY_PROFILE_FILES:
+        assert profile_file in workflow_filters["push"]
+        assert profile_file in workflow_filters["pull_request"]
+        assert profile_file in risk_profile_files
+
+        profile = ci_risk_profile.build_risk_profile([profile_file])
+        assert profile.backend_shared is True
+        assert profile.run_backend_blocking is True
+        assert profile.run_security is True
+
+
+def test_judgment_validity_sidecars_only_use_symlink_safe_writer() -> None:
+    source = (REPO_ROOT / "scripts/evals/judgment_validity.py").read_text(encoding="utf-8")
+    writer_source = source[
+        source.index("def write_judgment_validity_sidecar") : source.index(
+            "return {", source.index("def write_judgment_validity_sidecar")
+        )
+    ]
+    safe_writer_source = source[
+        source.index("def _safe_write_text") : source.index(
+            "# ---------------------------------------------------------------------------",
+            source.index("def _safe_write_text"),
+        )
+    ]
+
+    assert 'getattr(os, "O_NOFOLLOW", None)' in safe_writer_source
+    assert 'raise OSError("Symlink-safe writes are not supported on this platform")' in (
+        safe_writer_source
+    )
+    assert "os.open(path, flags, 0o600)" in safe_writer_source
+    assert "_safe_write_text(items_path, items_content)" in writer_source
+    assert "_safe_write_text(report_path, report_content)" in writer_source
+    assert ".open(" not in writer_source
+    assert ".write_text(" not in writer_source
+
+
+def test_eval_validity_contract_rejects_coercive_validator_patterns() -> None:
+    source = (REPO_ROOT / "scripts/evals/eval_validity_contract.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    validator_names = {"validate_eval_variant_record", "validate_eval_outcome_record"}
+    coercive_calls = {"str", "list", "dict"}
+    violations: list[str] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name not in validator_names:
+            continue
+        for child in ast.walk(node):
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Name):
+                if child.func.id in coercive_calls:
+                    violations.append(f"{node.name}:{child.func.id}:line {child.lineno}")
+
+    assert violations == []
+
+
+def test_eval_validity_contract_requires_defensive_copies_and_value_error() -> None:
+    tags = ["rag"]
+    payload: dict[str, Any] = {"query": "test"}
+    variant = eval_validity_contract.validate_eval_variant_record(
+        {
+            "canonical_id": "item_001",
+            "variant_id": "item_001_canonical",
+            "variant_family": "canonical",
+            "transform_type": "none",
+            "expected_relation": "same_decision",
+            "slice_tags": tags,
+            "input_payload": payload,
+        }
+    )
+    outcome = eval_validity_contract.validate_eval_outcome_record(
+        {
+            "canonical_id": "item_001",
+            "variant_id": "item_001_canonical",
+            "variant_family": "canonical",
+            "transform_type": "none",
+            "passed": True,
+            "score": 1.0,
+            "decision": "pass",
+            "slice_tags": tags,
+        }
+    )
+
+    tags.append("mutated")
+    payload["query"] = "changed"
+
+    assert variant["slice_tags"] == ["rag"]
+    assert variant["input_payload"] == {"query": "test"}
+    assert outcome["slice_tags"] == ["rag"]
+
+    for validator, raw in (
+        (
+            eval_validity_contract.validate_eval_variant_record,
+            {
+                "canonical_id": "item_001",
+                "variant_id": "item_001_canonical",
+                "variant_family": "canonical",
+                "transform_type": "none",
+                "expected_relation": "same_decision",
+                "slice_tags": "rag",
+                "input_payload": {"query": "test"},
+            },
+        ),
+        (
+            eval_validity_contract.validate_eval_outcome_record,
+            {
+                "canonical_id": "item_001",
+                "variant_id": "item_001_canonical",
+                "variant_family": "canonical",
+                "transform_type": "none",
+                "passed": True,
+                "score": 1.0,
+                "decision": "pass",
+                "slice_tags": "rag",
+            },
+        ),
+    ):
+        try:
+            validator(raw)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("malformed slice_tags must raise ValueError")
+
+
+def test_changed_docs_do_not_add_local_users_absolute_paths() -> None:
+    result = subprocess.run(
+        [
+            _binary("git"),
+            "diff",
+            "--unified=0",
+            "origin/main...HEAD",
+            "--",
+            "docs",
+            "docs/review",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    leaked_lines = [
+        line
+        for line in result.stdout.splitlines()
+        if line.startswith("+") and not line.startswith("+++") and "/Users/" in line
+    ]
+
+    assert leaked_lines == []
+
+
+def test_judgment_validity_module_exports_expected_sidecar_filenames() -> None:
+    assert judgment_validity.JUDGMENT_VALIDITY_ITEMS_FILENAME == "judgment_validity_items.jsonl"
+    assert judgment_validity.JUDGMENT_VALIDITY_REPORT_FILENAME == "judgment_validity_report.json"

--- a/tests/guards/test_security_devtooling_regression_guards.py
+++ b/tests/guards/test_security_devtooling_regression_guards.py
@@ -31,6 +31,7 @@ MAKEFILE = REPO_ROOT / "Makefile"
 PYTHON_DEPENDENCY_SUBMISSION = REPO_ROOT / ".github/workflows/python-dependency-submission.yml"
 PIP_AUDIT_HELPER = REPO_ROOT / "scripts/ci_pip_audit.sh"
 LOCAL_USERS_PATH_PATTERN = re.compile(r"/Users/(?!\.\.\.)([^/\s`]+)(?:/|$)")
+DOCS_LEAKAGE_GUARD_BASE_ENV = "PULSEPLATE_DOCS_LEAKAGE_GUARD_BASE"
 
 SECURITY_DEPENDENCY_PROFILE_FILES: tuple[str, ...] = (
     "requirements-rag-vector.in",
@@ -63,6 +64,61 @@ def _workflow_path_filters() -> dict[str, set[str]]:
         assert isinstance(event_block, dict), f"{event} block must be a mapping"
         filters[event] = set(event_block["paths"])
     return filters
+
+
+def _function_source(module_path: Path, function_name: str) -> str:
+    source = module_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    lines = source.splitlines()
+
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            assert node.end_lineno is not None
+            return "\n".join(lines[node.lineno - 1 : node.end_lineno])
+
+    raise AssertionError(f"missing function: {function_name}")
+
+
+def _git_ref_exists(ref: str) -> bool:
+    result = subprocess.run(
+        [_binary("git"), "rev-parse", "--verify", "--quiet", ref],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    return result.returncode == 0
+
+
+def _docs_diff_base() -> str:
+    configured = os.environ.get(DOCS_LEAKAGE_GUARD_BASE_ENV, "").strip()
+    candidates = [configured, "origin/main", "main", "HEAD~1"]
+
+    for candidate in candidates:
+        if candidate and _git_ref_exists(candidate):
+            return candidate
+
+    raise AssertionError("no usable git base ref for docs leakage guard")
+
+
+def _changed_docs_diff() -> str:
+    base_ref = _docs_diff_base()
+    result = subprocess.run(
+        [
+            _binary("git"),
+            "diff",
+            "--unified=0",
+            f"{base_ref}...HEAD",
+            "--",
+            "docs",
+            "docs/review",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    return result.stdout
 
 
 def _make_print_compose_project_name(cwd: Path, env: dict[str, str]) -> str:
@@ -168,18 +224,9 @@ def test_dependency_profiles_are_covered_by_all_security_surfaces() -> None:
 
 
 def test_judgment_validity_sidecars_only_use_symlink_safe_writer() -> None:
-    source = (REPO_ROOT / "scripts/evals/judgment_validity.py").read_text(encoding="utf-8")
-    writer_source = source[
-        source.index("def write_judgment_validity_sidecar") : source.index(
-            "return {", source.index("def write_judgment_validity_sidecar")
-        )
-    ]
-    safe_writer_source = source[
-        source.index("def _safe_write_text") : source.index(
-            "# ---------------------------------------------------------------------------",
-            source.index("def _safe_write_text"),
-        )
-    ]
+    module_path = REPO_ROOT / "scripts/evals/judgment_validity.py"
+    writer_source = _function_source(module_path, "write_judgment_validity_sidecar")
+    safe_writer_source = _function_source(module_path, "_safe_write_text")
 
     assert 'getattr(os, "O_NOFOLLOW", None)' in safe_writer_source
     assert 'raise OSError("Symlink-safe writes are not supported on this platform")' in (
@@ -280,24 +327,9 @@ def test_eval_validity_contract_requires_defensive_copies_and_value_error() -> N
 
 
 def test_changed_docs_do_not_add_local_users_absolute_paths() -> None:
-    result = subprocess.run(
-        [
-            _binary("git"),
-            "diff",
-            "--unified=0",
-            "origin/main...HEAD",
-            "--",
-            "docs",
-            "docs/review",
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-        cwd=REPO_ROOT,
-    )
     leaked_lines = [
         line
-        for line in result.stdout.splitlines()
+        for line in _changed_docs_diff().splitlines()
         if line.startswith("+")
         and not line.startswith("+++")
         and LOCAL_USERS_PATH_PATTERN.search(line)

--- a/tests/guards/test_security_devtooling_regression_guards.py
+++ b/tests/guards/test_security_devtooling_regression_guards.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import ast
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 from typing import Any
@@ -29,6 +30,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 MAKEFILE = REPO_ROOT / "Makefile"
 PYTHON_DEPENDENCY_SUBMISSION = REPO_ROOT / ".github/workflows/python-dependency-submission.yml"
 PIP_AUDIT_HELPER = REPO_ROOT / "scripts/ci_pip_audit.sh"
+LOCAL_USERS_PATH_PATTERN = re.compile(r"/Users/(?!\.\.\.)([^/\s`]+)(?:/|$)")
 
 SECURITY_DEPENDENCY_PROFILE_FILES: tuple[str, ...] = (
     "requirements-rag-vector.in",
@@ -296,7 +298,9 @@ def test_changed_docs_do_not_add_local_users_absolute_paths() -> None:
     leaked_lines = [
         line
         for line in result.stdout.splitlines()
-        if line.startswith("+") and not line.startswith("+++") and "/Users/" in line
+        if line.startswith("+")
+        and not line.startswith("+++")
+        and LOCAL_USERS_PATH_PATTERN.search(line)
     ]
 
     assert leaked_lines == []


### PR DESCRIPTION
## Summary
- Add preventive guard coverage for security/dev-tooling regressions found across PR #1664-#1667.
- Guard Makefile compose project-name shell safety, optional RAG/vector dependency profile coverage, eval sidecar symlink-safe writes, eval validity strict validation/defensive copies, and docs local path leakage.
- Update AGENTS/dependency docs with the narrow policy expectations.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- Pre-open PR had no review threads.
- Role order used: agent-coordinator -> architecture-specialist -> security-auditor -> dev-operator -> qa-engineer-agent -> bug-hunter.
- Premortem frame applied: 48 hours after PR-5 merged, another Codex security finding appears for the same class of issue.

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1669_FIXED_MAPPING.md`

## Merge Readiness
- [x] `python3 scripts/orchestration/check_preflight.py` -> PASS
- [x] `python3 scripts/orchestration/check_agent_consistency.py` -> PASS
- [x] focused pytest guard/devtooling/eval/supply-chain suite -> PASS
- [x] `pre-commit run --all-files` -> PASS
- [x] `make validate-changed` -> PASS
- [x] Push pre-push hooks -> PASS, including `pip-audit`, backend pre-push pytest, and full-repo Bandit
- [x] Full local `make verify` intentionally not run: operator-approved machine-heavy exception for guard/CI tooling PRs. Heavy-suite parity is delegated to current-head GitHub sharded CI plus strict merge-readiness wrapper.
- [ ] Current-head GitHub CI complete and passing
- [ ] CodeRabbit/Cubic/Sourcery no-actionables confirmed
- [ ] Strict merge-readiness wrapper passed

## Deferred / Follow-ups
- No deferred code changes in this PR.
- If future optional dependency profiles expand beyond `requirements-rag-vector*`, the registry can be generalized in a separate coordinator-owned guard lane rather than widening this PR.

## Summary by Sourcery

Добавлены защитные регрессионные тесты и документация, чтобы предотвратить регрессии в безопасности инструментов разработки и безопасности артефактов оценок (eval artifacts).

Документация:
- Задокументирован реестр покрытия безопасности для необязательных профилей зависимостей RAG/vector в документации по управлению зависимостями.
- Уточнены требования к безопасности сайдкаров артефактов eval и строгим ожиданиям валидности eval в документации по AGENTS и в документации по скриптам агента.
- Добавлен артефакт обзора сопоставления «исправлено в коммите» (fixed-in-commit mapping) для этого PR в `docs/review`.

Тесты:
- Добавлены сфокусированные регрессионные защитные тесты, охватывающие безопасность `project-name` в `Makefile` для `compose`, покрытие безопасности для необязательных профилей зависимостей RAG/vector, безопасную для симлинков (symlink-safe) запись сайдкаров eval, поведение строгой валидности eval и утечки путей в документации.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add regression guard tests and documentation to prevent regressions in dev tooling security and eval artifact safety.

Documentation:
- Document the security coverage registry for optional RAG/vector dependency profiles in dependency management docs.
- Clarify eval artifact sidecar safety and strict eval validity expectations in AGENTS documentation and scripts agent docs.
- Add a fixed-in-commit mapping review artifact for this PR under docs/review.

Tests:
- Introduce focused regression guard tests covering Makefile compose project-name safety, optional RAG/vector dependency profile security coverage, eval sidecar symlink-safe writes, strict eval validity behavior, and docs path leakage.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added security guidelines for evaluation artifacts (symlink-safe sidecar writers, strict JSONL validation with ValueError on malformed fields, defensive copying).
  * Introduced a security coverage registry for optional RAG/vector dependency profiles and required CI/audit coverage rules.
  * Added review/governance docs capturing resolution, premortem checklist, and regression-guard expectations.

* **Tests**
  * Added regression-guard tests enforcing Makefile/devcontainer safety, dependency-profile coverage across security surfaces, eval-sidecar writer and validator behavior, and docs leakage protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->