### PR TITLE
fix(container): remediate GnuTLS CVE-2026-33846 in production image

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -161,11 +161,11 @@ CVE-2025-29088
 
 ## CVE-2025-9820 – GnuTLS GNUTLS-SA-2025-11-18
 ##
-## This CVE affects GnuTLS library. Our application does NOT use GnuTLS:
+## This CVE affects GnuTLS library. Our application does NOT use GnuTLS directly:
 ##
-## 1. libgnutls30 is NOT installed in python:3.13-slim container (verified)
-## 2. No dependencies in requirements.txt reference GnuTLS
-## 3. Python's SSL/TLS uses OpenSSL, not GnuTLS
+## 1. libgnutls30 is installed in the Debian production image because `apt` depends on it
+## 2. No Python dependencies in requirements.txt reference GnuTLS
+## 3. Python's application TLS uses OpenSSL, not GnuTLS
 ##
 ## Debian Security Assessment:
 ##   - Severity: UNKNOWN (Debian marks as "Minor issue")
@@ -176,15 +176,14 @@ CVE-2025-29088
 ## Source: https://security-tracker.debian.org/tracker/CVE-2025-9820
 ## Advisory: https://www.gnutls.org/security-new.html#GNUTLS-SA-2025-11-18
 ##
-## This is likely a stale scan result or phantom dependency detection.
-## GnuTLS is not part of our application's dependency tree. Even if it
-## were present as a transitive dependency, Debian marks this as minor
-## and does not require a security update.
+## This is not a phantom package. It is an OS package retained for Debian apt.
+## GnuTLS is not part of our application's Python dependency tree, and Debian
+## marks this CVE as minor with no security advisory required.
 ##
 ## Our application:
 ## - Uses Python's standard ssl module (OpenSSL-based)
-## - Does not import or link against GnuTLS
-## - Has zero attack surface for this GnuTLS-specific vulnerability
+## - Does not import GnuTLS from application code
+## - Does not expose GnuTLS/DTLS runtime protocol handling
 
 CVE-2025-9820
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,9 +133,15 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Revisit when bookworm publishes a fixed package.
 #
 # Security hardening:
-# Explicitly install openssl/libssl3/libgnutls30 to pull the latest available versions
-# from bookworm-security. libgnutls30 is retained because apt depends on it; installing
-# it here prevents the production image from keeping a stale base-layer GnuTLS package.
+# Explicitly install libgnutls30, alongside the existing OpenSSL packages, to pull
+# the latest available version from bookworm-security. The
+# python:3.13.6-slim-bookworm base image is expected to ship bookworm-security
+# apt sources; if Debian advances libgnutls30, keep this unpinned install on the
+# newest security package and update the exact-version Rego waiver only after
+# checking the new package's CVE status. A mismatch between image inventory and
+# trivy/ignore-policy.rego is an intentional security-review blocker.
+# libgnutls30 is retained because apt depends on it; installing it here prevents
+# the production image from keeping a stale base-layer GnuTLS package.
 # CVE-2026-33846 is still vulnerable in bookworm-security as of 2026-05-05, so the
 # residual HIGH finding is tracked by a narrow Trivy policy waiver instead of a bare ignore.
 # Do not remove unless Trivy alerts are resolved and the base image consistently ships updated TLS packages.

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,12 +133,17 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Revisit when bookworm publishes a fixed package.
 #
 # Security hardening:
-# Explicitly install openssl/libssl3 to pull the latest available versions from bookworm-security.
-# Do not remove unless Trivy alerts are resolved and the base image consistently ships updated OpenSSL.
+# Explicitly install openssl/libssl3/libgnutls30 to pull the latest available versions
+# from bookworm-security. libgnutls30 is retained because apt depends on it; installing
+# it here prevents the production image from keeping a stale base-layer GnuTLS package.
+# CVE-2026-33846 is still vulnerable in bookworm-security as of 2026-05-05, so the
+# residual HIGH finding is tracked by a narrow Trivy policy waiver instead of a bare ignore.
+# Do not remove unless Trivy alerts are resolved and the base image consistently ships updated TLS packages.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         libc6 \
+        libgnutls30 \
         libssl3 \
         openssl \
     && rm -rf /var/lib/apt/lists/* \

--- a/docs/review/PR_1670_FIXED_MAPPING.md
+++ b/docs/review/PR_1670_FIXED_MAPPING.md
@@ -30,12 +30,12 @@ PR #1670 remediates GitHub Code Scanning alert #590 for `libgnutls30` / `CVE-202
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190630293
 Disposition: FIXED
-Commit: pending-review-fix-commit
+Commit: ea64e91dd
 Evidence: `docs/security/CVE-2026-33846-gnutls.md` now uses `Python/OpenSSL-based`.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190650352
 Disposition: FIXED
-Commit: pending-review-fix-commit
+Commit: ea64e91dd
 Evidence: `Dockerfile` now documents the unpinned bookworm-security workflow, exact Rego version-sync requirement, and intentional security-review blocker when image inventory and waiver version diverge.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190650352
@@ -45,12 +45,12 @@ Reason: Pinning `libgnutls30=3.7.9-2+deb12u6` would freeze the production image 
 
 - CodeRabbit review comment on `docs/review/PR_1670_FIXED_MAPPING.md` submitted 2026-05-05T18:24:10Z
 Disposition: FIXED
-Commit: pending-review-fix-commit
+Commit: ea64e91dd
 Evidence: This mapping now states that FIXED closes the GitHub alert mapping while DEFERRED tracks residual upstream distro risk until bookworm receives a true fix.
 
 - Sourcery high-level maintainability comments submitted 2026-05-05T18:18:24Z
 Disposition: FIXED
-Commit: pending-review-fix-commit
+Commit: ea64e91dd
 Evidence: `Dockerfile` now records the shared version-sync workflow, and the security docs/mapping use stable anchors/file-level evidence instead of exact line numbers for the touched GnuTLS surfaces.
 
 ## Security Alert Disposition

--- a/docs/review/PR_1670_FIXED_MAPPING.md
+++ b/docs/review/PR_1670_FIXED_MAPPING.md
@@ -33,15 +33,11 @@ Disposition: FIXED
 Commit: ea64e91dd
 Evidence: `docs/security/CVE-2026-33846-gnutls.md` now uses `Python/OpenSSL-based`.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190650352
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190650352 -> ea64e91dd
 Disposition: FIXED
 Commit: ea64e91dd
 Evidence: `Dockerfile` now documents the unpinned bookworm-security workflow, exact Rego version-sync requirement, and intentional security-review blocker when image inventory and waiver version diverge.
-
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190650352
-Disposition: NOT-A-BUG
-Evidence: `Dockerfile` intentionally keeps `libgnutls30` unpinned so rebuilds pull the newest available bookworm-security package; `trivy/ignore-policy.rego` remains exact-version scoped so package drift surfaces for security review rather than being silently waived.
-Reason: Pinning `libgnutls30=3.7.9-2+deb12u6` would freeze the production image on today's vulnerable package and work against the remediation order for future Debian security updates.
+Reason: The same thread's package-pinning alternative is intentionally not adopted because pinning `libgnutls30=3.7.9-2+deb12u6` would freeze the production image on today's vulnerable package and work against the remediation order for future Debian security updates.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#pullrequestreview-4230613375 -> ea64e91dd
 Disposition: FIXED
@@ -102,8 +98,18 @@ Decision: proceed with changes; do not claim full remediation until Debian bookw
 
 - [ ] Current-head CI green
 - [ ] GitHub Trivy / Code Scanning confirms alert #590 is closed or correctly suppressed on current head
-- [x] Review mapping artifact created
+- [ ] Review mapping artifact created
 - [ ] No actionable bot comments remain
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190727598 -> pending-review-fix-commit
+Disposition: FIXED
+Commit: pending-review-fix-commit
+Evidence: `docs/review/PR_1670_FIXED_MAPPING.md` keeps merge-readiness checklist items unchecked until the final merge cycle.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190753629 -> pending-review-fix-commit
+Disposition: FIXED
+Commit: pending-review-fix-commit
+Evidence: `docs/review/PR_1670_FIXED_MAPPING.md` now maps `discussion_r3190650352` exactly once, with the pinning rationale folded into that single disposition block.
 - [ ] Strict merge wrapper passes with auth
 - [ ] Mandatory wait-window elapsed
 

--- a/docs/review/PR_1670_FIXED_MAPPING.md
+++ b/docs/review/PR_1670_FIXED_MAPPING.md
@@ -43,15 +43,15 @@ Disposition: NOT-A-BUG
 Evidence: `Dockerfile` intentionally keeps `libgnutls30` unpinned so rebuilds pull the newest available bookworm-security package; `trivy/ignore-policy.rego` remains exact-version scoped so package drift surfaces for security review rather than being silently waived.
 Reason: Pinning `libgnutls30=3.7.9-2+deb12u6` would freeze the production image on today's vulnerable package and work against the remediation order for future Debian security updates.
 
-- CodeRabbit review comment on `docs/review/PR_1670_FIXED_MAPPING.md` submitted 2026-05-05T18:24:10Z
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#pullrequestreview-4230613375 -> ea64e91dd
 Disposition: FIXED
 Commit: ea64e91dd
 Evidence: This mapping now states that FIXED closes the GitHub alert mapping while DEFERRED tracks residual upstream distro risk until bookworm receives a true fix.
 
-- Sourcery high-level maintainability comments submitted 2026-05-05T18:18:24Z
-Disposition: FIXED
-Commit: ea64e91dd
-Evidence: `Dockerfile` now records the shared version-sync workflow, and the security docs/mapping use stable anchors/file-level evidence instead of exact line numbers for the touched GnuTLS surfaces.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#pullrequestreview-4230581506
+Disposition: NOT-A-BUG
+Evidence: `trivy/ignore-policy.rego` intentionally keeps separate exact CVE/package/version rules for auditability, while `Dockerfile` now records the version-sync workflow and security docs/mapping use stable anchors/file-level evidence except where repo docs gates require a `file:line` anchor.
+Reason: A shared helper would reduce repetition but also widen a security-waiver surface; explicit per-CVE rules are safer for this HIGH OS-package waiver lane.
 
 ## Security Alert Disposition
 

--- a/docs/review/PR_1670_FIXED_MAPPING.md
+++ b/docs/review/PR_1670_FIXED_MAPPING.md
@@ -28,14 +28,39 @@ PR #1670 remediates GitHub Code Scanning alert #590 for `libgnutls30` / `CVE-202
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190630293
+Disposition: FIXED
+Commit: pending-review-fix-commit
+Evidence: `docs/security/CVE-2026-33846-gnutls.md` now uses `Python/OpenSSL-based`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190650352
+Disposition: FIXED
+Commit: pending-review-fix-commit
+Evidence: `Dockerfile` now documents the unpinned bookworm-security workflow, exact Rego version-sync requirement, and intentional security-review blocker when image inventory and waiver version diverge.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190650352
+Disposition: NOT-A-BUG
+Evidence: `Dockerfile` intentionally keeps `libgnutls30` unpinned so rebuilds pull the newest available bookworm-security package; `trivy/ignore-policy.rego` remains exact-version scoped so package drift surfaces for security review rather than being silently waived.
+Reason: Pinning `libgnutls30=3.7.9-2+deb12u6` would freeze the production image on today's vulnerable package and work against the remediation order for future Debian security updates.
+
+- CodeRabbit review comment on `docs/review/PR_1670_FIXED_MAPPING.md` submitted 2026-05-05T18:24:10Z
+Disposition: FIXED
+Commit: pending-review-fix-commit
+Evidence: This mapping now states that FIXED closes the GitHub alert mapping while DEFERRED tracks residual upstream distro risk until bookworm receives a true fix.
+
+- Sourcery high-level maintainability comments submitted 2026-05-05T18:18:24Z
+Disposition: FIXED
+Commit: pending-review-fix-commit
+Evidence: `Dockerfile` now records the shared version-sync workflow, and the security docs/mapping use stable anchors/file-level evidence instead of exact line numbers for the touched GnuTLS surfaces.
 
 ## Security Alert Disposition
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/590 -> da8e636a57ad5f7432b004c8a64d220449ebe481
 Disposition: FIXED
 Commit: da8e636a57ad5f7432b004c8a64d220449ebe481
-Evidence: `Dockerfile:136` and `Dockerfile:146` explicitly install `libgnutls30` from bookworm-security; local production image inventory shows `libgnutls30:arm64 3.7.9-2+deb12u6`; `docs/security/CVE-2026-33846-gnutls.md` documents the remaining upstream-unfixed bookworm risk.
+Evidence: The runtime security-hardening package install block in `Dockerfile` explicitly installs `libgnutls30` from bookworm-security; local production image inventory shows `libgnutls30:arm64 3.7.9-2+deb12u6`; `docs/security/CVE-2026-33846-gnutls.md` documents the remaining upstream-unfixed bookworm risk.
+
+Alert #590 uses two dispositions because FIXED means the GitHub alert mapping is closed by commit `da8e636a57ad5f7432b004c8a64d220449ebe481`, while DEFERRED means residual upstream distro risk remains tracked in `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-gnutls-cve-2026-33846` and `docs/security/CVE-2026-33846-gnutls.md` until bookworm receives a true fixed package.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/590 -> da8e636a57ad5f7432b004c8a64d220449ebe481
 Disposition: DEFERRED

--- a/docs/review/PR_1670_FIXED_MAPPING.md
+++ b/docs/review/PR_1670_FIXED_MAPPING.md
@@ -81,3 +81,8 @@ Decision: proceed with changes; do not claim full remediation until Debian bookw
 - [ ] No actionable bot comments remain
 - [ ] Strict merge wrapper passes with auth
 - [ ] Mandatory wait-window elapsed
+
+## Phase2 Body Mirror Follow-up
+
+- PASS: `python3 scripts/ci/check_pr_body_phase2_gates.py --body "$(cat /tmp/gnutls-pr-body-live.md)" --pr-number 1670` after updating the live PR body to include the exact required checklist item `Discussion-thread pass completed`.
+- Reason: the first PR-body CI run used an older event body snapshot with extra wording after the required checklist text; live body now matches the Phase2 contract.

--- a/docs/review/PR_1670_FIXED_MAPPING.md
+++ b/docs/review/PR_1670_FIXED_MAPPING.md
@@ -1,0 +1,83 @@
+# PR #1670 Fixed in Commit Mapping
+
+## Summary
+
+PR #1670 remediates GitHub Code Scanning alert #590 for `libgnutls30` / `CVE-2026-33846` in the production Docker image as far as Debian bookworm currently permits.
+
+## Scope
+
+- `Dockerfile`
+- `.trivyignore`
+- `trivy/ignore-policy.rego`
+- `docs/security/CVE-2026-33846-gnutls.md`
+- `docs/security/CVE-2026-33845-gnutls.md`
+- `docs/security/CVE-2025-14831-gnutls.md`
+- `docs/roadmap/BACKLOG_LEDGER.md`
+
+## Role Order
+
+- [x] Declared role order preserved: `agent-coordinator -> security-auditor -> dev-operator -> architecture-specialist -> qa-engineer-agent -> bug-hunter`
+- [x] Pre-open coordinator packet: `555101d9887b`
+- [x] Post-open coordinator packet with declared order: `16c5c048a51f`
+- [x] Mandatory post-open review lane included: `qa-engineer-agent -> bug-hunter`
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Security Alert Disposition
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/590 -> da8e636a57ad5f7432b004c8a64d220449ebe481
+Disposition: FIXED
+Commit: da8e636a57ad5f7432b004c8a64d220449ebe481
+Evidence: `Dockerfile:136` and `Dockerfile:146` explicitly install `libgnutls30` from bookworm-security; local production image inventory shows `libgnutls30:arm64 3.7.9-2+deb12u6`; `docs/security/CVE-2026-33846-gnutls.md` documents the remaining upstream-unfixed bookworm risk.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/590 -> da8e636a57ad5f7432b004c8a64d220449ebe481
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-gnutls-cve-2026-33846`
+Reason: Debian still marks bookworm/bookworm-security vulnerable for `CVE-2026-33846` and reports a fixed version only for unstable `3.8.13-1` at triage time. The residual HIGH finding is temporarily accepted through exact package/version Rego policy until a fixed bookworm package exists.
+
+## Premortem Summary
+
+Frame: It is 48 hours after this container security PR merged. GitHub still reports CVE-2026-33846 or a worse runtime image regression appeared. Why?
+
+- Different image target scanned: addressed by building and checking `--target production`, matching `.github/workflows/trivy.yml`.
+- Fix misses final production image: addressed by final production image inventory after rebuild.
+- Suppression hides real HIGH finding: addressed with exact CVE/package/version/PkgID Rego policy and a remove-by window.
+- Package removal breaks apt/TLS: avoided; `libgnutls30` remains installed because `apt` depends on it.
+- Adjacent GnuTLS policy drift: addressed by updating `CVE-2026-33845` waiver to `3.7.9-2+deb12u6` and marking `CVE-2025-14831` resolved for production image.
+- CI scans a different target: current repo `.github/workflows/trivy.yml` builds and scans `target: production`; current-head CI remains required before merge readiness.
+
+Decision: proceed with changes; do not claim full remediation until Debian bookworm publishes a fixed package.
+
+## Validation
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `python3 scripts/orchestration/task_bootstrap.py --pr-phase pre_open ...` -> packet `555101d9887b`
+- PASS: `python3 scripts/orchestration/task_bootstrap.py --pr-phase post_open_review ...` -> packet `16c5c048a51f`
+- PASS: `docker build --pull --target production ... -t pulseplate:gnutls-check .`
+- PASS: production image package inventory shows `libgnutls30:arm64 3.7.9-2+deb12u6`
+- PASS: container `/health` smoke on alternate host port 8009 returned `{"status":"ok", ... "environment":"ci"}`
+- PASS: `python3 scripts/ci/check_trivy_ignore_policy_expiry.py`
+- PASS: `python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-33846-gnutls.md docs/security/CVE-2026-33845-gnutls.md docs/security/CVE-2025-14831-gnutls.md`
+- PASS: `git diff --check`
+- PASS: `pre-commit run --all-files`
+- PASS: `make validate-changed`
+- PASS: pre-push hooks: `pip-audit`, backend pre-push pytest, full-repo Bandit, docker build test
+- LOCAL GAP: `trivy` CLI unavailable locally (`TRIVY_LOCAL_UNAVAILABLE`); require GitHub current-head Trivy/Code Scanning evidence before merge-readiness claim.
+- DEFERRED: full `make verify` / `make diff-cov` because the diff-cover path runs full `coverage run -m pytest -q` across the 11k-test suite. Partial full verify before operator stop passed `verify-env`, `flake8`, `mypy`, and `test-fast`.
+
+## Merge Readiness
+
+- [ ] Current-head CI green
+- [ ] GitHub Trivy / Code Scanning confirms alert #590 is closed or correctly suppressed on current head
+- [x] Review mapping artifact created
+- [ ] No actionable bot comments remain
+- [ ] Strict merge wrapper passes with auth
+- [ ] Mandatory wait-window elapsed

--- a/docs/review/PR_1670_FIXED_MAPPING.md
+++ b/docs/review/PR_1670_FIXED_MAPPING.md
@@ -101,14 +101,14 @@ Decision: proceed with changes; do not claim full remediation until Debian bookw
 - [ ] Review mapping artifact created
 - [ ] No actionable bot comments remain
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190727598 -> pending-review-fix-commit
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190727598 -> a94bc4595
 Disposition: FIXED
-Commit: pending-review-fix-commit
+Commit: a94bc4595
 Evidence: `docs/review/PR_1670_FIXED_MAPPING.md` keeps merge-readiness checklist items unchecked until the final merge cycle.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190753629 -> pending-review-fix-commit
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190753629 -> a94bc4595
 Disposition: FIXED
-Commit: pending-review-fix-commit
+Commit: a94bc4595
 Evidence: `docs/review/PR_1670_FIXED_MAPPING.md` now maps `discussion_r3190650352` exactly once, with the pinning rationale folded into that single disposition block.
 - [ ] Strict merge wrapper passes with auth
 - [ ] Mandatory wait-window elapsed

--- a/docs/review/PR_1670_FIXED_MAPPING.md
+++ b/docs/review/PR_1670_FIXED_MAPPING.md
@@ -49,6 +49,31 @@ Disposition: NOT-A-BUG
 Evidence: `trivy/ignore-policy.rego` intentionally keeps separate exact CVE/package/version rules for auditability, while `Dockerfile` now records the version-sync workflow and security docs/mapping use stable anchors/file-level evidence except where repo docs gates require a `file:line` anchor.
 Reason: A shared helper would reduce repetition but also widen a security-waiver surface; explicit per-CVE rules are safer for this HIGH OS-package waiver lane.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#pullrequestreview-4230601979 -> ea64e91dd
+Disposition: FIXED
+Commit: ea64e91dd
+Evidence: `Dockerfile` records the libgnutls30 version-sync workflow and explains why the package remains unpinned while exact-version Rego drift blocks security review.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#pullrequestreview-4230690696 -> a94bc4595
+Disposition: FIXED
+Commit: a94bc4595
+Evidence: `docs/review/PR_1670_FIXED_MAPPING.md` keeps merge-readiness checklist items unchecked until the final merge cycle.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190727598 -> a94bc4595
+Disposition: FIXED
+Commit: a94bc4595
+Evidence: `docs/review/PR_1670_FIXED_MAPPING.md` keeps merge-readiness checklist items unchecked until the final merge cycle.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#pullrequestreview-4230719969 -> a94bc4595
+Disposition: FIXED
+Commit: a94bc4595
+Evidence: `docs/review/PR_1670_FIXED_MAPPING.md` maps `discussion_r3190650352` exactly once, with the pinning rationale folded into that single disposition block.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190753629 -> a94bc4595
+Disposition: FIXED
+Commit: a94bc4595
+Evidence: `docs/review/PR_1670_FIXED_MAPPING.md` maps `discussion_r3190650352` exactly once, with the pinning rationale folded into that single disposition block.
+
 ## Security Alert Disposition
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/590 -> da8e636a57ad5f7432b004c8a64d220449ebe481
@@ -101,15 +126,6 @@ Decision: proceed with changes; do not claim full remediation until Debian bookw
 - [ ] Review mapping artifact created
 - [ ] No actionable bot comments remain
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190727598 -> a94bc4595
-Disposition: FIXED
-Commit: a94bc4595
-Evidence: `docs/review/PR_1670_FIXED_MAPPING.md` keeps merge-readiness checklist items unchecked until the final merge cycle.
-
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1670#discussion_r3190753629 -> a94bc4595
-Disposition: FIXED
-Commit: a94bc4595
-Evidence: `docs/review/PR_1670_FIXED_MAPPING.md` now maps `discussion_r3190650352` exactly once, with the pinning rationale folded into that single disposition block.
 - [ ] Strict merge wrapper passes with auth
 - [ ] Mandatory wait-window elapsed
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4282,7 +4282,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Status: Open
   - Area: security / base-image / code-scanning
   - Finding Type: container base image vulnerability
-  - Reason: GitHub Code Scanning alert #589 reports `libgnutls30` `CVE-2026-33845` at `3.7.9-2+deb12u5` with no fixed version reported by Trivy/GitHub at triage time. This is covered by a narrow temporary suppression in `trivy/ignore-policy.rego` while monitoring Debian/Trivy fixed-version metadata.
+  - Reason: GitHub Code Scanning alert #589 reports `libgnutls30` `CVE-2026-33845` at `3.7.9-2+deb12u5`. The CVE-2026-33846 PR upgrades the production image to the latest available bookworm-security package (`3.7.9-2+deb12u6`), but Debian still marks bookworm/bookworm-security vulnerable and reports a fixed version only for unstable `3.8.13-1` at triage time. This is covered by a narrow temporary suppression in `trivy/ignore-policy.rego` while monitoring Debian/Trivy fixed-version metadata.
   - Links:
     - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/589
     - docs/security/CVE-2026-33845-gnutls.md
@@ -4292,6 +4292,26 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Remove suppression rule from `trivy/ignore-policy.rego`
     - Mark `docs/security/CVE-2026-33845-gnutls.md` resolved or update with remediation evidence
     - Trivy Code Scanning alert #589 remains closed on `main`
+
+<a id="ledger-p1-remove-trivy-suppression-gnutls-cve-2026-33846"></a>
+- [ ] Remove Trivy suppression for libgnutls30 CVE-2026-33846
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: TBD (follow-up after upstream bookworm fix)
+  - Status: Open
+  - Area: security / base-image / code-scanning
+  - Finding Type: container base image vulnerability
+  - Reason: GitHub Code Scanning alert #590 reports `libgnutls30` `CVE-2026-33846` at `3.7.9-2+deb12u5`. This PR upgrades the production image to the latest available bookworm-security package (`3.7.9-2+deb12u6`), but Debian still marks bookworm/bookworm-security vulnerable and reports a fixed version only for unstable `3.8.13-1` at triage time. The remaining risk is covered by a narrow temporary suppression in `trivy/ignore-policy.rego`.
+  - Links:
+    - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/590
+    - docs/security/CVE-2026-33846-gnutls.md
+    - trivy/ignore-policy.rego
+    - https://security-tracker.debian.org/tracker/CVE-2026-33846
+  - DoD:
+    - Debian bookworm publishes a fixed `libgnutls30` package context or Trivy/GitHub reports a non-empty fixed version for bookworm
+    - Remove suppression rule from `trivy/ignore-policy.rego`
+    - Mark `docs/security/CVE-2026-33846-gnutls.md` resolved or update with remediation evidence
+    - Trivy Code Scanning alert #590 remains closed on `main`
 
 <a id="ledger-p1-reconcile-open-dependabot-alerts"></a>
 - [ ] P1: Reconcile open Dependabot alerts on `main` after manifest fixes

--- a/docs/security/CVE-2025-14831-gnutls.md
+++ b/docs/security/CVE-2025-14831-gnutls.md
@@ -49,7 +49,7 @@ The production-image removal condition is satisfied when:
 ## Suppression implementation
 
 - Policy file: `trivy/ignore-policy.rego`
-- Evidence anchors: `docs/roadmap/BACKLOG_LEDGER.md:4296`, `Dockerfile:136`, `Dockerfile:146`, `trivy/ignore-policy.rego:180`
+- Evidence anchors: CVE-2025-14831 backlog entry in `docs/roadmap/BACKLOG_LEDGER.md`, runtime security-hardening package install block in `Dockerfile`, `cve-2025-14831-gnutls-suppression` in `trivy/ignore-policy.rego`, and gate-required anchor `docs/security/CVE-2025-14831-gnutls.md:52`
 - Rule matches:
   - `input.VulnerabilityID == "CVE-2025-14831"`
   - `input.PkgName == "libgnutls30"`

--- a/docs/security/CVE-2025-14831-gnutls.md
+++ b/docs/security/CVE-2025-14831-gnutls.md
@@ -1,36 +1,38 @@
-# CVE-2025-14831 — libgnutls30 (Debian bookworm) — SUPPRESSED
+# CVE-2025-14831 — libgnutls30 (Debian bookworm) — RESOLVED FOR PRODUCTION IMAGE
 
 ## Summary
 
 - **CVE**: CVE-2025-14831
 - **Package**: `libgnutls30`
-- **Installed version (observed)**: `3.7.9-2+deb12u5`
+- **Installed version (originally observed)**: `3.7.9-2+deb12u5`
+- **Production image version after CVE-2026-33846 PR**: `3.7.9-2+deb12u6`
 - **Fixed version**: `3.7.9-2+deb12u6` (DSA-6140-1)
 - **Trivy rule**: `OsPackageVulnerability`
 - **Severity (Trivy security severity level)**: Medium
 - **GitHub alert**: `security/code-scanning/536`
 - **Observed on**: 2026-02-10
-- **Status**: SUPPRESSED (base image not yet updated to include fix)
+- **Status**: RESOLVED for the production Docker target by explicitly installing `libgnutls30` from bookworm-security
 
 ## Current Situation
 
 The fix for CVE-2025-14831 is available in Debian bookworm as `3.7.9-2+deb12u6` (DSA-6140-1).
-However, our container base image (`python:3.13.6-slim`) still ships with the vulnerable
-version `3.7.9-2+deb12u5`.
+The production Docker target now explicitly installs `libgnutls30` from bookworm-security, so the
+runtime image no longer retains the vulnerable `3.7.9-2+deb12u5` base-layer package.
 
 **Timeline:**
 - 2026-02-10: Alert first observed
 - 2026-02-27: Suppression removed assuming fix deployed (PR #929)
 - 2026-02-27: Re-added suppression after discovering base image still has vulnerable version
+- 2026-05-05: Production Docker target updated to install `libgnutls30 3.7.9-2+deb12u6`
 
-## Why we suppress
+## Why the historical suppression existed
 
 - This is an **OS package** vulnerability in the base image, not application (Python/FastAPI) code.
-- The fix exists in Debian repos but the base image hasn't been updated to pull it.
-- We cannot force the upstream base image to update; we can only wait or rebuild with `--no-cache`.
+- The fix existed in Debian repos but the base image had not been updated to pull it.
 
-We apply a **narrow suppression** (package + exact installed version) to keep code-scanning
-alerts actionable while monitoring for base image updates.
+The production target now pulls the fixed package in its runtime apt layer. Any remaining
+`CVE-2025-14831` suppression scoped to `3.7.9-2+deb12u5` is historical and should not match the
+current production image.
 
 ## Monitor / upstream status
 
@@ -39,15 +41,15 @@ alerts actionable while monitoring for base image updates.
 
 ## Removal condition
 
-Remove the suppression when:
+The production-image removal condition is satisfied when:
 
-1. Base image is updated to include `libgnutls30 >= 3.7.9-2+deb12u6`, or
-2. A container rebuild with `--no-cache` pulls the fixed version
+1. Production image inventory shows `libgnutls30 >= 3.7.9-2+deb12u6`.
+2. GitHub Code Scanning alert #536 remains closed on `main`.
 
 ## Suppression implementation
 
 - Policy file: `trivy/ignore-policy.rego`
-- Evidence anchors: `trivy/ignore-policy.rego:95`, `AGENTS.md:1375`
+- Evidence anchors: `docs/roadmap/BACKLOG_LEDGER.md:4296`, `Dockerfile:136`, `Dockerfile:146`, `trivy/ignore-policy.rego:180`
 - Rule matches:
   - `input.VulnerabilityID == "CVE-2025-14831"`
   - `input.PkgName == "libgnutls30"`
@@ -56,4 +58,4 @@ Remove the suppression when:
 ## Review / expiry
 
 - **Review-by**: 2026-05-27 (shared policy-file expiry window)
-- **Last updated**: 2026-02-27
+- **Last updated**: 2026-05-05

--- a/docs/security/CVE-2026-33845-gnutls.md
+++ b/docs/security/CVE-2026-33845-gnutls.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Temporary narrow suppression with fixed-version monitoring.
+Latest available bookworm package installed; temporary narrow suppression with fixed-version monitoring.
 
 ## Alert
 
@@ -10,7 +10,8 @@ Temporary narrow suppression with fixed-version monitoring.
 - Tool: Trivy
 - Image: `katsiarynakavaleuskaya/pulseplate:1`
 - Package: `libgnutls30`
-- Installed version: `3.7.9-2+deb12u5`
+- Installed version reported by alert: `3.7.9-2+deb12u5`
+- Package version after CVE-2026-33846 PR: `3.7.9-2+deb12u6`
 - Vulnerability: `CVE-2026-33845`
 - Severity: HIGH
 - Fixed version reported by GitHub/Trivy: empty at triage time
@@ -24,14 +25,15 @@ remotely exploitable denial of service and possible information disclosure.
 
 ## Current decision
 
-No fixed package version is reported for the observed Debian package context.
-The repository therefore uses a narrow, time-boxed Trivy suppression for
-exactly:
+No fixed package version is reported for the relevant Debian bookworm package context.
+This PR upgrades the production image from `3.7.9-2+deb12u5` to the latest available
+bookworm-security package, `3.7.9-2+deb12u6`, but Debian still marks that package
+vulnerable. The repository therefore uses a narrow, time-boxed Trivy suppression for exactly:
 
 - `VulnerabilityID == CVE-2026-33845`
 - `PkgName == libgnutls30`
-- `InstalledVersion == 3.7.9-2+deb12u5`
-- `PkgID` prefix match for `libgnutls30@3.7.9-2+deb12u5`
+- `InstalledVersion == 3.7.9-2+deb12u6`
+- `PkgID` prefix match for `libgnutls30@3.7.9-2+deb12u6`
 - Image scoped to PulsePlate refs (GHCR and Docker Hub); falls back to broad
   match when Trivy does not populate the Image field
 - Distro scoped to Debian; falls back to broad match when Trivy does not
@@ -39,9 +41,10 @@ exactly:
 
 ## Why not bump immediately
 
-The alert reports an empty Fixed Version. A repository-level package bump or
-Docker base-image change is not actionable until Debian publishes a fixed
-package line or Trivy metadata reports a fixed version for this package context.
+The alert reports an empty Fixed Version for bookworm. A full remediation is not
+available until Debian publishes a fixed bookworm package line or Trivy metadata
+reports a fixed version for this package context. The PR still installs the latest
+available bookworm-security package to avoid retaining a stale base-layer version.
 
 ## Risk note
 
@@ -65,13 +68,14 @@ Remove the suppression when either condition is true:
 
 ## Suppression implementation
 
-- Policy file: `trivy/ignore-policy.rego`
-- Ledger anchor: `docs/roadmap/BACKLOG_LEDGER.md` security suppression tracking section
+- Policy evidence: `trivy/ignore-policy.rego:191` and `trivy/ignore-policy.rego:213`
+- Ledger evidence: `docs/roadmap/BACKLOG_LEDGER.md:4284`
 
 ## Evidence anchors
 
-- `trivy/ignore-policy.rego:181` (anchor: `cve-2026-33845-gnutls-suppression`)
-- `docs/roadmap/BACKLOG_LEDGER.md:4102`
+- `Dockerfile:136` and `Dockerfile:146`
+- `trivy/ignore-policy.rego:191` (anchor: `cve-2026-33845-gnutls-suppression`)
+- `docs/roadmap/BACKLOG_LEDGER.md:4284`
 
 ## Review / expiry
 

--- a/docs/security/CVE-2026-33845-gnutls.md
+++ b/docs/security/CVE-2026-33845-gnutls.md
@@ -68,13 +68,13 @@ Remove the suppression when either condition is true:
 
 ## Suppression implementation
 
-- Policy evidence: `trivy/ignore-policy.rego:191` and `trivy/ignore-policy.rego:213`
+- Policy evidence: `cve-2026-33845-gnutls-suppression` in `trivy/ignore-policy.rego`
 - Ledger evidence: `docs/roadmap/BACKLOG_LEDGER.md:4284`
 
 ## Evidence anchors
 
-- `Dockerfile:136` and `Dockerfile:146`
-- `trivy/ignore-policy.rego:191` (anchor: `cve-2026-33845-gnutls-suppression`)
+- Runtime security-hardening package install block in `Dockerfile`
+- `cve-2026-33845-gnutls-suppression` in `trivy/ignore-policy.rego`
 - `docs/roadmap/BACKLOG_LEDGER.md:4284`
 
 ## Review / expiry

--- a/docs/security/CVE-2026-33846-gnutls.md
+++ b/docs/security/CVE-2026-33846-gnutls.md
@@ -1,0 +1,105 @@
+# CVE-2026-33846 - libgnutls30 / Trivy alert #590
+
+## Status
+
+Latest available bookworm package installed; temporary narrow suppression for residual upstream-unfixed risk.
+
+## Alert
+
+- GitHub Code Scanning alert: #590
+- Tool: Trivy
+- Package: `libgnutls30`
+- Installed version reported by alert: `3.7.9-2+deb12u5`
+- Package version after this PR: `3.7.9-2+deb12u6`
+- Vulnerability: `CVE-2026-33846`
+- Severity: HIGH
+
+## Summary
+
+GnuTLS has a heap buffer overflow in DTLS handshake fragment reassembly. The
+issue is remotely exploitable in affected DTLS handshake paths and may cause
+crashes or memory corruption.
+
+## Production image finding
+
+Before this PR, the production Docker target installed `libgnutls30` from the
+base image at `3.7.9-2+deb12u5`. The package is real, not a phantom dependency:
+Debian `apt` depends on `libgnutls30`.
+
+This PR explicitly installs `libgnutls30` in the runtime apt layer so the
+production image pulls the latest available bookworm-security package instead
+of retaining a stale base-layer package.
+
+## Current decision
+
+Debian still marks bookworm and bookworm-security vulnerable for this CVE as of
+2026-05-05. Debian reports the fixed version only for unstable:
+`gnutls28 3.8.13-1`.
+
+Because no fixed bookworm package exists, the repository uses a narrow,
+time-boxed Trivy suppression for exactly:
+
+- `VulnerabilityID == CVE-2026-33846`
+- `PkgName == libgnutls30`
+- `InstalledVersion == 3.7.9-2+deb12u6`
+- `PkgID` prefix match for `libgnutls30@3.7.9-2+deb12u6`
+- Image scoped to PulsePlate refs when Trivy populates the Image field
+- Distro scoped to Debian when Trivy populates the Distro field
+
+This is temporary risk acceptance, not full remediation.
+
+## Attack-surface assessment
+
+PulsePlate application TLS is Python/OpenSSL based. The app does not import
+GnuTLS from Python code and does not expose a GnuTLS DTLS endpoint. The package
+is retained by the Debian base system for `apt`, not by application protocol
+handling.
+
+The residual risk is still tracked as HIGH because the vulnerable OS package is
+present in the image and the CVE is remotely exploitable in affected DTLS
+consumers.
+
+## Removal condition
+
+Remove the suppression when either condition is true:
+
+1. Debian bookworm publishes a fixed `libgnutls30` package.
+2. Trivy/GitHub reports a non-empty fixed version for this package context and
+   the production image can be rebuilt with it.
+
+## Monitor
+
+- <https://security-tracker.debian.org/tracker/CVE-2026-33846>
+- <https://avd.aquasec.com/nvd/cve-2026-33846>
+- <https://www.gnutls.org/security-new.html#GNUTLS-SA-2026-04-29-1>
+
+## Suppression implementation
+
+- Dockerfile evidence: `Dockerfile:136` and `Dockerfile:146`
+- Policy evidence: `trivy/ignore-policy.rego:227` and `trivy/ignore-policy.rego:266`
+- Backlog evidence: `docs/roadmap/BACKLOG_LEDGER.md:4296`
+- Policy anchor: `cve-2026-33846-gnutls-suppression`
+- Remove-by / next review: 2026-05-27
+
+## Validation
+
+Required evidence for this PR:
+
+```bash
+docker build --pull --target production \
+  --build-arg PULSEPLATE_PYTHON_INDEX_URL="$PULSEPLATE_PYTHON_INDEX_URL" \
+  --build-arg PULSEPLATE_PYTHON_TRUSTED_HOST="${PULSEPLATE_PYTHON_TRUSTED_HOST:-}" \
+  --build-arg PULSEPLATE_REQUIREMENTS_FILE=requirements-docker-runtime.txt \
+  -t pulseplate:gnutls-check .
+
+docker run --rm pulseplate:gnutls-check sh -lc '
+  cat /etc/os-release
+  dpkg-query -W libgnutls30
+  apt-cache policy libgnutls30 || true
+  apt-cache rdepends --installed libgnutls30 || true
+'
+
+python3 scripts/ci/check_trivy_ignore_policy_expiry.py
+pre-commit run --all-files
+make validate-changed
+```

--- a/docs/security/CVE-2026-33846-gnutls.md
+++ b/docs/security/CVE-2026-33846-gnutls.md
@@ -50,7 +50,7 @@ This is temporary risk acceptance, not full remediation.
 
 ## Attack-surface assessment
 
-PulsePlate application TLS is Python/OpenSSL based. The app does not import
+PulsePlate application TLS is Python/OpenSSL-based. The app does not import
 GnuTLS from Python code and does not expose a GnuTLS DTLS endpoint. The package
 is retained by the Debian base system for `apt`, not by application protocol
 handling.
@@ -75,8 +75,8 @@ Remove the suppression when either condition is true:
 
 ## Suppression implementation
 
-- Dockerfile evidence: `Dockerfile:136` and `Dockerfile:146`
-- Policy evidence: `trivy/ignore-policy.rego:227` and `trivy/ignore-policy.rego:266`
+- Dockerfile evidence: runtime security-hardening package install block in `Dockerfile`
+- Policy evidence: `cve-2026-33846-gnutls-suppression` in `trivy/ignore-policy.rego`
 - Backlog evidence: `docs/roadmap/BACKLOG_LEDGER.md:4296`
 - Policy anchor: `cve-2026-33846-gnutls-suppression`
 - Remove-by / next review: 2026-05-27

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -11,7 +11,7 @@ default ignore := false
 #
 # Suppression expires: 2026-05-27 (manual removal)
 # Last reviewed: 2026-04-02
-# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2026-4046-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-14831-gnutls.md, docs/security/CVE-2026-33845-gnutls.md, docs/security/CVE-2025-69720-ncurses.md, docs/security/CVE-2026-29111-systemd.md, docs/security/CVE-2026-4878-libcap2.md
+# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2026-4046-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-14831-gnutls.md, docs/security/CVE-2026-33845-gnutls.md, docs/security/CVE-2026-33846-gnutls.md, docs/security/CVE-2025-69720-ncurses.md, docs/security/CVE-2026-29111-systemd.md, docs/security/CVE-2026-4878-libcap2.md
 
 ignore if {
 	input.VulnerabilityID == "CVE-2026-0915"
@@ -179,17 +179,18 @@ ignore if {
 }
 
 # anchor:cve-2026-33845-gnutls-suppression
-# CVE-2026-33845 (GnuTLS) - no fixed release for observed Debian package at triage time
+# CVE-2026-33845 (GnuTLS) - no fixed release for Debian bookworm at triage time
 # Review-by: 2026-05-27 (manual removal)
 # Rationale: Trivy code-scanning alert #589 reports libgnutls30 fixed-version unknown
-#   for `3.7.9-2+deb12u5` in the production image. No repository-level
-#   remediation path exists until Debian publishes a fixed package line or
-#   Trivy metadata reports a Fixed Version.
+#   in the production image. The Dockerfile now explicitly installs libgnutls30
+#   from bookworm-security so the image does not retain stale `3.7.9-2+deb12u5`,
+#   but Debian still marks bookworm-security `3.7.9-2+deb12u6` vulnerable.
+#   Fixed version is only published for unstable (`3.8.13-1`) at triage time.
 # Monitor: https://security-tracker.debian.org/tracker/CVE-2026-33845
 # Documented in: docs/security/CVE-2026-33845-gnutls.md
 # Removal condition: Remove when Debian publishes fixed libgnutls30 package / Trivy metadata gains fixed version for this package context
 
-cve_2026_33845_libgnutls30_version := "3.7.9-2+deb12u5"
+cve_2026_33845_libgnutls30_version := "3.7.9-2+deb12u6"
 
 cve_2026_33845_image_reference_match if {
 	startswith(input.Image, "ghcr.io/katsiarynakavaleuskaya/pulseplate")
@@ -222,6 +223,54 @@ ignore if {
 	cve_2026_33845_image_reference_match
 	cve_2026_33845_distro_match
 	startswith(input.PkgID, sprintf("libgnutls30@%s", [cve_2026_33845_libgnutls30_version]))
+}
+
+# anchor:cve-2026-33846-gnutls-suppression
+# CVE-2026-33846 (GnuTLS) - no fixed release for Debian bookworm at triage time
+# Review-by: 2026-05-27 (manual removal)
+# Rationale: GitHub Code Scanning alert #590 reports libgnutls30 CVE-2026-33846
+#   in the production image. The Dockerfile now explicitly installs libgnutls30
+#   from bookworm-security so the image does not retain stale `3.7.9-2+deb12u5`,
+#   but Debian still marks bookworm-security `3.7.9-2+deb12u6` vulnerable.
+#   Fixed version is only published for unstable (`3.8.13-1`) at triage time.
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2026-33846
+# Documented in: docs/security/CVE-2026-33846-gnutls.md
+# Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-gnutls-cve-2026-33846
+# Removal condition: Remove when Debian bookworm publishes fixed libgnutls30 package / Trivy metadata gains fixed version for this package context
+
+cve_2026_33846_libgnutls30_version := "3.7.9-2+deb12u6"
+
+cve_2026_33846_image_reference_match if {
+	startswith(input.Image, "ghcr.io/katsiarynakavaleuskaya/pulseplate")
+}
+
+cve_2026_33846_image_reference_match if {
+	startswith(input.Image, "katsiarynakavaleuskaya/pulseplate")
+}
+
+cve_2026_33846_image_reference_match if {
+	# Fallback: Trivy sometimes omits the Image field in certain scan contexts;
+	# suppression still requires exact CVE + package + version + pkgID prefix match.
+	not input.Image
+}
+
+cve_2026_33846_distro_match if {
+	input.Distro == "debian"
+}
+
+cve_2026_33846_distro_match if {
+	# Fallback: Trivy sometimes omits the Distro field;
+	# suppression still requires exact CVE + package + version + pkgID prefix match.
+	not input.Distro
+}
+
+ignore if {
+	input.VulnerabilityID == "CVE-2026-33846"
+	input.PkgName == "libgnutls30"
+	input.InstalledVersion == cve_2026_33846_libgnutls30_version
+	cve_2026_33846_image_reference_match
+	cve_2026_33846_distro_match
+	startswith(input.PkgID, sprintf("libgnutls30@%s", [cve_2026_33846_libgnutls30_version]))
 }
 
 # CVE-2026-3184 (util-linux family) - upstream unfixed in Debian bookworm


### PR DESCRIPTION
## Summary

Remediates GitHub Code Scanning alert #590 for `libgnutls30` / `CVE-2026-33846` in the production Docker image as far as Debian bookworm currently permits.

- Explicitly installs `libgnutls30` in the runtime apt layer so production no longer retains stale base-layer `3.7.9-2+deb12u5`.
- Upgrades the production image to latest available bookworm-security `libgnutls30 3.7.9-2+deb12u6`.
- Adds a narrow temporary Trivy Rego waiver for the residual `CVE-2026-33846` risk because Debian still marks bookworm/bookworm-security vulnerable and only unstable has a fixed version.
- Reconciles adjacent GnuTLS docs/policy for `CVE-2026-33845`, `CVE-2025-14831`, and stale `.trivyignore` text.

## Scope

- Docker production image OS package handling.
- Trivy Rego policy and security docs.
- Backlog tracking for waiver removal.

Out of scope: Python dependency upgrades, app runtime/API behavior changes, Debian-to-Alpine/distroless migration, broad Docker slimming or CI/CD redesign, unrelated Trivy alert cleanup.

## Security Alert

- Alert: https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/590
- Package: `libgnutls30`
- Alert version: `3.7.9-2+deb12u5`
- Post-PR package version: `3.7.9-2+deb12u6`
- Debian tracker: https://security-tracker.debian.org/tracker/CVE-2026-33846
- Current disposition: latest bookworm-security package installed; residual upstream-unfixed risk accepted temporarily with exact package/version Rego policy.

## Remediation / Disposition

This is not a Python/FastAPI code bug. It is an OS package vulnerability in the Debian production image.

Evidence from local production image inventory:

```text
libgnutls30:arm64 3.7.9-2+deb12u6
libtasn1-6:arm64 4.19.0-2+deb12u1
ca-certificates 20230311+deb12u1
libc6:arm64 2.36-9+deb12u13
libssl3:arm64 3.0.19-1~deb12u2
openssl 3.0.19-1~deb12u2
Reverse Depends: apt
```

Temporary waiver is scoped to exact `CVE-2026-33846` + `libgnutls30` + `3.7.9-2+deb12u6` + PkgID prefix, with remove-by / next review on 2026-05-27.

## Validation

Local gates run:

```text
PASS: python3 scripts/orchestration/check_preflight.py
PASS: python3 scripts/orchestration/check_agent_consistency.py
PASS: task_bootstrap.py --pr-phase pre_open -> packet 555101d9887b
PASS: task_bootstrap.py --pr-phase post_open_review -> packet 16c5c048a51f
PASS: docker build --pull --target production ... -t pulseplate:gnutls-check .
PASS: production image package inventory shows libgnutls30 3.7.9-2+deb12u6
PASS: container /health smoke on alternate host port 8009 -> {"status":"ok", ... "environment":"ci"}
PASS: python3 scripts/ci/check_trivy_ignore_policy_expiry.py
PASS: python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-33846-gnutls.md docs/security/CVE-2026-33845-gnutls.md docs/security/CVE-2025-14831-gnutls.md
PASS: git diff --check
PASS: pre-commit run --all-files
PASS: make validate-changed
PASS: pre-push hooks: pip-audit, backend pytest, full-repo Bandit, docker build test
```

Local Trivy note: `TRIVY_LOCAL_UNAVAILABLE`.

Machine-heavy deferral:

- Full `make verify` was started and passed `verify-env`, `flake8`, `mypy`, and `test-fast`, then was stopped during full coverage because it runs the 11k-test coverage suite.
- `make diff-cov` is deferred for the same reason: in this repo it depends on `coverage run -m pytest -q` across the full suite.
- Merge readiness must rely on the narrow local gates above plus current-head GitHub CI/Trivy/security evidence.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Post-open external bot/review-thread pass completed for current actionable comments

### Fixed in Commit Mapping

Canonical artifact: `docs/review/PR_1670_FIXED_MAPPING.md`

Current mapping:

- Security alert #590 -> `da8e636a5` as FIXED for stale `deb12u5` package remediation
- Security alert #590 -> DEFERRED for residual upstream-unfixed `deb12u6` risk, tracked in `BACKLOG_LEDGER.md`
- Sourcery typo thread `discussion_r3190630293` -> `ea64e91dd` as FIXED
- CodeRabbit Dockerfile maintenance/version-sync thread `discussion_r3190650352` -> `ea64e91dd` as FIXED for workflow documentation
- CodeRabbit Dockerfile pinning suggestion on `discussion_r3190650352` -> NOT-A-BUG because unpinned latest bookworm-security install is intentional and exact-version Rego drift blocks security review
- CodeRabbit mapping disambiguation review `pullrequestreview-4230613375` -> `ea64e91dd` as FIXED in `docs/review/PR_1670_FIXED_MAPPING.md`
- Sourcery high-level maintainability review `pullrequestreview-4230581506` -> NOT-A-BUG for shared-helper refactor; explicit per-CVE Rego rules are intentionally safer for HIGH waiver auditability, with docs anchor cleanup applied where repo gates permit
- CodeRabbit mapping checkbox thread `discussion_r3190727598` -> `a94bc4595` as FIXED; merge-readiness checklist remains unchecked until final merge cycle
- Cubic duplicate-disposition thread `discussion_r3190753629` -> `a94bc4595` as FIXED; `discussion_r3190650352` is mapped exactly once with pinning rationale folded into the single disposition
- CodeRabbit review `pullrequestreview-4230601979` -> `ea64e91dd` as FIXED for Dockerfile workflow documentation
- CodeRabbit review `pullrequestreview-4230690696` -> `a94bc4595` as FIXED for unchecked merge-readiness mapping checklist
- Cubic review `pullrequestreview-4230719969` -> `a94bc4595` as FIXED for duplicate-disposition cleanup

## Merge Readiness

- [ ] Current-head CI complete and passing
- [ ] GitHub Trivy / Code Scanning confirms alert #590 is closed or correctly suppressed on current head
- [x] `docs/review/PR_1670_FIXED_MAPPING.md` exists
- [ ] No unresolved review threads
- [ ] No actionable CodeRabbit/Sourcery/Cubic comments remain unmapped
- [ ] Strict merge wrapper passes with auth
- [ ] Mandatory wait-window elapsed after latest bot/review activity

## Deferred / Follow-ups

- Remove `CVE-2026-33846` waiver when Debian bookworm publishes a fixed `libgnutls30` package or Trivy/GitHub reports a fixed bookworm version.
- Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-gnutls-cve-2026-33846`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Explicitly adjust TLS package handling in the runtime image; add narrow, time‑boxed Trivy suppressions (with expiry and re‑evaluation guidance) for multiple GnuTLS and glibc CVEs, and clarify OS-package rationale plus monitoring/removal steps.

* **Documentation**
  * Added and updated security pages, remediation mapping, backlog entries, and validation/merge‑gating guidance documenting CVE status, suppression evidence, and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


