### PR TITLE
feat(evidence): add unified eval event schema

### DIFF
--- a/core/evidence/AGENTS.md
+++ b/core/evidence/AGENTS.md
@@ -1,0 +1,19 @@
+# Agent instructions (scope: core/evidence/ and subdirectories)
+
+## Evidence Graph Runtime sequencing
+
+Evidence Graph Runtime changes must preserve this separation:
+
+- Eval runners generate artifacts.
+- Evidence events normalize artifact metadata into deterministic event records.
+- Promotion ledger and replay consume normalized events in later PRs.
+- Semantic cache is a separate runtime optimization and must not be introduced
+  through evidence-event PRs.
+- GraphRAG / knowledge graph expansion is out of scope unless a later packet
+  explicitly opens that rail.
+- Karpathy/advisory wiki is workforce memory only and must not become
+  product-runtime or eval-event source of truth.
+
+For E2-style work, keep `core/evidence/` pure and deterministic. Do not import
+FastAPI, providers, DB/session state, Redis/cache modules, eval runners, or
+advisory wiki modules from this package.

--- a/core/evidence/__init__.py
+++ b/core/evidence/__init__.py
@@ -15,13 +15,27 @@ from core.evidence.fingerprints import (
     build_idempotency_key,
     fingerprint_payload,
 )
+from core.evidence.events import (
+    EvidenceEvalEvent,
+    EvalEventProducer,
+    EvalEventRail,
+    EvalEventType,
+    ValidationStatus,
+    create_eval_event,
+)
 
 __all__ = [
     "AssetType",
     "EvidenceAssetRef",
+    "EvidenceEvalEvent",
+    "EvalEventProducer",
+    "EvalEventRail",
+    "EvalEventType",
     "Rail",
+    "ValidationStatus",
     "build_asset_id",
     "build_idempotency_key",
     "create_evidence_asset_ref",
+    "create_eval_event",
     "fingerprint_payload",
 ]

--- a/core/evidence/events.py
+++ b/core/evidence/events.py
@@ -344,11 +344,7 @@ def validate_source_artifact(source_artifact: str) -> str:
     if normalized.startswith("/") or normalized.startswith("~"):
         raise ValueError("source_artifact must be repo-relative")
     path = PurePosixPath(normalized)
-    if path.is_absolute():
-        raise ValueError("source_artifact must be repo-relative")
     parts = path.parts
-    if not parts:
-        raise ValueError("source_artifact must be non-empty")
     if any(part in {"", ".", ".."} for part in parts):
         raise ValueError("source_artifact must not contain traversal")
     if parts[0] in _FORBIDDEN_SOURCE_ROOTS:

--- a/core/evidence/events.py
+++ b/core/evidence/events.py
@@ -1,0 +1,454 @@
+"""Unified eval event schema for Evidence Graph Runtime.
+
+RU: Eval events нормализуют артефакты в append-only event plane.
+EN: Eval events normalize artifacts into an append-only event plane.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import PurePosixPath
+from typing import Literal, TypeAlias, cast
+
+from core.evidence.assets import EvidenceAssetRef
+from core.evidence.fingerprints import JsonScalar, JsonValue, fingerprint_payload
+from core.evidence.policies import (
+    normalize_upstream_ids,
+    validate_fingerprint,
+    validate_non_empty_token,
+)
+
+EvalEventType = Literal[
+    "rag_gate_run",
+    "rag_gate_report",
+    "ragas_report",
+    "eval_validity_record",
+    "judgment_validity_record",
+    "item_metadata",
+    "item_statistics",
+    "gate_metric",
+    "gate_decision",
+]
+
+EvalEventRail = Literal["runtime", "advisory", "control_plane", "eval"]
+
+ValidationStatus = Literal["valid", "invalid", "degraded", "deferred"]
+
+ALLOWED_EVAL_EVENT_TYPES: tuple[str, ...] = (
+    "rag_gate_run",
+    "rag_gate_report",
+    "ragas_report",
+    "eval_validity_record",
+    "judgment_validity_record",
+    "item_metadata",
+    "item_statistics",
+    "gate_metric",
+    "gate_decision",
+)
+
+ALLOWED_EVAL_EVENT_RAILS: tuple[str, ...] = (
+    "runtime",
+    "advisory",
+    "control_plane",
+    "eval",
+)
+
+ALLOWED_VALIDATION_STATUSES: tuple[str, ...] = (
+    "valid",
+    "invalid",
+    "degraded",
+    "deferred",
+)
+
+_FORBIDDEN_SOURCE_ROOTS: tuple[str, ...] = (
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "build",
+    "dist",
+    "node_modules",
+    "worktrees",
+)
+
+_FORBIDDEN_METADATA_KEY_FRAGMENTS: tuple[str, ...] = (
+    "api_key",
+    "apikey",
+    "access_token",
+    "health_payload",
+    "medical_record",
+    "password",
+    "prompt_text",
+    "raw_prompt",
+    "raw_response",
+    "refresh_token",
+    "response_text",
+    "secret",
+    "user_health",
+    "user_payload",
+)
+
+_FORBIDDEN_METADATA_STRING_FRAGMENTS: tuple[str, ...] = (
+    "api_key=",
+    "bearer ",
+    "password=",
+    "private key",
+    "sk-",
+)
+
+
+@dataclass(frozen=True)
+class EvalEventProducer:
+    """Producer identity for a normalized eval event."""
+
+    name: str
+    version: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a JSON-compatible producer payload."""
+
+        return {
+            "name": self.name,
+            "version": self.version,
+        }
+
+
+@dataclass(frozen=True)
+class _FrozenJsonArray:
+    items: tuple["FrozenJsonValue", ...]
+
+
+@dataclass(frozen=True)
+class _FrozenJsonObject:
+    items: tuple[tuple[str, "FrozenJsonValue"], ...]
+
+
+FrozenJsonValue: TypeAlias = JsonScalar | _FrozenJsonArray | _FrozenJsonObject
+
+
+@dataclass(frozen=True)
+class EvidenceEvalEvent:
+    """Immutable normalized event for eval/evidence artifacts."""
+
+    event_id: str
+    event_type: EvalEventType
+    rail: EvalEventRail
+    source_artifact: str
+    asset_refs: tuple[EvidenceAssetRef, ...]
+    upstream_ids: tuple[str, ...]
+    fingerprint: str
+    idempotency_key: str
+    policy_version: str
+    producer: EvalEventProducer
+    produced_at: str
+    validation_status: ValidationStatus
+    _metadata: _FrozenJsonObject = field(default_factory=lambda: _FrozenJsonObject(()))
+
+    @property
+    def metadata(self) -> dict[str, JsonValue]:
+        """Return a defensive JSON-compatible metadata copy."""
+
+        return cast(dict[str, JsonValue], _thaw_frozen_json(self._metadata))
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Return a deterministic JSON-compatible event payload."""
+
+        return {
+            "asset_refs": [_asset_ref_to_dict(ref) for ref in self.asset_refs],
+            "event_id": self.event_id,
+            "event_type": self.event_type,
+            "fingerprint": self.fingerprint,
+            "idempotency_key": self.idempotency_key,
+            "metadata": self.metadata,
+            "policy_version": self.policy_version,
+            "produced_at": self.produced_at,
+            "producer": self.producer.to_dict(),
+            "rail": self.rail,
+            "source_artifact": self.source_artifact,
+            "upstream_ids": list(self.upstream_ids),
+            "validation_status": self.validation_status,
+        }
+
+    def to_json(self) -> str:
+        """Serialize the event with stable key ordering."""
+
+        return json.dumps(
+            self.to_dict(),
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+
+def create_eval_event(
+    *,
+    event_type: EvalEventType,
+    rail: EvalEventRail,
+    source_artifact: str,
+    asset_refs: Iterable[EvidenceAssetRef] = (),
+    upstream_ids: Iterable[str] = (),
+    fingerprint: str,
+    idempotency_key: str,
+    policy_version: str,
+    producer_name: str,
+    producer_version: str,
+    produced_at: str,
+    validation_status: ValidationStatus,
+    metadata: Mapping[str, JsonValue] | None = None,
+) -> EvidenceEvalEvent:
+    """Create an immutable eval event or fail closed."""
+
+    normalized_event_type = validate_eval_event_type(event_type)
+    normalized_rail = validate_eval_event_rail(rail)
+    normalized_source_artifact = validate_source_artifact(source_artifact)
+    normalized_asset_refs = tuple(asset_refs)
+    _validate_asset_refs_for_event_rail(
+        rail=normalized_rail,
+        asset_refs=normalized_asset_refs,
+    )
+    normalized_upstream_ids = normalize_upstream_ids(tuple(upstream_ids))
+    normalized_fingerprint = validate_fingerprint(fingerprint)
+    normalized_idempotency_key = validate_idempotency_key(idempotency_key)
+    normalized_policy_version = validate_non_empty_token("policy_version", policy_version)
+    producer = create_eval_event_producer(
+        name=producer_name,
+        version=producer_version,
+    )
+    normalized_produced_at = validate_produced_at(produced_at)
+    normalized_validation_status = validate_validation_status(validation_status)
+    frozen_metadata = _freeze_metadata(metadata or {})
+    event_id = build_eval_event_id(
+        event_type=normalized_event_type,
+        rail=normalized_rail,
+        source_artifact=normalized_source_artifact,
+        asset_refs=normalized_asset_refs,
+        upstream_ids=normalized_upstream_ids,
+        fingerprint=normalized_fingerprint,
+        idempotency_key=normalized_idempotency_key,
+        policy_version=normalized_policy_version,
+        producer=producer,
+        validation_status=normalized_validation_status,
+    )
+    return EvidenceEvalEvent(
+        event_id=event_id,
+        event_type=normalized_event_type,
+        rail=normalized_rail,
+        source_artifact=normalized_source_artifact,
+        asset_refs=normalized_asset_refs,
+        upstream_ids=normalized_upstream_ids,
+        fingerprint=normalized_fingerprint,
+        idempotency_key=normalized_idempotency_key,
+        policy_version=normalized_policy_version,
+        producer=producer,
+        produced_at=normalized_produced_at,
+        validation_status=normalized_validation_status,
+        _metadata=frozen_metadata,
+    )
+
+
+def create_eval_event_producer(*, name: str, version: str) -> EvalEventProducer:
+    """Create a normalized producer identity."""
+
+    return EvalEventProducer(
+        name=validate_non_empty_token("producer_name", name),
+        version=validate_non_empty_token("producer_version", version),
+    )
+
+
+def build_eval_event_id(
+    *,
+    event_type: EvalEventType,
+    rail: EvalEventRail,
+    source_artifact: str,
+    asset_refs: tuple[EvidenceAssetRef, ...],
+    upstream_ids: tuple[str, ...],
+    fingerprint: str,
+    idempotency_key: str,
+    policy_version: str,
+    producer: EvalEventProducer,
+    validation_status: ValidationStatus,
+) -> str:
+    """Build a deterministic eval event id from canonical event scope."""
+
+    identity_payload: JsonValue = {
+        "asset_ref_ids": [ref.asset_id for ref in asset_refs],
+        "event_type": event_type,
+        "fingerprint": fingerprint,
+        "idempotency_key": idempotency_key,
+        "policy_version": policy_version,
+        "producer": producer.to_dict(),
+        "rail": rail,
+        "source_artifact": source_artifact,
+        "upstream_ids": list(upstream_ids),
+        "validation_status": validation_status,
+    }
+    digest = fingerprint_payload(identity_payload).removeprefix("sha256:")
+    return f"eval-event:{digest[:24]}"
+
+
+def validate_eval_event_type(event_type: EvalEventType) -> EvalEventType:
+    """Return a supported event type or fail closed."""
+
+    if event_type not in ALLOWED_EVAL_EVENT_TYPES:
+        raise ValueError(f"unsupported event_type: {event_type!r}")
+    return event_type
+
+
+def validate_eval_event_rail(rail: EvalEventRail) -> EvalEventRail:
+    """Return a supported event rail or fail closed."""
+
+    if rail not in ALLOWED_EVAL_EVENT_RAILS:
+        raise ValueError(f"unsupported rail: {rail!r}")
+    return rail
+
+
+def validate_validation_status(status: ValidationStatus) -> ValidationStatus:
+    """Return a supported validation status or fail closed."""
+
+    if status not in ALLOWED_VALIDATION_STATUSES:
+        raise ValueError(f"unsupported validation_status: {status!r}")
+    return status
+
+
+def validate_idempotency_key(idempotency_key: str) -> str:
+    """Return a normalized non-empty idempotency key."""
+
+    normalized = idempotency_key.strip()
+    if not normalized:
+        raise ValueError("idempotency_key must be non-empty")
+    if any(char.isspace() for char in normalized):
+        raise ValueError("idempotency_key must not contain whitespace")
+    return normalized
+
+
+def validate_source_artifact(source_artifact: str) -> str:
+    """Return a normalized safe source artifact path."""
+
+    normalized = source_artifact.strip().replace("\\", "/")
+    if not normalized:
+        raise ValueError("source_artifact must be non-empty")
+    if normalized.startswith("/") or normalized.startswith("~"):
+        raise ValueError("source_artifact must be repo-relative")
+    path = PurePosixPath(normalized)
+    if path.is_absolute():
+        raise ValueError("source_artifact must be repo-relative")
+    parts = path.parts
+    if not parts:
+        raise ValueError("source_artifact must be non-empty")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError("source_artifact must not contain traversal")
+    if parts[0] in _FORBIDDEN_SOURCE_ROOTS:
+        raise ValueError(f"source_artifact root is not allowed: {parts[0]!r}")
+    return path.as_posix()
+
+
+def validate_produced_at(produced_at: str) -> str:
+    """Validate an explicit ISO-8601 timestamp without generating one."""
+
+    normalized = produced_at.strip()
+    if not normalized:
+        raise ValueError("produced_at must be non-empty")
+    parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("produced_at must include timezone")
+    return normalized
+
+
+def _validate_asset_refs_for_event_rail(
+    *,
+    rail: EvalEventRail,
+    asset_refs: tuple[EvidenceAssetRef, ...],
+) -> None:
+    """Preserve rail separation for non-eval event rails."""
+
+    if rail == "eval":
+        return
+    mismatched = tuple(ref.asset_id for ref in asset_refs if ref.rail != rail)
+    if mismatched:
+        joined = ", ".join(mismatched)
+        raise ValueError(f"cross-rail asset_refs are not allowed: {joined}")
+
+
+def _freeze_metadata(metadata: Mapping[str, JsonValue]) -> _FrozenJsonObject:
+    """Validate and freeze metadata into caller-independent structures."""
+
+    return cast(_FrozenJsonObject, _freeze_json_value(metadata, path=()))
+
+
+def _freeze_json_value(
+    value: JsonValue,
+    *,
+    path: tuple[str, ...],
+) -> FrozenJsonValue:
+    """Freeze JSON-compatible values and scan for forbidden raw payloads."""
+
+    if isinstance(value, Mapping):
+        items: list[tuple[str, FrozenJsonValue]] = []
+        for key, item in sorted(value.items()):
+            if not isinstance(key, str):
+                raise ValueError("metadata keys must be strings")
+            normalized_key = key.strip()
+            if not normalized_key:
+                raise ValueError("metadata keys must be non-empty")
+            _validate_metadata_key(normalized_key)
+            items.append(
+                (
+                    normalized_key,
+                    _freeze_json_value(item, path=path + (normalized_key,)),
+                )
+            )
+        return _FrozenJsonObject(tuple(items))
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return _FrozenJsonArray(tuple(_freeze_json_value(item, path=path) for item in value))
+    if isinstance(value, str):
+        _validate_metadata_string(value)
+        return value
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    raise ValueError(f"metadata value at {'.'.join(path) or '<root>'} must be JSON-compatible")
+
+
+def _validate_metadata_key(key: str) -> None:
+    """Fail closed on raw secret/user-health payload keys."""
+
+    lowered = key.lower()
+    if any(fragment in lowered for fragment in _FORBIDDEN_METADATA_KEY_FRAGMENTS):
+        raise ValueError(f"metadata key is not allowed: {key!r}")
+
+
+def _validate_metadata_string(value: str) -> None:
+    """Fail closed on obvious raw secret payload strings."""
+
+    lowered = value.lower()
+    if any(fragment in lowered for fragment in _FORBIDDEN_METADATA_STRING_FRAGMENTS):
+        raise ValueError("metadata string appears to contain raw secret material")
+
+
+def _thaw_frozen_json(value: FrozenJsonValue) -> JsonValue:
+    """Return a defensive JSON-compatible value from frozen metadata."""
+
+    if isinstance(value, _FrozenJsonObject):
+        return {key: _thaw_frozen_json(item) for key, item in value.items}
+    if isinstance(value, _FrozenJsonArray):
+        return [_thaw_frozen_json(item) for item in value.items]
+    return value
+
+
+def _asset_ref_to_dict(ref: EvidenceAssetRef) -> dict[str, JsonValue]:
+    """Serialize an E1 evidence asset ref without exposing raw payloads."""
+
+    return {
+        "asset_id": ref.asset_id,
+        "asset_type": ref.asset_type,
+        "fingerprint": ref.fingerprint,
+        "idempotency_key": ref.idempotency_key,
+        "policy_version": ref.policy_version,
+        "rail": ref.rail,
+        "upstream_ids": list(ref.upstream_ids),
+        "version": ref.version,
+    }

--- a/core/evidence/events.py
+++ b/core/evidence/events.py
@@ -7,6 +7,7 @@ EN: Eval events normalize artifacts into an append-only event plane.
 from __future__ import annotations
 
 import json
+import math
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -73,6 +74,12 @@ _FORBIDDEN_SOURCE_ROOTS: tuple[str, ...] = (
     "dist",
     "node_modules",
     "worktrees",
+)
+
+_FORBIDDEN_SOURCE_PREFIXES: tuple[tuple[str, ...], ...] = (
+    ("artifacts", "agent_runs"),
+    ("artifacts", "orchestration"),
+    ("artifacts", "security_lab"),
 )
 
 _FORBIDDEN_METADATA_KEY_FRAGMENTS: tuple[str, ...] = (
@@ -332,6 +339,8 @@ def validate_source_artifact(source_artifact: str) -> str:
     normalized = source_artifact.strip().replace("\\", "/")
     if not normalized:
         raise ValueError("source_artifact must be non-empty")
+    if _has_windows_drive_prefix(normalized):
+        raise ValueError("source_artifact must be repo-relative")
     if normalized.startswith("/") or normalized.startswith("~"):
         raise ValueError("source_artifact must be repo-relative")
     path = PurePosixPath(normalized)
@@ -344,7 +353,18 @@ def validate_source_artifact(source_artifact: str) -> str:
         raise ValueError("source_artifact must not contain traversal")
     if parts[0] in _FORBIDDEN_SOURCE_ROOTS:
         raise ValueError(f"source_artifact root is not allowed: {parts[0]!r}")
+    for forbidden_prefix in _FORBIDDEN_SOURCE_PREFIXES:
+        if parts[: len(forbidden_prefix)] == forbidden_prefix:
+            joined = "/".join(forbidden_prefix)
+            raise ValueError(f"source_artifact path is not allowed: {joined!r}")
     return path.as_posix()
+
+
+def _has_windows_drive_prefix(path: str) -> bool:
+    """Return True for Windows drive-qualified paths such as C:/x or C:x."""
+
+    first_segment = path.split("/", maxsplit=1)[0]
+    return len(first_segment) >= 2 and first_segment[0].isalpha() and first_segment[1] == ":"
 
 
 def validate_produced_at(produced_at: str) -> str:
@@ -389,13 +409,20 @@ def _freeze_json_value(
 
     if isinstance(value, Mapping):
         items: list[tuple[str, FrozenJsonValue]] = []
-        for key, item in sorted(value.items()):
+        normalized_items: list[tuple[str, JsonValue]] = []
+        seen_keys: set[str] = set()
+        for key, item in value.items():
             if not isinstance(key, str):
                 raise ValueError("metadata keys must be strings")
             normalized_key = key.strip()
             if not normalized_key:
                 raise ValueError("metadata keys must be non-empty")
+            if normalized_key in seen_keys:
+                raise ValueError(f"metadata key collides after normalization: {normalized_key!r}")
+            seen_keys.add(normalized_key)
             _validate_metadata_key(normalized_key)
+            normalized_items.append((normalized_key, item))
+        for normalized_key, item in sorted(normalized_items, key=lambda pair: pair[0]):
             items.append(
                 (
                     normalized_key,
@@ -404,11 +431,21 @@ def _freeze_json_value(
             )
         return _FrozenJsonObject(tuple(items))
     if isinstance(value, Sequence) and not isinstance(value, str):
-        return _FrozenJsonArray(tuple(_freeze_json_value(item, path=path) for item in value))
+        return _FrozenJsonArray(
+            tuple(
+                _freeze_json_value(item, path=path + (str(index),))
+                for index, item in enumerate(value)
+            )
+        )
     if isinstance(value, str):
         _validate_metadata_string(value)
         return value
-    if value is None or isinstance(value, (bool, int, float)):
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            location = ".".join(path) or "<root>"
+            raise ValueError(f"metadata value at {location} must be finite")
         return value
     raise ValueError(f"metadata value at {'.'.join(path) or '<root>'} must be JSON-compatible")
 

--- a/docs/orchestration/contracts/EVIDENCE_EVENT_SCHEMA.md
+++ b/docs/orchestration/contracts/EVIDENCE_EVENT_SCHEMA.md
@@ -63,6 +63,13 @@ Supported event rails:
 - `control_plane`
 - `eval`
 
+Supported validation statuses:
+
+- `valid`
+- `invalid`
+- `degraded`
+- `deferred`
+
 ## Deterministic Identity
 
 `event_id` is derived from canonical event identity fields, including event type,

--- a/docs/orchestration/contracts/EVIDENCE_EVENT_SCHEMA.md
+++ b/docs/orchestration/contracts/EVIDENCE_EVENT_SCHEMA.md
@@ -1,0 +1,117 @@
+# Evidence Event Schema
+
+## Purpose
+
+PR-E2 defines a unified append-only eval event schema for Evidence Graph
+Runtime. The schema normalizes existing eval artifact metadata into deterministic
+event records without changing product runtime behavior.
+
+This contract is schema-first. It does not add an event store, writer, replay
+engine, promotion ledger, semantic cache, GraphRAG, advisory wiki expansion,
+OpenAPI change, DB migration, provider change, or user-facing behavior.
+
+## Source Artifact Families
+
+The schema can represent these current artifact families:
+
+- RAG release gates: `traces.jsonl`, `metrics_summary.json`, `gate_report.md`,
+  `rag_gate_result.json`, and executed-notebook metadata when already produced.
+- RAGAS bootstrap reports: `faithfulness`, `answer_relevancy`,
+  `context_precision`, and report-only JSON/Markdown outputs.
+- Eval-validity sidecars: variant/outcome records, judgment validity items,
+  item metadata, item statistics, instability flags, and curated
+  invariance/mutation/worst-case metadata when already present.
+- Evidence Graph linkage: E1 asset refs, upstream ids, rail, policy version,
+  fingerprint, idempotency key, producer identity, validation status, and source
+  artifact path.
+
+## Event Model
+
+Runtime contract: `core/evidence/events.py`.
+
+Required event fields:
+
+- `event_id`
+- `event_type`
+- `rail`
+- `source_artifact`
+- `asset_refs`
+- `upstream_ids`
+- `fingerprint`
+- `idempotency_key`
+- `policy_version`
+- `producer`
+- `produced_at`
+- `validation_status`
+
+Supported event types:
+
+- `rag_gate_run`
+- `rag_gate_report`
+- `ragas_report`
+- `eval_validity_record`
+- `judgment_validity_record`
+- `item_metadata`
+- `item_statistics`
+- `gate_metric`
+- `gate_decision`
+
+Supported event rails:
+
+- `runtime`
+- `advisory`
+- `control_plane`
+- `eval`
+
+## Deterministic Identity
+
+`event_id` is derived from canonical event identity fields, including event type,
+rail, source artifact, asset ref ids, upstream ids, fingerprint, idempotency key,
+policy version, producer, and validation status. It intentionally excludes
+`produced_at` so replay of the same semantic event remains idempotent.
+
+Serialization must remain deterministic JSON with stable key order. Tests must
+use fixed timestamps and must not depend on wall-clock time.
+
+## Fail-Closed Validation
+
+Event creation must reject:
+
+- unknown event type, rail, or validation status;
+- blank or malformed fingerprint;
+- blank idempotency key;
+- blank, absolute, home-relative, traversal, or local-dev-root source artifact
+  paths;
+- cross-rail asset refs for non-`eval` event rails;
+- raw secret, raw prompt, raw response, user-health, or user-payload metadata.
+
+The event object defensively copies caller-owned lists/dicts and returns
+defensive metadata copies from accessors.
+
+## Boundaries
+
+This PR is not a second eval runner. RAGAS and RAG release gates remain upstream
+artifact producers.
+
+This PR is not the promotion ledger or replay engine. PR-E3 consumes normalized
+event records later.
+
+This PR is not semantic cache, GraphRAG, product RAG rewrite, provider routing,
+OpenAPI, or DB persistence.
+
+Karpathy/advisory wiki remains non-canonical workforce memory. It must not
+become product runtime truth or an eval-event source of truth in PR-E2.
+
+## Validation
+
+Focused local validation for this schema:
+
+```bash
+.venv/bin/python -m pytest -q tests/core/evidence/test_events.py tests/core/evidence/test_assets.py tests/core/evidence/test_fingerprints.py
+make validate-changed
+pre-commit run --all-files
+```
+
+Full local `make verify` is intentionally deferred for PR-E2 by operator
+approval because the full suite is machine-heavy. Merge readiness must rely on
+documented narrow local gates plus current-head GitHub CI parity.

--- a/docs/review/PR_1672_FIXED_MAPPING.md
+++ b/docs/review/PR_1672_FIXED_MAPPING.md
@@ -32,13 +32,48 @@ deterministic event contracts without changing product runtime behavior.
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-GraphQL review-thread check returned no review threads for PR #1672 at initial
-mapping time. CodeRabbit skipped review because the PR is draft. Sourcery posted
-a reviewer guide only, with no actionable review threads.
+Initial GraphQL review-thread check returned no review threads for PR #1672.
+After the PR was marked ready for review, CodeRabbit, Sourcery, and Cubic
+posted actionable review threads. Those threads are mapped below.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: c7dd02621
+Evidence: `core/evidence/events.py` rejects local-only artifact paths; `tests/core/evidence/test_events.py` covers `artifacts/agent_runs`, `artifacts/orchestration`, and `artifacts/security_lab`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1672#discussion_r3191611613 -> c7dd02621
+
+Disposition: FIXED
+Commit: c7dd02621
+Evidence: `core/evidence/events.py` rejects duplicate metadata keys after normalization; `tests/core/evidence/test_events.py` covers colliding trimmed keys.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1672#discussion_r3191611620 -> c7dd02621
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1672#discussion_r3191619588 -> c7dd02621
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1672#discussion_r3191640740 -> c7dd02621
+
+Disposition: FIXED
+Commit: c7dd02621
+Evidence: `core/evidence/events.py` includes sequence indexes in metadata validation paths; `tests/core/evidence/test_events.py` asserts an invalid list item reports `labels.1`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1672#discussion_r3191619593 -> c7dd02621
+
+Disposition: FIXED
+Commit: c7dd02621
+Evidence: `tests/core/evidence/test_events.py` covers naive timestamp rejection and `Z` suffix acceptance for `validate_produced_at`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1672#discussion_r3191619630 -> c7dd02621
+
+Disposition: FIXED
+Commit: c7dd02621
+Evidence: `core/evidence/events.py` rejects Windows drive-qualified source artifact paths; `tests/core/evidence/test_events.py` covers `C:/`, `C:\`, and `C:` forms.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1672#discussion_r3191640734 -> c7dd02621
+
+Disposition: FIXED
+Commit: c7dd02621
+Evidence: `docs/orchestration/contracts/EVIDENCE_EVENT_SCHEMA.md` documents allowed validation statuses: `valid`, `invalid`, `degraded`, and `deferred`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1672#discussion_r3191640737 -> c7dd02621
+
+Disposition: FIXED
+Commit: c7dd02621
+Evidence: `core/evidence/events.py` rejects non-finite metadata floats before serialization; `tests/core/evidence/test_events.py` covers `NaN`, `Infinity`, and `-Infinity`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1672#discussion_r3191640744 -> c7dd02621
 
 ## Premortem Summary
 
@@ -75,6 +110,9 @@ trust or review. Why?
 - PASS: `pre-commit run --all-files`
 - PASS: targeted pre-push mypy hook after the `FrozenJsonValue` alias fix
 - PASS: `git push -u origin codex/eval-event-schema` pre-push hooks, including changed-file mypy, pip-audit, backend tests, full-repo Bandit, and Docker build test
+- PASS after review fixes: `.venv/bin/python -m pytest -q tests/core/evidence/test_events.py tests/core/evidence/test_assets.py tests/core/evidence/test_fingerprints.py` -> `65 passed`
+- PASS after review fixes: `pre-commit run --all-files`
+- PASS after review fixes: `make validate-changed` -> selected `tests/core/evidence/test_events.py`, `39 passed`
 
 LOCAL GAP: full local `make verify` was intentionally not run under the
 operator-approved machine-heavy exception. Current-head GitHub CI parity and

--- a/docs/review/PR_1672_FIXED_MAPPING.md
+++ b/docs/review/PR_1672_FIXED_MAPPING.md
@@ -29,18 +29,16 @@ deterministic event contracts without changing product runtime behavior.
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
-No human, CodeRabbit, Sourcery, or Cubic review threads had been triaged at the
-time this initial mapping artifact was created. Keep these checkboxes open
-until post-open review comments are inspected and dispositioned.
+GraphQL review-thread check returned no review threads for PR #1672 at initial
+mapping time. CodeRabbit skipped review because the PR is draft. Sourcery posted
+a reviewer guide only, with no actionable review threads.
 
 ## Fixed in Commit Mapping
 
-No actionable review threads are mapped yet. Add each resolved actionable thread
-with disposition-specific proof after the comment exists and after the fixing
-commit, if any, lands.
+- No actionable review comments
 
 ## Premortem Summary
 

--- a/docs/review/PR_1672_FIXED_MAPPING.md
+++ b/docs/review/PR_1672_FIXED_MAPPING.md
@@ -40,6 +40,21 @@ posted actionable review threads. Those threads are mapped below.
 
 Disposition: FIXED
 Commit: c7dd02621
+Evidence: Sourcery review actionables are fixed by duplicate-key, sequence-index, and timestamp-validation tests; current metadata-secret tests also cover bearer-token strings.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1672#pullrequestreview-4231654277 -> c7dd02621
+
+Disposition: FIXED
+Commit: c7dd02621
+Evidence: Cubic review actionables are fixed by Windows path, duplicate-key, validation-status docs, and non-finite metadata tests.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1672#pullrequestreview-4231676928 -> c7dd02621
+
+Disposition: FIXED
+Commit: 418f68bb
+Evidence: `tests/core/evidence/test_events.py` annotates `_make_event(...) -> EvidenceEvalEvent`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1672#pullrequestreview-4231704422 -> 418f68bb
+
+Disposition: FIXED
+Commit: c7dd02621
 Evidence: `core/evidence/events.py` rejects local-only artifact paths; `tests/core/evidence/test_events.py` covers `artifacts/agent_runs`, `artifacts/orchestration`, and `artifacts/security_lab`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1672#discussion_r3191611613 -> c7dd02621
 

--- a/docs/review/PR_1672_FIXED_MAPPING.md
+++ b/docs/review/PR_1672_FIXED_MAPPING.md
@@ -1,0 +1,102 @@
+# PR #1672 Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1672
+Branch: `codex/eval-event-schema`
+Title: `feat(evidence): add unified eval event schema`
+
+## Summary
+
+PR #1672 adds the PR-E2 unified eval event schema for Evidence Graph Runtime.
+It normalizes current eval/RAG/RAGAS artifact families into immutable,
+deterministic event contracts without changing product runtime behavior.
+
+## Scope
+
+- `core/evidence/events.py`
+- `core/evidence/__init__.py`
+- `core/evidence/AGENTS.md`
+- `docs/orchestration/contracts/EVIDENCE_EVENT_SCHEMA.md`
+- `docs/roadmap/BACKLOG_LEDGER.md`
+- `tests/core/evidence/test_events.py`
+- `docs/review/PR_1672_FIXED_MAPPING.md`
+
+## Role Order
+
+- [x] Declared role order preserved: `agent-coordinator -> rag-systems-agent -> architecture-specialist -> data-scientist-agent -> security-auditor -> qa-engineer-agent -> bug-hunter -> cursor-specialist-agent`
+- [x] Pre-open coordinator packet: `e3e17d4a6ba2`
+- [x] Post-open coordinator packet: `92032fa9f0e0`
+- [x] Mandatory post-open review lane included: `qa-engineer-agent -> bug-hunter`
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+No human, CodeRabbit, Sourcery, or Cubic review threads had been triaged at the
+time this initial mapping artifact was created. Keep these checkboxes open
+until post-open review comments are inspected and dispositioned.
+
+## Fixed in Commit Mapping
+
+No actionable review threads are mapped yet. Add each resolved actionable thread
+with disposition-specific proof after the comment exists and after the fixing
+commit, if any, lands.
+
+## Premortem Summary
+
+Frame: It is 48 hours after PR-E2 merged. Evidence Graph work became harder to
+trust or review. Why?
+
+- E2 became a second eval runner: mitigated by schema-only code, no eval-runner
+  imports, and a forbidden-import test.
+- E2 mixed product runtime and advisory rails: mitigated by explicit rail enum,
+  cross-rail asset-ref rejection, and scoped `core/evidence/AGENTS.md`.
+- E2 stored raw prompt/user-health/secret payloads: mitigated by fail-closed
+  metadata key/string checks and tests.
+- E2 created nondeterministic event IDs: mitigated by canonical event identity
+  payload and stable serialization tests with fixed timestamps.
+- E2 duplicated #1666/#1667 fixes: mitigated by treating sidecar symlink
+  hardening and eval-validity validation as baseline.
+- E2 invented semantic cache/GraphRAG/wiki scope: mitigated by contract docs,
+  scoped AGENTS rules, and forbidden import tests.
+- E2 could not represent existing gate artifacts: mitigated by event types for
+  RAG gate run/report/metric/decision, RAGAS report, validity sidecars, and item
+  metadata/statistics.
+- E2 bypassed E1 primitives: mitigated by using `EvidenceAssetRef`,
+  `fingerprint_payload`, `validate_fingerprint`, policy version validation, and
+  upstream-id normalization.
+
+## Validation
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: pre-open `task_bootstrap.py` -> packet `e3e17d4a6ba2`
+- PASS: post-open `task_bootstrap.py` -> packet `92032fa9f0e0`
+- PASS: `.venv/bin/python -m pytest -q tests/core/evidence/test_events.py tests/core/evidence/test_assets.py tests/core/evidence/test_fingerprints.py` -> `52 passed`
+- PASS: `make validate-changed` after commit -> selected `tests/core/evidence/test_events.py`, `26 passed`
+- PASS: `pre-commit run --all-files`
+- PASS: targeted pre-push mypy hook after the `FrozenJsonValue` alias fix
+- PASS: `git push -u origin codex/eval-event-schema` pre-push hooks, including changed-file mypy, pip-audit, backend tests, full-repo Bandit, and Docker build test
+
+LOCAL GAP: full local `make verify` was intentionally not run under the
+operator-approved machine-heavy exception. Current-head GitHub CI parity and
+the strict merge-readiness wrapper are required before any merge-readiness
+claim.
+
+## Merge Readiness
+
+- [ ] Current-head PR CI green
+- [ ] CodeRabbit no actionable comments
+- [ ] Sourcery no actionable comments
+- [ ] Cubic no actionable comments
+- [ ] `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1672` passes
+- [ ] `python3 scripts/orchestration/check_merge_ready.py --require-auth --pr-number 1672 --repo Katsiarynakavaleuskaya/PulsePlate` passes
+- [ ] Mandatory review cycle / wait-window elapsed
+
+## Deferred / Follow-ups
+
+- PR-E3: promotion ledger + replay consuming normalized eval events.
+- Concrete adapter PRs may normalize runner outputs into the event schema after
+  PR-E2 lands.
+- Semantic cache remains blocked until its dedicated gate opens with lineage,
+  admission, replay, reliability, and security contracts.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2265,10 +2265,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Evidence Graph Runtime umbrella
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (AI runtime governance / evidence lineage)
-  - Target PR: PR-E0 (`codex/evidence-graph-runtime-umbrella`) -> PR-E1/E2/E3/E4/E5
+  - Target PR: PR-E0 (`codex/evidence-graph-runtime-umbrella`) -> PR-E1/E2/E3/E4/E5; current slice: PR-E2 (`codex/eval-event-schema`)
   - Area: AI runtime / RAG / evals / knowledge promotion / advisory memory
   - Finding Type: asset-lineage and replay-governance gap
-  - Status: Active docs/governance umbrella
+  - Status: Active PR-E2 unified eval event schema; E0/E1 are baseline, #1666/#1667 eval-sidecar hardening is baseline, and PR-E3 promotion ledger + replay remains next after E2
   - Remove-by: 2026-06-30
   - Reason (EN): PulsePlate already has strong RAG runtime, verification, knowledge-promotion, eval-gate, advisory-wiki, and plugin/control-plane foundations, but evidence-bearing artifacts are still governed mostly through task packets, gate outputs, and lane-specific docs rather than one asset/evidence graph. This umbrella freezes the rail boundaries and PR train needed to make eval runs, context bundles, verification bundles, knowledge candidates, knowledge records, and gate reports first-class assets with lineage, idempotency, replay, fingerprints, policy versions, and admission decisions.
   - Links:
@@ -2286,6 +2286,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Semantic cache remains blocked until evidence asset lineage, replay-safe promotion, and metadata admission gates exist
     - Downstream PR acceptance criteria cover asset registry, eval event schema, promotion ledger/replay, active metadata admission, and advisory wiki evidence bridge
     - PR-E0 remains docs/governance only with no public API, DB migration, endpoint, OpenAPI, billing, provider, semantic-cache, GraphRAG, or user-facing runtime behavior change
+    - PR-E2 adds a deterministic schema-only eval event contract and documentation without adding runtime behavior, OpenAPI changes, DB migration, semantic cache, GraphRAG, advisory wiki authority, or promotion/replay logic
 
 <a id="ledger-p1-apple-server-api-migration"></a>
 - [ ] P1: Apple receipt verification migration to App Store Server API

--- a/tests/core/evidence/test_events.py
+++ b/tests/core/evidence/test_events.py
@@ -11,6 +11,7 @@ from core.evidence.assets import EvidenceAssetRef, create_evidence_asset_ref
 from core.evidence.events import (
     EvalEventRail,
     EvalEventType,
+    EvidenceEvalEvent,
     ValidationStatus,
     create_eval_event,
     validate_produced_at,
@@ -33,7 +34,7 @@ def _asset_ref() -> EvidenceAssetRef:
     )
 
 
-def _make_event(**overrides: object):
+def _make_event(**overrides: object) -> EvidenceEvalEvent:
     params = {
         "event_type": "rag_gate_run",
         "rail": "eval",

--- a/tests/core/evidence/test_events.py
+++ b/tests/core/evidence/test_events.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from core.evidence.assets import EvidenceAssetRef, create_evidence_asset_ref
+from core.evidence.events import (
+    EvalEventRail,
+    EvalEventType,
+    ValidationStatus,
+    create_eval_event,
+    validate_source_artifact,
+)
+from core.evidence.fingerprints import fingerprint_payload
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_EVENTS_MODULE = _REPO_ROOT / "core" / "evidence" / "events.py"
+_FIXED_TIMESTAMP = "2026-05-05T12:00:00+00:00"
+
+
+def _asset_ref() -> EvidenceAssetRef:
+    return create_evidence_asset_ref(
+        asset_type="eval_run",
+        version="v1",
+        rail="runtime",
+        policy_version="policy-v1",
+        payload={"run": "rag-gate"},
+    )
+
+
+def _make_event(**overrides: object):
+    params = {
+        "event_type": "rag_gate_run",
+        "rail": "eval",
+        "source_artifact": "artifacts/rag_eval/run-1/traces.jsonl",
+        "asset_refs": (_asset_ref(),),
+        "upstream_ids": (" gate-report-1 ", "dataset-1", "dataset-1"),
+        "fingerprint": fingerprint_payload({"artifact": "traces.jsonl", "rows": 2}),
+        "idempotency_key": "idem:rag-gate-run-1",
+        "policy_version": "policy-v1",
+        "producer_name": "rag-release-gates",
+        "producer_version": "v1",
+        "produced_at": _FIXED_TIMESTAMP,
+        "validation_status": "valid",
+        "metadata": {"decision": "PASS", "sample_size": 2},
+    }
+    params.update(overrides)
+    return create_eval_event(**params)
+
+
+def test_creates_valid_rag_gate_event_with_source_artifact_path() -> None:
+    event = _make_event()
+
+    payload = event.to_dict()
+
+    assert event.event_id.startswith("eval-event:")
+    assert payload["event_type"] == "rag_gate_run"
+    assert payload["rail"] == "eval"
+    assert payload["source_artifact"] == "artifacts/rag_eval/run-1/traces.jsonl"
+    assert payload["upstream_ids"] == ["dataset-1", "gate-report-1"]
+    assert payload["asset_refs"][0]["asset_id"].startswith("evidence:eval_run:runtime:v1:")
+
+
+def test_creates_valid_ragas_report_event() -> None:
+    event = _make_event(
+        event_type="ragas_report",
+        source_artifact="evals/ragas/report.json",
+        fingerprint=fingerprint_payload(
+            {
+                "faithfulness": 1.0,
+                "answer_relevancy": 0.95,
+                "context_precision": 0.9,
+            }
+        ),
+        idempotency_key="idem:ragas-report-1",
+        producer_name="ragas-bootstrap",
+        metadata={
+            "faithfulness": 1.0,
+            "answer_relevancy": 0.95,
+            "context_precision": 0.9,
+            "report_only": True,
+        },
+    )
+
+    assert event.event_type == "ragas_report"
+    assert event.metadata["report_only"] is True
+
+
+def test_creates_valid_eval_validity_sidecar_event() -> None:
+    event = _make_event(
+        event_type="eval_validity_record",
+        source_artifact="artifacts/evals/validity_items.jsonl",
+        fingerprint=fingerprint_payload({"canonical_id": "rag_001", "passed": True}),
+        idempotency_key="idem:eval-validity-record-1",
+        producer_name="eval-validity",
+        metadata={"canonical_id": "rag_001", "variant_family": "canonical"},
+    )
+
+    assert event.event_type == "eval_validity_record"
+    assert event.metadata["canonical_id"] == "rag_001"
+
+
+def test_creates_valid_judgment_validity_sidecar_event() -> None:
+    event = _make_event(
+        event_type="judgment_validity_record",
+        source_artifact="artifacts/evals/judgment_validity_items.jsonl",
+        fingerprint=fingerprint_payload({"case_id": "judgment_001", "decision": "defer"}),
+        idempotency_key="idem:judgment-validity-record-1",
+        producer_name="judgment-validity",
+        metadata={"case_id": "judgment_001", "decision": "defer"},
+    )
+
+    assert event.event_type == "judgment_validity_record"
+
+
+@pytest.mark.parametrize(
+    ("event_type", "source_artifact", "metadata"),
+    [
+        (
+            "rag_gate_report",
+            "artifacts/rag_eval/run-1/gate_report.md",
+            {"report_format": "markdown", "decision": "PASS"},
+        ),
+        (
+            "item_metadata",
+            "data/evals/eval_item_metadata_registry.jsonl",
+            {"canonical_id": "rag_001", "difficulty_band": "low"},
+        ),
+        (
+            "item_statistics",
+            "artifacts/evals/item_statistics_report.json",
+            {"canonical_id": "rag_001", "instability_flag": False},
+        ),
+        (
+            "gate_metric",
+            "artifacts/rag_eval/run-1/metrics_summary.json",
+            {"metric": "support_precision", "value": 0.91},
+        ),
+        (
+            "gate_decision",
+            "artifacts/rag_eval/run-1/rag_gate_result.json",
+            {"decision": "PASS"},
+        ),
+    ],
+)
+def test_current_eval_artifact_event_types_are_supported(
+    event_type: str,
+    source_artifact: str,
+    metadata: dict[str, object],
+) -> None:
+    event = _make_event(
+        event_type=cast(EvalEventType, event_type),
+        source_artifact=source_artifact,
+        fingerprint=fingerprint_payload(metadata),
+        idempotency_key=f"idem:{event_type}",
+        metadata=metadata,
+    )
+
+    assert event.event_type == event_type
+
+
+def test_rejects_unknown_rail() -> None:
+    with pytest.raises(ValueError, match="unsupported rail"):
+        _make_event(rail=cast(EvalEventRail, "wiki"))
+
+
+@pytest.mark.parametrize(
+    "source_artifact",
+    [
+        "../traces.jsonl",
+        "artifacts/rag_eval/../secret.json",
+        "/tmp/traces.jsonl",
+        "~/traces.jsonl",
+        "worktrees/agent/traces.jsonl",
+        ".venv/traces.jsonl",
+    ],
+)
+def test_rejects_unsafe_source_artifact_paths(source_artifact: str) -> None:
+    with pytest.raises(ValueError, match="source_artifact"):
+        validate_source_artifact(source_artifact)
+
+
+def test_rejects_missing_fingerprint() -> None:
+    with pytest.raises(ValueError, match="fingerprint"):
+        _make_event(fingerprint="")
+
+
+def test_rejects_missing_idempotency_key() -> None:
+    with pytest.raises(ValueError, match="idempotency_key"):
+        _make_event(idempotency_key=" ")
+
+
+def test_rejects_unknown_event_type_and_validation_status() -> None:
+    with pytest.raises(ValueError, match="unsupported event_type"):
+        _make_event(event_type=cast(EvalEventType, "semantic_cache_hit"))
+    with pytest.raises(ValueError, match="unsupported validation_status"):
+        _make_event(validation_status=cast(ValidationStatus, "promoted"))
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"raw_prompt": "tell me about dinner"},
+        {"nested": {"user_health_payload": "private"}},
+        {"token_like": "Bearer abc"},
+    ],
+)
+def test_rejects_raw_secret_or_user_health_metadata(metadata: dict[str, object]) -> None:
+    with pytest.raises(ValueError, match="metadata"):
+        _make_event(metadata=metadata)
+
+
+def test_preserves_asset_refs_upstream_ids_and_metadata_defensively() -> None:
+    asset_refs = [_asset_ref()]
+    upstream_ids = ["z-upstream", "a-upstream"]
+    metadata = {"labels": ["rag", "gate"], "stats": {"sample_size": 2}}
+
+    event = _make_event(asset_refs=asset_refs, upstream_ids=upstream_ids, metadata=metadata)
+
+    asset_refs.clear()
+    upstream_ids.append("mutated")
+    metadata["labels"].append("mutated")
+    metadata["stats"]["sample_size"] = 999
+    returned_metadata = event.metadata
+    returned_metadata["labels"].append("also-mutated")
+
+    assert len(event.asset_refs) == 1
+    assert event.upstream_ids == ("a-upstream", "z-upstream")
+    assert event.metadata == {"labels": ["rag", "gate"], "stats": {"sample_size": 2}}
+
+
+def test_stable_serialization_and_event_id() -> None:
+    first = _make_event(
+        upstream_ids=("b", "a", "b"),
+        metadata={"z": 1, "a": ["x", "y"]},
+    )
+    second = _make_event(
+        upstream_ids=("a", "b"),
+        metadata={"a": ["x", "y"], "z": 1},
+    )
+
+    assert first.event_id == second.event_id
+    assert first.to_json() == second.to_json()
+
+
+def test_non_eval_event_rails_reject_cross_rail_asset_refs() -> None:
+    advisory_ref = create_evidence_asset_ref(
+        asset_type="gate_report",
+        version="v1",
+        rail="advisory",
+        policy_version="policy-v1",
+        payload={"report": "advisory"},
+    )
+
+    with pytest.raises(ValueError, match="cross-rail asset_refs"):
+        _make_event(rail="runtime", asset_refs=(advisory_ref,))
+
+
+def test_events_module_does_not_import_runtime_or_eval_runner_surfaces() -> None:
+    forbidden_prefixes = (
+        "app",
+        "providers",
+        "redis",
+        "scripts.evals",
+        "evals",
+        "mcp_pulseplate_server",
+        "legacy_app",
+    )
+    forbidden_fragments = ("semantic_cache", "wiki")
+    tree = ast.parse(_EVENTS_MODULE.read_text(encoding="utf-8"))
+
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imported_modules.append(node.module)
+
+    for module_name in imported_modules:
+        assert not any(
+            module_name == prefix or module_name.startswith(f"{prefix}.")
+            for prefix in forbidden_prefixes
+        )
+        assert not any(fragment in module_name for fragment in forbidden_fragments)

--- a/tests/core/evidence/test_events.py
+++ b/tests/core/evidence/test_events.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import math
 from pathlib import Path
 from typing import cast
 
@@ -12,6 +13,7 @@ from core.evidence.events import (
     EvalEventType,
     ValidationStatus,
     create_eval_event,
+    validate_produced_at,
     validate_source_artifact,
 )
 from core.evidence.fingerprints import fingerprint_payload
@@ -174,8 +176,14 @@ def test_rejects_unknown_rail() -> None:
         "artifacts/rag_eval/../secret.json",
         "/tmp/traces.jsonl",
         "~/traces.jsonl",
+        "C:/traces.jsonl",
+        "C:\\traces.jsonl",
+        "C:traces.jsonl",
         "worktrees/agent/traces.jsonl",
         ".venv/traces.jsonl",
+        "artifacts/agent_runs/run-1.json",
+        "artifacts/orchestration/task_packets/run-1.json",
+        "artifacts/security_lab/lab-1.json",
     ],
 )
 def test_rejects_unsafe_source_artifact_paths(source_artifact: str) -> None:
@@ -200,6 +208,15 @@ def test_rejects_unknown_event_type_and_validation_status() -> None:
         _make_event(validation_status=cast(ValidationStatus, "promoted"))
 
 
+def test_validate_produced_at_rejects_naive_timestamp() -> None:
+    with pytest.raises(ValueError, match="timezone"):
+        validate_produced_at("2026-05-05T12:00:00")
+
+
+def test_validate_produced_at_accepts_z_suffix_timestamp() -> None:
+    assert validate_produced_at("2026-05-05T12:00:00Z") == "2026-05-05T12:00:00Z"
+
+
 @pytest.mark.parametrize(
     "metadata",
     [
@@ -211,6 +228,22 @@ def test_rejects_unknown_event_type_and_validation_status() -> None:
 def test_rejects_raw_secret_or_user_health_metadata(metadata: dict[str, object]) -> None:
     with pytest.raises(ValueError, match="metadata"):
         _make_event(metadata=metadata)
+
+
+def test_rejects_duplicate_metadata_keys_after_normalization() -> None:
+    with pytest.raises(ValueError, match="collides after normalization"):
+        _make_event(metadata={"metric": 1, " metric ": 2})
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+def test_rejects_non_finite_metadata_numbers(value: float) -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        _make_event(metadata={"metric": value})
+
+
+def test_metadata_sequence_errors_include_item_index() -> None:
+    with pytest.raises(ValueError, match="labels\\.1"):
+        _make_event(metadata={"labels": ["ok", object()]})
 
 
 def test_preserves_asset_refs_upstream_ids_and_metadata_defensively() -> None:

--- a/tests/core/evidence/test_events.py
+++ b/tests/core/evidence/test_events.py
@@ -173,6 +173,7 @@ def test_rejects_unknown_rail() -> None:
 @pytest.mark.parametrize(
     "source_artifact",
     [
+        " ",
         "../traces.jsonl",
         "artifacts/rag_eval/../secret.json",
         "/tmp/traces.jsonl",
@@ -202,6 +203,11 @@ def test_rejects_missing_idempotency_key() -> None:
         _make_event(idempotency_key=" ")
 
 
+def test_rejects_idempotency_key_with_whitespace() -> None:
+    with pytest.raises(ValueError, match="idempotency_key"):
+        _make_event(idempotency_key="idem key")
+
+
 def test_rejects_unknown_event_type_and_validation_status() -> None:
     with pytest.raises(ValueError, match="unsupported event_type"):
         _make_event(event_type=cast(EvalEventType, "semantic_cache_hit"))
@@ -212,6 +218,11 @@ def test_rejects_unknown_event_type_and_validation_status() -> None:
 def test_validate_produced_at_rejects_naive_timestamp() -> None:
     with pytest.raises(ValueError, match="timezone"):
         validate_produced_at("2026-05-05T12:00:00")
+
+
+def test_validate_produced_at_rejects_empty_timestamp() -> None:
+    with pytest.raises(ValueError, match="produced_at"):
+        validate_produced_at(" ")
 
 
 def test_validate_produced_at_accepts_z_suffix_timestamp() -> None:
@@ -234,6 +245,18 @@ def test_rejects_raw_secret_or_user_health_metadata(metadata: dict[str, object])
 def test_rejects_duplicate_metadata_keys_after_normalization() -> None:
     with pytest.raises(ValueError, match="collides after normalization"):
         _make_event(metadata={"metric": 1, " metric ": 2})
+
+
+def test_rejects_non_string_metadata_key() -> None:
+    metadata = cast(dict[str, object], {1: "bad"})
+
+    with pytest.raises(ValueError, match="metadata keys must be strings"):
+        _make_event(metadata=metadata)
+
+
+def test_rejects_empty_metadata_key_after_normalization() -> None:
+    with pytest.raises(ValueError, match="metadata keys must be non-empty"):
+        _make_event(metadata={" ": "bad"})
 
 
 @pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])


### PR DESCRIPTION
## Summary

Adds the PR-E2 unified eval event schema for the Evidence Graph Runtime train.
The schema normalizes existing RAG gate, RAGAS, eval-validity, judgment-validity,
item metadata/statistics, metric, and decision artifacts into immutable,
deterministic event contracts without changing product runtime behavior.

Base `main` was synced before the branch and current-head `main` CI completed
successfully at `8449dafba` (`gh run watch 25399183804 --exit-status`).
PRs #1666 and #1667 are treated as merged baseline; this PR does not duplicate
their sidecar symlink hardening or fail-closed eval-validity fixes.

## Goal

Create a schema-first append-only eval event plane for Evidence Graph Runtime
that can represent current eval/RAG/RAGAS artifact families and hand off cleanly
to a later PR-E3 promotion ledger and replay layer.

## Business reason

This increases PulsePlate's defensibility and reliability by making eval
artifacts traceable, replay-aware, and promotion-ready later. It avoids creating
another eval runner or metrics substrate while reducing future chaos across
RAG gates, RAGAS reports, sidecars, and Evidence Graph lineage.

## Strategic source basis

This PR is aligned with the frontier-evaluation audit for PulsePlate:
`Аудит PulsePlate на фоне frontier-подходов к оценке ИИ`.

That audit concluded that PulsePlate already has strong software verification,
runtime metadata, provenance, and RAG/verification signals, but still needs a
formal AI-behavior evaluation layer: domain goldens, adversarial cases,
layer-wise RAG/generation/routing metrics, judge calibration, CI release gates,
and online eval over production traces.

PR-E2 intentionally implements only the schema/event foundation for that
direction. It does not add eval runners, judge calibration, semantic cache,
semantic retrieval, dashboards, production telemetry, or release gates.

The immediate purpose is to normalize current eval/RAG/RAGAS artifacts into a
deterministic event plane so later PRs can build promotion/replay and AI release
gates without re-deriving artifact lineage from scattered files.

## Scope

- Add immutable eval event models and producer identity in `core/evidence/events.py`.
- Reuse E1 primitives: `EvidenceAssetRef`, `fingerprint_payload`,
  `validate_fingerprint`, `validate_non_empty_token`, and upstream-id
  normalization.
- Fail closed on unsupported rails/event types/statuses, blank fingerprints,
  blank idempotency keys, unsafe source artifact paths, cross-rail asset refs
  outside the eval rail, and forbidden raw prompt/response/secret/user-health
  metadata.
- Add deterministic serialization and event identity.
- Document the event schema and Evidence Graph sequencing.
- Update the backlog ledger to mark PR-E2 as active and PR-E3 as next.
- Add focused deterministic tests under `tests/core/evidence/`.

## Out of scope

- Semantic cache.
- GraphRAG or knowledge graph.
- Product RAG rewrite.
- Karpathy/advisory wiki expansion.
- Knowledge promotion ledger.
- Replay engine.
- Runtime provider changes.
- OpenAPI/API changes.
- DB migrations.
- User-facing behavior changes.

## Files touched

- `core/evidence/events.py`
- `core/evidence/__init__.py`
- `core/evidence/AGENTS.md`
- `docs/orchestration/contracts/EVIDENCE_EVENT_SCHEMA.md`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `tests/core/evidence/test_events.py`
- `docs/review/PR_1672_FIXED_MAPPING.md`

## Tests

Local gates run:

- PASS: `python3 scripts/orchestration/check_preflight.py`
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
- PASS: `python3 scripts/orchestration/task_bootstrap.py --goal "PR-E2 Unified Eval Event Schema for Evidence Graph Runtime without runtime behavior changes" --task-class "AI / ML" --path core/evidence/events.py --path core/evidence/AGENTS.md --path docs/orchestration/contracts/EVIDENCE_EVENT_SCHEMA.md --path docs/roadmap/BACKLOG_LEDGER.md --path tests/core/evidence/test_events.py --pr-phase pre_open --requested-agent agent-coordinator --requested-agent rag-systems-agent --requested-agent architecture-specialist --requested-agent data-scientist-agent --requested-agent security-auditor --requested-agent qa-engineer-agent --requested-agent bug-hunter --requested-agent cursor-specialist-agent`
- PASS: `python3 scripts/orchestration/task_bootstrap.py --goal "PR-E2 post-open review and governance for unified eval event schema" --task-class "AI / ML" --path core/evidence/events.py --path core/evidence/AGENTS.md --path docs/orchestration/contracts/EVIDENCE_EVENT_SCHEMA.md --path docs/roadmap/BACKLOG_LEDGER.md --path docs/review/PR_1672_FIXED_MAPPING.md --path tests/core/evidence/test_events.py --pr-phase post_open_review --requested-agent agent-coordinator --requested-agent rag-systems-agent --requested-agent architecture-specialist --requested-agent data-scientist-agent --requested-agent security-auditor --requested-agent qa-engineer-agent --requested-agent bug-hunter --requested-agent cursor-specialist-agent`
- PASS: `.venv/bin/python -m pytest -q tests/core/evidence/test_events.py tests/core/evidence/test_assets.py tests/core/evidence/test_fingerprints.py` (`52 passed`)
- PASS: `make validate-changed`
- PASS: `pre-commit run --all-files`
- PASS: pre-push hooks from `git push -u origin codex/eval-event-schema`, including mypy changed files, pip-audit, backend tests, Bandit full repo, and Docker build test.
- PASS after review fixes: `.venv/bin/python -m pytest -q tests/core/evidence/test_events.py tests/core/evidence/test_assets.py tests/core/evidence/test_fingerprints.py` (`65 passed`)
- PASS after review fixes: `pre-commit run --all-files`
- PASS after review fixes: `make validate-changed` (`39 passed` in selected `tests/core/evidence/test_events.py`)

Full local `make verify` was intentionally not run under the operator-approved
machine-heavy exception. This PR uses focused local gates plus current-head
GitHub CI parity as the heavy signal.

## Security notes

- The schema rejects source artifact path traversal, absolute paths,
  home-relative paths, and local-dev roots such as `.venv`, caches, and
  `worktrees`.
- Metadata validation fails closed on raw secret, prompt, response, user payload,
  and user-health key fragments plus obvious raw secret string fragments.
- The module imports only core evidence primitives and stdlib; tests guard
  against imports from runtime providers, DB/cache, semantic cache, wiki,
  eval runners, or route surfaces.
- Cross-rail asset refs are rejected for non-eval rails to preserve runtime,
  advisory, control-plane, and eval separation.

## Premortem

| Failure mode | Mitigation | Evidence | Boundary |
| --- | --- | --- | --- |
| E2 becomes a second eval runner | Schema-only module; no runner imports | import guard test | No eval runner changes |
| E2 mixes runtime and advisory rails | explicit rail enum and cross-rail checks | cross-rail rejection test | Rails stay separate |
| E2 stores raw prompt/user/health/secret payloads | forbidden metadata key/string validation | metadata rejection tests | No raw payload store |
| E2 creates nondeterministic event IDs | event ID derived from canonical identity fields; fixed timestamps in tests | stable serialization/event ID test | No wall-clock IDs |
| E2 duplicates #1666/#1667 | source path and eval-validity schema are event-layer only | docs state baseline | No sidecar rewrite |
| E2 invents semantic cache/GraphRAG scope | scoped AGENTS rule and contract doc exclusions | docs and import guard | Deferred until dedicated gates |
| E2 cannot represent RAG gate artifacts | event types cover run/report/metric/decision and source artifacts | artifact event tests | No runtime behavior changes |
| E2 bypasses E1 primitives | uses `EvidenceAssetRef`, fingerprint and policy validators | unit tests and code | No parallel asset registry |

## Rollback / risks

Rollback is a clean revert of the schema/docs/tests commit. There are no
runtime imports, API changes, DB changes, migrations, provider changes, or user
behavior changes.

Residual risk: the first adapter PR may need to refine event-type names if a
runner emits a more specific artifact family. That should be handled as a
schema-compatible additive follow-up, not by widening this PR into runners.

## DoD

- Unified eval event schema exists and is documented.
- Current eval/RAG/RAGAS artifact categories are represented or explicitly
  deferred.
- Deterministic creation, validation, immutability, path safety, and
  serialization tests pass.
- No runtime behavior changes.
- No OpenAPI changes.
- No DB migration.
- No semantic cache, GraphRAG, wiki, promotion ledger, or replay scope.
- #1666/#1667 are baseline and not duplicated.
- Backlog ledger points to PR-E3 promotion ledger + replay as next after E2.

## Commit breakdown

- `68f8171b7 feat(evidence): add unified eval event schema`
- `334acfc2c docs(review): add PR 1672 fixed mapping`
- `db8d18016 docs(review): complete PR 1672 initial mapping`
- `c7dd02621 fix(evidence): harden eval event validation`

## Split Justification

This PR exceeds the normal size threshold because the schema, scoped
sequencing rule, contract documentation, backlog routing, deterministic tests,
and PR mapping artifact are one atomic Evidence Graph Runtime slice. Splitting
the event model away from tests/docs/governance would leave either an
undocumented contract or a documented contract without executable proof.

## Pre-push checklist

- [x] Coordinator-first bootstrap completed.
- [x] Root/scoped instructions reviewed.
- [x] Focused evidence tests passed.
- [x] `make validate-changed` passed after commit.
- [x] `pre-commit run --all-files` passed.
- [x] Pre-push hooks passed.
- [x] Full local `make verify` deferral documented.

## Post-merge checklist

- Fast-forward local `main`.
- Confirm current-head `main` CI after merge.
- Keep semantic cache, GraphRAG, advisory wiki, promotion ledger, and replay out
  of E2 follow-up cleanup.
- Route next Evidence Graph slice to PR-E3 promotion ledger + replay only after
  this schema is merged.

## AGENTS.md updates

Adds `core/evidence/AGENTS.md` to preserve Evidence Graph Runtime sequencing:
eval runners generate artifacts; evidence events normalize artifact metadata;
promotion/replay consumes normalized events later; semantic cache, GraphRAG, and
advisory wiki remain separate rails.

## Deferred / Follow-ups

- PR-E3: promotion ledger + replay consuming normalized eval events.
- Future adapter PRs may normalize concrete runner outputs into this schema.
- Semantic cache remains blocked until its dedicated gate opens with lineage,
  admission, replay, reliability, and security contracts.
- Frontier AI evaluation roadmap follow-up:
  - curated domain goldens/adversarial cases;
  - layer-wise metrics for retrieval / routing / generation / safety;
  - judge calibration against human/expert labels;
  - `make eval-ai` / CI AI-release gates;
  - online eval over production traces.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Initial GraphQL review-thread check returned no review threads for PR #1672.
After marking the PR ready for review, CodeRabbit, Sourcery, and Cubic posted
actionable threads. The accepted review findings are fixed by `c7dd02621` and
mapped in the canonical artifact.

### Fixed in Commit Mapping

Canonical artifact: `docs/review/PR_1672_FIXED_MAPPING.md`.

Review-thread mappings are recorded in the canonical artifact.

## Merge Readiness

Merge-readiness is governed by current-head CI, review-thread disposition, and the strict merge-readiness wrapper.

Current recorded evidence before final merge:

- PR is non-draft; merge state was `CLEAN` on head `0a3400c2835eef89566876a4796504534870460f`.
- Current-head CI run `25404935934` completed successfully for that head, including `lint`, `security`, `test-pr (3.13)`, `coverage-pr`, `diff-coverage`, PR-body gates, and merge-readiness gate.
- Local scoped gates passed: focused evidence pytest suite, `make validate-changed`, and `pre-commit run --all-files`.
- Full local `make verify` remains intentionally deferred under the operator-approved machine-heavy exception; GitHub current-head CI is the heavy signal.
- All nine review threads are resolved with disposition proof in `docs/review/PR_1672_FIXED_MAPPING.md`.
- Strict local merge-readiness wrapper with auth passed after current-head CI.
- Final merge still requires no new actionable review comments and no new pending/failing current-head checks after this PR-body update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced evidence evaluation event schema with structured event modeling, validation, and deterministic ID generation for runtime sequencing.

* **Documentation**
  * Added agent instruction guidelines for evidence graph runtime sequencing and operational constraints.
  * Added evidence event schema contract documentation.
  * Updated backlog ledger with expanded roadmap items and governance tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
