### PR TITLE
feat(evidence): add promotion ledger and replay scaffold

### DIFF
--- a/core/evidence/AGENTS.md
+++ b/core/evidence/AGENTS.md
@@ -14,6 +14,10 @@ Evidence Graph Runtime changes must preserve this separation:
 - Karpathy/advisory wiki is workforce memory only and must not become
   product-runtime or eval-event source of truth.
 
-For E2-style work, keep `core/evidence/` pure and deterministic. Do not import
-FastAPI, providers, DB/session state, Redis/cache modules, eval runners, or
-advisory wiki modules from this package.
+For E2/E3-style work, keep `core/evidence/` pure and deterministic. Do not
+import FastAPI, providers, DB/session state, Redis/cache modules, eval runners,
+or advisory wiki modules from this package.
+
+E3 promotion ledger/replay changes may add append-only promotion contracts and
+dry-run replay summaries only. They must not write files, call runtime stores,
+create promotion side effects, or duplicate `core/knowledge/promotion.py`.

--- a/core/evidence/__init__.py
+++ b/core/evidence/__init__.py
@@ -23,6 +23,16 @@ from core.evidence.events import (
     ValidationStatus,
     create_eval_event,
 )
+from core.evidence.promotion_ledger import (
+    PromotionDecision,
+    PromotionLedgerEntry,
+    create_promotion_ledger_entry,
+)
+from core.evidence.replay import (
+    PromotionDiff,
+    PromotionReplaySummary,
+    dry_run_replay,
+)
 
 __all__ = [
     "AssetType",
@@ -31,11 +41,17 @@ __all__ = [
     "EvalEventProducer",
     "EvalEventRail",
     "EvalEventType",
+    "PromotionDecision",
+    "PromotionDiff",
+    "PromotionLedgerEntry",
+    "PromotionReplaySummary",
     "Rail",
     "ValidationStatus",
     "build_asset_id",
     "build_idempotency_key",
     "create_evidence_asset_ref",
     "create_eval_event",
+    "create_promotion_ledger_entry",
+    "dry_run_replay",
     "fingerprint_payload",
 ]

--- a/core/evidence/promotion_ledger.py
+++ b/core/evidence/promotion_ledger.py
@@ -61,9 +61,17 @@ _FORBIDDEN_METADATA_KEY_FRAGMENTS: tuple[str, ...] = (
 _FORBIDDEN_METADATA_STRING_FRAGMENTS: tuple[str, ...] = (
     "api_key=",
     "bearer ",
+    "health payload",
+    "medical record",
     "password=",
     "private key",
+    "prompt:",
+    "raw prompt",
+    "raw response",
+    "response:",
     "sk-",
+    "user health",
+    "user payload",
 )
 
 _PATH_LIKE_PREFIXES: tuple[str, ...] = (
@@ -295,6 +303,8 @@ def create_promotion_ledger_entry(
     normalized_decision = validate_promotion_decision(decision)
     if normalized_decision in _PROMOTING_DECISIONS and source_validation_status != "valid":
         raise ValueError("promoting decisions require a valid source_event")
+    if source_event.rail != "eval":
+        raise ValueError("source_event rail must be eval")
     normalized_upstream_ids = normalize_upstream_ids(
         (
             source_event.event_id,
@@ -456,6 +466,8 @@ def _freeze_json_value(
                 )
             )
         return _FrozenJsonObject(tuple(items))
+    if isinstance(value, bytes | bytearray):
+        raise ValueError(f"metadata value at {'.'.join(path) or '<root>'} must be JSON-compatible")
     if isinstance(value, Sequence) and not isinstance(value, str):
         return _FrozenJsonArray(
             tuple(

--- a/core/evidence/promotion_ledger.py
+++ b/core/evidence/promotion_ledger.py
@@ -1,0 +1,518 @@
+"""Promotion ledger contracts for Evidence Graph Runtime.
+
+RU: E3 ledger фиксирует promotion decisions без runtime writes.
+EN: E3 ledger records promotion decisions without runtime writes.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal, TypeAlias, cast
+
+from core.evidence.events import (
+    EvidenceEvalEvent,
+    EvalEventProducer,
+    EvalEventType,
+    ValidationStatus,
+    create_eval_event_producer,
+    validate_eval_event_type,
+    validate_idempotency_key,
+    validate_produced_at,
+    validate_validation_status,
+)
+from core.evidence.fingerprints import JsonScalar, JsonValue, fingerprint_payload
+from core.evidence.policies import (
+    normalize_upstream_ids,
+    validate_fingerprint,
+    validate_non_empty_token,
+)
+
+PromotionDecision = Literal["promote", "reject", "defer", "supersede"]
+
+ALLOWED_PROMOTION_DECISIONS: tuple[str, ...] = (
+    "promote",
+    "reject",
+    "defer",
+    "supersede",
+)
+
+_PROMOTING_DECISIONS: tuple[str, ...] = ("promote", "supersede")
+
+_FORBIDDEN_METADATA_KEY_FRAGMENTS: tuple[str, ...] = (
+    "api_key",
+    "apikey",
+    "access_token",
+    "health_payload",
+    "medical_record",
+    "password",
+    "prompt",
+    "raw_prompt",
+    "raw_response",
+    "refresh_token",
+    "response",
+    "secret",
+    "user_health",
+    "user_payload",
+)
+
+_FORBIDDEN_METADATA_STRING_FRAGMENTS: tuple[str, ...] = (
+    "api_key=",
+    "bearer ",
+    "password=",
+    "private key",
+    "sk-",
+)
+
+_PATH_LIKE_PREFIXES: tuple[str, ...] = (
+    "artifacts/",
+    "core/",
+    "data/",
+    "docs/",
+    "evals/",
+    "scripts/",
+    "tests/",
+)
+
+_PATH_LIKE_SUFFIXES: tuple[str, ...] = (
+    ".csv",
+    ".ipynb",
+    ".json",
+    ".jsonl",
+    ".md",
+    ".parquet",
+    ".txt",
+)
+
+
+@dataclass(frozen=True)
+class _FrozenJsonArray:
+    items: tuple["FrozenJsonValue", ...]
+
+
+@dataclass(frozen=True)
+class _FrozenJsonObject:
+    items: tuple[tuple[str, "FrozenJsonValue"], ...]
+
+
+FrozenJsonValue: TypeAlias = JsonScalar | _FrozenJsonArray | _FrozenJsonObject
+
+
+@dataclass(frozen=True, init=False)
+class PromotionLedgerEntry:
+    """Immutable append-only ledger entry for one promotion decision."""
+
+    ledger_entry_id: str
+    promotion_id: str
+    source_event_id: str
+    source_event_type: EvalEventType
+    source_event_fingerprint: str
+    decision: PromotionDecision
+    idempotency_key: str
+    policy_version: str
+    producer: EvalEventProducer
+    produced_at: str
+    upstream_ids: tuple[str, ...]
+    supersedes: tuple[str, ...]
+    validation_status: ValidationStatus
+    reason_codes: tuple[str, ...]
+    _metadata: _FrozenJsonObject
+
+    def __init__(
+        self,
+        *,
+        promotion_id: str,
+        source_event_id: str,
+        source_event_type: EvalEventType,
+        source_event_fingerprint: str,
+        decision: PromotionDecision,
+        idempotency_key: str,
+        policy_version: str,
+        producer: EvalEventProducer,
+        produced_at: str,
+        upstream_ids: Iterable[str] = (),
+        supersedes: Iterable[str] = (),
+        validation_status: ValidationStatus,
+        reason_codes: Iterable[str] = (),
+        metadata: Mapping[str, JsonValue] | None = None,
+        ledger_entry_id: str | None = None,
+    ) -> None:
+        """Create and validate a deterministic ledger entry."""
+
+        normalized_promotion_id = validate_non_empty_token(
+            "promotion_id",
+            promotion_id,
+        )
+        normalized_source_event_id = _validate_identity_token(
+            "source_event_id",
+            source_event_id,
+        )
+        normalized_source_event_type = validate_eval_event_type(source_event_type)
+        normalized_source_fingerprint = validate_fingerprint(source_event_fingerprint)
+        normalized_decision = validate_promotion_decision(decision)
+        normalized_idempotency_key = validate_idempotency_key(idempotency_key)
+        normalized_policy_version = validate_non_empty_token(
+            "policy_version",
+            policy_version,
+        )
+        normalized_producer = create_eval_event_producer(
+            name=producer.name,
+            version=producer.version,
+        )
+        normalized_produced_at = validate_produced_at(produced_at)
+        normalized_upstream_ids = normalize_upstream_ids(tuple(upstream_ids))
+        normalized_supersedes = _normalize_unique_identity_tokens(
+            "supersedes",
+            tuple(supersedes),
+        )
+        normalized_validation_status = validate_validation_status(validation_status)
+        normalized_reason_codes = _normalize_reason_codes(tuple(reason_codes))
+        frozen_metadata = _freeze_metadata(metadata or {})
+
+        if normalized_decision in _PROMOTING_DECISIONS and normalized_validation_status != "valid":
+            raise ValueError("promoting decisions require valid validation_status")
+        if normalized_decision == "supersede" and not normalized_supersedes:
+            raise ValueError("supersede decision requires supersedes entries")
+
+        built_entry_id = build_ledger_entry_id(
+            promotion_id=normalized_promotion_id,
+            source_event_id=normalized_source_event_id,
+            source_event_type=normalized_source_event_type,
+            source_event_fingerprint=normalized_source_fingerprint,
+            decision=normalized_decision,
+            idempotency_key=normalized_idempotency_key,
+            policy_version=normalized_policy_version,
+            producer=normalized_producer,
+            upstream_ids=normalized_upstream_ids,
+            supersedes=normalized_supersedes,
+            validation_status=normalized_validation_status,
+            reason_codes=normalized_reason_codes,
+            metadata=cast(dict[str, JsonValue], _thaw_frozen_json(frozen_metadata)),
+        )
+        normalized_entry_id = (
+            built_entry_id
+            if ledger_entry_id is None
+            else _validate_ledger_entry_id(ledger_entry_id)
+        )
+        if normalized_entry_id in normalized_supersedes:
+            raise ValueError("ledger entry cannot supersede itself")
+        if normalized_entry_id != built_entry_id:
+            raise ValueError("ledger_entry_id must match deterministic identity")
+
+        object.__setattr__(self, "ledger_entry_id", normalized_entry_id)
+        object.__setattr__(self, "promotion_id", normalized_promotion_id)
+        object.__setattr__(self, "source_event_id", normalized_source_event_id)
+        object.__setattr__(
+            self,
+            "source_event_type",
+            normalized_source_event_type,
+        )
+        object.__setattr__(
+            self,
+            "source_event_fingerprint",
+            normalized_source_fingerprint,
+        )
+        object.__setattr__(self, "decision", normalized_decision)
+        object.__setattr__(self, "idempotency_key", normalized_idempotency_key)
+        object.__setattr__(self, "policy_version", normalized_policy_version)
+        object.__setattr__(self, "producer", normalized_producer)
+        object.__setattr__(self, "produced_at", normalized_produced_at)
+        object.__setattr__(self, "upstream_ids", normalized_upstream_ids)
+        object.__setattr__(self, "supersedes", normalized_supersedes)
+        object.__setattr__(self, "validation_status", normalized_validation_status)
+        object.__setattr__(self, "reason_codes", normalized_reason_codes)
+        object.__setattr__(self, "_metadata", frozen_metadata)
+
+    @property
+    def metadata(self) -> dict[str, JsonValue]:
+        """Return a defensive JSON-compatible metadata copy."""
+
+        return cast(dict[str, JsonValue], _thaw_frozen_json(self._metadata))
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Return a deterministic JSON-compatible ledger payload."""
+
+        return {
+            "decision": self.decision,
+            "idempotency_key": self.idempotency_key,
+            "ledger_entry_id": self.ledger_entry_id,
+            "metadata": self.metadata,
+            "policy_version": self.policy_version,
+            "produced_at": self.produced_at,
+            "producer": self.producer.to_dict(),
+            "promotion_id": self.promotion_id,
+            "reason_codes": list(self.reason_codes),
+            "source_event_fingerprint": self.source_event_fingerprint,
+            "source_event_id": self.source_event_id,
+            "source_event_type": self.source_event_type,
+            "supersedes": list(self.supersedes),
+            "upstream_ids": list(self.upstream_ids),
+            "validation_status": self.validation_status,
+        }
+
+    def to_json(self) -> str:
+        """Serialize the entry with stable key ordering."""
+
+        return json.dumps(
+            self.to_dict(),
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+
+def create_promotion_ledger_entry(
+    *,
+    source_event: EvidenceEvalEvent,
+    promotion_id: str,
+    decision: PromotionDecision,
+    idempotency_key: str,
+    producer: EvalEventProducer,
+    produced_at: str,
+    policy_version: str | None = None,
+    upstream_ids: Iterable[str] = (),
+    supersedes: Iterable[str] = (),
+    validation_status: ValidationStatus | None = None,
+    reason_codes: Iterable[str] = (),
+    metadata: Mapping[str, JsonValue] | None = None,
+    ledger_entry_id: str | None = None,
+) -> PromotionLedgerEntry:
+    """Create a ledger entry from an E2 eval event or fail closed."""
+
+    if not isinstance(source_event, EvidenceEvalEvent):
+        raise ValueError("source_event must be an EvidenceEvalEvent")
+    source_event_id = _validate_identity_token(
+        "source_event_id",
+        source_event.event_id,
+    )
+    source_event_fingerprint = validate_fingerprint(source_event.fingerprint)
+    source_validation_status = validate_validation_status(
+        source_event.validation_status,
+    )
+    normalized_decision = validate_promotion_decision(decision)
+    if normalized_decision in _PROMOTING_DECISIONS and source_validation_status != "valid":
+        raise ValueError("promoting decisions require a valid source_event")
+    normalized_upstream_ids = normalize_upstream_ids(
+        (
+            source_event.event_id,
+            *source_event.upstream_ids,
+            *tuple(upstream_ids),
+        )
+    )
+    return PromotionLedgerEntry(
+        promotion_id=promotion_id,
+        source_event_id=source_event_id,
+        source_event_type=source_event.event_type,
+        source_event_fingerprint=source_event_fingerprint,
+        decision=normalized_decision,
+        idempotency_key=idempotency_key,
+        policy_version=policy_version or source_event.policy_version,
+        producer=producer,
+        produced_at=produced_at,
+        upstream_ids=normalized_upstream_ids,
+        supersedes=supersedes,
+        validation_status=validation_status or source_validation_status,
+        reason_codes=reason_codes,
+        metadata=metadata,
+        ledger_entry_id=ledger_entry_id,
+    )
+
+
+def build_ledger_entry_id(
+    *,
+    promotion_id: str,
+    source_event_id: str,
+    source_event_type: EvalEventType,
+    source_event_fingerprint: str,
+    decision: PromotionDecision,
+    idempotency_key: str,
+    policy_version: str,
+    producer: EvalEventProducer,
+    upstream_ids: tuple[str, ...],
+    supersedes: tuple[str, ...],
+    validation_status: ValidationStatus,
+    reason_codes: tuple[str, ...],
+    metadata: Mapping[str, JsonValue],
+) -> str:
+    """Build a deterministic ledger entry id from canonical identity fields."""
+
+    identity_payload: JsonValue = {
+        "decision": decision,
+        "idempotency_key": idempotency_key,
+        "metadata": metadata,
+        "policy_version": policy_version,
+        "producer": producer.to_dict(),
+        "promotion_id": promotion_id,
+        "reason_codes": list(reason_codes),
+        "source_event_fingerprint": source_event_fingerprint,
+        "source_event_id": source_event_id,
+        "source_event_type": source_event_type,
+        "supersedes": list(supersedes),
+        "upstream_ids": list(upstream_ids),
+        "validation_status": validation_status,
+    }
+    digest = fingerprint_payload(identity_payload).removeprefix("sha256:")
+    return f"promotion-ledger:{digest[:24]}"
+
+
+def validate_promotion_decision(decision: PromotionDecision) -> PromotionDecision:
+    """Return a supported promotion decision or fail closed."""
+
+    if decision not in ALLOWED_PROMOTION_DECISIONS:
+        raise ValueError(f"unsupported decision: {decision!r}")
+    return decision
+
+
+def _validate_identity_token(name: str, value: str) -> str:
+    """Validate IDs that may contain separators but no whitespace."""
+
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{name} must be non-empty")
+    if any(char.isspace() for char in normalized):
+        raise ValueError(f"{name} must not contain whitespace")
+    return normalized
+
+
+def _validate_ledger_entry_id(ledger_entry_id: str) -> str:
+    """Return a deterministic ledger id token."""
+
+    normalized = _validate_identity_token("ledger_entry_id", ledger_entry_id)
+    if not normalized.startswith("promotion-ledger:"):
+        raise ValueError("ledger_entry_id must start with 'promotion-ledger:'")
+    return normalized
+
+
+def _normalize_unique_identity_tokens(
+    name: str,
+    values: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Normalize identity tokens while rejecting duplicate collisions."""
+
+    normalized_values: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = _validate_identity_token(name, value)
+        if normalized in seen:
+            raise ValueError(f"{name} contains duplicate entries")
+        seen.add(normalized)
+        normalized_values.append(normalized)
+    return tuple(sorted(normalized_values))
+
+
+def _normalize_reason_codes(reason_codes: tuple[str, ...]) -> tuple[str, ...]:
+    """Normalize reason codes and reject collisions after normalization."""
+
+    normalized_codes: list[str] = []
+    seen: set[str] = set()
+    for reason_code in reason_codes:
+        normalized = validate_non_empty_token(
+            "reason_code",
+            reason_code.strip().lower(),
+        )
+        if normalized in seen:
+            raise ValueError("reason_codes collide after normalization")
+        seen.add(normalized)
+        normalized_codes.append(normalized)
+    return tuple(sorted(normalized_codes))
+
+
+def _freeze_metadata(metadata: Mapping[str, JsonValue]) -> _FrozenJsonObject:
+    """Validate and freeze metadata into caller-independent structures."""
+
+    return cast(_FrozenJsonObject, _freeze_json_value(metadata, path=()))
+
+
+def _freeze_json_value(
+    value: JsonValue,
+    *,
+    path: tuple[str, ...],
+) -> FrozenJsonValue:
+    """Freeze JSON-compatible metadata and scan unsafe raw payloads."""
+
+    if isinstance(value, Mapping):
+        items: list[tuple[str, FrozenJsonValue]] = []
+        normalized_items: list[tuple[str, JsonValue]] = []
+        seen_keys: set[str] = set()
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError("metadata keys must be strings")
+            normalized_key = key.strip()
+            if not normalized_key:
+                raise ValueError("metadata keys must be non-empty")
+            if normalized_key in seen_keys:
+                raise ValueError(f"metadata key collides after normalization: {normalized_key!r}")
+            seen_keys.add(normalized_key)
+            _validate_metadata_key(normalized_key)
+            normalized_items.append((normalized_key, item))
+        for normalized_key, item in sorted(normalized_items, key=lambda pair: pair[0]):
+            items.append(
+                (
+                    normalized_key,
+                    _freeze_json_value(item, path=path + (normalized_key,)),
+                )
+            )
+        return _FrozenJsonObject(tuple(items))
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return _FrozenJsonArray(
+            tuple(
+                _freeze_json_value(item, path=path + (str(index),))
+                for index, item in enumerate(value)
+            )
+        )
+    if isinstance(value, str):
+        _validate_metadata_string(value)
+        return value
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            location = ".".join(path) or "<root>"
+            raise ValueError(f"metadata value at {location} must be finite")
+        return value
+    raise ValueError(f"metadata value at {'.'.join(path) or '<root>'} must be JSON-compatible")
+
+
+def _validate_metadata_key(key: str) -> None:
+    """Fail closed on raw prompt/response/secret/user-health metadata keys."""
+
+    lowered = key.lower()
+    if any(fragment in lowered for fragment in _FORBIDDEN_METADATA_KEY_FRAGMENTS):
+        raise ValueError(f"metadata key is not allowed: {key!r}")
+
+
+def _validate_metadata_string(value: str) -> None:
+    """Fail closed on obvious raw secret or path-like payload strings."""
+
+    normalized = value.strip()
+    lowered = normalized.lower().replace("\\", "/")
+    if any(fragment in lowered for fragment in _FORBIDDEN_METADATA_STRING_FRAGMENTS):
+        raise ValueError("metadata string appears to contain raw secret material")
+    if (
+        lowered.startswith("/")
+        or lowered.startswith("~")
+        or "../" in lowered
+        or _has_windows_drive_prefix(lowered)
+        or (lowered.startswith(_PATH_LIKE_PREFIXES) and lowered.endswith(_PATH_LIKE_SUFFIXES))
+    ):
+        raise ValueError("metadata string appears to contain path-like material")
+
+
+def _has_windows_drive_prefix(value: str) -> bool:
+    """Return True for Windows drive-qualified strings such as C:/x or C:x."""
+
+    first_segment = value.split("/", maxsplit=1)[0]
+    return len(first_segment) >= 2 and first_segment[0].isalpha() and first_segment[1] == ":"
+
+
+def _thaw_frozen_json(value: FrozenJsonValue) -> JsonValue:
+    """Return a defensive JSON-compatible value from frozen metadata."""
+
+    if isinstance(value, _FrozenJsonObject):
+        return {key: _thaw_frozen_json(item) for key, item in value.items}
+    if isinstance(value, _FrozenJsonArray):
+        return [_thaw_frozen_json(item) for item in value.items]
+    return value

--- a/core/evidence/promotion_ledger.py
+++ b/core/evidence/promotion_ledger.py
@@ -448,13 +448,16 @@ def _freeze_json_value(
         normalized_items: list[tuple[str, JsonValue]] = []
         seen_keys: set[str] = set()
         for key, item in value.items():
+            key_path = ".".join(path + (str(key),)) or "<root>"
             if not isinstance(key, str):
-                raise ValueError("metadata keys must be strings")
-            normalized_key = key.strip()
+                raise ValueError(f"metadata key at {key_path} must be a string")
+            normalized_key = key.strip().lower()
             if not normalized_key:
-                raise ValueError("metadata keys must be non-empty")
+                raise ValueError(f"metadata key at {key_path} must be non-empty")
             if normalized_key in seen_keys:
-                raise ValueError(f"metadata key collides after normalization: {normalized_key!r}")
+                raise ValueError(
+                    f"metadata key at {key_path} collides after normalization: {normalized_key!r}"
+                )
             seen_keys.add(normalized_key)
             _validate_metadata_key(normalized_key)
             normalized_items.append((normalized_key, item))

--- a/core/evidence/replay.py
+++ b/core/evidence/replay.py
@@ -1,0 +1,176 @@
+"""Dry-run replay helpers for Evidence Graph promotion ledger entries."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from core.evidence.fingerprints import JsonValue
+from core.evidence.promotion_ledger import PromotionLedgerEntry
+
+
+@dataclass(frozen=True)
+class PromotionDiff:
+    """Deterministic replay diff buckets."""
+
+    added: tuple[str, ...] = ()
+    duplicate: tuple[str, ...] = ()
+    superseded: tuple[str, ...] = ()
+    rejected: tuple[str, ...] = ()
+    deferred: tuple[str, ...] = ()
+    conflict: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Return a JSON-compatible deterministic diff payload."""
+
+        return {
+            "added": list(self.added),
+            "conflict": list(self.conflict),
+            "deferred": list(self.deferred),
+            "duplicate": list(self.duplicate),
+            "rejected": list(self.rejected),
+            "superseded": list(self.superseded),
+        }
+
+
+@dataclass(frozen=True)
+class PromotionReplaySummary:
+    """Dry-run replay result without mutating or writing ledger state."""
+
+    candidate_entry_ids: tuple[str, ...]
+    existing_entry_ids: tuple[str, ...]
+    applied_entry_ids: tuple[str, ...]
+    diff: PromotionDiff
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Return a JSON-compatible deterministic replay payload."""
+
+        return {
+            "applied_entry_ids": list(self.applied_entry_ids),
+            "candidate_entry_ids": list(self.candidate_entry_ids),
+            "diff": self.diff.to_dict(),
+            "existing_entry_ids": list(self.existing_entry_ids),
+        }
+
+    def to_json(self) -> str:
+        """Serialize replay summary with stable key ordering."""
+
+        return json.dumps(
+            self.to_dict(),
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+
+def dry_run_replay(
+    *,
+    existing_entries: Iterable[PromotionLedgerEntry] = (),
+    candidate_entries: Iterable[PromotionLedgerEntry] = (),
+) -> PromotionReplaySummary:
+    """Replay candidate ledger entries deterministically without side effects."""
+
+    existing = _sorted_entries(tuple(existing_entries))
+    candidates = _sorted_entries(tuple(candidate_entries))
+
+    existing_ids = tuple(entry.ledger_entry_id for entry in existing)
+    candidate_ids = tuple(entry.ledger_entry_id for entry in candidates)
+    seen_idempotency: dict[str, PromotionLedgerEntry] = {
+        entry.idempotency_key: entry for entry in existing
+    }
+    active_by_scope: dict[str, PromotionLedgerEntry] = {
+        entry.promotion_id: entry
+        for entry in existing
+        if entry.decision in {"promote", "supersede"}
+    }
+    candidate_scope_owner: dict[str, PromotionLedgerEntry] = {}
+
+    added: list[str] = []
+    duplicate: list[str] = []
+    superseded: list[str] = []
+    rejected: list[str] = []
+    deferred: list[str] = []
+    conflict: list[str] = []
+    applied = list(existing_ids)
+
+    for entry in candidates:
+        seen_entry = seen_idempotency.get(entry.idempotency_key)
+        if seen_entry is not None:
+            if seen_entry.ledger_entry_id == entry.ledger_entry_id:
+                duplicate.append(entry.ledger_entry_id)
+            else:
+                conflict.append(entry.ledger_entry_id)
+            continue
+
+        candidate_owner = candidate_scope_owner.get(entry.promotion_id)
+        if candidate_owner is not None and candidate_owner.ledger_entry_id != entry.ledger_entry_id:
+            conflict.append(entry.ledger_entry_id)
+            continue
+
+        active_entry = active_by_scope.get(entry.promotion_id)
+        if entry.decision == "promote" and active_entry is not None:
+            conflict.append(entry.ledger_entry_id)
+            continue
+        if (
+            entry.decision == "supersede"
+            and active_entry is not None
+            and active_entry.ledger_entry_id not in entry.supersedes
+        ):
+            conflict.append(entry.ledger_entry_id)
+            continue
+
+        seen_idempotency[entry.idempotency_key] = entry
+        candidate_scope_owner[entry.promotion_id] = entry
+
+        if entry.decision == "promote":
+            added.append(entry.ledger_entry_id)
+            active_by_scope[entry.promotion_id] = entry
+            applied.append(entry.ledger_entry_id)
+        elif entry.decision == "supersede":
+            superseded.append(entry.ledger_entry_id)
+            active_by_scope[entry.promotion_id] = entry
+            applied.append(entry.ledger_entry_id)
+        elif entry.decision == "reject":
+            rejected.append(entry.ledger_entry_id)
+        elif entry.decision == "defer":
+            deferred.append(entry.ledger_entry_id)
+        else:
+            conflict.append(entry.ledger_entry_id)
+
+    return PromotionReplaySummary(
+        candidate_entry_ids=candidate_ids,
+        existing_entry_ids=existing_ids,
+        applied_entry_ids=tuple(sorted(applied)),
+        diff=PromotionDiff(
+            added=tuple(sorted(added)),
+            duplicate=tuple(sorted(duplicate)),
+            superseded=tuple(sorted(superseded)),
+            rejected=tuple(sorted(rejected)),
+            deferred=tuple(sorted(deferred)),
+            conflict=tuple(sorted(conflict)),
+        ),
+    )
+
+
+def _sorted_entries(
+    entries: tuple[PromotionLedgerEntry, ...],
+) -> tuple[PromotionLedgerEntry, ...]:
+    """Validate and sort entries deterministically."""
+
+    for entry in entries:
+        if not isinstance(entry, PromotionLedgerEntry):
+            raise ValueError("replay entries must be PromotionLedgerEntry instances")
+    return tuple(sorted(entries, key=_entry_sort_key))
+
+
+def _entry_sort_key(entry: PromotionLedgerEntry) -> tuple[str, str, str, str]:
+    """Return stable ordering key for replay inputs."""
+
+    return (
+        entry.promotion_id,
+        entry.source_event_id,
+        entry.decision,
+        entry.ledger_entry_id,
+    )

--- a/core/evidence/replay.py
+++ b/core/evidence/replay.py
@@ -129,8 +129,6 @@ def dry_run_replay(
         elif entry.decision == "defer":
             deferred.append(entry.ledger_entry_id)
             applied.append(entry.ledger_entry_id)
-        else:
-            conflict.append(entry.ledger_entry_id)
 
     return PromotionReplaySummary(
         candidate_entry_ids=candidate_ids,

--- a/core/evidence/replay.py
+++ b/core/evidence/replay.py
@@ -89,12 +89,6 @@ def dry_run_replay(
     applied = list(existing_ids)
 
     for entry in candidates:
-        if entry.decision == "supersede":
-            active_entry = active_by_scope.get(entry.promotion_id)
-            if active_entry is None or active_entry.ledger_entry_id not in entry.supersedes:
-                conflict.append(entry.ledger_entry_id)
-                continue
-
         seen_entry = seen_idempotency.get(entry.idempotency_key)
         if seen_entry is not None:
             if seen_entry.ledger_entry_id == entry.ledger_entry_id:
@@ -109,6 +103,11 @@ def dry_run_replay(
             continue
 
         active_entry = active_by_scope.get(entry.promotion_id)
+        if entry.decision == "supersede" and (
+            active_entry is None or active_entry.ledger_entry_id not in entry.supersedes
+        ):
+            conflict.append(entry.ledger_entry_id)
+            continue
         if entry.decision == "promote" and active_entry is not None:
             conflict.append(entry.ledger_entry_id)
             continue

--- a/core/evidence/replay.py
+++ b/core/evidence/replay.py
@@ -77,14 +77,7 @@ def dry_run_replay(
 
     existing_ids = tuple(entry.ledger_entry_id for entry in existing)
     candidate_ids = tuple(entry.ledger_entry_id for entry in candidates)
-    seen_idempotency: dict[str, PromotionLedgerEntry] = {
-        entry.idempotency_key: entry for entry in existing
-    }
-    active_by_scope: dict[str, PromotionLedgerEntry] = {
-        entry.promotion_id: entry
-        for entry in existing
-        if entry.decision in {"promote", "supersede"}
-    }
+    seen_idempotency, active_by_scope = _seed_existing_replay_state(existing)
     candidate_scope_owner: dict[str, PromotionLedgerEntry] = {}
 
     added: list[str] = []
@@ -96,6 +89,12 @@ def dry_run_replay(
     applied = list(existing_ids)
 
     for entry in candidates:
+        if entry.decision == "supersede":
+            active_entry = active_by_scope.get(entry.promotion_id)
+            if active_entry is None or active_entry.ledger_entry_id not in entry.supersedes:
+                conflict.append(entry.ledger_entry_id)
+                continue
+
         seen_entry = seen_idempotency.get(entry.idempotency_key)
         if seen_entry is not None:
             if seen_entry.ledger_entry_id == entry.ledger_entry_id:
@@ -113,13 +112,6 @@ def dry_run_replay(
         if entry.decision == "promote" and active_entry is not None:
             conflict.append(entry.ledger_entry_id)
             continue
-        if (
-            entry.decision == "supersede"
-            and active_entry is not None
-            and active_entry.ledger_entry_id not in entry.supersedes
-        ):
-            conflict.append(entry.ledger_entry_id)
-            continue
 
         seen_idempotency[entry.idempotency_key] = entry
         candidate_scope_owner[entry.promotion_id] = entry
@@ -134,8 +126,10 @@ def dry_run_replay(
             applied.append(entry.ledger_entry_id)
         elif entry.decision == "reject":
             rejected.append(entry.ledger_entry_id)
+            applied.append(entry.ledger_entry_id)
         elif entry.decision == "defer":
             deferred.append(entry.ledger_entry_id)
+            applied.append(entry.ledger_entry_id)
         else:
             conflict.append(entry.ledger_entry_id)
 
@@ -165,12 +159,56 @@ def _sorted_entries(
     return tuple(sorted(entries, key=_entry_sort_key))
 
 
+def _seed_existing_replay_state(
+    existing: tuple[PromotionLedgerEntry, ...],
+) -> tuple[dict[str, PromotionLedgerEntry], dict[str, PromotionLedgerEntry]]:
+    """Build fail-closed replay indexes from existing ledger entries."""
+
+    seen_idempotency: dict[str, PromotionLedgerEntry] = {}
+    active_by_scope: dict[str, PromotionLedgerEntry] = {}
+    for entry in existing:
+        previous = seen_idempotency.get(entry.idempotency_key)
+        if previous is not None:
+            raise ValueError(
+                f"existing ledger has duplicate idempotency_key: {entry.idempotency_key}"
+            )
+        seen_idempotency[entry.idempotency_key] = entry
+
+        if entry.decision == "promote":
+            active_entry = active_by_scope.get(entry.promotion_id)
+            if active_entry is not None:
+                raise ValueError(
+                    f"existing ledger has conflicting active promotion_id: {entry.promotion_id}"
+                )
+            active_by_scope[entry.promotion_id] = entry
+        elif entry.decision == "supersede":
+            active_entry = active_by_scope.get(entry.promotion_id)
+            if active_entry is None or active_entry.ledger_entry_id not in entry.supersedes:
+                raise ValueError(
+                    f"existing ledger has orphan supersede entry: {entry.ledger_entry_id}"
+                )
+            active_by_scope[entry.promotion_id] = entry
+    return seen_idempotency, active_by_scope
+
+
 def _entry_sort_key(entry: PromotionLedgerEntry) -> tuple[str, str, str, str]:
     """Return stable ordering key for replay inputs."""
 
     return (
         entry.promotion_id,
-        entry.source_event_id,
-        entry.decision,
+        _decision_sort_rank(entry.decision),
         entry.ledger_entry_id,
+        entry.source_event_id,
     )
+
+
+def _decision_sort_rank(decision: str) -> str:
+    """Return stable semantic order for ledger replay decisions."""
+
+    ranks = {
+        "promote": "0",
+        "supersede": "1",
+        "reject": "2",
+        "defer": "3",
+    }
+    return ranks[decision]

--- a/docs/orchestration/contracts/EVIDENCE_PROMOTION_REPLAY.md
+++ b/docs/orchestration/contracts/EVIDENCE_PROMOTION_REPLAY.md
@@ -1,0 +1,129 @@
+<!-- markdownlint-disable MD013 -->
+# Evidence Promotion Ledger And Replay Contract
+
+## Purpose
+
+PR-E3 adds the first Evidence Graph promotion/replay layer after the unified
+eval event schema from PR-E2.
+
+```text
+normalized eval event
+-> promotion ledger entry
+-> deterministic dry-run replay
+-> promotion diff report
+```
+
+This contract is internal and schema-first. It does not add product runtime
+behavior, routes, OpenAPI, DB writes, eval runners, dashboards, semantic cache,
+GraphRAG, or advisory-wiki authority.
+
+## Ledger Entry Contract
+
+`core/evidence/promotion_ledger.py` defines immutable promotion ledger entries
+with these canonical fields:
+
+- `ledger_entry_id`
+- `promotion_id`
+- `source_event_id`
+- `source_event_type`
+- `source_event_fingerprint`
+- `decision`
+- `idempotency_key`
+- `policy_version`
+- `producer`
+- `produced_at`
+- `upstream_ids`
+- `supersedes`
+- `validation_status`
+- `reason_codes`
+- `metadata`
+
+Supported decisions are intentionally narrow:
+
+- `promote`
+- `reject`
+- `defer`
+- `supersede`
+
+`ledger_entry_id` is deterministic and derived from canonical entry fields via
+`fingerprint_payload`. It does not depend on wall-clock time; `produced_at` is
+recorded for audit context only.
+
+## Validation
+
+The ledger fails closed on:
+
+- unsupported decisions or validation statuses;
+- blank source event IDs, source fingerprints, idempotency keys, policy
+  versions, producer names, or producer versions;
+- promotion/supersession of source events that are not `valid`;
+- promotion/supersession entries whose ledger validation status is not `valid`;
+- self-supersession and duplicate `supersedes` entries;
+- duplicate/colliding reason codes after normalization;
+- metadata that appears to contain raw prompts, raw responses, user-health
+  payloads, secrets, or path-like artifact payloads;
+- caller-owned mutable structures changing after validation.
+
+Reject/defer decisions may record invalid, degraded, or deferred source events,
+but they do not promote those events.
+
+## Replay Contract
+
+`core/evidence/replay.py` defines a dry-run-only replay helper. It accepts
+existing ledger entries and candidate ledger entries, sorts them
+deterministically, and returns a summary with a promotion diff.
+
+Diff buckets are:
+
+- `added`
+- `duplicate`
+- `superseded`
+- `rejected`
+- `deferred`
+- `conflict`
+
+Replay deduplicates by `idempotency_key`. The same key and same entry is a
+duplicate. The same key with different deterministic identity is a conflict.
+Candidate entries with conflicting `promotion_id` scope are reported as
+non-promoting conflicts unless they are explicit supersession entries.
+
+Replay does not mutate inputs, write files, call a database, call providers,
+call eval runners, or import product runtime modules.
+
+## Rail Boundaries
+
+E3 consumes normalized eval events from `core/evidence/events.py`. It does not
+make eval events product truth and does not mix product runtime, advisory wiki,
+control-plane, or eval rails.
+
+Forbidden imports include:
+
+- FastAPI/routes and `legacy_app`;
+- providers and `llm.py`;
+- DB/session layers;
+- Redis/cache/GPTCache or semantic cache;
+- GraphRAG/knowledge graph runtime;
+- eval runners and `scripts.evals`;
+- advisory wiki or local support-plane modules.
+
+`core/knowledge/promotion.py` remains a separate product knowledge-promotion
+seam. E3 does not import or rewrite it.
+
+## Premortem Notes
+
+| Failure mode | Mitigation in E3 | Evidence |
+| --- | --- | --- |
+| Hidden writer/store | Replay is dry-run-only and returns values only | `tests/core/evidence/test_replay.py` |
+| Duplicate knowledge-promotion layer | E3 lives under `core/evidence` and does not import `core/knowledge/promotion.py` | import guard tests |
+| Invalid evidence promoted silently | Promote/supersede require valid source event and valid ledger status | ledger tests |
+| Nondeterministic replay | Entries are sorted and IDs are content-derived | replay determinism tests |
+| Weak idempotency | Duplicate keys dedupe; colliding keys conflict | replay tests |
+| Raw prompt/health/secret leakage | Metadata validation fails closed | ledger metadata tests |
+| Semantic cache or GraphRAG side door | Import guards block cache/GraphRAG/wiki/runtime modules | AST guard tests |
+
+## E4 Handoff
+
+PR-E4 can build active metadata admission on top of these deterministic ledger
+and replay contracts. E4 should own admission decisions such as
+`allow_execute`, `allow_promote`, and `allow_serve`; E3 only provides the
+append-only ledger and dry-run replay substrate.

--- a/docs/review/PR_1673_FIXED_MAPPING.md
+++ b/docs/review/PR_1673_FIXED_MAPPING.md
@@ -55,28 +55,28 @@ strict merge-readiness remain required before merge.
   - Evidence: `core/evidence/promotion_ledger.py` validates `source_event.event_id` and `source_event.fingerprint` before lineage normalization.
 - Coordinator sidecar finding: factory did not accept `ledger_entry_id` passthrough used by deterministic-id tests -> `d57a5b5af`
   - Evidence: `create_promotion_ledger_entry(...)` accepts optional `ledger_entry_id` and passes it to `PromotionLedgerEntry`.
-- Bug-hunter sidecar finding: existing ledger conflicts are silently overwritten -> pending commit
+- Bug-hunter sidecar finding: existing ledger conflicts are silently overwritten -> ab3bd46f8
   - Disposition: FIXED
   - Evidence: `core/evidence/replay.py` builds existing replay indexes with fail-closed duplicate idempotency and active-scope checks; `tests/core/evidence/test_replay.py` covers both corrupt baseline cases.
-- Bug-hunter sidecar finding: supersede can apply without an active target -> pending commit
+- Bug-hunter sidecar finding: supersede can apply without an active target -> ab3bd46f8
   - Disposition: FIXED
   - Evidence: `core/evidence/replay.py` reports candidate orphan supersession as `conflict` and rejects orphan existing supersession; `tests/core/evidence/test_replay.py` covers both paths.
-- Bug-hunter sidecar finding: promotion creation does not enforce eval rail boundary -> pending commit
+- Bug-hunter sidecar finding: promotion creation does not enforce eval rail boundary -> ab3bd46f8
   - Disposition: FIXED
   - Evidence: `core/evidence/promotion_ledger.py` rejects non-`eval` source events; `tests/core/evidence/test_promotion_ledger.py` covers runtime rail rejection.
-- Bug-hunter sidecar finding: metadata leakage guard misses raw payload values -> pending commit
+- Bug-hunter sidecar finding: metadata leakage guard misses raw payload values -> ab3bd46f8
   - Disposition: FIXED
   - Evidence: `core/evidence/promotion_ledger.py` scans value strings for raw prompt/response/user-health payload markers and rejects bytes/bytearray; `tests/core/evidence/test_promotion_ledger.py` covers these cases.
-- QA sidecar finding: replay drops accepted reject/defer ledger entries -> pending commit
+- QA sidecar finding: replay drops accepted reject/defer ledger entries -> ab3bd46f8
   - Disposition: FIXED
   - Evidence: `core/evidence/replay.py` appends accepted reject/defer entries to `applied_entry_ids`; `tests/core/evidence/test_replay.py` asserts preservation.
-- QA sidecar finding: existing supersession state is order-derived, not ledger-derived -> pending commit
+- QA sidecar finding: existing supersession state is order-derived, not ledger-derived -> ab3bd46f8
   - Disposition: FIXED
   - Evidence: `core/evidence/replay.py` sorts promote before supersede and resolves current active entries through supersession semantics; `tests/core/evidence/test_replay.py` covers an existing promote -> supersede -> candidate supersede chain.
-- QA sidecar finding: bytes-like metadata is silently normalized as JSON arrays -> pending commit
+- QA sidecar finding: bytes-like metadata is silently normalized as JSON arrays -> ab3bd46f8
   - Disposition: FIXED
   - Evidence: `core/evidence/promotion_ledger.py` rejects bytes/bytearray before generic sequence handling; `tests/core/evidence/test_promotion_ledger.py` covers bytes metadata rejection.
-- QA sidecar finding: fixed mapping artifact is not in canonical Phase2 format -> pending commit
+- QA sidecar finding: fixed mapping artifact is not in canonical Phase2 format -> ab3bd46f8
   - Disposition: FIXED
   - Evidence: this artifact now includes `## Discussion Thread Pass` and canonical no-thread mapping language.
 

--- a/docs/review/PR_1673_FIXED_MAPPING.md
+++ b/docs/review/PR_1673_FIXED_MAPPING.md
@@ -1,0 +1,70 @@
+# PR 1673 Fixed Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673
+Branch: `codex/evidence-promotion-ledger-replay`
+Title: `feat(evidence): add promotion ledger and replay scaffold`
+
+## Scope
+
+PR-E3 adds deterministic Evidence Graph promotion ledger contracts and a pure
+dry-run replay scaffold over PR-E2 eval events.
+
+Out of scope: runtime routes, OpenAPI, DB migrations, providers, eval runners,
+semantic cache, GraphRAG, advisory wiki authority, dashboards, online eval,
+judge calibration, goldens, billing/auth/compliance changes.
+
+## Coordinator Bootstrap
+
+- Pre-open packet: `b95c4f512a1a`
+- Post-open review packet: `edd7a12bccc3`
+- Declared pre-open role order:
+  `agent-coordinator -> architecture-specialist -> rag-systems-agent -> data-scientist-agent -> security-auditor -> qa-engineer-agent -> bug-hunter -> cursor-specialist-agent`
+- Mandatory post-open lane:
+  `qa-engineer-agent -> bug-hunter`
+
+## Local Validation
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `.venv/bin/python -m pytest -q tests/core/evidence/test_promotion_ledger.py tests/core/evidence/test_replay.py tests/core/evidence/test_events.py tests/core/evidence/test_assets.py tests/core/evidence/test_fingerprints.py`
+- PASS: `.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null core/evidence tests/core/evidence/test_promotion_ledger.py tests/core/evidence/test_replay.py`
+- PASS: `make validate-changed`
+- PASS: `pre-commit run --all-files`
+- PASS: pre-push hook set: changed-files mypy, pip-audit, backend pre-push tests, full-repo bandit, docker build test
+
+Full local `make verify` was intentionally not run under the
+operator-approved machine-heavy exception. Current-head GitHub CI parity and
+strict merge-readiness remain required before merge.
+
+## Premortem Actions
+
+| Risk | Disposition | Evidence |
+| --- | --- | --- |
+| Hidden writer/store | FIXED | `core/evidence/replay.py` returns dry-run summaries only; replay tests assert mutation-free behavior. |
+| Duplicate `core/knowledge/promotion.py` | FIXED | E3 lives under `core/evidence`; import guards block runtime/knowledge-adjacent side doors. |
+| Invalid/degraded evidence promoted | FIXED | Promote/supersede require valid source event and valid ledger status. |
+| Nondeterministic replay | FIXED | Replay sorts entries deterministically and tests stable output regardless of input order. |
+| Weak idempotency | FIXED | Replay dedupes identical idempotency keys and reports collisions as conflict. |
+| Raw prompt/health/secret metadata | FIXED | Ledger metadata safety rejects prompt/response/user-health/secret/path-like payloads. |
+| Semantic cache/GraphRAG side door | FIXED | AST import guards block cache, semantic-cache, GraphRAG, wiki/support-plane, runtime, DB, provider, and eval-runner imports. |
+
+## Fixed in Commit Mapping
+
+- Coordinator sidecar finding: validate source event id before upstream normalization -> `d57a5b5af`
+  - Evidence: `core/evidence/promotion_ledger.py` validates `source_event.event_id` and `source_event.fingerprint` before lineage normalization.
+- Coordinator sidecar finding: factory did not accept `ledger_entry_id` passthrough used by deterministic-id tests -> `d57a5b5af`
+  - Evidence: `create_promotion_ledger_entry(...)` accepts optional `ledger_entry_id` and passes it to `PromotionLedgerEntry`.
+
+No GitHub review threads existed when this mapping artifact was first added.
+
+## Merge Readiness
+
+Not merge-ready at mapping creation time.
+
+Required before merge:
+
+- current-head CI parity clean;
+- CodeRabbit/Sourcery/Cubic no-actionables;
+- all review threads resolved with disposition evidence;
+- strict merge-readiness wrapper with auth;
+- mandatory review wait-window after latest bot/review activity.

--- a/docs/review/PR_1673_FIXED_MAPPING.md
+++ b/docs/review/PR_1673_FIXED_MAPPING.md
@@ -55,7 +55,18 @@ strict merge-readiness remain required before merge.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#pullrequestreview-4234281123 -> 13d165f81
+Disposition: FIXED
+Commit: 13d165f81
+Evidence: core/evidence/promotion_ledger.py metadata key validation now reports path context, normalizes keys case-insensitively, and tests/core/evidence/test_promotion_ledger.py covers key collisions plus Windows path metadata rejection.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#pullrequestreview-4234351988 -> ab3bd46f8
+Disposition: FIXED
+Commit: ab3bd46f8
+Evidence: core/evidence/replay.py reports candidate orphan supersession as conflict and fails closed on orphan existing supersession; tests/core/evidence/test_replay.py covers both paths.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#pullrequestreview-4234449600 -> 13d165f81
+Disposition: FIXED
+Commit: 13d165f81
+Evidence: core/evidence/replay.py checks duplicate idempotency before supersede scope validation; tests/core/evidence/test_replay.py covers duplicate supersede replay without conflict.
 
 ## Sidecar Review Findings
 

--- a/docs/review/PR_1673_FIXED_MAPPING.md
+++ b/docs/review/PR_1673_FIXED_MAPPING.md
@@ -48,9 +48,17 @@ strict merge-readiness remain required before merge.
 | Raw prompt/health/secret metadata | FIXED | Ledger metadata safety rejects prompt/response/user-health/secret/path-like payloads. |
 | Semantic cache/GraphRAG side door | FIXED | AST import guards block cache, semantic-cache, GraphRAG, wiki/support-plane, runtime, DB, provider, and eval-runner imports. |
 
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
 ## Fixed in Commit Mapping
 
-- No GitHub review thread URLs existed when this mapping artifact was first added.
+- No actionable review comments
+
+## Sidecar Review Findings
+
 - Coordinator sidecar finding: validate source event id before upstream normalization -> `d57a5b5af`
   - Evidence: `core/evidence/promotion_ledger.py` validates `source_event.event_id` and `source_event.fingerprint` before lineage normalization.
 - Coordinator sidecar finding: factory did not accept `ledger_entry_id` passthrough used by deterministic-id tests -> `d57a5b5af`
@@ -79,13 +87,6 @@ strict merge-readiness remain required before merge.
 - QA sidecar finding: fixed mapping artifact is not in canonical Phase2 format -> ab3bd46f8
   - Disposition: FIXED
   - Evidence: this artifact now includes `## Discussion Thread Pass` and canonical no-thread mapping language.
-
-## Discussion Thread Pass
-
-- [x] GitHub review threads inspected at mapping creation time.
-- [x] No GitHub review thread URLs existed when this mapping artifact was first added.
-- [x] Sidecar QA/bug-hunter findings are mapped above as local review findings with dispositions and evidence.
-- [x] No actionable GitHub review comments are resolved by this artifact.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1673_FIXED_MAPPING.md
+++ b/docs/review/PR_1673_FIXED_MAPPING.md
@@ -59,11 +59,31 @@ strict merge-readiness remain required before merge.
 Disposition: FIXED
 Commit: 13d165f81
 Evidence: core/evidence/promotion_ledger.py metadata key validation now reports path context, normalizes keys case-insensitively, and tests/core/evidence/test_promotion_ledger.py covers key collisions plus Windows path metadata rejection.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#discussion_r3193898908 -> 13d165f81
+Disposition: FIXED
+Commit: 13d165f81
+Evidence: core/evidence/promotion_ledger.py includes metadata key path context for nested key validation errors.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#discussion_r3193898930 -> 13d165f81
+Disposition: FIXED
+Commit: 13d165f81
+Evidence: tests/core/evidence/test_promotion_ledger.py covers metadata key normalization collisions and Windows-style path metadata rejection.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#discussion_r3193903328 -> ab3bd46f8
+Disposition: FIXED
+Commit: ab3bd46f8
+Evidence: core/evidence/replay.py requires an active replay target before accepting supersede; tests/core/evidence/test_replay.py covers candidate and existing orphan supersede handling.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#pullrequestreview-4234351988 -> ab3bd46f8
 Disposition: FIXED
 Commit: ab3bd46f8
 Evidence: core/evidence/replay.py reports candidate orphan supersession as conflict and fails closed on orphan existing supersession; tests/core/evidence/test_replay.py covers both paths.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#discussion_r3193951021 -> ab3bd46f8
+Disposition: FIXED
+Commit: ab3bd46f8
+Evidence: core/evidence/replay.py reports candidate orphan supersession as conflict and fails closed on orphan existing supersession; tests/core/evidence/test_replay.py covers both paths.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#pullrequestreview-4234449600 -> 13d165f81
+Disposition: FIXED
+Commit: 13d165f81
+Evidence: core/evidence/replay.py checks duplicate idempotency before supersede scope validation; tests/core/evidence/test_replay.py covers duplicate supersede replay without conflict.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#discussion_r3194014399 -> 13d165f81
 Disposition: FIXED
 Commit: 13d165f81
 Evidence: core/evidence/replay.py checks duplicate idempotency before supersede scope validation; tests/core/evidence/test_replay.py covers duplicate supersede replay without conflict.

--- a/docs/review/PR_1673_FIXED_MAPPING.md
+++ b/docs/review/PR_1673_FIXED_MAPPING.md
@@ -50,12 +50,42 @@ strict merge-readiness remain required before merge.
 
 ## Fixed in Commit Mapping
 
+- No GitHub review thread URLs existed when this mapping artifact was first added.
 - Coordinator sidecar finding: validate source event id before upstream normalization -> `d57a5b5af`
   - Evidence: `core/evidence/promotion_ledger.py` validates `source_event.event_id` and `source_event.fingerprint` before lineage normalization.
 - Coordinator sidecar finding: factory did not accept `ledger_entry_id` passthrough used by deterministic-id tests -> `d57a5b5af`
   - Evidence: `create_promotion_ledger_entry(...)` accepts optional `ledger_entry_id` and passes it to `PromotionLedgerEntry`.
+- Bug-hunter sidecar finding: existing ledger conflicts are silently overwritten -> pending commit
+  - Disposition: FIXED
+  - Evidence: `core/evidence/replay.py` builds existing replay indexes with fail-closed duplicate idempotency and active-scope checks; `tests/core/evidence/test_replay.py` covers both corrupt baseline cases.
+- Bug-hunter sidecar finding: supersede can apply without an active target -> pending commit
+  - Disposition: FIXED
+  - Evidence: `core/evidence/replay.py` reports candidate orphan supersession as `conflict` and rejects orphan existing supersession; `tests/core/evidence/test_replay.py` covers both paths.
+- Bug-hunter sidecar finding: promotion creation does not enforce eval rail boundary -> pending commit
+  - Disposition: FIXED
+  - Evidence: `core/evidence/promotion_ledger.py` rejects non-`eval` source events; `tests/core/evidence/test_promotion_ledger.py` covers runtime rail rejection.
+- Bug-hunter sidecar finding: metadata leakage guard misses raw payload values -> pending commit
+  - Disposition: FIXED
+  - Evidence: `core/evidence/promotion_ledger.py` scans value strings for raw prompt/response/user-health payload markers and rejects bytes/bytearray; `tests/core/evidence/test_promotion_ledger.py` covers these cases.
+- QA sidecar finding: replay drops accepted reject/defer ledger entries -> pending commit
+  - Disposition: FIXED
+  - Evidence: `core/evidence/replay.py` appends accepted reject/defer entries to `applied_entry_ids`; `tests/core/evidence/test_replay.py` asserts preservation.
+- QA sidecar finding: existing supersession state is order-derived, not ledger-derived -> pending commit
+  - Disposition: FIXED
+  - Evidence: `core/evidence/replay.py` sorts promote before supersede and resolves current active entries through supersession semantics; `tests/core/evidence/test_replay.py` covers an existing promote -> supersede -> candidate supersede chain.
+- QA sidecar finding: bytes-like metadata is silently normalized as JSON arrays -> pending commit
+  - Disposition: FIXED
+  - Evidence: `core/evidence/promotion_ledger.py` rejects bytes/bytearray before generic sequence handling; `tests/core/evidence/test_promotion_ledger.py` covers bytes metadata rejection.
+- QA sidecar finding: fixed mapping artifact is not in canonical Phase2 format -> pending commit
+  - Disposition: FIXED
+  - Evidence: this artifact now includes `## Discussion Thread Pass` and canonical no-thread mapping language.
 
-No GitHub review threads existed when this mapping artifact was first added.
+## Discussion Thread Pass
+
+- [x] GitHub review threads inspected at mapping creation time.
+- [x] No GitHub review thread URLs existed when this mapping artifact was first added.
+- [x] Sidecar QA/bug-hunter findings are mapped above as local review findings with dispositions and evidence.
+- [x] No actionable GitHub review comments are resolved by this artifact.
 
 ## Merge Readiness
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2297,10 +2297,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Evidence Graph Runtime umbrella
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (AI runtime governance / evidence lineage)
-  - Target PR: PR-E0 (`codex/evidence-graph-runtime-umbrella`) -> PR-E1/E2/E3/E4/E5; current slice: PR-E2 (`codex/eval-event-schema`)
+  - Target PR: PR-E0 (`codex/evidence-graph-runtime-umbrella`) -> PR-E1/E2/E3/E4/E5; current slice: PR-E3 (`codex/evidence-promotion-ledger-replay`)
   - Area: AI runtime / RAG / evals / knowledge promotion / advisory memory
   - Finding Type: asset-lineage and replay-governance gap
-  - Status: Active PR-E2 unified eval event schema; E0/E1 are baseline, #1666/#1667 eval-sidecar hardening is baseline, and PR-E3 promotion ledger + replay remains next after E2
+  - Status: Active PR-E3 promotion ledger + dry-run replay scaffold; E0/E1/E2 are baseline, #1666/#1667 eval-sidecar hardening is baseline, and PR-E4 active metadata admission remains next after E3
   - Remove-by: 2026-06-30
   - Reason (EN): PulsePlate already has strong RAG runtime, verification, knowledge-promotion, eval-gate, advisory-wiki, and plugin/control-plane foundations, but evidence-bearing artifacts are still governed mostly through task packets, gate outputs, and lane-specific docs rather than one asset/evidence graph. This umbrella freezes the rail boundaries and PR train needed to make eval runs, context bundles, verification bundles, knowledge candidates, knowledge records, and gate reports first-class assets with lineage, idempotency, replay, fingerprints, policy versions, and admission decisions.
   - Links:
@@ -2319,6 +2319,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Downstream PR acceptance criteria cover asset registry, eval event schema, promotion ledger/replay, active metadata admission, and advisory wiki evidence bridge
     - PR-E0 remains docs/governance only with no public API, DB migration, endpoint, OpenAPI, billing, provider, semantic-cache, GraphRAG, or user-facing runtime behavior change
     - PR-E2 adds a deterministic schema-only eval event contract and documentation without adding runtime behavior, OpenAPI changes, DB migration, semantic cache, GraphRAG, advisory wiki authority, or promotion/replay logic
+    - PR-E3 adds deterministic promotion ledger and dry-run replay contracts without adding runtime behavior, OpenAPI changes, DB migration, semantic cache, GraphRAG, advisory wiki authority, eval runners, or persistent writers
 
 <a id="ledger-p1-apple-server-api-migration"></a>
 - [ ] P1: Apple receipt verification migration to App Store Server API

--- a/docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md
+++ b/docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD013 -->
 # PulsePlate Evidence Graph Runtime Epic
 
-**Status:** PR-E0 governance umbrella
+**Status:** PR-E3 promotion ledger and replay scaffold
 **Date:** 2026-04-28 (`America/New_York`)
 **Canonical backlog anchor:** [`ledger-p1-evidence-graph-runtime`](./BACKLOG_LEDGER.md#ledger-p1-evidence-graph-runtime)
 
@@ -72,14 +72,16 @@ for later slices.
    - Done when JSONL events carry `event_id`, asset reference, created time,
      policy version, and append-only writer coverage.
 
-3. **PR-E3: Knowledge promotion ledger and replay**
+3. **PR-E3: Evidence promotion ledger and replay scaffold**
    - Backlog owner: [`ledger-p1-evidence-graph-runtime`](./BACKLOG_LEDGER.md#ledger-p1-evidence-graph-runtime).
-   - Add append-only promotion events, idempotency keys, deterministic
-     supersession, dry-run replay, and promotion diff reporting.
+   - Add deterministic promotion ledger entries, idempotency keys,
+     supersession, dry-run replay, and promotion diff reporting over normalized
+     eval events from PR-E2.
    - Depends on PR-E1 and PR-E2.
-   - No user-facing runtime changes.
-   - Done when replay is idempotent, invalid verification bundles fail closed,
-     and dry-run replay reports deterministic diffs.
+   - No user-facing runtime changes, persistent writers, eval runners,
+     semantic cache, GraphRAG, or advisory-wiki authority.
+   - Done when replay is idempotent, invalid/degraded source events cannot be
+     promoted silently, and dry-run replay reports deterministic diffs.
 
 4. **PR-E4: Active metadata admission**
    - Backlog owner: [`ledger-p1-evidence-graph-runtime`](./BACKLOG_LEDGER.md#ledger-p1-evidence-graph-runtime).

--- a/tests/core/evidence/test_promotion_ledger.py
+++ b/tests/core/evidence/test_promotion_ledger.py
@@ -132,6 +132,16 @@ def test_rejects_invalid_source_event_for_promote_or_supersede() -> None:
         )
 
 
+def test_rejects_non_eval_source_event_rail() -> None:
+    runtime_source = _source_event(
+        rail="runtime",
+        idempotency_key="idem:runtime-source-event",
+    )
+
+    with pytest.raises(ValueError, match="source_event rail"):
+        _entry(source_event=runtime_source)
+
+
 def test_reject_and_defer_can_record_degraded_source_without_promoting() -> None:
     degraded_source = _source_event(validation_status="degraded")
     rejected = _entry(
@@ -220,6 +230,9 @@ def test_preserves_metadata_defensively() -> None:
         {"raw_prompt": "tell me about dinner"},
         {"raw_response": "model output"},
         {"nested": {"user_health_payload": "private"}},
+        {"notes": "raw prompt: tell me about dinner"},
+        {"notes": "user health payload from eval item"},
+        {"notes": cast(Any, b"raw-bytes")},
         {"token_like": "Bearer abc"},
         {"artifact": "artifacts/rag_eval/run-1/traces.jsonl"},
     ],

--- a/tests/core/evidence/test_promotion_ledger.py
+++ b/tests/core/evidence/test_promotion_ledger.py
@@ -224,6 +224,17 @@ def test_preserves_metadata_defensively() -> None:
     assert entry.metadata == {"labels": ["rag", "gate"], "stats": {"sample_size": 2}}
 
 
+def test_metadata_keys_are_normalized_and_collision_checked_with_path_context() -> None:
+    entry = _entry(metadata={" Labels ": ["rag"], "STATS": {" Sample_Size ": 2}})
+
+    assert entry.metadata == {"labels": ["rag"], "stats": {"sample_size": 2}}
+
+    with pytest.raises(ValueError, match=r"metadata key at stats\.sample_size"):
+        _entry(metadata={"stats": {" Sample_Size ": 2, "sample_size": 3}})
+    with pytest.raises(ValueError, match=r"metadata key at 1"):
+        _entry(metadata=cast(dict[str, Any], {1: "bad"}))
+
+
 @pytest.mark.parametrize(
     "metadata",
     [
@@ -235,6 +246,7 @@ def test_preserves_metadata_defensively() -> None:
         {"notes": cast(Any, b"raw-bytes")},
         {"token_like": "Bearer abc"},
         {"artifact": "artifacts/rag_eval/run-1/traces.jsonl"},
+        {"note": "C:/Users/example/eval.json"},
     ],
 )
 def test_rejects_raw_prompt_response_secret_user_health_or_path_metadata(

--- a/tests/core/evidence/test_promotion_ledger.py
+++ b/tests/core/evidence/test_promotion_ledger.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from core.evidence.assets import create_evidence_asset_ref
+from core.evidence.events import (
+    EvalEventProducer,
+    EvidenceEvalEvent,
+    ValidationStatus,
+    create_eval_event,
+)
+from core.evidence.fingerprints import fingerprint_payload
+from core.evidence.promotion_ledger import (
+    PromotionDecision,
+    create_promotion_ledger_entry,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PROMOTION_MODULE = _REPO_ROOT / "core" / "evidence" / "promotion_ledger.py"
+_FIXED_TIMESTAMP = "2026-05-06T12:00:00+00:00"
+
+
+def _source_event(**overrides: object) -> EvidenceEvalEvent:
+    asset_ref = create_evidence_asset_ref(
+        asset_type="eval_run",
+        version="v1",
+        rail="runtime",
+        policy_version="policy-v1",
+        payload={"run": "rag-gate"},
+    )
+    params: dict[str, Any] = {
+        "event_type": "rag_gate_run",
+        "rail": "eval",
+        "source_artifact": "artifacts/rag_eval/run-1/traces.jsonl",
+        "asset_refs": (asset_ref,),
+        "upstream_ids": ("dataset-1", " gate-report-1 ", "dataset-1"),
+        "fingerprint": fingerprint_payload({"artifact": "traces.jsonl", "rows": 2}),
+        "idempotency_key": "idem:rag-gate-run-1",
+        "policy_version": "policy-v1",
+        "producer_name": "rag-release-gates",
+        "producer_version": "v1",
+        "produced_at": _FIXED_TIMESTAMP,
+        "validation_status": "valid",
+        "metadata": {"decision": "PASS", "sample_size": 2},
+    }
+    params.update(overrides)
+    return create_eval_event(**params)
+
+
+def _producer() -> EvalEventProducer:
+    return EvalEventProducer(name="evidence-promotion-ledger", version="v1")
+
+
+def _entry(**overrides: object):
+    params: dict[str, Any] = {
+        "source_event": _source_event(),
+        "promotion_id": "promotion-rag-gate-1",
+        "decision": "promote",
+        "idempotency_key": "idem:promotion-rag-gate-1",
+        "producer": _producer(),
+        "produced_at": _FIXED_TIMESTAMP,
+        "reason_codes": (" accepted ", "policy-pass"),
+        "metadata": {"confidence": 1.0, "labels": ["rag", "gate"]},
+    }
+    params.update(overrides)
+    return create_promotion_ledger_entry(**params)
+
+
+def test_creates_valid_promotion_ledger_entry_from_eval_event() -> None:
+    source = _source_event()
+    entry = _entry(source_event=source)
+
+    assert entry.ledger_entry_id.startswith("promotion-ledger:")
+    assert entry.source_event_id == source.event_id
+    assert entry.source_event_fingerprint == source.fingerprint
+    assert entry.source_event_type == "rag_gate_run"
+    assert entry.policy_version == "policy-v1"
+    assert source.event_id in entry.upstream_ids
+    assert entry.reason_codes == ("accepted", "policy-pass")
+
+
+def test_rejects_blank_source_event_id() -> None:
+    source = replace(_source_event(), event_id=" ")
+
+    with pytest.raises(ValueError, match="source_event_id"):
+        _entry(source_event=source)
+
+
+def test_rejects_blank_source_event_fingerprint() -> None:
+    source = replace(_source_event(), fingerprint=" ")
+
+    with pytest.raises(ValueError, match="fingerprint"):
+        _entry(source_event=source)
+
+
+def test_rejects_unsupported_decision() -> None:
+    with pytest.raises(ValueError, match="unsupported decision"):
+        _entry(decision=cast(PromotionDecision, "cache"))
+
+
+def test_rejects_missing_idempotency_key() -> None:
+    with pytest.raises(ValueError, match="idempotency_key"):
+        _entry(idempotency_key=" ")
+
+
+def test_rejects_blank_policy_version() -> None:
+    with pytest.raises(ValueError, match="policy_version"):
+        _entry(policy_version=" ")
+
+
+def test_rejects_unsupported_validation_status() -> None:
+    with pytest.raises(ValueError, match="unsupported validation_status"):
+        _entry(validation_status=cast(ValidationStatus, "promoted"))
+
+
+def test_rejects_invalid_source_event_for_promote_or_supersede() -> None:
+    invalid_source = _source_event(validation_status="degraded")
+
+    with pytest.raises(ValueError, match="valid source_event"):
+        _entry(source_event=invalid_source)
+    with pytest.raises(ValueError, match="valid source_event"):
+        _entry(
+            source_event=invalid_source,
+            decision="supersede",
+            idempotency_key="idem:supersede-invalid-source",
+            supersedes=("promotion-ledger:abc123",),
+        )
+
+
+def test_reject_and_defer_can_record_degraded_source_without_promoting() -> None:
+    degraded_source = _source_event(validation_status="degraded")
+    rejected = _entry(
+        source_event=degraded_source,
+        decision="reject",
+        idempotency_key="idem:reject-degraded",
+    )
+    deferred = _entry(
+        source_event=degraded_source,
+        decision="defer",
+        idempotency_key="idem:defer-degraded",
+    )
+
+    assert rejected.decision == "reject"
+    assert rejected.validation_status == "degraded"
+    assert deferred.decision == "defer"
+    assert deferred.validation_status == "degraded"
+
+
+def test_rejects_self_supersession_and_duplicate_supersedes() -> None:
+    base = _entry()
+
+    with pytest.raises(ValueError, match="supersede decision requires"):
+        _entry(decision="supersede", idempotency_key="idem:supersede-missing")
+    with pytest.raises(ValueError, match="duplicate"):
+        _entry(
+            decision="supersede",
+            idempotency_key="idem:supersede-duplicates",
+            supersedes=(base.ledger_entry_id, base.ledger_entry_id),
+        )
+
+    superseding = _entry(
+        decision="supersede",
+        idempotency_key="idem:supersedes-base",
+        supersedes=(base.ledger_entry_id,),
+    )
+    with pytest.raises(ValueError, match="supersede itself"):
+        create_promotion_ledger_entry(
+            source_event=_source_event(),
+            promotion_id="promotion-rag-gate-1",
+            decision="supersede",
+            idempotency_key="idem:supersedes-base",
+            producer=_producer(),
+            produced_at=_FIXED_TIMESTAMP,
+            supersedes=(base.ledger_entry_id, superseding.ledger_entry_id),
+            ledger_entry_id=superseding.ledger_entry_id,
+        )
+
+
+def test_normalizes_and_sorts_upstream_supersedes_and_reason_codes() -> None:
+    base = _entry()
+    entry = _entry(
+        decision="supersede",
+        idempotency_key="idem:supersede-sorted",
+        upstream_ids=("z-upstream", "a-upstream", "z-upstream"),
+        supersedes=("promotion-ledger:bbbb", base.ledger_entry_id),
+        reason_codes=("ZETA", "alpha"),
+    )
+
+    assert entry.upstream_ids == tuple(sorted(entry.upstream_ids))
+    assert entry.supersedes == tuple(sorted(entry.supersedes))
+    assert entry.reason_codes == ("alpha", "zeta")
+
+    with pytest.raises(ValueError, match="reason_codes collide"):
+        _entry(reason_codes=("Alpha", " alpha "))
+
+
+def test_preserves_metadata_defensively() -> None:
+    metadata: dict[str, Any] = {
+        "labels": ["rag", "gate"],
+        "stats": {"sample_size": 2},
+    }
+    entry = _entry(metadata=metadata)
+
+    metadata["labels"].append("mutated")
+    metadata["stats"]["sample_size"] = 999
+    returned = entry.metadata
+    returned["labels"].append("also-mutated")
+
+    assert entry.metadata == {"labels": ["rag", "gate"], "stats": {"sample_size": 2}}
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"raw_prompt": "tell me about dinner"},
+        {"raw_response": "model output"},
+        {"nested": {"user_health_payload": "private"}},
+        {"token_like": "Bearer abc"},
+        {"artifact": "artifacts/rag_eval/run-1/traces.jsonl"},
+    ],
+)
+def test_rejects_raw_prompt_response_secret_user_health_or_path_metadata(
+    metadata: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="metadata"):
+        _entry(metadata=metadata)
+
+
+def test_stable_serialization_and_ledger_entry_id() -> None:
+    first = _entry(
+        upstream_ids=("z", "a", "z"),
+        reason_codes=("BETA", "alpha"),
+        metadata={"z": 1, "a": ["x", "y"]},
+    )
+    second = _entry(
+        upstream_ids=("a", "z"),
+        reason_codes=("alpha", "beta"),
+        metadata={"a": ["x", "y"], "z": 1},
+    )
+
+    assert first.ledger_entry_id == second.ledger_entry_id
+    assert first.to_json() == second.to_json()
+
+
+def test_rejects_non_deterministic_or_mismatched_ledger_entry_id() -> None:
+    with pytest.raises(ValueError, match="ledger_entry_id"):
+        _entry(ledger_entry_id="promotion-ledger:not-the-derived-id")
+
+
+def test_promotion_ledger_module_does_not_import_runtime_surfaces() -> None:
+    forbidden_prefixes = (
+        "app",
+        "fastapi",
+        "legacy_app",
+        "providers",
+        "redis",
+        "scripts.evals",
+        "evals",
+        "sqlalchemy",
+        "mcp_pulseplate_server",
+    )
+    forbidden_fragments = (
+        "cache",
+        "graphrag",
+        "semantic_cache",
+        "support_plane",
+        "wiki",
+    )
+    tree = ast.parse(_PROMOTION_MODULE.read_text(encoding="utf-8"))
+
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imported_modules.append(node.module)
+
+    for module_name in imported_modules:
+        assert not any(
+            module_name == prefix or module_name.startswith(f"{prefix}.")
+            for prefix in forbidden_prefixes
+        )
+        assert not any(fragment in module_name.lower() for fragment in forbidden_fragments)

--- a/tests/core/evidence/test_promotion_ledger.py
+++ b/tests/core/evidence/test_promotion_ledger.py
@@ -17,6 +17,7 @@ from core.evidence.events import (
 from core.evidence.fingerprints import fingerprint_payload
 from core.evidence.promotion_ledger import (
     PromotionDecision,
+    PromotionLedgerEntry,
     create_promotion_ledger_entry,
 )
 
@@ -116,6 +117,16 @@ def test_rejects_blank_policy_version() -> None:
 def test_rejects_unsupported_validation_status() -> None:
     with pytest.raises(ValueError, match="unsupported validation_status"):
         _entry(validation_status=cast(ValidationStatus, "promoted"))
+
+
+def test_rejects_invalid_ledger_status_for_promoting_decision() -> None:
+    with pytest.raises(ValueError, match="valid validation_status"):
+        _entry(validation_status="degraded")
+
+
+def test_rejects_non_eval_event_source() -> None:
+    with pytest.raises(ValueError, match="EvidenceEvalEvent"):
+        _entry(source_event=object())
 
 
 def test_rejects_invalid_source_event_for_promote_or_supersede() -> None:
@@ -275,6 +286,39 @@ def test_stable_serialization_and_ledger_entry_id() -> None:
 def test_rejects_non_deterministic_or_mismatched_ledger_entry_id() -> None:
     with pytest.raises(ValueError, match="ledger_entry_id"):
         _entry(ledger_entry_id="promotion-ledger:not-the-derived-id")
+
+
+def test_rejects_identity_whitespace_and_invalid_ledger_prefix() -> None:
+    source = _source_event()
+
+    with pytest.raises(ValueError, match="source_event_id"):
+        PromotionLedgerEntry(
+            promotion_id="promotion-rag-gate-1",
+            source_event_id="event with whitespace",
+            source_event_type=source.event_type,
+            source_event_fingerprint=source.fingerprint,
+            decision="promote",
+            idempotency_key="idem:promotion-rag-gate-whitespace",
+            policy_version=source.policy_version,
+            producer=_producer(),
+            produced_at=_FIXED_TIMESTAMP,
+            validation_status="valid",
+        )
+    with pytest.raises(ValueError, match="ledger_entry_id"):
+        _entry(ledger_entry_id="not-promotion-ledger")
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {" ": 1},
+        {"finite": float("inf")},
+        {"unsupported": cast(Any, object())},
+    ],
+)
+def test_rejects_empty_nonfinite_or_unsupported_metadata(metadata: dict[str, Any]) -> None:
+    with pytest.raises(ValueError, match="metadata"):
+        _entry(metadata=metadata)
 
 
 def test_promotion_ledger_module_does_not_import_runtime_surfaces() -> None:

--- a/tests/core/evidence/test_replay.py
+++ b/tests/core/evidence/test_replay.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from core.evidence.assets import create_evidence_asset_ref
+from core.evidence.events import EvalEventProducer, EvidenceEvalEvent, create_eval_event
+from core.evidence.fingerprints import fingerprint_payload
+from typing import cast
+
+from core.evidence.promotion_ledger import (
+    PromotionDecision,
+    PromotionLedgerEntry,
+    create_promotion_ledger_entry,
+)
+from core.evidence.replay import dry_run_replay
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_REPLAY_MODULE = _REPO_ROOT / "core" / "evidence" / "replay.py"
+_FIXED_TIMESTAMP = "2026-05-06T12:00:00+00:00"
+
+
+def _source_event(*, run_id: str = "1") -> EvidenceEvalEvent:
+    asset_ref = create_evidence_asset_ref(
+        asset_type="eval_run",
+        version="v1",
+        rail="runtime",
+        policy_version="policy-v1",
+        payload={"run": f"rag-gate-{run_id}"},
+    )
+    return create_eval_event(
+        event_type="rag_gate_run",
+        rail="eval",
+        source_artifact=f"artifacts/rag_eval/run-{run_id}/traces.jsonl",
+        asset_refs=(asset_ref,),
+        upstream_ids=(f"dataset-{run_id}",),
+        fingerprint=fingerprint_payload({"artifact": "traces.jsonl", "run": run_id}),
+        idempotency_key=f"idem:rag-gate-run-{run_id}",
+        policy_version="policy-v1",
+        producer_name="rag-release-gates",
+        producer_version="v1",
+        produced_at=_FIXED_TIMESTAMP,
+        validation_status="valid",
+        metadata={"decision": "PASS", "run": run_id},
+    )
+
+
+def _producer() -> EvalEventProducer:
+    return EvalEventProducer(name="evidence-promotion-ledger", version="v1")
+
+
+def _entry(
+    *,
+    run_id: str = "1",
+    promotion_id: str | None = None,
+    decision: str = "promote",
+    idempotency_key: str | None = None,
+    supersedes: tuple[str, ...] = (),
+) -> PromotionLedgerEntry:
+    return create_promotion_ledger_entry(
+        source_event=_source_event(run_id=run_id),
+        promotion_id=promotion_id or f"promotion-rag-gate-{run_id}",
+        decision=cast(PromotionDecision, decision),
+        idempotency_key=idempotency_key or f"idem:promotion-rag-gate-{run_id}",
+        producer=_producer(),
+        produced_at=_FIXED_TIMESTAMP,
+        supersedes=supersedes,
+        reason_codes=("policy-pass",),
+        metadata={"confidence": 1.0},
+    )
+
+
+def test_dry_run_replay_is_deterministic_regardless_of_input_order() -> None:
+    first = _entry(run_id="1")
+    second = _entry(run_id="2")
+
+    forward = dry_run_replay(candidate_entries=(first, second))
+    reverse = dry_run_replay(candidate_entries=(second, first))
+
+    assert forward.to_json() == reverse.to_json()
+    assert forward.diff.added == tuple(sorted((first.ledger_entry_id, second.ledger_entry_id)))
+
+
+def test_duplicate_idempotency_key_is_reported_as_duplicate() -> None:
+    entry = _entry()
+    summary = dry_run_replay(candidate_entries=(entry, entry))
+
+    assert summary.diff.added == (entry.ledger_entry_id,)
+    assert summary.diff.duplicate == (entry.ledger_entry_id,)
+
+
+def test_idempotency_collision_is_reported_as_conflict() -> None:
+    first = _entry(run_id="1", idempotency_key="idem:collision")
+    second = _entry(run_id="2", idempotency_key="idem:collision")
+    summary = dry_run_replay(candidate_entries=(first, second))
+
+    assert summary.diff.added == (first.ledger_entry_id,)
+    assert summary.diff.conflict == (second.ledger_entry_id,)
+
+
+def test_same_promotion_scope_conflict_is_non_promoting() -> None:
+    first = _entry(run_id="1", promotion_id="promotion-shared")
+    second = _entry(
+        run_id="2",
+        promotion_id="promotion-shared",
+        idempotency_key="idem:promotion-shared-second",
+    )
+    summary = dry_run_replay(candidate_entries=(second, first))
+
+    assert len(summary.diff.added) == 1
+    assert len(summary.diff.conflict) == 1
+    assert set(summary.diff.added + summary.diff.conflict) == {
+        first.ledger_entry_id,
+        second.ledger_entry_id,
+    }
+
+
+def test_supersede_reject_and_defer_buckets_are_deterministic() -> None:
+    existing = _entry(run_id="1")
+    superseding = _entry(
+        run_id="2",
+        promotion_id=existing.promotion_id,
+        decision="supersede",
+        idempotency_key="idem:supersede-existing",
+        supersedes=(existing.ledger_entry_id,),
+    )
+    rejected = _entry(
+        run_id="3",
+        decision="reject",
+        idempotency_key="idem:reject-run-3",
+    )
+    deferred = _entry(
+        run_id="4",
+        decision="defer",
+        idempotency_key="idem:defer-run-4",
+    )
+
+    summary = dry_run_replay(
+        existing_entries=(existing,),
+        candidate_entries=(deferred, superseding, rejected),
+    )
+
+    assert summary.diff.superseded == (superseding.ledger_entry_id,)
+    assert summary.diff.rejected == (rejected.ledger_entry_id,)
+    assert summary.diff.deferred == (deferred.ledger_entry_id,)
+    assert summary.diff.added == ()
+    assert summary.diff.conflict == ()
+
+
+def test_replay_does_not_mutate_caller_owned_lists() -> None:
+    existing = [_entry(run_id="1")]
+    candidates = [_entry(run_id="2")]
+
+    summary = dry_run_replay(existing_entries=existing, candidate_entries=candidates)
+    existing.append(_entry(run_id="3"))
+    candidates.clear()
+
+    assert summary.existing_entry_ids == (existing[0].ledger_entry_id,)
+    assert summary.diff.added == (summary.candidate_entry_ids[0],)
+
+
+def test_replay_fails_closed_on_invalid_entries() -> None:
+    with pytest.raises(ValueError, match="PromotionLedgerEntry"):
+        dry_run_replay(candidate_entries=cast(tuple[PromotionLedgerEntry, ...], (object(),)))
+
+
+def test_replay_module_does_not_import_runtime_surfaces() -> None:
+    forbidden_prefixes = (
+        "app",
+        "fastapi",
+        "legacy_app",
+        "providers",
+        "redis",
+        "scripts.evals",
+        "evals",
+        "sqlalchemy",
+        "mcp_pulseplate_server",
+    )
+    forbidden_fragments = (
+        "cache",
+        "graphrag",
+        "semantic_cache",
+        "support_plane",
+        "wiki",
+    )
+    tree = ast.parse(_REPLAY_MODULE.read_text(encoding="utf-8"))
+
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imported_modules.append(node.module)
+
+    for module_name in imported_modules:
+        assert not any(
+            module_name == prefix or module_name.startswith(f"{prefix}.")
+            for prefix in forbidden_prefixes
+        )
+        assert not any(fragment in module_name.lower() for fragment in forbidden_fragments)

--- a/tests/core/evidence/test_replay.py
+++ b/tests/core/evidence/test_replay.py
@@ -91,6 +91,26 @@ def test_duplicate_idempotency_key_is_reported_as_duplicate() -> None:
     assert summary.diff.duplicate == (entry.ledger_entry_id,)
 
 
+def test_duplicate_supersede_is_reported_before_scope_validation() -> None:
+    existing = _entry(run_id="1")
+    superseding = _entry(
+        run_id="2",
+        promotion_id=existing.promotion_id,
+        decision="supersede",
+        idempotency_key="idem:supersede-existing-duplicate",
+        supersedes=(existing.ledger_entry_id,),
+    )
+
+    summary = dry_run_replay(
+        existing_entries=(existing,),
+        candidate_entries=(superseding, superseding),
+    )
+
+    assert summary.diff.superseded == (superseding.ledger_entry_id,)
+    assert summary.diff.duplicate == (superseding.ledger_entry_id,)
+    assert summary.diff.conflict == ()
+
+
 def test_idempotency_collision_is_reported_as_conflict() -> None:
     first = _entry(run_id="1", idempotency_key="idem:collision")
     second = _entry(run_id="2", idempotency_key="idem:collision")

--- a/tests/core/evidence/test_replay.py
+++ b/tests/core/evidence/test_replay.py
@@ -100,6 +100,26 @@ def test_idempotency_collision_is_reported_as_conflict() -> None:
     assert summary.diff.conflict == (second.ledger_entry_id,)
 
 
+def test_existing_idempotency_collision_fails_closed() -> None:
+    first = _entry(run_id="1", idempotency_key="idem:existing-collision")
+    second = _entry(run_id="2", idempotency_key="idem:existing-collision")
+
+    with pytest.raises(ValueError, match="duplicate idempotency_key"):
+        dry_run_replay(existing_entries=(first, second))
+
+
+def test_existing_active_scope_collision_fails_closed() -> None:
+    first = _entry(run_id="1", promotion_id="promotion-shared")
+    second = _entry(
+        run_id="2",
+        promotion_id="promotion-shared",
+        idempotency_key="idem:promotion-shared-second",
+    )
+
+    with pytest.raises(ValueError, match="conflicting active promotion_id"):
+        dry_run_replay(existing_entries=(first, second))
+
+
 def test_same_promotion_scope_conflict_is_non_promoting() -> None:
     first = _entry(run_id="1", promotion_id="promotion-shared")
     second = _entry(
@@ -115,6 +135,33 @@ def test_same_promotion_scope_conflict_is_non_promoting() -> None:
         first.ledger_entry_id,
         second.ledger_entry_id,
     }
+
+
+def test_candidate_orphan_supersede_is_reported_as_conflict() -> None:
+    superseding = _entry(
+        run_id="2",
+        promotion_id="promotion-rag-gate-1",
+        decision="supersede",
+        idempotency_key="idem:orphan-supersede",
+        supersedes=("promotion-ledger:missing",),
+    )
+    summary = dry_run_replay(candidate_entries=(superseding,))
+
+    assert summary.diff.superseded == ()
+    assert summary.diff.conflict == (superseding.ledger_entry_id,)
+
+
+def test_existing_orphan_supersede_fails_closed() -> None:
+    superseding = _entry(
+        run_id="2",
+        promotion_id="promotion-rag-gate-1",
+        decision="supersede",
+        idempotency_key="idem:existing-orphan-supersede",
+        supersedes=("promotion-ledger:missing",),
+    )
+
+    with pytest.raises(ValueError, match="orphan supersede"):
+        dry_run_replay(existing_entries=(superseding,))
 
 
 def test_supersede_reject_and_defer_buckets_are_deterministic() -> None:
@@ -146,6 +193,34 @@ def test_supersede_reject_and_defer_buckets_are_deterministic() -> None:
     assert summary.diff.rejected == (rejected.ledger_entry_id,)
     assert summary.diff.deferred == (deferred.ledger_entry_id,)
     assert summary.diff.added == ()
+    assert summary.diff.conflict == ()
+    assert rejected.ledger_entry_id in summary.applied_entry_ids
+    assert deferred.ledger_entry_id in summary.applied_entry_ids
+
+
+def test_existing_supersession_chain_resolves_current_active_entry() -> None:
+    first = _entry(run_id="1")
+    second = _entry(
+        run_id="2",
+        promotion_id=first.promotion_id,
+        decision="supersede",
+        idempotency_key="idem:supersede-first",
+        supersedes=(first.ledger_entry_id,),
+    )
+    third = _entry(
+        run_id="3",
+        promotion_id=first.promotion_id,
+        decision="supersede",
+        idempotency_key="idem:supersede-second",
+        supersedes=(second.ledger_entry_id,),
+    )
+
+    summary = dry_run_replay(
+        existing_entries=(second, first),
+        candidate_entries=(third,),
+    )
+
+    assert summary.diff.superseded == (third.ledger_entry_id,)
     assert summary.diff.conflict == ()
 
 

--- a/tests/core/evidence/test_replay.py
+++ b/tests/core/evidence/test_replay.py
@@ -140,6 +140,23 @@ def test_existing_active_scope_collision_fails_closed() -> None:
         dry_run_replay(existing_entries=(first, second))
 
 
+def test_candidate_promote_against_existing_active_scope_is_conflict() -> None:
+    existing = _entry(run_id="1", promotion_id="promotion-shared")
+    candidate = _entry(
+        run_id="2",
+        promotion_id="promotion-shared",
+        idempotency_key="idem:promotion-shared-candidate",
+    )
+
+    summary = dry_run_replay(
+        existing_entries=(existing,),
+        candidate_entries=(candidate,),
+    )
+
+    assert summary.diff.added == ()
+    assert summary.diff.conflict == (candidate.ledger_entry_id,)
+
+
 def test_same_promotion_scope_conflict_is_non_promoting() -> None:
     first = _entry(run_id="1", promotion_id="promotion-shared")
     second = _entry(


### PR DESCRIPTION
## Summary

Adds PR-E3 for the Evidence Graph Runtime train: deterministic promotion ledger entries and a pure dry-run replay scaffold over PR-E2 eval events.

## Goal

Turn normalized eval events into replay-aware promotion ledger contracts without adding product runtime behavior.

## Business reason

This PR increases PulsePlate defensibility by making eval evidence replayable and promotion-safe. It turns PR-E2 events into deterministic promotion/replay contracts so later AI release gates, metadata admission, and semantic-cache decisions cannot be built on scattered, non-replayable artifacts.

This PR does not add visible product features.

## Scope

- Add immutable promotion ledger contracts in `core/evidence/promotion_ledger.py`.
- Add pure dry-run replay and deterministic promotion diff reporting in `core/evidence/replay.py`.
- Export internal E3 contracts from `core/evidence/__init__.py`.
- Document the E3 promotion/replay contract and update Evidence Graph sequencing docs.
- Add focused deterministic tests and import guards.

## Out of scope

- Semantic cache, GraphRAG, product RAG behavior, eval runners, RAGAS runner behavior, online eval, judge calibration, goldens, dashboards.
- Product runtime routes, FastAPI routers, OpenAPI, DB migrations, providers, Redis/cache/GPTCache, billing/auth/compliance surfaces.
- Karpathy/advisory wiki as product/runtime/eval source of truth.

## Split Justification

This PR is intentionally one Evidence Graph slice even though the diff is larger than a tiny patch: the implementation, tests, docs contract, backlog/epic status, scoped AGENTS rule, and fixed-mapping artifact all describe the same internal E3 contract. Splitting the ledger and replay into separate PRs would leave either ledger identity without replay safety or replay tests without the contract they exercise. Runtime/API/DB/provider/cache/wiki/eval-runner behavior remains out of scope.

## Files touched

- `core/evidence/promotion_ledger.py`
- `core/evidence/replay.py`
- `core/evidence/__init__.py`
- `core/evidence/AGENTS.md`
- `docs/orchestration/contracts/EVIDENCE_PROMOTION_REPLAY.md`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md`
- `tests/core/evidence/test_promotion_ledger.py`
- `tests/core/evidence/test_replay.py`

## Tests

Local bounded gates run; full `make verify` intentionally not run under the operator-approved machine-heavy exception.

- PASS: `python3 scripts/orchestration/check_preflight.py`
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
- PASS: `python3 scripts/orchestration/task_bootstrap.py --goal "PR-E3 Evidence Graph promotion ledger and dry-run replay scaffold" --task-class "ai-runtime-governance" ... --pr-phase pre_open` (`b95c4f512a1a`)
- PASS: `python3 scripts/orchestration/task_bootstrap.py --goal "Post-open review for PR 1673 Evidence Graph promotion ledger and dry-run replay scaffold" --task-class "ai-runtime-governance" ... --pr-phase post_open_review` (`edd7a12bccc3`)
- PASS: `.venv/bin/python -m pytest -q tests/core/evidence/test_promotion_ledger.py tests/core/evidence/test_replay.py tests/core/evidence/test_events.py tests/core/evidence/test_assets.py tests/core/evidence/test_fingerprints.py`
- PASS: `.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null core/evidence tests/core/evidence/test_promotion_ledger.py tests/core/evidence/test_replay.py`
- PASS: `make validate-changed`
- PASS: `pre-commit run --all-files`
- PASS during pre-push hook: changed-files mypy, pip-audit, backend pre-push tests, full-repo bandit, docker build test

## Security notes

- Metadata validation rejects raw prompt/response/user-health/secret/path-like payload material.
- Ledger/replay modules have AST import guards against runtime routes, providers, DB/session layers, Redis/cache/semantic-cache, GraphRAG, eval runners, advisory wiki/support-plane modules.
- Replay is dry-run only: no file writes, DB calls, provider calls, eval-runner calls, or runtime side effects.

## Premortem

| Failure mode | Mitigation | Test/docs evidence |
| --- | --- | --- |
| E3 becomes a hidden writer/store | Replay returns immutable summaries only | `tests/core/evidence/test_replay.py`, contract doc |
| E3 duplicates `core/knowledge/promotion.py` | E3 stays under `core/evidence` and imports only E2/E1 contracts | AST import guards, contract doc |
| Eval events treated as product truth | Ledger records promotion decisions; E4 owns admission later | contract doc, backlog/epic updates |
| Rails mixed silently | No runtime/advisory/cache/wiki imports; E2 event rails remain source metadata | import guards |
| Invalid/degraded evidence promoted | Promote/supersede require valid source and valid ledger status | ledger tests |
| Replay nondeterministic | Stable sorting and deterministic IDs | replay determinism tests |
| Duplicate promotions | Idempotency dedupe and conflict buckets | replay tests |
| Raw prompt/health/secret metadata leaks | Metadata safety checks fail closed | ledger metadata tests |
| Semantic cache/GraphRAG side door | Forbidden import guards and docs boundary | import guard tests, contract doc |
| Mapping replaces fixes | Coordinator sidecar findings were fixed before mapping | commit `d57a5b5af` |

## Rollback / risks

Rollback is a revert of this internal contract PR. Since no runtime callers, DB migrations, providers, OpenAPI, routes, caches, or eval runners are changed, rollback risk is limited to internal evidence-contract imports/tests/docs.

## DoD

- [x] Promotion ledger contract exists.
- [x] Dry-run replay scaffold exists.
- [x] Ledger entries are deterministic and append-only by contract.
- [x] Replay is idempotent and mutation-free.
- [x] Promotion diff summary is deterministic.
- [x] Invalid/degraded/duplicate/conflicting inputs fail closed or report deterministic non-promoting outcomes.
- [x] Tests cover deterministic identity, replay, idempotency, supersession, duplicate handling, metadata safety, and import boundaries.
- [x] No runtime/API/OpenAPI/DB/provider/eval-runner/semantic-cache/wiki changes.
- [x] Backlog points to PR-E4 active metadata admission as the next Evidence Graph step after E3.
- [x] Premortem findings are addressed in code/tests/docs before mapping.

## Commit breakdown

- `d57a5b5af` - `feat(evidence): add promotion ledger replay scaffold`
- `a8a08f3fc` - `docs(review): add PR 1673 fixed mapping`
- `ab3bd46f8` - `fix(evidence): harden promotion replay edge cases`
- `85371cf07` - `docs(review): map PR 1673 sidecar fixes`
- `13d165f81` - `fix(evidence): preserve supersede duplicate replay`
- `5d7f858ab` - `docs(review): map PR 1673 bot review fixes`
- `4855090fd` - `test(evidence): cover promotion replay diff branches`
- `52526da0a` - `docs(review): map PR 1673 review comment urls`

## Pre-push checklist

- [x] Preflight and agent consistency pass.
- [x] Coordinator packet created.
- [x] Focused tests pass.
- [x] `make validate-changed` pass.
- [x] `pre-commit run --all-files` pass.
- [x] Full `make verify` intentionally deferred under operator-approved machine-heavy exception.

## Post-merge checklist

- Sync local `main` with `git fetch --prune origin` and `git merge --ff-only origin/main`.
- Confirm `HEAD...origin/main` is `0 0`.
- Prune merged branch.
- Start PR-E4 active metadata admission only after E3 merge and local sync.

## AGENTS.md updates

Scoped `core/evidence/AGENTS.md` now clarifies E3 dry-run/no-writer boundaries and explicitly forbids duplicating `core/knowledge/promotion.py`.

## Deferred / Follow-ups

- PR-E4 active metadata admission: deterministic `allow_execute`, `allow_promote`, and `allow_serve` decisions over evidence metadata.
- Later AI evaluation roadmap: curated domain goldens/adversarial cases, layer-wise metrics, judge calibration, CI AI-release gates, online eval over production traces.
- Semantic cache remains blocked until asset lineage, replay-safe promotion, metadata admission, reliability/security gates, and dedicated semantic-cache rollout contract exist.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#pullrequestreview-4234281123 -> 13d165f81
Disposition: FIXED
Commit: 13d165f81
Evidence: core/evidence/promotion_ledger.py metadata key validation now reports path context, normalizes keys case-insensitively, and tests/core/evidence/test_promotion_ledger.py covers key collisions plus Windows path metadata rejection.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#discussion_r3193898908 -> 13d165f81
Disposition: FIXED
Commit: 13d165f81
Evidence: core/evidence/promotion_ledger.py includes metadata key path context for nested key validation errors.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#discussion_r3193898930 -> 13d165f81
Disposition: FIXED
Commit: 13d165f81
Evidence: tests/core/evidence/test_promotion_ledger.py covers metadata key normalization collisions and Windows-style path metadata rejection.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#discussion_r3193903328 -> ab3bd46f8
Disposition: FIXED
Commit: ab3bd46f8
Evidence: core/evidence/replay.py requires an active replay target before accepting supersede; tests/core/evidence/test_replay.py covers candidate and existing orphan supersede handling.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#pullrequestreview-4234351988 -> ab3bd46f8
Disposition: FIXED
Commit: ab3bd46f8
Evidence: core/evidence/replay.py reports candidate orphan supersession as conflict and fails closed on orphan existing supersession; tests/core/evidence/test_replay.py covers both paths.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#discussion_r3193951021 -> ab3bd46f8
Disposition: FIXED
Commit: ab3bd46f8
Evidence: core/evidence/replay.py reports candidate orphan supersession as conflict and fails closed on orphan existing supersession; tests/core/evidence/test_replay.py covers both paths.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#pullrequestreview-4234449600 -> 13d165f81
Disposition: FIXED
Commit: 13d165f81
Evidence: core/evidence/replay.py checks duplicate idempotency before supersede scope validation; tests/core/evidence/test_replay.py covers duplicate supersede replay without conflict.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1673#discussion_r3194014399 -> 13d165f81
Disposition: FIXED
Commit: 13d165f81
Evidence: core/evidence/replay.py checks duplicate idempotency before supersede scope validation; tests/core/evidence/test_replay.py covers duplicate supersede replay without conflict.

Sidecar QA/bug-hunter findings are tracked in `docs/review/PR_1673_FIXED_MAPPING.md` under `## Sidecar Review Findings`.

## Merge Readiness

Not merge-ready at PR open. Required before merge:

- Current-head CI parity clean.
- Required checks green with no pending required jobs.
- CodeRabbit/Sourcery/Cubic no actionable items.
- Review threads resolved only with disposition evidence.
- Strict merge-readiness wrapper with auth.
- Mandatory review wait-window.

## Summary by Sourcery

Ввести внутренний регистр (ledger) продвижения доказательств и каркас для dry-run replay поверх существующих eval-событий, с сопутствующими экспортами, документацией и тестами, не изменяя поведение во время выполнения.

Новые возможности:
- Добавить неизменяемый `PromotionLedgerEntry` и связанные вспомогательные функции для детерминированных, только добавляемых решений о продвижении доказательств.
- Добавить `dry_run_replay` и структурированную отчетность по diff поверх записей регистра продвижения для анализа воспроизведения и идемпотентности.
- Экспортировать новые контракты регистра продвижения и replay через публичные экспорты `core.evidence`.

Улучшения:
- Ужесточить документацию по управлению Evidence Graph во время выполнения и рекомендации AGENTS относительно чистоты E3, границ импорта и отделения от продвижения продуктовых знаний.

Документация:
- Задокументировать Evidence Promotion Ledger и контракт Replay и обновить epic и статус backlog для Evidence Graph runtime, чтобы отразить PR-E3.
- Уточнить `core/evidence/AGENTS.md`, чтобы описать E3 dry-run, границы без записи (no-writer) и запретить дублирование `core/knowledge/promotion.py`.

Тесты:
- Добавить сфокусированные модульные тесты для идентичности регистра продвижения, валидации, безопасности метаданных и импорт-гвардов.
- Добавить детерминированные тесты воспроизведения, покрывающие порядок, идемпотентность, конфликты, корзины supersession и импорт-гварды модуля replay.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an internal evidence promotion ledger and dry-run replay scaffold on top of existing eval events, with supporting exports, docs, and tests, without changing runtime behavior.

New Features:
- Add immutable PromotionLedgerEntry and related helpers for deterministic, append-only evidence promotion decisions.
- Add dry_run_replay and structured diff reporting over promotion ledger entries for replay and idempotency analysis.
- Expose new promotion ledger and replay contracts via core.evidence public exports.

Enhancements:
- Tighten Evidence Graph runtime governance docs and AGENTS guidelines around E3 purity, import boundaries, and separation from product knowledge promotion.

Documentation:
- Document the Evidence Promotion Ledger and Replay contract and update Evidence Graph runtime epic and backlog status to reflect PR-E3.
- Clarify core/evidence AGENTS.md to describe E3 dry-run, no-writer boundaries and forbid duplicating core/knowledge/promotion.py.

Tests:
- Add focused unit tests for promotion ledger identity, validation, metadata safety, and import guards.
- Add deterministic replay tests covering ordering, idempotency, conflicts, supersession buckets, and replay module import guards.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic promotion ledger and a dry-run replay scaffold for the Evidence Graph. Hardens edge cases with fail-closed checks and deterministic supersession; no runtime changes.

- **New Features**
  - Immutable ledger in `core/evidence/promotion_ledger.py` with promote/reject/defer/supersede, deterministic `ledger_entry_id`, idempotency, supersession, reason codes; factory `create_promotion_ledger_entry` and exports in `core/evidence/__init__.py`.
  - Dry-run replay in `core/evidence/replay.py` with stable diffs (`added`, `duplicate`, `superseded`, `rejected`, `deferred`, `conflict`) and `PromotionReplaySummary`; strict metadata safety (rejects prompt/response/secret/user-health/path-like values) and docs/tests added.

- **Bug Fixes**
  - Replay fails closed on corrupt existing ledgers (duplicate `idempotency_key`, conflicting active `promotion_id`, orphan `supersede`) and reports candidate orphan supersedes as `conflict`.
  - Supersede duplicates are reported as `duplicate` (idempotency checked before scope validation); `reject`/`defer` remain in `applied_entry_ids`; stable ordering (promote before supersede).

<sup>Written for commit 52526da0ac30f64bc30119fadd36903ad18f5f7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

