### PR TITLE
feat(frontend): refine public web launch shell after governed polish

### DIFF
--- a/docs/review/PR_1674_FIXED_MAPPING.md
+++ b/docs/review/PR_1674_FIXED_MAPPING.md
@@ -1,0 +1,81 @@
+# PR #1674 Fixed Mapping
+
+## Summary
+
+PR #1674 is a bounded visible frontend follow-up after merged PR #1608.
+
+It tightens the public launch shell at `/` and `/marketing` without changing backend,
+OpenAPI, auth, billing, iOS, `/tokens`, generated token mirrors, Figma, Canva, Storybook
+configuration, or external reference intake.
+
+## Discussion Thread Pass
+
+Status: pending external review.
+
+No GitHub review threads were present when this artifact was created. Future CodeRabbit,
+Sourcery, Cubic, human, or CI findings must be added here with disposition evidence before
+threads are resolved.
+
+## Fixed In Commit Mapping
+
+### Pre-Open Review Findings
+
+- Premortem: backlog closeout needed durable evidence instead of a branch assertion.
+  - Disposition: FIXED
+  - Commit: `58f36ee3b`
+  - Evidence: `docs/roadmap/BACKLOG_LEDGER.md` now cites PR #1608 merged on
+    2026-04-30 with merge SHA `25d5cb954b11278700bf399434b98338b6a501b6`, PR #1608
+    validation evidence, and this branch's route sanity evidence.
+
+- Frontend/design review: mobile hero title override used viewport-based font scaling.
+  - Disposition: FIXED
+  - Commit: `58f36ee3b`
+  - Evidence: `frontend/src/components/marketing/marketing.css` uses a stable
+    `2.6rem` mobile hero title size.
+
+### External Review Threads
+
+None yet.
+
+## Local Evidence
+
+Passed locally:
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open`
+- `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review`
+- `npm --prefix frontend run test -- --run src/components/marketing/__tests__/MarketingLaunchPage.test.tsx src/__tests__/App.test.tsx`
+- `npm --prefix frontend run build`
+- `npm --prefix frontend run test:accessibility`
+- `make validate-changed`
+- `make design-guard`
+- `make tokens-check`
+- `pre-commit run --all-files`
+- Playwright route sanity for `/` and `/marketing`: title/H1 present,
+  `marketing-page=1`, `tabBar=0`, `horizontalOverflowPx=0`, no page/console errors.
+- Generated token mirror diff check returned empty output for:
+  - `frontend/src/styles/tokens.css`
+  - `frontend/src/styles/tokens.ts`
+  - `ios/PulsePlate/DesignSystem/DesignTokens.generated.swift`
+
+Not run:
+
+- Full local `make verify`, by operator machine-budget decision for this lane. Merge
+  readiness must rely on current-head CI, review-bot pass/no-actionables, this fixed
+  mapping artifact, thread dispositions, and the wait-window.
+
+## Merge Readiness
+
+Not claimed.
+
+Current-head CI, external review bots, review-thread disposition, and mandatory wait-window
+must complete before any merge-readiness claim.
+
+## Deferred / Follow-Ups
+
+- Design Intelligence PR-1 DESIGN.md generator remains separate.
+- External reference manifest tooling remains separate.
+- Screen evidence pack remains separate.
+- Design scorecard remains separate.
+- iOS visual parity remains separate.

--- a/docs/review/PR_1674_FIXED_MAPPING.md
+++ b/docs/review/PR_1674_FIXED_MAPPING.md
@@ -10,14 +10,12 @@ configuration, or external reference intake.
 
 ## Discussion Thread Pass
 
-Status: pending external review.
-
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-No GitHub review threads were present when this artifact was created. Future CodeRabbit,
-Sourcery, Cubic, human, or CI findings must be added here with disposition evidence before
-threads are resolved.
+GitHub review threads were inspected and mapped below. Future CodeRabbit, Sourcery, Cubic,
+human, or CI findings must be added here with disposition evidence before threads are
+resolved.
 
 ## Fixed in Commit Mapping
 

--- a/docs/review/PR_1674_FIXED_MAPPING.md
+++ b/docs/review/PR_1674_FIXED_MAPPING.md
@@ -12,11 +12,18 @@ configuration, or external reference intake.
 
 Status: pending external review.
 
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
 No GitHub review threads were present when this artifact was created. Future CodeRabbit,
 Sourcery, Cubic, human, or CI findings must be added here with disposition evidence before
 threads are resolved.
 
-## Fixed In Commit Mapping
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Internal Review Findings
 
 ### Pre-Open Review Findings
 

--- a/docs/review/PR_1674_FIXED_MAPPING.md
+++ b/docs/review/PR_1674_FIXED_MAPPING.md
@@ -54,6 +54,11 @@ Disposition: FIXED
 Commit: 9bc395ec2f76d9a69f559a456785ef295bc02bdc
 Evidence: CodeRabbit actionable comments are mapped above with fix commit evidence.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1674#pullrequestreview-4234400255 -> 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Disposition: FIXED
+Commit: 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Evidence: CodeRabbit follow-up review is mapped above to the pending-status contradiction fix in `docs/review/PR_1674_FIXED_MAPPING.md`.
+
 ## Internal Review Findings
 
 ### Pre-Open Review Findings

--- a/docs/review/PR_1674_FIXED_MAPPING.md
+++ b/docs/review/PR_1674_FIXED_MAPPING.md
@@ -19,7 +19,35 @@ resolved.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1674#discussion_r3193941462 -> 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Disposition: FIXED
+Commit: 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md` now says PR #1608 fixed mapping recorded the focused frontend tests.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1674#discussion_r3193946860 -> 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Disposition: FIXED
+Commit: 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md` keeps `ledger-p1-web-launch-design-polish-v1` open and records same-day docs-only closeout after PR #1674.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1674#discussion_r3193963595 -> 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Disposition: FIXED
+Commit: 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Evidence: `docs/review/PR_1674_FIXED_MAPPING.md` now places the required checked boxes directly under `## Discussion Thread Pass`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1674#discussion_r3193963624 -> 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Disposition: FIXED
+Commit: 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md` keeps the web launch polish item open for docs-only closeout after this mixed-scope PR.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1674#pullrequestreview-4234339257 -> 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Disposition: FIXED
+Commit: 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Evidence: Sourcery grammar finding addressed in `docs/roadmap/BACKLOG_LEDGER.md`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1674#pullrequestreview-4234373012 -> 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Disposition: FIXED
+Commit: 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Evidence: CodeRabbit actionable comments are mapped above with fix commit evidence.
 
 ## Internal Review Findings
 

--- a/docs/review/PR_1674_FIXED_MAPPING.md
+++ b/docs/review/PR_1674_FIXED_MAPPING.md
@@ -34,6 +34,11 @@ Disposition: FIXED
 Commit: 9bc395ec2f76d9a69f559a456785ef295bc02bdc
 Evidence: `docs/review/PR_1674_FIXED_MAPPING.md` now places the required checked boxes directly under `## Discussion Thread Pass`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1674#discussion_r3193980410 -> 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Disposition: FIXED
+Commit: 9bc395ec2f76d9a69f559a456785ef295bc02bdc
+Evidence: `docs/review/PR_1674_FIXED_MAPPING.md` removed the contradictory pending-status line from `## Discussion Thread Pass`.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1674#discussion_r3193963624 -> 9bc395ec2f76d9a69f559a456785ef295bc02bdc
 Disposition: FIXED
 Commit: 9bc395ec2f76d9a69f559a456785ef295bc02bdc

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -70,11 +70,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 
 
 <a id="ledger-p1-web-launch-design-polish-v1"></a>
-- [x] P1: Web launch shell design polish v1
+- [ ] P1: Web launch shell design polish v1
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR #1608 / `codex/web-launch-design-polish-v1` (merged)
-  - Status: Complete
+  - Status: In progress; PR #1608 merged, keep open until same-day docs-only closeout after PR #1674
   - Area: web / launch / design system
   - Finding Type: design handoff implementation
   - Reason (EN): PR #1593 accepted the Figma Make `PulsePlate_Web` packet as reference-only design direction. The public launch shell now needs a bounded repo-first polish pass for `/` and `/marketing` using existing tokens/components, wellness-safe copy, and no Figma/Canva runtime authority.
@@ -84,7 +84,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/figma/orchestration/sessions/2026-04-30_web_launch_design_polish_v1/02_DESIGN_IMPLEMENTATION_NOTES.md`
     - `frontend/src/pages/Marketing/PulsePlateMarketingPage.tsx`
     - `frontend/src/components/marketing/`
-  - Evidence: PR #1608 merged on 2026-04-30 (`25d5cb954b11278700bf399434b98338b6a501b6`); PR #1608 fixed mapping recorded focused frontend tests, build evidence, and the reference-only Figma/Canva boundary. Follow-up branch `feat/web-launch-shell-polish-v2` revalidated `/` and `/marketing` render behavior with no tabbar or horizontal-overflow regression before closing this stale ledger state.
+  - Evidence: PR #1608 merged on 2026-04-30 (`25d5cb954b11278700bf399434b98338b6a501b6`); PR #1608 fixed mapping recorded the focused frontend tests, build evidence, and the reference-only Figma/Canva boundary. Follow-up branch `feat/web-launch-shell-polish-v2` revalidated `/` and `/marketing` render behavior with no tabbar or horizontal-overflow regression, but this mixed-scope PR intentionally leaves final ledger closure to a same-day docs-only closeout after merge.
   - DoD:
     - `/` and `/marketing` still render the public launch shell and keep the tabbar hidden
     - launch page polish uses repo tokens/components and existing routes only

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -70,11 +70,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 
 
 <a id="ledger-p1-web-launch-design-polish-v1"></a>
-- [ ] P1: Web launch shell design polish v1
+- [x] P1: Web launch shell design polish v1
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR #1608 / `codex/web-launch-design-polish-v1`
-  - Status: Active draft-override implementation lane
+  - Target PR: PR #1608 / `codex/web-launch-design-polish-v1` (merged)
+  - Status: Complete
   - Area: web / launch / design system
   - Finding Type: design handoff implementation
   - Reason (EN): PR #1593 accepted the Figma Make `PulsePlate_Web` packet as reference-only design direction. The public launch shell now needs a bounded repo-first polish pass for `/` and `/marketing` using existing tokens/components, wellness-safe copy, and no Figma/Canva runtime authority.
@@ -84,6 +84,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/figma/orchestration/sessions/2026-04-30_web_launch_design_polish_v1/02_DESIGN_IMPLEMENTATION_NOTES.md`
     - `frontend/src/pages/Marketing/PulsePlateMarketingPage.tsx`
     - `frontend/src/components/marketing/`
+  - Evidence: PR #1608 merged on 2026-04-30 (`25d5cb954b11278700bf399434b98338b6a501b6`); PR #1608 fixed mapping recorded focused frontend tests, build evidence, and the reference-only Figma/Canva boundary. Follow-up branch `feat/web-launch-shell-polish-v2` revalidated `/` and `/marketing` render behavior with no tabbar or horizontal-overflow regression before closing this stale ledger state.
   - DoD:
     - `/` and `/marketing` still render the public launch shell and keep the tabbar hidden
     - launch page polish uses repo tokens/components and existing routes only

--- a/frontend/src/components/marketing/__tests__/MarketingLaunchPage.test.tsx
+++ b/frontend/src/components/marketing/__tests__/MarketingLaunchPage.test.tsx
@@ -14,6 +14,7 @@ describe('PulsePlateMarketingPage', () => {
   it('renders the polished wellness-safe launch hero and existing CTAs', () => {
     renderMarketingPage();
 
+    expect(screen.getByTestId('marketing-page')).toBeInTheDocument();
     expect(
       screen.getByRole('heading', {
         level: 1,

--- a/frontend/src/components/marketing/marketing.css
+++ b/frontend/src/components/marketing/marketing.css
@@ -308,6 +308,10 @@
   gap: 1rem;
 }
 
+.ppm-preview-row > * {
+  min-width: 0;
+}
+
 .ppm-grid-2,
 .ppm-status-grid,
 .ppm-surfaces-grid,
@@ -752,7 +756,18 @@
     flex-direction: column;
   }
 
-  .ppm-actions .ppm-btn {
+  .ppm-actions .ppm-btn,
+  .ppm-cta-actions .ppm-btn {
     width: 100%;
+  }
+
+  .ppm-pill {
+    justify-content: center;
+    min-height: 2.75rem;
+  }
+
+  .ppm-hero-title {
+    font-size: 2.6rem;
+    line-height: 1;
   }
 }

--- a/frontend/src/pages/Marketing/PulsePlateMarketingPage.tsx
+++ b/frontend/src/pages/Marketing/PulsePlateMarketingPage.tsx
@@ -24,7 +24,7 @@ export default function PulsePlateMarketingPage(): JSX.Element {
     }, []);
 
     return (
-        <main className="ppm-page">
+        <main className="ppm-page" data-testid="marketing-page">
             <HeroSection />
             <ProductStatusBand />
             <HowItWorksSection />


### PR DESCRIPTION
## Summary

Refines the actual public web launch shell for `/` and `/marketing` after merged PR #1608, using existing PulsePlate repo-owned tokens/components.

This PR is a bounded visible frontend follow-up plus stale backlog closeout, not a docs-only design theory PR.

## Goal

Make the public web entry point a little sturdier on mobile while preserving the governed design-system boundaries already established by PR #1608.

## Business reason

The public launch shell is the first trust/conversion surface. This follow-up keeps the merged polish lane accurate in the backlog and tightens mobile CTA/pill behavior without widening product scope.

## Scope

- Add a stable `marketing-page` test id to the real marketing shell.
- Cover the real marketing shell root in the focused marketing test.
- Tighten mobile CTA width, pill alignment, and hero title sizing.
- Add `min-width: 0` protection for preview-row children.
- Mark `ledger-p1-web-launch-design-polish-v1` complete using PR #1608 merge evidence plus this branch's route sanity evidence.

## Out of scope

- No backend/OpenAPI changes.
- No billing/auth/payment changes.
- No iOS changes.
- No Figma/Canva changes.
- No DESIGN.md generator.
- No external reference ingestion.
- No new token system.
- No generated token mirror edits.

## Source of truth

Design changes are implemented directly against repo-owned tokens/components. Figma, Canva, Storybook, external references, and future DESIGN.md are evidence/reference layers only and do not override repo truth.

## Files changed

- `frontend/src/pages/Marketing/PulsePlateMarketingPage.tsx`
- `frontend/src/components/marketing/marketing.css`
- `frontend/src/components/marketing/__tests__/MarketingLaunchPage.test.tsx`
- `docs/roadmap/BACKLOG_LEDGER.md`

## Tests / bounded checks

Full local `make verify` intentionally not run by operator machine-budget policy; no merge-readiness claim is made from local bounded checks alone.

Passed locally:

- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open --design-source code_native_brief --task-mode implement`
- `npm --prefix frontend run test -- --run src/components/marketing/__tests__/MarketingLaunchPage.test.tsx src/__tests__/App.test.tsx`
- `npm --prefix frontend run build`
- `npm --prefix frontend run test:accessibility`
- `make validate-changed`
- `make design-guard`
- `make tokens-check`
- `pre-commit run --all-files`
- Playwright local route sanity for `/` and `/marketing`: title/H1 present, `marketing-page=1`, `tabBar=0`, `horizontalOverflowPx=0`, no page/console errors.
- Generated token mirror diff check returned empty output for `frontend/src/styles/tokens.css`, `frontend/src/styles/tokens.ts`, and `ios/PulsePlate/DesignSystem/DesignTokens.generated.swift`.

Notes:

- `npm --prefix frontend run build` passed with existing Vite warnings about static/dynamic imports and chunk size.
- `make tokens-check` initially failed in the fresh worktree because Python deps were unavailable (`ModuleNotFoundError: No module named 'fastapi'`); rerun passed after adding a worktree-local `.venv` symlink to the repo root venv.

## Security notes

No secrets, auth, billing, backend, deployment, or external integrations touched. No external design assets copied. Wellness-only boundaries preserved.

## Premortem

Premortem reviewed the actual code diff, not only mapping.

Findings handled:

- Backlog closeout needed durable evidence, not just a branch assertion. Fixed by citing PR #1608 merged date, merge SHA `25d5cb954b11278700bf399434b98338b6a501b6`, PR #1608 validation evidence, and this branch's route sanity evidence.
- Mobile hero title override used viewport-based scaling. Fixed by switching the mobile override to a stable `2.6rem` size.

No findings for second design SoT, copied external layout/assets/copy, raw token drift, backend/auth/billing/iOS/generated-token changes, unsupported wellness/medical/pricing claims, unavailable runtime data, or obvious accessibility/focus regressions.

## Bug-hunter pass

Bug-hunter/design review checked:

- `/` and `/marketing` route sanity.
- Public shell tabbar remains hidden.
- No generated token mirror diff.
- No backend/API/billing/auth/iOS diff.
- No raw external asset/copy import.
- No obvious mobile horizontal overflow.
- Focus/accessibility bounded checks pass.
- Backlog closeout is backed by live PR #1608 merge truth.

## Deferred / Follow-ups

- Design Intelligence PR-1 DESIGN.md generator remains separate.
- External reference manifest tooling remains separate.
- Screen evidence pack remains separate.
- Design scorecard remains separate.
- iOS visual parity remains separate.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Review comments were inspected and mapped in `docs/review/PR_1674_FIXED_MAPPING.md`; future review threads must also be added there with disposition evidence before resolution.

### Fixed in Commit Mapping

Canonical artifact: `docs/review/PR_1674_FIXED_MAPPING.md`.

## Merge Readiness

Do not mark until current-head CI, review bots, fixed mapping, review-thread dispositions, and wait-window pass.

## Rollback

Revert this frontend/backlog PR. No backend/iOS/token/Figma/deploy rollback required.

## DoD

- `/` renders the governed launch shell.
- `/marketing` renders the governed launch shell.
- No token mirror diff.
- No backend/API/billing/auth/iOS diff.
- Wellness-safe copy preserved.
- Bounded checks pass.
- Review governance satisfied before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new review documentation for PR #1674
  * Updated backlog ledger with cross-domain entries and status updates

* **Tests**
  * Enhanced test coverage for the marketing page validation

* **Style**
  * Improved mobile responsiveness for marketing page components, including button layout and typography adjustments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->