### PR TITLE
feat(evidence): add active metadata admission gates

### DIFF
--- a/core/evidence/AGENTS.md
+++ b/core/evidence/AGENTS.md
@@ -21,3 +21,30 @@ or advisory wiki modules from this package.
 E3 promotion ledger/replay changes may add append-only promotion contracts and
 dry-run replay summaries only. They must not write files, call runtime stores,
 create promotion side effects, or duplicate `core/knowledge/promotion.py`.
+
+## E4 active metadata admission
+
+E4 admission logic must stay pure and deterministic.
+
+Allowed:
+
+- policy/input/decision dataclasses
+- deterministic `allow_execute`, `allow_promote`, and `allow_serve` decisions
+- explicit `now` / timestamp input
+- `reason_codes`, `blocking_reasons`, and `warnings`
+- metadata validation
+
+Forbidden:
+
+- runtime writes
+- DB/session access
+- provider calls
+- FastAPI/router imports
+- eval runner imports
+- semantic cache, Redis, or GPTCache imports
+- GraphRAG runtime imports
+- advisory wiki/local support-plane imports
+- product knowledge-promotion rewrites
+
+Admission decisions are gates, not side effects. They may block future
+promotion/serve actions, but this package must not perform those actions.

--- a/core/evidence/__init__.py
+++ b/core/evidence/__init__.py
@@ -4,6 +4,19 @@ RU: Канонические контракты evidence asset registry.
 EN: Canonical evidence asset registry contracts.
 """
 
+from core.evidence.admission import (
+    AdmissionAction,
+    AdmissionDecision,
+    AdmissionInput,
+    AdmissionPolicy,
+    AdmissionTargetType,
+    admission_input_from_eval_event,
+    admission_input_from_ledger_entry,
+    decide_admission,
+    decide_allow_execute,
+    decide_allow_promote,
+    decide_allow_serve,
+)
 from core.evidence.assets import (
     AssetType,
     EvidenceAssetRef,
@@ -35,6 +48,11 @@ from core.evidence.replay import (
 )
 
 __all__ = [
+    "AdmissionAction",
+    "AdmissionDecision",
+    "AdmissionInput",
+    "AdmissionPolicy",
+    "AdmissionTargetType",
     "AssetType",
     "EvidenceAssetRef",
     "EvidenceEvalEvent",
@@ -47,11 +65,17 @@ __all__ = [
     "PromotionReplaySummary",
     "Rail",
     "ValidationStatus",
+    "admission_input_from_eval_event",
+    "admission_input_from_ledger_entry",
     "build_asset_id",
     "build_idempotency_key",
     "create_evidence_asset_ref",
     "create_eval_event",
     "create_promotion_ledger_entry",
+    "decide_admission",
+    "decide_allow_execute",
+    "decide_allow_promote",
+    "decide_allow_serve",
     "dry_run_replay",
     "fingerprint_payload",
 ]

--- a/core/evidence/admission.py
+++ b/core/evidence/admission.py
@@ -30,7 +30,6 @@ from core.evidence.policies import (
     validate_non_empty_token,
 )
 from core.evidence.promotion_ledger import (
-    ALLOWED_PROMOTION_DECISIONS,
     PromotionDecision,
     PromotionLedgerEntry,
     validate_promotion_decision,

--- a/core/evidence/admission.py
+++ b/core/evidence/admission.py
@@ -175,6 +175,8 @@ class AdmissionPolicy:
             "max_fallback_rate",
             _validate_metric("max_fallback_rate", self.max_fallback_rate),
         )
+        if not isinstance(self.allow_degraded, bool):
+            raise ValueError("allow_degraded must be a boolean")
         if self.stale_after_seconds < 0:
             raise ValueError("stale_after_seconds must be non-negative")
         object.__setattr__(
@@ -564,6 +566,7 @@ def decide_admission(
         target_type=admission_input.target_type,
         fingerprint=admission_input.fingerprint,
         idempotency_key=admission_input.idempotency_key,
+        produced_at=now_timestamp,
         reason_codes=normalized_reason_codes,
         blocking_reasons=normalized_blocking_reasons,
         warnings=normalized_warnings,
@@ -577,7 +580,7 @@ def decide_admission(
         target_type=admission_input.target_type,
         fingerprint=admission_input.fingerprint,
         idempotency_key=admission_input.idempotency_key,
-        produced_at=admission_input.produced_at,
+        produced_at=now_timestamp,
         reason_codes=normalized_reason_codes,
         blocking_reasons=normalized_blocking_reasons,
         warnings=normalized_warnings,
@@ -668,6 +671,7 @@ def build_admission_decision_id(
     target_type: AdmissionTargetType,
     fingerprint: str,
     idempotency_key: str,
+    produced_at: str,
     reason_codes: tuple[str, ...],
     blocking_reasons: tuple[str, ...],
     warnings: tuple[str, ...],
@@ -681,6 +685,7 @@ def build_admission_decision_id(
         "fingerprint": fingerprint,
         "idempotency_key": idempotency_key,
         "policy_version": policy_version,
+        "produced_at": produced_at,
         "reason_codes": list(reason_codes),
         "target_id": target_id,
         "target_type": target_type,

--- a/core/evidence/admission.py
+++ b/core/evidence/admission.py
@@ -1,0 +1,917 @@
+"""Active metadata admission contracts for Evidence Graph Runtime.
+
+RU: E4 admission принимает deterministic gate-решения без runtime side effects.
+EN: E4 admission makes deterministic gate decisions without runtime side effects.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, TypeAlias, cast
+
+from core.evidence.events import (
+    ALLOWED_EVAL_EVENT_TYPES,
+    EvidenceEvalEvent,
+    EvalEventType,
+    ValidationStatus,
+    validate_eval_event_type,
+    validate_idempotency_key,
+    validate_produced_at,
+    validate_validation_status,
+)
+from core.evidence.fingerprints import JsonScalar, JsonValue, fingerprint_payload
+from core.evidence.policies import (
+    normalize_upstream_ids,
+    validate_fingerprint,
+    validate_non_empty_token,
+)
+from core.evidence.promotion_ledger import (
+    ALLOWED_PROMOTION_DECISIONS,
+    PromotionDecision,
+    PromotionLedgerEntry,
+    validate_promotion_decision,
+)
+
+AdmissionAction = Literal["execute", "promote", "serve"]
+AdmissionTargetType = Literal[
+    "evidence_asset",
+    "eval_event",
+    "promotion_ledger_entry",
+    "replay_summary",
+]
+
+ALLOWED_ADMISSION_ACTIONS: tuple[str, ...] = ("execute", "promote", "serve")
+ALLOWED_ADMISSION_TARGET_TYPES: tuple[str, ...] = (
+    "evidence_asset",
+    "eval_event",
+    "promotion_ledger_entry",
+    "replay_summary",
+)
+
+DEFAULT_ALLOWED_VALIDATION_STATUSES: tuple[ValidationStatus, ...] = ("valid",)
+DEFAULT_ALLOWED_EVENT_TYPES: tuple[EvalEventType, ...] = cast(
+    tuple[EvalEventType, ...],
+    ALLOWED_EVAL_EVENT_TYPES,
+)
+DEFAULT_ALLOWED_DECISIONS: tuple[PromotionDecision, ...] = ("promote", "supersede")
+
+_PROMOTE_ACTION: AdmissionAction = "promote"
+_SERVE_ACTION: AdmissionAction = "serve"
+_EXECUTE_ACTION: AdmissionAction = "execute"
+
+_FORBIDDEN_METADATA_KEY_FRAGMENTS: tuple[str, ...] = (
+    "api_key",
+    "apikey",
+    "access_token",
+    "health_payload",
+    "medical_record",
+    "password",
+    "prompt",
+    "raw_prompt",
+    "raw_response",
+    "refresh_token",
+    "response",
+    "secret",
+    "user_health",
+    "user_payload",
+)
+
+_FORBIDDEN_METADATA_STRING_FRAGMENTS: tuple[str, ...] = (
+    "api_key=",
+    "bearer ",
+    "health payload",
+    "medical record",
+    "password=",
+    "private key",
+    "prompt:",
+    "raw prompt",
+    "raw response",
+    "response:",
+    "sk-",
+    "user health",
+    "user payload",
+)
+
+_CURRENT_DIRECTORY_PATH_VALUES: tuple[str, ...] = (".", "./", "./.")
+_PATH_LIKE_PREFIXES: tuple[str, ...] = (
+    "artifacts/",
+    "core/",
+    "data/",
+    "docs/",
+    "evals/",
+    "scripts/",
+    "tests/",
+)
+_PATH_LIKE_SUFFIXES: tuple[str, ...] = (
+    ".csv",
+    ".ipynb",
+    ".json",
+    ".jsonl",
+    ".md",
+    ".parquet",
+    ".txt",
+)
+
+
+@dataclass(frozen=True)
+class _FrozenJsonArray:
+    items: tuple["FrozenJsonValue", ...]
+
+
+@dataclass(frozen=True)
+class _FrozenJsonObject:
+    items: tuple[tuple[str, "FrozenJsonValue"], ...]
+
+
+FrozenJsonValue: TypeAlias = JsonScalar | _FrozenJsonArray | _FrozenJsonObject
+
+
+@dataclass(frozen=True)
+class AdmissionPolicy:
+    """Deterministic metadata admission policy thresholds."""
+
+    policy_version: str
+    min_verification_rate: float = 0.9
+    min_coverage_rate: float = 0.8
+    max_fallback_rate: float = 0.1
+    allow_degraded: bool = False
+    allowed_validation_statuses: tuple[ValidationStatus, ...] = DEFAULT_ALLOWED_VALIDATION_STATUSES
+    stale_after_seconds: int = 30 * 24 * 60 * 60
+    allowed_event_types: tuple[EvalEventType, ...] = DEFAULT_ALLOWED_EVENT_TYPES
+    allowed_decisions: tuple[PromotionDecision, ...] = DEFAULT_ALLOWED_DECISIONS
+
+    def __post_init__(self) -> None:
+        """Normalize policy fields without mutating caller-owned structures."""
+
+        object.__setattr__(
+            self,
+            "policy_version",
+            validate_non_empty_token("policy_version", self.policy_version),
+        )
+        object.__setattr__(
+            self,
+            "min_verification_rate",
+            _validate_metric("min_verification_rate", self.min_verification_rate),
+        )
+        object.__setattr__(
+            self,
+            "min_coverage_rate",
+            _validate_metric("min_coverage_rate", self.min_coverage_rate),
+        )
+        object.__setattr__(
+            self,
+            "max_fallback_rate",
+            _validate_metric("max_fallback_rate", self.max_fallback_rate),
+        )
+        if self.stale_after_seconds < 0:
+            raise ValueError("stale_after_seconds must be non-negative")
+        object.__setattr__(
+            self,
+            "allowed_validation_statuses",
+            tuple(
+                sorted(
+                    {
+                        validate_validation_status(status)
+                        for status in self.allowed_validation_statuses
+                    }
+                )
+            ),
+        )
+        object.__setattr__(
+            self,
+            "allowed_event_types",
+            tuple(
+                sorted(
+                    {
+                        validate_eval_event_type(event_type)
+                        for event_type in self.allowed_event_types
+                    }
+                )
+            ),
+        )
+        object.__setattr__(
+            self,
+            "allowed_decisions",
+            tuple(
+                sorted(
+                    {validate_promotion_decision(decision) for decision in self.allowed_decisions}
+                )
+            ),
+        )
+
+
+@dataclass(frozen=True, init=False)
+class AdmissionInput:
+    """Normalized admission target metadata."""
+
+    target_id: str
+    target_type: AdmissionTargetType
+    fingerprint: str
+    idempotency_key: str
+    policy_version: str
+    produced_at: str
+    validation_status: ValidationStatus
+    coverage_rate: float
+    verification_rate: float
+    fallback_rate: float
+    degraded_reason: str | None
+    upstream_ids: tuple[str, ...]
+    source_event_id: str | None
+    promotion_id: str | None
+    event_type: EvalEventType | None
+    promotion_decision: PromotionDecision | None
+    _metadata: _FrozenJsonObject
+
+    def __init__(
+        self,
+        *,
+        target_id: str,
+        target_type: AdmissionTargetType,
+        fingerprint: str,
+        idempotency_key: str,
+        policy_version: str,
+        produced_at: str,
+        validation_status: ValidationStatus,
+        coverage_rate: float,
+        verification_rate: float,
+        fallback_rate: float,
+        degraded_reason: str | None = None,
+        upstream_ids: Iterable[str] = (),
+        source_event_id: str | None = None,
+        promotion_id: str | None = None,
+        event_type: EvalEventType | None = None,
+        promotion_decision: PromotionDecision | None = None,
+        metadata: Mapping[str, JsonValue] | None = None,
+    ) -> None:
+        """Create validated metadata admission input."""
+
+        object.__setattr__(
+            self,
+            "target_id",
+            _validate_identity_token("target_id", target_id),
+        )
+        object.__setattr__(
+            self,
+            "target_type",
+            validate_admission_target_type(target_type),
+        )
+        object.__setattr__(self, "fingerprint", validate_fingerprint(fingerprint))
+        object.__setattr__(
+            self,
+            "idempotency_key",
+            validate_idempotency_key(idempotency_key),
+        )
+        object.__setattr__(
+            self,
+            "policy_version",
+            validate_non_empty_token("policy_version", policy_version),
+        )
+        object.__setattr__(self, "produced_at", validate_produced_at(produced_at))
+        object.__setattr__(
+            self,
+            "validation_status",
+            validate_validation_status(validation_status),
+        )
+        object.__setattr__(
+            self,
+            "coverage_rate",
+            _validate_metric("coverage_rate", coverage_rate),
+        )
+        object.__setattr__(
+            self,
+            "verification_rate",
+            _validate_metric("verification_rate", verification_rate),
+        )
+        object.__setattr__(
+            self,
+            "fallback_rate",
+            _validate_metric("fallback_rate", fallback_rate),
+        )
+        object.__setattr__(
+            self,
+            "degraded_reason",
+            (
+                None
+                if degraded_reason is None
+                else _validate_metadata_safe_text("degraded_reason", degraded_reason)
+            ),
+        )
+        object.__setattr__(
+            self,
+            "upstream_ids",
+            normalize_upstream_ids(tuple(upstream_ids)),
+        )
+        object.__setattr__(
+            self,
+            "source_event_id",
+            (
+                None
+                if source_event_id is None
+                else _validate_identity_token("source_event_id", source_event_id)
+            ),
+        )
+        object.__setattr__(
+            self,
+            "promotion_id",
+            (
+                None
+                if promotion_id is None
+                else _validate_identity_token("promotion_id", promotion_id)
+            ),
+        )
+        object.__setattr__(
+            self,
+            "event_type",
+            None if event_type is None else validate_eval_event_type(event_type),
+        )
+        object.__setattr__(
+            self,
+            "promotion_decision",
+            None if promotion_decision is None else validate_promotion_decision(promotion_decision),
+        )
+        object.__setattr__(self, "_metadata", _freeze_metadata(metadata or {}))
+
+    @property
+    def metadata(self) -> dict[str, JsonValue]:
+        """Return a defensive JSON-compatible metadata copy."""
+
+        return cast(dict[str, JsonValue], _thaw_frozen_json(self._metadata))
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Return a deterministic JSON-compatible admission input payload."""
+
+        return {
+            "coverage_rate": self.coverage_rate,
+            "degraded_reason": self.degraded_reason,
+            "event_type": self.event_type,
+            "fallback_rate": self.fallback_rate,
+            "fingerprint": self.fingerprint,
+            "idempotency_key": self.idempotency_key,
+            "metadata": self.metadata,
+            "policy_version": self.policy_version,
+            "produced_at": self.produced_at,
+            "promotion_decision": self.promotion_decision,
+            "promotion_id": self.promotion_id,
+            "source_event_id": self.source_event_id,
+            "target_id": self.target_id,
+            "target_type": self.target_type,
+            "upstream_ids": list(self.upstream_ids),
+            "validation_status": self.validation_status,
+            "verification_rate": self.verification_rate,
+        }
+
+
+@dataclass(frozen=True)
+class AdmissionDecision:
+    """Deterministic admission gate result."""
+
+    decision_id: str
+    action: AdmissionAction
+    allowed: bool
+    policy_version: str
+    target_id: str
+    target_type: AdmissionTargetType
+    fingerprint: str
+    idempotency_key: str
+    produced_at: str
+    reason_codes: tuple[str, ...]
+    blocking_reasons: tuple[str, ...]
+    warnings: tuple[str, ...]
+    _metadata: _FrozenJsonObject
+
+    @property
+    def metadata(self) -> dict[str, JsonValue]:
+        """Return a defensive JSON-compatible metadata copy."""
+
+        return cast(dict[str, JsonValue], _thaw_frozen_json(self._metadata))
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Return a deterministic JSON-compatible decision payload."""
+
+        return {
+            "action": self.action,
+            "allowed": self.allowed,
+            "blocking_reasons": list(self.blocking_reasons),
+            "decision_id": self.decision_id,
+            "fingerprint": self.fingerprint,
+            "idempotency_key": self.idempotency_key,
+            "metadata": self.metadata,
+            "policy_version": self.policy_version,
+            "produced_at": self.produced_at,
+            "reason_codes": list(self.reason_codes),
+            "target_id": self.target_id,
+            "target_type": self.target_type,
+            "warnings": list(self.warnings),
+        }
+
+    def to_json(self) -> str:
+        """Serialize the decision with stable key ordering."""
+
+        return json.dumps(
+            self.to_dict(),
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+
+def decide_allow_execute(
+    *,
+    admission_input: AdmissionInput,
+    policy: AdmissionPolicy,
+    now: str,
+) -> AdmissionDecision:
+    """Return an execute admission decision."""
+
+    return decide_admission(
+        action="execute",
+        admission_input=admission_input,
+        policy=policy,
+        now=now,
+    )
+
+
+def decide_allow_promote(
+    *,
+    admission_input: AdmissionInput,
+    policy: AdmissionPolicy,
+    now: str,
+) -> AdmissionDecision:
+    """Return a promote admission decision."""
+
+    return decide_admission(
+        action="promote",
+        admission_input=admission_input,
+        policy=policy,
+        now=now,
+    )
+
+
+def decide_allow_serve(
+    *,
+    admission_input: AdmissionInput,
+    policy: AdmissionPolicy,
+    now: str,
+) -> AdmissionDecision:
+    """Return a serve admission decision."""
+
+    return decide_admission(
+        action="serve",
+        admission_input=admission_input,
+        policy=policy,
+        now=now,
+    )
+
+
+def decide_admission(
+    *,
+    action: AdmissionAction,
+    admission_input: AdmissionInput,
+    policy: AdmissionPolicy,
+    now: str,
+) -> AdmissionDecision:
+    """Make a deterministic admission decision without side effects."""
+
+    normalized_action = validate_admission_action(action)
+    if admission_input.policy_version != policy.policy_version:
+        raise ValueError("admission input policy_version must match policy")
+    now_timestamp = validate_produced_at(now)
+
+    reason_codes: list[str] = []
+    blocking_reasons: list[str] = []
+    warnings: list[str] = []
+
+    if admission_input.validation_status not in policy.allowed_validation_statuses:
+        blocking_reasons.append("validation_status_not_allowed")
+
+    stale_state = _staleness_state(
+        produced_at=admission_input.produced_at,
+        now=now_timestamp,
+        stale_after_seconds=policy.stale_after_seconds,
+    )
+    if stale_state is not None:
+        blocking_reasons.append(stale_state)
+
+    if (
+        admission_input.event_type is not None
+        and admission_input.event_type not in policy.allowed_event_types
+    ):
+        blocking_reasons.append("event_type_not_allowed")
+
+    if (
+        admission_input.promotion_decision is not None
+        and admission_input.promotion_decision not in policy.allowed_decisions
+    ):
+        blocking_reasons.append("promotion_decision_not_allowed")
+
+    if admission_input.degraded_reason:
+        if policy.allow_degraded:
+            warnings.append("degraded_input_allowed")
+        else:
+            blocking_reasons.append("degraded_reason_not_allowed")
+
+    if normalized_action == _PROMOTE_ACTION:
+        _append_promote_reasons(
+            admission_input=admission_input,
+            policy=policy,
+            blocking_reasons=blocking_reasons,
+        )
+    elif normalized_action == _SERVE_ACTION:
+        _append_serve_reasons(
+            admission_input=admission_input,
+            policy=policy,
+            blocking_reasons=blocking_reasons,
+        )
+
+    allowed = not blocking_reasons
+    reason_codes.append(f"{normalized_action}_{'allowed' if allowed else 'blocked'}")
+    if admission_input.validation_status != "valid" and policy.allow_degraded:
+        warnings.append("non_valid_status_allowed_by_policy")
+
+    normalized_reason_codes = _normalize_reason_codes(tuple(reason_codes))
+    normalized_blocking_reasons = _normalize_reason_codes(tuple(blocking_reasons))
+    normalized_warnings = _normalize_reason_codes(tuple(warnings))
+    frozen_metadata = _freeze_metadata(
+        {
+            "input": admission_input.to_dict(),
+            "policy": _policy_identity_payload(policy),
+        }
+    )
+    decision_id = build_admission_decision_id(
+        action=normalized_action,
+        allowed=allowed,
+        policy_version=policy.policy_version,
+        target_id=admission_input.target_id,
+        target_type=admission_input.target_type,
+        fingerprint=admission_input.fingerprint,
+        idempotency_key=admission_input.idempotency_key,
+        reason_codes=normalized_reason_codes,
+        blocking_reasons=normalized_blocking_reasons,
+        warnings=normalized_warnings,
+    )
+    return AdmissionDecision(
+        decision_id=decision_id,
+        action=normalized_action,
+        allowed=allowed,
+        policy_version=policy.policy_version,
+        target_id=admission_input.target_id,
+        target_type=admission_input.target_type,
+        fingerprint=admission_input.fingerprint,
+        idempotency_key=admission_input.idempotency_key,
+        produced_at=admission_input.produced_at,
+        reason_codes=normalized_reason_codes,
+        blocking_reasons=normalized_blocking_reasons,
+        warnings=normalized_warnings,
+        _metadata=frozen_metadata,
+    )
+
+
+def admission_input_from_eval_event(
+    *,
+    event: EvidenceEvalEvent,
+    coverage_rate: float,
+    verification_rate: float,
+    fallback_rate: float,
+    degraded_reason: str | None = None,
+    metadata: Mapping[str, JsonValue] | None = None,
+) -> AdmissionInput:
+    """Create admission input from an E2 eval event contract."""
+
+    if not isinstance(event, EvidenceEvalEvent):
+        raise ValueError("event must be an EvidenceEvalEvent")
+    return AdmissionInput(
+        target_id=event.event_id,
+        target_type="eval_event",
+        fingerprint=event.fingerprint,
+        idempotency_key=event.idempotency_key,
+        policy_version=event.policy_version,
+        produced_at=event.produced_at,
+        validation_status=event.validation_status,
+        coverage_rate=coverage_rate,
+        verification_rate=verification_rate,
+        fallback_rate=fallback_rate,
+        degraded_reason=degraded_reason,
+        upstream_ids=event.upstream_ids,
+        source_event_id=event.event_id,
+        event_type=event.event_type,
+        metadata=metadata,
+    )
+
+
+def admission_input_from_ledger_entry(
+    *,
+    entry: PromotionLedgerEntry,
+    coverage_rate: float,
+    verification_rate: float,
+    fallback_rate: float,
+    degraded_reason: str | None = None,
+    metadata: Mapping[str, JsonValue] | None = None,
+) -> AdmissionInput:
+    """Create admission input from an E3 promotion ledger entry."""
+
+    if not isinstance(entry, PromotionLedgerEntry):
+        raise ValueError("entry must be a PromotionLedgerEntry")
+    return AdmissionInput(
+        target_id=entry.ledger_entry_id,
+        target_type="promotion_ledger_entry",
+        fingerprint=entry.source_event_fingerprint,
+        idempotency_key=entry.idempotency_key,
+        policy_version=entry.policy_version,
+        produced_at=entry.produced_at,
+        validation_status=entry.validation_status,
+        coverage_rate=coverage_rate,
+        verification_rate=verification_rate,
+        fallback_rate=fallback_rate,
+        degraded_reason=degraded_reason,
+        upstream_ids=entry.upstream_ids,
+        source_event_id=entry.source_event_id,
+        promotion_id=entry.promotion_id,
+        event_type=entry.source_event_type,
+        promotion_decision=entry.decision,
+        metadata=metadata,
+    )
+
+
+def build_admission_decision_id(
+    *,
+    action: AdmissionAction,
+    allowed: bool,
+    policy_version: str,
+    target_id: str,
+    target_type: AdmissionTargetType,
+    fingerprint: str,
+    idempotency_key: str,
+    reason_codes: tuple[str, ...],
+    blocking_reasons: tuple[str, ...],
+    warnings: tuple[str, ...],
+) -> str:
+    """Build deterministic admission decision id from canonical fields."""
+
+    identity_payload: JsonValue = {
+        "action": action,
+        "allowed": allowed,
+        "blocking_reasons": list(blocking_reasons),
+        "fingerprint": fingerprint,
+        "idempotency_key": idempotency_key,
+        "policy_version": policy_version,
+        "reason_codes": list(reason_codes),
+        "target_id": target_id,
+        "target_type": target_type,
+        "warnings": list(warnings),
+    }
+    digest = fingerprint_payload(identity_payload).removeprefix("sha256:")
+    return f"admission-decision:{digest[:24]}"
+
+
+def validate_admission_action(action: AdmissionAction) -> AdmissionAction:
+    """Return a supported admission action or fail closed."""
+
+    if action not in ALLOWED_ADMISSION_ACTIONS:
+        raise ValueError(f"unsupported admission action: {action!r}")
+    return action
+
+
+def validate_admission_target_type(
+    target_type: AdmissionTargetType,
+) -> AdmissionTargetType:
+    """Return a supported admission target type or fail closed."""
+
+    if target_type not in ALLOWED_ADMISSION_TARGET_TYPES:
+        raise ValueError(f"unsupported admission target_type: {target_type!r}")
+    return target_type
+
+
+def _append_promote_reasons(
+    *,
+    admission_input: AdmissionInput,
+    policy: AdmissionPolicy,
+    blocking_reasons: list[str],
+) -> None:
+    """Append strict promote blocking reasons."""
+
+    if admission_input.validation_status != "valid":
+        blocking_reasons.append("promote_requires_valid_status")
+    if admission_input.verification_rate < policy.min_verification_rate:
+        blocking_reasons.append("verification_rate_below_threshold")
+    if admission_input.coverage_rate < policy.min_coverage_rate:
+        blocking_reasons.append("coverage_rate_below_threshold")
+    if admission_input.fallback_rate > policy.max_fallback_rate:
+        blocking_reasons.append("fallback_rate_above_threshold")
+    if not admission_input.upstream_ids:
+        blocking_reasons.append("upstream_lineage_required")
+
+
+def _append_serve_reasons(
+    *,
+    admission_input: AdmissionInput,
+    policy: AdmissionPolicy,
+    blocking_reasons: list[str],
+) -> None:
+    """Append serve-specific blocking reasons."""
+
+    if admission_input.validation_status != "valid" and not policy.allow_degraded:
+        blocking_reasons.append("serve_requires_valid_status")
+
+
+def _staleness_state(
+    *,
+    produced_at: str,
+    now: str,
+    stale_after_seconds: int,
+) -> str | None:
+    """Return deterministic staleness blocker or None."""
+
+    produced_dt = _parse_timestamp(produced_at)
+    now_dt = _parse_timestamp(now)
+    age_seconds = (now_dt - produced_dt).total_seconds()
+    if age_seconds < 0:
+        return "produced_at_in_future"
+    if age_seconds > stale_after_seconds:
+        return "stale_input"
+    return None
+
+
+def _parse_timestamp(value: str) -> datetime:
+    """Parse an already validated timezone-aware ISO timestamp."""
+
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must include timezone")
+    return parsed
+
+
+def _policy_identity_payload(policy: AdmissionPolicy) -> dict[str, JsonValue]:
+    """Return deterministic policy identity fields for decision metadata."""
+
+    return {
+        "allow_degraded": policy.allow_degraded,
+        "allowed_decisions": list(policy.allowed_decisions),
+        "allowed_event_types": list(policy.allowed_event_types),
+        "allowed_validation_statuses": list(policy.allowed_validation_statuses),
+        "max_fallback_rate": policy.max_fallback_rate,
+        "min_coverage_rate": policy.min_coverage_rate,
+        "min_verification_rate": policy.min_verification_rate,
+        "policy_version": policy.policy_version,
+        "stale_after_seconds": policy.stale_after_seconds,
+    }
+
+
+def _validate_metric(name: str, value: float) -> float:
+    """Validate admission metrics as finite rates in [0, 1]."""
+
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{name} must be a finite number")
+    normalized = float(value)
+    if not math.isfinite(normalized):
+        raise ValueError(f"{name} must be finite")
+    if normalized < 0.0 or normalized > 1.0:
+        raise ValueError(f"{name} must be between 0 and 1")
+    return normalized
+
+
+def _validate_identity_token(name: str, value: str) -> str:
+    """Validate IDs that may contain separators but no whitespace."""
+
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{name} must be non-empty")
+    if any(char.isspace() for char in normalized):
+        raise ValueError(f"{name} must not contain whitespace")
+    return normalized
+
+
+def _validate_metadata_safe_text(name: str, value: str) -> str:
+    """Validate optional free-text reason fields through metadata safety rules."""
+
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{name} must be non-empty when provided")
+    _validate_metadata_string(normalized)
+    return normalized
+
+
+def _normalize_reason_codes(reason_codes: tuple[str, ...]) -> tuple[str, ...]:
+    """Normalize reason codes and reject collisions after normalization."""
+
+    normalized_codes: list[str] = []
+    seen: set[str] = set()
+    for reason_code in reason_codes:
+        normalized = validate_non_empty_token(
+            "reason_code",
+            reason_code.strip().lower(),
+        )
+        if normalized in seen:
+            raise ValueError("reason_codes collide after normalization")
+        seen.add(normalized)
+        normalized_codes.append(normalized)
+    return tuple(sorted(normalized_codes))
+
+
+def _freeze_metadata(metadata: Mapping[str, JsonValue]) -> _FrozenJsonObject:
+    """Validate and freeze metadata into caller-independent structures."""
+
+    return cast(_FrozenJsonObject, _freeze_json_value(metadata, path=()))
+
+
+def _freeze_json_value(
+    value: JsonValue,
+    *,
+    path: tuple[str, ...],
+) -> FrozenJsonValue:
+    """Freeze JSON-compatible metadata and scan unsafe raw payloads."""
+
+    if isinstance(value, Mapping):
+        items: list[tuple[str, FrozenJsonValue]] = []
+        normalized_items: list[tuple[str, JsonValue]] = []
+        seen_keys: set[str] = set()
+        for key, item in value.items():
+            key_path = ".".join(path + (str(key),)) or "<root>"
+            if not isinstance(key, str):
+                raise ValueError(f"metadata key at {key_path} must be a string")
+            normalized_key = key.strip().lower()
+            if not normalized_key:
+                raise ValueError(f"metadata key at {key_path} must be non-empty")
+            if normalized_key in seen_keys:
+                raise ValueError(
+                    f"metadata key at {key_path} collides after normalization: {normalized_key!r}"
+                )
+            seen_keys.add(normalized_key)
+            _validate_metadata_key(normalized_key)
+            normalized_items.append((normalized_key, item))
+        for normalized_key, item in sorted(normalized_items, key=lambda pair: pair[0]):
+            items.append(
+                (
+                    normalized_key,
+                    _freeze_json_value(item, path=path + (normalized_key,)),
+                )
+            )
+        return _FrozenJsonObject(tuple(items))
+    if isinstance(value, bytes | bytearray):
+        raise ValueError(f"metadata value at {'.'.join(path) or '<root>'} must be JSON-compatible")
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return _FrozenJsonArray(
+            tuple(
+                _freeze_json_value(item, path=path + (str(index),))
+                for index, item in enumerate(value)
+            )
+        )
+    if isinstance(value, str):
+        _validate_metadata_string(value)
+        return value
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            location = ".".join(path) or "<root>"
+            raise ValueError(f"metadata value at {location} must be finite")
+        return value
+    raise ValueError(f"metadata value at {'.'.join(path) or '<root>'} must be JSON-compatible")
+
+
+def _validate_metadata_key(key: str) -> None:
+    """Fail closed on raw prompt/response/secret/user-health metadata keys."""
+
+    lowered = key.lower()
+    if any(fragment in lowered for fragment in _FORBIDDEN_METADATA_KEY_FRAGMENTS):
+        raise ValueError(f"metadata key is not allowed: {key!r}")
+
+
+def _validate_metadata_string(value: str) -> None:
+    """Fail closed on raw secret, user-health, prompt, or path-like strings."""
+
+    normalized = value.strip()
+    lowered = normalized.lower().replace("\\", "/")
+    if lowered in _CURRENT_DIRECTORY_PATH_VALUES:
+        raise ValueError("metadata string appears to contain path-like material")
+    if any(fragment in lowered for fragment in _FORBIDDEN_METADATA_STRING_FRAGMENTS):
+        raise ValueError("metadata string appears to contain raw secret material")
+    if (
+        lowered.startswith("/")
+        or lowered.startswith("~")
+        or "../" in lowered
+        or _has_windows_drive_prefix(lowered)
+        or (lowered.startswith(_PATH_LIKE_PREFIXES) and lowered.endswith(_PATH_LIKE_SUFFIXES))
+    ):
+        raise ValueError("metadata string appears to contain path-like material")
+
+
+def _has_windows_drive_prefix(value: str) -> bool:
+    """Return True for Windows drive-qualified strings such as C:/x or C:x."""
+
+    first_segment = value.split("/", maxsplit=1)[0]
+    return len(first_segment) >= 2 and first_segment[0].isalpha() and first_segment[1] == ":"
+
+
+def _thaw_frozen_json(value: FrozenJsonValue) -> JsonValue:
+    """Return a defensive JSON-compatible value from frozen metadata."""
+
+    if isinstance(value, _FrozenJsonObject):
+        return {key: _thaw_frozen_json(item) for key, item in value.items}
+    if isinstance(value, _FrozenJsonArray):
+        return [_thaw_frozen_json(item) for item in value.items]
+    return value

--- a/core/evidence/admission.py
+++ b/core/evidence/admission.py
@@ -778,10 +778,7 @@ def _staleness_state(
 def _parse_timestamp(value: str) -> datetime:
     """Parse an already validated timezone-aware ISO timestamp."""
 
-    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    if parsed.tzinfo is None:
-        raise ValueError("timestamp must include timezone")
-    return parsed
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 def _policy_identity_payload(policy: AdmissionPolicy) -> dict[str, JsonValue]:
@@ -851,20 +848,19 @@ def _validate_metadata_safe_text(name: str, value: str) -> str:
 
 
 def _normalize_reason_codes(reason_codes: tuple[str, ...]) -> tuple[str, ...]:
-    """Normalize reason codes and reject collisions after normalization."""
+    """Normalize generated reason codes deterministically."""
 
-    normalized_codes: list[str] = []
-    seen: set[str] = set()
-    for reason_code in reason_codes:
-        normalized = validate_non_empty_token(
-            "reason_code",
-            reason_code.strip().lower(),
+    return tuple(
+        sorted(
+            {
+                validate_non_empty_token(
+                    "reason_code",
+                    reason_code.strip().lower(),
+                )
+                for reason_code in reason_codes
+            }
         )
-        if normalized in seen:
-            raise ValueError("reason_codes collide after normalization")
-        seen.add(normalized)
-        normalized_codes.append(normalized)
-    return tuple(sorted(normalized_codes))
+    )
 
 
 def _freeze_metadata(metadata: Mapping[str, JsonValue]) -> _FrozenJsonObject:

--- a/core/evidence/admission.py
+++ b/core/evidence/admission.py
@@ -67,14 +67,20 @@ _FORBIDDEN_METADATA_KEY_FRAGMENTS: tuple[str, ...] = (
     "api_key",
     "apikey",
     "access_token",
+    "answer_text",
     "health_payload",
     "medical_record",
     "password",
     "prompt",
+    "prompt_text",
+    "question_text",
+    "query_text",
     "raw_prompt",
+    "raw_query",
     "raw_response",
     "refresh_token",
     "response",
+    "response_text",
     "secret",
     "user_health",
     "user_payload",
@@ -88,7 +94,9 @@ _FORBIDDEN_METADATA_STRING_FRAGMENTS: tuple[str, ...] = (
     "password=",
     "private key",
     "prompt:",
+    "query:",
     "raw prompt",
+    "raw query",
     "raw response",
     "response:",
     "sk-",
@@ -521,6 +529,12 @@ def decide_admission(
             policy=policy,
             blocking_reasons=blocking_reasons,
         )
+    elif normalized_action == _EXECUTE_ACTION:
+        _append_execute_reasons(
+            admission_input=admission_input,
+            policy=policy,
+            blocking_reasons=blocking_reasons,
+        )
     elif normalized_action == _SERVE_ACTION:
         _append_serve_reasons(
             admission_input=admission_input,
@@ -599,7 +613,11 @@ def admission_input_from_eval_event(
         upstream_ids=event.upstream_ids,
         source_event_id=event.event_id,
         event_type=event.event_type,
-        metadata=metadata,
+        metadata=_merge_source_metadata(
+            source_key="event_metadata",
+            source_metadata=event.metadata,
+            metadata=metadata,
+        ),
     )
 
 
@@ -633,7 +651,11 @@ def admission_input_from_ledger_entry(
         promotion_id=entry.promotion_id,
         event_type=entry.source_event_type,
         promotion_decision=entry.decision,
-        metadata=metadata,
+        metadata=_merge_source_metadata(
+            source_key="ledger_metadata",
+            source_metadata=entry.metadata,
+            metadata=metadata,
+        ),
     )
 
 
@@ -684,6 +706,18 @@ def validate_admission_target_type(
     if target_type not in ALLOWED_ADMISSION_TARGET_TYPES:
         raise ValueError(f"unsupported admission target_type: {target_type!r}")
     return target_type
+
+
+def _append_execute_reasons(
+    *,
+    admission_input: AdmissionInput,
+    policy: AdmissionPolicy,
+    blocking_reasons: list[str],
+) -> None:
+    """Append execute-specific blocking reasons."""
+
+    if admission_input.validation_status != "valid" and not policy.allow_degraded:
+        blocking_reasons.append("execute_requires_degraded_policy")
 
 
 def _append_promote_reasons(
@@ -759,6 +793,22 @@ def _policy_identity_payload(policy: AdmissionPolicy) -> dict[str, JsonValue]:
         "policy_version": policy.policy_version,
         "stale_after_seconds": policy.stale_after_seconds,
     }
+
+
+def _merge_source_metadata(
+    *,
+    source_key: str,
+    source_metadata: Mapping[str, JsonValue],
+    metadata: Mapping[str, JsonValue] | None,
+) -> dict[str, JsonValue]:
+    """Preserve source metadata so adapters cannot bypass admission safety."""
+
+    payload: dict[str, JsonValue] = {
+        source_key: dict(source_metadata),
+    }
+    if metadata is not None:
+        payload["admission_metadata"] = dict(metadata)
+    return payload
 
 
 def _validate_metric(name: str, value: float) -> float:

--- a/docs/orchestration/contracts/EVIDENCE_METADATA_ADMISSION.md
+++ b/docs/orchestration/contracts/EVIDENCE_METADATA_ADMISSION.md
@@ -1,0 +1,145 @@
+# Evidence Metadata Admission Contract
+
+PR-E4 adds a pure, deterministic admission layer over the Evidence Graph
+Runtime contracts from PR-E1, PR-E2, and PR-E3.
+
+This contract decides whether an evidence target may be used for:
+
+- `allow_execute`
+- `allow_promote`
+- `allow_serve`
+
+The layer is internal only. It does not write files, call providers, read or
+write databases, change OpenAPI, add routes, run evals, or enable semantic
+cache.
+
+## Inputs
+
+`AdmissionInput` is the normalized metadata shape used by all admission
+decisions.
+
+Required fields:
+
+- `target_id`
+- `target_type`
+- `fingerprint`
+- `idempotency_key`
+- `policy_version`
+- `produced_at`
+- `validation_status`
+- `coverage_rate`
+- `verification_rate`
+- `fallback_rate`
+- `upstream_ids`
+
+Optional linkage:
+
+- `source_event_id`
+- `promotion_id`
+- `event_type`
+- `promotion_decision`
+- `degraded_reason`
+- `metadata`
+
+Inputs fail closed on blank identity fields, malformed fingerprints, unsupported
+validation statuses, non-finite or out-of-range metrics, unsafe metadata, and
+path-like metadata strings.
+
+## Policy
+
+`AdmissionPolicy` defines deterministic thresholds and allowlists:
+
+- `policy_version`
+- `min_verification_rate`
+- `min_coverage_rate`
+- `max_fallback_rate`
+- `allow_degraded`
+- `allowed_validation_statuses`
+- `stale_after_seconds`
+- `allowed_event_types`
+- `allowed_decisions`
+
+Current time is never read inside the admission helper. Callers must pass an
+explicit `now` timestamp, which keeps replay and tests deterministic.
+
+## Decisions
+
+`AdmissionDecision` returns:
+
+- `decision_id`
+- `action`
+- `allowed`
+- `policy_version`
+- `target_id`
+- `target_type`
+- `fingerprint`
+- `idempotency_key`
+- `produced_at`
+- `reason_codes`
+- `blocking_reasons`
+- `warnings`
+- `metadata`
+
+`decision_id` is derived from canonical decision fields using
+`fingerprint_payload(...)`. Wall-clock time is not part of decision identity.
+
+## Semantics
+
+`allow_execute` blocks malformed identity, invalid fingerprint, unsupported
+status, stale or future input, degraded input unless policy explicitly permits
+it, and unsafe metadata.
+
+`allow_promote` is the strict path. It requires:
+
+- `validation_status == "valid"`
+- non-stale input
+- `verification_rate >= min_verification_rate`
+- `coverage_rate >= min_coverage_rate`
+- `fallback_rate <= max_fallback_rate`
+- non-empty upstream lineage
+- allowed event type and promotion decision when present
+- no degraded reason unless policy explicitly permits degraded mode
+
+`allow_serve` allows valid non-stale evidence when policy permits the target
+event or promotion decision. It blocks stale, degraded, or invalid evidence
+unless degraded serving is explicitly allowed by policy.
+
+## Metadata Safety
+
+Admission metadata is frozen defensively and returned only as a copy.
+
+Forbidden metadata includes:
+
+- raw prompt or response fields;
+- user-health or medical payload fields;
+- secret-bearing keys or obvious token strings;
+- bytes or non-JSON-compatible values;
+- path-like strings, including current-directory values such as `.`, `./`, and
+  `./.`.
+
+Metadata safety is intentionally local to `core/evidence/admission.py` in E4 to
+avoid a broad cross-module refactor.
+
+## Boundaries
+
+E4 is not:
+
+- semantic cache;
+- Redis, GPTCache, or cache-hit logic;
+- GraphRAG or knowledge graph runtime;
+- product RAG behavior;
+- `core/knowledge/promotion.py`;
+- eval runner behavior;
+- online eval, goldens, judge calibration, or dashboards;
+- runtime routes, providers, OpenAPI, DB, billing, auth, or user-facing behavior.
+
+Semantic cache prerequisites are not complete after E4. E4 only satisfies the
+active metadata admission prerequisite; semantic cache still requires a separate
+dedicated gate, observability, false-hit guardrails, and rollout contract.
+
+## E5 Handoff
+
+The next Evidence Graph slice is PR-E5 advisory wiki evidence bridge. E5 may
+connect advisory artifacts to evidence identity and admission metadata, but it
+must preserve advisory wiki as non-canonical workforce memory rather than
+product runtime truth.

--- a/docs/review/PR_1678_FIXED_MAPPING.md
+++ b/docs/review/PR_1678_FIXED_MAPPING.md
@@ -136,6 +136,7 @@ wire E4 carefully without treating it as semantic-cache approval.
 - `1fff9eae9` - `docs(review): add PR 1678 fixed mapping`
 - `e7b72d4d9` - `test(evidence): close admission review gaps`
 - `3b0b4a497` - `fix(evidence): tighten admission decision validation`
+- `767747fed` - `test(evidence): cover admission fail-closed branches`
 
 ## Pre-push Checklist
 

--- a/docs/review/PR_1678_FIXED_MAPPING.md
+++ b/docs/review/PR_1678_FIXED_MAPPING.md
@@ -135,6 +135,7 @@ wire E4 carefully without treating it as semantic-cache approval.
 - `79dbda67a` - `feat(evidence): add active metadata admission gates`
 - `1fff9eae9` - `docs(review): add PR 1678 fixed mapping`
 - `e7b72d4d9` - `test(evidence): close admission review gaps`
+- `3b0b4a497` - `fix(evidence): tighten admission decision validation`
 
 ## Pre-push Checklist
 
@@ -186,6 +187,10 @@ merge readiness.
 Disposition: FIXED
 Commit: e7b72d4d9
 Evidence: `tests/core/evidence/test_admission.py` mutates the returned `AdmissionInput.metadata` view and asserts subsequent reads are unchanged.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#pullrequestreview-4235145977 -> 3b0b4a497
+Disposition: FIXED
+Commit: 3b0b4a497
+Evidence: Cubic identified decision timestamp and `allow_degraded` validation risks; `core/evidence/admission.py` now validates `allow_degraded` as a strict bool and sets `AdmissionDecision.produced_at` from explicit `now`, while `tests/core/evidence/test_admission.py` covers both paths.
 
 ## Sidecar Review Findings
 

--- a/docs/review/PR_1678_FIXED_MAPPING.md
+++ b/docs/review/PR_1678_FIXED_MAPPING.md
@@ -173,16 +173,19 @@ knowledge promotion.
 
 ## Discussion Thread Pass
 
-- [x] Post-open `qa-engineer-agent -> bug-hunter` sidecar review pass completed.
-- [ ] CodeRabbit/Sourcery/Cubic actionables pending live review truth after latest push.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Post-open `qa-engineer-agent -> bug-hunter` sidecar review pass completed.
+CodeRabbit/Sourcery/Cubic final no-actionables check remains required before
+merge readiness.
 
 ## Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#pullrequestreview-4235099053 -> e7b72d4d9
 Disposition: FIXED
 Commit: e7b72d4d9
-Evidence: `tests/core/evidence/test_admission.py` now mutates the returned
-`AdmissionInput.metadata` view and asserts subsequent reads are unchanged.
+Evidence: `tests/core/evidence/test_admission.py` mutates the returned `AdmissionInput.metadata` view and asserts subsequent reads are unchanged.
 
 ## Sidecar Review Findings
 

--- a/docs/review/PR_1678_FIXED_MAPPING.md
+++ b/docs/review/PR_1678_FIXED_MAPPING.md
@@ -137,6 +137,7 @@ wire E4 carefully without treating it as semantic-cache approval.
 - `e7b72d4d9` - `test(evidence): close admission review gaps`
 - `3b0b4a497` - `fix(evidence): tighten admission decision validation`
 - `767747fed` - `test(evidence): cover admission fail-closed branches`
+- `38fe2b04d` - `fix(evidence): address admission review comments`
 
 ## Pre-push Checklist
 
@@ -192,6 +193,26 @@ Evidence: `tests/core/evidence/test_admission.py` mutates the returned `Admissio
 Disposition: FIXED
 Commit: 3b0b4a497
 Evidence: Cubic identified decision timestamp and `allow_degraded` validation risks; `core/evidence/admission.py` now validates `allow_degraded` as a strict bool and sets `AdmissionDecision.produced_at` from explicit `now`, while `tests/core/evidence/test_admission.py` covers both paths.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#discussion_r3194605225 -> 3b0b4a497
+Disposition: FIXED
+Commit: 3b0b4a497
+Evidence: `core/evidence/admission.py` validates `AdmissionPolicy.allow_degraded` as strict bool, and `tests/core/evidence/test_admission.py` rejects non-bool truthy degraded policy values.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#discussion_r3194605231 -> 3b0b4a497
+Disposition: FIXED
+Commit: 3b0b4a497
+Evidence: `core/evidence/admission.py` sets `AdmissionDecision.produced_at` from explicit decision `now`, and `tests/core/evidence/test_admission.py` covers decision-time output.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#pullrequestreview-4235246205 -> 38fe2b04d
+Disposition: FIXED
+Commit: 38fe2b04d
+Evidence: `core/evidence/admission.py` removes the unused promotion-decision import, and `docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md` clarifies E4 as contract-level admission with runtime wiring deferred.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#discussion_r3194694058 -> 38fe2b04d
+Disposition: FIXED
+Commit: 38fe2b04d
+Evidence: `core/evidence/admission.py` removes the unused `ALLOWED_PROMOTION_DECISIONS` import while preserving required promotion ledger imports.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#discussion_r3194694074 -> 38fe2b04d
+Disposition: FIXED
+Commit: 38fe2b04d
+Evidence: `docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md` now states E4 produces deterministic contract-level blocking decisions and defers runtime integration to a separate wiring PR.
 
 ## Sidecar Review Findings
 

--- a/docs/review/PR_1678_FIXED_MAPPING.md
+++ b/docs/review/PR_1678_FIXED_MAPPING.md
@@ -193,6 +193,10 @@ Evidence: `tests/core/evidence/test_admission.py` mutates the returned `Admissio
 Disposition: FIXED
 Commit: 3b0b4a497
 Evidence: Cubic identified decision timestamp and `allow_degraded` validation risks; `core/evidence/admission.py` now validates `allow_degraded` as a strict bool and sets `AdmissionDecision.produced_at` from explicit `now`, while `tests/core/evidence/test_admission.py` covers both paths.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#discussion_r3194572157 -> 3b0b4a497
+Disposition: FIXED
+Commit: 3b0b4a497
+Evidence: `core/evidence/admission.py` rejects non-bool `AdmissionPolicy.allow_degraded`, and `tests/core/evidence/test_admission.py` covers string truthy degraded policy rejection.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#discussion_r3194605225 -> 3b0b4a497
 Disposition: FIXED
 Commit: 3b0b4a497

--- a/docs/review/PR_1678_FIXED_MAPPING.md
+++ b/docs/review/PR_1678_FIXED_MAPPING.md
@@ -1,0 +1,193 @@
+# PR 1678 Fixed Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678
+Branch: `codex/evidence-active-metadata-admission`
+Title: `feat(evidence): add active metadata admission gates`
+
+## Summary
+
+PR-E4 adds deterministic active metadata admission gates for Evidence Graph
+Runtime. It introduces internal `allow_execute`, `allow_promote`, and
+`allow_serve` decision contracts over E1/E2/E3 evidence metadata.
+
+## Goal
+
+Make evidence execution, promotion, and serving decisions deterministic,
+replay-compatible, policy-visible, metadata-safe, and side-effect free.
+
+## Business Reason
+
+This PR closes the next Evidence Graph reliability gap by preventing future AI
+release gates, semantic-cache gates, and metadata admission decisions from
+relying on scattered ad hoc checks.
+
+This PR does not add visible product features.
+
+## Scope
+
+- `core/evidence/admission.py` with admission policy/input/decision contracts.
+- Deterministic `decide_admission`, `decide_allow_execute`,
+  `decide_allow_promote`, and `decide_allow_serve` helpers.
+- Fail-closed metadata validation for prompt/response/user-health/secret and
+  path-like payloads.
+- Focused tests for thresholds, staleness, metadata safety, mutation safety,
+  stable serialization, and import boundaries.
+- Contract, backlog, epic, and scoped agent-instruction documentation.
+
+## Out Of Scope
+
+- Semantic cache, Redis, GPTCache, or cache-hit logic.
+- GraphRAG or knowledge graph runtime.
+- Product RAG behavior or `core/knowledge/promotion.py` rewrites.
+- Runtime routes, FastAPI, OpenAPI, DB migrations, providers, eval runners, or
+  RAGAS runner behavior.
+- Online eval, judge calibration, goldens, dashboards, frontend/iOS/design
+  changes, billing/auth/compliance surfaces, or advisory wiki authority.
+
+## Files Touched
+
+- `core/evidence/admission.py`
+- `core/evidence/__init__.py`
+- `core/evidence/AGENTS.md`
+- `tests/core/evidence/test_admission.py`
+- `docs/orchestration/contracts/EVIDENCE_METADATA_ADMISSION.md`
+- `docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md`
+- `docs/roadmap/BACKLOG_LEDGER.md`
+- `docs/review/PR_1678_FIXED_MAPPING.md`
+
+## Coordinator Bootstrap
+
+- Pre-open packet: `a7b8aa010ed7`
+- Post-open review packet: `fa1dd5432386`
+- Declared pre-open role order:
+  `agent-coordinator -> architecture-specialist -> rag-systems-agent -> data-scientist-agent -> security-auditor -> qa-engineer-agent -> bug-hunter -> cursor-specialist-agent`
+- Mandatory post-open lane:
+  `qa-engineer-agent -> bug-hunter`
+
+## Tests
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `.venv/bin/python -m pytest -q tests/core/evidence/test_admission.py tests/core/evidence/test_promotion_ledger.py tests/core/evidence/test_replay.py tests/core/evidence/test_events.py tests/core/evidence/test_assets.py tests/core/evidence/test_fingerprints.py`
+- PASS: `.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null core/evidence tests/core/evidence/test_admission.py`
+- PASS: `make validate-changed`
+- PASS: `pre-commit run --all-files`
+- PASS: pre-push hook set: changed-files mypy, pip-audit, backend pre-push
+  tests, full-repo Bandit, docker build test
+
+Full local `make verify` was intentionally not run under the
+operator-approved machine-heavy exception. Current-head GitHub CI parity and
+strict merge-readiness remain required before merge.
+
+## Security Notes
+
+Admission metadata rejects raw prompt/response/user-health/secret fields,
+obvious secret strings, bytes, non-JSON values, and path-like strings including
+`.`, `./`, and `./.`.
+
+AST import guards block runtime, provider, DB/session, Redis/cache/GPTCache,
+semantic cache, GraphRAG, eval-runner, and advisory wiki/support-plane imports.
+
+## Premortem
+
+| Risk | Disposition | Evidence |
+| --- | --- | --- |
+| Runtime side effects | FIXED | `core/evidence/admission.py` is pure contracts/helpers; no writes, DB, network, routes, or providers. |
+| Semantic cache or GraphRAG side door | FIXED | Import guard blocks cache/GraphRAG fragments; docs state semantic-cache prerequisites remain incomplete. |
+| Product knowledge promotion duplication | FIXED | E4 does not import or rewrite `core/knowledge/promotion.py`; import guard blocks `knowledge` fragments. |
+| Invalid/degraded evidence promotion | FIXED | Promote path requires valid status plus threshold and lineage checks. |
+| Wall-clock nondeterminism | FIXED | Decision helpers require explicit `now`; tests cover stale and future timestamps. |
+| Bad numeric metrics | FIXED | Metrics must be finite values in `[0, 1]`; tests cover NaN/inf/out-of-range. |
+| Raw prompt/health/secret metadata | FIXED | Recursive metadata validation and tests reject unsafe keys and strings. |
+| PR #1676-style current-directory path bug | FIXED | Admission metadata rejects `.`, `./`, `./.` with stable `ValueError`. |
+| Rail/runtime/advisory mixing | FIXED | `core/evidence/AGENTS.md` and AST tests keep E4 inside pure evidence contracts. |
+| Checklist-only fixes | FIXED | Premortem findings were converted into validators, tests, and docs before mapping. |
+| Scope widening into eval platform | FIXED | PR excludes goldens, judge calibration, dashboards, online eval, and eval runners. |
+
+## Rollback / Risks
+
+Rollback is low risk: revert the internal contract/test/docs commits. No
+runtime caller, API, DB, provider, cache, or eval runner is changed.
+
+Residual risk: no production caller exercises admission yet. Later PRs must
+wire E4 carefully without treating it as semantic-cache approval.
+
+## DoD
+
+- [x] `core/evidence/admission.py` exists.
+- [x] Admission policy/input/decision contracts exist.
+- [x] `allow_execute`, `allow_promote`, and `allow_serve` semantics are
+  deterministic and test-covered.
+- [x] Invalid/degraded/stale/low-coverage/high-fallback evidence blocks
+  promotion.
+- [x] Metadata safety is fail-closed.
+- [x] No runtime/API/OpenAPI/DB/provider/eval-runner/cache/wiki changes.
+- [x] No semantic cache or GraphRAG scope.
+- [x] No product knowledge promotion rewrite.
+- [x] Tests cover metrics, staleness, validation status, metadata safety,
+  mutation safety, stable serialization, import boundaries, and PR
+  #1676-style path regression.
+- [x] Backlog/Evidence epic points to PR-E5 advisory wiki evidence bridge as
+  the next Evidence Graph step after E4.
+
+## Commit Breakdown
+
+- `79dbda67a` - `feat(evidence): add active metadata admission gates`
+- Mapping artifact commit: pending
+
+## Pre-push Checklist
+
+- [x] Coordinator preflight and agent consistency gates run.
+- [x] Focused pytest bundle passed.
+- [x] Narrow mypy passed.
+- [x] `make validate-changed` passed after implementation commit.
+- [x] `pre-commit run --all-files` passed.
+- [x] Branch pushed successfully.
+
+## Post-merge Checklist
+
+- Sync local `main` with `git fetch --prune origin` and
+  `git merge --ff-only origin/main`.
+- Confirm `HEAD...origin/main = 0 0`.
+- Prune merged branch/worktree only after merge.
+- Keep semantic cache blocked until a separate dedicated gate opens.
+- Start PR-E5 advisory wiki evidence bridge only from clean synced main and
+  current repo truth.
+
+## AGENTS.md Updates
+
+Updated `core/evidence/AGENTS.md` with E4-specific guidance: admission
+decisions are pure gates, require explicit timestamp input, and must not write,
+import runtime/provider/DB/cache/wiki/eval-runner surfaces, or rewrite product
+knowledge promotion.
+
+## Deferred / Follow-ups
+
+- PR-E5 advisory wiki evidence bridge remains next in the Evidence Graph train.
+- Semantic cache remains deferred until its dedicated gate opens with
+  observability, false-hit guardrails, rollout contract, and current-head CI
+  governance.
+- AI release gates, goldens, judge calibration, dashboards, and online eval
+  remain later eval-roadmap work, not E4.
+
+## Discussion Thread Pass
+
+- [ ] Post-open review pass pending.
+- [ ] CodeRabbit/Sourcery/Cubic actionables pending live review truth.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments at mapping creation time.
+
+## Merge Readiness
+
+Not merge-ready at mapping creation time.
+
+Required before merge:
+
+- current-head CI parity clean;
+- diff coverage clean;
+- CodeRabbit/Sourcery/Cubic no-actionables;
+- all review threads resolved with disposition evidence;
+- strict merge-readiness wrapper with auth;
+- mandatory review wait-window after latest bot/review activity.

--- a/docs/review/PR_1678_FIXED_MAPPING.md
+++ b/docs/review/PR_1678_FIXED_MAPPING.md
@@ -133,7 +133,8 @@ wire E4 carefully without treating it as semantic-cache approval.
 ## Commit Breakdown
 
 - `79dbda67a` - `feat(evidence): add active metadata admission gates`
-- Mapping artifact commit: pending
+- `1fff9eae9` - `docs(review): add PR 1678 fixed mapping`
+- `e7b72d4d9` - `test(evidence): close admission review gaps`
 
 ## Pre-push Checklist
 
@@ -172,12 +173,38 @@ knowledge promotion.
 
 ## Discussion Thread Pass
 
-- [ ] Post-open review pass pending.
-- [ ] CodeRabbit/Sourcery/Cubic actionables pending live review truth.
+- [x] Post-open `qa-engineer-agent -> bug-hunter` sidecar review pass completed.
+- [ ] CodeRabbit/Sourcery/Cubic actionables pending live review truth after latest push.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments at mapping creation time.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#pullrequestreview-4235099053 -> e7b72d4d9
+Disposition: FIXED
+Commit: e7b72d4d9
+Evidence: `tests/core/evidence/test_admission.py` now mutates the returned
+`AdmissionInput.metadata` view and asserts subsequent reads are unchanged.
+
+## Sidecar Review Findings
+
+- QA sidecar finding: `admission_input_from_eval_event()` dropped source
+  event metadata and could bypass E4 metadata safety -> e7b72d4d9
+  - Disposition: FIXED
+  - Evidence: `core/evidence/admission.py` merges source metadata under
+    `event_metadata`; `tests/core/evidence/test_admission.py` covers unsafe
+    E2 event metadata rejected by the E4 adapter.
+- QA sidecar finding: `execute` could allow degraded status without
+  `allow_degraded` -> e7b72d4d9
+  - Disposition: FIXED
+  - Evidence: `core/evidence/admission.py` adds execute-specific degraded
+    blocking; `tests/core/evidence/test_admission.py` covers degraded execute
+    denial when only the status allowlist includes degraded.
+- Bug-hunter sidecar finding: raw `query_text` / eval-row text aliases could
+  pass E4 adapter metadata safety -> e7b72d4d9
+  - Disposition: FIXED
+  - Evidence: `core/evidence/admission.py` expands the metadata denylist for
+    `query_text`, `question_text`, `answer_text`, and raw query aliases;
+    `tests/core/evidence/test_admission.py` covers adapter rejection for those
+    fields.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1678_FIXED_MAPPING.md
+++ b/docs/review/PR_1678_FIXED_MAPPING.md
@@ -189,6 +189,10 @@ merge readiness.
 Disposition: FIXED
 Commit: e7b72d4d9
 Evidence: `tests/core/evidence/test_admission.py` mutates the returned `AdmissionInput.metadata` view and asserts subsequent reads are unchanged.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#discussion_r3194564127 -> e7b72d4d9
+Disposition: FIXED
+Commit: e7b72d4d9
+Evidence: `tests/core/evidence/test_admission.py` mutates the returned `AdmissionInput.metadata` dict and verifies later reads are unchanged.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#pullrequestreview-4235145977 -> 3b0b4a497
 Disposition: FIXED
 Commit: 3b0b4a497

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2297,10 +2297,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Evidence Graph Runtime umbrella
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (AI runtime governance / evidence lineage)
-  - Target PR: PR-E0 (`codex/evidence-graph-runtime-umbrella`) -> PR-E1/E2/E3/E4/E5; current slice: PR-E3 (`codex/evidence-promotion-ledger-replay`)
+  - Target PR: PR-E0 (`codex/evidence-graph-runtime-umbrella`) -> PR-E1/E2/E3/E4/E5; current slice: PR-E4 (`codex/evidence-active-metadata-admission`)
   - Area: AI runtime / RAG / evals / knowledge promotion / advisory memory
   - Finding Type: asset-lineage and replay-governance gap
-  - Status: Active PR-E3 promotion ledger + dry-run replay scaffold; E0/E1/E2 are baseline, #1666/#1667 eval-sidecar hardening is baseline, and PR-E4 active metadata admission remains next after E3
+  - Status: Active PR-E4 metadata admission gates; E0/E1/E2/E3 are baseline, #1666/#1667 eval-sidecar hardening is baseline, #1676 source-artifact path hardening is baseline, and PR-E5 advisory wiki evidence bridge remains next after E4
   - Remove-by: 2026-06-30
   - Reason (EN): PulsePlate already has strong RAG runtime, verification, knowledge-promotion, eval-gate, advisory-wiki, and plugin/control-plane foundations, but evidence-bearing artifacts are still governed mostly through task packets, gate outputs, and lane-specific docs rather than one asset/evidence graph. This umbrella freezes the rail boundaries and PR train needed to make eval runs, context bundles, verification bundles, knowledge candidates, knowledge records, and gate reports first-class assets with lineage, idempotency, replay, fingerprints, policy versions, and admission decisions.
   - Links:
@@ -2320,6 +2320,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - PR-E0 remains docs/governance only with no public API, DB migration, endpoint, OpenAPI, billing, provider, semantic-cache, GraphRAG, or user-facing runtime behavior change
     - PR-E2 adds a deterministic schema-only eval event contract and documentation without adding runtime behavior, OpenAPI changes, DB migration, semantic cache, GraphRAG, advisory wiki authority, or promotion/replay logic
     - PR-E3 adds deterministic promotion ledger and dry-run replay contracts without adding runtime behavior, OpenAPI changes, DB migration, semantic cache, GraphRAG, advisory wiki authority, eval runners, or persistent writers
+    - PR-E4 adds deterministic `allow_execute`, `allow_promote`, and `allow_serve` metadata admission contracts without adding runtime behavior, OpenAPI changes, DB migration, semantic cache, GraphRAG, advisory wiki authority, eval runners, or side effects
 
 <a id="ledger-p1-apple-server-api-migration"></a>
 - [ ] P1: Apple receipt verification migration to App Store Server API

--- a/docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md
+++ b/docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md
@@ -91,8 +91,9 @@ for later slices.
    - Depends on PR-E1, PR-E2, and PR-E3.
    - No LLM call, hidden bypass flag, runtime writer, semantic cache, GraphRAG,
      or advisory-wiki authority.
-   - Done when admission can block execute/promote/serve decisions before any
-     side effect and all blocking reasons are deterministic and test-covered.
+   - Done when the contract can produce deterministic non-allowing decisions
+     for execute/promote/serve candidates before any side effect; runtime
+     integration remains deferred to a separate wiring PR.
 
 5. **PR-E5: Advisory wiki evidence bridge**
    - Backlog owner: [`ledger-p1-evidence-graph-runtime`](./BACKLOG_LEDGER.md#ledger-p1-evidence-graph-runtime).

--- a/docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md
+++ b/docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD013 -->
 # PulsePlate Evidence Graph Runtime Epic
 
-**Status:** PR-E3 promotion ledger and replay scaffold
+**Status:** PR-E4 active metadata admission gates
 **Date:** 2026-04-28 (`America/New_York`)
 **Canonical backlog anchor:** [`ledger-p1-evidence-graph-runtime`](./BACKLOG_LEDGER.md#ledger-p1-evidence-graph-runtime)
 
@@ -89,9 +89,10 @@ for later slices.
      `allow_serve` using stale-upstream, policy, degraded-reason, fallback-rate,
      coverage, verification, and fingerprint checks.
    - Depends on PR-E1, PR-E2, and PR-E3.
-   - No LLM call or hidden bypass flag.
-   - Done when admission can block promotion before writes and all blocking
-     reasons are deterministic and test-covered.
+   - No LLM call, hidden bypass flag, runtime writer, semantic cache, GraphRAG,
+     or advisory-wiki authority.
+   - Done when admission can block execute/promote/serve decisions before any
+     side effect and all blocking reasons are deterministic and test-covered.
 
 5. **PR-E5: Advisory wiki evidence bridge**
    - Backlog owner: [`ledger-p1-evidence-graph-runtime`](./BACKLOG_LEDGER.md#ledger-p1-evidence-graph-runtime).
@@ -119,6 +120,9 @@ After PR-E1 + PR-E2:
 
 After PR-E1 + PR-E2 + PR-E3:
   PR-E4 active metadata admission
+
+After PR-E4:
+  PR-E5 advisory wiki evidence bridge
 ```
 
 ## Hard Boundaries

--- a/tests/core/evidence/test_admission.py
+++ b/tests/core/evidence/test_admission.py
@@ -175,6 +175,39 @@ def test_admission_input_can_be_created_from_eval_event() -> None:
     assert admission_input.metadata["event_metadata"] == event.metadata
 
 
+def test_admission_adapter_preserves_source_and_admission_metadata() -> None:
+    event = _source_event()
+    admission_input = admission_input_from_eval_event(
+        event=event,
+        coverage_rate=0.9,
+        verification_rate=0.95,
+        fallback_rate=0.02,
+        metadata={"operator_note": "reviewed"},
+    )
+
+    assert admission_input.metadata == {
+        "admission_metadata": {"operator_note": "reviewed"},
+        "event_metadata": event.metadata,
+    }
+
+
+def test_admission_adapters_reject_wrong_source_contracts() -> None:
+    with pytest.raises(ValueError, match="EvidenceEvalEvent"):
+        admission_input_from_eval_event(
+            event=cast(EvidenceEvalEvent, object()),
+            coverage_rate=0.9,
+            verification_rate=0.95,
+            fallback_rate=0.02,
+        )
+    with pytest.raises(ValueError, match="PromotionLedgerEntry"):
+        admission_input_from_ledger_entry(
+            entry=cast(Any, object()),
+            coverage_rate=0.9,
+            verification_rate=0.95,
+            fallback_rate=0.02,
+        )
+
+
 def test_eval_event_adapter_preserves_source_metadata_for_admission_safety() -> None:
     event = _source_event(
         idempotency_key="idem:rag-gate-run-unsafe-e4-metadata",
@@ -269,6 +302,17 @@ def test_admission_blocks_execute_degraded_status_without_degraded_policy() -> N
 
     assert decision.allowed is False
     assert "execute_requires_degraded_policy" in decision.blocking_reasons
+
+
+def test_admission_blocks_status_not_allowed() -> None:
+    decision = decide_allow_execute(
+        admission_input=_input(validation_status="degraded"),
+        policy=_policy(),
+        now=_NOW,
+    )
+
+    assert decision.allowed is False
+    assert "validation_status_not_allowed" in decision.blocking_reasons
 
 
 def test_admission_blocks_promote_when_verification_below_threshold() -> None:
@@ -408,6 +452,12 @@ def test_admission_rejects_non_finite_or_out_of_range_metrics(metric_value: floa
         _input(coverage_rate=metric_value)
 
 
+@pytest.mark.parametrize("metric_value", [True, "0.5"])
+def test_admission_rejects_non_numeric_metric_types(metric_value: object) -> None:
+    with pytest.raises(ValueError, match="coverage_rate"):
+        _input(coverage_rate=cast(float, metric_value))
+
+
 def test_admission_rejects_unsupported_event_type_and_decision_by_policy() -> None:
     event_blocked = decide_allow_execute(
         admission_input=_input(event_type="ragas_report"),
@@ -441,6 +491,30 @@ def test_admission_rejects_policy_mismatch_and_bad_policy_values() -> None:
         _policy(stale_after_seconds=-1)
     with pytest.raises(ValueError, match="allow_degraded"):
         _policy(allow_degraded=cast(Any, "yes"))
+
+
+def test_admission_rejects_identity_whitespace_and_empty_degraded_reason() -> None:
+    with pytest.raises(ValueError, match="target_id"):
+        _input(target_id="eval-event:bad token")
+    with pytest.raises(ValueError, match="degraded_reason"):
+        _input(degraded_reason=" ")
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        cast(dict[str, object], {1: "bad"}),
+        {" ": "bad"},
+        {"label": "first", " Label ": "second"},
+        {"metric": float("inf")},
+        {"unsupported": object()},
+    ],
+)
+def test_admission_rejects_non_string_empty_colliding_or_unsupported_metadata(
+    metadata: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="metadata"):
+        _input(metadata=metadata)
 
 
 def test_admission_preserves_metadata_upstreams_and_decision_metadata_defensively() -> None:

--- a/tests/core/evidence/test_admission.py
+++ b/tests/core/evidence/test_admission.py
@@ -124,6 +124,7 @@ def test_admission_allows_valid_execute_input() -> None:
     assert decision.action == "execute"
     assert decision.reason_codes == ("execute_allowed",)
     assert decision.blocking_reasons == ()
+    assert decision.produced_at == _NOW
     assert decision.decision_id.startswith("admission-decision:")
 
 
@@ -438,6 +439,8 @@ def test_admission_rejects_policy_mismatch_and_bad_policy_values() -> None:
         )
     with pytest.raises(ValueError, match="stale_after_seconds"):
         _policy(stale_after_seconds=-1)
+    with pytest.raises(ValueError, match="allow_degraded"):
+        _policy(allow_degraded=cast(Any, "yes"))
 
 
 def test_admission_preserves_metadata_upstreams_and_decision_metadata_defensively() -> None:

--- a/tests/core/evidence/test_admission.py
+++ b/tests/core/evidence/test_admission.py
@@ -171,6 +171,41 @@ def test_admission_input_can_be_created_from_eval_event() -> None:
     assert admission_input.target_id == event.event_id
     assert admission_input.source_event_id == event.event_id
     assert admission_input.event_type == "rag_gate_run"
+    assert admission_input.metadata["event_metadata"] == event.metadata
+
+
+def test_eval_event_adapter_preserves_source_metadata_for_admission_safety() -> None:
+    event = _source_event(
+        idempotency_key="idem:rag-gate-run-unsafe-e4-metadata",
+        metadata={"prompt": "unsafe but accepted by E2"},
+    )
+
+    with pytest.raises(ValueError, match="metadata key"):
+        admission_input_from_eval_event(
+            event=event,
+            coverage_rate=0.9,
+            verification_rate=0.95,
+            fallback_rate=0.02,
+        )
+
+
+@pytest.mark.parametrize(
+    "metadata_key",
+    ["query_text", "answer_text", "raw_query", "question_text"],
+)
+def test_eval_event_adapter_rejects_raw_eval_row_text_aliases(metadata_key: str) -> None:
+    event = _source_event(
+        idempotency_key=f"idem:rag-gate-run-{metadata_key}",
+        metadata={metadata_key: "Need help with spiraling thoughts"},
+    )
+
+    with pytest.raises(ValueError, match="metadata key"):
+        admission_input_from_eval_event(
+            event=event,
+            coverage_rate=0.9,
+            verification_rate=0.95,
+            fallback_rate=0.02,
+        )
 
 
 def test_admission_blocks_execute_with_malformed_fingerprint() -> None:
@@ -222,6 +257,17 @@ def test_admission_blocks_promote_when_status_is_not_valid(status: str) -> None:
 
     assert decision.allowed is False
     assert "promote_requires_valid_status" in decision.blocking_reasons
+
+
+def test_admission_blocks_execute_degraded_status_without_degraded_policy() -> None:
+    decision = decide_allow_execute(
+        admission_input=_input(validation_status="degraded"),
+        policy=_policy(allowed_validation_statuses=("valid", "degraded")),
+        now=_NOW,
+    )
+
+    assert decision.allowed is False
+    assert "execute_requires_degraded_policy" in decision.blocking_reasons
 
 
 def test_admission_blocks_promote_when_verification_below_threshold() -> None:
@@ -405,6 +451,8 @@ def test_admission_preserves_metadata_upstreams_and_decision_metadata_defensivel
     metadata["labels"].append("mutated")
     metadata["stats"]["coverage"] = 0.1
     upstream_ids.append("mutated")
+    returned_input_metadata = cast(dict[str, Any], admission_input.metadata)
+    returned_input_metadata["labels"].append("mutated-view")
 
     decision = decide_allow_execute(
         admission_input=admission_input,

--- a/tests/core/evidence/test_admission.py
+++ b/tests/core/evidence/test_admission.py
@@ -1,0 +1,493 @@
+from __future__ import annotations
+
+import ast
+import math
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from core.evidence.admission import (
+    AdmissionAction,
+    AdmissionInput,
+    AdmissionPolicy,
+    admission_input_from_eval_event,
+    admission_input_from_ledger_entry,
+    decide_admission,
+    decide_allow_execute,
+    decide_allow_promote,
+    decide_allow_serve,
+)
+from core.evidence.assets import create_evidence_asset_ref
+from core.evidence.events import (
+    EvalEventProducer,
+    EvidenceEvalEvent,
+    ValidationStatus,
+    create_eval_event,
+)
+from core.evidence.fingerprints import fingerprint_payload
+from core.evidence.promotion_ledger import create_promotion_ledger_entry
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_ADMISSION_MODULE = _REPO_ROOT / "core" / "evidence" / "admission.py"
+_FIXED_TIMESTAMP = "2026-05-06T12:00:00+00:00"
+_NOW = "2026-05-06T13:00:00+00:00"
+
+
+def _source_event(**overrides: object) -> EvidenceEvalEvent:
+    asset_ref = create_evidence_asset_ref(
+        asset_type="eval_run",
+        version="v1",
+        rail="runtime",
+        policy_version="policy-v1",
+        payload={"run": "rag-gate"},
+    )
+    params: dict[str, Any] = {
+        "event_type": "rag_gate_run",
+        "rail": "eval",
+        "source_artifact": "artifacts/rag_eval/run-1/traces.jsonl",
+        "asset_refs": (asset_ref,),
+        "upstream_ids": ("dataset-1", "gate-report-1"),
+        "fingerprint": fingerprint_payload({"artifact": "traces.jsonl", "rows": 2}),
+        "idempotency_key": "idem:rag-gate-run-1",
+        "policy_version": "policy-v1",
+        "producer_name": "rag-release-gates",
+        "producer_version": "v1",
+        "produced_at": _FIXED_TIMESTAMP,
+        "validation_status": "valid",
+        "metadata": {"decision": "PASS", "sample_size": 2},
+    }
+    params.update(overrides)
+    return create_eval_event(**params)
+
+
+def _producer() -> EvalEventProducer:
+    return EvalEventProducer(name="evidence-promotion-ledger", version="v1")
+
+
+def _ledger_entry(**overrides: object):
+    params: dict[str, Any] = {
+        "source_event": _source_event(),
+        "promotion_id": "promotion-rag-gate-1",
+        "decision": "promote",
+        "idempotency_key": "idem:promotion-rag-gate-1",
+        "producer": _producer(),
+        "produced_at": _FIXED_TIMESTAMP,
+        "reason_codes": ("policy-pass",),
+        "metadata": {"confidence": 1.0},
+    }
+    params.update(overrides)
+    return create_promotion_ledger_entry(**params)
+
+
+def _policy(**overrides: object) -> AdmissionPolicy:
+    params: dict[str, Any] = {
+        "policy_version": "policy-v1",
+        "min_verification_rate": 0.9,
+        "min_coverage_rate": 0.8,
+        "max_fallback_rate": 0.1,
+        "stale_after_seconds": 24 * 60 * 60,
+    }
+    params.update(overrides)
+    return AdmissionPolicy(**params)
+
+
+def _input(**overrides: object) -> AdmissionInput:
+    params: dict[str, Any] = {
+        "target_id": "eval-event:target-1",
+        "target_type": "eval_event",
+        "fingerprint": fingerprint_payload({"target": "eval-event-1"}),
+        "idempotency_key": "idem:admission-target-1",
+        "policy_version": "policy-v1",
+        "produced_at": _FIXED_TIMESTAMP,
+        "validation_status": "valid",
+        "coverage_rate": 0.95,
+        "verification_rate": 0.98,
+        "fallback_rate": 0.02,
+        "upstream_ids": ("gate-report-1", "dataset-1", "dataset-1"),
+        "source_event_id": "eval-event:source-1",
+        "event_type": "rag_gate_run",
+        "metadata": {"labels": ["rag", "gate"]},
+    }
+    params.update(overrides)
+    return AdmissionInput(**params)
+
+
+def test_admission_allows_valid_execute_input() -> None:
+    decision = decide_allow_execute(
+        admission_input=_input(),
+        policy=_policy(),
+        now=_NOW,
+    )
+
+    assert decision.allowed is True
+    assert decision.action == "execute"
+    assert decision.reason_codes == ("execute_allowed",)
+    assert decision.blocking_reasons == ()
+    assert decision.decision_id.startswith("admission-decision:")
+
+
+def test_admission_allows_valid_promote_input() -> None:
+    decision = decide_allow_promote(
+        admission_input=_input(),
+        policy=_policy(),
+        now=_NOW,
+    )
+
+    assert decision.allowed is True
+    assert decision.reason_codes == ("promote_allowed",)
+
+
+def test_admission_allows_serve_for_valid_non_stale_promoted_evidence() -> None:
+    entry = _ledger_entry()
+    admission_input = admission_input_from_ledger_entry(
+        entry=entry,
+        coverage_rate=0.95,
+        verification_rate=0.99,
+        fallback_rate=0.01,
+    )
+
+    decision = decide_allow_serve(
+        admission_input=admission_input,
+        policy=_policy(),
+        now=_NOW,
+    )
+
+    assert decision.allowed is True
+    assert decision.target_type == "promotion_ledger_entry"
+    assert decision.reason_codes == ("serve_allowed",)
+
+
+def test_admission_input_can_be_created_from_eval_event() -> None:
+    event = _source_event()
+
+    admission_input = admission_input_from_eval_event(
+        event=event,
+        coverage_rate=0.9,
+        verification_rate=0.95,
+        fallback_rate=0.02,
+    )
+
+    assert admission_input.target_id == event.event_id
+    assert admission_input.source_event_id == event.event_id
+    assert admission_input.event_type == "rag_gate_run"
+
+
+def test_admission_blocks_execute_with_malformed_fingerprint() -> None:
+    with pytest.raises(ValueError, match="fingerprint"):
+        _input(fingerprint="not-a-fingerprint")
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("target_id", " ", "target_id"),
+        ("target_type", "cache", "target_type"),
+        ("idempotency_key", " ", "idempotency_key"),
+        ("policy_version", " ", "policy_version"),
+    ],
+)
+def test_admission_rejects_blank_identity_or_unsupported_target_type(
+    field: str,
+    value: str,
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        _input(**{field: value})
+
+
+def test_admission_rejects_unsupported_status_and_action() -> None:
+    with pytest.raises(ValueError, match="unsupported validation_status"):
+        _input(validation_status=cast(ValidationStatus, "promoted"))
+
+    with pytest.raises(ValueError, match="unsupported admission action"):
+        decide_admission(
+            action=cast(AdmissionAction, "cache"),
+            admission_input=_input(),
+            policy=_policy(),
+            now=_NOW,
+        )
+
+
+@pytest.mark.parametrize("status", ["invalid", "degraded", "deferred"])
+def test_admission_blocks_promote_when_status_is_not_valid(status: str) -> None:
+    decision = decide_allow_promote(
+        admission_input=_input(validation_status=cast(ValidationStatus, status)),
+        policy=_policy(
+            allow_degraded=True,
+            allowed_validation_statuses=("valid", "invalid", "degraded", "deferred"),
+        ),
+        now=_NOW,
+    )
+
+    assert decision.allowed is False
+    assert "promote_requires_valid_status" in decision.blocking_reasons
+
+
+def test_admission_blocks_promote_when_verification_below_threshold() -> None:
+    decision = decide_allow_promote(
+        admission_input=_input(verification_rate=0.89),
+        policy=_policy(min_verification_rate=0.9),
+        now=_NOW,
+    )
+
+    assert decision.allowed is False
+    assert "verification_rate_below_threshold" in decision.blocking_reasons
+
+
+def test_admission_blocks_promote_when_coverage_below_threshold() -> None:
+    decision = decide_allow_promote(
+        admission_input=_input(coverage_rate=0.79),
+        policy=_policy(min_coverage_rate=0.8),
+        now=_NOW,
+    )
+
+    assert decision.allowed is False
+    assert "coverage_rate_below_threshold" in decision.blocking_reasons
+
+
+def test_admission_blocks_promote_when_fallback_above_threshold() -> None:
+    decision = decide_allow_promote(
+        admission_input=_input(fallback_rate=0.11),
+        policy=_policy(max_fallback_rate=0.1),
+        now=_NOW,
+    )
+
+    assert decision.allowed is False
+    assert "fallback_rate_above_threshold" in decision.blocking_reasons
+
+
+def test_admission_blocks_degraded_reason_unless_policy_allows_it() -> None:
+    blocked = decide_allow_promote(
+        admission_input=_input(degraded_reason="low-confidence-eval"),
+        policy=_policy(),
+        now=_NOW,
+    )
+    allowed = decide_allow_promote(
+        admission_input=_input(degraded_reason="low-confidence-eval"),
+        policy=_policy(allow_degraded=True),
+        now=_NOW,
+    )
+
+    assert blocked.allowed is False
+    assert "degraded_reason_not_allowed" in blocked.blocking_reasons
+    assert allowed.allowed is True
+    assert allowed.warnings == ("degraded_input_allowed",)
+
+
+def test_admission_blocks_stale_and_future_timestamps_with_explicit_now() -> None:
+    stale = decide_allow_execute(
+        admission_input=_input(produced_at="2026-05-05T12:00:00+00:00"),
+        policy=_policy(stale_after_seconds=60),
+        now=_NOW,
+    )
+    future = decide_allow_execute(
+        admission_input=_input(produced_at="2026-05-07T12:00:00+00:00"),
+        policy=_policy(),
+        now=_NOW,
+    )
+
+    assert stale.allowed is False
+    assert "stale_input" in stale.blocking_reasons
+    assert future.allowed is False
+    assert "produced_at_in_future" in future.blocking_reasons
+
+
+def test_admission_blocks_promote_without_upstream_lineage() -> None:
+    decision = decide_allow_promote(
+        admission_input=_input(upstream_ids=()),
+        policy=_policy(),
+        now=_NOW,
+    )
+
+    assert decision.allowed is False
+    assert "upstream_lineage_required" in decision.blocking_reasons
+
+
+def test_admission_blocks_serve_for_stale_or_degraded_evidence_unless_policy_allows_it() -> None:
+    stale = decide_allow_serve(
+        admission_input=_input(produced_at="2026-05-05T12:00:00+00:00"),
+        policy=_policy(stale_after_seconds=60),
+        now=_NOW,
+    )
+    degraded = decide_allow_serve(
+        admission_input=_input(validation_status="degraded"),
+        policy=_policy(allowed_validation_statuses=("valid", "degraded")),
+        now=_NOW,
+    )
+    allowed_degraded = decide_allow_serve(
+        admission_input=_input(validation_status="degraded"),
+        policy=_policy(
+            allow_degraded=True,
+            allowed_validation_statuses=("valid", "degraded"),
+        ),
+        now=_NOW,
+    )
+
+    assert stale.allowed is False
+    assert "stale_input" in stale.blocking_reasons
+    assert degraded.allowed is False
+    assert "serve_requires_valid_status" in degraded.blocking_reasons
+    assert allowed_degraded.allowed is True
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"raw_prompt": "tell me about dinner"},
+        {"raw_response": "model output"},
+        {"nested": {"user_health_payload": "private"}},
+        {"notes": "raw prompt: tell me about dinner"},
+        {"notes": "user health payload from eval item"},
+        {"notes": cast(Any, b"raw-bytes")},
+        {"token_like": "Bearer abc"},
+        {"artifact": "artifacts/rag_eval/run-1/traces.jsonl"},
+        {"note": "C:/Users/example/eval.json"},
+        {"note": "."},
+        {"note": "./"},
+        {"note": "./."},
+    ],
+)
+def test_admission_metadata_rejects_prompt_response_secret_user_health_or_paths(
+    metadata: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="metadata"):
+        _input(metadata=metadata)
+
+
+@pytest.mark.parametrize("metric_value", [math.nan, math.inf, -math.inf, -0.1, 1.1])
+def test_admission_rejects_non_finite_or_out_of_range_metrics(metric_value: float) -> None:
+    with pytest.raises(ValueError, match="coverage_rate"):
+        _input(coverage_rate=metric_value)
+
+
+def test_admission_rejects_unsupported_event_type_and_decision_by_policy() -> None:
+    event_blocked = decide_allow_execute(
+        admission_input=_input(event_type="ragas_report"),
+        policy=_policy(allowed_event_types=("rag_gate_run",)),
+        now=_NOW,
+    )
+    decision_blocked = decide_allow_serve(
+        admission_input=_input(
+            target_type="promotion_ledger_entry",
+            promotion_decision="reject",
+            promotion_id="promotion-rag-gate-1",
+        ),
+        policy=_policy(allowed_decisions=("promote", "supersede")),
+        now=_NOW,
+    )
+
+    assert event_blocked.allowed is False
+    assert "event_type_not_allowed" in event_blocked.blocking_reasons
+    assert decision_blocked.allowed is False
+    assert "promotion_decision_not_allowed" in decision_blocked.blocking_reasons
+
+
+def test_admission_rejects_policy_mismatch_and_bad_policy_values() -> None:
+    with pytest.raises(ValueError, match="policy_version"):
+        decide_allow_execute(
+            admission_input=_input(policy_version="policy-v2"),
+            policy=_policy(),
+            now=_NOW,
+        )
+    with pytest.raises(ValueError, match="stale_after_seconds"):
+        _policy(stale_after_seconds=-1)
+
+
+def test_admission_preserves_metadata_upstreams_and_decision_metadata_defensively() -> None:
+    metadata: dict[str, Any] = {
+        "labels": ["rag", "gate"],
+        "stats": {"coverage": 0.95},
+    }
+    upstream_ids = ["z-upstream", "a-upstream"]
+    admission_input = _input(metadata=metadata, upstream_ids=upstream_ids)
+
+    metadata["labels"].append("mutated")
+    metadata["stats"]["coverage"] = 0.1
+    upstream_ids.append("mutated")
+
+    decision = decide_allow_execute(
+        admission_input=admission_input,
+        policy=_policy(),
+        now=_NOW,
+    )
+    returned_metadata = cast(dict[str, Any], decision.metadata)
+    returned_metadata["input"]["metadata"]["labels"].append("also-mutated")
+
+    assert admission_input.upstream_ids == ("a-upstream", "z-upstream")
+    assert admission_input.metadata == {
+        "labels": ["rag", "gate"],
+        "stats": {"coverage": 0.95},
+    }
+    decision_metadata = cast(dict[str, Any], decision.metadata)
+    assert decision_metadata["input"]["metadata"] == {
+        "labels": ["rag", "gate"],
+        "stats": {"coverage": 0.95},
+    }
+
+
+def test_admission_stable_serialization_and_decision_identity() -> None:
+    first = _input(
+        upstream_ids=("z-upstream", "a-upstream", "z-upstream"),
+        metadata={"z": 1, "a": ["x", "y"]},
+    )
+    second = _input(
+        upstream_ids=("a-upstream", "z-upstream"),
+        metadata={"a": ["x", "y"], "z": 1},
+    )
+
+    first_decision = decide_allow_promote(
+        admission_input=first,
+        policy=_policy(),
+        now=_NOW,
+    )
+    second_decision = decide_allow_promote(
+        admission_input=second,
+        policy=_policy(),
+        now=_NOW,
+    )
+
+    assert first_decision.decision_id == second_decision.decision_id
+    assert first_decision.to_json() == second_decision.to_json()
+
+
+def test_admission_rejects_current_directory_degraded_reason_without_index_error() -> None:
+    with pytest.raises(ValueError, match="path-like"):
+        _input(degraded_reason="./.")
+
+
+def test_admission_module_does_not_import_runtime_surfaces() -> None:
+    forbidden_prefixes = (
+        "app",
+        "fastapi",
+        "legacy_app",
+        "providers",
+        "redis",
+        "scripts.evals",
+        "evals",
+        "sqlalchemy",
+        "mcp_pulseplate_server",
+    )
+    forbidden_fragments = (
+        "cache",
+        "graphrag",
+        "semantic_cache",
+        "support_plane",
+        "wiki",
+        "knowledge",
+    )
+    tree = ast.parse(_ADMISSION_MODULE.read_text(encoding="utf-8"))
+
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imported_modules.append(node.module)
+
+    for module_name in imported_modules:
+        assert not any(
+            module_name == prefix or module_name.startswith(f"{prefix}.")
+            for prefix in forbidden_prefixes
+        )
+        assert not any(fragment in module_name.lower() for fragment in forbidden_fragments)


### PR DESCRIPTION
# PR 1678 Fixed Mapping

PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678
Branch: `codex/evidence-active-metadata-admission`
Title: `feat(evidence): add active metadata admission gates`

## Summary

PR-E4 adds deterministic active metadata admission gates for Evidence Graph
Runtime. It introduces internal `allow_execute`, `allow_promote`, and
`allow_serve` decision contracts over E1/E2/E3 evidence metadata.

## Goal

Make evidence execution, promotion, and serving decisions deterministic,
replay-compatible, policy-visible, metadata-safe, and side-effect free.

## Business Reason

This PR closes the next Evidence Graph reliability gap by preventing future AI
release gates, semantic-cache gates, and metadata admission decisions from
relying on scattered ad hoc checks.

This PR does not add visible product features.

## Split Justification

This PR is larger than the default Tier 1 size target because PR-E4 needs one coherent contract slice: the pure admission module, deterministic tests, contract documentation, scoped evidence-agent guidance, backlog/epic status updates, and review-governance mapping. The scope remains intentionally bounded to `core/evidence`, `tests/core/evidence`, Evidence Graph docs, and the canonical review artifact. No runtime/API/DB/provider/cache/wiki/frontend/iOS files are touched.

## Scope

- `core/evidence/admission.py` with admission policy/input/decision contracts.
- Deterministic `decide_admission`, `decide_allow_execute`,
  `decide_allow_promote`, and `decide_allow_serve` helpers.
- Fail-closed metadata validation for prompt/response/user-health/secret and
  path-like payloads.
- Focused tests for thresholds, staleness, metadata safety, mutation safety,
  stable serialization, and import boundaries.
- Contract, backlog, epic, and scoped agent-instruction documentation.

## Out Of Scope

- Semantic cache, Redis, GPTCache, or cache-hit logic.
- GraphRAG or knowledge graph runtime.
- Product RAG behavior or `core/knowledge/promotion.py` rewrites.
- Runtime routes, FastAPI, OpenAPI, DB migrations, providers, eval runners, or
  RAGAS runner behavior.
- Online eval, judge calibration, goldens, dashboards, frontend/iOS/design
  changes, billing/auth/compliance surfaces, or advisory wiki authority.

## Files Touched

- `core/evidence/admission.py`
- `core/evidence/__init__.py`
- `core/evidence/AGENTS.md`
- `tests/core/evidence/test_admission.py`
- `docs/orchestration/contracts/EVIDENCE_METADATA_ADMISSION.md`
- `docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/review/PR_1678_FIXED_MAPPING.md`

## Coordinator Bootstrap

- Pre-open packet: `a7b8aa010ed7`
- Post-open review packet: `fa1dd5432386`
- Declared pre-open role order:
  `agent-coordinator -> architecture-specialist -> rag-systems-agent -> data-scientist-agent -> security-auditor -> qa-engineer-agent -> bug-hunter -> cursor-specialist-agent`
- Mandatory post-open lane:
  `qa-engineer-agent -> bug-hunter`

## Tests

- PASS: `python3 scripts/orchestration/check_preflight.py`
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
- PASS: `.venv/bin/python -m pytest -q tests/core/evidence/test_admission.py tests/core/evidence/test_promotion_ledger.py tests/core/evidence/test_replay.py tests/core/evidence/test_events.py tests/core/evidence/test_assets.py tests/core/evidence/test_fingerprints.py`
- PASS: `.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null core/evidence tests/core/evidence/test_admission.py`
- PASS: `make validate-changed`
- PASS: `pre-commit run --all-files`
- PASS: pre-push hook set: changed-files mypy, pip-audit, backend pre-push
  tests, full-repo Bandit, docker build test

Full local `make verify` was intentionally not run under the
operator-approved machine-heavy exception. Current-head GitHub CI parity and
strict merge-readiness remain required before merge.

## Security Notes

Admission metadata rejects raw prompt/response/user-health/secret fields,
obvious secret strings, bytes, non-JSON values, and path-like strings including
`.`, `./`, and `./.`.

AST import guards block runtime, provider, DB/session, Redis/cache/GPTCache,
semantic cache, GraphRAG, eval-runner, and advisory wiki/support-plane imports.

## Premortem

| Risk | Disposition | Evidence |
| --- | --- | --- |
| Runtime side effects | FIXED | `core/evidence/admission.py` is pure contracts/helpers; no writes, DB, network, routes, or providers. |
| Semantic cache or GraphRAG side door | FIXED | Import guard blocks cache/GraphRAG fragments; docs state semantic-cache prerequisites remain incomplete. |
| Product knowledge promotion duplication | FIXED | E4 does not import or rewrite `core/knowledge/promotion.py`; import guard blocks `knowledge` fragments. |
| Invalid/degraded evidence promotion | FIXED | Promote path requires valid status plus threshold and lineage checks. |
| Wall-clock nondeterminism | FIXED | Decision helpers require explicit `now`; tests cover stale and future timestamps. |
| Bad numeric metrics | FIXED | Metrics must be finite values in `[0, 1]`; tests cover NaN/inf/out-of-range. |
| Raw prompt/health/secret metadata | FIXED | Recursive metadata validation and tests reject unsafe keys and strings. |
| PR #1676-style current-directory path bug | FIXED | Admission metadata rejects `.`, `./`, `./.` with stable `ValueError`. |
| Rail/runtime/advisory mixing | FIXED | `core/evidence/AGENTS.md` and AST tests keep E4 inside pure evidence contracts. |
| Checklist-only fixes | FIXED | Premortem findings were converted into validators, tests, and docs before mapping. |
| Scope widening into eval platform | FIXED | PR excludes goldens, judge calibration, dashboards, online eval, and eval runners. |

## Rollback / Risks

Rollback is low risk: revert the internal contract/test/docs commits. No
runtime caller, API, DB, provider, cache, or eval runner is changed.

Residual risk: no production caller exercises admission yet. Later PRs must
wire E4 carefully without treating it as semantic-cache approval.

## DoD

- [x] `core/evidence/admission.py` exists.
- [x] Admission policy/input/decision contracts exist.
- [x] `allow_execute`, `allow_promote`, and `allow_serve` semantics are
  deterministic and test-covered.
- [x] Invalid/degraded/stale/low-coverage/high-fallback evidence blocks
  promotion.
- [x] Metadata safety is fail-closed.
- [x] No runtime/API/OpenAPI/DB/provider/eval-runner/cache/wiki changes.
- [x] No semantic cache or GraphRAG scope.
- [x] No product knowledge promotion rewrite.
- [x] Tests cover metrics, staleness, validation status, metadata safety,
  mutation safety, stable serialization, import boundaries, and PR
  #1676-style path regression.
- [x] Backlog/Evidence epic points to PR-E5 advisory wiki evidence bridge as
  the next Evidence Graph step after E4.

## Commit Breakdown

- `79dbda67a` - `feat(evidence): add active metadata admission gates`
- `1fff9eae9` - `docs(review): add PR 1678 fixed mapping`
- `e7b72d4d9` - `test(evidence): close admission review gaps`
- `3b0b4a497` - `fix(evidence): tighten admission decision validation`
- `767747fed` - `test(evidence): cover admission fail-closed branches`
- `38fe2b04d` - `fix(evidence): address admission review comments`

## Pre-push Checklist

- [x] Coordinator preflight and agent consistency gates run.
- [x] Focused pytest bundle passed.
- [x] Narrow mypy passed.
- [x] `make validate-changed` passed after implementation commit.
- [x] `pre-commit run --all-files` passed.
- [x] Branch pushed successfully.

## Post-merge Checklist

- Sync local `main` with `git fetch --prune origin` and
  `git merge --ff-only origin/main`.
- Confirm `HEAD...origin/main = 0 0`.
- Prune merged branch/worktree only after merge.
- Keep semantic cache blocked until a separate dedicated gate opens.
- Start PR-E5 advisory wiki evidence bridge only from clean synced main and
  current repo truth.

## AGENTS.md Updates

Updated `core/evidence/AGENTS.md` with E4-specific guidance: admission
decisions are pure gates, require explicit timestamp input, and must not write,
import runtime/provider/DB/cache/wiki/eval-runner surfaces, or rewrite product
knowledge promotion.

## Deferred / Follow-ups

- PR-E5 advisory wiki evidence bridge remains next in the Evidence Graph train.
- Semantic cache remains deferred until its dedicated gate opens with
  observability, false-hit guardrails, rollout contract, and current-head CI
  governance.
- AI release gates, goldens, judge calibration, dashboards, and online eval
  remain later eval-roadmap work, not E4.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Post-open `qa-engineer-agent -> bug-hunter` sidecar review pass completed.
CodeRabbit/Sourcery/Cubic final no-actionables check remains required before
merge readiness.

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#pullrequestreview-4235099053 -> e7b72d4d9
Disposition: FIXED
Commit: e7b72d4d9
Evidence: `tests/core/evidence/test_admission.py` mutates the returned `AdmissionInput.metadata` view and asserts subsequent reads are unchanged.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#discussion_r3194564127 -> e7b72d4d9
Disposition: FIXED
Commit: e7b72d4d9
Evidence: `tests/core/evidence/test_admission.py` mutates the returned `AdmissionInput.metadata` dict and verifies later reads are unchanged.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#pullrequestreview-4235145977 -> 3b0b4a497
Disposition: FIXED
Commit: 3b0b4a497
Evidence: Cubic identified decision timestamp and `allow_degraded` validation risks; `core/evidence/admission.py` now validates `allow_degraded` as a strict bool and sets `AdmissionDecision.produced_at` from explicit `now`, while `tests/core/evidence/test_admission.py` covers both paths.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#discussion_r3194572157 -> 3b0b4a497
Disposition: FIXED
Commit: 3b0b4a497
Evidence: `core/evidence/admission.py` rejects non-bool `AdmissionPolicy.allow_degraded`, and `tests/core/evidence/test_admission.py` covers string truthy degraded policy rejection.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#discussion_r3194605225 -> 3b0b4a497
Disposition: FIXED
Commit: 3b0b4a497
Evidence: `core/evidence/admission.py` validates `AdmissionPolicy.allow_degraded` as strict bool, and `tests/core/evidence/test_admission.py` rejects non-bool truthy degraded policy values.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#discussion_r3194605231 -> 3b0b4a497
Disposition: FIXED
Commit: 3b0b4a497
Evidence: `core/evidence/admission.py` sets `AdmissionDecision.produced_at` from explicit decision `now`, and `tests/core/evidence/test_admission.py` covers decision-time output.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#pullrequestreview-4235246205 -> 38fe2b04d
Disposition: FIXED
Commit: 38fe2b04d
Evidence: `core/evidence/admission.py` removes the unused promotion-decision import, and `docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md` clarifies E4 as contract-level admission with runtime wiring deferred.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#discussion_r3194694058 -> 38fe2b04d
Disposition: FIXED
Commit: 38fe2b04d
Evidence: `core/evidence/admission.py` removes the unused `ALLOWED_PROMOTION_DECISIONS` import while preserving required promotion ledger imports.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1678#discussion_r3194694074 -> 38fe2b04d
Disposition: FIXED
Commit: 38fe2b04d
Evidence: `docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md` now states E4 produces deterministic contract-level blocking decisions and defers runtime integration to a separate wiring PR.

## Sidecar Review Findings

- QA sidecar finding: `admission_input_from_eval_event()` dropped source
  event metadata and could bypass E4 metadata safety -> e7b72d4d9
  - Disposition: FIXED
  - Evidence: `core/evidence/admission.py` merges source metadata under
    `event_metadata`; `tests/core/evidence/test_admission.py` covers unsafe
    E2 event metadata rejected by the E4 adapter.
- QA sidecar finding: `execute` could allow degraded status without
  `allow_degraded` -> e7b72d4d9
  - Disposition: FIXED
  - Evidence: `core/evidence/admission.py` adds execute-specific degraded
    blocking; `tests/core/evidence/test_admission.py` covers degraded execute
    denial when only the status allowlist includes degraded.
- Bug-hunter sidecar finding: raw `query_text` / eval-row text aliases could
  pass E4 adapter metadata safety -> e7b72d4d9
  - Disposition: FIXED
  - Evidence: `core/evidence/admission.py` expands the metadata denylist for
    `query_text`, `question_text`, `answer_text`, and raw query aliases;
    `tests/core/evidence/test_admission.py` covers adapter rejection for those
    fields.

## Merge Readiness

Not merge-ready at mapping creation time.

Required before merge:

- current-head CI parity clean;
- diff coverage clean;
- CodeRabbit/Sourcery/Cubic no-actionables;
- all review threads resolved with disposition evidence;
- strict merge-readiness wrapper with auth;
- mandatory review wait-window after latest bot/review activity.
