### PR TITLE
feat(release): add review build production-candidate equivalence check

### DIFF
--- a/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
+++ b/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
@@ -101,9 +101,9 @@ changes.
 | PR-0 | `release/release-control-plane-pr0-bootstrap` | Epic, packet, C4 release-risk context, ledger anchor | docs/ledger validation and repo policy guards |
 | PR-1 | `release/release-control-plane-pr1-reviewer-hash` | Reviewer-packet hash contract consuming App Store readiness artifacts | reviewer hash schema tests and Fastlane artifact-name discovery |
 | PR-2 | `release/release-control-plane-pr2-rag-gate-export` | RAG/ML gate result export contract over the existing eval runner | gate-result schema tests |
-| PR-3 | `release/release-control-plane-pr3-release-manifest` | Release manifest generator and validator | manifest validator tests |
-| PR-4 | `release/release-control-plane-pr4-build-equivalence` | Review build equals production-candidate equivalence check | equivalence tests |
-| PR-5 | `release/release-control-plane-pr5-ci-gates` | CI integration for release packet, gate result, SBOM/provenance references, and fail-closed decision | focused CI/workflow contract tests |
+| PR-3 | `release/release-control-plane-pr3-release-manifest` | Release manifest generator and validator, merged as PR #1605 | manifest validator tests |
+| PR-4 | `release/release-control-plane-pr4-build-equivalence` | Active review build equals production-candidate equivalence check | equivalence tests |
+| PR-5 | `release/release-control-plane-pr5-ci-gates` | Deferred CI integration for release packet, gate result, SBOM/provenance references, and fail-closed decision | focused CI/workflow contract tests |
 
 ## Release Packet Contract
 
@@ -196,6 +196,27 @@ required identity groups are complete, RAG gate result is `PASS`, supply-chain
 digests are valid OCI `sha256:<hex>` values, and `attestation_status` is
 `VERIFIED`; otherwise it is `BLOCK` with deterministic `decision_reasons`.
 
+### PR-4 Build Equivalence Contract
+
+PR-4 defines an internal deterministic checker that compares App Review build
+identity and production-candidate build identity against the PR-3
+`release-manifest.v1` contract. The machine-readable schema and field contract
+live in
+[`docs/release/BUILD_EQUIVALENCE_CONTRACT.md`](../release/BUILD_EQUIVALENCE_CONTRACT.md)
+and
+[`docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json`](../release/BUILD_EQUIVALENCE_CONTRACT.schema.json).
+
+The deterministic helper is `scripts/release/build_equivalence.py`. It consumes
+explicit review-build identity, production-candidate identity, and release
+manifest JSON paths. It compares build identity, artifact digest,
+`release_manifest_hash`, and optional reviewer, ML, and supply-chain identity
+snapshots when present. It returns `EQUIVALENT` only when all required fields
+match; otherwise it returns `BLOCK` with deterministic `reason_codes` and
+`mismatch_details`. PR-4 does not add GitHub Actions enforcement, protected App
+Store upload automation, Fastlane mutation, runtime behavior, OpenAPI changes,
+RAG behavior changes, semantic cache, or product-facing behavior. PR-5 remains
+the deferred CI fail-closed enforcement slice.
+
 ## Bootstrap Commands
 
 Run from synced root before each slice:
@@ -249,7 +270,7 @@ Focused gates by future slice:
   `pytest -q tests/test_release_reviewer_packet_hashes.py`
 - RAG gate export: `pytest -q tests/test_rag_release_gates_runner.py`
 - release manifest: `pytest -q tests/test_release_manifest.py`
-- build equivalence: review/prod digest mismatch tests
+- build equivalence: `pytest -q tests/test_build_equivalence.py`
 - supply chain: `pytest -q tests/test_check_docker_provenance_attestation.py tests/test_python_supply_chain_controls.py`
 
 Full `make verify` remains the default before readiness claims unless the

--- a/docs/release/BUILD_EQUIVALENCE_CONTRACT.md
+++ b/docs/release/BUILD_EQUIVALENCE_CONTRACT.md
@@ -1,0 +1,123 @@
+# Build Equivalence Contract
+
+**Schema version:** `release-build-equivalence.v1`
+**Input schema version:** `release-build-identity.v1`
+**Release-control-plane slice:** PR-4, `release/release-control-plane-pr4-build-equivalence`
+**Schema:** [`BUILD_EQUIVALENCE_CONTRACT.schema.json`](BUILD_EQUIVALENCE_CONTRACT.schema.json)
+
+## Purpose
+
+This contract defines the internal deterministic check that compares the App
+Review build identity with the production-candidate build identity before a
+release can be called equivalent.
+
+PR-4 consumes the PR-3 `release-manifest.v1` contract and does not add CI
+fail-closed enforcement, App Store Connect execution, Fastlane upload mutation,
+backend routes, OpenAPI changes, iOS runtime behavior, RAG behavior changes, or
+product-facing behavior. CI enforcement remains scoped to PR-5.
+
+## Input Build Identity
+
+Each compared build identity artifact is an explicit JSON file:
+
+```json
+{
+  "schema_version": "release-build-identity.v1",
+  "hash_algorithm": "sha256",
+  "canonicalization": "json-sorted-compact-utf8-single-trailing-newline",
+  "build_identity": {
+    "git_sha": "<git sha>",
+    "ios_build_number": "100",
+    "marketing_version": "1.0",
+    "bundle_id": "app.pulseplate.PulsePlate"
+  },
+  "artifact_digest": "sha256:<64 lowercase hex>",
+  "release_manifest_hash": "<64 lowercase hex>",
+  "reviewer_identity": {},
+  "ml_identity": {},
+  "supply_chain_identity": {}
+}
+```
+
+The `reviewer_identity`, `ml_identity`, and `supply_chain_identity` snapshots
+are optional in input artifacts. When present on either side, they are compared
+against both the opposite build artifact and the release manifest.
+
+## Output Decision
+
+The checker writes deterministic JSON:
+
+```json
+{
+  "schema_version": "release-build-equivalence.v1",
+  "hash_algorithm": "sha256",
+  "canonicalization": "json-sorted-compact-utf8-single-trailing-newline",
+  "decision": "EQUIVALENT",
+  "reason_codes": [],
+  "mismatch_details": [],
+  "compared_fields": [
+    "build_identity.git_sha",
+    "build_identity.bundle_id",
+    "build_identity.marketing_version",
+    "build_identity.ios_build_number",
+    "artifact_digest",
+    "release_manifest_hash"
+  ],
+  "release_manifest_hash": "<64 lowercase hex>",
+  "tool_version": "release-build-equivalence.v1"
+}
+```
+
+`EQUIVALENT` means all required identity and digest fields match the PR-3
+manifest and each other. `BLOCK` means at least one required field is missing,
+malformed, unsupported, or mismatched. Reason codes and mismatch details are
+sorted deterministically.
+
+## Fail-Closed Reasons
+
+Stable reason codes include:
+
+- `missing_review_build_identity`
+- `missing_production_candidate_identity`
+- `malformed_review_build_identity`
+- `malformed_production_candidate_identity`
+- `invalid_release_manifest`
+- `git_sha_mismatch`
+- `bundle_id_mismatch`
+- `marketing_version_mismatch`
+- `ios_build_number_mismatch`
+- `review_build_digest_mismatch`
+- `release_manifest_hash_mismatch`
+- `reviewer_identity_mismatch`
+- `ml_identity_mismatch`
+- `supply_chain_identity_mismatch`
+- `unsupported_digest_format`
+- `attestation_not_verified`
+
+## CLI
+
+Run from the repository root with explicit file paths:
+
+```bash
+python3 scripts/release/build_equivalence.py \
+  --review-build artifacts/release/review_build_identity.json \
+  --production-candidate artifacts/release/production_candidate_identity.json \
+  --release-manifest artifacts/release/release_manifest.json \
+  --output artifacts/release/build_equivalence_result.json
+```
+
+The command writes a deterministic result JSON. It exits `0` for
+`EQUIVALENT`, exits nonzero for `BLOCK`, and exits nonzero with a controlled
+`ERROR:` line for unreadable or malformed input.
+
+## Boundaries
+
+This contract does not:
+
+- add GitHub Actions enforcement or required checks;
+- run `xcodebuild`, Fastlane, Docker, `gh`, `curl`, or App Store Connect APIs;
+- read signing material, App Store credentials, protected GitHub environment
+  secrets, provider credentials, or deployment credentials;
+- change release manifest format or create a second manifest contract;
+- change RAG thresholds, runtime retrieval/generation, backend APIs, OpenAPI,
+  iOS features, billing, semantic cache, GraphRAG, or product-facing behavior.

--- a/docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json
+++ b/docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json
@@ -33,8 +33,9 @@
     },
     "reason_codes": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
-        "type": "string"
+        "$ref": "#/$defs/reason_code"
       }
     },
     "mismatch_details": {
@@ -45,8 +46,9 @@
     },
     "compared_fields": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
-        "type": "string"
+        "$ref": "#/$defs/compared_field"
       }
     },
     "release_manifest_hash": {
@@ -58,6 +60,41 @@
     }
   },
   "$defs": {
+    "reason_code": {
+      "type": "string",
+      "enum": [
+        "missing_review_build_identity",
+        "missing_production_candidate_identity",
+        "malformed_review_build_identity",
+        "malformed_production_candidate_identity",
+        "invalid_release_manifest",
+        "git_sha_mismatch",
+        "bundle_id_mismatch",
+        "marketing_version_mismatch",
+        "ios_build_number_mismatch",
+        "review_build_digest_mismatch",
+        "release_manifest_hash_mismatch",
+        "reviewer_identity_mismatch",
+        "ml_identity_mismatch",
+        "supply_chain_identity_mismatch",
+        "unsupported_digest_format",
+        "attestation_not_verified"
+      ]
+    },
+    "compared_field": {
+      "type": "string",
+      "enum": [
+        "build_identity.git_sha",
+        "build_identity.bundle_id",
+        "build_identity.marketing_version",
+        "build_identity.ios_build_number",
+        "artifact_digest",
+        "release_manifest_hash",
+        "reviewer_identity",
+        "ml_identity",
+        "supply_chain_identity"
+      ]
+    },
     "mismatch_detail": {
       "type": "object",
       "additionalProperties": false,

--- a/docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json
+++ b/docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.app/schemas/release-build-equivalence.v1.json",
+  "title": "PulsePlate Build Equivalence Decision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "hash_algorithm",
+    "canonicalization",
+    "decision",
+    "reason_codes",
+    "mismatch_details",
+    "compared_fields",
+    "release_manifest_hash",
+    "tool_version"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "release-build-equivalence.v1"
+    },
+    "hash_algorithm": {
+      "const": "sha256"
+    },
+    "canonicalization": {
+      "const": "json-sorted-compact-utf8-single-trailing-newline"
+    },
+    "decision": {
+      "enum": [
+        "EQUIVALENT",
+        "BLOCK"
+      ]
+    },
+    "reason_codes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "mismatch_details": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/mismatch_detail"
+      }
+    },
+    "compared_fields": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "release_manifest_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "tool_version": {
+      "const": "release-build-equivalence.v1"
+    }
+  },
+  "$defs": {
+    "mismatch_detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "field",
+        "reason_code"
+      ],
+      "properties": {
+        "field": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason_code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "review_build": {},
+        "production_candidate": {},
+        "release_manifest": {}
+      }
+    }
+  }
+}

--- a/docs/release/RELEASE_CONTROL_PLANE_EPIC.md
+++ b/docs/release/RELEASE_CONTROL_PLANE_EPIC.md
@@ -91,6 +91,7 @@ review governance.
 
 4. **PR-3: release manifest generator and validator**
    - Branch: `release/release-control-plane-pr3-release-manifest`
+   - Merged as PR #1605 on 2026-04-30.
    - Generate and validate the internal release packet.
    - Fail closed on missing required identity groups.
    - Contract: [`RELEASE_MANIFEST_CONTRACT.md`](RELEASE_MANIFEST_CONTRACT.md)
@@ -99,11 +100,16 @@ review governance.
 
 5. **PR-4: review build equals production candidate**
    - Branch: `release/release-control-plane-pr4-build-equivalence`
+   - Active PR-4 slice.
    - Add digest/hash equivalence checks so the reviewed build and production candidate cannot silently diverge.
+   - Contract: [`BUILD_EQUIVALENCE_CONTRACT.md`](BUILD_EQUIVALENCE_CONTRACT.md)
+     and [`BUILD_EQUIVALENCE_CONTRACT.schema.json`](BUILD_EQUIVALENCE_CONTRACT.schema.json).
+   - Helper: `scripts/release/build_equivalence.py`.
 
 6. **PR-5: CI release decision integration**
    - Branch: `release/release-control-plane-pr5-ci-gates`
    - Add focused CI gates for release packet, RAG gate result, SBOM/provenance references, and `ALLOW` / `BLOCK` decision.
+   - Deferred until PR-4 has landed; PR-4 must not add CI fail-closed enforcement.
 
 ## Boundaries
 
@@ -173,3 +179,7 @@ Blocked: diagnosis, treatment, therapy, crisis support, guaranteed outcomes.
 5. Defer MLflow, Hugging Face cards, VEX/OPA, and protected uploads to later explicitly scoped slices.
 6. PR-1 hashes reviewer notes separately from localized App Store metadata and treats App Privacy JSON as upstream context only.
 7. PR-3 keeps the release manifest internal and fail-closed, but leaves CI enforcement to PR-5 and build equivalence to PR-4.
+8. PR-4 keeps build equivalence internal and deterministic, proving review-build
+   and production-candidate identity through digest/hash comparison only. It
+   leaves CI fail-closed enforcement to PR-5 and does not treat branch names,
+   tags, or human labels as equivalence evidence.

--- a/docs/review/PR_1679_FIXED_MAPPING.md
+++ b/docs/review/PR_1679_FIXED_MAPPING.md
@@ -1,0 +1,62 @@
+# PR 1679 Fixed Mapping
+
+**PR:** <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1679>
+**Branch:** `release/release-control-plane-pr4-build-equivalence`
+**Release-control-plane slice:** PR-4 build equivalence check
+**Canonical commit:** `56c94adda`
+**Latest review-fix commit:** `789d03ceb`
+
+## Scope
+
+PR-4 adds an internal deterministic build-equivalence checker for App Review
+build identity versus production-candidate build identity. It consumes the PR-3
+`release-manifest.v1` contract and compares build identity, artifact digest,
+release manifest hash, reviewer identity, ML identity, and supply-chain
+identity.
+
+Out of scope: PR-5 CI fail-closed enforcement, workflow mutation, App Store
+Connect execution, Fastlane upload mutation, backend routes, OpenAPI changes,
+iOS runtime changes, RAG behavior changes, semantic cache, GraphRAG, and
+product-facing behavior.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Post-open QA review found two actionable PR-4 contract gaps. Both are
+dispositioned as `FIXED` below before resolving any review thread.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1679 -> 789d03ceb
+Disposition: FIXED
+Commit: 789d03ceb
+Evidence: `scripts/release/build_equivalence.py` now turns missing review or production build identity files into deterministic `BLOCK` decisions with stable missing-identity reason codes, and now compares manifest-present `reviewer_identity`, `ml_identity`, and `supply_chain_identity` even when both build identity artifacts omit those snapshots; `tests/test_build_equivalence.py` covers missing review/prod identity files writing `BLOCK` output and omitted manifest identity snapshots returning deterministic identity mismatch reasons.
+
+## Validation
+
+- `python3 scripts/orchestration/check_preflight.py` PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS
+- `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-4: build equivalence check" --task-class Orchestration --pr-phase pre_open --path docs/roadmap/BACKLOG_LEDGER.md --path docs/release/BUILD_EQUIVALENCE_CONTRACT.md --path docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json --path scripts/release/build_equivalence.py --path tests/test_build_equivalence.py --path docs/release/RELEASE_CONTROL_PLANE_EPIC.md --path docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md --requested-agent ...` PASS, packet `4dcaa5e6be7d`
+- `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-4 post-open review: build equivalence check" --task-class Orchestration --pr-phase post_open_review --path docs/roadmap/BACKLOG_LEDGER.md --path docs/release/BUILD_EQUIVALENCE_CONTRACT.md --path docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json --path scripts/release/build_equivalence.py --path tests/test_build_equivalence.py --path docs/release/RELEASE_CONTROL_PLANE_EPIC.md --path docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md --path docs/review/PR_1679_FIXED_MAPPING.md --requested-agent ...` PASS, packet `81b582fc6671`
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_build_equivalence.py` PASS (`21 passed`) after `789d03ceb`
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_release_manifest.py` PASS (`20 passed`)
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_repo_policy_guards.py` PASS (`14 passed`)
+- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/BUILD_EQUIVALENCE_CONTRACT.md docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/roadmap/BACKLOG_LEDGER.md` PASS
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` PASS (`tests/test_build_equivalence.py`, `18 passed`) before `789d03ceb`
+- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pre-commit run --all-files` PASS before `789d03ceb`
+- Push-time hooks PASS before PR open: changed-file mypy, pip-audit, backend pre-push tests, full-repo Bandit, Docker build test
+
+## Machine-Heavy Deferral
+
+Full local `make verify` was intentionally not run per operator CPU constraint.
+This PR follows the operator-approved machine-heavy exception path: narrow local
+gates plus current-head GitHub CI before any merge-ready claim.
+
+## Merge Readiness
+
+- [ ] PR is ready for review and no longer draft.
+- [ ] Current-head required CI is green with no pending required checks.
+- [ ] CodeRabbit/Sourcery/Cubic actionable comments are dispositioned.
+- [ ] Strict merge readiness gate passes with auth.

--- a/docs/review/PR_1679_FIXED_MAPPING.md
+++ b/docs/review/PR_1679_FIXED_MAPPING.md
@@ -4,7 +4,7 @@
 **Branch:** `release/release-control-plane-pr4-build-equivalence`
 **Release-control-plane slice:** PR-4 build equivalence check
 **Canonical commit:** `56c94adda`
-**Latest review-fix commit:** `789d03ceb`
+**Latest review-fix commit:** `1a1878444`
 
 ## Scope
 
@@ -24,8 +24,8 @@ product-facing behavior.
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-Post-open QA review found two actionable PR-4 contract gaps. Both are
-dispositioned as `FIXED` below before resolving any review thread.
+Post-open QA, CodeRabbit, and Cubic review found actionable PR-4 contract gaps.
+All are dispositioned as `FIXED` below before resolving any review thread.
 
 ## Fixed in Commit Mapping
 
@@ -34,13 +34,38 @@ Disposition: FIXED
 Commit: 789d03ceb
 Evidence: `scripts/release/build_equivalence.py` now turns missing review or production build identity files into deterministic `BLOCK` decisions with stable missing-identity reason codes, and now compares manifest-present `reviewer_identity`, `ml_identity`, and `supply_chain_identity` even when both build identity artifacts omit those snapshots; `tests/test_build_equivalence.py` covers missing review/prod identity files writing `BLOCK` output and omitted manifest identity snapshots returning deterministic identity mismatch reasons.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1679#discussion_r3194675016 -> 1a1878444
+Disposition: FIXED
+Commit: 1a1878444
+Evidence: `docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json` constrains `reason_codes` and `compared_fields` with `$defs` enums and `uniqueItems`, preserving deterministic schema validation for known PR-4 output values.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1679#discussion_r3194675029 -> 1a1878444
+Disposition: FIXED
+Commit: 1a1878444
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md` now names PR #1679 in both the release-control-plane Target PR chain and PR-4 active status while preserving PR-5 as deferred.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1679#pullrequestreview-4235223961 -> 1a1878444
+Disposition: FIXED
+Commit: 1a1878444
+Evidence: CodeRabbit review summary actionables are covered by the two inline dispositions above: schema enum hardening and ledger PR #1679 traceability.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1679#discussion_r3194676918 -> 1a1878444
+Disposition: FIXED
+Commit: 1a1878444
+Evidence: `scripts/release/build_equivalence.py` now attributes malformed production-candidate validation values to `production_candidate` in `mismatch_details`; `tests/test_build_equivalence.py` covers the production-candidate schema-version malformed case.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1679#pullrequestreview-4235226467 -> 1a1878444
+Disposition: FIXED
+Commit: 1a1878444
+Evidence: Cubic review summary actionable is covered by the inline disposition above: malformed production-candidate validation errors are no longer emitted under `review_build`.
+
 ## Validation
 
 - `python3 scripts/orchestration/check_preflight.py` PASS
 - `python3 scripts/orchestration/check_agent_consistency.py` PASS
 - `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-4: build equivalence check" --task-class Orchestration --pr-phase pre_open --path docs/roadmap/BACKLOG_LEDGER.md --path docs/release/BUILD_EQUIVALENCE_CONTRACT.md --path docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json --path scripts/release/build_equivalence.py --path tests/test_build_equivalence.py --path docs/release/RELEASE_CONTROL_PLANE_EPIC.md --path docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md --requested-agent ...` PASS, packet `4dcaa5e6be7d`
 - `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-4 post-open review: build equivalence check" --task-class Orchestration --pr-phase post_open_review --path docs/roadmap/BACKLOG_LEDGER.md --path docs/release/BUILD_EQUIVALENCE_CONTRACT.md --path docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json --path scripts/release/build_equivalence.py --path tests/test_build_equivalence.py --path docs/release/RELEASE_CONTROL_PLANE_EPIC.md --path docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md --path docs/review/PR_1679_FIXED_MAPPING.md --requested-agent ...` PASS, packet `81b582fc6671`
-- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_build_equivalence.py` PASS (`21 passed`) after `789d03ceb`
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_build_equivalence.py` PASS (`22 passed`) after `1a1878444`
 - `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_release_manifest.py` PASS (`20 passed`)
 - `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_repo_policy_guards.py` PASS (`14 passed`)
 - `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/BUILD_EQUIVALENCE_CONTRACT.md docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/roadmap/BACKLOG_LEDGER.md` PASS

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -445,10 +445,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Release automation control plane for C4, App Store Review, ML gates, and supply chain
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-RELEASE-CONTROL-PLANE-PR0 -> PR-TBD-RELEASE-CONTROL-PLANE-PR5
+  - Target PR: PR-TBD-RELEASE-CONTROL-PLANE-PR0 -> PR #1605 -> `release/release-control-plane-pr4-build-equivalence` -> PR-TBD-RELEASE-CONTROL-PLANE-PR5
   - Area: release / App Store / AI evals / supply-chain / orchestration
   - Finding Type: release evidence unification gap
-  - Status: PR-0, PR-1, and PR-2 merged; PR-3 active in branch `release/release-control-plane-pr3-release-manifest`.
+  - Status: PR-0, PR-1, and PR-2 merged; PR-3 merged in PR #1605 on 2026-04-30; PR-4 active in branch `release/release-control-plane-pr4-build-equivalence`; PR-5 remains deferred for CI fail-closed enforcement. The release-control-plane epic is not complete and is not production-ready.
   - Reason (EN): The App Store readiness PR train is owned separately, while the attached release-automation document also identifies a cross-cutting control-plane gap: build identity, reviewer packet identity, RAG/ML gate identity, supply-chain provenance, and the final release decision are not yet represented by one machine-readable release packet. This line complements PR `#1582` without editing its branch or worktree.
   - Links:
     - `docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md`
@@ -459,7 +459,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/release/RAG_GATE_RESULT_EXPORT_CONTRACT.schema.json`
     - `docs/release/RELEASE_MANIFEST_CONTRACT.md`
     - `docs/release/RELEASE_MANIFEST_CONTRACT.schema.json`
+    - `docs/release/BUILD_EQUIVALENCE_CONTRACT.md`
+    - `docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json`
     - `scripts/release/release_manifest.py`
+    - `scripts/release/build_equivalence.py`
     - `docs/architecture/C4_RELEASE_CONTROL_PLANE_CONTEXT.md`
     - `docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md`
     - `scripts/evals/run_rag_release_gates.py`
@@ -469,9 +472,9 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - PR-0 lands governance docs, C4 release-risk context, packet, and this ledger anchor without runtime/workflow changes.
     - PR-1 defines reviewer-packet hash contract after App Store readiness artifacts land on `main`, including `reviewer_notes_hash`, `appstore_metadata_hash`, canonical UTF-8 SHA-256 rules, and schema tests.
     - PR-2 exports a stable RAG/ML gate-result schema from the existing release-gate runner without creating a second eval source of truth, including `rag_gate_result_hash`, `eval_artifact_hash`, existing `PASS` / `NO-GO` eval decision fields, and safe artifact references.
-    - PR-3 adds a release manifest generator and fail-closed validator.
-    - PR-4 proves review-build and production-candidate equivalence by digest/hash checks.
-    - PR-5 integrates focused CI gates for manifest, ML gate result, SBOM/provenance references, and `ALLOW` / `BLOCK` decision.
+    - PR-3 adds a release manifest generator and fail-closed validator. Completed by PR #1605.
+    - PR-4 proves review-build and production-candidate equivalence by digest/hash checks. Active in `release/release-control-plane-pr4-build-equivalence`.
+    - PR-5 integrates focused CI gates for manifest, ML gate result, SBOM/provenance references, and `ALLOW` / `BLOCK` decision. Deferred until PR-4 merges; PR-4 must not add CI fail-closed enforcement.
 
 <a id="ledger-p1-planning-flow-monetization-wave"></a>
 - [ ] P1: Planning-flow monetization wave over the canonical FREE -> PRO -> VIP ladder

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -445,10 +445,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Release automation control plane for C4, App Store Review, ML gates, and supply chain
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-RELEASE-CONTROL-PLANE-PR0 -> PR #1605 -> `release/release-control-plane-pr4-build-equivalence` -> PR-TBD-RELEASE-CONTROL-PLANE-PR5
+  - Target PR: PR-TBD-RELEASE-CONTROL-PLANE-PR0 -> PR #1605 -> PR #1679 (`release/release-control-plane-pr4-build-equivalence`) -> PR-TBD-RELEASE-CONTROL-PLANE-PR5
   - Area: release / App Store / AI evals / supply-chain / orchestration
   - Finding Type: release evidence unification gap
-  - Status: PR-0, PR-1, and PR-2 merged; PR-3 merged in PR #1605 on 2026-04-30; PR-4 active in branch `release/release-control-plane-pr4-build-equivalence`; PR-5 remains deferred for CI fail-closed enforcement. The release-control-plane epic is not complete and is not production-ready.
+  - Status: PR-0, PR-1, and PR-2 merged; PR-3 merged in PR #1605 on 2026-04-30; PR-4 active in PR #1679 on branch `release/release-control-plane-pr4-build-equivalence`; PR-5 remains deferred for CI fail-closed enforcement. The release-control-plane epic is not complete and is not production-ready.
   - Reason (EN): The App Store readiness PR train is owned separately, while the attached release-automation document also identifies a cross-cutting control-plane gap: build identity, reviewer packet identity, RAG/ML gate identity, supply-chain provenance, and the final release decision are not yet represented by one machine-readable release packet. This line complements PR `#1582` without editing its branch or worktree.
   - Links:
     - `docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md`

--- a/scripts/release/build_equivalence.py
+++ b/scripts/release/build_equivalence.py
@@ -137,10 +137,17 @@ def _validate_build_artifact(
     payload: dict[str, Any],
     *,
     label: str,
+    source_field: str,
     missing_reason: str,
     malformed_reason: str,
 ) -> list[Mismatch]:
     mismatches: list[Mismatch] = []
+
+    def _source_mismatch(field: str, reason_code: str, value: Any) -> Mismatch:
+        if source_field == "review_build":
+            return Mismatch(field, reason_code, review_build=value)
+        return Mismatch(field, reason_code, production_candidate=value)
+
     if not payload:
         mismatches.append(Mismatch(label, missing_reason))
         return mismatches
@@ -159,7 +166,7 @@ def _validate_build_artifact(
                 Mismatch(
                     field_name,
                     malformed_reason,
-                    review_build=value,
+                    **{source_field: value},
                     release_manifest=expected_value,
                 )
             )
@@ -174,7 +181,7 @@ def _validate_build_artifact(
                 mismatches.append(Mismatch(f"build_identity.{field_name}", missing_reason))
             elif not isinstance(value, str) or not value:
                 mismatches.append(
-                    Mismatch(f"build_identity.{field_name}", malformed_reason, review_build=value)
+                    _source_mismatch(f"build_identity.{field_name}", malformed_reason, value)
                 )
 
     artifact_digest = payload.get("artifact_digest")
@@ -184,7 +191,7 @@ def _validate_build_artifact(
         artifact_digest, str
     ) or not release_manifest.OCI_SHA256_DIGEST_RE.fullmatch(artifact_digest):
         mismatches.append(
-            Mismatch("artifact_digest", "unsupported_digest_format", review_build=artifact_digest)
+            _source_mismatch("artifact_digest", "unsupported_digest_format", artifact_digest)
         )
 
     release_manifest_hash = payload.get("release_manifest_hash")
@@ -194,18 +201,14 @@ def _validate_build_artifact(
         release_manifest_hash
     ):
         mismatches.append(
-            Mismatch(
-                "release_manifest_hash",
-                "unsupported_digest_format",
-                review_build=release_manifest_hash,
+            _source_mismatch(
+                "release_manifest_hash", "unsupported_digest_format", release_manifest_hash
             )
         )
 
     for group_name in OPTIONAL_IDENTITY_GROUPS:
         if group_name in payload and not isinstance(payload[group_name], dict):
-            mismatches.append(
-                Mismatch(group_name, malformed_reason, review_build=payload[group_name])
-            )
+            mismatches.append(_source_mismatch(group_name, malformed_reason, payload[group_name]))
     return mismatches
 
 
@@ -340,6 +343,7 @@ def build_equivalence_decision(
         _validate_build_artifact(
             review_payload,
             label="review_build_identity",
+            source_field="review_build",
             missing_reason="missing_review_build_identity",
             malformed_reason="malformed_review_build_identity",
         )
@@ -348,6 +352,7 @@ def build_equivalence_decision(
         _validate_build_artifact(
             production_payload,
             label="production_candidate_identity",
+            source_field="production_candidate",
             missing_reason="missing_production_candidate_identity",
             malformed_reason="malformed_production_candidate_identity",
         )

--- a/scripts/release/build_equivalence.py
+++ b/scripts/release/build_equivalence.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Compare App Review and production-candidate build identities."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    # Support direct invocation from repository root:
+    # `python3 scripts/release/build_equivalence.py ...`
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.release import release_manifest
+
+SCHEMA_VERSION = "release-build-equivalence.v1"
+BUILD_IDENTITY_SCHEMA_VERSION = "release-build-identity.v1"
+EQUIVALENT_DECISION = "EQUIVALENT"
+BLOCK_DECISION = "BLOCK"
+TOOL_VERSION = SCHEMA_VERSION
+
+BUILD_IDENTITY_FIELDS = (
+    "git_sha",
+    "bundle_id",
+    "marketing_version",
+    "ios_build_number",
+)
+OPTIONAL_IDENTITY_GROUPS = (
+    "reviewer_identity",
+    "ml_identity",
+    "supply_chain_identity",
+)
+BASE_COMPARED_FIELDS = (
+    "build_identity.git_sha",
+    "build_identity.bundle_id",
+    "build_identity.marketing_version",
+    "build_identity.ios_build_number",
+    "artifact_digest",
+    "release_manifest_hash",
+)
+REASON_ORDER = {
+    "missing_review_build_identity": 10,
+    "missing_production_candidate_identity": 20,
+    "malformed_review_build_identity": 30,
+    "malformed_production_candidate_identity": 40,
+    "invalid_release_manifest": 50,
+    "unsupported_digest_format": 60,
+    "attestation_not_verified": 70,
+    "git_sha_mismatch": 80,
+    "bundle_id_mismatch": 90,
+    "marketing_version_mismatch": 100,
+    "ios_build_number_mismatch": 110,
+    "review_build_digest_mismatch": 120,
+    "release_manifest_hash_mismatch": 130,
+    "reviewer_identity_mismatch": 140,
+    "ml_identity_mismatch": 150,
+    "supply_chain_identity_mismatch": 160,
+}
+FIELD_REASON_CODES = {
+    "git_sha": "git_sha_mismatch",
+    "bundle_id": "bundle_id_mismatch",
+    "marketing_version": "marketing_version_mismatch",
+    "ios_build_number": "ios_build_number_mismatch",
+}
+
+
+class BuildEquivalenceError(ValueError):
+    """Raised when build equivalence input cannot be read or parsed."""
+
+
+@dataclass(frozen=True)
+class Mismatch:
+    """One deterministic mismatch detail."""
+
+    field: str
+    reason_code: str
+    review_build: Any = None
+    production_candidate: Any = None
+    release_manifest: Any = None
+
+    def as_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "field": self.field,
+            "reason_code": self.reason_code,
+        }
+        if self.review_build is not None:
+            payload["review_build"] = self.review_build
+        if self.production_candidate is not None:
+            payload["production_candidate"] = self.production_candidate
+        if self.release_manifest is not None:
+            payload["release_manifest"] = self.release_manifest
+        return payload
+
+
+def _load_json(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise BuildEquivalenceError(f"{label} is not readable: {path}: {exc}") from exc
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise BuildEquivalenceError(f"{label} is not valid JSON: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise BuildEquivalenceError(f"{label} must contain a JSON object: {path}")
+    return payload
+
+
+def _stable_reason_codes(mismatches: list[Mismatch]) -> list[str]:
+    reason_codes = {mismatch.reason_code for mismatch in mismatches}
+    return sorted(reason_codes, key=lambda reason: (REASON_ORDER.get(reason, 10_000), reason))
+
+
+def _stable_mismatch_details(mismatches: list[Mismatch]) -> list[dict[str, Any]]:
+    return [
+        mismatch.as_payload()
+        for mismatch in sorted(
+            mismatches,
+            key=lambda item: (REASON_ORDER.get(item.reason_code, 10_000), item.field),
+        )
+    ]
+
+
+def _validate_build_artifact(
+    payload: dict[str, Any],
+    *,
+    label: str,
+    missing_reason: str,
+    malformed_reason: str,
+) -> list[Mismatch]:
+    mismatches: list[Mismatch] = []
+    if not payload:
+        mismatches.append(Mismatch(label, missing_reason))
+        return mismatches
+
+    expected_metadata = {
+        "schema_version": BUILD_IDENTITY_SCHEMA_VERSION,
+        "hash_algorithm": release_manifest.HASH_ALGORITHM,
+        "canonicalization": release_manifest.CANONICALIZATION,
+    }
+    for field_name, expected_value in expected_metadata.items():
+        value = payload.get(field_name)
+        if value is None:
+            mismatches.append(Mismatch(field_name, missing_reason))
+        elif value != expected_value:
+            mismatches.append(
+                Mismatch(
+                    field_name,
+                    malformed_reason,
+                    review_build=value,
+                    release_manifest=expected_value,
+                )
+            )
+
+    build_identity = payload.get("build_identity")
+    if not isinstance(build_identity, dict):
+        mismatches.append(Mismatch("build_identity", missing_reason))
+    else:
+        for field_name in BUILD_IDENTITY_FIELDS:
+            value = build_identity.get(field_name)
+            if value is None:
+                mismatches.append(Mismatch(f"build_identity.{field_name}", missing_reason))
+            elif not isinstance(value, str) or not value:
+                mismatches.append(
+                    Mismatch(f"build_identity.{field_name}", malformed_reason, review_build=value)
+                )
+
+    artifact_digest = payload.get("artifact_digest")
+    if artifact_digest is None:
+        mismatches.append(Mismatch("artifact_digest", missing_reason))
+    elif not isinstance(
+        artifact_digest, str
+    ) or not release_manifest.OCI_SHA256_DIGEST_RE.fullmatch(artifact_digest):
+        mismatches.append(
+            Mismatch("artifact_digest", "unsupported_digest_format", review_build=artifact_digest)
+        )
+
+    release_manifest_hash = payload.get("release_manifest_hash")
+    if release_manifest_hash is None:
+        mismatches.append(Mismatch("release_manifest_hash", missing_reason))
+    elif not isinstance(release_manifest_hash, str) or not release_manifest.SHA256_HEX_RE.fullmatch(
+        release_manifest_hash
+    ):
+        mismatches.append(
+            Mismatch(
+                "release_manifest_hash",
+                "unsupported_digest_format",
+                review_build=release_manifest_hash,
+            )
+        )
+
+    for group_name in OPTIONAL_IDENTITY_GROUPS:
+        if group_name in payload and not isinstance(payload[group_name], dict):
+            mismatches.append(
+                Mismatch(group_name, malformed_reason, review_build=payload[group_name])
+            )
+    return mismatches
+
+
+def _manifest_mismatches(manifest_payload: dict[str, Any]) -> list[Mismatch]:
+    errors = release_manifest.validate_manifest_payload(manifest_payload)
+    mismatches = [
+        Mismatch("release_manifest", "invalid_release_manifest", release_manifest=error)
+        for error in errors
+    ]
+    supply_chain_identity = manifest_payload.get("supply_chain_identity")
+    if isinstance(supply_chain_identity, dict):
+        if (
+            supply_chain_identity.get("attestation_status")
+            != release_manifest.VERIFIED_ATTESTATION_STATUS
+        ):
+            mismatches.append(
+                Mismatch(
+                    "supply_chain_identity.attestation_status",
+                    "attestation_not_verified",
+                    release_manifest=supply_chain_identity.get("attestation_status"),
+                )
+            )
+    return mismatches
+
+
+def _build_identity(payload: dict[str, Any]) -> dict[str, Any]:
+    value = payload.get("build_identity")
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _compare_required_identity(
+    *,
+    review_payload: dict[str, Any],
+    production_payload: dict[str, Any],
+    manifest_payload: dict[str, Any],
+) -> list[Mismatch]:
+    mismatches: list[Mismatch] = []
+    review_build = _build_identity(review_payload)
+    production_build = _build_identity(production_payload)
+    manifest_build = _build_identity(manifest_payload)
+
+    for field_name in BUILD_IDENTITY_FIELDS:
+        review_value = review_build.get(field_name)
+        production_value = production_build.get(field_name)
+        manifest_value = manifest_build.get(field_name)
+        if review_value != production_value or review_value != manifest_value:
+            mismatches.append(
+                Mismatch(
+                    f"build_identity.{field_name}",
+                    FIELD_REASON_CODES[field_name],
+                    review_build=review_value,
+                    production_candidate=production_value,
+                    release_manifest=manifest_value,
+                )
+            )
+
+    review_digest = review_payload.get("artifact_digest")
+    production_digest = production_payload.get("artifact_digest")
+    if review_digest != production_digest:
+        mismatches.append(
+            Mismatch(
+                "artifact_digest",
+                "review_build_digest_mismatch",
+                review_build=review_digest,
+                production_candidate=production_digest,
+            )
+        )
+
+    review_manifest_hash = review_payload.get("release_manifest_hash")
+    production_manifest_hash = production_payload.get("release_manifest_hash")
+    manifest_hash = manifest_payload.get("release_manifest_hash")
+    if review_manifest_hash != production_manifest_hash or review_manifest_hash != manifest_hash:
+        mismatches.append(
+            Mismatch(
+                "release_manifest_hash",
+                "release_manifest_hash_mismatch",
+                review_build=review_manifest_hash,
+                production_candidate=production_manifest_hash,
+                release_manifest=manifest_hash,
+            )
+        )
+    return mismatches
+
+
+def _compare_optional_identity_groups(
+    *,
+    review_payload: dict[str, Any],
+    production_payload: dict[str, Any],
+    manifest_payload: dict[str, Any],
+) -> list[Mismatch]:
+    mismatches: list[Mismatch] = []
+    reason_by_group = {
+        "reviewer_identity": "reviewer_identity_mismatch",
+        "ml_identity": "ml_identity_mismatch",
+        "supply_chain_identity": "supply_chain_identity_mismatch",
+    }
+    for group_name in OPTIONAL_IDENTITY_GROUPS:
+        if group_name not in review_payload and group_name not in production_payload:
+            continue
+        review_value = review_payload.get(group_name)
+        production_value = production_payload.get(group_name)
+        manifest_value = manifest_payload.get(group_name)
+        if review_value != production_value or review_value != manifest_value:
+            mismatches.append(
+                Mismatch(
+                    group_name,
+                    reason_by_group[group_name],
+                    review_build=review_value,
+                    production_candidate=production_value,
+                    release_manifest=manifest_value,
+                )
+            )
+    return mismatches
+
+
+def build_equivalence_decision(
+    *,
+    review_payload: dict[str, Any],
+    production_payload: dict[str, Any],
+    manifest_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a deterministic build equivalence decision payload."""
+
+    mismatches: list[Mismatch] = []
+    mismatches.extend(
+        _validate_build_artifact(
+            review_payload,
+            label="review_build_identity",
+            missing_reason="missing_review_build_identity",
+            malformed_reason="malformed_review_build_identity",
+        )
+    )
+    mismatches.extend(
+        _validate_build_artifact(
+            production_payload,
+            label="production_candidate_identity",
+            missing_reason="missing_production_candidate_identity",
+            malformed_reason="malformed_production_candidate_identity",
+        )
+    )
+    mismatches.extend(_manifest_mismatches(manifest_payload))
+    mismatches.extend(
+        _compare_required_identity(
+            review_payload=review_payload,
+            production_payload=production_payload,
+            manifest_payload=manifest_payload,
+        )
+    )
+    mismatches.extend(
+        _compare_optional_identity_groups(
+            review_payload=review_payload,
+            production_payload=production_payload,
+            manifest_payload=manifest_payload,
+        )
+    )
+
+    reason_codes = _stable_reason_codes(mismatches)
+    compared_fields = list(BASE_COMPARED_FIELDS)
+    for group_name in OPTIONAL_IDENTITY_GROUPS:
+        if group_name in review_payload or group_name in production_payload:
+            compared_fields.append(group_name)
+    compared_fields = sorted(dict.fromkeys(compared_fields))
+
+    manifest_hash = manifest_payload.get("release_manifest_hash")
+    if not isinstance(manifest_hash, str) or not release_manifest.SHA256_HEX_RE.fullmatch(
+        manifest_hash
+    ):
+        manifest_hash = "0" * 64
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "hash_algorithm": release_manifest.HASH_ALGORITHM,
+        "canonicalization": release_manifest.CANONICALIZATION,
+        "decision": BLOCK_DECISION if reason_codes else EQUIVALENT_DECISION,
+        "reason_codes": reason_codes,
+        "mismatch_details": _stable_mismatch_details(mismatches),
+        "compared_fields": compared_fields,
+        "release_manifest_hash": manifest_hash,
+        "tool_version": TOOL_VERSION,
+    }
+
+
+def compare_build_files(
+    *,
+    review_build_path: Path,
+    production_candidate_path: Path,
+    release_manifest_path: Path,
+) -> dict[str, Any]:
+    """Load input files and return a deterministic build equivalence decision."""
+
+    review_payload = _load_json(review_build_path, label="review build identity")
+    production_payload = _load_json(
+        production_candidate_path,
+        label="production candidate identity",
+    )
+    manifest_payload = _load_json(release_manifest_path, label="release manifest")
+    return build_equivalence_decision(
+        review_payload=review_payload,
+        production_payload=production_payload,
+        manifest_payload=manifest_payload,
+    )
+
+
+def write_decision(path: Path, payload: dict[str, Any]) -> None:
+    """Write stable JSON with a trailing newline."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--review-build", type=Path, required=True)
+    parser.add_argument("--production-candidate", type=Path, required=True)
+    parser.add_argument("--release-manifest", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        decision = compare_build_files(
+            review_build_path=args.review_build,
+            production_candidate_path=args.production_candidate,
+            release_manifest_path=args.release_manifest,
+        )
+        write_decision(args.output, decision)
+        if decision["decision"] == EQUIVALENT_DECISION:
+            print(f"PASS: build identities are equivalent: {args.output}")
+            return 0
+        print(f"BLOCK: build identities are not equivalent: {args.output}")
+        for reason_code in decision["reason_codes"]:
+            print(f"REASON: {reason_code}")
+        return 1
+    except BuildEquivalenceError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/build_equivalence.py
+++ b/scripts/release/build_equivalence.py
@@ -110,6 +110,14 @@ def _load_json(path: Path, *, label: str) -> dict[str, Any]:
     return payload
 
 
+def _load_optional_identity_json(path: Path, *, label: str) -> dict[str, Any]:
+    """Load a build identity artifact, returning empty payload when absent."""
+
+    if not path.exists():
+        return {}
+    return _load_json(path, label=label)
+
+
 def _stable_reason_codes(mismatches: list[Mismatch]) -> list[str]:
     reason_codes = {mismatch.reason_code for mismatch in mismatches}
     return sorted(reason_codes, key=lambda reason: (REASON_ORDER.get(reason, 10_000), reason))
@@ -297,7 +305,11 @@ def _compare_optional_identity_groups(
         "supply_chain_identity": "supply_chain_identity_mismatch",
     }
     for group_name in OPTIONAL_IDENTITY_GROUPS:
-        if group_name not in review_payload and group_name not in production_payload:
+        if (
+            group_name not in manifest_payload
+            and group_name not in review_payload
+            and group_name not in production_payload
+        ):
             continue
         review_value = review_payload.get(group_name)
         production_value = production_payload.get(group_name)
@@ -390,8 +402,11 @@ def compare_build_files(
 ) -> dict[str, Any]:
     """Load input files and return a deterministic build equivalence decision."""
 
-    review_payload = _load_json(review_build_path, label="review build identity")
-    production_payload = _load_json(
+    review_payload = _load_optional_identity_json(
+        review_build_path,
+        label="review build identity",
+    )
+    production_payload = _load_optional_identity_json(
         production_candidate_path,
         label="production candidate identity",
     )

--- a/tests/test_build_equivalence.py
+++ b/tests/test_build_equivalence.py
@@ -304,6 +304,23 @@ def test_missing_production_identity_file_writes_block_decision(tmp_path: Path, 
     assert "missing_production_candidate_identity" in decision["reason_codes"]
 
 
+def test_malformed_production_identity_reports_production_candidate(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    production_payload = _build_identity(manifest_payload)
+    production_payload["schema_version"] = "release-build-identity.v0"
+
+    decision = _decision(manifest_payload, production_payload=production_payload)
+
+    assert decision["decision"] == "BLOCK"
+    assert "malformed_production_candidate_identity" in decision["reason_codes"]
+    assert {
+        "field": "schema_version",
+        "reason_code": "malformed_production_candidate_identity",
+        "production_candidate": "release-build-identity.v0",
+        "release_manifest": "release-build-identity.v1",
+    } in decision["mismatch_details"]
+
+
 def test_malformed_json_uses_controlled_error(tmp_path: Path, capsys) -> None:
     manifest_payload = _build_manifest(tmp_path)
     manifest_path = tmp_path / "release_manifest.json"
@@ -448,7 +465,8 @@ def test_ledger_release_control_plane_state_is_reconciled() -> None:
 
     assert "PR-3 merged in PR #1605" in ledger_text
     assert (
-        "PR-4 active in branch `release/release-control-plane-pr4-build-equivalence`" in ledger_text
+        "PR-4 active in PR #1679 on branch `release/release-control-plane-pr4-build-equivalence`"
+        in ledger_text
     )
     assert "PR-5 remains deferred for CI fail-closed enforcement" in ledger_text
     assert "not production-ready" in ledger_text

--- a/tests/test_build_equivalence.py
+++ b/tests/test_build_equivalence.py
@@ -235,11 +235,71 @@ def test_missing_review_identity_blocks(tmp_path: Path) -> None:
     assert "missing_review_build_identity" in decision["reason_codes"]
 
 
+def test_missing_review_identity_file_writes_block_decision(tmp_path: Path, capsys) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    manifest_path = tmp_path / "release_manifest.json"
+    review_path = tmp_path / "missing-review.json"
+    production_path = tmp_path / "production.json"
+    output_path = tmp_path / "equivalence.json"
+    _write_json(manifest_path, manifest_payload)
+    _write_json(production_path, _build_identity(manifest_payload))
+
+    status = build_equivalence.main(
+        [
+            "--review-build",
+            str(review_path),
+            "--production-candidate",
+            str(production_path),
+            "--release-manifest",
+            str(manifest_path),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    output = capsys.readouterr().out
+    decision = json.loads(output_path.read_text(encoding="utf-8"))
+    assert status == 1
+    assert "BLOCK:" in output
+    assert decision["decision"] == "BLOCK"
+    assert "missing_review_build_identity" in decision["reason_codes"]
+
+
 def test_missing_production_identity_blocks(tmp_path: Path) -> None:
     manifest_payload = _build_manifest(tmp_path)
 
     decision = _decision(manifest_payload, production_payload={})
 
+    assert decision["decision"] == "BLOCK"
+    assert "missing_production_candidate_identity" in decision["reason_codes"]
+
+
+def test_missing_production_identity_file_writes_block_decision(tmp_path: Path, capsys) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    manifest_path = tmp_path / "release_manifest.json"
+    review_path = tmp_path / "review.json"
+    production_path = tmp_path / "missing-production.json"
+    output_path = tmp_path / "equivalence.json"
+    _write_json(manifest_path, manifest_payload)
+    _write_json(review_path, _build_identity(manifest_payload))
+
+    status = build_equivalence.main(
+        [
+            "--review-build",
+            str(review_path),
+            "--production-candidate",
+            str(production_path),
+            "--release-manifest",
+            str(manifest_path),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    output = capsys.readouterr().out
+    decision = json.loads(output_path.read_text(encoding="utf-8"))
+    assert status == 1
+    assert "BLOCK:" in output
     assert decision["decision"] == "BLOCK"
     assert "missing_production_candidate_identity" in decision["reason_codes"]
 
@@ -325,6 +385,25 @@ def test_optional_identity_mismatch_blocks(tmp_path: Path) -> None:
 
     assert decision["decision"] == "BLOCK"
     assert "ml_identity_mismatch" in decision["reason_codes"]
+
+
+def test_manifest_identity_snapshots_are_required_for_equivalence(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    review_payload = _build_identity(manifest_payload, include_optional_groups=False)
+    production_payload = _build_identity(manifest_payload, include_optional_groups=False)
+
+    decision = _decision(
+        manifest_payload,
+        review_payload=review_payload,
+        production_payload=production_payload,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert decision["reason_codes"] == [
+        "reviewer_identity_mismatch",
+        "ml_identity_mismatch",
+        "supply_chain_identity_mismatch",
+    ]
 
 
 def test_attestation_not_verified_blocks(tmp_path: Path) -> None:

--- a/tests/test_build_equivalence.py
+++ b/tests/test_build_equivalence.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.release import build_equivalence
+from scripts.release import release_manifest
+from scripts.release import reviewer_packet_hashes
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+OCI_DIGEST = "sha256:" + ("a" * 64)
+PROVENANCE_DIGEST = "sha256:" + ("b" * 64)
+REVIEW_BUILD_DIGEST = "sha256:" + ("e" * 64)
+TEST_GIT_SHA = "git-sha-for-build-equivalence-tests"
+
+
+def _write_metadata_pack(repo_root: Path) -> None:
+    notes_path = repo_root / "ios/fastlane/metadata/review_information/notes.txt"
+    notes_path.parent.mkdir(parents=True, exist_ok=True)
+    notes_path.write_text("Reviewer note\n", encoding="utf-8")
+
+    privacy_path = repo_root / "ios/fastlane/app_privacy_details.json"
+    privacy_path.parent.mkdir(parents=True, exist_ok=True)
+    privacy_path.write_text('[{"data_protections":["DATA_NOT_COLLECTED"]}]\n', encoding="utf-8")
+
+    for locale in reviewer_packet_hashes.REQUIRED_LOCALES:
+        locale_dir = repo_root / "ios/fastlane/metadata" / locale
+        locale_dir.mkdir(parents=True, exist_ok=True)
+        for filename in reviewer_packet_hashes.REQUIRED_METADATA_FILES:
+            (locale_dir / filename).write_text(
+                f"{locale}:{filename}\n",
+                encoding="utf-8",
+            )
+
+
+def _rag_payload() -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "release-rag-gate-result.v1",
+        "hash_algorithm": "sha256",
+        "canonicalization": release_manifest.CANONICALIZATION,
+        "eval_artifact_hash": "c" * 64,
+        "experiment_id": "unit-test",
+        "timestamp": "2026-04-30T00:00:00Z",
+        "release_decision": "PASS",
+        "gate_checks": {"answer_precision_min": True},
+        "threshold_results": [],
+        "strict_violations": [],
+        "runtime_warnings": [],
+        "dataset_path_used": "tests/fixtures/rag.jsonl",
+        "dataset_fallback_used": False,
+        "sample_size": 1,
+        "git_sha": TEST_GIT_SHA,
+        "retriever_mode": "local_tfidf",
+        "generator_mode": "extractive_stub",
+        "small_fixture_metric_gates_advisory": False,
+        "source_artifacts": [
+            {
+                "kind": "metrics_summary",
+                "path": "artifacts/rag_eval/unit-test/metrics_summary.json",
+                "hash": "d" * 64,
+            }
+        ],
+    }
+    payload["rag_gate_result_hash"] = release_manifest.sha256_lower_hex(
+        release_manifest.canonical_json_bytes(payload)
+    )
+    return payload
+
+
+def _write_rag_gate_result(repo_root: Path) -> Path:
+    rag_path = repo_root / "artifacts/rag_eval/unit-test/rag_gate_result.json"
+    rag_path.parent.mkdir(parents=True, exist_ok=True)
+    rag_path.write_text(json.dumps(_rag_payload(), sort_keys=True) + "\n", encoding="utf-8")
+    return rag_path
+
+
+def _build_manifest(repo_root: Path, *, attestation_status: str = "VERIFIED") -> dict[str, object]:
+    _write_metadata_pack(repo_root)
+    rag_path = _write_rag_gate_result(repo_root)
+    return release_manifest.build_manifest_payload(
+        repo_root=repo_root,
+        git_sha=TEST_GIT_SHA,
+        ios_build_number="100",
+        marketing_version="1.0",
+        bundle_id="app.pulseplate.PulsePlate",
+        rag_gate_result_path=rag_path,
+        sbom_digest=OCI_DIGEST,
+        provenance_digest=PROVENANCE_DIGEST,
+        attestation_status=attestation_status,
+    )
+
+
+def _rehash_manifest(payload: dict[str, object]) -> dict[str, object]:
+    updated = dict(payload)
+    updated.pop("release_manifest_hash", None)
+    updated["release_manifest_hash"] = release_manifest.sha256_lower_hex(
+        release_manifest.canonical_json_bytes(updated)
+    )
+    return updated
+
+
+def _build_identity(
+    manifest_payload: dict[str, object],
+    *,
+    artifact_digest: str = REVIEW_BUILD_DIGEST,
+    include_optional_groups: bool = True,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "release-build-identity.v1",
+        "hash_algorithm": "sha256",
+        "canonicalization": release_manifest.CANONICALIZATION,
+        "build_identity": dict(manifest_payload["build_identity"]),
+        "artifact_digest": artifact_digest,
+        "release_manifest_hash": manifest_payload["release_manifest_hash"],
+    }
+    if include_optional_groups:
+        payload["reviewer_identity"] = dict(manifest_payload["reviewer_identity"])
+        payload["ml_identity"] = dict(manifest_payload["ml_identity"])
+        payload["supply_chain_identity"] = dict(manifest_payload["supply_chain_identity"])
+    return payload
+
+
+def _decision(
+    manifest_payload: dict[str, object],
+    *,
+    review_payload: dict[str, object] | None = None,
+    production_payload: dict[str, object] | None = None,
+) -> dict[str, object]:
+    if review_payload is None:
+        review_payload = _build_identity(manifest_payload)
+    if production_payload is None:
+        production_payload = _build_identity(manifest_payload)
+    return build_equivalence.build_equivalence_decision(
+        review_payload=review_payload,
+        production_payload=production_payload,
+        manifest_payload=manifest_payload,
+    )
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_equivalent_build_identities_return_equivalent(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+
+    decision = _decision(manifest_payload)
+
+    assert decision["decision"] == "EQUIVALENT"
+    assert decision["reason_codes"] == []
+    assert decision["mismatch_details"] == []
+    assert decision["release_manifest_hash"] == manifest_payload["release_manifest_hash"]
+    assert HASH_RE.fullmatch(str(decision["release_manifest_hash"]))
+
+
+def test_git_sha_mismatch_blocks(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    production_payload = _build_identity(manifest_payload)
+    production_payload["build_identity"]["git_sha"] = "other-sha"
+
+    decision = _decision(manifest_payload, production_payload=production_payload)
+
+    assert decision["decision"] == "BLOCK"
+    assert "git_sha_mismatch" in decision["reason_codes"]
+
+
+def test_bundle_id_mismatch_blocks(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    production_payload = _build_identity(manifest_payload)
+    production_payload["build_identity"]["bundle_id"] = "app.pulseplate.Other"
+
+    decision = _decision(manifest_payload, production_payload=production_payload)
+
+    assert decision["decision"] == "BLOCK"
+    assert "bundle_id_mismatch" in decision["reason_codes"]
+
+
+def test_marketing_version_mismatch_blocks(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    production_payload = _build_identity(manifest_payload)
+    production_payload["build_identity"]["marketing_version"] = "1.1"
+
+    decision = _decision(manifest_payload, production_payload=production_payload)
+
+    assert decision["decision"] == "BLOCK"
+    assert "marketing_version_mismatch" in decision["reason_codes"]
+
+
+def test_ios_build_number_mismatch_blocks(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    production_payload = _build_identity(manifest_payload)
+    production_payload["build_identity"]["ios_build_number"] = "101"
+
+    decision = _decision(manifest_payload, production_payload=production_payload)
+
+    assert decision["decision"] == "BLOCK"
+    assert "ios_build_number_mismatch" in decision["reason_codes"]
+
+
+def test_review_build_digest_mismatch_blocks(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    production_payload = _build_identity(
+        manifest_payload,
+        artifact_digest="sha256:" + ("f" * 64),
+    )
+
+    decision = _decision(manifest_payload, production_payload=production_payload)
+
+    assert decision["decision"] == "BLOCK"
+    assert "review_build_digest_mismatch" in decision["reason_codes"]
+
+
+def test_release_manifest_hash_mismatch_blocks(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    production_payload = _build_identity(manifest_payload)
+    production_payload["release_manifest_hash"] = "1" * 64
+
+    decision = _decision(manifest_payload, production_payload=production_payload)
+
+    assert decision["decision"] == "BLOCK"
+    assert "release_manifest_hash_mismatch" in decision["reason_codes"]
+
+
+def test_missing_review_identity_blocks(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+
+    decision = _decision(manifest_payload, review_payload={})
+
+    assert decision["decision"] == "BLOCK"
+    assert "missing_review_build_identity" in decision["reason_codes"]
+
+
+def test_missing_production_identity_blocks(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+
+    decision = _decision(manifest_payload, production_payload={})
+
+    assert decision["decision"] == "BLOCK"
+    assert "missing_production_candidate_identity" in decision["reason_codes"]
+
+
+def test_malformed_json_uses_controlled_error(tmp_path: Path, capsys) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    manifest_path = tmp_path / "release_manifest.json"
+    review_path = tmp_path / "review.json"
+    production_path = tmp_path / "production.json"
+    output_path = tmp_path / "equivalence.json"
+    _write_json(manifest_path, manifest_payload)
+    review_path.write_text("{not-json\n", encoding="utf-8")
+    _write_json(production_path, _build_identity(manifest_payload))
+
+    status = build_equivalence.main(
+        [
+            "--review-build",
+            str(review_path),
+            "--production-candidate",
+            str(production_path),
+            "--release-manifest",
+            str(manifest_path),
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert status == 1
+    assert "ERROR:" in output
+    assert "review build identity is not valid JSON" in output
+
+
+def test_unsupported_digest_format_blocks(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    review_payload = _build_identity(manifest_payload)
+    review_payload["artifact_digest"] = "e" * 64
+
+    decision = _decision(manifest_payload, review_payload=review_payload)
+
+    assert decision["decision"] == "BLOCK"
+    assert "unsupported_digest_format" in decision["reason_codes"]
+
+
+def test_output_json_is_deterministic(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    decision = _decision(manifest_payload)
+    first_path = tmp_path / "first.json"
+    second_path = tmp_path / "second.json"
+
+    build_equivalence.write_decision(first_path, decision)
+    build_equivalence.write_decision(second_path, decision)
+
+    assert first_path.read_bytes() == second_path.read_bytes()
+    assert first_path.read_text(encoding="utf-8").endswith("\n")
+
+
+def test_reason_code_ordering_is_deterministic(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    production_payload = _build_identity(
+        manifest_payload,
+        artifact_digest="sha256:" + ("f" * 64),
+    )
+    production_payload["build_identity"]["git_sha"] = "other-sha"
+    production_payload["release_manifest_hash"] = "1" * 64
+
+    decision = _decision(manifest_payload, production_payload=production_payload)
+
+    assert decision["reason_codes"] == [
+        "git_sha_mismatch",
+        "review_build_digest_mismatch",
+        "release_manifest_hash_mismatch",
+    ]
+
+
+def test_optional_identity_mismatch_blocks(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    production_payload = _build_identity(manifest_payload)
+    production_payload["ml_identity"] = dict(production_payload["ml_identity"])
+    production_payload["ml_identity"]["rag_gate_result_hash"] = "9" * 64
+
+    decision = _decision(manifest_payload, production_payload=production_payload)
+
+    assert decision["decision"] == "BLOCK"
+    assert "ml_identity_mismatch" in decision["reason_codes"]
+
+
+def test_attestation_not_verified_blocks(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path, attestation_status="PENDING")
+
+    decision = _decision(manifest_payload)
+
+    assert decision["decision"] == "BLOCK"
+    assert "attestation_not_verified" in decision["reason_codes"]
+
+
+def test_schema_file_matches_emitted_payload_shape(tmp_path: Path) -> None:
+    manifest_payload = _build_manifest(tmp_path)
+    decision = _decision(manifest_payload)
+    schema = json.loads(
+        (REPO_ROOT / "docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert set(schema["required"]) <= set(decision)
+    assert decision["schema_version"] == schema["properties"]["schema_version"]["const"]
+    assert decision["hash_algorithm"] == schema["properties"]["hash_algorithm"]["const"]
+    assert decision["canonicalization"] == schema["properties"]["canonicalization"]["const"]
+
+
+def test_cli_direct_invocation_help() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/release/build_equivalence.py", "--help"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "usage:" in result.stdout.lower()
+
+
+def test_ledger_release_control_plane_state_is_reconciled() -> None:
+    ledger_text = (REPO_ROOT / "docs/roadmap/BACKLOG_LEDGER.md").read_text(encoding="utf-8")
+
+    assert "PR-3 merged in PR #1605" in ledger_text
+    assert (
+        "PR-4 active in branch `release/release-control-plane-pr4-build-equivalence`" in ledger_text
+    )
+    assert "PR-5 remains deferred for CI fail-closed enforcement" in ledger_text
+    assert "not production-ready" in ledger_text


### PR DESCRIPTION
## Summary
- Adds deterministic PR-4 build-equivalence checker.
- Proves review build and production-candidate identity match through digest/hash/identity comparisons.
- Updates ledger so PR-3 is merged, PR-4 is active, PR-5 remains deferred.
- Does not add CI fail-closed enforcement.

## Scope
- build equivalence contract
- checker
- focused tests
- release-control-plane docs
- ledger reconciliation

## Out of scope
- PR-5 CI gates
- workflow mutation
- App Store upload automation
- runtime/API/iOS changes
- RAG behavior changes
- product-facing behavior

## Validation
- `python3 scripts/orchestration/check_preflight.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-4: build equivalence check" --task-class Orchestration --pr-phase pre_open --path docs/roadmap/BACKLOG_LEDGER.md --path docs/release/BUILD_EQUIVALENCE_CONTRACT.md --path docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json --path scripts/release/build_equivalence.py --path tests/test_build_equivalence.py --path docs/release/RELEASE_CONTROL_PLANE_EPIC.md --path docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md --requested-agent ...` PASS, packet `4dcaa5e6be7d`
- `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-4 post-open review: build equivalence check" --task-class Orchestration --pr-phase post_open_review --path docs/roadmap/BACKLOG_LEDGER.md --path docs/release/BUILD_EQUIVALENCE_CONTRACT.md --path docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json --path scripts/release/build_equivalence.py --path tests/test_build_equivalence.py --path docs/release/RELEASE_CONTROL_PLANE_EPIC.md --path docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md --path docs/review/PR_1679_FIXED_MAPPING.md --requested-agent ...` PASS, packet `81b582fc6671`
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_build_equivalence.py` PASS (`22 passed`)
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_release_manifest.py` PASS (`20 passed`)
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_repo_policy_guards.py` PASS (`14 passed`)
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/BUILD_EQUIVALENCE_CONTRACT.md docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/roadmap/BACKLOG_LEDGER.md docs/review/PR_1679_FIXED_MAPPING.md` PASS
- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` PASS (`22 passed`)
- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pre-commit run --all-files` PASS
- Push-time hooks PASS after review fixes: changed-file mypy, pip-audit, backend pre-push tests, full-repo Bandit, Docker build test

## Machine-heavy deferral
Full local `make verify` was not run per operator-approved bounded-check path for this coordinator-owned release tooling PR. This PR uses the documented narrow local gate bundle plus current-head GitHub CI as the heavy signal before any merge-readiness claim.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1679 -> 789d03ceb
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1679#discussion_r3194675016 -> 1a1878444
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1679#discussion_r3194675029 -> 1a1878444
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1679#pullrequestreview-4235223961 -> 1a1878444
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1679#discussion_r3194676918 -> 1a1878444
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1679#pullrequestreview-4235226467 -> 1a1878444

## Split Justification
This PR is above the normal LoC threshold because PR-4 must land the build-equivalence contract, schema, checker, focused tests, ledger reconciliation, release-control-plane packet update, and fixed-mapping artifact together to keep the release-control-plane source of truth coherent. Splitting the checker from the schema/tests or ledger state would create a temporary branch where the contract is either undocumented, untested, or stale relative to PR #1605. PR-5 CI fail-closed enforcement remains a separate follow-up and is explicitly deferred.

## Deferred / Follow-ups
- PR-5 remains the deferred follow-up for CI fail-closed release decision integration: `release/release-control-plane-pr5-ci-gates`.
- This PR intentionally does not add workflow enforcement, protected upload automation, App Store Connect execution, runtime/API/iOS changes, or RAG behavior changes.

## Merge Readiness
- [ ] PR is ready for review and no longer draft.
- [ ] Current-head required CI is green with no pending required checks.
- [x] CodeRabbit/Sourcery/Cubic actionable comments are dispositioned.
- [ ] Strict merge readiness gate passes with auth.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added build equivalence validation tool to deterministically compare release builds and production candidates.

* **Documentation**
  * Added Build Equivalence Contract documentation with schema, decision model, and CLI usage guidelines.
  * Updated release control plane and backlog ledger with new workflow entries and governance anchors.
  * Added comprehensive review documentation for validation tracking.

* **Tests**
  * Added extensive test coverage for build equivalence validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->