### PR TITLE
feat(design): add external reference manifest and normalization tooling

### DIFF
--- a/docs/design/REFERENCE_MANIFEST_SCHEMA.md
+++ b/docs/design/REFERENCE_MANIFEST_SCHEMA.md
@@ -117,6 +117,18 @@ References may contribute only derived, normalized metadata and an explicit `ado
 - `icon-silhouette-check` must be `passed` or `not_applicable` before any Results/Evidence finalization.
 - `design-guard` must be `passed` or `not_applicable` before any design export or icon-core lock update.
 
+## PR-2 Tooling
+
+`scripts/design/reference_manifest.py` provides the first repo-local deterministic checker for this schema:
+
+```bash
+python3 scripts/design/reference_manifest.py validate <path>
+python3 scripts/design/reference_manifest.py validate-dir <dir>
+python3 scripts/design/reference_manifest.py normalize <path>
+```
+
+The checker validates manifest shape, status/decision alignment, license and copy-risk controls, wellness-only wording, and PulsePlate component vocabulary mappings. It does not crawl external sources, score references, import assets, write Figma/Canva, or promote any reference into runtime truth.
+
 ## Source Policy Encoding
 
 - Refero Styles: read-only benchmark corpus; no copying.

--- a/docs/design/reference_manifest/examples/README.md
+++ b/docs/design/reference_manifest/examples/README.md
@@ -1,0 +1,12 @@
+<!-- markdownlint-disable MD013 -->
+# Reference Manifest Examples
+
+These records are synthetic, repo-local fixtures for `scripts/design/reference_manifest.py`.
+
+They demonstrate derived metadata only. They do not copy external screenshots, exact layouts, brands, marketing copy, visual identity, or proprietary component implementations. References remain read-only and non-canonical until a later reviewed PR promotes a normalized decision into a design brief.
+
+Validate examples with:
+
+```bash
+python3 scripts/design/reference_manifest.py validate-dir docs/design/reference_manifest/examples
+```

--- a/docs/design/reference_manifest/examples/open_design_component_taxonomy.sample.json
+++ b/docs/design/reference_manifest/examples/open_design_component_taxonomy.sample.json
@@ -1,0 +1,57 @@
+{
+  "accessibility_notes": "Synthetic derived notes: component grouping must preserve semantic labels, focus order, keyboard support, and touch target comfort.",
+  "adopt_adapt_reject_decision": "adapt",
+  "attribution_required": false,
+  "component_patterns": [
+    "button",
+    "card",
+    "segmented_control",
+    "tabs"
+  ],
+  "design-guard": "required",
+  "forbidden_copy_elements": [
+    "external brand",
+    "exact layout",
+    "marketing copy",
+    "proprietary component implementation",
+    "screenshot"
+  ],
+  "icon-silhouette-check": "not_applicable",
+  "layout_patterns": [
+    "component taxonomy grouping",
+    "navigation plus content"
+  ],
+  "legal_copy_risks": [
+    "component implementation details must not be copied",
+    "source taxonomy labels require PulsePlate vocabulary normalization"
+  ],
+  "license_status": "restricted",
+  "mapped_pulseplate_components": [
+    "button",
+    "card",
+    "segmented_control",
+    "tabs"
+  ],
+  "monetization_notes": "Synthetic read-only non-canonical evidence only; does not create pricing, billing, entitlement, or App Store truth.",
+  "motion_notes": "Synthetic derived metadata: state transitions need reduced-motion-safe alternatives.",
+  "normalization_notes": "Synthetic read-only non-canonical evidence: generic component taxonomy maps to PulsePlate segmented_control, tabs, card, and button ids.",
+  "palette_archetype": "neutral surface system with restrained status accents",
+  "platform": [
+    "cross_platform",
+    "web"
+  ],
+  "product_category": "design system",
+  "radius_profile": "subtle",
+  "reference_id": "open-design-component-taxonomy-synthetic-001",
+  "source_name": "Open design synthetic component taxonomy metadata",
+  "source_url": "https://example.invalid/open-design-component-taxonomy-synthetic",
+  "spacing_density": "comfortable",
+  "status": "normalized",
+  "surface_type": [
+    "settings",
+    "dashboard"
+  ],
+  "typography_archetype": "structured labels with clear section hierarchy",
+  "visual_archetype": "repo-normalized component taxonomy",
+  "wellness_safety_notes": "Synthetic read-only non-canonical evidence; no diagnostic, treatment, therapy, crisis, emergency, medical, or guaranteed outcome claims."
+}

--- a/docs/design/reference_manifest/examples/refero_dashboard_density.sample.json
+++ b/docs/design/reference_manifest/examples/refero_dashboard_density.sample.json
@@ -1,0 +1,57 @@
+{
+  "accessibility_notes": "Synthetic derived notes: verify contrast, visible focus, keyboard traversal, touch target comfort, and non-color-only state communication before any future brief.",
+  "adopt_adapt_reject_decision": "adapt",
+  "attribution_required": false,
+  "component_patterns": [
+    "badge",
+    "button",
+    "card",
+    "progress"
+  ],
+  "design-guard": "required",
+  "forbidden_copy_elements": [
+    "external brand",
+    "exact layout",
+    "marketing copy",
+    "proprietary component implementation",
+    "screenshot"
+  ],
+  "icon-silhouette-check": "not_applicable",
+  "layout_patterns": [
+    "summary plus detail",
+    "stacked dashboard grouping"
+  ],
+  "legal_copy_risks": [
+    "brand-specific wording must not be copied",
+    "testimonial or ranking claims remain forbidden"
+  ],
+  "license_status": "unknown",
+  "mapped_pulseplate_components": [
+    "badge",
+    "button",
+    "card",
+    "progress"
+  ],
+  "monetization_notes": "Synthetic read-only non-canonical evidence may inform value framing later; pricing, billing, and entitlement truth remain repo/backend/store-owned.",
+  "motion_notes": "Synthetic derived metadata: use subtle transitions only and preserve reduced-motion fallback.",
+  "normalization_notes": "Synthetic read-only non-canonical evidence: dashboard density maps to PulsePlate card, badge, progress, and button vocabulary without copying source layout.",
+  "palette_archetype": "derived dark foundation with controlled accent",
+  "platform": [
+    "web",
+    "ios"
+  ],
+  "product_category": "wellness planning",
+  "radius_profile": "medium",
+  "reference_id": "refero-dashboard-density-synthetic-001",
+  "source_name": "Refero Styles synthetic dashboard density metadata",
+  "source_url": "https://example.invalid/refero-dashboard-density-synthetic",
+  "spacing_density": "balanced",
+  "status": "read_only",
+  "surface_type": [
+    "dashboard",
+    "onboarding"
+  ],
+  "typography_archetype": "clear hierarchy with compact labels",
+  "visual_archetype": "calm premium planning dashboard",
+  "wellness_safety_notes": "Synthetic read-only non-canonical evidence; avoid diagnostic, treatment, therapy, crisis, emergency, medical, and guaranteed outcome claims."
+}

--- a/docs/review/PR_1680_FIXED_MAPPING.md
+++ b/docs/review/PR_1680_FIXED_MAPPING.md
@@ -1,0 +1,78 @@
+# PR #1680 Fixed Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680
+Branch: `feat/design-reference-manifest-tooling-v1`
+Title: `feat(design): add external reference manifest and normalization tooling`
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] Initial post-open mapping artifact created
+- [x] Premortem / advisory findings fixed before PR open
+
+## Local Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` -> PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS
+- `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open` -> PASS (`artifacts/orchestration/task_packets/d7a5d322a084.json`, local/gitignored)
+- `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review` -> PASS (`artifacts/orchestration/task_packets/40281bf2d2e6.json`, local/gitignored)
+- `python3 scripts/design/reference_manifest.py validate-dir docs/design/reference_manifest/examples` -> PASS
+- `. .venv/bin/activate && python3 -m pytest -q tests/design/test_reference_manifest.py` -> PASS (22 tests)
+- `make validate-changed` -> PASS
+- `make design-guard` -> PASS
+- `make tokens-check` -> PASS
+- `pre-commit run --all-files` -> PASS
+- `git diff -- frontend/src/styles/tokens.css frontend/src/styles/tokens.ts ios/PulsePlate/DesignSystem/DesignTokens.generated.swift` -> empty
+
+Full local `make verify` was intentionally not run by operator machine-budget policy.
+
+## Commit Mapping
+
+- `62a532c808a5f891b3fdd408bc53b299e8817d8c` -> `feat(design): add reference manifest validation tooling`
+- `e7462a17a41cfd403f4dc409c1f633317b8ea20d` -> `fix(design): harden reference manifest validation`
+- `75f24c1eb186b4f131ad138b8c4d7625fc2500e2` -> `test(design): cover reference manifest validation rules`
+- `4d4fe5672dcdc425d45915cd92dcff1e77561043` -> `docs(design): add reference manifest examples and wave status`
+
+### Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: e7462a17a41cfd403f4dc409c1f633317b8ea20d
+Evidence: Premortem finding "component patterns were not vocabulary-grounded" was fixed; `scripts/design/reference_manifest.py` validates `component_patterns` against PulsePlate vocabulary ids, canonical names, and aliases; `tests/design/test_reference_manifest.py` covers unknown component patterns and accepted canonical aliases.
+
+Disposition: FIXED
+
+Commit: e7462a17a41cfd403f4dc409c1f633317b8ea20d
+Evidence: Premortem finding "direct-copy and implementation-authority wording could bypass validation" was fixed; `scripts/design/reference_manifest.py` broadens direct-copy detection for protected elements before/after copy verbs and implementation-authority phrasing; `tests/design/test_reference_manifest.py` covers screenshot-copy, implementation-reference, and duplicate vendor layout/brand variants.
+
+Disposition: FIXED
+
+Commit: e7462a17a41cfd403f4dc409c1f633317b8ea20d
+Evidence: Premortem finding "malformed JSON could escape as traceback instead of deterministic CLI error" was fixed; `_load_json` converts JSON/read errors into `ManifestError`; `tests/design/test_reference_manifest.py` asserts `ERROR:` output and no traceback for malformed JSON.
+
+## Premortem
+
+Premortem reviewed actual code/docs/tests diff and confirmed:
+
+- external references remain read-only and non-canonical,
+- no crawler, network access, Figma writes, Canva writes, external assets, or plugin architecture were introduced,
+- manifest validation fails closed on status, decision, license, copy-risk, wellness-safety, component mapping, component pattern, and source-of-truth drift risks,
+- PR-4 scorecard engine and PR-3 screen evidence pack remain deferred,
+- no frontend, iOS, backend, OpenAPI, billing, auth, deployment, `/tokens`, or generated token mirror files are changed.
+
+## Bug-Hunter Pass
+
+Bug-hunter checks covered:
+
+- examples are synthetic and valid,
+- `validate-dir` checks all example JSON files,
+- `normalize` output is deterministic,
+- malformed JSON fails with deterministic `ERROR:` output,
+- unknown component ids and component patterns fail,
+- `candidate_for_brief` requires resolved license/copy fields,
+- no token mirror diff,
+- no runtime diff.
+
+## Merge Readiness
+
+Not claimed. Merge readiness remains blocked until current-head CI, review-thread dispositions, bot no-actionables, this mapping artifact, PR body mirror, mandatory wait-window, and strict `check_merge_ready.py --require-auth` pass.

--- a/docs/review/PR_1680_FIXED_MAPPING.md
+++ b/docs/review/PR_1680_FIXED_MAPPING.md
@@ -43,6 +43,7 @@ Full local `make verify` was intentionally not run by operator machine-budget po
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235600795 -> 72544e57c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235682587 -> 5b5c08a95
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235691089 -> 5b5c08a95
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235756295 -> 3b30deaf8
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195008771 -> 72544e57c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195008797 -> 72544e57c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195087415 -> 5b5c08a95

--- a/docs/review/PR_1680_FIXED_MAPPING.md
+++ b/docs/review/PR_1680_FIXED_MAPPING.md
@@ -41,41 +41,56 @@ Full local `make verify` was intentionally not run by operator machine-budget po
 ### Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235600795 -> 72544e57c
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235682587 -> 5b5c08a95
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235691089 -> 5b5c08a95
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235756295 -> 3b30deaf8
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195008771 -> 72544e57c
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195008797 -> 72544e57c
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195087415 -> 5b5c08a95
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195087430 -> 5b5c08a95
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195087435 -> 5b5c08a95
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195095771 -> 5b5c08a95
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195158612 -> 3b30deaf8
+Disposition: FIXED
+Commit: 72544e57c
+Evidence: Cubic review summary was fixed by the resolved discussion thread fixes in `scripts/design/reference_manifest.py` and `tests/design/test_reference_manifest.py`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235682587 -> 5b5c08a95
+Disposition: FIXED
+Commit: 5b5c08a95
+Evidence: CodeRabbit review summary was fixed by adding PR #1680 ledger traceability, source-of-truth metadata scan narrowing, and deterministic normalize error handling.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235691089 -> 5b5c08a95
+Disposition: FIXED
+Commit: 5b5c08a95
+Evidence: Cubic review summary was fixed by deterministic malformed UTF-8 vocabulary handling in `scripts/design/reference_manifest.py` with coverage in `tests/design/test_reference_manifest.py`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235756295 -> 3b30deaf8
+Disposition: FIXED
+Commit: 3b30deaf8
+Evidence: CodeRabbit review summary repeated the direct-copy metadata scanning finding; `scripts/design/reference_manifest.py` now scopes `_validate_copy_risk` to trusted narrative fields, covered by `tests/design/test_reference_manifest.py`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195008771 -> 72544e57c
 Disposition: FIXED
 Commit: 72544e57c
 Evidence: Cubic flagged asymmetric status/decision validation; `scripts/design/reference_manifest.py` now rejects `status=rejected` unless `adopt_adapt_reject_decision=reject`, and `tests/design/test_reference_manifest.py` covers the contradictory rejected/adapt state.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195008797 -> 72544e57c
 Disposition: FIXED
 Commit: 72544e57c
 Evidence: Cubic flagged vocabulary load failures escaping deterministic validation; `scripts/design/reference_manifest.py` now converts vocabulary JSON/read failures into `ManifestError` validation errors, and `tests/design/test_reference_manifest.py` asserts malformed vocabulary returns `ERROR:` without traceback.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195087415 -> 5b5c08a95
 Disposition: FIXED
 Commit: 5b5c08a95
 Evidence: CodeRabbit flagged missing PR-2 traceability; `docs/roadmap/BACKLOG_LEDGER.md` now names PR #1680 in the Design Intelligence Target PR chain.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195087430 -> 5b5c08a95
 Disposition: FIXED
 Commit: 5b5c08a95
 Evidence: CodeRabbit flagged source-of-truth scanning over untrusted metadata; `scripts/design/reference_manifest.py` now scans only trusted narrative policy fields, and `tests/design/test_reference_manifest.py` covers a `source_url` containing source-of-truth wording without influencing validation.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195087435 -> 5b5c08a95
 Disposition: FIXED
 Commit: 5b5c08a95
 Evidence: CodeRabbit flagged malformed `normalize` input producing traceback; `scripts/design/reference_manifest.py` now catches `ManifestError` in the `normalize` path, and `tests/design/test_reference_manifest.py` covers deterministic `ERROR:` output without traceback.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195095771 -> 5b5c08a95
 Disposition: FIXED
 Commit: 5b5c08a95
 Evidence: Cubic flagged malformed UTF-8 vocabulary reads; `scripts/design/reference_manifest.py` now converts `UnicodeDecodeError` into deterministic `ManifestError`, and `tests/design/test_reference_manifest.py` covers malformed UTF-8 vocabulary without traceback.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195158612 -> 3b30deaf8
 Disposition: FIXED
 Commit: 3b30deaf8
 Evidence: CodeRabbit flagged direct-copy scanning over untrusted metadata; `scripts/design/reference_manifest.py` now scopes copy-risk scanning to trusted narrative fields, and `tests/design/test_reference_manifest.py` covers a metadata URL containing copy/screenshot wording without triggering validation.

--- a/docs/review/PR_1680_FIXED_MAPPING.md
+++ b/docs/review/PR_1680_FIXED_MAPPING.md
@@ -39,6 +39,8 @@ Full local `make verify` was intentionally not run by operator machine-budget po
 ### Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235600795 -> 72544e57c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235682587 -> 5b5c08a95
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235691089 -> 5b5c08a95
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195008771 -> 72544e57c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195008797 -> 72544e57c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195087415 -> 5b5c08a95

--- a/docs/review/PR_1680_FIXED_MAPPING.md
+++ b/docs/review/PR_1680_FIXED_MAPPING.md
@@ -18,7 +18,7 @@ Title: `feat(design): add external reference manifest and normalization tooling`
 - `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open` -> PASS (`artifacts/orchestration/task_packets/d7a5d322a084.json`, local/gitignored)
 - `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review` -> PASS (`artifacts/orchestration/task_packets/40281bf2d2e6.json`, local/gitignored)
 - `python3 scripts/design/reference_manifest.py validate-dir docs/design/reference_manifest/examples` -> PASS
-- `. .venv/bin/activate && python3 -m pytest -q tests/design/test_reference_manifest.py` -> PASS (22 tests)
+- `. .venv/bin/activate && python3 -m pytest -q tests/design/test_reference_manifest.py` -> PASS (24 tests)
 - `make validate-changed` -> PASS
 - `make design-guard` -> PASS
 - `make tokens-check` -> PASS
@@ -33,10 +33,21 @@ Full local `make verify` was intentionally not run by operator machine-budget po
 - `e7462a17a41cfd403f4dc409c1f633317b8ea20d` -> `fix(design): harden reference manifest validation`
 - `75f24c1eb186b4f131ad138b8c4d7625fc2500e2` -> `test(design): cover reference manifest validation rules`
 - `4d4fe5672dcdc425d45915cd92dcff1e77561043` -> `docs(design): add reference manifest examples and wave status`
+- `72544e57c` -> `fix(design): close reference manifest review gaps`
 
 ### Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235600795 -> 72544e57c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195008771 -> 72544e57c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195008797 -> 72544e57c
+
+Disposition: FIXED
+Commit: 72544e57c
+Evidence: Cubic flagged asymmetric status/decision validation; `scripts/design/reference_manifest.py` now rejects `status=rejected` unless `adopt_adapt_reject_decision=reject`, and `tests/design/test_reference_manifest.py` covers the contradictory rejected/adapt state.
+
+Disposition: FIXED
+Commit: 72544e57c
+Evidence: Cubic flagged vocabulary load failures escaping deterministic validation; `scripts/design/reference_manifest.py` now converts vocabulary JSON/read failures into `ManifestError` validation errors, and `tests/design/test_reference_manifest.py` asserts malformed vocabulary returns `ERROR:` without traceback.
 
 ## Premortem Fix Evidence
 

--- a/docs/review/PR_1680_FIXED_MAPPING.md
+++ b/docs/review/PR_1680_FIXED_MAPPING.md
@@ -18,7 +18,7 @@ Title: `feat(design): add external reference manifest and normalization tooling`
 - `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open` -> PASS (`artifacts/orchestration/task_packets/d7a5d322a084.json`, local/gitignored)
 - `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review` -> PASS (`artifacts/orchestration/task_packets/40281bf2d2e6.json`, local/gitignored)
 - `python3 scripts/design/reference_manifest.py validate-dir docs/design/reference_manifest/examples` -> PASS
-- `. .venv/bin/activate && python3 -m pytest -q tests/design/test_reference_manifest.py` -> PASS (24 tests)
+- `. .venv/bin/activate && python3 -m pytest -q tests/design/test_reference_manifest.py` -> PASS (27 tests)
 - `make validate-changed` -> PASS
 - `make design-guard` -> PASS
 - `make tokens-check` -> PASS
@@ -34,12 +34,17 @@ Full local `make verify` was intentionally not run by operator machine-budget po
 - `75f24c1eb186b4f131ad138b8c4d7625fc2500e2` -> `test(design): cover reference manifest validation rules`
 - `4d4fe5672dcdc425d45915cd92dcff1e77561043` -> `docs(design): add reference manifest examples and wave status`
 - `72544e57c` -> `fix(design): close reference manifest review gaps`
+- `5b5c08a95` -> `fix(design): close reference manifest bot review gaps`
 
 ### Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#pullrequestreview-4235600795 -> 72544e57c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195008771 -> 72544e57c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195008797 -> 72544e57c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195087415 -> 5b5c08a95
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195087430 -> 5b5c08a95
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195087435 -> 5b5c08a95
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195095771 -> 5b5c08a95
 
 Disposition: FIXED
 Commit: 72544e57c
@@ -48,6 +53,22 @@ Evidence: Cubic flagged asymmetric status/decision validation; `scripts/design/r
 Disposition: FIXED
 Commit: 72544e57c
 Evidence: Cubic flagged vocabulary load failures escaping deterministic validation; `scripts/design/reference_manifest.py` now converts vocabulary JSON/read failures into `ManifestError` validation errors, and `tests/design/test_reference_manifest.py` asserts malformed vocabulary returns `ERROR:` without traceback.
+
+Disposition: FIXED
+Commit: 5b5c08a95
+Evidence: CodeRabbit flagged missing PR-2 traceability; `docs/roadmap/BACKLOG_LEDGER.md` now names PR #1680 in the Design Intelligence Target PR chain.
+
+Disposition: FIXED
+Commit: 5b5c08a95
+Evidence: CodeRabbit flagged source-of-truth scanning over untrusted metadata; `scripts/design/reference_manifest.py` now scans only trusted narrative policy fields, and `tests/design/test_reference_manifest.py` covers a `source_url` containing source-of-truth wording without influencing validation.
+
+Disposition: FIXED
+Commit: 5b5c08a95
+Evidence: CodeRabbit flagged malformed `normalize` input producing traceback; `scripts/design/reference_manifest.py` now catches `ManifestError` in the `normalize` path, and `tests/design/test_reference_manifest.py` covers deterministic `ERROR:` output without traceback.
+
+Disposition: FIXED
+Commit: 5b5c08a95
+Evidence: Cubic flagged malformed UTF-8 vocabulary reads; `scripts/design/reference_manifest.py` now converts `UnicodeDecodeError` into deterministic `ManifestError`, and `tests/design/test_reference_manifest.py` covers malformed UTF-8 vocabulary without traceback.
 
 ## Premortem Fix Evidence
 
@@ -83,6 +104,7 @@ Bug-hunter checks covered:
 - `validate-dir` checks all example JSON files,
 - `normalize` output is deterministic,
 - malformed JSON fails with deterministic `ERROR:` output,
+- malformed UTF-8 vocabulary and malformed normalize input fail with deterministic `ERROR:` output,
 - unknown component ids and component patterns fail,
 - `candidate_for_brief` requires resolved license/copy fields,
 - no token mirror diff,

--- a/docs/review/PR_1680_FIXED_MAPPING.md
+++ b/docs/review/PR_1680_FIXED_MAPPING.md
@@ -36,6 +36,10 @@ Full local `make verify` was intentionally not run by operator machine-budget po
 
 ### Fixed in Commit Mapping
 
+- No actionable review comments
+
+## Premortem Fix Evidence
+
 Disposition: FIXED
 Commit: e7462a17a41cfd403f4dc409c1f633317b8ea20d
 Evidence: Premortem finding "component patterns were not vocabulary-grounded" was fixed; `scripts/design/reference_manifest.py` validates `component_patterns` against PulsePlate vocabulary ids, canonical names, and aliases; `tests/design/test_reference_manifest.py` covers unknown component patterns and accepted canonical aliases.

--- a/docs/review/PR_1680_FIXED_MAPPING.md
+++ b/docs/review/PR_1680_FIXED_MAPPING.md
@@ -18,7 +18,7 @@ Title: `feat(design): add external reference manifest and normalization tooling`
 - `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open` -> PASS (`artifacts/orchestration/task_packets/d7a5d322a084.json`, local/gitignored)
 - `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review` -> PASS (`artifacts/orchestration/task_packets/40281bf2d2e6.json`, local/gitignored)
 - `python3 scripts/design/reference_manifest.py validate-dir docs/design/reference_manifest/examples` -> PASS
-- `. .venv/bin/activate && python3 -m pytest -q tests/design/test_reference_manifest.py` -> PASS (27 tests)
+- `. .venv/bin/activate && python3 -m pytest -q tests/design/test_reference_manifest.py` -> PASS (28 tests)
 - `make validate-changed` -> PASS
 - `make design-guard` -> PASS
 - `make tokens-check` -> PASS
@@ -35,6 +35,8 @@ Full local `make verify` was intentionally not run by operator machine-budget po
 - `4d4fe5672dcdc425d45915cd92dcff1e77561043` -> `docs(design): add reference manifest examples and wave status`
 - `72544e57c` -> `fix(design): close reference manifest review gaps`
 - `5b5c08a95` -> `fix(design): close reference manifest bot review gaps`
+- `e759dc7af` -> `docs(review): map pr 1680 bot review summaries`
+- `3b30deaf8` -> `fix(design): scope reference copy-risk scanning`
 
 ### Fixed in Commit Mapping
 
@@ -47,6 +49,7 @@ Full local `make verify` was intentionally not run by operator machine-budget po
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195087430 -> 5b5c08a95
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195087435 -> 5b5c08a95
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195095771 -> 5b5c08a95
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1680#discussion_r3195158612 -> 3b30deaf8
 
 Disposition: FIXED
 Commit: 72544e57c
@@ -71,6 +74,10 @@ Evidence: CodeRabbit flagged malformed `normalize` input producing traceback; `s
 Disposition: FIXED
 Commit: 5b5c08a95
 Evidence: Cubic flagged malformed UTF-8 vocabulary reads; `scripts/design/reference_manifest.py` now converts `UnicodeDecodeError` into deterministic `ManifestError`, and `tests/design/test_reference_manifest.py` covers malformed UTF-8 vocabulary without traceback.
+
+Disposition: FIXED
+Commit: 3b30deaf8
+Evidence: CodeRabbit flagged direct-copy scanning over untrusted metadata; `scripts/design/reference_manifest.py` now scopes copy-risk scanning to trusted narrative fields, and `tests/design/test_reference_manifest.py` covers a metadata URL containing copy/screenshot wording without triggering validation.
 
 ## Premortem Fix Evidence
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1171,7 +1171,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Reference-driven design intelligence wave for web and iOS
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (design / web / iOS / agentic workflow / reference corpus)
-  - Target PR: PR #1671 (`docs(design): open reference-driven design intelligence wave for web and iOS`, branch `docs/design-intelligence-wave-v1`) -> PR #1677 / PR-1 `feat(design): generate PulsePlate DESIGN.md from token and component contracts` -> PR-2 `feat(design): add external reference manifest and normalization tooling` (`feat/design-reference-manifest-tooling-v1`)
+  - Target PR: PR #1671 (`docs(design): open reference-driven design intelligence wave for web and iOS`, branch `docs/design-intelligence-wave-v1`) -> PR #1677 / PR-1 `feat(design): generate PulsePlate DESIGN.md from token and component contracts` -> PR #1680 / PR-2 `feat(design): add external reference manifest and normalization tooling` (`feat/design-reference-manifest-tooling-v1`)
   - Status: PR-0 merged in PR #1671; PR-1 merged in PR #1677 with generated/drift-checked `docs/design/DESIGN.md`; PR-2 active on branch `feat/design-reference-manifest-tooling-v1` to add external reference manifest validation and normalization tooling. Do not close the wave or mark PR-3/PR-4/PR-5/PR-6 complete in this PR.
   - Area: design / web / iOS / agentic workflow / reference corpus
   - Finding Type: reference-driven design intelligence bootstrap and governance

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1171,8 +1171,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Reference-driven design intelligence wave for web and iOS
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (design / web / iOS / agentic workflow / reference corpus)
-  - Target PR: PR #1671 (`docs(design): open reference-driven design intelligence wave for web and iOS`, branch `docs/design-intelligence-wave-v1`) -> PR #1677 / PR-1 `feat(design): generate PulsePlate DESIGN.md from token and component contracts` (`feat/design-md-generator-v1`)
-  - Status: PR-0 merged in PR #1671; PR-1 active in PR #1677 on branch `feat/design-md-generator-v1` to add generated/drift-checked `docs/design/DESIGN.md`. Do not close the wave or mark PR-2/PR-3/PR-4/PR-5/PR-6 complete in this PR.
+  - Target PR: PR #1671 (`docs(design): open reference-driven design intelligence wave for web and iOS`, branch `docs/design-intelligence-wave-v1`) -> PR #1677 / PR-1 `feat(design): generate PulsePlate DESIGN.md from token and component contracts` -> PR-2 `feat(design): add external reference manifest and normalization tooling` (`feat/design-reference-manifest-tooling-v1`)
+  - Status: PR-0 merged in PR #1671; PR-1 merged in PR #1677 with generated/drift-checked `docs/design/DESIGN.md`; PR-2 active on branch `feat/design-reference-manifest-tooling-v1` to add external reference manifest validation and normalization tooling. Do not close the wave or mark PR-3/PR-4/PR-5/PR-6 complete in this PR.
   - Area: design / web / iOS / agentic workflow / reference corpus
   - Finding Type: reference-driven design intelligence bootstrap and governance
   - Anchor: `ledger-p1-design-intelligence-wave`

--- a/scripts/design/reference_manifest.py
+++ b/scripts/design/reference_manifest.py
@@ -309,7 +309,7 @@ def _validate_component_mapping(record: dict[str, Any], repo_root: Path, errors:
 
 
 def _validate_copy_risk(record: dict[str, Any], errors: list[str]) -> None:
-    text = _field_text(record, exclude={"forbidden_copy_elements", "legal_copy_risks"})
+    text = _narrative_text(record)
     for pattern in DIRECT_COPY_PATTERNS:
         if re.search(pattern, text):
             errors.append("direct-copy intent is forbidden")

--- a/scripts/design/reference_manifest.py
+++ b/scripts/design/reference_manifest.py
@@ -149,8 +149,13 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 def _load_component_terms(repo_root: Path) -> set[str]:
     path = repo_root / VOCABULARY_PATH
-    with path.open(encoding="utf-8") as handle:
-        data = json.load(handle)
+    try:
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"{VOCABULARY_PATH}: invalid JSON: {exc.msg}") from exc
+    except OSError as exc:
+        raise ManifestError(f"{VOCABULARY_PATH}: cannot read vocabulary: {exc}") from exc
     if not isinstance(data, list):
         raise ManifestError(f"{VOCABULARY_PATH}: expected JSON array")
     component_terms: set[str] = set()
@@ -169,8 +174,13 @@ def _load_component_terms(repo_root: Path) -> set[str]:
 
 def _load_component_ids(repo_root: Path) -> set[str]:
     path = repo_root / VOCABULARY_PATH
-    with path.open(encoding="utf-8") as handle:
-        data = json.load(handle)
+    try:
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"{VOCABULARY_PATH}: invalid JSON: {exc.msg}") from exc
+    except OSError as exc:
+        raise ManifestError(f"{VOCABULARY_PATH}: cannot read vocabulary: {exc}") from exc
     if not isinstance(data, list):
         raise ManifestError(f"{VOCABULARY_PATH}: expected JSON array")
     return {
@@ -247,6 +257,8 @@ def _validate_status_alignment(record: dict[str, Any], errors: list[str]) -> Non
     license_status = record.get("license_status")
     if decision == "reject" and status != "rejected":
         errors.append("adopt_adapt_reject_decision=reject requires status=rejected")
+    if status == "rejected" and decision != "reject":
+        errors.append("status=rejected requires adopt_adapt_reject_decision=reject")
     if status == "candidate_for_brief":
         if decision not in {"adopt", "adapt"}:
             errors.append("status=candidate_for_brief requires decision adopt or adapt")
@@ -263,8 +275,12 @@ def _validate_status_alignment(record: dict[str, Any], errors: list[str]) -> Non
 
 
 def _validate_component_mapping(record: dict[str, Any], repo_root: Path, errors: list[str]) -> None:
-    component_terms = _load_component_terms(repo_root)
-    component_ids = _load_component_ids(repo_root)
+    try:
+        component_terms = _load_component_terms(repo_root)
+        component_ids = _load_component_ids(repo_root)
+    except ManifestError as exc:
+        errors.append(str(exc))
+        return
     for component_id in record.get("mapped_pulseplate_components", []):
         if component_id not in component_ids:
             errors.append(f"unknown PulsePlate component mapping: {component_id}")

--- a/scripts/design/reference_manifest.py
+++ b/scripts/design/reference_manifest.py
@@ -110,6 +110,14 @@ SOT_DRIFT_PATTERNS = [
     r"\boverrides?\b.{0,40}\b(repo|tokens|runtime|backend|openapi|ui vocabulary)\b",
 ]
 
+NARRATIVE_SOT_FIELDS = {
+    "accessibility_notes",
+    "motion_notes",
+    "normalization_notes",
+    "monetization_notes",
+    "wellness_safety_notes",
+}
+
 NEGATION_MARKERS = (
     "avoid",
     "no ",
@@ -138,6 +146,8 @@ def _load_json(path: Path) -> dict[str, Any]:
     try:
         with path.open(encoding="utf-8") as handle:
             data = json.load(handle)
+    except UnicodeDecodeError as exc:
+        raise ManifestError(f"{path}: invalid UTF-8: {exc.reason}") from exc
     except json.JSONDecodeError as exc:
         raise ManifestError(f"{path}: invalid JSON: {exc.msg}") from exc
     except OSError as exc:
@@ -152,6 +162,8 @@ def _load_component_terms(repo_root: Path) -> set[str]:
     try:
         with path.open(encoding="utf-8") as handle:
             data = json.load(handle)
+    except UnicodeDecodeError as exc:
+        raise ManifestError(f"{VOCABULARY_PATH}: invalid UTF-8: {exc.reason}") from exc
     except json.JSONDecodeError as exc:
         raise ManifestError(f"{VOCABULARY_PATH}: invalid JSON: {exc.msg}") from exc
     except OSError as exc:
@@ -177,6 +189,8 @@ def _load_component_ids(repo_root: Path) -> set[str]:
     try:
         with path.open(encoding="utf-8") as handle:
             data = json.load(handle)
+    except UnicodeDecodeError as exc:
+        raise ManifestError(f"{VOCABULARY_PATH}: invalid UTF-8: {exc.reason}") from exc
     except json.JSONDecodeError as exc:
         raise ManifestError(f"{VOCABULARY_PATH}: invalid JSON: {exc.msg}") from exc
     except OSError as exc:
@@ -212,6 +226,11 @@ def _field_text(record: dict[str, Any], *, exclude: set[str] | None = None) -> s
         if key in excluded:
             continue
         parts.append(_stringify(record[key]))
+    return "\n".join(parts).lower()
+
+
+def _narrative_text(record: dict[str, Any]) -> str:
+    parts = [_stringify(record[field]) for field in sorted(NARRATIVE_SOT_FIELDS) if field in record]
     return "\n".join(parts).lower()
 
 
@@ -310,7 +329,7 @@ def _validate_wellness_safety(record: dict[str, Any], errors: list[str]) -> None
 
 
 def _validate_source_of_truth(record: dict[str, Any], errors: list[str]) -> None:
-    text = _field_text(record)
+    text = _narrative_text(record)
     if "read-only" in text or "read only" in text or "non-canonical" in text:
         pass
     else:
@@ -420,7 +439,11 @@ def run(argv: list[str] | None = None, *, repo_root: Path = REPO_ROOT) -> int:
 
     if args.command == "normalize":
         path = _repo_path(args.path, repo_root)
-        record = _load_json(path)
+        try:
+            record = _load_json(path)
+        except ManifestError as exc:
+            _print_errors([str(exc)], sys.stderr)
+            return 1
         errors = validate_record(record, repo_root=repo_root)
         if errors:
             _print_errors([f"{path}: {error}" for error in errors], sys.stderr)

--- a/scripts/design/reference_manifest.py
+++ b/scripts/design/reference_manifest.py
@@ -85,9 +85,12 @@ EXPORT_GATE_VALUES = {"required", "passed", "not_applicable", "blocked"}
 DIRECT_COPY_PATTERNS = [
     r"\bcopy\b.{0,40}\b(screenshot|asset|brand|exact layout|layout|component|marketing text|copy)\b",
     r"\bclone\b.{0,40}\b(screenshot|asset|brand|exact layout|layout|component|marketing text|copy)\b",
+    r"\bduplicate\b.{0,40}\b(screenshot|asset|brand|exact layout|layout|component|marketing text|copy|brand style)\b",
     r"\breuse\b.{0,40}\b(screenshot|asset|brand|exact layout|layout|component|marketing text|copy)\b",
     r"\breplicate\b.{0,40}\b(screenshot|asset|brand|exact layout|layout|component|marketing text|copy)\b",
     r"\buse\b.{0,40}\b(external brand|vendor brand|proprietary component|copied marketing text)\b",
+    r"\b(screenshot|asset|brand|exact layout|vendor layout|layout|component|marketing text|copy)\b.{0,60}\b(copy|copied|clone|duplicate|duplicated|reuse|replicate|implementation reference)\b",
+    r"\b(use|treat)\b.{0,40}\b(screenshot|asset|external brand|vendor brand|exact screenshot|exact layout|vendor layout)\b.{0,40}\b(implementation reference|implementation authority|runtime authority)\b",
 ]
 
 WELLNESS_CLAIM_TERMS = [
@@ -132,11 +135,36 @@ def _repo_path(path: str | Path, repo_root: Path) -> Path:
 
 
 def _load_json(path: Path) -> dict[str, Any]:
-    with path.open(encoding="utf-8") as handle:
-        data = json.load(handle)
+    try:
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"{path}: invalid JSON: {exc.msg}") from exc
+    except OSError as exc:
+        raise ManifestError(f"{path}: cannot read manifest: {exc}") from exc
     if not isinstance(data, dict):
         raise ManifestError(f"{path}: manifest must be a JSON object")
     return data
+
+
+def _load_component_terms(repo_root: Path) -> set[str]:
+    path = repo_root / VOCABULARY_PATH
+    with path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, list):
+        raise ManifestError(f"{VOCABULARY_PATH}: expected JSON array")
+    component_terms: set[str] = set()
+    for item in data:
+        if not isinstance(item, dict) or not isinstance(item.get("id"), str):
+            raise ManifestError(f"{VOCABULARY_PATH}: every component requires a string id")
+        component_terms.add(item["id"])
+        canonical_name = item.get("canonical_name")
+        if isinstance(canonical_name, str):
+            component_terms.add(canonical_name)
+        aliases = item.get("aliases", [])
+        if isinstance(aliases, list):
+            component_terms.update(alias for alias in aliases if isinstance(alias, str))
+    return component_terms
 
 
 def _load_component_ids(repo_root: Path) -> set[str]:
@@ -145,12 +173,9 @@ def _load_component_ids(repo_root: Path) -> set[str]:
         data = json.load(handle)
     if not isinstance(data, list):
         raise ManifestError(f"{VOCABULARY_PATH}: expected JSON array")
-    component_ids: set[str] = set()
-    for item in data:
-        if not isinstance(item, dict) or not isinstance(item.get("id"), str):
-            raise ManifestError(f"{VOCABULARY_PATH}: every component requires a string id")
-        component_ids.add(item["id"])
-    return component_ids
+    return {
+        item["id"] for item in data if isinstance(item, dict) and isinstance(item.get("id"), str)
+    }
 
 
 def _stringify(value: Any) -> str:
@@ -238,10 +263,14 @@ def _validate_status_alignment(record: dict[str, Any], errors: list[str]) -> Non
 
 
 def _validate_component_mapping(record: dict[str, Any], repo_root: Path, errors: list[str]) -> None:
+    component_terms = _load_component_terms(repo_root)
     component_ids = _load_component_ids(repo_root)
     for component_id in record.get("mapped_pulseplate_components", []):
         if component_id not in component_ids:
             errors.append(f"unknown PulsePlate component mapping: {component_id}")
+    for component_pattern in record.get("component_patterns", []):
+        if component_pattern not in component_terms:
+            errors.append(f"unknown PulsePlate component pattern: {component_pattern}")
 
 
 def _validate_copy_risk(record: dict[str, Any], errors: list[str]) -> None:
@@ -292,7 +321,10 @@ def validate_record(record: dict[str, Any], *, repo_root: Path = REPO_ROOT) -> l
 
 
 def validate_path(path: Path, *, repo_root: Path = REPO_ROOT) -> list[str]:
-    record = _load_json(path)
+    try:
+        record = _load_json(path)
+    except ManifestError as exc:
+        return [str(exc)]
     return [f"{path}: {error}" for error in validate_record(record, repo_root=repo_root)]
 
 

--- a/scripts/design/reference_manifest.py
+++ b/scripts/design/reference_manifest.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Validate and normalize external UI/UX reference manifests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, TextIO
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VOCABULARY_PATH = Path("docs/design/ui_component_vocabulary.json")
+
+REQUIRED_FIELDS = [
+    "reference_id",
+    "source_name",
+    "source_url",
+    "license_status",
+    "attribution_required",
+    "product_category",
+    "platform",
+    "surface_type",
+    "visual_archetype",
+    "palette_archetype",
+    "typography_archetype",
+    "spacing_density",
+    "radius_profile",
+    "component_patterns",
+    "layout_patterns",
+    "motion_notes",
+    "accessibility_notes",
+    "wellness_safety_notes",
+    "monetization_notes",
+    "legal_copy_risks",
+    "adopt_adapt_reject_decision",
+    "normalization_notes",
+    "mapped_pulseplate_components",
+    "forbidden_copy_elements",
+    "icon-silhouette-check",
+    "design-guard",
+    "status",
+]
+
+STRING_FIELDS = {
+    "reference_id",
+    "source_name",
+    "source_url",
+    "license_status",
+    "product_category",
+    "visual_archetype",
+    "palette_archetype",
+    "typography_archetype",
+    "spacing_density",
+    "radius_profile",
+    "motion_notes",
+    "accessibility_notes",
+    "wellness_safety_notes",
+    "monetization_notes",
+    "adopt_adapt_reject_decision",
+    "normalization_notes",
+    "icon-silhouette-check",
+    "design-guard",
+    "status",
+}
+
+ARRAY_FIELDS = {
+    "platform",
+    "surface_type",
+    "component_patterns",
+    "layout_patterns",
+    "legal_copy_risks",
+    "mapped_pulseplate_components",
+    "forbidden_copy_elements",
+}
+
+STATUS_VALUES = {"read_only", "normalized", "rejected", "candidate_for_brief"}
+DECISION_VALUES = {"adopt", "adapt", "reject"}
+LICENSE_VALUES = {"permissive", "restricted", "unknown", "internal_only", "not_applicable"}
+SPACING_DENSITY_VALUES = {"compact", "balanced", "comfortable", "editorial", "unknown"}
+RADIUS_PROFILE_VALUES = {"sharp", "subtle", "medium", "soft", "pill", "mixed", "unknown"}
+EXPORT_GATE_VALUES = {"required", "passed", "not_applicable", "blocked"}
+
+DIRECT_COPY_PATTERNS = [
+    r"\bcopy\b.{0,40}\b(screenshot|asset|brand|exact layout|layout|component|marketing text|copy)\b",
+    r"\bclone\b.{0,40}\b(screenshot|asset|brand|exact layout|layout|component|marketing text|copy)\b",
+    r"\breuse\b.{0,40}\b(screenshot|asset|brand|exact layout|layout|component|marketing text|copy)\b",
+    r"\breplicate\b.{0,40}\b(screenshot|asset|brand|exact layout|layout|component|marketing text|copy)\b",
+    r"\buse\b.{0,40}\b(external brand|vendor brand|proprietary component|copied marketing text)\b",
+]
+
+WELLNESS_CLAIM_TERMS = [
+    "diagnos",
+    "treat",
+    "therapy",
+    "therapeutic",
+    "emergency",
+    "crisis",
+    "guaranteed",
+    "medical",
+    "cure",
+]
+
+SOT_DRIFT_PATTERNS = [
+    r"\b(source of truth|source-of-truth|canonical truth|runtime authority|token authority)\b",
+    r"\boverrides?\b.{0,40}\b(repo|tokens|runtime|backend|openapi|ui vocabulary)\b",
+]
+
+NEGATION_MARKERS = (
+    "avoid",
+    "no ",
+    "not ",
+    "must not",
+    "does not",
+    "do not",
+    "without",
+    "non-",
+    "never",
+)
+
+
+class ManifestError(ValueError):
+    """Raised when a reference manifest fails deterministic validation."""
+
+
+def _repo_path(path: str | Path, repo_root: Path) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return repo_root / candidate
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ManifestError(f"{path}: manifest must be a JSON object")
+    return data
+
+
+def _load_component_ids(repo_root: Path) -> set[str]:
+    path = repo_root / VOCABULARY_PATH
+    with path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, list):
+        raise ManifestError(f"{VOCABULARY_PATH}: expected JSON array")
+    component_ids: set[str] = set()
+    for item in data:
+        if not isinstance(item, dict) or not isinstance(item.get("id"), str):
+            raise ManifestError(f"{VOCABULARY_PATH}: every component requires a string id")
+        component_ids.add(item["id"])
+    return component_ids
+
+
+def _stringify(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return " ".join(_stringify(item) for item in value)
+    if isinstance(value, dict):
+        return " ".join(_stringify(item) for item in value.values())
+    return str(value)
+
+
+def _has_negation_near(text: str, index: int) -> bool:
+    sentence_start = max(text.rfind(".", 0, index), text.rfind(";", 0, index))
+    window_start = max(0, sentence_start + 1, index - 96)
+    window = text[window_start:index].lower()
+    return any(marker in window for marker in NEGATION_MARKERS)
+
+
+def _field_text(record: dict[str, Any], *, exclude: set[str] | None = None) -> str:
+    excluded = exclude or set()
+    parts = []
+    for key in sorted(record):
+        if key in excluded:
+            continue
+        parts.append(_stringify(record[key]))
+    return "\n".join(parts).lower()
+
+
+def _validate_required_fields(record: dict[str, Any], errors: list[str]) -> None:
+    for field in REQUIRED_FIELDS:
+        if field not in record:
+            errors.append(f"missing required field: {field}")
+
+
+def _validate_field_types(record: dict[str, Any], errors: list[str]) -> None:
+    for field in STRING_FIELDS:
+        if field in record and (not isinstance(record[field], str) or not record[field].strip()):
+            errors.append(f"{field} must be a non-empty string")
+    for field in ARRAY_FIELDS:
+        if field in record:
+            values = record[field]
+            if not isinstance(values, list):
+                errors.append(f"{field} must be an array")
+            elif any(not isinstance(item, str) or not item.strip() for item in values):
+                errors.append(f"{field} must contain only non-empty strings")
+    if "attribution_required" in record and not isinstance(record["attribution_required"], bool):
+        errors.append("attribution_required must be a boolean")
+
+
+def _validate_enums(record: dict[str, Any], errors: list[str]) -> None:
+    enum_fields = [
+        ("status", STATUS_VALUES),
+        ("adopt_adapt_reject_decision", DECISION_VALUES),
+        ("license_status", LICENSE_VALUES),
+        ("spacing_density", SPACING_DENSITY_VALUES),
+        ("radius_profile", RADIUS_PROFILE_VALUES),
+        ("icon-silhouette-check", EXPORT_GATE_VALUES),
+        ("design-guard", EXPORT_GATE_VALUES),
+    ]
+    for field, allowed in enum_fields:
+        if field in record and record[field] not in allowed:
+            errors.append(f"{field} must be one of: {', '.join(sorted(allowed))}")
+
+
+def _validate_status_alignment(record: dict[str, Any], errors: list[str]) -> None:
+    status = record.get("status")
+    decision = record.get("adopt_adapt_reject_decision")
+    license_status = record.get("license_status")
+    if decision == "reject" and status != "rejected":
+        errors.append("adopt_adapt_reject_decision=reject requires status=rejected")
+    if status == "candidate_for_brief":
+        if decision not in {"adopt", "adapt"}:
+            errors.append("status=candidate_for_brief requires decision adopt or adapt")
+        if license_status == "unknown":
+            errors.append("license_status=unknown cannot be candidate_for_brief")
+        for field in ("normalization_notes", "legal_copy_risks", "mapped_pulseplate_components"):
+            value = record.get(field)
+            if isinstance(value, str) and not value.strip():
+                errors.append(f"candidate_for_brief requires non-empty {field}")
+            if isinstance(value, list) and not value:
+                errors.append(f"candidate_for_brief requires non-empty {field}")
+    if status != "rejected" and not record.get("forbidden_copy_elements"):
+        errors.append("non-rejected references require forbidden_copy_elements")
+
+
+def _validate_component_mapping(record: dict[str, Any], repo_root: Path, errors: list[str]) -> None:
+    component_ids = _load_component_ids(repo_root)
+    for component_id in record.get("mapped_pulseplate_components", []):
+        if component_id not in component_ids:
+            errors.append(f"unknown PulsePlate component mapping: {component_id}")
+
+
+def _validate_copy_risk(record: dict[str, Any], errors: list[str]) -> None:
+    text = _field_text(record, exclude={"forbidden_copy_elements", "legal_copy_risks"})
+    for pattern in DIRECT_COPY_PATTERNS:
+        if re.search(pattern, text):
+            errors.append("direct-copy intent is forbidden")
+            break
+
+
+def _validate_wellness_safety(record: dict[str, Any], errors: list[str]) -> None:
+    notes = str(record.get("wellness_safety_notes", "")).lower()
+    for term in WELLNESS_CLAIM_TERMS:
+        for match in re.finditer(re.escape(term), notes):
+            if not _has_negation_near(notes, match.start()):
+                errors.append(
+                    "wellness_safety_notes must not promote medical, treatment, crisis, "
+                    "emergency, therapy, diagnosis, cure, or guaranteed-outcome claims"
+                )
+                return
+
+
+def _validate_source_of_truth(record: dict[str, Any], errors: list[str]) -> None:
+    text = _field_text(record)
+    if "read-only" in text or "read only" in text or "non-canonical" in text:
+        pass
+    else:
+        errors.append("manifest must state references are read-only or non-canonical evidence")
+    for pattern in SOT_DRIFT_PATTERNS:
+        for match in re.finditer(pattern, text):
+            if not _has_negation_near(text, match.start()):
+                errors.append("external references must not become a source of truth")
+                return
+
+
+def validate_record(record: dict[str, Any], *, repo_root: Path = REPO_ROOT) -> list[str]:
+    errors: list[str] = []
+    _validate_required_fields(record, errors)
+    _validate_field_types(record, errors)
+    _validate_enums(record, errors)
+    _validate_status_alignment(record, errors)
+    if not errors:
+        _validate_component_mapping(record, repo_root, errors)
+    _validate_copy_risk(record, errors)
+    _validate_wellness_safety(record, errors)
+    _validate_source_of_truth(record, errors)
+    return errors
+
+
+def validate_path(path: Path, *, repo_root: Path = REPO_ROOT) -> list[str]:
+    record = _load_json(path)
+    return [f"{path}: {error}" for error in validate_record(record, repo_root=repo_root)]
+
+
+def validate_dir(path: Path, *, repo_root: Path = REPO_ROOT) -> list[str]:
+    files = sorted(item for item in path.rglob("*.json") if item.is_file())
+    if not files:
+        return [f"{path}: no JSON manifest files found"]
+    errors: list[str] = []
+    for file_path in files:
+        errors.extend(validate_path(file_path, repo_root=repo_root))
+    return errors
+
+
+def _recommendation(record: dict[str, Any]) -> str:
+    if record["status"] == "rejected" or record["adopt_adapt_reject_decision"] == "reject":
+        return "reject"
+    if record["status"] == "candidate_for_brief":
+        return "candidate_for_brief"
+    return "read_only"
+
+
+def normalized_summary(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "copy_risk_summary": sorted(record["forbidden_copy_elements"]),
+        "decision": record["adopt_adapt_reject_decision"],
+        "license_risk_summary": {
+            "attribution_required": record["attribution_required"],
+            "legal_copy_risks": sorted(record["legal_copy_risks"]),
+            "license_status": record["license_status"],
+        },
+        "mapped_pulseplate_component_ids": sorted(record["mapped_pulseplate_components"]),
+        "platform": sorted(record["platform"]),
+        "recommendation": _recommendation(record),
+        "reference_id": record["reference_id"],
+        "source_name": record["source_name"],
+        "status": record["status"],
+        "surface_type": sorted(record["surface_type"]),
+        "wellness_safety_summary": record["wellness_safety_notes"],
+    }
+
+
+def _print_errors(errors: list[str], stderr: TextIO) -> None:
+    for error in errors:
+        print(f"ERROR: {error}", file=stderr)
+
+
+def run(argv: list[str] | None = None, *, repo_root: Path = REPO_ROOT) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser("validate")
+    validate_parser.add_argument("path")
+
+    validate_dir_parser = subparsers.add_parser("validate-dir")
+    validate_dir_parser.add_argument("dir")
+
+    normalize_parser = subparsers.add_parser("normalize")
+    normalize_parser.add_argument("path")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "validate":
+        errors = validate_path(_repo_path(args.path, repo_root), repo_root=repo_root)
+        if errors:
+            _print_errors(errors, sys.stderr)
+            return 1
+        print(f"OK: {args.path} is valid.")
+        return 0
+
+    if args.command == "validate-dir":
+        errors = validate_dir(_repo_path(args.dir, repo_root), repo_root=repo_root)
+        if errors:
+            _print_errors(errors, sys.stderr)
+            return 1
+        print(f"OK: {args.dir} manifests are valid.")
+        return 0
+
+    if args.command == "normalize":
+        path = _repo_path(args.path, repo_root)
+        record = _load_json(path)
+        errors = validate_record(record, repo_root=repo_root)
+        if errors:
+            _print_errors([f"{path}: {error}" for error in errors], sys.stderr)
+            return 1
+        print(json.dumps(normalized_summary(record), indent=2, sort_keys=True))
+        return 0
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/tests/design/test_reference_manifest.py
+++ b/tests/design/test_reference_manifest.py
@@ -132,6 +132,15 @@ def test_rejected_reference_requires_rejected_status():
     assert "adopt_adapt_reject_decision=reject requires status=rejected" in errors
 
 
+def test_rejected_status_requires_reject_decision():
+    module = load_manifest_module()
+    record = valid_record(adopt_adapt_reject_decision="adapt", status="rejected")
+
+    errors = module.validate_record(record, repo_root=REPO_ROOT)
+
+    assert "status=rejected requires adopt_adapt_reject_decision=reject" in errors
+
+
 def test_unknown_license_cannot_be_candidate_for_brief():
     module = load_manifest_module()
     record = valid_record(license_status="unknown", status="candidate_for_brief")
@@ -235,6 +244,23 @@ def test_malformed_json_reports_deterministic_error(tmp_path, capsys):
     assert result == 1
     assert "ERROR:" in captured.err
     assert "invalid JSON" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_malformed_component_vocabulary_reports_validation_error(tmp_path, capsys):
+    module = load_manifest_module()
+    repo_root = make_temp_repo(tmp_path)
+    vocabulary_path = repo_root / "docs/design/ui_component_vocabulary.json"
+    vocabulary_path.write_text("{not json", encoding="utf-8")
+    manifest_path = repo_root / "manifest.json"
+    write_record(manifest_path, valid_record())
+
+    result = module.run(["validate", str(manifest_path)], repo_root=repo_root)
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "ERROR:" in captured.err
+    assert "ui_component_vocabulary.json: invalid JSON" in captured.err
     assert "Traceback" not in captured.err
 
 

--- a/tests/design/test_reference_manifest.py
+++ b/tests/design/test_reference_manifest.py
@@ -303,6 +303,13 @@ def test_source_of_truth_scan_ignores_untrusted_metadata_url():
     assert module.validate_record(record, repo_root=REPO_ROOT) == []
 
 
+def test_copy_risk_scan_ignores_untrusted_metadata_url():
+    module = load_manifest_module()
+    record = valid_record(source_url="https://example.invalid/copy-screenshot-layout")
+
+    assert module.validate_record(record, repo_root=REPO_ROOT) == []
+
+
 def test_validate_dir_validates_every_json_file(tmp_path, capsys):
     module = load_manifest_module()
     repo_root = make_temp_repo(tmp_path)

--- a/tests/design/test_reference_manifest.py
+++ b/tests/design/test_reference_manifest.py
@@ -247,6 +247,21 @@ def test_malformed_json_reports_deterministic_error(tmp_path, capsys):
     assert "Traceback" not in captured.err
 
 
+def test_normalize_malformed_json_reports_deterministic_error(tmp_path, capsys):
+    module = load_manifest_module()
+    repo_root = make_temp_repo(tmp_path)
+    path = repo_root / "broken.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    result = module.run(["normalize", str(path)], repo_root=repo_root)
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "ERROR:" in captured.err
+    assert "invalid JSON" in captured.err
+    assert "Traceback" not in captured.err
+
+
 def test_malformed_component_vocabulary_reports_validation_error(tmp_path, capsys):
     module = load_manifest_module()
     repo_root = make_temp_repo(tmp_path)
@@ -262,6 +277,30 @@ def test_malformed_component_vocabulary_reports_validation_error(tmp_path, capsy
     assert "ERROR:" in captured.err
     assert "ui_component_vocabulary.json: invalid JSON" in captured.err
     assert "Traceback" not in captured.err
+
+
+def test_malformed_component_vocabulary_utf8_reports_validation_error(tmp_path, capsys):
+    module = load_manifest_module()
+    repo_root = make_temp_repo(tmp_path)
+    vocabulary_path = repo_root / "docs/design/ui_component_vocabulary.json"
+    vocabulary_path.write_bytes(b"\xff\xfe\xfa")
+    manifest_path = repo_root / "manifest.json"
+    write_record(manifest_path, valid_record())
+
+    result = module.run(["validate", str(manifest_path)], repo_root=repo_root)
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "ERROR:" in captured.err
+    assert "ui_component_vocabulary.json: invalid UTF-8" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_source_of_truth_scan_ignores_untrusted_metadata_url():
+    module = load_manifest_module()
+    record = valid_record(source_url="https://example.invalid/source-of-truth-gallery")
+
+    assert module.validate_record(record, repo_root=REPO_ROOT) == []
 
 
 def test_validate_dir_validates_every_json_file(tmp_path, capsys):

--- a/tests/design/test_reference_manifest.py
+++ b/tests/design/test_reference_manifest.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+import runpy
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts/design/reference_manifest.py"
+
+
+def load_manifest_module() -> SimpleNamespace:
+    return SimpleNamespace(**runpy.run_path(str(MODULE_PATH)))
+
+
+def make_temp_repo(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    design_dir = repo_root / "docs/design"
+    design_dir.mkdir(parents=True)
+    shutil.copyfile(
+        REPO_ROOT / "docs/design/ui_component_vocabulary.json",
+        design_dir / "ui_component_vocabulary.json",
+    )
+    return repo_root
+
+
+def valid_record(**overrides):
+    record = {
+        "reference_id": "synthetic-reference-001",
+        "source_name": "Synthetic Reference",
+        "source_url": "https://example.invalid/synthetic-reference",
+        "license_status": "restricted",
+        "attribution_required": False,
+        "product_category": "wellness",
+        "platform": ["web", "ios"],
+        "surface_type": ["dashboard"],
+        "visual_archetype": "calm premium planning surface",
+        "palette_archetype": "derived dark foundation with restrained accent",
+        "typography_archetype": "clear hierarchy with compact labels",
+        "spacing_density": "balanced",
+        "radius_profile": "medium",
+        "component_patterns": ["card", "button"],
+        "layout_patterns": ["summary plus detail"],
+        "motion_notes": "Subtle motion only; reduced-motion fallback remains required.",
+        "accessibility_notes": "Derived notes cover contrast, focus, keyboard, and touch targets.",
+        "wellness_safety_notes": "Read-only non-canonical evidence; avoid diagnostic, treatment, crisis, medical, and guaranteed outcome claims.",
+        "monetization_notes": "Read-only non-canonical evidence for value framing; pricing truth remains repo-owned.",
+        "legal_copy_risks": ["brand-specific wording must be avoided"],
+        "adopt_adapt_reject_decision": "adapt",
+        "normalization_notes": "Read-only non-canonical evidence mapped into PulsePlate vocabulary.",
+        "mapped_pulseplate_components": ["card", "button"],
+        "forbidden_copy_elements": [
+            "screenshot",
+            "external brand",
+            "exact layout",
+            "marketing copy",
+        ],
+        "icon-silhouette-check": "not_applicable",
+        "design-guard": "required",
+        "status": "normalized",
+    }
+    record.update(overrides)
+    return record
+
+
+def write_record(path: Path, record: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_valid_read_only_reference_passes():
+    module = load_manifest_module()
+    record = valid_record(
+        license_status="unknown",
+        adopt_adapt_reject_decision="adapt",
+        status="read_only",
+    )
+
+    assert module.validate_record(record, repo_root=REPO_ROOT) == []
+
+
+def test_valid_normalized_reference_passes():
+    module = load_manifest_module()
+
+    assert module.validate_record(valid_record(), repo_root=REPO_ROOT) == []
+
+
+def test_valid_candidate_for_brief_requires_resolved_fields():
+    module = load_manifest_module()
+    record = valid_record(
+        license_status="restricted",
+        status="candidate_for_brief",
+        adopt_adapt_reject_decision="adapt",
+    )
+
+    assert module.validate_record(record, repo_root=REPO_ROOT) == []
+
+
+def test_missing_required_field_fails():
+    module = load_manifest_module()
+    record = valid_record()
+    del record["source_name"]
+
+    errors = module.validate_record(record, repo_root=REPO_ROOT)
+
+    assert "missing required field: source_name" in errors
+
+
+def test_candidate_for_brief_requires_normalization_notes_and_components():
+    module = load_manifest_module()
+    record = valid_record(
+        status="candidate_for_brief",
+        normalization_notes="",
+        mapped_pulseplate_components=[],
+    )
+
+    errors = module.validate_record(record, repo_root=REPO_ROOT)
+
+    assert "candidate_for_brief requires non-empty normalization_notes" in errors
+    assert "candidate_for_brief requires non-empty mapped_pulseplate_components" in errors
+
+
+def test_rejected_reference_requires_rejected_status():
+    module = load_manifest_module()
+    record = valid_record(adopt_adapt_reject_decision="reject", status="normalized")
+
+    errors = module.validate_record(record, repo_root=REPO_ROOT)
+
+    assert "adopt_adapt_reject_decision=reject requires status=rejected" in errors
+
+
+def test_unknown_license_cannot_be_candidate_for_brief():
+    module = load_manifest_module()
+    record = valid_record(license_status="unknown", status="candidate_for_brief")
+
+    errors = module.validate_record(record, repo_root=REPO_ROOT)
+
+    assert "license_status=unknown cannot be candidate_for_brief" in errors
+
+
+def test_unknown_pulseplate_component_mapping_fails():
+    module = load_manifest_module()
+    record = valid_record(mapped_pulseplate_components=["card", "invented_component"])
+
+    errors = module.validate_record(record, repo_root=REPO_ROOT)
+
+    assert "unknown PulsePlate component mapping: invented_component" in errors
+
+
+def test_unknown_component_pattern_fails():
+    module = load_manifest_module()
+    record = valid_record(component_patterns=["card", "invented_component"])
+
+    errors = module.validate_record(record, repo_root=REPO_ROOT)
+
+    assert "unknown PulsePlate component pattern: invented_component" in errors
+
+
+def test_component_patterns_accept_canonical_vocabulary_aliases():
+    module = load_manifest_module()
+    record = valid_record(component_patterns=["card", "segmented-control"])
+
+    assert module.validate_record(record, repo_root=REPO_ROOT) == []
+
+
+def test_missing_forbidden_copy_elements_fails_for_non_rejected_reference():
+    module = load_manifest_module()
+    record = valid_record(forbidden_copy_elements=[])
+
+    errors = module.validate_record(record, repo_root=REPO_ROOT)
+
+    assert "non-rejected references require forbidden_copy_elements" in errors
+
+
+def test_direct_copy_risk_fails_closed():
+    module = load_manifest_module()
+    record = valid_record(
+        normalization_notes="Read-only evidence, but copy screenshot layout exactly."
+    )
+
+    errors = module.validate_record(record, repo_root=REPO_ROOT)
+
+    assert "direct-copy intent is forbidden" in errors
+
+
+@pytest.mark.parametrize(
+    "normalization_notes",
+    [
+        "Read-only evidence says the screenshot should be copied into PulsePlate.",
+        "Read-only evidence says use the exact screenshot as implementation reference.",
+        "Read-only evidence says duplicate the vendor layout and brand style.",
+    ],
+)
+def test_direct_copy_variants_fail_closed(normalization_notes: str):
+    module = load_manifest_module()
+    record = valid_record(normalization_notes=normalization_notes)
+
+    errors = module.validate_record(record, repo_root=REPO_ROOT)
+
+    assert "direct-copy intent is forbidden" in errors
+
+
+def test_medical_treatment_claim_wording_fails_when_promoted():
+    module = load_manifest_module()
+    record = valid_record(
+        wellness_safety_notes="This reference supports treatment and guaranteed outcomes."
+    )
+
+    errors = module.validate_record(record, repo_root=REPO_ROOT)
+
+    assert any("wellness_safety_notes must not promote" in error for error in errors)
+
+
+def test_external_reference_source_of_truth_wording_fails():
+    module = load_manifest_module()
+    record = valid_record(normalization_notes="This external reference is the source of truth.")
+
+    errors = module.validate_record(record, repo_root=REPO_ROOT)
+
+    assert "external references must not become a source of truth" in errors
+
+
+def test_malformed_json_reports_deterministic_error(tmp_path, capsys):
+    module = load_manifest_module()
+    repo_root = make_temp_repo(tmp_path)
+    path = repo_root / "broken.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    result = module.run(["validate", str(path)], repo_root=repo_root)
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "ERROR:" in captured.err
+    assert "invalid JSON" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_validate_dir_validates_every_json_file(tmp_path, capsys):
+    module = load_manifest_module()
+    repo_root = make_temp_repo(tmp_path)
+    examples_dir = repo_root / "docs/design/reference_manifest/examples"
+    write_record(examples_dir / "one.json", valid_record(reference_id="one"))
+    write_record(examples_dir / "two.json", valid_record(reference_id="two", status="read_only"))
+
+    result = module.run(
+        ["validate-dir", "docs/design/reference_manifest/examples"],
+        repo_root=repo_root,
+    )
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "OK: docs/design/reference_manifest/examples manifests are valid." in captured.out
+
+
+def test_normalize_output_is_deterministic(tmp_path, capsys):
+    module = load_manifest_module()
+    repo_root = make_temp_repo(tmp_path)
+    path = repo_root / "manifest.json"
+    write_record(path, valid_record())
+
+    assert module.run(["normalize", str(path)], repo_root=repo_root) == 0
+    first = capsys.readouterr().out
+    assert module.run(["normalize", str(path)], repo_root=repo_root) == 0
+    second = capsys.readouterr().out
+
+    assert first == second
+    summary = json.loads(first)
+    assert summary["reference_id"] == "synthetic-reference-001"
+    assert summary["recommendation"] == "read_only"
+    assert summary["mapped_pulseplate_component_ids"] == ["button", "card"]
+
+
+def test_no_network_access_is_required_for_validation(tmp_path, monkeypatch):
+    module = load_manifest_module()
+    repo_root = make_temp_repo(tmp_path)
+    path = repo_root / "manifest.json"
+    write_record(path, valid_record(source_url="https://network.invalid/reference"))
+
+    def fail_network(*_args, **_kwargs):
+        raise AssertionError("network access is forbidden")
+
+    monkeypatch.setattr("socket.create_connection", fail_network)
+
+    assert module.run(["validate", str(path)], repo_root=repo_root) == 0
+
+
+def test_committed_examples_are_synthetic_and_valid():
+    module = load_manifest_module()
+
+    examples_dir = REPO_ROOT / "docs/design/reference_manifest/examples"
+    result = module.validate_dir(examples_dir, repo_root=REPO_ROOT)
+
+    assert result == []
+    for path in examples_dir.glob("*.json"):
+        record = json.loads(path.read_text(encoding="utf-8"))
+        serialized = json.dumps(record).lower()
+        assert "synthetic" in serialized
+        assert "copy screenshot" not in serialized
+        assert "exact layout" in record["forbidden_copy_elements"]


### PR DESCRIPTION
## Summary

Adds external UI/UX reference manifest validation and normalization tooling for the Design Intelligence wave.

This PR keeps external references read-only and non-canonical. It does not ingest, scrape, copy, or apply external designs.

## Goal

Let future design agents register and validate external UI/UX references without creating a second design source of truth.

## Business reason

PulsePlate needs market-aware design automation, but external references must pass license, copy-risk, wellness-safety, and PulsePlate vocabulary normalization before informing future briefs.

## Scope

- Add deterministic reference manifest validation CLI.
- Add synthetic example reference records.
- Add tests for reference status/decision/license/copy/component mapping rules.
- Update design docs/backlog narrowly.

## Out of scope

- No web redesign.
- No iOS redesign.
- No Figma writes.
- No Canva writes.
- No crawler.
- No external asset import.
- No GEPA.
- No screen evidence pack.
- No design scoring engine.
- No `/tokens` changes.
- No generated token mirror edits.
- No frontend/iOS/backend/OpenAPI/billing/auth changes.

## Source of truth

Repo code/docs/tests, `/tokens`, generated mirrors, UI vocabulary, backend/OpenAPI contracts, and runtime code remain canonical.

External references, Figma, Canva, Storybook, prompt outputs, and DESIGN.md are evidence/reference layers only and do not override repo truth.

## Design automation module classification

Design automation items are modules inside the existing PulsePlate Design Intelligence / Design Runtime system, not standalone plugins.

This PR implements only the external reference manifest/normalization module for PR-2. Other modules remain deferred to their correct PRs:

- Design Evidence Harvester -> PR-3
- Component Drift Inspector -> PR-4
- Icon Asset Validator -> release/design asset guard lane
- Launch Copy Compliance Linter -> release/compliance/marketing guard
- Marketing Asset Pack Compiler -> late GTM layer after accepted design/copy truth

## Files changed

- `scripts/design/reference_manifest.py`
- `tests/design/test_reference_manifest.py`
- `docs/design/reference_manifest/examples/README.md`
- `docs/design/reference_manifest/examples/refero_dashboard_density.sample.json`
- `docs/design/reference_manifest/examples/open_design_component_taxonomy.sample.json`
- `docs/design/REFERENCE_MANIFEST_SCHEMA.md`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/review/PR_1680_FIXED_MAPPING.md`

## Tests / bounded checks

Full local `make verify` was not run by operator machine-budget policy.

Actual local checks run:

- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open`
- `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review`
- `python3 scripts/design/reference_manifest.py validate-dir docs/design/reference_manifest/examples`
- `. .venv/bin/activate && python3 -m pytest -q tests/design/test_reference_manifest.py` (28 tests)
- `make validate-changed`
- `make design-guard`
- `make tokens-check`
- `pre-commit run --all-files`
- pre-push hook bundle from `git push`
- `git diff -- frontend/src/styles/tokens.css frontend/src/styles/tokens.ts ios/PulsePlate/DesignSystem/DesignTokens.generated.swift` returned empty output

Operator explicitly owns current-head `main` monitoring after PR #1677; this PR does not claim readiness from local gates alone.

## Security notes

No secrets, auth, billing, backend, deploy, external integration, crawler, or network access added.

External references are treated as untrusted read-only inputs. License/copy-risk rules fail closed.

## Premortem

Premortem reviewed actual code/docs/tests diff.

Findings fixed before PR open:

- Component patterns could bypass vocabulary grounding. Fixed by validating `component_patterns` against PulsePlate vocabulary ids, canonical names, and aliases.
- Direct-copy and implementation-authority wording was too narrow. Fixed by broadening fail-closed direct-copy patterns and adding negative tests.
- Malformed JSON could escape as traceback. Fixed by converting JSON/read errors into deterministic `ERROR:` CLI output and adding a test.
- CodeRabbit flagged metadata influencing source-of-truth checks. Fixed by scanning only trusted narrative policy fields and adding coverage for metadata URLs containing source-of-truth wording.
- CodeRabbit flagged malformed `normalize` input. Fixed by catching `ManifestError` in the normalize path and adding deterministic no-traceback coverage.
- Cubic flagged malformed UTF-8 vocabulary reads. Fixed by converting `UnicodeDecodeError` into deterministic `ManifestError` output and adding coverage.

## Bug-hunter pass

Bug-hunter checked:

- no second SoT claim
- no external copy path
- validation fail-closed checks
- component mapping and component pattern grounding
- malformed JSON deterministic failure
- malformed normalize input and malformed UTF-8 vocabulary deterministic failure
- no token mirror diff
- no runtime diff
- no plugin architecture introduced

## Split Justification

This PR is intentionally kept as one PR-2 executable slice because the public interface, fixtures, tests, and narrow docs/status updates validate one contract together. Splitting the CLI from its validation fixtures/tests would reduce reviewability and could allow an unproven external-reference intake surface to land without fail-closed evidence. Scope remains bounded to design tooling/docs/tests only; no runtime, token, frontend, iOS, backend, crawler, Figma, Canva, or scorecard-engine changes are included.

## Deferred / Follow-ups

- PR-3: screen evidence pack for web and iOS review surfaces.
- PR-4: deterministic design scorecard checks.
- PR-5: web launch shell alignment to accepted design brief.
- PR-6: iOS visual parity audit and bounded sync.
- PR-7: design-agent workflow and PR template.
- PR-8: GEPA-compatible prompt/rubric evolution lane.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

See `docs/review/PR_1680_FIXED_MAPPING.md`.

## Merge Readiness

Do not mark until CI/review/mapping/wait-window/strict wrapper pass.

## Rollback

Revert this tooling/docs PR. No runtime rollback required.

## DoD

- Reference manifest CLI exists.
- Example manifests validate.
- Invalid license/copy/status/component states fail closed.
- Tests cover validation rules.
- No runtime code changes.
- No generated token mirror diff.
- Bounded checks pass.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docs for the reference manifest schema, usage, validation scope, example manifests, review artifacts, and roadmap/backlog updates.

* **New Features**
  * Added a repo-local reference manifest validator with validate, validate-dir, and normalize commands.
  * Added synthetic example manifests and guidance to validate them.

* **Tests**
  * Added a comprehensive test suite covering validation rules, normalization, directory-wide checks, and network-free operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

