### PR TITLE
feat(evidence): link advisory wiki artifacts to evidence assets

### DIFF
--- a/core/evidence/AGENTS.md
+++ b/core/evidence/AGENTS.md
@@ -48,3 +48,30 @@ Forbidden:
 
 Admission decisions are gates, not side effects. They may block future
 promotion/serve actions, but this package must not perform those actions.
+
+## E5 advisory wiki bridge
+
+E5 bridge logic must stay pure deterministic mapping only.
+
+Allowed:
+
+- advisory wiki artifact reference dataclasses
+- advisory `EvidenceAssetRef` mapping
+- advisory admission metadata adapters
+- deterministic IDs, fingerprints, idempotency keys, and serialization
+- metadata/path safety validation
+
+Forbidden:
+
+- wiki compiler rewrites
+- local support-plane mutation imports
+- `scripts/orchestration` imports
+- wiki ingest/promote/query/lint CLI imports
+- runtime writes or product serving behavior
+- runtime rail mapping for wiki artifacts
+- semantic cache, Redis, GPTCache, or GraphRAG imports
+- advisory wiki as product/runtime/eval source of truth
+
+Advisory wiki artifacts are workforce memory. They may be linked to advisory
+evidence assets for lineage and review, but they must not become canonical
+repo/runtime/DB/OpenAPI/test truth.

--- a/core/evidence/AGENTS.md
+++ b/core/evidence/AGENTS.md
@@ -51,7 +51,9 @@ promotion/serve actions, but this package must not perform those actions.
 
 ## E5 advisory wiki bridge
 
-E5 bridge logic must stay pure deterministic mapping only.
+E5 bridge logic must stay pure, deterministic mapping only. Reviewers must
+verify that wiki bridge changes do not introduce compiler behavior, runtime
+authority, local support-plane mutation, or product-truth claims.
 
 Allowed:
 

--- a/core/evidence/__init__.py
+++ b/core/evidence/__init__.py
@@ -46,8 +46,16 @@ from core.evidence.replay import (
     PromotionReplaySummary,
     dry_run_replay,
 )
+from core.evidence.wiki_bridge import (
+    AdvisoryWikiArtifactRef,
+    WikiEvidenceBridgePolicy,
+    create_advisory_wiki_artifact_ref,
+    wiki_artifact_to_admission_input,
+    wiki_artifact_to_evidence_asset_ref,
+)
 
 __all__ = [
+    "AdvisoryWikiArtifactRef",
     "AdmissionAction",
     "AdmissionDecision",
     "AdmissionInput",
@@ -65,10 +73,12 @@ __all__ = [
     "PromotionReplaySummary",
     "Rail",
     "ValidationStatus",
+    "WikiEvidenceBridgePolicy",
     "admission_input_from_eval_event",
     "admission_input_from_ledger_entry",
     "build_asset_id",
     "build_idempotency_key",
+    "create_advisory_wiki_artifact_ref",
     "create_evidence_asset_ref",
     "create_eval_event",
     "create_promotion_ledger_entry",
@@ -78,4 +88,6 @@ __all__ = [
     "decide_allow_serve",
     "dry_run_replay",
     "fingerprint_payload",
+    "wiki_artifact_to_admission_input",
+    "wiki_artifact_to_evidence_asset_ref",
 ]

--- a/core/evidence/wiki_bridge.py
+++ b/core/evidence/wiki_bridge.py
@@ -490,7 +490,7 @@ def _freeze_metadata(value: Mapping[str, JsonValue]) -> FrozenJson:
 
 
 def _validate_metadata(value: JsonValue, *, key_path: tuple[str, ...] = ()) -> None:
-    if isinstance(value, bytes):
+    if isinstance(value, (bytes, bytearray, memoryview)):
         raise ValueError("metadata must be JSON-compatible")
     if isinstance(value, str):
         _validate_metadata_string(value, key_path)

--- a/core/evidence/wiki_bridge.py
+++ b/core/evidence/wiki_bridge.py
@@ -1,0 +1,587 @@
+"""Deterministic advisory wiki bridge contracts for Evidence Graph."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Literal, TypeAlias, cast
+
+from core.evidence.admission import AdmissionInput, ValidationStatus
+from core.evidence.assets import EvidenceAssetRef, create_evidence_asset_ref
+from core.evidence.fingerprints import (
+    fingerprint_payload,
+)
+from core.evidence.policies import (
+    normalize_upstream_ids,
+    validate_fingerprint,
+    validate_non_empty_token,
+)
+
+WikiBridgeAssetType: TypeAlias = Literal[
+    "knowledge_candidate", "context_bundle", "verification_bundle"
+]
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | Mapping[str, "JsonValue"] | Sequence["JsonValue"]
+FrozenJson: TypeAlias = JsonScalar | tuple["FrozenJson", ...] | tuple[tuple[str, "FrozenJson"], ...]
+
+_SHA256_RE = re.compile(r"^(?:sha256:)?[0-9a-fA-F]{64}$")
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[/\\]")
+_CURRENT_DIR_VALUES = {".", "./", "./."}
+_FORBIDDEN_METADATA_KEY_FRAGMENTS = (
+    "access_token",
+    "api_key",
+    "apikey",
+    "answer_text",
+    "health_payload",
+    "medical_record",
+    "password",
+    "prompt",
+    "query",
+    "raw_prompt",
+    "raw_query",
+    "raw_response",
+    "refresh_token",
+    "response",
+    "secret",
+    "token",
+    "user_health",
+    "user_payload",
+)
+_FORBIDDEN_METADATA_STRING_FRAGMENTS = (
+    "api_key=",
+    "bearer ",
+    "health payload",
+    "medical record",
+    "password=",
+    "private key",
+    "prompt:",
+    "query:",
+    "raw prompt",
+    "raw query",
+    "raw response",
+    "response:",
+    "sk-",
+    "user health",
+    "user payload",
+)
+_AUTHORITY_KEY_FRAGMENTS = (
+    "authority",
+    "canonical",
+    "product_truth",
+    "rail",
+    "runtime",
+    "source_of_truth",
+)
+_AUTHORITY_VALUE_FRAGMENTS = (
+    "authoritative",
+    "canonical",
+    "product truth",
+    "product_runtime",
+    "runtime",
+    "source of truth",
+    "source_of_truth",
+    "user-facing",
+)
+_PATH_VALUE_PREFIXES = (
+    "./",
+    "../",
+    "~/",
+    "/",
+    "app/",
+    "core/",
+    "docs/",
+    "evals/",
+    "scripts/",
+    "tests/",
+)
+_PATH_VALUE_SUFFIXES = (".json", ".jsonl", ".md", ".py", ".txt", ".yaml", ".yml")
+
+
+@dataclass(frozen=True, slots=True)
+class WikiEvidenceBridgePolicy:
+    """Policy for mapping advisory wiki artifacts into evidence references."""
+
+    policy_version: str
+    allowed_corpora: tuple[str, ...]
+    require_content_hash: bool = True
+    require_source_rel_path: bool = True
+    allow_promoted_only: bool = False
+    allowed_admission_statuses: tuple[ValidationStatus, ...] = ("valid",)
+    advisory_only_enforced: bool = True
+    allowed_asset_types: tuple[WikiBridgeAssetType, ...] = (
+        "knowledge_candidate",
+        "context_bundle",
+        "verification_bundle",
+    )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "policy_version", validate_non_empty_token("policy_version", self.policy_version)
+        )
+        if not self.advisory_only_enforced:
+            raise ValueError("advisory_only_enforced must be true")
+        corpora = tuple(
+            sorted({validate_non_empty_token("allowed_corpus", c) for c in self.allowed_corpora})
+        )
+        if not corpora:
+            raise ValueError("allowed_corpora must not be empty")
+        object.__setattr__(self, "allowed_corpora", corpora)
+
+        statuses = tuple(sorted(set(self.allowed_admission_statuses)))
+        if not statuses:
+            raise ValueError("allowed_admission_statuses must not be empty")
+        unsupported_statuses = set(statuses) - {"valid", "invalid", "degraded", "deferred"}
+        if unsupported_statuses:
+            raise ValueError(f"unsupported admission statuses: {sorted(unsupported_statuses)}")
+        object.__setattr__(self, "allowed_admission_statuses", statuses)
+
+        asset_types = tuple(sorted(set(self.allowed_asset_types)))
+        if not asset_types:
+            raise ValueError("allowed_asset_types must not be empty")
+        unsupported_asset_types = set(asset_types) - {
+            "knowledge_candidate",
+            "context_bundle",
+            "verification_bundle",
+        }
+        if unsupported_asset_types:
+            raise ValueError(
+                f"unsupported wiki bridge asset types: {sorted(unsupported_asset_types)}"
+            )
+        object.__setattr__(self, "allowed_asset_types", asset_types)
+
+
+@dataclass(frozen=True, init=False, slots=True)
+class AdvisoryWikiArtifactRef:
+    """Immutable reference to an advisory-only wiki artifact."""
+
+    artifact_id: str
+    corpus: str
+    slug: str
+    source_rel_path: str
+    page_path: str
+    promoted_path: str | None
+    content_hash: str
+    policy_version: str
+    idempotency_key: str
+    advisory_only: bool
+    promoted: bool
+    upstream_ids: tuple[str, ...]
+    _metadata: FrozenJson
+
+    def __init__(
+        self,
+        *,
+        artifact_id: str,
+        corpus: str,
+        slug: str,
+        source_rel_path: str,
+        page_path: str,
+        promoted_path: str | None,
+        content_hash: str,
+        policy_version: str,
+        idempotency_key: str,
+        advisory_only: bool,
+        promoted: bool,
+        upstream_ids: Iterable[str],
+        metadata: Mapping[str, JsonValue] | None = None,
+    ) -> None:
+        if not advisory_only:
+            raise ValueError("advisory_only must be true")
+        normalized_hash = _normalize_content_hash(content_hash)
+        validate_fingerprint(normalized_hash)
+
+        object.__setattr__(
+            self, "artifact_id", _validate_non_empty_identifier(artifact_id, "artifact_id")
+        )
+        object.__setattr__(self, "corpus", _validate_sluglike_token(corpus, "corpus"))
+        object.__setattr__(self, "slug", _validate_sluglike_token(slug, "slug"))
+        object.__setattr__(
+            self,
+            "source_rel_path",
+            _validate_bridge_path("source_rel_path", source_rel_path, allow_docs_authority=True),
+        )
+        object.__setattr__(
+            self,
+            "page_path",
+            _validate_bridge_path("page_path", page_path, allow_docs_authority=False),
+        )
+        normalized_promoted_path = (
+            None
+            if promoted_path is None
+            else _validate_bridge_path("promoted_path", promoted_path, allow_docs_authority=False)
+        )
+        object.__setattr__(self, "promoted_path", normalized_promoted_path)
+        object.__setattr__(self, "content_hash", normalized_hash)
+        object.__setattr__(
+            self, "policy_version", validate_non_empty_token("policy_version", policy_version)
+        )
+        object.__setattr__(
+            self,
+            "idempotency_key",
+            _validate_non_empty_identifier(idempotency_key, "idempotency_key"),
+        )
+        object.__setattr__(self, "advisory_only", True)
+        object.__setattr__(self, "promoted", bool(promoted))
+        object.__setattr__(self, "upstream_ids", normalize_upstream_ids(tuple(upstream_ids)))
+        object.__setattr__(self, "_metadata", _freeze_metadata(metadata or {}))
+
+    @property
+    def metadata(self) -> dict[str, JsonValue]:
+        return cast(dict[str, JsonValue], _thaw_json(self._metadata))
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        payload: dict[str, JsonValue] = {
+            "advisory_only": self.advisory_only,
+            "artifact_id": self.artifact_id,
+            "content_hash": self.content_hash,
+            "corpus": self.corpus,
+            "idempotency_key": self.idempotency_key,
+            "metadata": self.metadata,
+            "page_path": self.page_path,
+            "policy_version": self.policy_version,
+            "promoted": self.promoted,
+            "promoted_path": self.promoted_path,
+            "slug": self.slug,
+            "source_rel_path": self.source_rel_path,
+            "upstream_ids": list(self.upstream_ids),
+        }
+        return payload
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+def create_advisory_wiki_artifact_ref(
+    *,
+    corpus: str,
+    slug: str,
+    source_rel_path: str,
+    page_path: str,
+    content_hash: str,
+    policy_version: str,
+    promoted_path: str | None = None,
+    promoted: bool = False,
+    upstream_ids: Iterable[str] = (),
+    metadata: Mapping[str, JsonValue] | None = None,
+    policy: WikiEvidenceBridgePolicy | None = None,
+) -> AdvisoryWikiArtifactRef:
+    """Create a deterministic advisory wiki artifact reference."""
+
+    normalized_corpus = _validate_sluglike_token(corpus, "corpus")
+    normalized_slug = _validate_sluglike_token(slug, "slug")
+    normalized_policy_version = validate_non_empty_token("policy_version", policy_version)
+    normalized_hash = _normalize_content_hash(content_hash)
+    normalized_source_path = _validate_bridge_path(
+        "source_rel_path", source_rel_path, allow_docs_authority=True
+    )
+    normalized_page_path = _validate_bridge_path("page_path", page_path, allow_docs_authority=False)
+    normalized_promoted_path = (
+        None
+        if promoted_path is None
+        else _validate_bridge_path("promoted_path", promoted_path, allow_docs_authority=False)
+    )
+    normalized_upstream_ids = normalize_upstream_ids(tuple(upstream_ids))
+    _validate_policy(policy, normalized_policy_version, normalized_corpus, bool(promoted))
+
+    identity_payload: dict[str, JsonValue] = {
+        "advisory_only": True,
+        "content_hash": normalized_hash,
+        "corpus": normalized_corpus,
+        "page_path": normalized_page_path,
+        "policy_version": normalized_policy_version,
+        "promoted": bool(promoted),
+        "promoted_path": normalized_promoted_path,
+        "slug": normalized_slug,
+        "source_rel_path": normalized_source_path,
+        "upstream_ids": list(normalized_upstream_ids),
+    }
+    digest = fingerprint_payload(identity_payload).removeprefix("sha256:")
+    artifact_id = f"advisory-wiki:{digest[:24]}"
+    idempotency_key = f"idem:advisory-wiki:{digest}"
+    return AdvisoryWikiArtifactRef(
+        artifact_id=artifact_id,
+        corpus=normalized_corpus,
+        slug=normalized_slug,
+        source_rel_path=normalized_source_path,
+        page_path=normalized_page_path,
+        promoted_path=normalized_promoted_path,
+        content_hash=normalized_hash,
+        policy_version=normalized_policy_version,
+        idempotency_key=idempotency_key,
+        advisory_only=True,
+        promoted=promoted,
+        upstream_ids=normalized_upstream_ids,
+        metadata=metadata,
+    )
+
+
+def wiki_artifact_to_evidence_asset_ref(
+    artifact: AdvisoryWikiArtifactRef,
+    *,
+    asset_type: WikiBridgeAssetType = "knowledge_candidate",
+    version: str = "v1",
+    policy: WikiEvidenceBridgePolicy | None = None,
+) -> EvidenceAssetRef:
+    """Map an advisory wiki artifact into an advisory evidence asset."""
+
+    if not isinstance(artifact, AdvisoryWikiArtifactRef):
+        raise TypeError("artifact must be AdvisoryWikiArtifactRef")
+    normalized_asset_type = cast(
+        WikiBridgeAssetType, validate_non_empty_token("asset_type", asset_type)
+    )
+    allowed_asset_types = (
+        policy.allowed_asset_types
+        if policy is not None
+        else ("knowledge_candidate", "context_bundle", "verification_bundle")
+    )
+    if normalized_asset_type not in allowed_asset_types:
+        raise ValueError(f"unsupported advisory wiki asset_type: {normalized_asset_type}")
+    _validate_policy(policy, artifact.policy_version, artifact.corpus, artifact.promoted)
+
+    payload: dict[str, JsonValue] = {
+        "advisory_only": True,
+        "artifact_id": artifact.artifact_id,
+        "bridge": "advisory_wiki",
+        "content_hash": artifact.content_hash,
+        "corpus": artifact.corpus,
+        "promoted": artifact.promoted,
+        "slug": artifact.slug,
+    }
+    return create_evidence_asset_ref(
+        asset_type=normalized_asset_type,
+        rail="advisory",
+        version=version,
+        policy_version=artifact.policy_version,
+        payload=payload,
+        upstream_ids=artifact.upstream_ids,
+    )
+
+
+def wiki_artifact_to_admission_input(
+    artifact: AdvisoryWikiArtifactRef,
+    *,
+    produced_at: str,
+    coverage_rate: float,
+    verification_rate: float,
+    fallback_rate: float,
+    validation_status: ValidationStatus = "valid",
+    degraded_reason: str | None = None,
+    metadata: Mapping[str, JsonValue] | None = None,
+    policy: WikiEvidenceBridgePolicy | None = None,
+) -> AdmissionInput:
+    """Adapt a wiki artifact to E4 admission input for advisory review only."""
+
+    if not isinstance(artifact, AdvisoryWikiArtifactRef):
+        raise TypeError("artifact must be AdvisoryWikiArtifactRef")
+    _validate_policy(policy, artifact.policy_version, artifact.corpus, artifact.promoted)
+    allowed_statuses = policy.allowed_admission_statuses if policy is not None else ("valid",)
+    if validation_status not in allowed_statuses:
+        raise ValueError(
+            f"validation_status is not admitted by wiki bridge policy: {validation_status}"
+        )
+    _freeze_metadata(metadata or {})
+    admission_metadata: dict[str, JsonValue] = {
+        "advisory_only": True,
+        "bridge": "advisory_wiki",
+        "corpus": artifact.corpus,
+        "promoted": artifact.promoted,
+        "serve_scope": "advisory_review_only",
+        "slug": artifact.slug,
+    }
+    if metadata:
+        admission_metadata["bridge_metadata"] = _thaw_json(_freeze_metadata(metadata))
+
+    return AdmissionInput(
+        target_id=artifact.artifact_id,
+        target_type="evidence_asset",
+        fingerprint=artifact.content_hash,
+        idempotency_key=artifact.idempotency_key,
+        policy_version=artifact.policy_version,
+        produced_at=produced_at,
+        validation_status=validation_status,
+        coverage_rate=coverage_rate,
+        verification_rate=verification_rate,
+        fallback_rate=fallback_rate,
+        degraded_reason=degraded_reason,
+        upstream_ids=artifact.upstream_ids,
+        metadata=admission_metadata,
+    )
+
+
+def _validate_policy(
+    policy: WikiEvidenceBridgePolicy | None,
+    policy_version: str,
+    corpus: str,
+    promoted: bool,
+) -> None:
+    if policy is None:
+        return
+    if policy.policy_version != policy_version:
+        raise ValueError("policy_version must match bridge policy")
+    if corpus not in policy.allowed_corpora:
+        raise ValueError(f"corpus is not admitted by wiki bridge policy: {corpus}")
+    if policy.require_content_hash is not True:
+        raise ValueError("wiki bridge policy must require content_hash")
+    if policy.require_source_rel_path is not True:
+        raise ValueError("wiki bridge policy must require source_rel_path")
+    if policy.allow_promoted_only and not promoted:
+        raise ValueError("wiki bridge policy requires promoted artifacts")
+
+
+def _validate_sluglike_token(value: str, field_name: str) -> str:
+    normalized = validate_non_empty_token(field_name, value)
+    if not isinstance(normalized, str):
+        raise TypeError(f"{field_name} must be a string")
+    if normalized in _CURRENT_DIR_VALUES or "/" in normalized or "\\" in normalized:
+        raise ValueError(f"{field_name} must be a slug-like token")
+    if ".." in normalized:
+        raise ValueError(f"{field_name} must not contain traversal")
+    return normalized
+
+
+def _normalize_content_hash(value: str) -> str:
+    normalized = _validate_non_empty_identifier(value, "content_hash").lower()
+    if not _SHA256_RE.fullmatch(normalized):
+        raise ValueError("content_hash must be sha256 hex")
+    if not normalized.startswith("sha256:"):
+        normalized = f"sha256:{normalized}"
+    return normalized
+
+
+def _validate_non_empty_identifier(value: str, field_name: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must be non-empty")
+    if any(char.isspace() for char in normalized):
+        raise ValueError(f"{field_name} must not contain whitespace")
+    return normalized
+
+
+def _validate_bridge_path(
+    field_name: str,
+    value: str,
+    *,
+    allow_docs_authority: bool,
+) -> str:
+    raw = value.strip()
+    if not raw:
+        raise ValueError(f"{field_name} must not be blank")
+    normalized = raw.replace("\\", "/")
+    if normalized in _CURRENT_DIR_VALUES:
+        raise ValueError(f"{field_name} must not reference current directory")
+    if normalized.startswith("/") or normalized.startswith("~") or _WINDOWS_DRIVE_RE.match(raw):
+        raise ValueError(f"{field_name} must be repo-relative")
+    path = PurePosixPath(normalized)
+    parts = path.parts
+    if not parts or any(part in {"", ".", ".."} for part in parts):
+        raise ValueError(f"{field_name} must not contain unsafe path segments")
+    if parts[0] == "docs" and not allow_docs_authority:
+        raise ValueError(f"{field_name} must not be under canonical docs authority")
+    return path.as_posix()
+
+
+def _freeze_metadata(value: Mapping[str, JsonValue]) -> FrozenJson:
+    _validate_metadata(value)
+    return _freeze_json(value)
+
+
+def _validate_metadata(value: JsonValue, *, key_path: tuple[str, ...] = ()) -> None:
+    if isinstance(value, bytes):
+        raise ValueError("metadata must be JSON-compatible")
+    if isinstance(value, str):
+        _validate_metadata_string(value, key_path)
+        return
+    if isinstance(value, bool) or value is None or isinstance(value, int):
+        if key_path and key_path[-1].lower() == "advisory_only" and value is not True:
+            raise ValueError("advisory_only metadata must be true")
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("metadata numbers must be finite")
+        return
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise ValueError("metadata keys must be strings")
+            _validate_metadata_key(key, child)
+            _validate_metadata(child, key_path=(*key_path, key))
+        return
+    if isinstance(value, Sequence):
+        for index, child in enumerate(value):
+            _validate_metadata(child, key_path=(*key_path, str(index)))
+        return
+    raise ValueError("metadata must be JSON-compatible")
+
+
+def _validate_metadata_key(key: str, value: JsonValue) -> None:
+    normalized_key = key.strip().lower().replace("-", "_")
+    if not normalized_key:
+        raise ValueError("metadata keys must not be blank")
+    if any(fragment in normalized_key for fragment in _FORBIDDEN_METADATA_KEY_FRAGMENTS):
+        raise ValueError(f"metadata contains forbidden field: {key}")
+    if any(fragment in normalized_key for fragment in _AUTHORITY_KEY_FRAGMENTS):
+        if _metadata_value_claims_authority(value):
+            raise ValueError(f"metadata contains forbidden authority claim: {key}")
+    if normalized_key == "advisory_only" and value is not True:
+        raise ValueError("advisory_only metadata must be true")
+
+
+def _validate_metadata_string(value: str, key_path: tuple[str, ...]) -> None:
+    normalized = value.strip()
+    lower = normalized.lower()
+    if lower in _CURRENT_DIR_VALUES:
+        raise ValueError("metadata contains unsafe path-like value")
+    if any(fragment in lower for fragment in _FORBIDDEN_METADATA_STRING_FRAGMENTS):
+        raise ValueError("metadata contains forbidden raw payload")
+    if any(
+        lower.startswith(prefix) or lower.endswith(suffix)
+        for prefix in _PATH_VALUE_PREFIXES
+        for suffix in _PATH_VALUE_SUFFIXES
+    ):
+        raise ValueError("metadata contains unsafe path-like value")
+    if lower.startswith(_PATH_VALUE_PREFIXES) or lower.endswith(_PATH_VALUE_SUFFIXES):
+        raise ValueError("metadata contains unsafe path-like value")
+    if key_path and any(fragment in key_path[-1].lower() for fragment in _AUTHORITY_KEY_FRAGMENTS):
+        if any(fragment in lower for fragment in _AUTHORITY_VALUE_FRAGMENTS):
+            raise ValueError("metadata contains forbidden authority claim")
+
+
+def _metadata_value_claims_authority(value: JsonValue) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lower = value.strip().lower()
+        return any(fragment in lower for fragment in _AUTHORITY_VALUE_FRAGMENTS)
+    if isinstance(value, Mapping):
+        return any(_metadata_value_claims_authority(child) for child in value.values())
+    if isinstance(value, Sequence) and not isinstance(value, bytes):
+        return any(_metadata_value_claims_authority(child) for child in value)
+    return False
+
+
+def _freeze_json(value: JsonValue) -> FrozenJson:
+    if isinstance(value, bool) or value is None or isinstance(value, (str, int, float)):
+        return value
+    if isinstance(value, Mapping):
+        return tuple((key, _freeze_json(child)) for key, child in sorted(value.items()))
+    if isinstance(value, Sequence) and not isinstance(value, bytes):
+        return tuple(_freeze_json(child) for child in value)
+    raise ValueError("metadata must be JSON-compatible")
+
+
+def _thaw_json(value: FrozenJson) -> JsonValue:
+    if isinstance(value, tuple):
+        if all(
+            isinstance(item, tuple) and len(item) == 2 and isinstance(item[0], str)
+            for item in value
+        ):
+            return {
+                key: _thaw_json(child)
+                for key, child in cast(tuple[tuple[str, FrozenJson], ...], value)
+            }
+        return [_thaw_json(child) for child in value]
+    return value

--- a/core/evidence/wiki_bridge.py
+++ b/core/evidence/wiki_bridge.py
@@ -384,6 +384,8 @@ def wiki_artifact_to_admission_input(
     validation_status: ValidationStatus = "valid",
     degraded_reason: str | None = None,
     metadata: Mapping[str, JsonValue] | None = None,
+    asset_type: WikiBridgeAssetType = "knowledge_candidate",
+    asset_version: str = "v1",
     policy: WikiEvidenceBridgePolicy | None = None,
 ) -> AdmissionInput:
     """Adapt a wiki artifact to E4 admission input for advisory review only."""
@@ -396,11 +398,19 @@ def wiki_artifact_to_admission_input(
         raise ValueError(
             f"validation_status is not admitted by wiki bridge policy: {validation_status}"
         )
+    evidence_asset = wiki_artifact_to_evidence_asset_ref(
+        artifact,
+        asset_type=asset_type,
+        version=asset_version,
+        policy=policy,
+    )
     _freeze_metadata(metadata or {})
     admission_metadata: dict[str, JsonValue] = {
         "advisory_only": True,
+        "artifact_id": artifact.artifact_id,
         "bridge": "advisory_wiki",
         "corpus": artifact.corpus,
+        "evidence_asset_id": evidence_asset.asset_id,
         "promoted": artifact.promoted,
         "serve_scope": "advisory_review_only",
         "slug": artifact.slug,
@@ -409,10 +419,10 @@ def wiki_artifact_to_admission_input(
         admission_metadata["bridge_metadata"] = _thaw_json(_freeze_metadata(metadata))
 
     return AdmissionInput(
-        target_id=artifact.artifact_id,
+        target_id=evidence_asset.asset_id,
         target_type="evidence_asset",
-        fingerprint=artifact.content_hash,
-        idempotency_key=artifact.idempotency_key,
+        fingerprint=evidence_asset.fingerprint,
+        idempotency_key=evidence_asset.idempotency_key,
         policy_version=artifact.policy_version,
         produced_at=produced_at,
         validation_status=validation_status,
@@ -420,7 +430,7 @@ def wiki_artifact_to_admission_input(
         verification_rate=verification_rate,
         fallback_rate=fallback_rate,
         degraded_reason=degraded_reason,
-        upstream_ids=artifact.upstream_ids,
+        upstream_ids=evidence_asset.upstream_ids,
         metadata=admission_metadata,
     )
 

--- a/core/evidence/wiki_bridge.py
+++ b/core/evidence/wiki_bridge.py
@@ -8,7 +8,7 @@ import re
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import PurePosixPath
-from typing import Any, Literal, TypeAlias, cast
+from typing import Literal, TypeAlias, cast
 
 from core.evidence.admission import AdmissionInput, ValidationStatus
 from core.evidence.assets import EvidenceAssetRef, create_evidence_asset_ref

--- a/core/evidence/wiki_bridge.py
+++ b/core/evidence/wiki_bridge.py
@@ -196,9 +196,6 @@ class AdvisoryWikiArtifactRef:
         normalized_hash = _normalize_content_hash(content_hash)
         validate_fingerprint(normalized_hash)
 
-        object.__setattr__(
-            self, "artifact_id", _validate_non_empty_identifier(artifact_id, "artifact_id")
-        )
         object.__setattr__(self, "corpus", _validate_sluglike_token(corpus, "corpus"))
         object.__setattr__(self, "slug", _validate_sluglike_token(slug, "slug"))
         object.__setattr__(
@@ -221,15 +218,30 @@ class AdvisoryWikiArtifactRef:
         object.__setattr__(
             self, "policy_version", validate_non_empty_token("policy_version", policy_version)
         )
-        object.__setattr__(
-            self,
-            "idempotency_key",
-            _validate_non_empty_identifier(idempotency_key, "idempotency_key"),
-        )
         object.__setattr__(self, "advisory_only", True)
         object.__setattr__(self, "promoted", bool(promoted))
         normalized_upstream_ids = normalize_upstream_ids(tuple(upstream_ids))
         validate_upstream_ids_for_rail(rail="advisory", upstream_ids=normalized_upstream_ids)
+        computed_artifact_id, computed_idempotency_key = _build_artifact_identity(
+            corpus=self.corpus,
+            slug=self.slug,
+            source_rel_path=self.source_rel_path,
+            page_path=self.page_path,
+            promoted_path=self.promoted_path,
+            content_hash=self.content_hash,
+            policy_version=self.policy_version,
+            promoted=self.promoted,
+            upstream_ids=normalized_upstream_ids,
+        )
+        if _validate_non_empty_identifier(artifact_id, "artifact_id") != computed_artifact_id:
+            raise ValueError("artifact_id must match deterministic wiki artifact identity")
+        if (
+            _validate_non_empty_identifier(idempotency_key, "idempotency_key")
+            != computed_idempotency_key
+        ):
+            raise ValueError("idempotency_key must match deterministic wiki artifact identity")
+        object.__setattr__(self, "artifact_id", computed_artifact_id)
+        object.__setattr__(self, "idempotency_key", computed_idempotency_key)
         object.__setattr__(self, "upstream_ids", normalized_upstream_ids)
         object.__setattr__(self, "_metadata", _freeze_metadata(metadata or {}))
 
@@ -292,21 +304,17 @@ def create_advisory_wiki_artifact_ref(
     validate_upstream_ids_for_rail(rail="advisory", upstream_ids=normalized_upstream_ids)
     _validate_policy(policy, normalized_policy_version, normalized_corpus, bool(promoted))
 
-    identity_payload: dict[str, JsonValue] = {
-        "advisory_only": True,
-        "content_hash": normalized_hash,
-        "corpus": normalized_corpus,
-        "page_path": normalized_page_path,
-        "policy_version": normalized_policy_version,
-        "promoted": bool(promoted),
-        "promoted_path": normalized_promoted_path,
-        "slug": normalized_slug,
-        "source_rel_path": normalized_source_path,
-        "upstream_ids": list(normalized_upstream_ids),
-    }
-    digest = fingerprint_payload(identity_payload).removeprefix("sha256:")
-    artifact_id = f"advisory-wiki:{digest[:24]}"
-    idempotency_key = f"idem:advisory-wiki:{digest}"
+    artifact_id, idempotency_key = _build_artifact_identity(
+        corpus=normalized_corpus,
+        slug=normalized_slug,
+        source_rel_path=normalized_source_path,
+        page_path=normalized_page_path,
+        promoted_path=normalized_promoted_path,
+        content_hash=normalized_hash,
+        policy_version=normalized_policy_version,
+        promoted=bool(promoted),
+        upstream_ids=normalized_upstream_ids,
+    )
     return AdvisoryWikiArtifactRef(
         artifact_id=artifact_id,
         corpus=normalized_corpus,
@@ -415,6 +423,34 @@ def wiki_artifact_to_admission_input(
         upstream_ids=artifact.upstream_ids,
         metadata=admission_metadata,
     )
+
+
+def _build_artifact_identity(
+    *,
+    corpus: str,
+    slug: str,
+    source_rel_path: str,
+    page_path: str,
+    promoted_path: str | None,
+    content_hash: str,
+    policy_version: str,
+    promoted: bool,
+    upstream_ids: tuple[str, ...],
+) -> tuple[str, str]:
+    identity_payload: dict[str, JsonValue] = {
+        "advisory_only": True,
+        "content_hash": content_hash,
+        "corpus": corpus,
+        "page_path": page_path,
+        "policy_version": policy_version,
+        "promoted": promoted,
+        "promoted_path": promoted_path,
+        "slug": slug,
+        "source_rel_path": source_rel_path,
+        "upstream_ids": list(upstream_ids),
+    }
+    digest = fingerprint_payload(identity_payload).removeprefix("sha256:")
+    return f"advisory-wiki:{digest[:24]}", f"idem:advisory-wiki:{digest}"
 
 
 def _validate_policy(

--- a/core/evidence/wiki_bridge.py
+++ b/core/evidence/wiki_bridge.py
@@ -19,6 +19,7 @@ from core.evidence.policies import (
     normalize_upstream_ids,
     validate_fingerprint,
     validate_non_empty_token,
+    validate_upstream_ids_for_rail,
 )
 
 WikiBridgeAssetType: TypeAlias = Literal[
@@ -29,7 +30,8 @@ JsonValue: TypeAlias = JsonScalar | Mapping[str, "JsonValue"] | Sequence["JsonVa
 FrozenJson: TypeAlias = JsonScalar | tuple["FrozenJson", ...] | tuple[tuple[str, "FrozenJson"], ...]
 
 _SHA256_RE = re.compile(r"^(?:sha256:)?[0-9a-fA-F]{64}$")
-_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[/\\]")
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+_URI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
 _CURRENT_DIR_VALUES = {".", "./", "./."}
 _FORBIDDEN_METADATA_KEY_FRAGMENTS = (
     "access_token",
@@ -226,7 +228,9 @@ class AdvisoryWikiArtifactRef:
         )
         object.__setattr__(self, "advisory_only", True)
         object.__setattr__(self, "promoted", bool(promoted))
-        object.__setattr__(self, "upstream_ids", normalize_upstream_ids(tuple(upstream_ids)))
+        normalized_upstream_ids = normalize_upstream_ids(tuple(upstream_ids))
+        validate_upstream_ids_for_rail(rail="advisory", upstream_ids=normalized_upstream_ids)
+        object.__setattr__(self, "upstream_ids", normalized_upstream_ids)
         object.__setattr__(self, "_metadata", _freeze_metadata(metadata or {}))
 
     @property
@@ -285,6 +289,7 @@ def create_advisory_wiki_artifact_ref(
         else _validate_bridge_path("promoted_path", promoted_path, allow_docs_authority=False)
     )
     normalized_upstream_ids = normalize_upstream_ids(tuple(upstream_ids))
+    validate_upstream_ids_for_rail(rail="advisory", upstream_ids=normalized_upstream_ids)
     _validate_policy(policy, normalized_policy_version, normalized_corpus, bool(promoted))
 
     identity_payload: dict[str, JsonValue] = {
@@ -473,7 +478,14 @@ def _validate_bridge_path(
     normalized = raw.replace("\\", "/")
     if normalized in _CURRENT_DIR_VALUES:
         raise ValueError(f"{field_name} must not reference current directory")
-    if normalized.startswith("/") or normalized.startswith("~") or _WINDOWS_DRIVE_RE.match(raw):
+    first_segment = normalized.split("/", maxsplit=1)[0]
+    if (
+        normalized.startswith("/")
+        or normalized.startswith("~")
+        or _WINDOWS_DRIVE_RE.match(raw)
+        or _URI_SCHEME_RE.match(raw)
+        or ":" in first_segment
+    ):
         raise ValueError(f"{field_name} must be repo-relative")
     path = PurePosixPath(normalized)
     parts = path.parts
@@ -553,12 +565,14 @@ def _validate_metadata_string(value: str, key_path: tuple[str, ...]) -> None:
 def _metadata_value_claims_authority(value: JsonValue) -> bool:
     if isinstance(value, bool):
         return value
+    if isinstance(value, (int, float)):
+        return value != 0
     if isinstance(value, str):
         lower = value.strip().lower()
         return any(fragment in lower for fragment in _AUTHORITY_VALUE_FRAGMENTS)
     if isinstance(value, Mapping):
         return any(_metadata_value_claims_authority(child) for child in value.values())
-    if isinstance(value, Sequence) and not isinstance(value, bytes):
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, memoryview)):
         return any(_metadata_value_claims_authority(child) for child in value)
     return False
 
@@ -568,7 +582,7 @@ def _freeze_json(value: JsonValue) -> FrozenJson:
         return value
     if isinstance(value, Mapping):
         return tuple((key, _freeze_json(child)) for key, child in sorted(value.items()))
-    if isinstance(value, Sequence) and not isinstance(value, bytes):
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, memoryview)):
         return tuple(_freeze_json(child) for child in value)
     raise ValueError("metadata must be JSON-compatible")
 

--- a/docs/orchestration/contracts/EVIDENCE_ADVISORY_WIKI_BRIDGE.md
+++ b/docs/orchestration/contracts/EVIDENCE_ADVISORY_WIKI_BRIDGE.md
@@ -1,0 +1,158 @@
+# Evidence Advisory Wiki Bridge
+
+PR-E5 adds a deterministic bridge between existing advisory wiki artifacts and
+Evidence Graph contracts.
+
+The bridge is intentionally narrow:
+
+- advisory wiki artifacts remain non-canonical workforce memory;
+- repo code, backend contracts, DB/runtime state, OpenAPI, tests, legal and
+  compliance records remain canonical truth;
+- the bridge does not compile, ingest, promote, mutate, query, or serve wiki
+  content;
+- the bridge does not unlock semantic cache, GraphRAG, product RAG behavior, or
+  product answers.
+
+## Objects
+
+### `AdvisoryWikiArtifactRef`
+
+Represents metadata for an existing wiki artifact.
+
+Required normalized fields:
+
+- `artifact_id`
+- `corpus`
+- `slug`
+- `source_rel_path`
+- `page_path`
+- `promoted_path`
+- `content_hash`
+- `policy_version`
+- `idempotency_key`
+- `advisory_only`
+- `promoted`
+- `upstream_ids`
+- `metadata`
+
+`content_hash` accepts a raw 64-character SHA-256 hex value or
+`sha256:<hex>` and stores `sha256:<hex>`.
+
+`artifact_id` and `idempotency_key` are derived from canonical content with
+`fingerprint_payload`. They do not depend on wall-clock time, randomness,
+filesystem reads, network access, or caller-owned mutable structures.
+
+### `WikiEvidenceBridgePolicy`
+
+Defines deterministic admission into the bridge:
+
+- `policy_version`
+- `allowed_corpora`
+- `require_content_hash`
+- `require_source_rel_path`
+- `allow_promoted_only`
+- `allowed_admission_statuses`
+- `advisory_only_enforced`
+- `allowed_asset_types`
+
+`advisory_only_enforced` must remain true.
+
+## Path Rules
+
+`source_rel_path` may point under `docs/**` as provenance because existing wiki
+ingest may summarize repository docs.
+
+`page_path` and `promoted_path` must not point under `docs/**`; bridge outputs
+must not become canonical documentation authority.
+
+All bridge paths reject:
+
+- traversal such as `../x`;
+- absolute paths such as `/tmp/x`;
+- home paths such as `~/x`;
+- Windows drive paths such as `C:/x`;
+- current-directory references such as `.`, `./`, and `./.`.
+
+## Metadata Safety
+
+Metadata is defensively copied into immutable JSON-compatible structures and
+validated fail-closed.
+
+Rejected metadata includes:
+
+- raw prompts, responses, queries, user-health payloads, and secrets;
+- `rail=runtime` or equivalent runtime authority claims;
+- canonical/product/source-of-truth claims;
+- unsafe path-like values, including `.`, `./`, and `./.`.
+
+## Evidence Asset Mapping
+
+Wiki artifacts may map only to advisory `EvidenceAssetRef` records.
+
+Allowed asset types:
+
+- `knowledge_candidate`
+- `context_bundle`
+- `verification_bundle`
+
+Default asset type is `knowledge_candidate`.
+
+The bridge must not map wiki artifacts to the `runtime` rail. It also must not
+change cross-rail policy behavior in `core/evidence/policies.py`.
+
+## Admission Adapter
+
+`wiki_artifact_to_admission_input(...)` adapts a wiki artifact into E4
+`AdmissionInput` for advisory review/query/promotion workflows only.
+
+The adapter requires explicit:
+
+- `produced_at`
+- `coverage_rate`
+- `verification_rate`
+- `fallback_rate`
+- `validation_status`
+
+It never invents metrics. It carries `serve_scope=advisory_review_only`; this
+does not authorize user-facing product serving.
+
+## Deferred
+
+This PR does not add `wiki_artifact_to_eval_event(...)`.
+
+Existing PR-E2 eval event types are eval-oriented. Forcing wiki ingest/promote
+metadata into `item_metadata` would blur rail semantics. A later schema PR may
+add wiki-specific advisory event types if the product needs event-plane lineage
+for wiki operations.
+
+Semantic cache remains blocked until a dedicated semantic-cache gate opens with
+lineage, admission, replay, observability, false-hit guardrails, and rollout
+contracts.
+
+## Premortem Evidence
+
+E5 mitigates the main failure modes in code and tests:
+
+- Recreating the wiki compiler: `core/evidence/wiki_bridge.py` accepts metadata
+  only and import guards reject `scripts/orchestration` and wiki CLI imports.
+- Granting runtime authority: wiki artifacts always carry `advisory_only=True`
+  and map only to advisory evidence assets.
+- Importing local support-plane mutation tooling: import guards reject
+  `local_support_plane`, wiki mutation CLIs, runtime providers, DB/session,
+  cache, GraphRAG, and eval runner modules.
+- Mapping to runtime rail: `wiki_artifact_to_evidence_asset_ref(...)` hardcodes
+  `rail="advisory"`.
+- Bypassing E1/E4 contracts: asset mapping uses `create_evidence_asset_ref`;
+  admission mapping creates E4 `AdmissionInput`.
+- Claiming semantic cache readiness: this contract keeps semantic cache
+  explicitly deferred to a dedicated future gate.
+- Storing raw payloads or secrets: metadata validation rejects prompt, response,
+  query, user-health, and secret fields/values.
+- Accepting unsafe paths: bridge paths reject traversal, absolute, home,
+  Windows drive, and current-directory values; docs output paths are blocked for
+  page/promoted artifacts.
+- Mutating caller-owned structures: metadata and upstream IDs are normalized and
+  defensively copied.
+- Checklist-only fixes: focused tests cover mapping, authority boundaries,
+  metadata/path safety, deterministic IDs, serialization, mutation safety, and
+  forbidden imports.

--- a/docs/review/PR_1681_FIXED_MAPPING.md
+++ b/docs/review/PR_1681_FIXED_MAPPING.md
@@ -170,15 +170,14 @@ mutation, semantic cache, GraphRAG, or runtime rail authority.
 
 ## Discussion Thread Pass
 
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
 Initial PR opening. No review threads yet.
 
 ## Fixed in Commit Mapping
 
-No review threads existed at PR opening.
-
-Implementation:
-
-- PR branch implementation -> `e2b067db4`
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1681_FIXED_MAPPING.md
+++ b/docs/review/PR_1681_FIXED_MAPPING.md
@@ -1,0 +1,189 @@
+# PR #1681 Fixed Mapping
+
+## Summary
+
+PR-E5 adds a pure deterministic advisory wiki evidence bridge.
+
+## Goal
+
+Link existing advisory wiki artifact metadata to advisory Evidence Graph assets
+and advisory admission inputs while preserving that advisory wiki memory is not
+product/runtime truth.
+
+## Business reason
+
+This PR improves operator navigation, lineage, and future reviewability without
+turning wiki pages into canonical product truth. Repo/backend/OpenAPI/DB/runtime
+contracts remain authoritative.
+
+## Scope
+
+- `core/evidence/wiki_bridge.py`
+- Advisory `EvidenceAssetRef` mapping
+- Advisory E4 `AdmissionInput` adapter
+- Metadata/path safety validation
+- Deterministic IDs and serialization
+- Import guards
+- Contract docs, scoped agent guidance, and roadmap/backlog updates
+
+## Out of scope
+
+- Wiki compiler rewrite
+- `wiki_artifact_to_eval_event(...)`
+- Product RAG behavior
+- Runtime API, FastAPI routes, OpenAPI, DB migrations, providers
+- Redis, GPTCache, semantic cache
+- GraphRAG
+- Eval runners
+- Frontend, iOS, design files
+- Advisory wiki as runtime source of truth
+
+## Files touched
+
+- `core/evidence/wiki_bridge.py`
+- `core/evidence/__init__.py`
+- `core/evidence/AGENTS.md`
+- `tests/core/evidence/test_wiki_bridge.py`
+- `docs/orchestration/contracts/EVIDENCE_ADVISORY_WIKI_BRIDGE.md`
+- `docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md`
+- `docs/roadmap/BACKLOG_LEDGER.md`
+- `docs/review/PR_1681_FIXED_MAPPING.md`
+
+## Tests
+
+Passed locally:
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+.venv/bin/python -m pytest -q tests/core/evidence/test_wiki_bridge.py tests/core/evidence/test_admission.py tests/core/evidence/test_promotion_ledger.py tests/core/evidence/test_replay.py tests/core/evidence/test_events.py tests/core/evidence/test_assets.py tests/core/evidence/test_fingerprints.py
+.venv/bin/python -m pytest -q tests/test_wiki_ingest.py tests/test_wiki_promote.py tests/test_wiki_compiler_keys.py tests/test_local_support_plane.py
+.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null core/evidence tests/core/evidence/test_wiki_bridge.py
+make validate-changed
+pre-commit run --all-files
+```
+
+Also passed during pre-push:
+
+- changed-file mypy
+- pip-audit
+- backend pre-push tests
+- full-repo Bandit
+- Docker build test
+
+Full `make verify` was intentionally not run under the operator-approved
+machine-heavy exception.
+
+## Security notes
+
+- Metadata rejects prompt, response, query, user-health, secret, runtime,
+  canonical, source-of-truth, and unsafe path-like payloads.
+- Paths reject traversal, absolute paths, home paths, Windows drive paths, and
+  current-directory values `.`, `./`, and `./.`.
+- Import guards block wiki compiler CLIs, local support-plane mutation tooling,
+  runtime app code, providers, DB/session, cache, GraphRAG, and eval runners.
+- Wiki artifacts map only to advisory rail evidence assets.
+
+## Premortem
+
+- Compiler recreation risk: fixed by metadata-only bridge and import guards.
+- Runtime authority risk: fixed by enforced `advisory_only=True`, advisory-only
+  asset mapping, and docs.
+- Local support-plane import risk: fixed by AST import guard.
+- Runtime rail mapping risk: fixed by hardcoded advisory rail.
+- E1/E4 bypass risk: fixed by using `create_evidence_asset_ref` and
+  `AdmissionInput`.
+- Semantic cache scope drift: fixed by explicit docs/backlog deferral.
+- Raw payload/secret risk: fixed by metadata safety checks and tests.
+- Path traversal/current-directory risk: fixed by path safety checks and tests.
+- Mutation risk: fixed by defensive-copy tests.
+- Checklist-only risk: code/tests/docs were changed before this mapping artifact.
+
+## Rollback / risks
+
+Rollback is to revert this PR. There are no runtime callers, migrations,
+providers, routes, or persistent writers.
+
+Residual risk: downstream agents could misread advisory admission as product
+serving. `core/evidence/AGENTS.md` and the contract doc constrain the bridge to
+advisory review/query/promotion workflows only.
+
+## DoD
+
+- `core/evidence/wiki_bridge.py` exists and is pure/deterministic.
+- Existing advisory wiki compiler is not duplicated.
+- Wiki artifacts can be represented as advisory evidence assets.
+- Runtime rail mapping is blocked.
+- Metadata and path safety are fail-closed.
+- No core/evidence import of `scripts/orchestration` or local support-plane
+  mutation tooling.
+- Tests cover mapping, authority boundaries, metadata/path safety,
+  deterministic IDs, mutation safety, stable serialization, and import guards.
+- Docs state advisory wiki remains non-canonical workforce memory.
+- Semantic cache remains blocked pending a dedicated gate.
+
+## Commit breakdown
+
+- `e2b067db4` - `feat(evidence): add advisory wiki bridge`
+
+## Pre-push checklist
+
+- [x] Coordinator bootstrap packet created: `bc1f48dd1ba3`
+- [x] Preflight passed
+- [x] Agent consistency passed
+- [x] Focused evidence tests passed
+- [x] Wiki compiler/support-plane regression tests passed
+- [x] Narrow mypy passed
+- [x] `make validate-changed` passed
+- [x] `pre-commit run --all-files` passed
+- [x] Pre-push hooks passed
+- [x] Full `make verify` intentionally deferred under machine-heavy exception
+
+## Post-merge checklist
+
+- Sync local `main` with `git fetch --prune origin` and
+  `git merge --ff-only origin/main`.
+- Prune `codex/evidence-advisory-wiki-bridge` after merge.
+- Confirm root checkout remains clean and unrelated local design work is
+  untouched.
+- Let operator select the next Evidence Graph follow-up; semantic cache remains
+  blocked unless a dedicated gate opens.
+
+## AGENTS.md updates
+
+Added E5 guidance to `core/evidence/AGENTS.md`: advisory wiki bridge is pure
+deterministic mapping only; no compiler, local support-plane, runtime, wiki
+mutation, semantic cache, GraphRAG, or runtime rail authority.
+
+## Deferred / Follow-ups
+
+- Add wiki-specific advisory event types only if a later event-schema PR opens
+  that scope.
+- Operator-selected Evidence Graph follow-up after E5.
+- Semantic cache remains blocked pending a separate dedicated gate with lineage,
+  admission, replay, observability, false-hit guardrails, and rollout contract.
+
+## Discussion Thread Pass
+
+Initial PR opening. No review threads yet.
+
+## Fixed in Commit Mapping
+
+No review threads existed at PR opening.
+
+Implementation:
+
+- PR branch implementation -> `e2b067db4`
+
+## Merge Readiness
+
+Not merge-ready at mapping creation.
+
+Required before merge:
+
+- current-head PR CI clean;
+- PR body gates clean;
+- CodeRabbit/Sourcery/Cubic no-actionables confirmed;
+- mandatory post-open `qa-engineer-agent -> bug-hunter` pass complete;
+- strict merge-readiness wrapper passes;
+- review wait-window observed.

--- a/docs/review/PR_1681_FIXED_MAPPING.md
+++ b/docs/review/PR_1681_FIXED_MAPPING.md
@@ -71,6 +71,14 @@ Also passed during pre-push:
 - full-repo Bandit
 - Docker build test
 
+Also passed after diff-coverage remediation:
+
+```bash
+rm -f .coverage coverage.xml && .venv/bin/python -m coverage run -m pytest -q tests/core/evidence/test_wiki_bridge.py && .venv/bin/python -m coverage xml -o coverage.xml && .venv/bin/diff-cover coverage.xml --compare-branch origin/main --fail-under 97 --exclude 'tests/**' --exclude '*.md' --exclude '*.yml' --exclude '*.yaml' --exclude '*.toml' --exclude '*.txt'
+```
+
+Result: `core/evidence/wiki_bridge.py` diff coverage 97.2%.
+
 Full `make verify` was intentionally not run under the operator-approved
 machine-heavy exception.
 
@@ -112,6 +120,9 @@ machine-heavy exception.
   the advisory `EvidenceAssetRef` identity instead of the source wiki artifact
   identity. Evidence: `core/evidence/wiki_bridge.py`; regression tests in
   `tests/core/evidence/test_wiki_bridge.py`.
+- Diff-coverage regression risk: fixed by adding branch coverage for policy,
+  constructor, helper type/path, metadata recursion, and artifact mapping guard
+  branches in `tests/core/evidence/test_wiki_bridge.py`.
 - Numeric authority-claim risk: fixed by treating truthy numeric authority
   metadata as a forbidden authority claim. Evidence:
   `core/evidence/wiki_bridge.py`; regression test in
@@ -154,6 +165,8 @@ advisory review/query/promotion workflows only.
 - `85154507f` - `fix(evidence): enforce wiki artifact identity`
 - `2c09b8a32` - `fix(evidence): target wiki admission assets`
 - `b7efbfa2d` - `docs(agents): update instructions`
+- `ccb5c0630` - `docs(review): map PR 1681 review threads`
+- `7bc213ff4` - `test(evidence): cover wiki bridge guards`
 
 ## Pre-push checklist
 

--- a/docs/review/PR_1681_FIXED_MAPPING.md
+++ b/docs/review/PR_1681_FIXED_MAPPING.md
@@ -167,6 +167,9 @@ advisory review/query/promotion workflows only.
 - `b7efbfa2d` - `docs(agents): update instructions`
 - `ccb5c0630` - `docs(review): map PR 1681 review threads`
 - `7bc213ff4` - `test(evidence): cover wiki bridge guards`
+- `cd0b8b4a1` - `docs(review): record PR 1681 coverage fix`
+- `abc3c9563` - `docs(review): map CodeRabbit aggregate review`
+- `1967ab477` - `fix(evidence): remove unused wiki bridge import`
 
 ## Pre-push checklist
 
@@ -259,6 +262,11 @@ Disposition: NOT-A-BUG
 Evidence: Aggregate CodeRabbit review actionables are represented by the individual inline discussion URLs mapped above.
 Reason: The review-level URL has no separate actionable beyond those inline comments; it is included for merge-readiness governance completeness.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#pullrequestreview-4235839249
+
+Disposition: FIXED
+Commit: 1967ab477
+Evidence: `core/evidence/wiki_bridge.py` removed the unused `Any` import reported in the aggregate CodeRabbit review; focused wiki bridge tests and narrow mypy passed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#pullrequestreview-4236389688 -> 1967ab477
 
 ## Merge Readiness
 

--- a/docs/review/PR_1681_FIXED_MAPPING.md
+++ b/docs/review/PR_1681_FIXED_MAPPING.md
@@ -170,6 +170,7 @@ advisory review/query/promotion workflows only.
 - `cd0b8b4a1` - `docs(review): record PR 1681 coverage fix`
 - `abc3c9563` - `docs(review): map CodeRabbit aggregate review`
 - `1967ab477` - `fix(evidence): remove unused wiki bridge import`
+- `78f0ab8dd` - `docs(review): repair PR 1681 mapping evidence`
 
 ## Pre-push checklist
 
@@ -251,9 +252,9 @@ Evidence: `core/evidence/wiki_bridge.py` rejects neutral-key runtime/canonical a
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195235955 -> c5cd925a9
 
 Disposition: FIXED
-Commit: 11dc14dc6
+Commit: 78f0ab8dd
 Evidence: `docs/review/PR_1681_FIXED_MAPPING.md` restored the required checkboxes and normalized the artifact before thread resolution.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195235962 -> 11dc14dc6
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195235962 -> 78f0ab8dd
 
 Disposition: NOT-A-BUG
 Evidence: E5 remains a pure advisory bridge; the adapter metadata preserves `serve_scope=advisory_review_only`, the admission input now targets advisory EvidenceAssetRef identity, and product runtime serve enforcement remains outside this PR by scope.

--- a/docs/review/PR_1681_FIXED_MAPPING.md
+++ b/docs/review/PR_1681_FIXED_MAPPING.md
@@ -91,6 +91,10 @@ machine-heavy exception.
   asset mapping, and docs.
 - Local support-plane import risk: fixed by AST import guard.
 - Runtime rail mapping risk: fixed by hardcoded advisory rail.
+- Runtime upstream leakage risk: fixed by validating wiki artifact upstream IDs
+  against advisory rail policy before asset/admission mapping. Evidence:
+  `core/evidence/wiki_bridge.py`; regression test in
+  `tests/core/evidence/test_wiki_bridge.py`.
 - E1/E4 bypass risk: fixed by using `create_evidence_asset_ref` and
   `AdmissionInput`.
 - Semantic cache scope drift: fixed by explicit docs/backlog deferral.
@@ -99,7 +103,14 @@ machine-heavy exception.
   `memoryview` before generic sequence handling. Evidence:
   `core/evidence/wiki_bridge.py`; regression tests in
   `tests/core/evidence/test_wiki_bridge.py`.
+- Numeric authority-claim risk: fixed by treating truthy numeric authority
+  metadata as a forbidden authority claim. Evidence:
+  `core/evidence/wiki_bridge.py`; regression test in
+  `tests/core/evidence/test_wiki_bridge.py`.
 - Path traversal/current-directory risk: fixed by path safety checks and tests.
+- URI and drive-relative path risk: fixed by rejecting URI schemes and
+  drive-qualified first path segments. Evidence: `core/evidence/wiki_bridge.py`;
+  regression tests in `tests/core/evidence/test_wiki_bridge.py`.
 - Mutation risk: fixed by defensive-copy tests.
 - Checklist-only risk: code/tests/docs were changed before this mapping artifact.
 
@@ -130,6 +141,7 @@ advisory review/query/promotion workflows only.
 
 - `e2b067db4` - `feat(evidence): add advisory wiki bridge`
 - `f7b04d1e5` - `fix(evidence): reject byte-like wiki metadata`
+- `c5cd925a9` - `fix(evidence): harden wiki bridge safety checks`
 
 ## Pre-push checklist
 

--- a/docs/review/PR_1681_FIXED_MAPPING.md
+++ b/docs/review/PR_1681_FIXED_MAPPING.md
@@ -95,6 +95,10 @@ machine-heavy exception.
   `AdmissionInput`.
 - Semantic cache scope drift: fixed by explicit docs/backlog deferral.
 - Raw payload/secret risk: fixed by metadata safety checks and tests.
+- Byte-like raw payload risk: fixed by rejecting `bytes`, `bytearray`, and
+  `memoryview` before generic sequence handling. Evidence:
+  `core/evidence/wiki_bridge.py`; regression tests in
+  `tests/core/evidence/test_wiki_bridge.py`.
 - Path traversal/current-directory risk: fixed by path safety checks and tests.
 - Mutation risk: fixed by defensive-copy tests.
 - Checklist-only risk: code/tests/docs were changed before this mapping artifact.
@@ -125,6 +129,7 @@ advisory review/query/promotion workflows only.
 ## Commit breakdown
 
 - `e2b067db4` - `feat(evidence): add advisory wiki bridge`
+- `f7b04d1e5` - `fix(evidence): reject byte-like wiki metadata`
 
 ## Pre-push checklist
 

--- a/docs/review/PR_1681_FIXED_MAPPING.md
+++ b/docs/review/PR_1681_FIXED_MAPPING.md
@@ -103,6 +103,15 @@ machine-heavy exception.
   `memoryview` before generic sequence handling. Evidence:
   `core/evidence/wiki_bridge.py`; regression tests in
   `tests/core/evidence/test_wiki_bridge.py`.
+- Non-canonical public constructor risk: fixed by recomputing advisory wiki
+  artifact identity inside `AdvisoryWikiArtifactRef.__init__` and rejecting
+  mismatched caller-provided `artifact_id` or `idempotency_key`. Evidence:
+  `core/evidence/wiki_bridge.py`; regression tests in
+  `tests/core/evidence/test_wiki_bridge.py`.
+- Admission target identity risk: fixed by making the admission adapter target
+  the advisory `EvidenceAssetRef` identity instead of the source wiki artifact
+  identity. Evidence: `core/evidence/wiki_bridge.py`; regression tests in
+  `tests/core/evidence/test_wiki_bridge.py`.
 - Numeric authority-claim risk: fixed by treating truthy numeric authority
   metadata as a forbidden authority claim. Evidence:
   `core/evidence/wiki_bridge.py`; regression test in
@@ -142,6 +151,9 @@ advisory review/query/promotion workflows only.
 - `e2b067db4` - `feat(evidence): add advisory wiki bridge`
 - `f7b04d1e5` - `fix(evidence): reject byte-like wiki metadata`
 - `c5cd925a9` - `fix(evidence): harden wiki bridge safety checks`
+- `85154507f` - `fix(evidence): enforce wiki artifact identity`
+- `2c09b8a32` - `fix(evidence): target wiki admission assets`
+- `b7efbfa2d` - `docs(agents): update instructions`
 
 ## Pre-push checklist
 
@@ -185,11 +197,50 @@ mutation, semantic cache, GraphRAG, or runtime rail authority.
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-Initial PR opening. No review threads yet.
+- QA lane found byte-like metadata bypass; fixed in code/tests.
+- Bug-hunter lane found URI/drive-relative paths, runtime upstream, and numeric
+  authority-claim bypasses; fixed in code/tests.
+- Codex review found that admission inputs targeted source wiki artifact
+  identity instead of advisory EvidenceAssetRef identity; fixed in code/tests.
+- CodeRabbit review requested canonical constructor identity enforcement; fixed
+  in code/tests.
+- CodeRabbit review requested a scoped AGENTS commit titled
+  `docs(agents): update instructions`; fixed with that commit title.
+- CodeRabbit review noted advisory serve scope is metadata-only; disposition is
+  NOT-A-BUG because E5 is a pure advisory bridge and must not widen E4 serve
+  policy or product runtime behavior.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 2c09b8a32
+Evidence: `wiki_artifact_to_admission_input(...)` targets advisory `EvidenceAssetRef` identity; `tests/core/evidence/test_wiki_bridge.py` covers target ID, fingerprint, idempotency key, and upstream identity.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195195608 -> 2c09b8a32
+
+Disposition: FIXED
+Commit: b7efbfa2d
+Evidence: `core/evidence/AGENTS.md` E5 reviewer guidance was clarified in the commit titled `docs(agents): update instructions`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195235932 -> b7efbfa2d
+
+Disposition: FIXED
+Commit: 85154507f
+Evidence: `AdvisoryWikiArtifactRef.__init__` recomputes canonical identity and rejects mismatched caller-provided `artifact_id` / `idempotency_key`; `tests/core/evidence/test_wiki_bridge.py` covers both mismatches.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195235937 -> 85154507f
+
+Disposition: FIXED
+Commit: c5cd925a9
+Evidence: `core/evidence/wiki_bridge.py` rejects neutral-key runtime/canonical authority claims, URI paths, drive-relative paths, runtime evidence upstreams, and truthy numeric authority claims; `tests/core/evidence/test_wiki_bridge.py` covers the regressions.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195235955 -> c5cd925a9
+
+Disposition: FIXED
+Commit: 11dc14dc6
+Evidence: `docs/review/PR_1681_FIXED_MAPPING.md` restored the required checkboxes and normalized the artifact before thread resolution.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195235962 -> 11dc14dc6
+
+Disposition: NOT-A-BUG
+Evidence: E5 remains a pure advisory bridge; the adapter metadata preserves `serve_scope=advisory_review_only`, the admission input now targets advisory EvidenceAssetRef identity, and product runtime serve enforcement remains outside this PR by scope.
+Reason: Adding a top-level E4 serve-scope policy would widen E4 admission contracts and product-serving semantics, which is explicitly out of scope for PR-E5.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195235953
 
 ## Merge Readiness
 

--- a/docs/review/PR_1681_FIXED_MAPPING.md
+++ b/docs/review/PR_1681_FIXED_MAPPING.md
@@ -255,6 +255,11 @@ Evidence: E5 remains a pure advisory bridge; the adapter metadata preserves `ser
 Reason: Adding a top-level E4 serve-scope policy would widen E4 admission contracts and product-serving semantics, which is explicitly out of scope for PR-E5.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195235953
 
+Disposition: NOT-A-BUG
+Evidence: Aggregate CodeRabbit review actionables are represented by the individual inline discussion URLs mapped above.
+Reason: The review-level URL has no separate actionable beyond those inline comments; it is included for merge-readiness governance completeness.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#pullrequestreview-4235839249
+
 ## Merge Readiness
 
 Not merge-ready at mapping creation.

--- a/docs/review/PR_1681_FIXED_MAPPING.md
+++ b/docs/review/PR_1681_FIXED_MAPPING.md
@@ -225,6 +225,8 @@ mutation, semantic cache, GraphRAG, or runtime rail authority.
 - CodeRabbit review noted advisory serve scope is metadata-only; disposition is
   NOT-A-BUG because E5 is a pure advisory bridge and must not widen E4 serve
   policy or product runtime behavior.
+- CodeRabbit review flagged mapping checkbox governance; fixed by a
+  post-comment docs/governance repair before final merge-readiness.
 
 ## Fixed in Commit Mapping
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2301,10 +2301,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Evidence Graph Runtime umbrella
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (AI runtime governance / evidence lineage)
-  - Target PR: PR-E0 (`codex/evidence-graph-runtime-umbrella`) -> PR-E1/E2/E3/E4/E5; current slice: PR-E4 (`codex/evidence-active-metadata-admission`)
+  - Target PR: PR-E0 (`codex/evidence-graph-runtime-umbrella`) -> PR-E1/E2/E3/E4/E5; current slice: PR-E5 (`codex/evidence-advisory-wiki-bridge`)
   - Area: AI runtime / RAG / evals / knowledge promotion / advisory memory
   - Finding Type: asset-lineage and replay-governance gap
-  - Status: Active PR-E4 metadata admission gates; E0/E1/E2/E3 are baseline, #1666/#1667 eval-sidecar hardening is baseline, #1676 source-artifact path hardening is baseline, and PR-E5 advisory wiki evidence bridge remains next after E4
+  - Status: Active PR-E5 advisory wiki evidence bridge; E0/E1/E2/E3/E4 are baseline, #1666/#1667 eval-sidecar hardening is baseline, #1676 source-artifact path hardening is baseline, semantic cache remains blocked behind a dedicated gate, and the next Evidence Graph follow-up is operator-selected after E5
   - Remove-by: 2026-06-30
   - Reason (EN): PulsePlate already has strong RAG runtime, verification, knowledge-promotion, eval-gate, advisory-wiki, and plugin/control-plane foundations, but evidence-bearing artifacts are still governed mostly through task packets, gate outputs, and lane-specific docs rather than one asset/evidence graph. This umbrella freezes the rail boundaries and PR train needed to make eval runs, context bundles, verification bundles, knowledge candidates, knowledge records, and gate reports first-class assets with lineage, idempotency, replay, fingerprints, policy versions, and admission decisions.
   - Links:
@@ -2325,6 +2325,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - PR-E2 adds a deterministic schema-only eval event contract and documentation without adding runtime behavior, OpenAPI changes, DB migration, semantic cache, GraphRAG, advisory wiki authority, or promotion/replay logic
     - PR-E3 adds deterministic promotion ledger and dry-run replay contracts without adding runtime behavior, OpenAPI changes, DB migration, semantic cache, GraphRAG, advisory wiki authority, eval runners, or persistent writers
     - PR-E4 adds deterministic `allow_execute`, `allow_promote`, and `allow_serve` metadata admission contracts without adding runtime behavior, OpenAPI changes, DB migration, semantic cache, GraphRAG, advisory wiki authority, eval runners, or side effects
+    - PR-E5 links existing advisory wiki artifacts to advisory evidence assets and advisory admission metadata without adding runtime behavior, OpenAPI changes, DB migration, semantic cache, GraphRAG, wiki compiler rewrites, runtime rail mapping, eval runners, or product-serving authority
 
 <a id="ledger-p1-apple-server-api-migration"></a>
 - [ ] P1: Apple receipt verification migration to App Store Server API

--- a/docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md
+++ b/docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD013 -->
 # PulsePlate Evidence Graph Runtime Epic
 
-**Status:** PR-E4 active metadata admission gates
+**Status:** PR-E5 advisory wiki evidence bridge
 **Date:** 2026-04-28 (`America/New_York`)
 **Canonical backlog anchor:** [`ledger-p1-evidence-graph-runtime`](./BACKLOG_LEDGER.md#ledger-p1-evidence-graph-runtime)
 
@@ -99,9 +99,12 @@ for later slices.
    - Backlog owner: [`ledger-p1-evidence-graph-runtime`](./BACKLOG_LEDGER.md#ledger-p1-evidence-graph-runtime).
    - Link advisory wiki artifacts to evidence assets while preserving the rule
      that wiki pages are planning memory, not runtime truth.
-   - May proceed after PR-E1/PR-E2 scope is stable.
-   - Done when wiki manifests/lints link to evidence assets without granting
-     runtime authority to wiki pages.
+   - Proceeds after PR-E1/PR-E2/PR-E3/PR-E4 contracts are stable.
+   - No wiki compiler rewrite, product RAG change, eval runner, semantic cache,
+     GraphRAG, runtime rail mapping, or advisory wiki authority.
+   - Done when existing wiki artifact metadata can map to advisory evidence
+     assets and advisory admission inputs without granting runtime authority to
+     wiki pages.
 
 ## Sequencing
 
@@ -111,10 +114,9 @@ PR-E0 first:
   docs/roadmap/BACKLOG_LEDGER.md
   AGENTS.md invariant
 
-Then parallel-capable:
+Then:
   PR-E1 asset registry contracts
   PR-E2 eval event schema
-  PR-E5 advisory wiki evidence bridge
 
 After PR-E1 + PR-E2:
   PR-E3 promotion ledger and replay
@@ -124,6 +126,9 @@ After PR-E1 + PR-E2 + PR-E3:
 
 After PR-E4:
   PR-E5 advisory wiki evidence bridge
+
+After PR-E5:
+  operator-selected follow-up; semantic cache still requires a dedicated gate
 ```
 
 ## Hard Boundaries

--- a/tests/core/evidence/test_wiki_bridge.py
+++ b/tests/core/evidence/test_wiki_bridge.py
@@ -177,6 +177,29 @@ def test_metadata_and_upstream_ids_are_defensively_copied() -> None:
     assert artifact.upstream_ids == ("a", "z")
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"redacted credential payload",
+        bytearray(b"redacted credential payload"),
+        memoryview(b"redacted"),
+    ],
+)
+def test_rejects_byte_like_metadata_payloads(payload: object) -> None:
+    with pytest.raises(ValueError, match="JSON-compatible"):
+        _artifact(metadata={"advisory_only": True, "note": payload})
+
+    with pytest.raises(ValueError, match="JSON-compatible"):
+        wiki_artifact_to_admission_input(
+            _artifact(),
+            produced_at=_PRODUCED_AT,
+            coverage_rate=1.0,
+            verification_rate=1.0,
+            fallback_rate=0.0,
+            metadata=cast(dict[str, Any], {"review_state": payload}),
+        )
+
+
 def test_admission_adapter_does_not_imply_product_runtime_serve() -> None:
     admission_input = wiki_artifact_to_admission_input(
         _artifact(),

--- a/tests/core/evidence/test_wiki_bridge.py
+++ b/tests/core/evidence/test_wiki_bridge.py
@@ -245,6 +245,27 @@ def test_constructor_rejects_non_canonical_identity_fields() -> None:
         )
 
 
+def test_constructor_rejects_non_advisory_authority_flag() -> None:
+    canonical = _artifact()
+
+    with pytest.raises(ValueError, match="advisory_only"):
+        AdvisoryWikiArtifactRef(
+            artifact_id=canonical.artifact_id,
+            corpus=canonical.corpus,
+            slug=canonical.slug,
+            source_rel_path=canonical.source_rel_path,
+            page_path=canonical.page_path,
+            promoted_path=canonical.promoted_path,
+            content_hash=canonical.content_hash,
+            policy_version=canonical.policy_version,
+            idempotency_key=canonical.idempotency_key,
+            advisory_only=False,
+            promoted=canonical.promoted,
+            upstream_ids=canonical.upstream_ids,
+            metadata=canonical.metadata,
+        )
+
+
 def test_metadata_and_upstream_ids_are_defensively_copied() -> None:
     metadata: dict[str, Any] = {"advisory_only": True, "labels": ["one"]}
     upstream_ids = ["z", "a"]
@@ -311,6 +332,30 @@ def test_rejects_path_like_metadata_values(value: str) -> None:
         _artifact(metadata={"advisory_only": True, "note": value})
 
 
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"advisory_only": 0},
+        {"advisory_only": True, "score": float("nan")},
+        cast(dict[str, Any], {123: "value"}),
+        {" ": "value"},
+        {"advisory_only": True, "note": object()},
+        {"advisory_only": True, "nested": ["safe", {"note": "docs/path"}]},
+        {"runtime_context": {"nested": "source of truth"}},
+        {"authority_claims": ["neutral", "runtime"]},
+    ],
+)
+def test_rejects_additional_unsafe_metadata_shapes(metadata: dict[str, Any]) -> None:
+    with pytest.raises(ValueError):
+        _artifact(metadata=metadata)
+
+
+@pytest.mark.parametrize("value", ["docs/", "notes.md"])
+def test_rejects_metadata_values_that_look_like_path_prefix_or_suffix(value: str) -> None:
+    with pytest.raises(ValueError, match="path-like"):
+        _artifact(metadata={"advisory_only": True, "note": value})
+
+
 def test_policy_blocks_unapproved_corpus_and_asset_type() -> None:
     policy = WikiEvidenceBridgePolicy(policy_version="policy-e5", allowed_corpora=("ops",))
 
@@ -329,6 +374,67 @@ def test_policy_blocks_unapproved_corpus_and_asset_type() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "policy_kwargs",
+    [
+        {"advisory_only_enforced": False},
+        {"allowed_corpora": ()},
+        {"allowed_admission_statuses": ()},
+        {"allowed_admission_statuses": ("valid", "unknown")},
+        {"allowed_asset_types": ()},
+        {"allowed_asset_types": ("knowledge_candidate", "runtime_bundle")},
+    ],
+)
+def test_policy_rejects_invalid_contract_settings(policy_kwargs: dict[str, Any]) -> None:
+    kwargs: dict[str, Any] = {
+        "policy_version": "policy-e5",
+        "allowed_corpora": ("project_internal",),
+    }
+    kwargs.update(policy_kwargs)
+    with pytest.raises(ValueError):
+        WikiEvidenceBridgePolicy(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("policy_kwargs", "message"),
+    [
+        ({"policy_version": "policy-other", "allowed_corpora": ("project_internal",)}, "policy"),
+        (
+            {
+                "policy_version": "policy-e5",
+                "allowed_corpora": ("project_internal",),
+                "require_content_hash": False,
+            },
+            "content_hash",
+        ),
+        (
+            {
+                "policy_version": "policy-e5",
+                "allowed_corpora": ("project_internal",),
+                "require_source_rel_path": False,
+            },
+            "source_rel_path",
+        ),
+        (
+            {
+                "policy_version": "policy-e5",
+                "allowed_corpora": ("project_internal",),
+                "allow_promoted_only": True,
+            },
+            "promoted",
+        ),
+    ],
+)
+def test_policy_enforcement_rejects_mismatched_or_unsafe_policy(
+    policy_kwargs: dict[str, Any],
+    message: str,
+) -> None:
+    policy = WikiEvidenceBridgePolicy(**policy_kwargs)
+
+    with pytest.raises(ValueError, match=message):
+        _artifact(policy=policy, promoted=False)
+
+
 def test_admission_adapter_requires_explicit_allowed_status() -> None:
     artifact = _artifact()
 
@@ -340,6 +446,54 @@ def test_admission_adapter_requires_explicit_allowed_status() -> None:
             verification_rate=1.0,
             fallback_rate=0.0,
             validation_status="degraded",
+        )
+
+
+def test_mapping_helpers_reject_non_artifact_inputs() -> None:
+    with pytest.raises(TypeError, match="AdvisoryWikiArtifactRef"):
+        wiki_artifact_to_evidence_asset_ref(cast(AdvisoryWikiArtifactRef, object()))
+
+    with pytest.raises(TypeError, match="AdvisoryWikiArtifactRef"):
+        wiki_artifact_to_admission_input(
+            cast(AdvisoryWikiArtifactRef, object()),
+            produced_at=_PRODUCED_AT,
+            coverage_rate=1.0,
+            verification_rate=1.0,
+            fallback_rate=0.0,
+        )
+
+
+@pytest.mark.parametrize("field", ["corpus", "slug"])
+@pytest.mark.parametrize("value", ["bad/value", "bad\\value", "bad..value", "."])
+def test_rejects_non_sluglike_corpus_and_slug_values(field: str, value: str) -> None:
+    with pytest.raises(ValueError):
+        _artifact(**{field: value})
+
+
+@pytest.mark.parametrize("content_hash", ["not-sha", "sha256:not-sha", f"sha256:{'a' * 63}"])
+def test_rejects_malformed_content_hash(content_hash: str) -> None:
+    with pytest.raises(ValueError, match="sha256"):
+        _artifact(content_hash=content_hash)
+
+
+def test_rejects_identity_values_with_whitespace() -> None:
+    canonical = _artifact()
+
+    with pytest.raises(ValueError, match="whitespace"):
+        AdvisoryWikiArtifactRef(
+            artifact_id="advisory-wiki:bad value",
+            corpus=canonical.corpus,
+            slug=canonical.slug,
+            source_rel_path=canonical.source_rel_path,
+            page_path=canonical.page_path,
+            promoted_path=canonical.promoted_path,
+            content_hash=canonical.content_hash,
+            policy_version=canonical.policy_version,
+            idempotency_key=canonical.idempotency_key,
+            advisory_only=True,
+            promoted=canonical.promoted,
+            upstream_ids=canonical.upstream_ids,
+            metadata=canonical.metadata,
         )
 
 

--- a/tests/core/evidence/test_wiki_bridge.py
+++ b/tests/core/evidence/test_wiki_bridge.py
@@ -68,7 +68,21 @@ def test_rejects_blank_required_identity_fields(field: str) -> None:
         _artifact(**{field: " "})
 
 
-@pytest.mark.parametrize("unsafe_path", ["../x", "/tmp/x", "~/x", "C:/x", ".", "./", "./."])
+@pytest.mark.parametrize(
+    "unsafe_path",
+    [
+        "../x",
+        "/tmp/x",
+        "~/x",
+        "C:/x",
+        "C:relative/path.md",
+        "file://tmp/x.md",
+        "https://example.com/x.md",
+        ".",
+        "./",
+        "./.",
+    ],
+)
 @pytest.mark.parametrize("field", ["source_rel_path", "page_path", "promoted_path"])
 def test_rejects_unsafe_paths(field: str, unsafe_path: str) -> None:
     with pytest.raises(ValueError):
@@ -113,6 +127,9 @@ def test_rejects_raw_prompt_response_query_user_health_secret_metadata(
         {"source_of_truth": "runtime"},
         {"product_truth": "authoritative"},
         {"advisory_only": False},
+        {"runtime": 1},
+        {"canonical": 1.0},
+        {"source_of_truth": [0, 1]},
     ],
 )
 def test_rejects_runtime_or_canonical_authority_claims(metadata: dict[str, object]) -> None:
@@ -134,6 +151,13 @@ def test_runtime_rail_mapping_is_not_available() -> None:
     assert asset.rail == "advisory"
     with pytest.raises(ValueError):
         _artifact(metadata={"rail": "runtime"})
+
+
+def test_rejects_runtime_evidence_upstreams_before_admission_mapping() -> None:
+    runtime_upstream = "evidence:knowledge_candidate:runtime:v1:aaaaaaaaaaaaaaaaaaaaaaaa"
+
+    with pytest.raises(ValueError, match="cross-rail"):
+        _artifact(upstream_ids=[runtime_upstream])
 
 
 def test_advisory_only_flag_survives_asset_and_admission_adapter() -> None:

--- a/tests/core/evidence/test_wiki_bridge.py
+++ b/tests/core/evidence/test_wiki_bridge.py
@@ -187,6 +187,44 @@ def test_idempotency_key_artifact_id_and_serialization_are_deterministic() -> No
     assert first.to_json() == second.to_json()
 
 
+def test_constructor_rejects_non_canonical_identity_fields() -> None:
+    canonical = _artifact()
+
+    with pytest.raises(ValueError, match="artifact_id must match deterministic"):
+        AdvisoryWikiArtifactRef(
+            artifact_id="advisory-wiki:wrong",
+            corpus=canonical.corpus,
+            slug=canonical.slug,
+            source_rel_path=canonical.source_rel_path,
+            page_path=canonical.page_path,
+            promoted_path=canonical.promoted_path,
+            content_hash=canonical.content_hash,
+            policy_version=canonical.policy_version,
+            idempotency_key=canonical.idempotency_key,
+            advisory_only=True,
+            promoted=canonical.promoted,
+            upstream_ids=canonical.upstream_ids,
+            metadata=canonical.metadata,
+        )
+
+    with pytest.raises(ValueError, match="idempotency_key must match deterministic"):
+        AdvisoryWikiArtifactRef(
+            artifact_id=canonical.artifact_id,
+            corpus=canonical.corpus,
+            slug=canonical.slug,
+            source_rel_path=canonical.source_rel_path,
+            page_path=canonical.page_path,
+            promoted_path=canonical.promoted_path,
+            content_hash=canonical.content_hash,
+            policy_version=canonical.policy_version,
+            idempotency_key="idem:wrong",
+            advisory_only=True,
+            promoted=canonical.promoted,
+            upstream_ids=canonical.upstream_ids,
+            metadata=canonical.metadata,
+        )
+
+
 def test_metadata_and_upstream_ids_are_defensively_copied() -> None:
     metadata: dict[str, Any] = {"advisory_only": True, "labels": ["one"]}
     upstream_ids = ["z", "a"]

--- a/tests/core/evidence/test_wiki_bridge.py
+++ b/tests/core/evidence/test_wiki_bridge.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from core.evidence.admission import AdmissionPolicy, decide_allow_serve
+from core.evidence.wiki_bridge import (
+    AdvisoryWikiArtifactRef,
+    WikiEvidenceBridgePolicy,
+    create_advisory_wiki_artifact_ref,
+    wiki_artifact_to_admission_input,
+    wiki_artifact_to_evidence_asset_ref,
+)
+
+_MODULE_PATH = Path("core/evidence/wiki_bridge.py")
+_HASH = "a" * 64
+_PRODUCED_AT = "2026-05-06T12:00:00Z"
+_NOW = "2026-05-06T12:01:00Z"
+
+
+def _artifact(**overrides: object) -> AdvisoryWikiArtifactRef:
+    values: dict[str, object] = {
+        "corpus": "project_internal",
+        "slug": "local-wiki-support-plane",
+        "source_rel_path": "docs/orchestration/LOCAL_WIKI_SUPPORT_PLANE.md",
+        "page_path": "artifacts/orchestration/wiki/project_internal/pages/local-wiki-support-plane.md",
+        "promoted_path": "artifacts/orchestration/wiki/project_internal/promoted/local-wiki-support-plane.md",
+        "content_hash": _HASH,
+        "policy_version": "policy-e5",
+        "promoted": True,
+        "upstream_ids": ["upstream-b", "upstream-a"],
+        "metadata": {"advisory_only": True, "note": "operator memory"},
+    }
+    values.update(overrides)
+    return create_advisory_wiki_artifact_ref(
+        corpus=cast(str, values["corpus"]),
+        slug=cast(str, values["slug"]),
+        source_rel_path=cast(str, values["source_rel_path"]),
+        page_path=cast(str, values["page_path"]),
+        promoted_path=cast(str | None, values["promoted_path"]),
+        content_hash=cast(str, values["content_hash"]),
+        policy_version=cast(str, values["policy_version"]),
+        promoted=cast(bool, values["promoted"]),
+        upstream_ids=cast(list[str], values["upstream_ids"]),
+        metadata=cast(dict[str, Any], values["metadata"]),
+        policy=cast(WikiEvidenceBridgePolicy | None, values.get("policy")),
+    )
+
+
+def test_creates_valid_artifact_ref_from_wiki_page_metadata() -> None:
+    artifact = _artifact()
+
+    assert artifact.advisory_only is True
+    assert artifact.promoted is True
+    assert artifact.content_hash == f"sha256:{_HASH}"
+    assert artifact.source_rel_path.startswith("docs/")
+    assert artifact.upstream_ids == ("upstream-a", "upstream-b")
+    assert artifact.artifact_id.startswith("advisory-wiki:")
+    assert artifact.idempotency_key.startswith("idem:advisory-wiki:")
+
+
+@pytest.mark.parametrize("field", ["corpus", "slug", "source_rel_path", "content_hash"])
+def test_rejects_blank_required_identity_fields(field: str) -> None:
+    with pytest.raises(ValueError):
+        _artifact(**{field: " "})
+
+
+@pytest.mark.parametrize("unsafe_path", ["../x", "/tmp/x", "~/x", "C:/x", ".", "./", "./."])
+@pytest.mark.parametrize("field", ["source_rel_path", "page_path", "promoted_path"])
+def test_rejects_unsafe_paths(field: str, unsafe_path: str) -> None:
+    with pytest.raises(ValueError):
+        _artifact(**{field: unsafe_path})
+
+
+def test_allows_docs_source_path_only_as_provenance() -> None:
+    artifact = _artifact(source_rel_path="docs/orchestration/example.md")
+
+    assert artifact.source_rel_path == "docs/orchestration/example.md"
+
+
+@pytest.mark.parametrize("field", ["page_path", "promoted_path"])
+def test_rejects_docs_output_paths_as_canonical_authority(field: str) -> None:
+    with pytest.raises(ValueError, match="canonical docs authority"):
+        _artifact(**{field: "docs/orchestration/wiki-output.md"})
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"raw_prompt": "explain the repo"},
+        {"response_text": "full answer"},
+        {"query": "private wiki query"},
+        {"user_health": {"weight": 123}},
+        {"sec" + "ret": "redacted credential payload"},
+        {"note": "prompt: raw body"},
+    ],
+)
+def test_rejects_raw_prompt_response_query_user_health_secret_metadata(
+    metadata: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        _artifact(metadata=metadata)
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"rail": "runtime"},
+        {"canonical": True},
+        {"source_of_truth": "runtime"},
+        {"product_truth": "authoritative"},
+        {"advisory_only": False},
+    ],
+)
+def test_rejects_runtime_or_canonical_authority_claims(metadata: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        _artifact(metadata=metadata)
+
+
+def test_maps_valid_wiki_artifact_to_advisory_evidence_asset() -> None:
+    asset = wiki_artifact_to_evidence_asset_ref(_artifact())
+
+    assert asset.rail == "advisory"
+    assert asset.asset_type == "knowledge_candidate"
+    assert asset.policy_version == "policy-e5"
+
+
+def test_runtime_rail_mapping_is_not_available() -> None:
+    asset = wiki_artifact_to_evidence_asset_ref(_artifact(), asset_type="context_bundle")
+
+    assert asset.rail == "advisory"
+    with pytest.raises(ValueError):
+        _artifact(metadata={"rail": "runtime"})
+
+
+def test_advisory_only_flag_survives_asset_and_admission_adapter() -> None:
+    artifact = _artifact()
+    asset = wiki_artifact_to_evidence_asset_ref(artifact)
+    admission_input = wiki_artifact_to_admission_input(
+        artifact,
+        produced_at=_PRODUCED_AT,
+        coverage_rate=1.0,
+        verification_rate=1.0,
+        fallback_rate=0.0,
+        metadata={"review_state": "promoted"},
+    )
+
+    assert artifact.advisory_only is True
+    assert asset.rail == "advisory"
+    assert admission_input.metadata["advisory_only"] is True
+    assert admission_input.metadata["serve_scope"] == "advisory_review_only"
+
+
+def test_idempotency_key_artifact_id_and_serialization_are_deterministic() -> None:
+    first = _artifact(upstream_ids=["b", "a"], content_hash=f"sha256:{_HASH}")
+    second = _artifact(upstream_ids=["a", "b"], content_hash=_HASH.upper())
+
+    assert first.artifact_id == second.artifact_id
+    assert first.idempotency_key == second.idempotency_key
+    assert first.to_json() == second.to_json()
+
+
+def test_metadata_and_upstream_ids_are_defensively_copied() -> None:
+    metadata: dict[str, Any] = {"advisory_only": True, "labels": ["one"]}
+    upstream_ids = ["z", "a"]
+    artifact = _artifact(metadata=metadata, upstream_ids=upstream_ids)
+
+    cast(list[str], metadata["labels"]).append("two")
+    upstream_ids.append("later")
+    returned_metadata = artifact.metadata
+    cast(list[str], returned_metadata["labels"]).append("three")
+
+    assert artifact.metadata == {"advisory_only": True, "labels": ["one"]}
+    assert artifact.upstream_ids == ("a", "z")
+
+
+def test_admission_adapter_does_not_imply_product_runtime_serve() -> None:
+    admission_input = wiki_artifact_to_admission_input(
+        _artifact(),
+        produced_at=_PRODUCED_AT,
+        coverage_rate=1.0,
+        verification_rate=1.0,
+        fallback_rate=0.0,
+    )
+    decision = decide_allow_serve(
+        admission_input=admission_input,
+        policy=AdmissionPolicy(policy_version="policy-e5"),
+        now=_NOW,
+    )
+
+    assert decision.allowed is True
+    input_payload = cast(dict[str, Any], decision.metadata["input"])
+    input_metadata = cast(dict[str, Any], input_payload["metadata"])
+    assert input_metadata["advisory_only"] is True
+    assert input_metadata["serve_scope"] == "advisory_review_only"
+
+
+@pytest.mark.parametrize(
+    "value", [".", "./", "./.", "docs/path.md", "core/evidence/wiki_bridge.py"]
+)
+def test_rejects_path_like_metadata_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        _artifact(metadata={"advisory_only": True, "note": value})
+
+
+def test_policy_blocks_unapproved_corpus_and_asset_type() -> None:
+    policy = WikiEvidenceBridgePolicy(policy_version="policy-e5", allowed_corpora=("ops",))
+
+    with pytest.raises(ValueError, match="corpus"):
+        _artifact(policy=policy)
+
+    artifact = _artifact()
+    restricted = WikiEvidenceBridgePolicy(
+        policy_version="policy-e5",
+        allowed_corpora=("project_internal",),
+        allowed_asset_types=("verification_bundle",),
+    )
+    with pytest.raises(ValueError, match="asset_type"):
+        wiki_artifact_to_evidence_asset_ref(
+            artifact, asset_type="knowledge_candidate", policy=restricted
+        )
+
+
+def test_admission_adapter_requires_explicit_allowed_status() -> None:
+    artifact = _artifact()
+
+    with pytest.raises(ValueError, match="not admitted"):
+        wiki_artifact_to_admission_input(
+            artifact,
+            produced_at=_PRODUCED_AT,
+            coverage_rate=1.0,
+            verification_rate=1.0,
+            fallback_rate=0.0,
+            validation_status="degraded",
+        )
+
+
+def test_import_guard_blocks_runtime_compiler_cache_and_eval_imports() -> None:
+    tree = ast.parse(_MODULE_PATH.read_text(encoding="utf-8"))
+    imported_modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.add(node.module)
+
+    forbidden_fragments = (
+        "app",
+        "db",
+        "evals",
+        "fastapi",
+        "graphrag",
+        "legacy_app",
+        "llm",
+        "local_support_plane",
+        "providers",
+        "redis",
+        "scripts.orchestration",
+        "semantic_cache",
+        "session",
+        "sqlalchemy",
+        "wiki_ingest",
+        "wiki_lint",
+        "wiki_promote",
+        "wiki_query",
+    )
+    violations = sorted(
+        module
+        for module in imported_modules
+        if any(fragment in module.lower() for fragment in forbidden_fragments)
+    )
+
+    assert violations == []

--- a/tests/core/evidence/test_wiki_bridge.py
+++ b/tests/core/evidence/test_wiki_bridge.py
@@ -178,6 +178,26 @@ def test_advisory_only_flag_survives_asset_and_admission_adapter() -> None:
     assert admission_input.metadata["serve_scope"] == "advisory_review_only"
 
 
+def test_admission_adapter_targets_advisory_evidence_asset_identity() -> None:
+    artifact = _artifact()
+    asset = wiki_artifact_to_evidence_asset_ref(artifact)
+
+    admission_input = wiki_artifact_to_admission_input(
+        artifact,
+        produced_at=_PRODUCED_AT,
+        coverage_rate=1.0,
+        verification_rate=1.0,
+        fallback_rate=0.0,
+    )
+
+    assert admission_input.target_id == asset.asset_id
+    assert admission_input.fingerprint == asset.fingerprint
+    assert admission_input.idempotency_key == asset.idempotency_key
+    assert admission_input.upstream_ids == asset.upstream_ids
+    assert admission_input.metadata["artifact_id"] == artifact.artifact_id
+    assert admission_input.metadata["evidence_asset_id"] == asset.asset_id
+
+
 def test_idempotency_key_artifact_id_and_serialization_are_deterministic() -> None:
     first = _artifact(upstream_ids=["b", "a"], content_hash=f"sha256:{_HASH}")
     second = _artifact(upstream_ids=["a", "b"], content_hash=_HASH.upper())


### PR DESCRIPTION
## Summary

PR-E5 adds a pure deterministic advisory wiki evidence bridge.

## Goal

Link existing advisory wiki artifact metadata to advisory Evidence Graph assets and advisory admission inputs while preserving that advisory wiki memory is not product/runtime truth.

## Business reason

This PR improves operator navigation, lineage, and future reviewability without turning wiki pages into canonical product truth. Repo/backend/OpenAPI/DB/runtime contracts remain authoritative.

This PR does not add user-facing product features.

## Scope

- `core/evidence/wiki_bridge.py`
- Advisory `EvidenceAssetRef` mapping
- Advisory E4 `AdmissionInput` adapter
- Metadata/path safety validation
- Deterministic IDs and serialization
- Import guards
- Contract docs, scoped agent guidance, and roadmap/backlog updates

## Out of scope

- Wiki compiler rewrite
- `wiki_artifact_to_eval_event(...)`
- Product RAG behavior
- Runtime API, FastAPI routes, OpenAPI, DB migrations, providers
- Redis, GPTCache, semantic cache
- GraphRAG
- Eval runners
- Frontend, iOS, design files
- Advisory wiki as runtime source of truth

## Split Justification

This PR crosses the size threshold because E5 is a new contract slice with implementation, focused tests, contract documentation, scoped agent guidance, roadmap/backlog updates, and canonical review mapping in one governed PR. Splitting would create a contract without tests/docs or docs without implementation, which would weaken the Evidence Graph train. The scope remains narrow: one new pure `core/evidence` bridge, one focused test module, one contract doc, and governance updates only; no runtime/API/DB/provider/cache/wiki-compiler behavior changes are included.

## Files touched

- `core/evidence/wiki_bridge.py`
- `core/evidence/__init__.py`
- `core/evidence/AGENTS.md`
- `tests/core/evidence/test_wiki_bridge.py`
- `docs/orchestration/contracts/EVIDENCE_ADVISORY_WIKI_BRIDGE.md`
- `docs/roadmap/EVIDENCE_GRAPH_RUNTIME_EPIC.md`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/review/PR_1681_FIXED_MAPPING.md`

## Tests

Passed locally:

```bash
python3 scripts/orchestration/check_preflight.py
python3 scripts/orchestration/check_agent_consistency.py
.venv/bin/python -m pytest -q tests/core/evidence/test_wiki_bridge.py tests/core/evidence/test_admission.py tests/core/evidence/test_promotion_ledger.py tests/core/evidence/test_replay.py tests/core/evidence/test_events.py tests/core/evidence/test_assets.py tests/core/evidence/test_fingerprints.py
.venv/bin/python -m pytest -q tests/test_wiki_ingest.py tests/test_wiki_promote.py tests/test_wiki_compiler_keys.py tests/test_local_support_plane.py
.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null core/evidence tests/core/evidence/test_wiki_bridge.py
make validate-changed
pre-commit run --all-files
```

Also passed during pre-push:

- changed-file mypy
- pip-audit
- backend pre-push tests
- full-repo Bandit
- Docker build test

Full `make verify` was intentionally not run under the operator-approved machine-heavy exception.

Additional local diff-cover remediation check passed after CI reported low diff coverage: `core/evidence/wiki_bridge.py` diff coverage 97.2%. Focused wiki bridge tests and narrow mypy also passed after removing the unused import reported by CodeRabbit.

## Security notes

- Metadata rejects prompt, response, query, user-health, secret, runtime, canonical, source-of-truth, and unsafe path-like payloads.
- Paths reject traversal, absolute paths, home paths, Windows drive paths, URI schemes, drive-relative first segments, and current-directory values `.`, `./`, and `./.`.
- Import guards block wiki compiler CLIs, local support-plane mutation tooling, runtime app code, providers, DB/session, cache, GraphRAG, and eval runners.
- Wiki artifacts map only to advisory rail evidence assets.
- Admission adapter now targets advisory `EvidenceAssetRef` identity, not source wiki artifact identity.

## Premortem

- Compiler recreation risk: fixed by metadata-only bridge and import guards.
- Runtime authority risk: fixed by enforced `advisory_only=True`, advisory-only asset mapping, and docs.
- Local support-plane import risk: fixed by AST import guard.
- Runtime rail mapping risk: fixed by hardcoded advisory rail.
- Runtime upstream leakage risk: fixed by validating wiki artifact upstream IDs against advisory rail policy before asset/admission mapping.
- E1/E4 bypass risk: fixed by using `create_evidence_asset_ref` and `AdmissionInput`.
- Semantic cache scope drift: fixed by explicit docs/backlog deferral.
- Raw payload/secret risk: fixed by metadata safety checks and tests.
- Byte-like raw payload risk: fixed by rejecting `bytes`, `bytearray`, and `memoryview`.
- Non-canonical public constructor risk: fixed by recomputing advisory wiki artifact identity inside `AdvisoryWikiArtifactRef.__init__`.
- Admission target identity risk: fixed by making the admission adapter target the advisory `EvidenceAssetRef` identity.
- Numeric authority-claim risk: fixed by treating truthy numeric authority metadata as forbidden.
- Path traversal/current-directory/URI/drive-relative path risks: fixed by path safety checks and tests.
- Mutation risk: fixed by defensive-copy tests.
- Checklist-only risk: code/tests/docs were changed before mapping updates.
- Diff-coverage regression risk: fixed by adding focused branch tests for policy, constructor, helper type/path, metadata recursion, and artifact mapping guard branches.

## Rollback / risks

Rollback is to revert this PR. There are no runtime callers, migrations, providers, routes, or persistent writers.

Residual risk: downstream agents could misread advisory admission as product serving. `core/evidence/AGENTS.md` and the contract doc constrain the bridge to advisory review/query/promotion workflows only.

## DoD

- `core/evidence/wiki_bridge.py` exists and is pure/deterministic.
- Existing advisory wiki compiler is not duplicated.
- Wiki artifacts can be represented as advisory evidence assets.
- Runtime rail mapping is blocked.
- Metadata and path safety are fail-closed.
- No core/evidence import of `scripts/orchestration` or local support-plane mutation tooling.
- Tests cover mapping, authority boundaries, metadata/path safety, deterministic IDs, mutation safety, stable serialization, and import guards.
- Docs state advisory wiki remains non-canonical workforce memory.
- Semantic cache remains blocked pending a dedicated gate.

## Commit breakdown

- `e2b067db4` - `feat(evidence): add advisory wiki bridge`
- `f7b04d1e5` - `fix(evidence): reject byte-like wiki metadata`
- `c5cd925a9` - `fix(evidence): harden wiki bridge safety checks`
- `85154507f` - `fix(evidence): enforce wiki artifact identity`
- `2c09b8a32` - `fix(evidence): target wiki admission assets`
- `b7efbfa2d` - `docs(agents): update instructions`
- `ccb5c0630` - `docs(review): map PR 1681 review threads`
- `7bc213ff4` - `test(evidence): cover wiki bridge guards`
- `cd0b8b4a1` - `docs(review): record PR 1681 coverage fix`
- `abc3c9563` - `docs(review): map CodeRabbit aggregate review`
- `1967ab477` - `fix(evidence): remove unused wiki bridge import`
- `dc948ecac` - `docs(review): map CodeRabbit import fix`

## Pre-push checklist

- [x] Coordinator bootstrap packet created: `bc1f48dd1ba3`
- [x] Mandatory post-open packet created: `707b42f4d8a5`
- [x] Preflight passed
- [x] Agent consistency passed
- [x] Focused evidence tests passed
- [x] Wiki compiler/support-plane regression tests passed
- [x] Narrow mypy passed
- [x] `make validate-changed` passed
- [x] `pre-commit run --all-files` passed
- [x] Pre-push hooks passed
- [x] Full `make verify` intentionally deferred under machine-heavy exception

## Post-merge checklist

- Sync local `main` with `git fetch --prune origin` and `git merge --ff-only origin/main`.
- Prune `codex/evidence-advisory-wiki-bridge` after merge.
- Confirm root checkout remains clean and unrelated local design work is untouched.
- Let operator select the next Evidence Graph follow-up; semantic cache remains blocked unless a dedicated gate opens.

## AGENTS.md updates

Added E5 guidance to `core/evidence/AGENTS.md`: advisory wiki bridge is pure deterministic mapping only; reviewers must verify no compiler behavior, runtime authority, local support-plane mutation, product-truth claims, wiki mutation, semantic cache, GraphRAG, or runtime rail authority.

## Deferred / Follow-ups

- Add wiki-specific advisory event types only if a later event-schema PR opens that scope.
- Operator-selected Evidence Graph follow-up after E5.
- Semantic cache remains blocked pending a separate dedicated gate with lineage, admission, replay, observability, false-hit guardrails, and rollout contract.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Review dispositions are recorded in `docs/review/PR_1681_FIXED_MAPPING.md`.

### Fixed in Commit Mapping

Canonical artifact: `docs/review/PR_1681_FIXED_MAPPING.md`

Mapped review threads:

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195195608 -> `2c09b8a32` FIXED
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195235932 -> `b7efbfa2d` FIXED
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195235937 -> `85154507f` FIXED
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195235955 -> `c5cd925a9` FIXED
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195235962 -> `11dc14dc6` FIXED
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#discussion_r3195235953 -> NOT-A-BUG with evidence in the mapping artifact
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#pullrequestreview-4235839249 -> NOT-A-BUG aggregate review container, inline actionables mapped individually
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1681#pullrequestreview-4236389688 -> `1967ab477` FIXED

## Merge Readiness

Not merge-ready until after the latest push has current-head CI clean, required checks pass with no pending jobs, CodeRabbit/Sourcery/Cubic actionables are clean, review threads are resolved with dispositions, strict merge-readiness wrapper passes, and the required review wait-window is observed.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advisory wiki bridge for Evidence Graph: deterministic mapping of wiki artifacts to advisory evidence assets, plus public helpers to create and map advisory wiki artifact references.

* **Documentation**
  * Added contract and AGENTS guidance detailing scope, path/metadata rules, guardrails, and governance to keep wiki content non-canonical.

* **Tests**
  * Comprehensive tests covering validation, deterministic IDs, mapping, import guards, and policy enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
