### PR TITLE
ci(release): enforce release control plane decision gates

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -238,6 +238,125 @@ jobs:
           echo "Healthcheck failed after 3 attempts"
           exit 1
 
+  release-control-plane-fixture-gate:
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build release-control-plane fixture evidence
+        run: |
+          set -euo pipefail
+          FIXTURE_ROOT="${RUNNER_TEMP}/release-control-plane-fixture"
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from scripts.release import build_equivalence
+          from scripts.release import release_manifest
+          from scripts.release import reviewer_packet_hashes
+
+          fixture_root = Path(os.environ["RUNNER_TEMP"]) / "release-control-plane-fixture"
+          for locale in reviewer_packet_hashes.REQUIRED_LOCALES:
+              locale_dir = fixture_root / "ios/fastlane/metadata" / locale
+              locale_dir.mkdir(parents=True, exist_ok=True)
+              for filename in reviewer_packet_hashes.REQUIRED_METADATA_FILES:
+                  (locale_dir / filename).write_text(f"{locale}:{filename}\n", encoding="utf-8")
+          notes_path = fixture_root / "ios/fastlane/metadata/review_information/notes.txt"
+          notes_path.parent.mkdir(parents=True, exist_ok=True)
+          notes_path.write_text("Reviewer note\n", encoding="utf-8")
+          privacy_path = fixture_root / "ios/fastlane/app_privacy_details.json"
+          privacy_path.parent.mkdir(parents=True, exist_ok=True)
+          privacy_path.write_text('[{"data_protections":["DATA_NOT_COLLECTED"]}]\n', encoding="utf-8")
+
+          rag_payload = {
+              "schema_version": "release-rag-gate-result.v1",
+              "hash_algorithm": "sha256",
+              "canonicalization": release_manifest.CANONICALIZATION,
+              "eval_artifact_hash": "c" * 64,
+              "experiment_id": "fixture",
+              "timestamp": "2026-05-06T00:00:00Z",
+              "release_decision": "PASS",
+              "gate_checks": {"answer_precision_min": True},
+              "threshold_results": [],
+              "strict_violations": [],
+              "runtime_warnings": [],
+              "dataset_path_used": "tests/fixtures/rag.jsonl",
+              "dataset_fallback_used": False,
+              "sample_size": 1,
+              "git_sha": "fixture-git-sha",
+              "retriever_mode": "local_tfidf",
+              "generator_mode": "extractive_stub",
+              "small_fixture_metric_gates_advisory": False,
+              "source_artifacts": [
+                  {
+                      "kind": "metrics_summary",
+                      "path": "artifacts/rag_eval/fixture/metrics_summary.json",
+                      "hash": "d" * 64,
+                  }
+              ],
+          }
+          rag_payload["rag_gate_result_hash"] = release_manifest.sha256_lower_hex(
+              release_manifest.canonical_json_bytes(rag_payload)
+          )
+          rag_path = fixture_root / "artifacts/rag_eval/fixture/rag_gate_result.json"
+          rag_path.parent.mkdir(parents=True, exist_ok=True)
+          rag_path.write_text(json.dumps(rag_payload, sort_keys=True) + "\n", encoding="utf-8")
+
+          manifest_payload = release_manifest.build_manifest_payload(
+              repo_root=fixture_root,
+              git_sha="fixture-git-sha",
+              ios_build_number="100",
+              marketing_version="1.0",
+              bundle_id="app.pulseplate.PulsePlate",
+              rag_gate_result_path=rag_path,
+              sbom_digest="sha256:" + ("a" * 64),
+              provenance_digest="sha256:" + ("b" * 64),
+              attestation_status="VERIFIED",
+          )
+          identity_payload = {
+              "schema_version": "release-build-identity.v1",
+              "hash_algorithm": "sha256",
+              "canonicalization": release_manifest.CANONICALIZATION,
+              "build_identity": manifest_payload["build_identity"],
+              "artifact_digest": "sha256:" + ("e" * 64),
+              "release_manifest_hash": manifest_payload["release_manifest_hash"],
+              "reviewer_identity": manifest_payload["reviewer_identity"],
+              "ml_identity": manifest_payload["ml_identity"],
+              "supply_chain_identity": manifest_payload["supply_chain_identity"],
+          }
+          build_payload = build_equivalence.build_equivalence_decision(
+              review_payload=identity_payload,
+              production_payload=identity_payload,
+              manifest_payload=manifest_payload,
+          )
+          release_dir = fixture_root / "release-control-plane"
+          release_dir.mkdir(parents=True, exist_ok=True)
+          (release_dir / "release_manifest.json").write_text(
+              json.dumps(manifest_payload, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          (release_dir / "build_equivalence_result.json").write_text(
+              json.dumps(build_payload, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          echo "fixture_root=${FIXTURE_ROOT}" >> "$GITHUB_ENV"
+
+      - name: Validate release-control-plane fixture evidence
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check_release_control_plane.py \
+            --release-manifest "${fixture_root}/release-control-plane/release_manifest.json" \
+            --rag-gate-result "${fixture_root}/artifacts/rag_eval/fixture/rag_gate_result.json" \
+            --build-equivalence "${fixture_root}/release-control-plane/build_equivalence_result.json" \
+            --json-out "${fixture_root}/release-control-plane/release_control_plane_ci_gate.json" \
+            --markdown-out "${fixture_root}/release-control-plane/release_control_plane_ci_gate.md"
+
   # Pre-production quality gates
   production-gates:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
+++ b/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
@@ -102,8 +102,8 @@ changes.
 | PR-1 | `release/release-control-plane-pr1-reviewer-hash` | Reviewer-packet hash contract consuming App Store readiness artifacts | reviewer hash schema tests and Fastlane artifact-name discovery |
 | PR-2 | `release/release-control-plane-pr2-rag-gate-export` | RAG/ML gate result export contract over the existing eval runner | gate-result schema tests |
 | PR-3 | `release/release-control-plane-pr3-release-manifest` | Release manifest generator and validator, merged as PR #1605 | manifest validator tests |
-| PR-4 | `release/release-control-plane-pr4-build-equivalence` | Active review build equals production-candidate equivalence check | equivalence tests |
-| PR-5 | `release/release-control-plane-pr5-ci-gates` | Deferred CI integration for release packet, gate result, SBOM/provenance references, and fail-closed decision | focused CI/workflow contract tests |
+| PR-4 | `release/release-control-plane-pr4-build-equivalence` | Merged review build equals production-candidate equivalence check in PR #1679 | equivalence tests |
+| PR-5 | `release/release-control-plane-pr5-ci-gates` | Active CI integration for release packet, gate result, build equivalence, SBOM/provenance references, and fail-closed decision | focused CI/workflow contract tests |
 
 ## Release Packet Contract
 
@@ -214,8 +214,27 @@ snapshots when present. It returns `EQUIVALENT` only when all required fields
 match; otherwise it returns `BLOCK` with deterministic `reason_codes` and
 `mismatch_details`. PR-4 does not add GitHub Actions enforcement, protected App
 Store upload automation, Fastlane mutation, runtime behavior, OpenAPI changes,
-RAG behavior changes, semantic cache, or product-facing behavior. PR-5 remains
-the deferred CI fail-closed enforcement slice.
+RAG behavior changes, semantic cache, or product-facing behavior. PR-5 owns the
+focused CI fail-closed enforcement slice.
+
+### PR-5 Release Control Plane CI Gate
+
+PR-5 defines a deterministic CI checker that consumes the PR-3 release manifest,
+PR-2 RAG gate result, PR-4 build-equivalence result, and supply-chain identity
+references. The machine-readable schema and field contract live in
+[`docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md`](../release/RELEASE_CONTROL_PLANE_CI_GATE.md)
+and
+[`docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json`](../release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json).
+
+The deterministic helper is `scripts/ci/check_release_control_plane.py`. It
+returns `ALLOW` only when the release manifest is `ALLOW`, the RAG gate result
+is `PASS`, the build-equivalence decision is `EQUIVALENT`, supply-chain digests
+are valid, attestation is `VERIFIED`, and evidence hashes/identity fields match.
+Otherwise it returns `BLOCK` with deterministic reason codes. The workflow
+integration is a non-secret fixture validation job because protected production
+artifact wiring is not available in this slice. PR-5 does not add App Store
+Connect execution, Fastlane upload mutation, runtime/API/OpenAPI/iOS changes,
+RAG behavior changes, semantic cache, GraphRAG, or product-facing behavior.
 
 ## Bootstrap Commands
 

--- a/docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md
+++ b/docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md
@@ -50,6 +50,10 @@ The JSON output is stable sorted JSON with a trailing newline and contains:
 - `attestation_status`
 - `tool_version`
 
+The summary fields preserve the raw upstream string when malformed evidence is
+present so blocked CI artifacts can show the exact bad value that caused the
+failure.
+
 Schema: [`RELEASE_CONTROL_PLANE_CI_GATE.schema.json`](RELEASE_CONTROL_PLANE_CI_GATE.schema.json).
 
 ## Allow Rule

--- a/docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md
+++ b/docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md
@@ -1,0 +1,109 @@
+# Release Control Plane CI Gate
+
+Schema version: `release-control-plane-ci-gate.v1`
+
+PR-5 adds the internal CI/release-governance gate that consumes already-produced
+release evidence and emits a deterministic `ALLOW` or `BLOCK` decision.
+
+The gate is validation-only. It does not create release artifacts, contact App
+Store Connect, run Fastlane, read protected secrets, call network services, run
+Docker, run Xcode, mutate deploy targets, or change product runtime behavior.
+
+## Inputs
+
+The checker accepts explicit file paths only:
+
+```bash
+python3 scripts/ci/check_release_control_plane.py \
+  --release-manifest artifacts/release/release_manifest.json \
+  --rag-gate-result artifacts/rag_eval/<experiment_id>/rag_gate_result.json \
+  --build-equivalence artifacts/release/build_equivalence_result.json \
+  --json-out artifacts/release/release_control_plane_ci_gate.json \
+  --markdown-out artifacts/release/release_control_plane_ci_gate.md
+```
+
+Required evidence:
+
+- `release_manifest.v1`, produced by `scripts/release/release_manifest.py`.
+- `release-rag-gate-result.v1`, produced by the existing RAG release-gate runner.
+- `release-build-equivalence.v1`, produced by `scripts/release/build_equivalence.py`.
+
+Evidence source paths inside ML/RAG evidence must be relative artifact paths
+under `artifacts/`. Reviewer metadata and App Store source files remain governed
+by the release manifest contract and are not treated as protected CI evidence
+paths by this gate.
+
+## Output
+
+The JSON output is stable sorted JSON with a trailing newline and contains:
+
+- `schema_version`: `release-control-plane-ci-gate.v1`
+- `decision`: `ALLOW` or `BLOCK`
+- `reason_codes`: stable fail-closed reason codes
+- `mismatch_details`: deterministic field-level details
+- `checked_artifacts`: exact input file paths and SHA-256 file hashes
+- `evidence_hashes`: SHA-256 file hashes for the consumed evidence files
+- `evidence_digests`: SBOM and provenance OCI digests from the release manifest
+- `release_manifest_hash`
+- `build_equivalence_decision`
+- `rag_gate_decision`
+- `attestation_status`
+- `tool_version`
+
+Schema: [`RELEASE_CONTROL_PLANE_CI_GATE.schema.json`](RELEASE_CONTROL_PLANE_CI_GATE.schema.json).
+
+## Allow Rule
+
+The gate returns `ALLOW` only when all required evidence passes:
+
+- release manifest exists, is valid, and has `release_decision == "ALLOW"`
+- RAG gate result exists, is valid, and has `release_decision == "PASS"`
+- build equivalence result exists, is valid, and has `decision == "EQUIVALENT"`
+- release manifest hash matches the build-equivalence result
+- RAG hashes and decision match the manifest `ml_identity`
+- manifest build git SHA matches the RAG evidence git SHA
+- SBOM and provenance digests use `sha256:<64 lowercase hex>`
+- attestation status is `VERIFIED`
+- artifact evidence paths stay under allowed artifact locations
+
+## Block Reasons
+
+Stable reason codes:
+
+- `missing_release_manifest`
+- `malformed_release_manifest`
+- `invalid_release_manifest`
+- `release_manifest_block`
+- `missing_rag_gate_result`
+- `malformed_rag_gate_result`
+- `invalid_rag_gate_result`
+- `rag_gate_result_not_pass`
+- `missing_build_equivalence`
+- `malformed_build_equivalence`
+- `invalid_build_equivalence`
+- `build_equivalence_not_equivalent`
+- `missing_sbom_digest`
+- `missing_provenance_digest`
+- `attestation_not_verified`
+- `unsupported_digest_format`
+- `release_manifest_hash_mismatch`
+- `git_sha_mismatch`
+- `build_identity_mismatch`
+- `evidence_path_outside_allowed_artifacts`
+
+## CI Integration
+
+PR-5 wires a non-secret fixture validation job into the release-control-plane CI
+surface so the checker contract is exercised without requiring protected App
+Store credentials or production release artifacts.
+
+Production tag enforcement remains fail-closed at the checker level, but
+protected-environment artifact wiring is a follow-up because current CI does not
+yet publish real `release_manifest.json`, `rag_gate_result.json`, and
+`build_equivalence_result.json` into the production deploy path. The fixture job
+must not be interpreted as fake production evidence and must not be placed under
+`artifacts/release/`.
+
+Deferred protected-environment follow-up: wire real release evidence artifacts
+into the production tag path before production deploy, then invoke this checker
+against those real artifacts.

--- a/docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json
+++ b/docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json
@@ -112,35 +112,18 @@
       "type": [
         "string",
         "null"
-      ],
-      "enum": [
-        "EQUIVALENT",
-        "BLOCK",
-        null
       ]
     },
     "rag_gate_decision": {
       "type": [
         "string",
         "null"
-      ],
-      "enum": [
-        "PASS",
-        "NO-GO",
-        null
       ]
     },
     "attestation_status": {
       "type": [
         "string",
         "null"
-      ],
-      "enum": [
-        "VERIFIED",
-        "FAILED",
-        "MISSING",
-        "PENDING",
-        null
       ]
     },
     "tool_version": {

--- a/docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json
+++ b/docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json
@@ -1,0 +1,226 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseplate.app/schemas/release-control-plane-ci-gate.v1.json",
+  "title": "PulsePlate Release Control Plane CI Gate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "hash_algorithm",
+    "canonicalization",
+    "decision",
+    "reason_codes",
+    "mismatch_details",
+    "checked_artifacts",
+    "evidence_hashes",
+    "evidence_digests",
+    "release_manifest_hash",
+    "build_equivalence_decision",
+    "rag_gate_decision",
+    "attestation_status",
+    "tool_version"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "release-control-plane-ci-gate.v1"
+    },
+    "hash_algorithm": {
+      "const": "sha256"
+    },
+    "canonicalization": {
+      "const": "json-sorted-compact-utf8-single-trailing-newline"
+    },
+    "decision": {
+      "enum": [
+        "ALLOW",
+        "BLOCK"
+      ]
+    },
+    "reason_codes": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/reason_code"
+      }
+    },
+    "mismatch_details": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/mismatch_detail"
+      }
+    },
+    "checked_artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "release_manifest",
+        "rag_gate_result",
+        "build_equivalence"
+      ],
+      "properties": {
+        "release_manifest": {
+          "$ref": "#/$defs/checked_artifact"
+        },
+        "rag_gate_result": {
+          "$ref": "#/$defs/checked_artifact"
+        },
+        "build_equivalence": {
+          "$ref": "#/$defs/checked_artifact"
+        }
+      }
+    },
+    "evidence_hashes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "release_manifest",
+        "rag_gate_result",
+        "build_equivalence"
+      ],
+      "properties": {
+        "release_manifest": {
+          "$ref": "#/$defs/nullable_sha256_hex"
+        },
+        "rag_gate_result": {
+          "$ref": "#/$defs/nullable_sha256_hex"
+        },
+        "build_equivalence": {
+          "$ref": "#/$defs/nullable_sha256_hex"
+        }
+      }
+    },
+    "evidence_digests": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sbom_digest",
+        "provenance_digest"
+      ],
+      "properties": {
+        "sbom_digest": {
+          "$ref": "#/$defs/nullable_oci_digest"
+        },
+        "provenance_digest": {
+          "$ref": "#/$defs/nullable_oci_digest"
+        }
+      }
+    },
+    "release_manifest_hash": {
+      "$ref": "#/$defs/nullable_sha256_hex"
+    },
+    "build_equivalence_decision": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "EQUIVALENT",
+        "BLOCK",
+        null
+      ]
+    },
+    "rag_gate_decision": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "PASS",
+        "NO-GO",
+        null
+      ]
+    },
+    "attestation_status": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "VERIFIED",
+        "FAILED",
+        "MISSING",
+        "PENDING",
+        null
+      ]
+    },
+    "tool_version": {
+      "const": "release-control-plane-ci-gate.v1"
+    }
+  },
+  "$defs": {
+    "nullable_sha256_hex": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "nullable_oci_digest": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "checked_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "sha256"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "$ref": "#/$defs/nullable_sha256_hex"
+        }
+      }
+    },
+    "reason_code": {
+      "type": "string",
+      "enum": [
+        "missing_release_manifest",
+        "malformed_release_manifest",
+        "invalid_release_manifest",
+        "release_manifest_block",
+        "missing_rag_gate_result",
+        "malformed_rag_gate_result",
+        "invalid_rag_gate_result",
+        "rag_gate_result_not_pass",
+        "missing_build_equivalence",
+        "malformed_build_equivalence",
+        "invalid_build_equivalence",
+        "build_equivalence_not_equivalent",
+        "missing_sbom_digest",
+        "missing_provenance_digest",
+        "attestation_not_verified",
+        "unsupported_digest_format",
+        "release_manifest_hash_mismatch",
+        "git_sha_mismatch",
+        "build_identity_mismatch",
+        "evidence_path_outside_allowed_artifacts"
+      ]
+    },
+    "mismatch_detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "field",
+        "reason_code"
+      ],
+      "properties": {
+        "field": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason_code": {
+          "$ref": "#/$defs/reason_code"
+        },
+        "detail": {}
+      }
+    }
+  }
+}

--- a/docs/release/RELEASE_CONTROL_PLANE_EPIC.md
+++ b/docs/release/RELEASE_CONTROL_PLANE_EPIC.md
@@ -100,7 +100,7 @@ review governance.
 
 5. **PR-4: review build equals production candidate**
    - Branch: `release/release-control-plane-pr4-build-equivalence`
-   - Active PR-4 slice.
+   - Merged as PR #1679 on 2026-05-06.
    - Add digest/hash equivalence checks so the reviewed build and production candidate cannot silently diverge.
    - Contract: [`BUILD_EQUIVALENCE_CONTRACT.md`](BUILD_EQUIVALENCE_CONTRACT.md)
      and [`BUILD_EQUIVALENCE_CONTRACT.schema.json`](BUILD_EQUIVALENCE_CONTRACT.schema.json).
@@ -108,8 +108,12 @@ review governance.
 
 6. **PR-5: CI release decision integration**
    - Branch: `release/release-control-plane-pr5-ci-gates`
-   - Add focused CI gates for release packet, RAG gate result, SBOM/provenance references, and `ALLOW` / `BLOCK` decision.
-   - Deferred until PR-4 has landed; PR-4 must not add CI fail-closed enforcement.
+   - Active PR-5 slice.
+   - Add focused CI gates for release manifest, RAG gate result, build-equivalence result, SBOM/provenance references, and `ALLOW` / `BLOCK` decision.
+   - Contract: [`RELEASE_CONTROL_PLANE_CI_GATE.md`](RELEASE_CONTROL_PLANE_CI_GATE.md)
+     and [`RELEASE_CONTROL_PLANE_CI_GATE.schema.json`](RELEASE_CONTROL_PLANE_CI_GATE.schema.json).
+   - Helper: `scripts/ci/check_release_control_plane.py`.
+   - Protected App Store upload and App Store Connect execution remain out of scope.
 
 ## Boundaries
 
@@ -183,3 +187,6 @@ Blocked: diagnosis, treatment, therapy, crisis support, guaranteed outcomes.
    and production-candidate identity through digest/hash comparison only. It
    leaves CI fail-closed enforcement to PR-5 and does not treat branch names,
    tags, or human labels as equivalence evidence.
+9. PR-5 adds the CI release-decision checker and a non-secret fixture validation
+   job, while protected production artifact wiring and upload execution remain
+   later explicitly scoped protected-environment work.

--- a/docs/review/PR_1682_FIXED_MAPPING.md
+++ b/docs/review/PR_1682_FIXED_MAPPING.md
@@ -4,7 +4,7 @@
 **Branch:** `release/release-control-plane-pr5-ci-gates`
 **Release-control-plane slice:** PR-5 CI release decision integration
 **Canonical commit:** `eb798b4d9`
-**Latest review-fix commit:** `eb798b4d9`
+**Latest review-fix commit:** `62b0a2bc2`
 
 ## Scope
 
@@ -28,7 +28,7 @@ evidence. New comments after this timestamp require a new pass before merge.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682 -> eb798b4d9
 Disposition: FIXED
 Commit: eb798b4d9
-Evidence: Pre-push MyPy found `_sha256_file(...)` returning an `Any`-typed value in `scripts/ci/check_release_control_plane.py`; commit `eb798b4d9` fixed the type boundary without suppression. Evidence commands after the fix: `. .venv/bin/activate && mypy --no-incremental --cache-dir=/dev/null scripts/ci/check_release_control_plane.py` PASS, `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`19 passed`), `make validate-changed` PASS (`41 passed`), `pre-commit run --all-files` PASS, and pre-push hooks PASS.
+Evidence: Pre-push MyPy found `_sha256_file(...)` returning an `Any`-typed value in `scripts/ci/check_release_control_plane.py`; commit `eb798b4d9` fixed the type boundary without suppression. Evidence commands after the fix: `. .venv/bin/activate && mypy --no-incremental --cache-dir=/dev/null scripts/ci/check_release_control_plane.py` PASS, `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`22 passed`), `make validate-changed` PASS (`44 passed`), `pre-commit run --all-files` PASS, and pre-push hooks PASS.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#issuecomment-4387819794
 Disposition: NOT-A-BUG
@@ -55,6 +55,26 @@ Disposition: NOT-A-BUG
 Evidence: Cubic current-head status is PASS for PR #1682.
 Reason: No Cubic actionable finding is present to fix.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#discussion_r3195366317 -> 62b0a2bc2
+Disposition: FIXED
+Commit: 62b0a2bc2
+Evidence: `scripts/ci/check_release_control_plane.py` now validates empty `{}` evidence objects because payload checks use `is not None` instead of truthiness; `tests/test_release_control_plane_ci_gate.py::test_empty_evidence_objects_are_invalid_not_allowed` proves empty manifest, RAG, and build-equivalence files return `BLOCK` with invalid evidence reason codes.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#discussion_r3195410123 -> 62b0a2bc2
+Disposition: FIXED
+Commit: 62b0a2bc2
+Evidence: `docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json` now allows raw string-or-null summary values for `build_equivalence_decision`, `rag_gate_decision`, and `attestation_status`, while the checker still fails closed on malformed upstream values; `tests/test_release_control_plane_ci_gate.py::test_schema_allows_raw_malformed_summary_values_for_block_outputs` covers the blocked malformed-output path.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#pullrequestreview-4236025179 -> 62b0a2bc2
+Disposition: FIXED
+Commit: 62b0a2bc2
+Evidence: The CodeRabbit actionable P1 is fixed by the empty-evidence object handling above. The low-value workflow/docs test brittleness note was addressed with an inline test comment documenting that those assertions intentionally guard PR-5 textual integration and should migrate to YAML/schema parsing if the workflow contract grows.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#pullrequestreview-4236030844 -> 62b0a2bc2
+Disposition: FIXED
+Commit: 62b0a2bc2
+Evidence: The Cubic P2 schema finding is fixed by relaxing the malformed summary fields in `docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json` and covering the behavior in `tests/test_release_control_plane_ci_gate.py`.
+
 ## Split Justification
 
 This PR is intentionally one release-control-plane slice because the fail-closed
@@ -79,14 +99,14 @@ Artifact: [`docs/review/PR_1682_PREMORTEM.md`](PR_1682_PREMORTEM.md)
 - `python3 scripts/orchestration/check_agent_consistency.py` PASS
 - `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-5: CI release decision integration" --task-class Orchestration --pr-phase pre_open --path docs/roadmap/BACKLOG_LEDGER.md --path docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md --path scripts/ci/check_release_control_plane.py --path tests/test_release_control_plane_ci_gate.py --path docs/release/RELEASE_CONTROL_PLANE_EPIC.md --path docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md --path .github/workflows/cd.yml --requested-agent ...` PASS, packet `0ddd1b459d6d`
 - `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-5 post-open review: CI decision integration" --task-class Orchestration --pr-phase post_open_review --requested-agent qa-engineer-agent --requested-agent bug-hunter --requested-agent premortem-facilitator --requested-agent security-auditor` PASS, packet `f6116f0353a4`
-- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`19 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`22 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_release_manifest.py` PASS (`20 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_build_equivalence.py` PASS (`22 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_rag_release_gates_runner.py` PASS (`48 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_check_docker_provenance_attestation.py` PASS (`12 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_repo_policy_guards.py` PASS (`14 passed`)
 - `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/roadmap/BACKLOG_LEDGER.md` PASS
-- `make validate-changed` PASS (`41 passed`)
+- `make validate-changed` PASS (`44 passed`)
 - `pre-commit run --all-files` PASS
 - Pre-push hooks PASS, including changed-file MyPy, pip-audit, backend pre-push tests, full-repo Bandit, and docker build test
 

--- a/docs/review/PR_1682_FIXED_MAPPING.md
+++ b/docs/review/PR_1682_FIXED_MAPPING.md
@@ -16,11 +16,12 @@ iOS runtime, RAG behavior, semantic cache, GraphRAG, or product-facing behavior.
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
-Post-open review is in progress. No human or bot review thread has been
-resolved without disposition evidence.
+Post-open discussion pass completed for comments visible through 2026-05-06
+12:25 UTC. No human or bot review thread has been resolved without disposition
+evidence. New comments after this timestamp require a new pass before merge.
 
 ## Fixed in Commit Mapping
 
@@ -28,6 +29,26 @@ resolved without disposition evidence.
 Disposition: FIXED
 Commit: eb798b4d9
 Evidence: Pre-push MyPy found `_sha256_file(...)` returning an `Any`-typed value in `scripts/ci/check_release_control_plane.py`; commit `eb798b4d9` fixed the type boundary without suppression. Evidence commands after the fix: `. .venv/bin/activate && mypy --no-incremental --cache-dir=/dev/null scripts/ci/check_release_control_plane.py` PASS, `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`19 passed`), `make validate-changed` PASS (`41 passed`), `pre-commit run --all-files` PASS, and pre-push hooks PASS.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#issuecomment-4387819794
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit initially skipped because PR #1682 was draft. The PR was marked ready for review and CodeRabbit was explicitly requested with `@coderabbitai review` at https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#issuecomment-4387880259.
+Reason: Draft-skip status is review orchestration state, not a code defect.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#issuecomment-4387881022
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit acknowledged the explicit review trigger and reported review in progress.
+Reason: This is a bot status acknowledgement, not an actionable code or docs finding.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#pullrequestreview-4235933131
+Disposition: NOT-A-BUG
+Evidence: Sourcery reported a weekly rate limit and did not provide code findings.
+Reason: External review quota state is not an actionable repo defect.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#pullrequestreview-4235967433
+Disposition: NOT-A-BUG
+Evidence: Sourcery repeated the weekly rate-limit comment after the PR was marked ready.
+Reason: External review quota state is not an actionable repo defect.
 
 ## Premortem
 

--- a/docs/review/PR_1682_FIXED_MAPPING.md
+++ b/docs/review/PR_1682_FIXED_MAPPING.md
@@ -50,6 +50,21 @@ Disposition: NOT-A-BUG
 Evidence: Sourcery repeated the weekly rate-limit comment after the PR was marked ready.
 Reason: External review quota state is not an actionable repo defect.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682
+Disposition: NOT-A-BUG
+Evidence: Cubic current-head status is PASS for PR #1682.
+Reason: No Cubic actionable finding is present to fix.
+
+## Split Justification
+
+This PR is intentionally one release-control-plane slice because the fail-closed
+CI checker, schema contract, workflow fixture integration, focused tests, ledger
+reconciliation, premortem artifact, and fixed-mapping artifact must land
+together for PR-5 governance to be reviewable and deterministic. Splitting the
+checker from the contract or tests would create a temporary release-governance
+state where CI evidence semantics are either undocumented or untested. Protected
+production artifact wiring remains deferred as a separate follow-up.
+
 ## Premortem
 
 - [x] Premortem pass completed against actual changed files

--- a/docs/review/PR_1682_FIXED_MAPPING.md
+++ b/docs/review/PR_1682_FIXED_MAPPING.md
@@ -1,0 +1,70 @@
+# PR 1682 Fixed Mapping
+
+**PR:** <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682>
+**Branch:** `release/release-control-plane-pr5-ci-gates`
+**Release-control-plane slice:** PR-5 CI release decision integration
+**Canonical commit:** `eb798b4d9`
+**Latest review-fix commit:** `eb798b4d9`
+
+## Scope
+
+PR-5 adds a deterministic release-control-plane CI checker for release manifest,
+RAG gate result, build-equivalence result, and supply-chain evidence. It also
+wires a non-secret fixture validation job into CD without changing production
+deploy dependencies, App Store upload behavior, Fastlane, runtime/API/OpenAPI,
+iOS runtime, RAG behavior, semantic cache, GraphRAG, or product-facing behavior.
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+Post-open review is in progress. No human or bot review thread has been
+resolved without disposition evidence.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682 -> eb798b4d9
+Disposition: FIXED
+Commit: eb798b4d9
+Evidence: Pre-push MyPy found `_sha256_file(...)` returning an `Any`-typed value in `scripts/ci/check_release_control_plane.py`; commit `eb798b4d9` fixed the type boundary without suppression. Evidence commands after the fix: `. .venv/bin/activate && mypy --no-incremental --cache-dir=/dev/null scripts/ci/check_release_control_plane.py` PASS, `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`19 passed`), `make validate-changed` PASS (`41 passed`), `pre-commit run --all-files` PASS, and pre-push hooks PASS.
+
+## Premortem
+
+- [x] Premortem pass completed against actual changed files
+- [x] All P0/P1 premortem findings fixed or dispositioned as NOT-A-BUG with evidence
+- [x] P2 findings, if any, are linked in BACKLOG_LEDGER.md
+
+Artifact: [`docs/review/PR_1682_PREMORTEM.md`](PR_1682_PREMORTEM.md)
+
+## Validation
+
+- `python3 scripts/orchestration/check_preflight.py` PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS
+- `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-5: CI release decision integration" --task-class Orchestration --pr-phase pre_open --path docs/roadmap/BACKLOG_LEDGER.md --path docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md --path scripts/ci/check_release_control_plane.py --path tests/test_release_control_plane_ci_gate.py --path docs/release/RELEASE_CONTROL_PLANE_EPIC.md --path docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md --path .github/workflows/cd.yml --requested-agent ...` PASS, packet `0ddd1b459d6d`
+- `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-5 post-open review: CI decision integration" --task-class Orchestration --pr-phase post_open_review --requested-agent qa-engineer-agent --requested-agent bug-hunter --requested-agent premortem-facilitator --requested-agent security-auditor` PASS, packet `f6116f0353a4`
+- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`19 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_release_manifest.py` PASS (`20 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_build_equivalence.py` PASS (`22 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_rag_release_gates_runner.py` PASS (`48 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_check_docker_provenance_attestation.py` PASS (`12 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_repo_policy_guards.py` PASS (`14 passed`)
+- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/roadmap/BACKLOG_LEDGER.md` PASS
+- `make validate-changed` PASS (`41 passed`)
+- `pre-commit run --all-files` PASS
+- Pre-push hooks PASS, including changed-file MyPy, pip-audit, backend pre-push tests, full-repo Bandit, and docker build test
+
+## Machine-Heavy Deferral
+
+Full local `make verify` was intentionally not run per operator instruction.
+This PR follows the bounded local gate path with focused tests,
+`make validate-changed`, pre-commit, and current-head PR CI before any
+merge-readiness claim.
+
+## Merge Readiness
+
+- [ ] PR is ready for review and no longer draft.
+- [ ] Current-head required CI is green with no pending required checks.
+- [ ] CodeRabbit/Sourcery/Cubic actionable comments are dispositioned.
+- [ ] Discussion-thread pass is complete.
+- [ ] Strict merge readiness gate passes with auth.

--- a/docs/review/PR_1682_FIXED_MAPPING.md
+++ b/docs/review/PR_1682_FIXED_MAPPING.md
@@ -4,7 +4,7 @@
 **Branch:** `release/release-control-plane-pr5-ci-gates`
 **Release-control-plane slice:** PR-5 CI release decision integration
 **Canonical commit:** `eb798b4d9`
-**Latest review-fix commit:** `54b893af9`
+**Latest review-fix commit:** `87fca914d`
 
 ## Scope
 
@@ -20,7 +20,7 @@ iOS runtime, RAG behavior, semantic cache, GraphRAG, or product-facing behavior.
 - [x] Fixed in commit mapping completed
 
 Post-open discussion pass completed for comments visible through 2026-05-06
-13:30 UTC. No human or bot review thread has been resolved without disposition
+13:54 UTC. No human or bot review thread has been resolved without disposition
 evidence. New comments after this timestamp require a new pass before merge.
 
 ## Fixed in Commit Mapping
@@ -70,6 +70,11 @@ Disposition: FIXED
 Commit: 62b0a2bc2
 Evidence: The CodeRabbit actionable P1 is fixed by the empty-evidence object handling above. The low-value workflow/docs test brittleness note was addressed with an inline test comment documenting that those assertions intentionally guard PR-5 textual integration and should migrate to YAML/schema parsing if the workflow contract grows.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#pullrequestreview-4236152045 -> 78a800f7f
+Disposition: FIXED
+Commit: 78a800f7f
+Evidence: This CodeRabbit review summary corresponds to `discussion_r3195517017` and `discussion_r3195517031`; both were fixed in `78a800f7f` with tests covering incoherent `EQUIVALENT` build-equivalence payloads and `artifacts/../` path escapes.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#pullrequestreview-4236030844 -> 62b0a2bc2
 Disposition: FIXED
 Commit: 62b0a2bc2
@@ -94,6 +99,21 @@ Evidence: `_load_evidence(...)` now hashes the same bytes it parses and returns 
 Disposition: FIXED
 Commit: 54b893af9
 Evidence: `_stable_findings(...)` now uses canonical JSON for `detail` as a tie-breaker when reason code and field are equal; `tests/test_release_control_plane_ci_gate.py::test_mismatch_details_sorting_uses_detail_tiebreaker` covers deterministic ordering for tied findings.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#pullrequestreview-4236345057 -> 54b893af9
+Disposition: FIXED
+Commit: 54b893af9
+Evidence: This CodeRabbit review summary corresponds to `discussion_r3195692607` and `discussion_r3195692613`; both were fixed in `54b893af9` with tests covering loaded-byte evidence hashes and total sorting for tied findings.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#discussion_r3195902509 -> 87fca914d
+Disposition: FIXED
+Commit: 87fca914d
+Evidence: `_load_evidence(...)` now returns the computed file hash for bytes that were successfully read but fail UTF-8/JSON/object validation, preserving artifact hashes for malformed evidence records; `tests/test_release_control_plane_ci_gate.py::test_block_on_malformed_json` asserts malformed RAG evidence records keep the computed hash in both `checked_artifacts` and `evidence_hashes`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#pullrequestreview-4236590303 -> 87fca914d
+Disposition: FIXED
+Commit: 87fca914d
+Evidence: This Cubic review summary corresponds to `discussion_r3195902509`; the malformed-evidence hash preservation issue was fixed in `87fca914d` and covered by `tests/test_release_control_plane_ci_gate.py::test_block_on_malformed_json`.
 
 ## Split Justification
 

--- a/docs/review/PR_1682_FIXED_MAPPING.md
+++ b/docs/review/PR_1682_FIXED_MAPPING.md
@@ -4,7 +4,7 @@
 **Branch:** `release/release-control-plane-pr5-ci-gates`
 **Release-control-plane slice:** PR-5 CI release decision integration
 **Canonical commit:** `eb798b4d9`
-**Latest review-fix commit:** `62b0a2bc2`
+**Latest review-fix commit:** `78a800f7f`
 
 ## Scope
 
@@ -20,7 +20,7 @@ iOS runtime, RAG behavior, semantic cache, GraphRAG, or product-facing behavior.
 - [x] Fixed in commit mapping completed
 
 Post-open discussion pass completed for comments visible through 2026-05-06
-12:25 UTC. No human or bot review thread has been resolved without disposition
+12:59 UTC. No human or bot review thread has been resolved without disposition
 evidence. New comments after this timestamp require a new pass before merge.
 
 ## Fixed in Commit Mapping
@@ -75,6 +75,16 @@ Disposition: FIXED
 Commit: 62b0a2bc2
 Evidence: The Cubic P2 schema finding is fixed by relaxing the malformed summary fields in `docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json` and covering the behavior in `tests/test_release_control_plane_ci_gate.py`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#discussion_r3195517017 -> 78a800f7f
+Disposition: FIXED
+Commit: 78a800f7f
+Evidence: `scripts/ci/check_release_control_plane.py` now rejects incoherent build-equivalence payloads where `decision == "EQUIVALENT"` but `reason_codes` or `mismatch_details` contain findings; `tests/test_release_control_plane_ci_gate.py::test_block_when_equivalent_build_equivalence_has_mismatch_findings` covers the fail-closed path.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#discussion_r3195517031 -> 78a800f7f
+Disposition: FIXED
+Commit: 78a800f7f
+Evidence: `scripts/ci/check_release_control_plane.py` now validates embedded evidence paths with `PurePosixPath` parts and rejects absolute paths or `..` escapes even when the string begins with `artifacts/`; `tests/test_release_control_plane_ci_gate.py::test_evidence_paths_reject_parent_directory_escape` covers `artifacts/../leak.json`.
+
 ## Split Justification
 
 This PR is intentionally one release-control-plane slice because the fail-closed
@@ -99,7 +109,7 @@ Artifact: [`docs/review/PR_1682_PREMORTEM.md`](PR_1682_PREMORTEM.md)
 - `python3 scripts/orchestration/check_agent_consistency.py` PASS
 - `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-5: CI release decision integration" --task-class Orchestration --pr-phase pre_open --path docs/roadmap/BACKLOG_LEDGER.md --path docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md --path scripts/ci/check_release_control_plane.py --path tests/test_release_control_plane_ci_gate.py --path docs/release/RELEASE_CONTROL_PLANE_EPIC.md --path docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md --path .github/workflows/cd.yml --requested-agent ...` PASS, packet `0ddd1b459d6d`
 - `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-5 post-open review: CI decision integration" --task-class Orchestration --pr-phase post_open_review --requested-agent qa-engineer-agent --requested-agent bug-hunter --requested-agent premortem-facilitator --requested-agent security-auditor` PASS, packet `f6116f0353a4`
-- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`22 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`24 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_release_manifest.py` PASS (`20 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_build_equivalence.py` PASS (`22 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_rag_release_gates_runner.py` PASS (`48 passed`)

--- a/docs/review/PR_1682_FIXED_MAPPING.md
+++ b/docs/review/PR_1682_FIXED_MAPPING.md
@@ -4,7 +4,7 @@
 **Branch:** `release/release-control-plane-pr5-ci-gates`
 **Release-control-plane slice:** PR-5 CI release decision integration
 **Canonical commit:** `eb798b4d9`
-**Latest review-fix commit:** `78a800f7f`
+**Latest review-fix commit:** `54b893af9`
 
 ## Scope
 
@@ -20,7 +20,7 @@ iOS runtime, RAG behavior, semantic cache, GraphRAG, or product-facing behavior.
 - [x] Fixed in commit mapping completed
 
 Post-open discussion pass completed for comments visible through 2026-05-06
-12:59 UTC. No human or bot review thread has been resolved without disposition
+13:30 UTC. No human or bot review thread has been resolved without disposition
 evidence. New comments after this timestamp require a new pass before merge.
 
 ## Fixed in Commit Mapping
@@ -85,6 +85,16 @@ Disposition: FIXED
 Commit: 78a800f7f
 Evidence: `scripts/ci/check_release_control_plane.py` now validates embedded evidence paths with `PurePosixPath` parts and rejects absolute paths or `..` escapes even when the string begins with `artifacts/`; `tests/test_release_control_plane_ci_gate.py::test_evidence_paths_reject_parent_directory_escape` covers `artifacts/../leak.json`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#discussion_r3195692607 -> 54b893af9
+Disposition: FIXED
+Commit: 54b893af9
+Evidence: `_load_evidence(...)` now hashes the same bytes it parses and returns that digest through `checked_artifacts` and `evidence_hashes` without re-reading the evidence files; `tests/test_release_control_plane_ci_gate.py::test_evidence_hashes_use_loaded_bytes` covers a simulated mutation after the initial read.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682#discussion_r3195692613 -> 54b893af9
+Disposition: FIXED
+Commit: 54b893af9
+Evidence: `_stable_findings(...)` now uses canonical JSON for `detail` as a tie-breaker when reason code and field are equal; `tests/test_release_control_plane_ci_gate.py::test_mismatch_details_sorting_uses_detail_tiebreaker` covers deterministic ordering for tied findings.
+
 ## Split Justification
 
 This PR is intentionally one release-control-plane slice because the fail-closed
@@ -109,7 +119,7 @@ Artifact: [`docs/review/PR_1682_PREMORTEM.md`](PR_1682_PREMORTEM.md)
 - `python3 scripts/orchestration/check_agent_consistency.py` PASS
 - `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-5: CI release decision integration" --task-class Orchestration --pr-phase pre_open --path docs/roadmap/BACKLOG_LEDGER.md --path docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md --path scripts/ci/check_release_control_plane.py --path tests/test_release_control_plane_ci_gate.py --path docs/release/RELEASE_CONTROL_PLANE_EPIC.md --path docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md --path .github/workflows/cd.yml --requested-agent ...` PASS, packet `0ddd1b459d6d`
 - `python3 scripts/orchestration/task_bootstrap.py --goal "Release control plane PR-5 post-open review: CI decision integration" --task-class Orchestration --pr-phase post_open_review --requested-agent qa-engineer-agent --requested-agent bug-hunter --requested-agent premortem-facilitator --requested-agent security-auditor` PASS, packet `f6116f0353a4`
-- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`24 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`26 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_release_manifest.py` PASS (`20 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_build_equivalence.py` PASS (`22 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_rag_release_gates_runner.py` PASS (`48 passed`)

--- a/docs/review/PR_1682_PREMORTEM.md
+++ b/docs/review/PR_1682_PREMORTEM.md
@@ -95,21 +95,25 @@ Frame: It is 6 months from now. PR-5 merged, but a production release proceeded 
 
 **Risk:** Invalid evidence files are treated as absent or ignored.
 
-**Inspection:** `_load_evidence(...)` reports `malformed_*` reason codes and returns `BLOCK`.
+**Inspection:** `_load_evidence(...)` reports `malformed_*` reason codes and returns `BLOCK`. Post-open review also found that existing files containing `{}` bypassed validation because empty dictionaries were treated as falsey.
 
-**Disposition:** NOT-A-BUG
+**Disposition:** FIXED
 
-**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_block_on_malformed_json`.
+**Commit:** `62b0a2bc2`
+
+**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_block_on_malformed_json` and `test_empty_evidence_objects_are_invalid_not_allowed`.
 
 ### 9. Checker accepts invalid digest/hash format
 
 **Risk:** A non-OCI digest or malformed SHA-256 hash bypasses release evidence checks.
 
-**Inspection:** The checker reuses release-manifest regexes and maps digest/hash validation failures to `unsupported_digest_format`.
+**Inspection:** The checker reuses release-manifest regexes and maps digest/hash validation failures to `unsupported_digest_format`. Post-open review also found the output schema was too strict for blocked malformed summary strings.
 
-**Disposition:** NOT-A-BUG
+**Disposition:** FIXED
 
-**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_block_on_invalid_digest_format`.
+**Commit:** `62b0a2bc2`
+
+**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_block_on_invalid_digest_format` and `test_schema_allows_raw_malformed_summary_values_for_block_outputs`.
 
 ### 10. Reason ordering is nondeterministic
 
@@ -183,14 +187,14 @@ Unresolved P0/P1: none.
 
 - `python3 scripts/orchestration/check_preflight.py` PASS
 - `python3 scripts/orchestration/check_agent_consistency.py` PASS
-- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`19 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`22 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_release_manifest.py` PASS (`20 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_build_equivalence.py` PASS (`22 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_rag_release_gates_runner.py` PASS (`48 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_check_docker_provenance_attestation.py` PASS (`12 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_repo_policy_guards.py` PASS (`14 passed`)
 - `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/roadmap/BACKLOG_LEDGER.md` PASS
-- `make validate-changed` PASS (`41 passed`)
+- `make validate-changed` PASS (`44 passed`)
 - `pre-commit run --all-files` PASS
 - Pre-push hook PASS
 

--- a/docs/review/PR_1682_PREMORTEM.md
+++ b/docs/review/PR_1682_PREMORTEM.md
@@ -121,11 +121,13 @@ Frame: It is 6 months from now. PR-5 merged, but a production release proceeded 
 
 **Risk:** CI evidence changes across runs, making review and mapping unreliable.
 
-**Inspection:** `REASON_ORDER`, `_stable_reason_codes(...)`, and `_stable_findings(...)` define deterministic ordering.
+**Inspection:** `REASON_ORDER`, `_stable_reason_codes(...)`, and `_stable_findings(...)` define deterministic ordering. Post-open review found that `_stable_findings(...)` did not fully break ties when multiple findings shared the same reason code and field.
 
-**Disposition:** NOT-A-BUG
+**Disposition:** FIXED
 
-**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_reason_code_ordering_is_deterministic` and `test_output_json_is_deterministic`.
+**Commit:** `54b893af9`
+
+**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_reason_code_ordering_is_deterministic`, `test_output_json_is_deterministic`, and `test_mismatch_details_sorting_uses_detail_tiebreaker`.
 
 ### 11. Fixture evidence leaks into production release path
 
@@ -181,6 +183,18 @@ Frame: It is 6 months from now. PR-5 merged, but a production release proceeded 
 
 **Evidence:** `scripts/ci/check_release_control_plane.py` now rejects absolute paths, non-`artifacts` roots, and any `..` path part using `PurePosixPath`; `tests/test_release_control_plane_ci_gate.py::test_evidence_paths_reject_parent_directory_escape` covers `artifacts/../leak.json`.
 
+### 16. Evidence hashes do not match validated bytes
+
+**Risk:** The checker validates one file read, then re-reads the same path for `checked_artifacts` and `evidence_hashes`, allowing a race where the recorded digest is not the validated evidence.
+
+**Inspection:** Post-open review found `_load_evidence(...)` parsed one read while output hash fields re-opened paths later.
+
+**Disposition:** FIXED
+
+**Commit:** `54b893af9`
+
+**Evidence:** `_load_evidence(...)` now returns the SHA-256 digest of the parsed bytes and the final payload uses that digest without re-reading evidence files; `tests/test_release_control_plane_ci_gate.py::test_evidence_hashes_use_loaded_bytes` mutates a file after the initial read and proves the output hash stays tied to the loaded bytes.
+
 ## Synthesis
 
 Most likely failure: protected production artifact wiring is mistaken as complete because fixture validation exists.
@@ -201,7 +215,7 @@ Unresolved P0/P1: none.
 
 - `python3 scripts/orchestration/check_preflight.py` PASS
 - `python3 scripts/orchestration/check_agent_consistency.py` PASS
-- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`24 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`26 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_release_manifest.py` PASS (`20 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_build_equivalence.py` PASS (`22 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_rag_release_gates_runner.py` PASS (`48 passed`)

--- a/docs/review/PR_1682_PREMORTEM.md
+++ b/docs/review/PR_1682_PREMORTEM.md
@@ -185,15 +185,15 @@ Frame: It is 6 months from now. PR-5 merged, but a production release proceeded 
 
 ### 16. Evidence hashes do not match validated bytes
 
-**Risk:** The checker validates one file read, then re-reads the same path for `checked_artifacts` and `evidence_hashes`, allowing a race where the recorded digest is not the validated evidence.
+**Risk:** The checker validates one file read, then re-reads the same path for `checked_artifacts` and `evidence_hashes`, allowing a race where the recorded digest is not the validated evidence. A later review also found that malformed evidence with successfully read bytes should still preserve the computed artifact hash.
 
-**Inspection:** Post-open review found `_load_evidence(...)` parsed one read while output hash fields re-opened paths later.
+**Inspection:** Post-open review found `_load_evidence(...)` parsed one read while output hash fields re-opened paths later, then found the parse-error path dropped the computed digest.
 
 **Disposition:** FIXED
 
-**Commit:** `54b893af9`
+**Commit:** `54b893af9`, `87fca914d`
 
-**Evidence:** `_load_evidence(...)` now returns the SHA-256 digest of the parsed bytes and the final payload uses that digest without re-reading evidence files; `tests/test_release_control_plane_ci_gate.py::test_evidence_hashes_use_loaded_bytes` mutates a file after the initial read and proves the output hash stays tied to the loaded bytes.
+**Evidence:** `_load_evidence(...)` now returns the SHA-256 digest of read evidence bytes and the final payload uses that digest without re-reading evidence files. `tests/test_release_control_plane_ci_gate.py::test_evidence_hashes_use_loaded_bytes` mutates a file after the initial read and proves the output hash stays tied to the loaded bytes; `test_block_on_malformed_json` asserts malformed evidence records preserve the computed hash.
 
 ## Synthesis
 

--- a/docs/review/PR_1682_PREMORTEM.md
+++ b/docs/review/PR_1682_PREMORTEM.md
@@ -25,11 +25,13 @@ Frame: It is 6 months from now. PR-5 merged, but a production release proceeded 
 
 **Risk:** The CI checker trusts manifest labels and ignores PR-4 build-equivalence output.
 
-**Inspection:** `check_release_control_plane.py` requires `build_equivalence.decision == "EQUIVALENT"` and returns `build_equivalence_not_equivalent` otherwise.
+**Inspection:** `check_release_control_plane.py` requires `build_equivalence.decision == "EQUIVALENT"` and returns `build_equivalence_not_equivalent` otherwise. Post-open review found that a contradictory payload with `decision == "EQUIVALENT"` plus non-empty findings could still pass.
 
-**Disposition:** NOT-A-BUG
+**Disposition:** FIXED
 
-**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_block_when_build_equivalence_blocks` asserts `BLOCK`, `build_equivalence_not_equivalent`, and `build_identity_mismatch`.
+**Commit:** `78a800f7f`
+
+**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_block_when_build_equivalence_blocks` asserts `BLOCK`, `build_equivalence_not_equivalent`, and `build_identity_mismatch`. `tests/test_release_control_plane_ci_gate.py::test_block_when_equivalent_build_equivalence_has_mismatch_findings` asserts contradictory `EQUIVALENT` payloads return `BLOCK`.
 
 ### 2. Gate ALLOWs when RAG gate is NO-GO
 
@@ -167,6 +169,18 @@ Frame: It is 6 months from now. PR-5 merged, but a production release proceeded 
 
 **Evidence:** `scripts/ci/check_release_control_plane.py` now type-checks `_sha256_file(...)` without `Any` leakage; `. .venv/bin/activate && mypy --no-incremental --cache-dir=/dev/null scripts/ci/check_release_control_plane.py` passed; subsequent `make validate-changed`, `pre-commit run --all-files`, and pre-push hooks passed.
 
+### 15. Embedded evidence paths escape `artifacts/`
+
+**Risk:** A release evidence payload points to `artifacts/../outside.json`, bypasses the string prefix guard, and makes the CI gate trust metadata outside allowed artifact locations.
+
+**Inspection:** Post-open review found the path guard used a string prefix check and did not normalize POSIX path parts.
+
+**Disposition:** FIXED
+
+**Commit:** `78a800f7f`
+
+**Evidence:** `scripts/ci/check_release_control_plane.py` now rejects absolute paths, non-`artifacts` roots, and any `..` path part using `PurePosixPath`; `tests/test_release_control_plane_ci_gate.py::test_evidence_paths_reject_parent_directory_escape` covers `artifacts/../leak.json`.
+
 ## Synthesis
 
 Most likely failure: protected production artifact wiring is mistaken as complete because fixture validation exists.
@@ -187,7 +201,7 @@ Unresolved P0/P1: none.
 
 - `python3 scripts/orchestration/check_preflight.py` PASS
 - `python3 scripts/orchestration/check_agent_consistency.py` PASS
-- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`22 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`24 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_release_manifest.py` PASS (`20 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_build_equivalence.py` PASS (`22 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_rag_release_gates_runner.py` PASS (`48 passed`)

--- a/docs/review/PR_1682_PREMORTEM.md
+++ b/docs/review/PR_1682_PREMORTEM.md
@@ -1,0 +1,207 @@
+# PR 1682 Premortem Risk Review
+
+<!-- markdownlint-disable MD013 -->
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1682
+Mode: `pr-premortem`
+Release-control-plane slice: PR-5 CI release decision integration
+
+Frame: It is 6 months from now. PR-5 merged, but a production release proceeded with incomplete or incoherent release evidence.
+
+## Files Inspected
+
+- `scripts/ci/check_release_control_plane.py`
+- `tests/test_release_control_plane_ci_gate.py`
+- `.github/workflows/cd.yml`
+- `docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md`
+- `docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json`
+- `docs/release/RELEASE_CONTROL_PLANE_EPIC.md`
+- `docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md`
+- `docs/roadmap/BACKLOG_LEDGER.md`
+
+## Failure Modes
+
+### 1. Gate ALLOWs when build equivalence is BLOCK
+
+**Risk:** The CI checker trusts manifest labels and ignores PR-4 build-equivalence output.
+
+**Inspection:** `check_release_control_plane.py` requires `build_equivalence.decision == "EQUIVALENT"` and returns `build_equivalence_not_equivalent` otherwise.
+
+**Disposition:** NOT-A-BUG
+
+**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_block_when_build_equivalence_blocks` asserts `BLOCK`, `build_equivalence_not_equivalent`, and `build_identity_mismatch`.
+
+### 2. Gate ALLOWs when RAG gate is NO-GO
+
+**Risk:** A release with failed ML/RAG gates proceeds because the CI gate only validates JSON shape.
+
+**Inspection:** The checker validates the RAG export and requires `release_decision == "PASS"`.
+
+**Disposition:** NOT-A-BUG
+
+**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_block_when_rag_gate_result_is_no_go` and `test_block_when_release_manifest_decision_blocks`.
+
+### 3. Gate ALLOWs when release manifest is BLOCK
+
+**Risk:** Release manifest fail-closed decision is ignored by CI.
+
+**Inspection:** The checker reuses `release_manifest.validate_manifest_payload(...)` and requires `release_decision == "ALLOW"`.
+
+**Disposition:** NOT-A-BUG
+
+**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_block_when_release_manifest_decision_blocks`.
+
+### 4. Gate ignores missing SBOM/provenance evidence
+
+**Risk:** Supply-chain evidence is optional in practice.
+
+**Inspection:** The checker emits `missing_sbom_digest`, `missing_provenance_digest`, `unsupported_digest_format`, and `attestation_not_verified` as fail-closed reasons.
+
+**Disposition:** NOT-A-BUG
+
+**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_block_on_invalid_digest_format` and `test_block_when_attestation_not_verified`.
+
+### 5. Workflow requires App Store secrets in normal PR or tag validation
+
+**Risk:** CI becomes fragile or blocks ordinary release-control-plane validation on protected credentials.
+
+**Inspection:** The new `release-control-plane-fixture-gate` job uses only checkout and local Python fixture generation. It does not use `secrets.*`, Fastlane, or App Store Connect.
+
+**Disposition:** NOT-A-BUG
+
+**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_workflow_integration_does_not_require_app_store_secrets`.
+
+### 6. Workflow mutates upload/deploy behavior outside PR-5 scope
+
+**Risk:** PR-5 silently changes deployment dependencies or upload automation.
+
+**Inspection:** The fixture job is not added to production deploy `needs`, does not call Fastlane, and does not upload App Store artifacts.
+
+**Disposition:** NOT-A-BUG
+
+**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_workflow_integration_does_not_alter_app_store_upload_behavior`.
+
+### 7. Normal PR CI path breaks
+
+**Risk:** Release-control-plane validation destabilizes unrelated PR checks.
+
+**Inspection:** CD workflow still triggers only on `push` to `main` and `v*` tags. The new job is inside CD and is non-secret fixture validation.
+
+**Disposition:** NOT-A-BUG
+
+**Evidence:** `.github/workflows/cd.yml` keeps `on.push.branches: [main]` and `tags: ['v*']`; pre-commit `check-github-workflows` passed.
+
+### 8. Checker accepts malformed JSON
+
+**Risk:** Invalid evidence files are treated as absent or ignored.
+
+**Inspection:** `_load_evidence(...)` reports `malformed_*` reason codes and returns `BLOCK`.
+
+**Disposition:** NOT-A-BUG
+
+**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_block_on_malformed_json`.
+
+### 9. Checker accepts invalid digest/hash format
+
+**Risk:** A non-OCI digest or malformed SHA-256 hash bypasses release evidence checks.
+
+**Inspection:** The checker reuses release-manifest regexes and maps digest/hash validation failures to `unsupported_digest_format`.
+
+**Disposition:** NOT-A-BUG
+
+**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_block_on_invalid_digest_format`.
+
+### 10. Reason ordering is nondeterministic
+
+**Risk:** CI evidence changes across runs, making review and mapping unreliable.
+
+**Inspection:** `REASON_ORDER`, `_stable_reason_codes(...)`, and `_stable_findings(...)` define deterministic ordering.
+
+**Disposition:** NOT-A-BUG
+
+**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_reason_code_ordering_is_deterministic` and `test_output_json_is_deterministic`.
+
+### 11. Fixture evidence leaks into production release path
+
+**Risk:** The fixture job is mistaken for real production release evidence.
+
+**Inspection:** Fixture files are generated under `$RUNNER_TEMP/release-control-plane-fixture`, not under `artifacts/release/`, and the docs state production artifact wiring is deferred.
+
+**Disposition:** NOT-A-BUG
+
+**Evidence:** `.github/workflows/cd.yml` fixture root uses `${RUNNER_TEMP}`; `docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md` documents fixture-only workflow integration and deferred protected-environment wiring.
+
+### 12. Ledger closes App Store readiness incorrectly
+
+**Risk:** PR-5 overclaims production readiness.
+
+**Inspection:** Ledger marks PR-5 active but states full App Store readiness is not complete and the train is not production-ready.
+
+**Disposition:** NOT-A-BUG
+
+**Evidence:** `tests/test_release_control_plane_ci_gate.py::test_ledger_marks_pr4_merged_and_pr5_active`.
+
+### 13. Runtime/API/OpenAPI/iOS behavior changes
+
+**Risk:** CI governance PR drifts into product runtime.
+
+**Inspection:** Touched files are limited to `.github/workflows/cd.yml`, docs, `scripts/ci/check_release_control_plane.py`, and tests.
+
+**Disposition:** NOT-A-BUG
+
+**Evidence:** `git diff --name-only origin/main...HEAD` lists no `app/`, `core/`, `ios/`, OpenAPI, billing, or frontend runtime files.
+
+### 14. Mapping/checklists are used instead of fixing findings
+
+**Risk:** Review artifacts are treated as proof before underlying bugs are fixed.
+
+**Inspection:** Pre-push MyPy found a real checker type-boundary issue. Code was fixed before mapping artifacts were added.
+
+**Disposition:** FIXED
+
+**Commit:** `eb798b4d9`
+
+**Evidence:** `scripts/ci/check_release_control_plane.py` now type-checks `_sha256_file(...)` without `Any` leakage; `. .venv/bin/activate && mypy --no-incremental --cache-dir=/dev/null scripts/ci/check_release_control_plane.py` passed; subsequent `make validate-changed`, `pre-commit run --all-files`, and pre-push hooks passed.
+
+## Synthesis
+
+Most likely failure: protected production artifact wiring is mistaken as complete because fixture validation exists.
+
+Most dangerous failure: the checker returns `ALLOW` while build equivalence, RAG, manifest, or supply-chain evidence is incoherent.
+
+Hidden assumption: later protected-environment work will publish real evidence artifacts into the production tag path before deploy.
+
+Revised plan: keep the checker fail-closed, keep workflow integration fixture-only in this PR, and explicitly defer protected production artifact wiring in docs, PR body, and ledger.
+
+## Decision
+
+`proceed` — plan is sound after premortem inspection of actual code, workflow, docs, and tests.
+
+Unresolved P0/P1: none.
+
+## Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS
+- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`19 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_release_manifest.py` PASS (`20 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_build_equivalence.py` PASS (`22 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_rag_release_gates_runner.py` PASS (`48 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_check_docker_provenance_attestation.py` PASS (`12 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_repo_policy_guards.py` PASS (`14 passed`)
+- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/roadmap/BACKLOG_LEDGER.md` PASS
+- `make validate-changed` PASS (`41 passed`)
+- `pre-commit run --all-files` PASS
+- Pre-push hook PASS
+
+## Pre-merge Checklist
+
+- [x] Checker is fail-closed on missing/malformed evidence
+- [x] Checker requires manifest `ALLOW`
+- [x] Checker requires RAG `PASS`
+- [x] Checker requires build equivalence `EQUIVALENT`
+- [x] Checker requires verified supply-chain evidence
+- [x] Fixture workflow requires no App Store secrets
+- [x] Fixture workflow does not mutate App Store upload behavior
+- [x] No runtime/API/OpenAPI/iOS files changed
+- [x] No unresolved P0/P1 premortem findings

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -461,8 +461,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/release/RELEASE_MANIFEST_CONTRACT.schema.json`
     - `docs/release/BUILD_EQUIVALENCE_CONTRACT.md`
     - `docs/release/BUILD_EQUIVALENCE_CONTRACT.schema.json`
+    - `docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md`
+    - `docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json`
     - `scripts/release/release_manifest.py`
     - `scripts/release/build_equivalence.py`
+    - `scripts/ci/check_release_control_plane.py`
     - `docs/architecture/C4_RELEASE_CONTROL_PLANE_CONTEXT.md`
     - `docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md`
     - `scripts/evals/run_rag_release_gates.py`

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -445,10 +445,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Release automation control plane for C4, App Store Review, ML gates, and supply chain
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-RELEASE-CONTROL-PLANE-PR0 -> PR #1605 -> PR #1679 (`release/release-control-plane-pr4-build-equivalence`) -> PR-TBD-RELEASE-CONTROL-PLANE-PR5
+  - Target PR: PR-TBD-RELEASE-CONTROL-PLANE-PR0 -> PR #1605 -> PR #1679 -> PR-TBD-RELEASE-CONTROL-PLANE-PR5 (`release/release-control-plane-pr5-ci-gates`)
   - Area: release / App Store / AI evals / supply-chain / orchestration
   - Finding Type: release evidence unification gap
-  - Status: PR-0, PR-1, and PR-2 merged; PR-3 merged in PR #1605 on 2026-04-30; PR-4 active in PR #1679 on branch `release/release-control-plane-pr4-build-equivalence`; PR-5 remains deferred for CI fail-closed enforcement. The release-control-plane epic is not complete and is not production-ready.
+  - Status: PR-0, PR-1, and PR-2 merged; PR-3 merged in PR #1605 on 2026-04-30; PR-4 merged in PR #1679 on 2026-05-06; PR-5 is active on branch `release/release-control-plane-pr5-ci-gates` for CI fail-closed release-decision integration. Future protected upload and App Store Connect execution remain out of scope. The release-control-plane epic is not complete, full App Store readiness is not complete, and the train is not production-ready.
   - Reason (EN): The App Store readiness PR train is owned separately, while the attached release-automation document also identifies a cross-cutting control-plane gap: build identity, reviewer packet identity, RAG/ML gate identity, supply-chain provenance, and the final release decision are not yet represented by one machine-readable release packet. This line complements PR `#1582` without editing its branch or worktree.
   - Links:
     - `docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md`
@@ -473,8 +473,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - PR-1 defines reviewer-packet hash contract after App Store readiness artifacts land on `main`, including `reviewer_notes_hash`, `appstore_metadata_hash`, canonical UTF-8 SHA-256 rules, and schema tests.
     - PR-2 exports a stable RAG/ML gate-result schema from the existing release-gate runner without creating a second eval source of truth, including `rag_gate_result_hash`, `eval_artifact_hash`, existing `PASS` / `NO-GO` eval decision fields, and safe artifact references.
     - PR-3 adds a release manifest generator and fail-closed validator. Completed by PR #1605.
-    - PR-4 proves review-build and production-candidate equivalence by digest/hash checks. Active in `release/release-control-plane-pr4-build-equivalence`.
-    - PR-5 integrates focused CI gates for manifest, ML gate result, SBOM/provenance references, and `ALLOW` / `BLOCK` decision. Deferred until PR-4 merges; PR-4 must not add CI fail-closed enforcement.
+    - PR-4 proves review-build and production-candidate equivalence by digest/hash checks. Completed by PR #1679.
+    - PR-5 integrates focused CI gates for manifest, ML gate result, build-equivalence result, SBOM/provenance references, and `ALLOW` / `BLOCK` decision. Active in `release/release-control-plane-pr5-ci-gates`; protected upload and App Store Connect execution remain deferred follow-ups.
 
 <a id="ledger-p1-planning-flow-monetization-wave"></a>
 - [ ] P1: Planning-flow monetization wave over the canonical FREE -> PRO -> VIP ladder

--- a/scripts/ci/check_release_control_plane.py
+++ b/scripts/ci/check_release_control_plane.py
@@ -66,27 +66,33 @@ class Finding:
 
 def _load_evidence(
     path: Path, *, missing_reason: str, malformed_reason: str
-) -> tuple[dict[str, Any] | None, list[Finding]]:
+) -> tuple[dict[str, Any] | None, list[Finding], str | None]:
     findings: list[Finding] = []
     if not path.exists():
         findings.append(Finding(str(path), missing_reason))
-        return None, findings
+        return None, findings, None
     try:
-        raw_text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError) as exc:
+        raw_bytes = path.read_bytes()
+    except OSError as exc:
         findings.append(Finding(str(path), malformed_reason, str(exc)))
-        return None, findings
+        return None, findings, None
+    file_hash = release_manifest.sha256_lower_hex(raw_bytes)
+    try:
+        raw_text = raw_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        findings.append(Finding(str(path), malformed_reason, str(exc)))
+        return None, findings, None
     try:
         payload = json.loads(raw_text)
     except json.JSONDecodeError as exc:
         findings.append(Finding(str(path), malformed_reason, str(exc)))
-        return None, findings
+        return None, findings, None
     if not isinstance(payload, dict):
         findings.append(
             Finding(str(path), malformed_reason, "top-level JSON value must be an object")
         )
-        return None, findings
-    return payload, findings
+        return None, findings, None
+    return payload, findings, file_hash
 
 
 def _stable_reason_codes(findings: list[Finding]) -> list[str]:
@@ -101,27 +107,23 @@ def _stable_findings(findings: list[Finding]) -> list[dict[str, Any]]:
         finding.as_payload()
         for finding in sorted(
             findings,
-            key=lambda item: (REASON_ORDER.get(item.reason_code, 10_000), item.field),
+            key=lambda item: (
+                REASON_ORDER.get(item.reason_code, 10_000),
+                item.field,
+                (
+                    json.dumps(item.detail, ensure_ascii=False, sort_keys=True)
+                    if item.detail is not None
+                    else ""
+                ),
+            ),
         )
     ]
 
 
-def _sha256_file(path: Path) -> str | None:
-    if not path.exists() or not path.is_file():
-        return None
-    try:
-        digest = release_manifest.sha256_lower_hex(path.read_bytes())
-    except OSError:
-        return None
-    if not isinstance(digest, str):
-        return None
-    return digest
-
-
-def _artifact_entry(path: Path) -> dict[str, Any]:
+def _artifact_entry(path: Path, file_hash: str | None) -> dict[str, Any]:
     return {
         "path": path.as_posix(),
-        "sha256": _sha256_file(path),
+        "sha256": file_hash,
     }
 
 
@@ -386,6 +388,9 @@ def build_release_control_plane_decision(
     release_manifest_path: Path,
     rag_gate_result_path: Path,
     build_equivalence_path: Path,
+    release_manifest_file_hash: str | None = None,
+    rag_gate_result_file_hash: str | None = None,
+    build_equivalence_file_hash: str | None = None,
     load_findings: list[Finding] | None = None,
 ) -> dict[str, Any]:
     """Return a deterministic fail-closed release-control-plane decision."""
@@ -426,14 +431,23 @@ def build_release_control_plane_decision(
         "reason_codes": reason_codes,
         "mismatch_details": _stable_findings(findings),
         "checked_artifacts": {
-            "release_manifest": _artifact_entry(release_manifest_path),
-            "rag_gate_result": _artifact_entry(rag_gate_result_path),
-            "build_equivalence": _artifact_entry(build_equivalence_path),
+            "release_manifest": _artifact_entry(
+                release_manifest_path,
+                release_manifest_file_hash,
+            ),
+            "rag_gate_result": _artifact_entry(
+                rag_gate_result_path,
+                rag_gate_result_file_hash,
+            ),
+            "build_equivalence": _artifact_entry(
+                build_equivalence_path,
+                build_equivalence_file_hash,
+            ),
         },
         "evidence_hashes": {
-            "release_manifest": _sha256_file(release_manifest_path),
-            "rag_gate_result": _sha256_file(rag_gate_result_path),
-            "build_equivalence": _sha256_file(build_equivalence_path),
+            "release_manifest": release_manifest_file_hash,
+            "rag_gate_result": rag_gate_result_file_hash,
+            "build_equivalence": build_equivalence_file_hash,
         },
         "evidence_digests": {
             "sbom_digest": supply_chain_identity.get("sbom_digest"),
@@ -455,17 +469,17 @@ def check_release_control_plane_files(
 ) -> dict[str, Any]:
     """Load evidence files and return the deterministic CI gate payload."""
 
-    manifest_payload, manifest_findings = _load_evidence(
+    manifest_payload, manifest_findings, manifest_file_hash = _load_evidence(
         release_manifest_path,
         missing_reason="missing_release_manifest",
         malformed_reason="malformed_release_manifest",
     )
-    rag_payload, rag_findings = _load_evidence(
+    rag_payload, rag_findings, rag_file_hash = _load_evidence(
         rag_gate_result_path,
         missing_reason="missing_rag_gate_result",
         malformed_reason="malformed_rag_gate_result",
     )
-    build_payload, build_findings = _load_evidence(
+    build_payload, build_findings, build_file_hash = _load_evidence(
         build_equivalence_path,
         missing_reason="missing_build_equivalence",
         malformed_reason="malformed_build_equivalence",
@@ -477,6 +491,9 @@ def check_release_control_plane_files(
         release_manifest_path=release_manifest_path,
         rag_gate_result_path=rag_gate_result_path,
         build_equivalence_path=build_equivalence_path,
+        release_manifest_file_hash=manifest_file_hash,
+        rag_gate_result_file_hash=rag_file_hash,
+        build_equivalence_file_hash=build_file_hash,
         load_findings=[*manifest_findings, *rag_findings, *build_findings],
     )
 

--- a/scripts/ci/check_release_control_plane.py
+++ b/scripts/ci/check_release_control_plane.py
@@ -7,7 +7,7 @@ import argparse
 from dataclasses import dataclass
 import json
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 if __package__ in {None, ""}:
@@ -22,8 +22,6 @@ SCHEMA_VERSION = "release-control-plane-ci-gate.v1"
 ALLOW_DECISION = "ALLOW"
 BLOCK_DECISION = "BLOCK"
 TOOL_VERSION = SCHEMA_VERSION
-ALLOWED_EVIDENCE_PATH_PREFIXES = ("artifacts/",)
-
 REASON_ORDER = {
     "missing_release_manifest": 10,
     "malformed_release_manifest": 20,
@@ -242,6 +240,21 @@ def _validate_build_equivalence_result(payload: dict[str, Any]) -> list[Finding]
     ):
         findings.append(Finding("build_equivalence.reason_codes", "invalid_build_equivalence"))
 
+    mismatch_details = payload.get("mismatch_details")
+    if not isinstance(mismatch_details, list):
+        findings.append(Finding("build_equivalence.mismatch_details", "invalid_build_equivalence"))
+
+    if payload.get("decision") == build_equivalence.EQUIVALENT_DECISION:
+        if reason_codes or mismatch_details:
+            findings.append(
+                Finding(
+                    "build_equivalence.decision",
+                    "invalid_build_equivalence",
+                    payload.get("decision"),
+                )
+            )
+        return findings
+
     if payload.get("decision") != build_equivalence.EQUIVALENT_DECISION:
         findings.append(
             Finding(
@@ -250,7 +263,6 @@ def _validate_build_equivalence_result(payload: dict[str, Any]) -> list[Finding]
                 payload.get("decision"),
             )
         )
-        mismatch_details = payload.get("mismatch_details")
         if isinstance(mismatch_details, list):
             if any(
                 isinstance(item, dict) and str(item.get("field", "")).startswith("build_identity.")
@@ -272,8 +284,11 @@ def _validate_allowed_artifact_paths(entries: Any, *, field_name: str) -> list[F
         path_value = entry.get("path")
         if not isinstance(path_value, str):
             continue
-        if Path(path_value).is_absolute() or not path_value.startswith(
-            ALLOWED_EVIDENCE_PATH_PREFIXES
+        normalized_path = PurePosixPath(path_value)
+        if (
+            normalized_path.is_absolute()
+            or normalized_path.parts[:1] != ("artifacts",)
+            or ".." in normalized_path.parts
         ):
             findings.append(
                 Finding(

--- a/scripts/ci/check_release_control_plane.py
+++ b/scripts/ci/check_release_control_plane.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Validate release-control-plane evidence before release decisions."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    # Support direct invocation from repository root:
+    # `python3 scripts/ci/check_release_control_plane.py ...`
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.release import build_equivalence
+from scripts.release import release_manifest
+
+SCHEMA_VERSION = "release-control-plane-ci-gate.v1"
+ALLOW_DECISION = "ALLOW"
+BLOCK_DECISION = "BLOCK"
+TOOL_VERSION = SCHEMA_VERSION
+ALLOWED_EVIDENCE_PATH_PREFIXES = ("artifacts/",)
+
+REASON_ORDER = {
+    "missing_release_manifest": 10,
+    "malformed_release_manifest": 20,
+    "invalid_release_manifest": 30,
+    "release_manifest_block": 40,
+    "missing_rag_gate_result": 50,
+    "malformed_rag_gate_result": 60,
+    "invalid_rag_gate_result": 70,
+    "rag_gate_result_not_pass": 80,
+    "missing_build_equivalence": 90,
+    "malformed_build_equivalence": 100,
+    "invalid_build_equivalence": 110,
+    "build_equivalence_not_equivalent": 120,
+    "missing_sbom_digest": 130,
+    "missing_provenance_digest": 140,
+    "attestation_not_verified": 150,
+    "unsupported_digest_format": 160,
+    "release_manifest_hash_mismatch": 170,
+    "git_sha_mismatch": 180,
+    "build_identity_mismatch": 190,
+    "evidence_path_outside_allowed_artifacts": 200,
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One stable release-control-plane gate finding."""
+
+    field: str
+    reason_code: str
+    detail: Any = None
+
+    def as_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "field": self.field,
+            "reason_code": self.reason_code,
+        }
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        return payload
+
+
+def _load_evidence(
+    path: Path, *, missing_reason: str, malformed_reason: str
+) -> tuple[dict[str, Any] | None, list[Finding]]:
+    findings: list[Finding] = []
+    if not path.exists():
+        findings.append(Finding(str(path), missing_reason))
+        return None, findings
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        findings.append(Finding(str(path), malformed_reason, str(exc)))
+        return None, findings
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        findings.append(Finding(str(path), malformed_reason, str(exc)))
+        return None, findings
+    if not isinstance(payload, dict):
+        findings.append(
+            Finding(str(path), malformed_reason, "top-level JSON value must be an object")
+        )
+        return None, findings
+    return payload, findings
+
+
+def _stable_reason_codes(findings: list[Finding]) -> list[str]:
+    return sorted(
+        {finding.reason_code for finding in findings},
+        key=lambda reason: (REASON_ORDER.get(reason, 10_000), reason),
+    )
+
+
+def _stable_findings(findings: list[Finding]) -> list[dict[str, Any]]:
+    return [
+        finding.as_payload()
+        for finding in sorted(
+            findings,
+            key=lambda item: (REASON_ORDER.get(item.reason_code, 10_000), item.field),
+        )
+    ]
+
+
+def _sha256_file(path: Path) -> str | None:
+    if not path.exists() or not path.is_file():
+        return None
+    try:
+        return release_manifest.sha256_lower_hex(path.read_bytes())
+    except OSError:
+        return None
+
+
+def _artifact_entry(path: Path) -> dict[str, Any]:
+    return {
+        "path": path.as_posix(),
+        "sha256": _sha256_file(path),
+    }
+
+
+def _validate_release_manifest(payload: dict[str, Any]) -> list[Finding]:
+    findings = [
+        Finding("release_manifest", "invalid_release_manifest", error)
+        for error in release_manifest.validate_manifest_payload(payload)
+    ]
+    if payload.get("release_decision") != release_manifest.ALLOW_DECISION:
+        findings.append(
+            Finding(
+                "release_manifest.release_decision",
+                "release_manifest_block",
+                payload.get("release_decision"),
+            )
+        )
+    supply_chain_identity = payload.get("supply_chain_identity")
+    if not isinstance(supply_chain_identity, dict):
+        return findings
+
+    sbom_digest = supply_chain_identity.get("sbom_digest")
+    provenance_digest = supply_chain_identity.get("provenance_digest")
+    if sbom_digest is None:
+        findings.append(Finding("supply_chain_identity.sbom_digest", "missing_sbom_digest"))
+    elif not isinstance(sbom_digest, str) or not release_manifest.OCI_SHA256_DIGEST_RE.fullmatch(
+        sbom_digest
+    ):
+        findings.append(
+            Finding("supply_chain_identity.sbom_digest", "unsupported_digest_format", sbom_digest)
+        )
+    if provenance_digest is None:
+        findings.append(
+            Finding("supply_chain_identity.provenance_digest", "missing_provenance_digest")
+        )
+    elif not isinstance(
+        provenance_digest, str
+    ) or not release_manifest.OCI_SHA256_DIGEST_RE.fullmatch(provenance_digest):
+        findings.append(
+            Finding(
+                "supply_chain_identity.provenance_digest",
+                "unsupported_digest_format",
+                provenance_digest,
+            )
+        )
+    if (
+        supply_chain_identity.get("attestation_status")
+        != release_manifest.VERIFIED_ATTESTATION_STATUS
+    ):
+        findings.append(
+            Finding(
+                "supply_chain_identity.attestation_status",
+                "attestation_not_verified",
+                supply_chain_identity.get("attestation_status"),
+            )
+        )
+    return findings
+
+
+def _validate_rag_gate_result(payload: dict[str, Any]) -> list[Finding]:
+    findings = [
+        Finding("rag_gate_result", "invalid_rag_gate_result", error)
+        for error in release_manifest._validate_rag_gate_result(payload)  # noqa: SLF001
+    ]
+    if any("hash" in finding.detail for finding in findings if isinstance(finding.detail, str)):
+        findings.append(Finding("rag_gate_result", "unsupported_digest_format"))
+    if payload.get("release_decision") != "PASS":
+        findings.append(
+            Finding(
+                "rag_gate_result.release_decision",
+                "rag_gate_result_not_pass",
+                payload.get("release_decision"),
+            )
+        )
+    findings.extend(
+        _validate_allowed_artifact_paths(
+            payload.get("source_artifacts"),
+            field_name="rag_gate_result.source_artifacts",
+        )
+    )
+    return findings
+
+
+def _validate_build_equivalence_result(payload: dict[str, Any]) -> list[Finding]:
+    findings: list[Finding] = []
+    if payload.get("schema_version") != build_equivalence.SCHEMA_VERSION:
+        findings.append(
+            Finding(
+                "build_equivalence.schema_version",
+                "invalid_build_equivalence",
+                payload.get("schema_version"),
+            )
+        )
+    if payload.get("hash_algorithm") != release_manifest.HASH_ALGORITHM:
+        findings.append(Finding("build_equivalence.hash_algorithm", "invalid_build_equivalence"))
+    if payload.get("canonicalization") != release_manifest.CANONICALIZATION:
+        findings.append(Finding("build_equivalence.canonicalization", "invalid_build_equivalence"))
+
+    manifest_hash = payload.get("release_manifest_hash")
+    if not isinstance(manifest_hash, str) or not release_manifest.SHA256_HEX_RE.fullmatch(
+        manifest_hash
+    ):
+        findings.append(
+            Finding(
+                "build_equivalence.release_manifest_hash",
+                "unsupported_digest_format",
+                manifest_hash,
+            )
+        )
+    reason_codes = payload.get("reason_codes")
+    if not isinstance(reason_codes, list) or reason_codes != sorted(
+        reason_codes,
+        key=lambda reason: (
+            build_equivalence.REASON_ORDER.get(str(reason), 10_000),
+            str(reason),
+        ),
+    ):
+        findings.append(Finding("build_equivalence.reason_codes", "invalid_build_equivalence"))
+
+    if payload.get("decision") != build_equivalence.EQUIVALENT_DECISION:
+        findings.append(
+            Finding(
+                "build_equivalence.decision",
+                "build_equivalence_not_equivalent",
+                payload.get("decision"),
+            )
+        )
+        mismatch_details = payload.get("mismatch_details")
+        if isinstance(mismatch_details, list):
+            if any(
+                isinstance(item, dict) and str(item.get("field", "")).startswith("build_identity.")
+                for item in mismatch_details
+            ):
+                findings.append(
+                    Finding("build_equivalence.mismatch_details", "build_identity_mismatch")
+                )
+    return findings
+
+
+def _validate_allowed_artifact_paths(entries: Any, *, field_name: str) -> list[Finding]:
+    findings: list[Finding] = []
+    if not isinstance(entries, list):
+        return findings
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            continue
+        path_value = entry.get("path")
+        if not isinstance(path_value, str):
+            continue
+        if Path(path_value).is_absolute() or not path_value.startswith(
+            ALLOWED_EVIDENCE_PATH_PREFIXES
+        ):
+            findings.append(
+                Finding(
+                    f"{field_name}[{index}].path",
+                    "evidence_path_outside_allowed_artifacts",
+                    path_value,
+                )
+            )
+    return findings
+
+
+def _cross_evidence_findings(
+    *,
+    manifest_payload: dict[str, Any] | None,
+    rag_payload: dict[str, Any] | None,
+    build_equivalence_payload: dict[str, Any] | None,
+) -> list[Finding]:
+    findings: list[Finding] = []
+    if not manifest_payload:
+        return findings
+
+    manifest_hash = manifest_payload.get("release_manifest_hash")
+    if build_equivalence_payload:
+        build_manifest_hash = build_equivalence_payload.get("release_manifest_hash")
+        if manifest_hash != build_manifest_hash:
+            findings.append(
+                Finding(
+                    "build_equivalence.release_manifest_hash",
+                    "release_manifest_hash_mismatch",
+                    {"build_equivalence": build_manifest_hash, "release_manifest": manifest_hash},
+                )
+            )
+
+    ml_identity = manifest_payload.get("ml_identity")
+    if isinstance(ml_identity, dict):
+        findings.extend(
+            _validate_allowed_artifact_paths(
+                ml_identity.get("source_artifacts"),
+                field_name="release_manifest.ml_identity.source_artifacts",
+            )
+        )
+
+    if not rag_payload or not isinstance(ml_identity, dict):
+        return findings
+
+    hash_pairs = (
+        ("ml_identity.rag_gate_result_hash", "rag_gate_result_hash"),
+        ("ml_identity.eval_artifact_hash", "eval_artifact_hash"),
+    )
+    for manifest_field, rag_field in hash_pairs:
+        manifest_value = ml_identity.get(manifest_field.split(".")[-1])
+        rag_value = rag_payload.get(rag_field)
+        if manifest_value != rag_value:
+            findings.append(
+                Finding(
+                    manifest_field,
+                    "release_manifest_hash_mismatch",
+                    {"rag_gate_result": rag_value, "release_manifest": manifest_value},
+                )
+            )
+    if ml_identity.get("release_decision") != rag_payload.get("release_decision"):
+        findings.append(
+            Finding(
+                "ml_identity.release_decision",
+                "rag_gate_result_not_pass",
+                {
+                    "rag_gate_result": rag_payload.get("release_decision"),
+                    "release_manifest": ml_identity.get("release_decision"),
+                },
+            )
+        )
+
+    manifest_build = manifest_payload.get("build_identity")
+    if isinstance(manifest_build, dict) and manifest_build.get("git_sha") != rag_payload.get(
+        "git_sha"
+    ):
+        findings.append(
+            Finding(
+                "build_identity.git_sha",
+                "git_sha_mismatch",
+                {
+                    "rag_gate_result": rag_payload.get("git_sha"),
+                    "release_manifest": manifest_build.get("git_sha"),
+                },
+            )
+        )
+    return findings
+
+
+def build_release_control_plane_decision(
+    *,
+    release_manifest_payload: dict[str, Any] | None,
+    rag_gate_result_payload: dict[str, Any] | None,
+    build_equivalence_payload: dict[str, Any] | None,
+    release_manifest_path: Path,
+    rag_gate_result_path: Path,
+    build_equivalence_path: Path,
+    load_findings: list[Finding] | None = None,
+) -> dict[str, Any]:
+    """Return a deterministic fail-closed release-control-plane decision."""
+
+    findings = list(load_findings or [])
+    if release_manifest_payload:
+        findings.extend(_validate_release_manifest(release_manifest_payload))
+    if rag_gate_result_payload:
+        findings.extend(_validate_rag_gate_result(rag_gate_result_payload))
+    if build_equivalence_payload:
+        findings.extend(_validate_build_equivalence_result(build_equivalence_payload))
+    findings.extend(
+        _cross_evidence_findings(
+            manifest_payload=release_manifest_payload,
+            rag_payload=rag_gate_result_payload,
+            build_equivalence_payload=build_equivalence_payload,
+        )
+    )
+
+    reason_codes = _stable_reason_codes(findings)
+    manifest_hash = None
+    if release_manifest_payload:
+        value = release_manifest_payload.get("release_manifest_hash")
+        if isinstance(value, str) and release_manifest.SHA256_HEX_RE.fullmatch(value):
+            manifest_hash = value
+
+    supply_chain_identity = {}
+    if release_manifest_payload and isinstance(
+        release_manifest_payload.get("supply_chain_identity"), dict
+    ):
+        supply_chain_identity = release_manifest_payload["supply_chain_identity"]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "hash_algorithm": release_manifest.HASH_ALGORITHM,
+        "canonicalization": release_manifest.CANONICALIZATION,
+        "decision": BLOCK_DECISION if reason_codes else ALLOW_DECISION,
+        "reason_codes": reason_codes,
+        "mismatch_details": _stable_findings(findings),
+        "checked_artifacts": {
+            "release_manifest": _artifact_entry(release_manifest_path),
+            "rag_gate_result": _artifact_entry(rag_gate_result_path),
+            "build_equivalence": _artifact_entry(build_equivalence_path),
+        },
+        "evidence_hashes": {
+            "release_manifest": _sha256_file(release_manifest_path),
+            "rag_gate_result": _sha256_file(rag_gate_result_path),
+            "build_equivalence": _sha256_file(build_equivalence_path),
+        },
+        "evidence_digests": {
+            "sbom_digest": supply_chain_identity.get("sbom_digest"),
+            "provenance_digest": supply_chain_identity.get("provenance_digest"),
+        },
+        "release_manifest_hash": manifest_hash,
+        "build_equivalence_decision": (build_equivalence_payload or {}).get("decision"),
+        "rag_gate_decision": (rag_gate_result_payload or {}).get("release_decision"),
+        "attestation_status": supply_chain_identity.get("attestation_status"),
+        "tool_version": TOOL_VERSION,
+    }
+
+
+def check_release_control_plane_files(
+    *,
+    release_manifest_path: Path,
+    rag_gate_result_path: Path,
+    build_equivalence_path: Path,
+) -> dict[str, Any]:
+    """Load evidence files and return the deterministic CI gate payload."""
+
+    manifest_payload, manifest_findings = _load_evidence(
+        release_manifest_path,
+        missing_reason="missing_release_manifest",
+        malformed_reason="malformed_release_manifest",
+    )
+    rag_payload, rag_findings = _load_evidence(
+        rag_gate_result_path,
+        missing_reason="missing_rag_gate_result",
+        malformed_reason="malformed_rag_gate_result",
+    )
+    build_payload, build_findings = _load_evidence(
+        build_equivalence_path,
+        missing_reason="missing_build_equivalence",
+        malformed_reason="malformed_build_equivalence",
+    )
+    return build_release_control_plane_decision(
+        release_manifest_payload=manifest_payload,
+        rag_gate_result_payload=rag_payload,
+        build_equivalence_payload=build_payload,
+        release_manifest_path=release_manifest_path,
+        rag_gate_result_path=rag_gate_result_path,
+        build_equivalence_path=build_equivalence_path,
+        load_findings=[*manifest_findings, *rag_findings, *build_findings],
+    )
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write stable JSON with a trailing newline."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_markdown(path: Path, payload: dict[str, Any]) -> None:
+    """Write a stable Markdown summary for CI artifacts."""
+
+    lines = [
+        "# Release Control Plane CI Gate",
+        "",
+        f"- Decision: `{payload['decision']}`",
+        f"- Release manifest hash: `{payload.get('release_manifest_hash')}`",
+        f"- RAG gate decision: `{payload.get('rag_gate_decision')}`",
+        f"- Build equivalence decision: `{payload.get('build_equivalence_decision')}`",
+        f"- Attestation status: `{payload.get('attestation_status')}`",
+        "",
+        "## Reason Codes",
+        "",
+    ]
+    reason_codes = payload.get("reason_codes", [])
+    if reason_codes:
+        lines.extend(f"- `{reason_code}`" for reason_code in reason_codes)
+    else:
+        lines.append("- none")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--release-manifest", type=Path, required=True)
+    parser.add_argument("--rag-gate-result", type=Path, required=True)
+    parser.add_argument("--build-equivalence", type=Path, required=True)
+    parser.add_argument("--json-out", type=Path, required=True)
+    parser.add_argument("--markdown-out", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    decision = check_release_control_plane_files(
+        release_manifest_path=args.release_manifest,
+        rag_gate_result_path=args.rag_gate_result,
+        build_equivalence_path=args.build_equivalence,
+    )
+    write_json(args.json_out, decision)
+    if args.markdown_out:
+        write_markdown(args.markdown_out, decision)
+    if decision["decision"] == ALLOW_DECISION:
+        print(f"ALLOW: release-control-plane evidence passed: {args.json_out}")
+        return 0
+    print(f"BLOCK: release-control-plane evidence failed: {args.json_out}")
+    for reason_code in decision["reason_codes"]:
+        print(f"REASON: {reason_code}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_release_control_plane.py
+++ b/scripts/ci/check_release_control_plane.py
@@ -292,11 +292,11 @@ def _cross_evidence_findings(
     build_equivalence_payload: dict[str, Any] | None,
 ) -> list[Finding]:
     findings: list[Finding] = []
-    if not manifest_payload:
+    if manifest_payload is None:
         return findings
 
     manifest_hash = manifest_payload.get("release_manifest_hash")
-    if build_equivalence_payload:
+    if build_equivalence_payload is not None:
         build_manifest_hash = build_equivalence_payload.get("release_manifest_hash")
         if manifest_hash != build_manifest_hash:
             findings.append(
@@ -316,7 +316,7 @@ def _cross_evidence_findings(
             )
         )
 
-    if not rag_payload or not isinstance(ml_identity, dict):
+    if rag_payload is None or not isinstance(ml_identity, dict):
         return findings
 
     hash_pairs = (
@@ -376,11 +376,11 @@ def build_release_control_plane_decision(
     """Return a deterministic fail-closed release-control-plane decision."""
 
     findings = list(load_findings or [])
-    if release_manifest_payload:
+    if release_manifest_payload is not None:
         findings.extend(_validate_release_manifest(release_manifest_payload))
-    if rag_gate_result_payload:
+    if rag_gate_result_payload is not None:
         findings.extend(_validate_rag_gate_result(rag_gate_result_payload))
-    if build_equivalence_payload:
+    if build_equivalence_payload is not None:
         findings.extend(_validate_build_equivalence_result(build_equivalence_payload))
     findings.extend(
         _cross_evidence_findings(
@@ -392,13 +392,13 @@ def build_release_control_plane_decision(
 
     reason_codes = _stable_reason_codes(findings)
     manifest_hash = None
-    if release_manifest_payload:
+    if release_manifest_payload is not None:
         value = release_manifest_payload.get("release_manifest_hash")
         if isinstance(value, str) and release_manifest.SHA256_HEX_RE.fullmatch(value):
             manifest_hash = value
 
     supply_chain_identity = {}
-    if release_manifest_payload and isinstance(
+    if release_manifest_payload is not None and isinstance(
         release_manifest_payload.get("supply_chain_identity"), dict
     ):
         supply_chain_identity = release_manifest_payload["supply_chain_identity"]

--- a/scripts/ci/check_release_control_plane.py
+++ b/scripts/ci/check_release_control_plane.py
@@ -81,17 +81,17 @@ def _load_evidence(
         raw_text = raw_bytes.decode("utf-8")
     except UnicodeDecodeError as exc:
         findings.append(Finding(str(path), malformed_reason, str(exc)))
-        return None, findings, None
+        return None, findings, file_hash
     try:
         payload = json.loads(raw_text)
     except json.JSONDecodeError as exc:
         findings.append(Finding(str(path), malformed_reason, str(exc)))
-        return None, findings, None
+        return None, findings, file_hash
     if not isinstance(payload, dict):
         findings.append(
             Finding(str(path), malformed_reason, "top-level JSON value must be an object")
         )
-        return None, findings, None
+        return None, findings, file_hash
     return payload, findings, file_hash
 
 

--- a/scripts/ci/check_release_control_plane.py
+++ b/scripts/ci/check_release_control_plane.py
@@ -112,9 +112,12 @@ def _sha256_file(path: Path) -> str | None:
     if not path.exists() or not path.is_file():
         return None
     try:
-        return release_manifest.sha256_lower_hex(path.read_bytes())
+        digest = release_manifest.sha256_lower_hex(path.read_bytes())
     except OSError:
         return None
+    if not isinstance(digest, str):
+        return None
+    return digest
 
 
 def _artifact_entry(path: Path) -> dict[str, Any]:

--- a/tests/test_build_equivalence.py
+++ b/tests/test_build_equivalence.py
@@ -464,9 +464,9 @@ def test_ledger_release_control_plane_state_is_reconciled() -> None:
     ledger_text = (REPO_ROOT / "docs/roadmap/BACKLOG_LEDGER.md").read_text(encoding="utf-8")
 
     assert "PR-3 merged in PR #1605" in ledger_text
+    assert "PR-4 merged in PR #1679 on 2026-05-06" in ledger_text
+    assert "PR-5 is active on branch `release/release-control-plane-pr5-ci-gates`" in ledger_text
     assert (
-        "PR-4 active in PR #1679 on branch `release/release-control-plane-pr4-build-equivalence`"
-        in ledger_text
+        "Future protected upload and App Store Connect execution remain out of scope" in ledger_text
     )
-    assert "PR-5 remains deferred for CI fail-closed enforcement" in ledger_text
     assert "not production-ready" in ledger_text

--- a/tests/test_release_control_plane_ci_gate.py
+++ b/tests/test_release_control_plane_ci_gate.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from scripts.ci import check_release_control_plane
+from scripts.release import build_equivalence
+from scripts.release import release_manifest
+from scripts.release import reviewer_packet_hashes
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+OCI_DIGEST = "sha256:" + ("a" * 64)
+PROVENANCE_DIGEST = "sha256:" + ("b" * 64)
+ARTIFACT_DIGEST = "sha256:" + ("e" * 64)
+TEST_GIT_SHA = "git-sha-for-release-control-plane-ci-gate-tests"
+
+
+def _write_metadata_pack(repo_root: Path) -> None:
+    notes_path = repo_root / "ios/fastlane/metadata/review_information/notes.txt"
+    notes_path.parent.mkdir(parents=True, exist_ok=True)
+    notes_path.write_text("Reviewer note\n", encoding="utf-8")
+
+    privacy_path = repo_root / "ios/fastlane/app_privacy_details.json"
+    privacy_path.parent.mkdir(parents=True, exist_ok=True)
+    privacy_path.write_text('[{"data_protections":["DATA_NOT_COLLECTED"]}]\n', encoding="utf-8")
+
+    for locale in reviewer_packet_hashes.REQUIRED_LOCALES:
+        locale_dir = repo_root / "ios/fastlane/metadata" / locale
+        locale_dir.mkdir(parents=True, exist_ok=True)
+        for filename in reviewer_packet_hashes.REQUIRED_METADATA_FILES:
+            (locale_dir / filename).write_text(f"{locale}:{filename}\n", encoding="utf-8")
+
+
+def _rag_payload(
+    *, release_decision: str = "PASS", git_sha: str = TEST_GIT_SHA
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "release-rag-gate-result.v1",
+        "hash_algorithm": "sha256",
+        "canonicalization": release_manifest.CANONICALIZATION,
+        "eval_artifact_hash": "c" * 64,
+        "experiment_id": "unit-test",
+        "timestamp": "2026-05-06T00:00:00Z",
+        "release_decision": release_decision,
+        "gate_checks": {"answer_precision_min": release_decision == "PASS"},
+        "threshold_results": [],
+        "strict_violations": [] if release_decision == "PASS" else ["answer_precision_min"],
+        "runtime_warnings": [],
+        "dataset_path_used": "tests/fixtures/rag.jsonl",
+        "dataset_fallback_used": False,
+        "sample_size": 1,
+        "git_sha": git_sha,
+        "retriever_mode": "local_tfidf",
+        "generator_mode": "extractive_stub",
+        "small_fixture_metric_gates_advisory": False,
+        "source_artifacts": [
+            {
+                "kind": "metrics_summary",
+                "path": "artifacts/rag_eval/unit-test/metrics_summary.json",
+                "hash": "d" * 64,
+            }
+        ],
+    }
+    payload["rag_gate_result_hash"] = release_manifest.sha256_lower_hex(
+        release_manifest.canonical_json_bytes(payload)
+    )
+    return payload
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_rag_gate_result(
+    repo_root: Path,
+    *,
+    release_decision: str = "PASS",
+    git_sha: str = TEST_GIT_SHA,
+) -> tuple[Path, dict[str, object]]:
+    payload = _rag_payload(release_decision=release_decision, git_sha=git_sha)
+    rag_path = repo_root / "artifacts/rag_eval/unit-test/rag_gate_result.json"
+    _write_json(rag_path, payload)
+    return rag_path, payload
+
+
+def _build_manifest(
+    repo_root: Path,
+    *,
+    rag_decision: str = "PASS",
+    attestation_status: str = "VERIFIED",
+) -> tuple[dict[str, object], dict[str, object]]:
+    _write_metadata_pack(repo_root)
+    rag_path, rag_payload = _write_rag_gate_result(repo_root, release_decision=rag_decision)
+    manifest_payload = release_manifest.build_manifest_payload(
+        repo_root=repo_root,
+        git_sha=TEST_GIT_SHA,
+        ios_build_number="100",
+        marketing_version="1.0",
+        bundle_id="app.pulseplate.PulsePlate",
+        rag_gate_result_path=rag_path,
+        sbom_digest=OCI_DIGEST,
+        provenance_digest=PROVENANCE_DIGEST,
+        attestation_status=attestation_status,
+    )
+    return manifest_payload, rag_payload
+
+
+def _rehash_manifest(payload: dict[str, object]) -> dict[str, object]:
+    updated = dict(payload)
+    updated.pop("release_manifest_hash", None)
+    updated["release_manifest_hash"] = release_manifest.sha256_lower_hex(
+        release_manifest.canonical_json_bytes(updated)
+    )
+    return updated
+
+
+def _build_identity(
+    manifest_payload: dict[str, object], *, artifact_digest: str = ARTIFACT_DIGEST
+) -> dict[str, object]:
+    return {
+        "schema_version": "release-build-identity.v1",
+        "hash_algorithm": "sha256",
+        "canonicalization": release_manifest.CANONICALIZATION,
+        "build_identity": dict(manifest_payload["build_identity"]),
+        "artifact_digest": artifact_digest,
+        "release_manifest_hash": manifest_payload["release_manifest_hash"],
+        "reviewer_identity": dict(manifest_payload["reviewer_identity"]),
+        "ml_identity": dict(manifest_payload["ml_identity"]),
+        "supply_chain_identity": dict(manifest_payload["supply_chain_identity"]),
+    }
+
+
+def _build_equivalence_result(manifest_payload: dict[str, object]) -> dict[str, object]:
+    identity = _build_identity(manifest_payload)
+    return build_equivalence.build_equivalence_decision(
+        review_payload=identity,
+        production_payload=identity,
+        manifest_payload=manifest_payload,
+    )
+
+
+def _write_evidence(
+    tmp_path: Path,
+    *,
+    manifest_payload: dict[str, object] | None = None,
+    rag_payload: dict[str, object] | None = None,
+    build_payload: dict[str, object] | None = None,
+) -> tuple[Path, Path, Path]:
+    if manifest_payload is None or rag_payload is None:
+        manifest_payload, rag_payload = _build_manifest(tmp_path)
+    if build_payload is None:
+        build_payload = _build_equivalence_result(manifest_payload)
+
+    manifest_path = tmp_path / "artifacts/release/release_manifest.json"
+    rag_path = tmp_path / "artifacts/rag_eval/unit-test/rag_gate_result.json"
+    build_path = tmp_path / "artifacts/release/build_equivalence_result.json"
+    _write_json(manifest_path, manifest_payload)
+    _write_json(rag_path, rag_payload)
+    _write_json(build_path, build_payload)
+    return manifest_path, rag_path, build_path
+
+
+def _decision(
+    tmp_path: Path,
+    *,
+    manifest_payload: dict[str, object] | None = None,
+    rag_payload: dict[str, object] | None = None,
+    build_payload: dict[str, object] | None = None,
+) -> dict[str, object]:
+    manifest_path, rag_path, build_path = _write_evidence(
+        tmp_path,
+        manifest_payload=manifest_payload,
+        rag_payload=rag_payload,
+        build_payload=build_payload,
+    )
+    return check_release_control_plane.check_release_control_plane_files(
+        release_manifest_path=manifest_path,
+        rag_gate_result_path=rag_path,
+        build_equivalence_path=build_path,
+    )
+
+
+def test_allow_when_all_release_control_plane_evidence_passes(tmp_path: Path) -> None:
+    decision = _decision(tmp_path)
+
+    assert decision["decision"] == "ALLOW"
+    assert decision["reason_codes"] == []
+    assert decision["rag_gate_decision"] == "PASS"
+    assert decision["build_equivalence_decision"] == "EQUIVALENT"
+    assert decision["attestation_status"] == "VERIFIED"
+    assert HASH_RE.fullmatch(str(decision["release_manifest_hash"]))
+
+
+def test_block_when_release_manifest_missing(tmp_path: Path) -> None:
+    manifest_path, rag_path, build_path = _write_evidence(tmp_path)
+    manifest_path.unlink()
+
+    decision = check_release_control_plane.check_release_control_plane_files(
+        release_manifest_path=manifest_path,
+        rag_gate_result_path=rag_path,
+        build_equivalence_path=build_path,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert "missing_release_manifest" in decision["reason_codes"]
+
+
+def test_block_when_release_manifest_decision_blocks(tmp_path: Path) -> None:
+    manifest_payload, rag_payload = _build_manifest(tmp_path, rag_decision="NO-GO")
+    build_payload = _build_equivalence_result(manifest_payload)
+
+    decision = _decision(
+        tmp_path,
+        manifest_payload=manifest_payload,
+        rag_payload=rag_payload,
+        build_payload=build_payload,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert "release_manifest_block" in decision["reason_codes"]
+    assert "rag_gate_result_not_pass" in decision["reason_codes"]
+
+
+def test_block_when_rag_gate_result_missing(tmp_path: Path) -> None:
+    manifest_path, rag_path, build_path = _write_evidence(tmp_path)
+    rag_path.unlink()
+
+    decision = check_release_control_plane.check_release_control_plane_files(
+        release_manifest_path=manifest_path,
+        rag_gate_result_path=rag_path,
+        build_equivalence_path=build_path,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert "missing_rag_gate_result" in decision["reason_codes"]
+
+
+def test_block_when_rag_gate_result_is_no_go(tmp_path: Path) -> None:
+    manifest_payload, rag_payload = _build_manifest(tmp_path)
+    rag_payload["release_decision"] = "NO-GO"
+    rag_payload["strict_violations"] = ["answer_precision_min"]
+    rag_payload["rag_gate_result_hash"] = release_manifest.sha256_lower_hex(
+        release_manifest.canonical_json_bytes(
+            {key: value for key, value in rag_payload.items() if key != "rag_gate_result_hash"}
+        )
+    )
+
+    decision = _decision(tmp_path, manifest_payload=manifest_payload, rag_payload=rag_payload)
+
+    assert decision["decision"] == "BLOCK"
+    assert "rag_gate_result_not_pass" in decision["reason_codes"]
+
+
+def test_block_when_build_equivalence_missing(tmp_path: Path) -> None:
+    manifest_path, rag_path, build_path = _write_evidence(tmp_path)
+    build_path.unlink()
+
+    decision = check_release_control_plane.check_release_control_plane_files(
+        release_manifest_path=manifest_path,
+        rag_gate_result_path=rag_path,
+        build_equivalence_path=build_path,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert "missing_build_equivalence" in decision["reason_codes"]
+
+
+def test_block_when_build_equivalence_blocks(tmp_path: Path) -> None:
+    manifest_payload, rag_payload = _build_manifest(tmp_path)
+    build_payload = _build_equivalence_result(manifest_payload)
+    build_payload["decision"] = "BLOCK"
+    build_payload["reason_codes"] = ["git_sha_mismatch"]
+    build_payload["mismatch_details"] = [
+        {"field": "build_identity.git_sha", "reason_code": "git_sha_mismatch"}
+    ]
+
+    decision = _decision(
+        tmp_path,
+        manifest_payload=manifest_payload,
+        rag_payload=rag_payload,
+        build_payload=build_payload,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert "build_equivalence_not_equivalent" in decision["reason_codes"]
+    assert "build_identity_mismatch" in decision["reason_codes"]
+
+
+def test_block_when_attestation_not_verified(tmp_path: Path) -> None:
+    manifest_payload, rag_payload = _build_manifest(tmp_path, attestation_status="PENDING")
+    build_payload = _build_equivalence_result(manifest_payload)
+
+    decision = _decision(
+        tmp_path,
+        manifest_payload=manifest_payload,
+        rag_payload=rag_payload,
+        build_payload=build_payload,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert "attestation_not_verified" in decision["reason_codes"]
+
+
+def test_block_on_malformed_json(tmp_path: Path) -> None:
+    manifest_path, rag_path, build_path = _write_evidence(tmp_path)
+    rag_path.write_text("{not-json\n", encoding="utf-8")
+
+    decision = check_release_control_plane.check_release_control_plane_files(
+        release_manifest_path=manifest_path,
+        rag_gate_result_path=rag_path,
+        build_equivalence_path=build_path,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert "malformed_rag_gate_result" in decision["reason_codes"]
+
+
+def test_block_on_invalid_digest_format(tmp_path: Path) -> None:
+    manifest_payload, rag_payload = _build_manifest(tmp_path)
+    manifest_payload["supply_chain_identity"] = dict(manifest_payload["supply_chain_identity"])
+    manifest_payload["supply_chain_identity"]["sbom_digest"] = "not-an-oci-digest"
+    manifest_payload["release_decision"] = "BLOCK"
+    manifest_payload["decision_reasons"] = ["invalid_sbom_digest"]
+    manifest_payload = _rehash_manifest(manifest_payload)
+    build_payload = _build_equivalence_result(manifest_payload)
+
+    decision = _decision(
+        tmp_path,
+        manifest_payload=manifest_payload,
+        rag_payload=rag_payload,
+        build_payload=build_payload,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert "unsupported_digest_format" in decision["reason_codes"]
+
+
+def test_release_manifest_hash_mismatch_blocks(tmp_path: Path) -> None:
+    manifest_payload, rag_payload = _build_manifest(tmp_path)
+    build_payload = _build_equivalence_result(manifest_payload)
+    build_payload["release_manifest_hash"] = "1" * 64
+
+    decision = _decision(
+        tmp_path,
+        manifest_payload=manifest_payload,
+        rag_payload=rag_payload,
+        build_payload=build_payload,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert "release_manifest_hash_mismatch" in decision["reason_codes"]
+
+
+def test_git_sha_mismatch_between_manifest_and_rag_blocks(tmp_path: Path) -> None:
+    manifest_payload, _rag_payload_valid = _build_manifest(tmp_path)
+    _rag_path, rag_payload = _write_rag_gate_result(tmp_path, git_sha="other-git-sha")
+
+    decision = _decision(tmp_path, manifest_payload=manifest_payload, rag_payload=rag_payload)
+
+    assert decision["decision"] == "BLOCK"
+    assert "git_sha_mismatch" in decision["reason_codes"]
+
+
+def test_evidence_paths_must_stay_under_artifacts(tmp_path: Path) -> None:
+    manifest_payload, rag_payload = _build_manifest(tmp_path)
+    rag_payload["source_artifacts"] = [
+        {
+            "kind": "metrics_summary",
+            "path": "tmp/not-artifacts/metrics.json",
+            "hash": "d" * 64,
+        }
+    ]
+    rag_payload["rag_gate_result_hash"] = release_manifest.sha256_lower_hex(
+        release_manifest.canonical_json_bytes(
+            {key: value for key, value in rag_payload.items() if key != "rag_gate_result_hash"}
+        )
+    )
+
+    decision = _decision(tmp_path, manifest_payload=manifest_payload, rag_payload=rag_payload)
+
+    assert decision["decision"] == "BLOCK"
+    assert "evidence_path_outside_allowed_artifacts" in decision["reason_codes"]
+
+
+def test_reason_code_ordering_is_deterministic(tmp_path: Path) -> None:
+    manifest_payload, rag_payload = _build_manifest(tmp_path, attestation_status="PENDING")
+    build_payload = _build_equivalence_result(manifest_payload)
+    build_payload["decision"] = "BLOCK"
+    build_payload["reason_codes"] = ["git_sha_mismatch"]
+    build_payload["mismatch_details"] = [
+        {"field": "build_identity.git_sha", "reason_code": "git_sha_mismatch"}
+    ]
+    rag_payload["release_decision"] = "NO-GO"
+    rag_payload["rag_gate_result_hash"] = release_manifest.sha256_lower_hex(
+        release_manifest.canonical_json_bytes(
+            {key: value for key, value in rag_payload.items() if key != "rag_gate_result_hash"}
+        )
+    )
+
+    decision = _decision(
+        tmp_path,
+        manifest_payload=manifest_payload,
+        rag_payload=rag_payload,
+        build_payload=build_payload,
+    )
+
+    assert decision["reason_codes"] == sorted(
+        decision["reason_codes"],
+        key=lambda reason: (
+            check_release_control_plane.REASON_ORDER.get(str(reason), 10_000),
+            str(reason),
+        ),
+    )
+
+
+def test_output_json_is_deterministic(tmp_path: Path) -> None:
+    manifest_path, rag_path, build_path = _write_evidence(tmp_path)
+    first_output = tmp_path / "out/first.json"
+    second_output = tmp_path / "out/second.json"
+
+    first = check_release_control_plane.check_release_control_plane_files(
+        release_manifest_path=manifest_path,
+        rag_gate_result_path=rag_path,
+        build_equivalence_path=build_path,
+    )
+    second = check_release_control_plane.check_release_control_plane_files(
+        release_manifest_path=manifest_path,
+        rag_gate_result_path=rag_path,
+        build_equivalence_path=build_path,
+    )
+    check_release_control_plane.write_json(first_output, first)
+    check_release_control_plane.write_json(second_output, second)
+
+    assert first_output.read_text(encoding="utf-8") == second_output.read_text(encoding="utf-8")
+    assert first_output.read_text(encoding="utf-8").endswith("\n")
+
+
+def test_cli_writes_json_and_markdown_outputs(tmp_path: Path, capsys) -> None:
+    manifest_path, rag_path, build_path = _write_evidence(tmp_path)
+    json_out = tmp_path / "gate.json"
+    markdown_out = tmp_path / "gate.md"
+
+    status = check_release_control_plane.main(
+        [
+            "--release-manifest",
+            str(manifest_path),
+            "--rag-gate-result",
+            str(rag_path),
+            "--build-equivalence",
+            str(build_path),
+            "--json-out",
+            str(json_out),
+            "--markdown-out",
+            str(markdown_out),
+        ]
+    )
+
+    assert status == 0
+    assert "ALLOW:" in capsys.readouterr().out
+    assert json.loads(json_out.read_text(encoding="utf-8"))["decision"] == "ALLOW"
+    assert "- Decision: `ALLOW`" in markdown_out.read_text(encoding="utf-8")
+
+
+def test_workflow_integration_does_not_require_app_store_secrets() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/cd.yml").read_text(encoding="utf-8")
+    marker = "release-control-plane-fixture-gate:"
+    assert marker in workflow
+    job_block = workflow.split(marker, 1)[1].split("\n  production-gates:", 1)[0]
+
+    forbidden_terms = ("APP_STORE", "FASTLANE", "MATCH_PASSWORD", "ASC_", "APPSTORE")
+    assert not any(term in job_block for term in forbidden_terms)
+    assert "secrets." not in job_block
+
+
+def test_workflow_integration_does_not_alter_app_store_upload_behavior() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/cd.yml").read_text(encoding="utf-8")
+    fixture_job = workflow.split("release-control-plane-fixture-gate:", 1)[1].split(
+        "\n  production-gates:",
+        1,
+    )[0]
+    deploy_jobs = workflow.split("\n  deploy-production:", 1)[1]
+
+    assert "upload" not in fixture_job.lower()
+    assert "app store connect" not in fixture_job.lower()
+    assert "release-control-plane-fixture-gate" not in deploy_jobs
+
+
+def test_ledger_marks_pr4_merged_and_pr5_active() -> None:
+    ledger = (REPO_ROOT / "docs/roadmap/BACKLOG_LEDGER.md").read_text(encoding="utf-8")
+
+    assert "PR-4 merged in PR #1679 on 2026-05-06" in ledger
+    assert "PR-5 is active on branch `release/release-control-plane-pr5-ci-gates`" in ledger
+    assert "Future protected upload and App Store Connect execution remain out of scope" in ledger
+    assert "full App Store readiness is not complete" in ledger

--- a/tests/test_release_control_plane_ci_gate.py
+++ b/tests/test_release_control_plane_ci_gate.py
@@ -495,3 +495,12 @@ def test_ledger_marks_pr4_merged_and_pr5_active() -> None:
     assert "PR-5 is active on branch `release/release-control-plane-pr5-ci-gates`" in ledger
     assert "Future protected upload and App Store Connect execution remain out of scope" in ledger
     assert "full App Store readiness is not complete" in ledger
+
+
+def test_pr1682_premortem_artifact_has_no_unresolved_p0_p1_findings() -> None:
+    premortem = (REPO_ROOT / "docs/review/PR_1682_PREMORTEM.md").read_text(encoding="utf-8")
+
+    assert "Unresolved P0/P1: none." in premortem
+    assert "scripts/ci/check_release_control_plane.py" in premortem
+    assert "tests/test_release_control_plane_ci_gate.py" in premortem
+    assert ".github/workflows/cd.yml" in premortem

--- a/tests/test_release_control_plane_ci_gate.py
+++ b/tests/test_release_control_plane_ci_gate.py
@@ -498,6 +498,62 @@ def test_output_json_is_deterministic(tmp_path: Path) -> None:
     assert first_output.read_text(encoding="utf-8").endswith("\n")
 
 
+def test_evidence_hashes_use_loaded_bytes(tmp_path: Path, monkeypatch) -> None:
+    manifest_path, rag_path, build_path = _write_evidence(tmp_path)
+    loaded_rag_hash = release_manifest.sha256_lower_hex(rag_path.read_bytes())
+    real_read_bytes = Path.read_bytes
+    mutated = False
+
+    def racing_read(path: Path) -> bytes:
+        nonlocal mutated
+        raw_bytes = real_read_bytes(path)
+        if path == rag_path and not mutated:
+            mutated = True
+            rag_path.write_text('{"schema_version":"mutated-after-read"}\n', encoding="utf-8")
+        return raw_bytes
+
+    monkeypatch.setattr(Path, "read_bytes", racing_read)
+
+    decision = check_release_control_plane.check_release_control_plane_files(
+        release_manifest_path=manifest_path,
+        rag_gate_result_path=rag_path,
+        build_equivalence_path=build_path,
+    )
+
+    assert mutated
+    assert decision["checked_artifacts"]["rag_gate_result"]["sha256"] == loaded_rag_hash
+    assert decision["evidence_hashes"]["rag_gate_result"] == loaded_rag_hash
+    assert loaded_rag_hash != release_manifest.sha256_lower_hex(rag_path.read_bytes())
+
+
+def test_mismatch_details_sorting_uses_detail_tiebreaker() -> None:
+    findings = [
+        check_release_control_plane.Finding(
+            "build_equivalence.decision",
+            "invalid_build_equivalence",
+            {"payload": "b"},
+        ),
+        check_release_control_plane.Finding(
+            "build_equivalence.decision",
+            "invalid_build_equivalence",
+            {"payload": "a"},
+        ),
+    ]
+
+    assert check_release_control_plane._stable_findings(findings) == [  # noqa: SLF001
+        {
+            "field": "build_equivalence.decision",
+            "reason_code": "invalid_build_equivalence",
+            "detail": {"payload": "a"},
+        },
+        {
+            "field": "build_equivalence.decision",
+            "reason_code": "invalid_build_equivalence",
+            "detail": {"payload": "b"},
+        },
+    ]
+
+
 def test_schema_allows_raw_malformed_summary_values_for_block_outputs(tmp_path: Path) -> None:
     schema = json.loads(
         (REPO_ROOT / "docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json").read_text(

--- a/tests/test_release_control_plane_ci_gate.py
+++ b/tests/test_release_control_plane_ci_gate.py
@@ -289,6 +289,25 @@ def test_block_when_build_equivalence_blocks(tmp_path: Path) -> None:
     assert "build_identity_mismatch" in decision["reason_codes"]
 
 
+def test_block_when_equivalent_build_equivalence_has_mismatch_findings(tmp_path: Path) -> None:
+    manifest_payload, rag_payload = _build_manifest(tmp_path)
+    build_payload = _build_equivalence_result(manifest_payload)
+    build_payload["reason_codes"] = ["git_sha_mismatch"]
+    build_payload["mismatch_details"] = [
+        {"field": "build_identity.git_sha", "reason_code": "git_sha_mismatch"}
+    ]
+
+    decision = _decision(
+        tmp_path,
+        manifest_payload=manifest_payload,
+        rag_payload=rag_payload,
+        build_payload=build_payload,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert "invalid_build_equivalence" in decision["reason_codes"]
+
+
 def test_block_when_attestation_not_verified(tmp_path: Path) -> None:
     manifest_payload, rag_payload = _build_manifest(tmp_path, attestation_status="PENDING")
     build_payload = _build_equivalence_result(manifest_payload)
@@ -390,6 +409,27 @@ def test_evidence_paths_must_stay_under_artifacts(tmp_path: Path) -> None:
         {
             "kind": "metrics_summary",
             "path": "tmp/not-artifacts/metrics.json",
+            "hash": "d" * 64,
+        }
+    ]
+    rag_payload["rag_gate_result_hash"] = release_manifest.sha256_lower_hex(
+        release_manifest.canonical_json_bytes(
+            {key: value for key, value in rag_payload.items() if key != "rag_gate_result_hash"}
+        )
+    )
+
+    decision = _decision(tmp_path, manifest_payload=manifest_payload, rag_payload=rag_payload)
+
+    assert decision["decision"] == "BLOCK"
+    assert "evidence_path_outside_allowed_artifacts" in decision["reason_codes"]
+
+
+def test_evidence_paths_reject_parent_directory_escape(tmp_path: Path) -> None:
+    manifest_payload, rag_payload = _build_manifest(tmp_path)
+    rag_payload["source_artifacts"] = [
+        {
+            "kind": "metrics_summary",
+            "path": "artifacts/../leak.json",
             "hash": "d" * 64,
         }
     ]

--- a/tests/test_release_control_plane_ci_gate.py
+++ b/tests/test_release_control_plane_ci_gate.py
@@ -326,6 +326,7 @@ def test_block_when_attestation_not_verified(tmp_path: Path) -> None:
 def test_block_on_malformed_json(tmp_path: Path) -> None:
     manifest_path, rag_path, build_path = _write_evidence(tmp_path)
     rag_path.write_text("{not-json\n", encoding="utf-8")
+    malformed_hash = release_manifest.sha256_lower_hex(rag_path.read_bytes())
 
     decision = check_release_control_plane.check_release_control_plane_files(
         release_manifest_path=manifest_path,
@@ -335,6 +336,8 @@ def test_block_on_malformed_json(tmp_path: Path) -> None:
 
     assert decision["decision"] == "BLOCK"
     assert "malformed_rag_gate_result" in decision["reason_codes"]
+    assert decision["checked_artifacts"]["rag_gate_result"]["sha256"] == malformed_hash
+    assert decision["evidence_hashes"]["rag_gate_result"] == malformed_hash
 
 
 def test_empty_evidence_objects_are_invalid_not_allowed(tmp_path: Path) -> None:

--- a/tests/test_release_control_plane_ci_gate.py
+++ b/tests/test_release_control_plane_ci_gate.py
@@ -318,6 +318,26 @@ def test_block_on_malformed_json(tmp_path: Path) -> None:
     assert "malformed_rag_gate_result" in decision["reason_codes"]
 
 
+def test_empty_evidence_objects_are_invalid_not_allowed(tmp_path: Path) -> None:
+    manifest_path, rag_path, build_path = _write_evidence(
+        tmp_path,
+        manifest_payload={},
+        rag_payload={},
+        build_payload={},
+    )
+
+    decision = check_release_control_plane.check_release_control_plane_files(
+        release_manifest_path=manifest_path,
+        rag_gate_result_path=rag_path,
+        build_equivalence_path=build_path,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert "invalid_release_manifest" in decision["reason_codes"]
+    assert "invalid_rag_gate_result" in decision["reason_codes"]
+    assert "invalid_build_equivalence" in decision["reason_codes"]
+
+
 def test_block_on_invalid_digest_format(tmp_path: Path) -> None:
     manifest_payload, rag_payload = _build_manifest(tmp_path)
     manifest_payload["supply_chain_identity"] = dict(manifest_payload["supply_chain_identity"])
@@ -438,6 +458,35 @@ def test_output_json_is_deterministic(tmp_path: Path) -> None:
     assert first_output.read_text(encoding="utf-8").endswith("\n")
 
 
+def test_schema_allows_raw_malformed_summary_values_for_block_outputs(tmp_path: Path) -> None:
+    schema = json.loads(
+        (REPO_ROOT / "docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    manifest_payload, rag_payload = _build_manifest(tmp_path)
+    rag_payload["release_decision"] = "MALFORMED"
+    build_payload = _build_equivalence_result(manifest_payload)
+    build_payload["decision"] = "MAYBE"
+    manifest_payload["supply_chain_identity"] = dict(manifest_payload["supply_chain_identity"])
+    manifest_payload["supply_chain_identity"]["attestation_status"] = "BROKEN"
+
+    decision = _decision(
+        tmp_path,
+        manifest_payload=manifest_payload,
+        rag_payload=rag_payload,
+        build_payload=build_payload,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert decision["build_equivalence_decision"] == "MAYBE"
+    assert decision["rag_gate_decision"] == "MALFORMED"
+    assert decision["attestation_status"] == "BROKEN"
+    assert schema["properties"]["build_equivalence_decision"] == {"type": ["string", "null"]}
+    assert schema["properties"]["rag_gate_decision"] == {"type": ["string", "null"]}
+    assert schema["properties"]["attestation_status"] == {"type": ["string", "null"]}
+
+
 def test_cli_writes_json_and_markdown_outputs(tmp_path: Path, capsys) -> None:
     manifest_path, rag_path, build_path = _write_evidence(tmp_path)
     json_out = tmp_path / "gate.json"
@@ -464,6 +513,8 @@ def test_cli_writes_json_and_markdown_outputs(tmp_path: Path, capsys) -> None:
     assert "- Decision: `ALLOW`" in markdown_out.read_text(encoding="utf-8")
 
 
+# These workflow/docs assertions intentionally guard PR-5 textual integration
+# points. If the workflow contract grows, migrate them to YAML/schema parsing.
 def test_workflow_integration_does_not_require_app_store_secrets() -> None:
     workflow = (REPO_ROOT / ".github/workflows/cd.yml").read_text(encoding="utf-8")
     marker = "release-control-plane-fixture-gate:"


### PR DESCRIPTION
## Summary
- Adds PR-5 release-control-plane CI gate.
- Enforces release manifest, RAG gate result, build equivalence, and supply-chain evidence before release ALLOW.
- Updates ledger so PR-4 is merged and PR-5 is active/implemented.
- Does not add App Store upload automation or runtime changes.

## Scope
- release-control-plane CI checker
- focused CI/workflow integration
- tests
- docs
- ledger reconciliation
- premortem artifact

## Out of scope
- App Store Connect upload
- Fastlane upload mutation
- runtime/API/iOS changes
- OpenAPI changes
- RAG behavior changes
- product-facing behavior

## Validation
- `python3 scripts/orchestration/check_preflight.py` -> PASS; working tree clean; scoped AGENTS warning only for analyze mode without `--path`.
- `python3 scripts/orchestration/check_agent_consistency.py` -> `OK: agent docs and files are consistent.`
- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` -> 26 passed.
- `. .venv/bin/activate && pytest -q tests/test_release_manifest.py` -> 20 passed.
- `. .venv/bin/activate && pytest -q tests/test_build_equivalence.py` -> 22 passed.
- `. .venv/bin/activate && pytest -q tests/test_rag_release_gates_runner.py` -> 48 passed.
- `. .venv/bin/activate && pytest -q tests/test_check_docker_provenance_attestation.py` -> 12 passed.
- `. .venv/bin/activate && pytest -q tests/test_repo_policy_guards.py` -> 14 passed.
- `. .venv/bin/activate && mypy --no-incremental --cache-dir=/dev/null scripts/ci/check_release_control_plane.py` -> PASS.
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/roadmap/BACKLOG_LEDGER.md` -> `phase1-docs-gates: passed.`
- `make validate-changed` -> 48 passed; diff-based validation completed.
- `pre-commit run --all-files` -> passed.
- Pre-push hook -> passed, including backend pre-push tests and full-repo Bandit.

## Machine-heavy deferral
Full local `make verify` intentionally not run. This PR follows the operator-approved bounded-check path and uses `make validate-changed` plus focused release-control-plane checks.

## Premortem
- [x] Premortem pass completed against actual changed files
- [x] All P0/P1 premortem findings fixed or dispositioned as NOT-A-BUG with evidence
- [x] P2 findings, if any, are linked in BACKLOG_LEDGER.md

Link: `docs/review/PR_1682_PREMORTEM.md`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1682_FIXED_MAPPING.md`

## Split Justification
This PR is intentionally one release-control-plane slice because the fail-closed CI checker, its schema contract, workflow fixture integration, focused tests, ledger reconciliation, premortem artifact, and fixed-mapping artifact must land together for PR-5 governance to be reviewable and deterministic. Splitting the checker from the contract or tests would create a temporary release-governance state where CI evidence semantics are either undocumented or untested. Protected production artifact wiring remains deferred as a separate follow-up.

## Deferred / Follow-ups
- Protected-environment production artifact wiring remains deferred: real `release_manifest.json`, `rag_gate_result.json`, and `build_equivalence_result.json` must be published into the production tag path before the checker is invoked as production deploy evidence.
- App Store Connect upload execution and Fastlane upload mutation remain out of scope for this PR.

## Merge Readiness
Not merge-ready until:
- current PR head checks required for this PR are clean
- CodeRabbit/Sourcery/Cubic actionable comments are resolved or dispositioned
- `docs/review/PR_1682_FIXED_MAPPING.md` is complete for the latest review activity
- premortem has no unresolved P0/P1 findings
- strict merge-readiness gate passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CI gate job to the deployment workflow that runs before pre-production gates, builds a release-control-plane fixture, validates it, and emits JSON/Markdown evidence.

* **Documentation**
  * Added CI gate spec and JSON schema, updated epic/PR-slice records, premortem and review docs, and expanded backlog ledger to reflect CI-gate governance.

* **Tests**
  * Added comprehensive tests covering gate outcomes, evidence validation, deterministic outputs, CLI/Markdown outputs, and workflow integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

