### PR TITLE
feat(design): add screen evidence pack for web and iOS review surfaces

### DIFF
--- a/docs/design/SCREEN_EVIDENCE_PACK_SCHEMA.md
+++ b/docs/design/SCREEN_EVIDENCE_PACK_SCHEMA.md
@@ -1,0 +1,77 @@
+<!-- markdownlint-disable MD013 -->
+# Screen Evidence Pack Schema
+
+**Status:** Design Intelligence PR-3 contract
+**Purpose:** Define deterministic screen evidence metadata for PulsePlate web and iOS review surfaces.
+
+## Summary
+
+Screen evidence packs are review evidence only. They do not become PulsePlate source of truth, product truth, token truth, runtime UI, Figma truth, Storybook truth, App Store truth, or implementation authority.
+
+The repo source of truth remains code, docs, tests, `/tokens`, generated token mirrors, UI vocabulary, backend/OpenAPI contracts, and runtime implementation.
+
+## Hard Rule
+
+No screenshot, video, browser trace, Storybook build, DerivedData output, simulator artifact, or binary image is committed by this schema.
+
+Committed examples contain metadata only. Runtime capture outputs must stay local-only under ignored artifact paths such as `artifacts/design/screen_evidence/<run_id>/`.
+
+## Required Fields
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `evidence_id` | string | yes | Stable repo-local evidence id |
+| `generated_by` | string | yes | Tool or reviewer that created the metadata |
+| `generated_at_policy` | string | yes | `omitted` or `local_artifact_only` |
+| `platform` | string | yes | `web` or `ios` |
+| `surface_id` | string | yes | Stable review surface id, for example `web:/marketing` |
+| `surface_name` | string | yes | Human-readable surface name |
+| `route_or_screen` | string | yes | Web route or iOS screen id |
+| `source_of_truth_note` | string | yes | Must state the pack is review evidence and not source of truth |
+| `capture_mode` | string | yes | `automated`, `manual`, or `sample` |
+| `artifact_policy` | string | yes | `local_only` or `committed_sample_metadata` |
+| `viewport` | string | yes | Viewport, device, or simulator target descriptor |
+| `theme` | string | yes | Theme or design mode descriptor |
+| `locale` | string | yes | Locale reviewed |
+| `component_ids` | array | yes | PulsePlate UI vocabulary ids used or expected |
+| `token_mirror_paths_checked` | array | yes | Token mirror paths checked for this evidence |
+| `accessibility_evidence` | object | yes | Contrast, focus, keyboard, touch target, and landmark evidence |
+| `responsive_evidence` | object | yes | Viewport and responsive behavior evidence |
+| `motion_evidence` | object | yes | Motion and reduced-motion evidence |
+| `copy_safety_evidence` | object | yes | Wellness-only copy evidence |
+| `tabbar_or_navigation_evidence` | object | yes | Navigation shell or tabbar evidence |
+| `overflow_evidence` | object | yes | Horizontal overflow and clipping evidence |
+| `screenshot_artifact_path` | string | yes | Local-only screenshot path or empty string |
+| `dom_artifact_path` | string | yes | Local-only DOM summary path or empty string |
+| `a11y_artifact_path` | string | yes | Local-only accessibility report path or empty string |
+| `storybook_artifact_path` | string | yes | Local-only Storybook evidence path or empty string |
+| `ios_simulator_artifact_path` | string | yes | Local-only iOS artifact path or empty string |
+| `warnings` | array | yes | Review warnings and known limitations |
+| `status` | string | yes | `sample`, `captured`, `validated`, or `rejected` |
+
+## Validation Rules
+
+- Evidence manifests must never claim source-of-truth authority.
+- `source_of_truth_note` must state the pack is review evidence and not source of truth.
+- Component ids must exist in `docs/design/ui_component_vocabulary.json`.
+- Token mirror paths must be known repo token mirror paths.
+- Non-empty artifact paths must be repo-relative and stay under `artifacts/design/screen_evidence/`.
+- Artifact paths must not include `DerivedData`, `storybook-static`, `node_modules`, `.venv`, or `worktrees`.
+- `artifact_policy=committed_sample_metadata` requires all artifact path fields to be empty.
+- `copy_safety_evidence` must not promote diagnosis, treatment, therapy, emergency, crisis, guaranteed outcome, or medical claims.
+- `status=validated` requires non-empty evidence objects and token mirror path checks.
+- `platform=web` requires `route_or_screen`.
+- `platform=ios` with `capture_mode=automated` requires an iOS simulator artifact path.
+
+## Tooling
+
+`scripts/design/screen_evidence_pack.py` provides deterministic validation and summary tooling:
+
+```bash
+python3 scripts/design/screen_evidence_pack.py validate <manifest.json>
+python3 scripts/design/screen_evidence_pack.py validate-dir <dir>
+python3 scripts/design/screen_evidence_pack.py summarize <manifest.json>
+python3 scripts/design/screen_evidence_pack.py web-plan --routes / /marketing --out <dir>
+```
+
+The tool does not crawl websites, open Figma, write Canva, mutate runtime UI, run Playwright, commit screenshots, or score design quality. PR-4 will consume evidence later for deterministic scoring.

--- a/docs/design/screen_evidence/examples/README.md
+++ b/docs/design/screen_evidence/examples/README.md
@@ -1,0 +1,7 @@
+# Screen Evidence Examples
+
+These examples are synthetic metadata fixtures for the Design Intelligence PR-3 screen evidence pack contract.
+
+They do not include screenshots, videos, browser traces, Storybook static output, DerivedData, simulator artifacts, external layouts, external branding, copied assets, or copied marketing text.
+
+The JSON files demonstrate safe manifest shape only. Runtime evidence remains local-only under ignored artifact paths such as `artifacts/design/screen_evidence/<run_id>/`.

--- a/docs/design/screen_evidence/examples/ios_home.sample.json
+++ b/docs/design/screen_evidence/examples/ios_home.sample.json
@@ -1,0 +1,54 @@
+{
+  "a11y_artifact_path": "",
+  "accessibility_evidence": {
+    "voiceover": "Sample metadata requires VoiceOver label review in a future local capture.",
+    "touch_target": "Sample metadata requires touch target review in a future local capture."
+  },
+  "artifact_policy": "committed_sample_metadata",
+  "capture_mode": "sample",
+  "component_ids": [
+    "button",
+    "card",
+    "navigation_tab_bar",
+    "progress"
+  ],
+  "copy_safety_evidence": {
+    "wellness_boundary": "Review evidence only; avoid diagnosis, treatment, therapy, crisis, medical, and guaranteed outcome claims."
+  },
+  "dom_artifact_path": "",
+  "evidence_id": "ios-home-sample",
+  "generated_at_policy": "omitted",
+  "generated_by": "synthetic PR-3 sample metadata",
+  "ios_simulator_artifact_path": "",
+  "locale": "en-US",
+  "motion_evidence": {
+    "reduced_motion": "Sample metadata requires reduced-motion review if animation is present."
+  },
+  "overflow_evidence": {
+    "clipping": "Sample metadata requires clipping and dynamic type review in a future local capture."
+  },
+  "platform": "ios",
+  "responsive_evidence": {
+    "device_target": "Sample metadata describes an iPhone review surface template only."
+  },
+  "route_or_screen": "Home",
+  "screenshot_artifact_path": "",
+  "source_of_truth_note": "Screen evidence is review evidence only, non-canonical, and not source of truth; repo tokens, UI vocabulary, backend/OpenAPI contracts, tests, and runtime code win.",
+  "status": "sample",
+  "storybook_artifact_path": "",
+  "surface_id": "ios:home",
+  "surface_name": "iOS Home",
+  "tabbar_or_navigation_evidence": {
+    "tabbar": "Sample metadata requires tabbar presence and active-state review in a future local capture."
+  },
+  "theme": "repo-default",
+  "token_mirror_paths_checked": [
+    "ios/PulsePlate/DesignSystem/DesignTokens.generated.swift"
+  ],
+  "viewport": "iPhone-template",
+  "warnings": [
+    "sample metadata only",
+    "no simulator artifact committed",
+    "no iOS runtime mutation"
+  ]
+}

--- a/docs/design/screen_evidence/examples/web_marketing.sample.json
+++ b/docs/design/screen_evidence/examples/web_marketing.sample.json
@@ -1,0 +1,56 @@
+{
+  "a11y_artifact_path": "",
+  "accessibility_evidence": {
+    "focus": "Sample metadata requires visible focus evidence in a future local capture.",
+    "keyboard": "Sample metadata requires keyboard path evidence in a future local capture."
+  },
+  "artifact_policy": "committed_sample_metadata",
+  "capture_mode": "sample",
+  "component_ids": [
+    "button",
+    "card",
+    "hero",
+    "stats_card"
+  ],
+  "copy_safety_evidence": {
+    "wellness_boundary": "Review evidence only; avoid diagnosis, treatment, therapy, crisis, medical, and guaranteed outcome claims."
+  },
+  "dom_artifact_path": "",
+  "evidence_id": "web-marketing-sample",
+  "generated_at_policy": "omitted",
+  "generated_by": "synthetic PR-3 sample metadata",
+  "ios_simulator_artifact_path": "",
+  "locale": "en-US",
+  "motion_evidence": {
+    "reduced_motion": "Sample metadata requires reduced-motion review if motion is present."
+  },
+  "overflow_evidence": {
+    "horizontal_overflow": "Sample metadata requires no horizontal overflow evidence in a future local capture."
+  },
+  "platform": "web",
+  "responsive_evidence": {
+    "mobile": "Sample metadata requires mobile viewport evidence in a future local capture.",
+    "desktop": "Sample metadata requires desktop viewport evidence in a future local capture."
+  },
+  "route_or_screen": "/marketing",
+  "screenshot_artifact_path": "",
+  "source_of_truth_note": "Screen evidence is review evidence only, non-canonical, and not source of truth; repo tokens, UI vocabulary, backend/OpenAPI contracts, tests, and runtime code win.",
+  "status": "sample",
+  "storybook_artifact_path": "",
+  "surface_id": "web:/marketing",
+  "surface_name": "Marketing launch shell",
+  "tabbar_or_navigation_evidence": {
+    "navigation": "Sample metadata requires shell navigation evidence in a future local capture."
+  },
+  "theme": "repo-default",
+  "token_mirror_paths_checked": [
+    "frontend/src/styles/tokens.css",
+    "frontend/src/styles/tokens.ts"
+  ],
+  "viewport": "desktop-1440x1100",
+  "warnings": [
+    "sample metadata only",
+    "no screenshot committed",
+    "no runtime UI mutation"
+  ]
+}

--- a/docs/review/PR_1683_FIXED_MAPPING.md
+++ b/docs/review/PR_1683_FIXED_MAPPING.md
@@ -6,9 +6,14 @@ Title: `feat(design): add screen evidence pack for web and iOS review surfaces`
 
 ## Discussion Thread Pass
 
-- [x] Initial implementation review completed before PR open.
-- [x] Post-open coordinator bootstrap completed.
-- [x] No review threads were open when this artifact was created.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Notes:
+
+- Initial implementation review completed before PR open.
+- Post-open coordinator bootstrap completed.
+- No actionable review threads were open when this artifact was created.
 - [ ] Re-check CodeRabbit/Sourcery/Cubic after they comment.
 - [ ] Re-check GitHub review threads before merge-readiness.
 
@@ -54,11 +59,11 @@ Premortem reviewed actual code/docs/tests diff.
 
 ## Fixed in Commit Mapping
 
-No external review threads existed when this artifact was created.
+- No actionable review comments
 
-Internal premortem fix:
+## Internal Premortem Fixes
 
-- Source-of-truth override wording gap -> `4e3b34ce4`, covered by tests in `cc4a4a8b9`.
+- Source-of-truth override wording gap fixed in `4e3b34ce4`, covered by tests in `cc4a4a8b9`.
 
 ## Deferred / Follow-ups
 

--- a/docs/review/PR_1683_FIXED_MAPPING.md
+++ b/docs/review/PR_1683_FIXED_MAPPING.md
@@ -24,11 +24,11 @@ Notes:
 - `python3 scripts/design/screen_evidence_pack.py validate-dir docs/design/screen_evidence/examples`
 - `python3 scripts/design/screen_evidence_pack.py summarize docs/design/screen_evidence/examples/web_marketing.sample.json`
 - `python3 scripts/design/screen_evidence_pack.py web-plan --routes / /marketing --out /tmp/pulseplate-screen-evidence-plan`
-- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/design/test_screen_evidence_pack.py`
-- `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
+- `. .venv/bin/activate && python -m pytest -q tests/design/test_screen_evidence_pack.py`
+- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed`
 - `make design-guard`
 - `make tokens-check` with temporary root frontend `node_modules` symlink removed after the gate; no token mirror diff remained.
-- `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH pre-commit run --all-files`
+- `PATH=.venv/bin:$PATH pre-commit run --all-files`
 - Pre-push hooks also passed during `git push`.
 
 ## Premortem Risk Review

--- a/docs/review/PR_1683_FIXED_MAPPING.md
+++ b/docs/review/PR_1683_FIXED_MAPPING.md
@@ -1,0 +1,83 @@
+# PR #1683 Fixed Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1683
+Branch: `feat/design-screen-evidence-pack-v1`
+Title: `feat(design): add screen evidence pack for web and iOS review surfaces`
+
+## Discussion Thread Pass
+
+- [x] Initial implementation review completed before PR open.
+- [x] Post-open coordinator bootstrap completed.
+- [x] No review threads were open when this artifact was created.
+- [ ] Re-check CodeRabbit/Sourcery/Cubic after they comment.
+- [ ] Re-check GitHub review threads before merge-readiness.
+
+## Local Evidence
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `python3 scripts/design/screen_evidence_pack.py validate-dir docs/design/screen_evidence/examples`
+- `python3 scripts/design/screen_evidence_pack.py summarize docs/design/screen_evidence/examples/web_marketing.sample.json`
+- `python3 scripts/design/screen_evidence_pack.py web-plan --routes / /marketing --out /tmp/pulseplate-screen-evidence-plan`
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/design/test_screen_evidence_pack.py`
+- `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
+- `make design-guard`
+- `make tokens-check` with temporary root frontend `node_modules` symlink removed after the gate; no token mirror diff remained.
+- `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH pre-commit run --all-files`
+- Pre-push hooks also passed during `git push`.
+
+## Premortem Risk Review
+
+Premortem reviewed actual code/docs/tests diff.
+
+| Risk | Finding | Fix / Decision | Evidence |
+| --- | --- | --- | --- |
+| Evidence packs become a second design SoT | Validator requires review-evidence and non-canonical wording. Premortem found a `not source of truth, but overrides repo` wording gap. | FIXED in `4e3b34ce4`; covered in `cc4a4a8b9`. | `scripts/design/screen_evidence_pack.py`; `tests/design/test_screen_evidence_pack.py` |
+| Committed examples include binary artifacts | Examples use empty artifact paths with `committed_sample_metadata`; validator rejects committed sample artifact paths and binary references. | FIXED in schema/tool/tests. | `docs/design/screen_evidence/examples/*.json`; `tests/design/test_screen_evidence_pack.py` |
+| PR-3 accidentally implements PR-4 scoring | No score thresholds or scorecard engine added. | NOT-A-BUG: explicitly deferred to PR-4. | `docs/design/SCREEN_EVIDENCE_PACK_SCHEMA.md`; PR body Deferred section |
+| Runtime/token/frontend/iOS drift | Diff contains design tooling/docs/tests only; token mirror diff is empty. | NOT-A-BUG: no runtime files changed. | `git diff -- frontend/src/styles/tokens.css frontend/src/styles/tokens.ts ios/PulsePlate/DesignSystem/DesignTokens.generated.swift` |
+
+## Bug-Hunter Pass
+
+- [x] Docs/tooling/tests only.
+- [x] No runtime frontend/iOS/backend diff.
+- [x] No generated token mirror diff.
+- [x] No committed screenshots/videos/traces.
+- [x] Examples are sample metadata only.
+- [x] Invalid manifest states fail closed.
+- [x] Unknown components fail.
+- [x] Unsafe paths fail.
+- [x] No Figma/Canva authority drift.
+- [x] No external network/crawler introduced.
+- [x] No plugin architecture introduced.
+- [x] No PR-4 scorecard logic introduced.
+
+## Fixed in Commit Mapping
+
+No external review threads existed when this artifact was created.
+
+Internal premortem fix:
+
+- Source-of-truth override wording gap -> `4e3b34ce4`, covered by tests in `cc4a4a8b9`.
+
+## Deferred / Follow-ups
+
+- PR-4: deterministic design scorecard checks.
+- PR-5: web launch shell alignment to accepted design brief.
+- PR-6: iOS visual parity audit and bounded sync.
+- PR-7: design-agent workflow and PR template.
+- PR-8: GEPA-compatible prompt/rubric evolution lane.
+- Browser/Playwright `web-capture` remains deferred; PR-3 implements deterministic metadata planning only.
+
+## Merge Readiness
+
+Not claimed.
+
+Merge readiness remains blocked until:
+
+- current-head PR checks complete,
+- no actionable bot comments remain,
+- review threads have explicit dispositions,
+- this mapping artifact matches the PR body,
+- mandatory wait-window completes,
+- strict `check_merge_ready.py --require-auth` passes.

--- a/docs/review/PR_1683_FIXED_MAPPING.md
+++ b/docs/review/PR_1683_FIXED_MAPPING.md
@@ -13,7 +13,7 @@ Notes:
 
 - Initial implementation review completed before PR open.
 - Post-open coordinator bootstrap completed.
-- No actionable review threads were open when this artifact was created.
+- Codex review comments were triaged and fixed.
 - [ ] Re-check CodeRabbit/Sourcery/Cubic after they comment.
 - [ ] Re-check GitHub review threads before merge-readiness.
 
@@ -59,7 +59,11 @@ Premortem reviewed actual code/docs/tests diff.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1683#discussion_r3195503186 -> 0f97f4ec7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1683#discussion_r3195503198 -> 0f97f4ec7
+Disposition: FIXED
+Commit: 0f97f4ec7
+Evidence: `scripts/design/screen_evidence_pack.py` guards malformed component ids and negated source-of-truth wording; `tests/design/test_screen_evidence_pack.py` covers both regressions.
 
 ## Internal Premortem Fixes
 

--- a/docs/review/PR_1683_FIXED_MAPPING.md
+++ b/docs/review/PR_1683_FIXED_MAPPING.md
@@ -61,9 +61,10 @@ Premortem reviewed actual code/docs/tests diff.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1683#discussion_r3195503186 -> 0f97f4ec7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1683#discussion_r3195503198 -> 0f97f4ec7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1683#discussion_r3195537356 -> 1ca9cab4c
 Disposition: FIXED
-Commit: 0f97f4ec7
-Evidence: `scripts/design/screen_evidence_pack.py` guards malformed component ids and negated source-of-truth wording; `tests/design/test_screen_evidence_pack.py` covers both regressions.
+Commit: 0f97f4ec7; 1ca9cab4c
+Evidence: `scripts/design/screen_evidence_pack.py` guards malformed component ids and negated source-of-truth wording; `tests/design/test_screen_evidence_pack.py` covers both regressions; `docs/review/PR_1683_FIXED_MAPPING.md` uses portable repo-relative evidence commands.
 
 ## Internal Premortem Fixes
 

--- a/docs/review/PR_1683_FIXED_MAPPING.md
+++ b/docs/review/PR_1683_FIXED_MAPPING.md
@@ -60,11 +60,20 @@ Premortem reviewed actual code/docs/tests diff.
 ## Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1683#discussion_r3195503186 -> 0f97f4ec7
+Disposition: FIXED
+Commit: 0f97f4ec7
+Evidence: `scripts/design/screen_evidence_pack.py` guards malformed component ids; `tests/design/test_screen_evidence_pack.py` covers the regression.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1683#discussion_r3195503198 -> 0f97f4ec7
+Disposition: FIXED
+Commit: 0f97f4ec7
+Evidence: `scripts/design/screen_evidence_pack.py` accepts negated source-of-truth wording; `tests/design/test_screen_evidence_pack.py` covers the regression.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1683#pullrequestreview-4236174229 -> 1ca9cab4c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1683#discussion_r3195537356 -> 1ca9cab4c
 Disposition: FIXED
-Commit: 0f97f4ec7; 1ca9cab4c
-Evidence: `scripts/design/screen_evidence_pack.py` guards malformed component ids and negated source-of-truth wording; `tests/design/test_screen_evidence_pack.py` covers both regressions; `docs/review/PR_1683_FIXED_MAPPING.md` uses portable repo-relative evidence commands.
+Commit: 1ca9cab4c
+Evidence: `docs/review/PR_1683_FIXED_MAPPING.md` uses portable repo-relative evidence commands.
 
 ## Internal Premortem Fixes
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1174,8 +1174,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Reference-driven design intelligence wave for web and iOS
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (design / web / iOS / agentic workflow / reference corpus)
-  - Target PR: PR #1671 (`docs(design): open reference-driven design intelligence wave for web and iOS`, branch `docs/design-intelligence-wave-v1`) -> PR #1677 / PR-1 `feat(design): generate PulsePlate DESIGN.md from token and component contracts` -> PR #1680 / PR-2 `feat(design): add external reference manifest and normalization tooling` (`feat/design-reference-manifest-tooling-v1`)
-  - Status: PR-0 merged in PR #1671; PR-1 merged in PR #1677 with generated/drift-checked `docs/design/DESIGN.md`; PR-2 active on branch `feat/design-reference-manifest-tooling-v1` to add external reference manifest validation and normalization tooling. Do not close the wave or mark PR-3/PR-4/PR-5/PR-6 complete in this PR.
+  - Target PR: PR #1671 (`docs(design): open reference-driven design intelligence wave for web and iOS`, branch `docs/design-intelligence-wave-v1`) -> PR #1677 / PR-1 `feat(design): generate PulsePlate DESIGN.md from token and component contracts` -> PR #1680 / PR-2 `feat(design): add external reference manifest and normalization tooling` -> PR-3 `feat(design): add screen evidence pack for web and iOS review surfaces` (`feat/design-screen-evidence-pack-v1`)
+  - Status: PR-0 merged in PR #1671; PR-1 merged in PR #1677 with generated/drift-checked `docs/design/DESIGN.md`; PR-2 merged in PR #1680 with reference manifest validation and normalization tooling; PR-3 active on branch `feat/design-screen-evidence-pack-v1` to add metadata-only screen evidence pack validation for web and iOS review surfaces. Do not close the wave or mark PR-4/PR-5/PR-6/PR-7/PR-8 complete in this PR.
   - Area: design / web / iOS / agentic workflow / reference corpus
   - Finding Type: reference-driven design intelligence bootstrap and governance
   - Anchor: `ledger-p1-design-intelligence-wave`
@@ -1190,6 +1190,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/design/REFERENCE_SCORECARD.md`
     - `docs/design/PULSEPLATE_DESIGN_MD_BOOTSTRAP.md`
     - `docs/design/DESIGN.md` (PR-1 generated semantic wrapper; non-canonical)
+    - `docs/design/SCREEN_EVIDENCE_PACK_SCHEMA.md` (PR-3 screen evidence metadata schema; non-canonical)
   - DoD:
     - PR-0 runbook and packet exist
     - External reference policy exists

--- a/scripts/design/screen_evidence_pack.py
+++ b/scripts/design/screen_evidence_pack.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+"""Validate and summarize PulsePlate screen evidence pack manifests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, TextIO
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VOCABULARY_PATH = Path("docs/design/ui_component_vocabulary.json")
+LOCAL_ARTIFACT_PREFIX = "artifacts/design/screen_evidence/"
+
+REQUIRED_FIELDS = [
+    "evidence_id",
+    "generated_by",
+    "generated_at_policy",
+    "platform",
+    "surface_id",
+    "surface_name",
+    "route_or_screen",
+    "source_of_truth_note",
+    "capture_mode",
+    "artifact_policy",
+    "viewport",
+    "theme",
+    "locale",
+    "component_ids",
+    "token_mirror_paths_checked",
+    "accessibility_evidence",
+    "responsive_evidence",
+    "motion_evidence",
+    "copy_safety_evidence",
+    "tabbar_or_navigation_evidence",
+    "overflow_evidence",
+    "screenshot_artifact_path",
+    "dom_artifact_path",
+    "a11y_artifact_path",
+    "storybook_artifact_path",
+    "ios_simulator_artifact_path",
+    "warnings",
+    "status",
+]
+
+STRING_FIELDS = {
+    "evidence_id",
+    "generated_by",
+    "generated_at_policy",
+    "platform",
+    "surface_id",
+    "surface_name",
+    "route_or_screen",
+    "source_of_truth_note",
+    "capture_mode",
+    "artifact_policy",
+    "viewport",
+    "theme",
+    "locale",
+    "screenshot_artifact_path",
+    "dom_artifact_path",
+    "a11y_artifact_path",
+    "storybook_artifact_path",
+    "ios_simulator_artifact_path",
+    "status",
+}
+
+ARRAY_FIELDS = {
+    "component_ids",
+    "token_mirror_paths_checked",
+    "warnings",
+}
+
+OBJECT_FIELDS = {
+    "accessibility_evidence",
+    "responsive_evidence",
+    "motion_evidence",
+    "copy_safety_evidence",
+    "tabbar_or_navigation_evidence",
+    "overflow_evidence",
+}
+
+ARTIFACT_PATH_FIELDS = {
+    "screenshot_artifact_path",
+    "dom_artifact_path",
+    "a11y_artifact_path",
+    "storybook_artifact_path",
+    "ios_simulator_artifact_path",
+}
+
+GENERATED_AT_POLICY_VALUES = {"omitted", "local_artifact_only"}
+PLATFORM_VALUES = {"web", "ios"}
+CAPTURE_MODE_VALUES = {"automated", "manual", "sample"}
+ARTIFACT_POLICY_VALUES = {"local_only", "committed_sample_metadata"}
+STATUS_VALUES = {"sample", "captured", "validated", "rejected"}
+
+TOKEN_MIRROR_PATHS = {
+    "frontend/src/styles/tokens.css",
+    "frontend/src/styles/tokens.ts",
+    "ios/PulsePlate/DesignSystem/DesignTokens.generated.swift",
+}
+
+DISALLOWED_PATH_PARTS = {
+    ".venv",
+    "DerivedData",
+    "node_modules",
+    "storybook-static",
+    "worktrees",
+}
+
+BINARY_ARTIFACT_EXTENSIONS = {
+    ".har",
+    ".jpeg",
+    ".jpg",
+    ".mp4",
+    ".png",
+    ".trace",
+    ".webp",
+    ".zip",
+}
+
+WELLNESS_CLAIM_TERMS = [
+    "diagnos",
+    "treat",
+    "therapy",
+    "therapeutic",
+    "emergency",
+    "crisis",
+    "guaranteed",
+    "medical",
+    "cure",
+]
+
+NEGATION_MARKERS = (
+    "avoid",
+    "no ",
+    "not ",
+    "must not",
+    "does not",
+    "do not",
+    "without",
+    "non-",
+    "never",
+)
+
+SOT_AUTHORITY_PATTERNS = [
+    r"\b(is|are|becomes?|serves as|acts as)\b.{0,40}\b(source of truth|source-of-truth|canonical truth|runtime authority|token authority)\b",
+    r"\b(source of truth|source-of-truth|canonical truth|runtime authority|token authority)\b.{0,40}\b(overrides?|replaces?|beats|wins over)\b",
+    r"\boverrides?\b.{0,40}\b(repo|tokens|runtime|backend|openapi|ui vocabulary)\b",
+]
+
+
+class EvidenceManifestError(ValueError):
+    """Raised when a screen evidence manifest fails validation."""
+
+
+def _repo_path(path: str | Path, repo_root: Path) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return repo_root / candidate
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+    except UnicodeDecodeError as exc:
+        raise EvidenceManifestError(f"{path}: invalid UTF-8: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        raise EvidenceManifestError(f"{path}: invalid JSON: {exc.msg}") from exc
+    except OSError as exc:
+        raise EvidenceManifestError(f"{path}: cannot read manifest: {exc}") from exc
+    if not isinstance(data, dict):
+        raise EvidenceManifestError(f"{path}: manifest must be a JSON object")
+    return data
+
+
+def _load_component_ids(repo_root: Path) -> set[str]:
+    path = repo_root / VOCABULARY_PATH
+    try:
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+    except UnicodeDecodeError as exc:
+        raise EvidenceManifestError(f"{VOCABULARY_PATH}: invalid UTF-8: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        raise EvidenceManifestError(f"{VOCABULARY_PATH}: invalid JSON: {exc.msg}") from exc
+    except OSError as exc:
+        raise EvidenceManifestError(f"{VOCABULARY_PATH}: cannot read vocabulary: {exc}") from exc
+    if not isinstance(data, list):
+        raise EvidenceManifestError(f"{VOCABULARY_PATH}: expected JSON array")
+    component_ids = set()
+    for item in data:
+        if not isinstance(item, dict) or not isinstance(item.get("id"), str):
+            raise EvidenceManifestError(f"{VOCABULARY_PATH}: every component requires a string id")
+        component_ids.add(item["id"])
+    return component_ids
+
+
+def _stringify(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return " ".join(_stringify(item) for item in value)
+    if isinstance(value, dict):
+        return " ".join(_stringify(item) for item in value.values())
+    return str(value)
+
+
+def _has_negation_near(text: str, index: int) -> bool:
+    sentence_start = max(text.rfind(".", 0, index), text.rfind(";", 0, index))
+    window_start = max(0, sentence_start + 1, index - 96)
+    window = text[window_start:index].lower()
+    return any(marker in window for marker in NEGATION_MARKERS)
+
+
+def _field_text(record: dict[str, Any]) -> str:
+    return "\n".join(_stringify(record[key]) for key in sorted(record)).lower()
+
+
+def _validate_required_fields(record: dict[str, Any], errors: list[str]) -> None:
+    for field in REQUIRED_FIELDS:
+        if field not in record:
+            errors.append(f"missing required field: {field}")
+
+
+def _validate_field_types(record: dict[str, Any], errors: list[str]) -> None:
+    for field in STRING_FIELDS:
+        if field in record and not isinstance(record[field], str):
+            errors.append(f"{field} must be a string")
+    for field in STRING_FIELDS - ARTIFACT_PATH_FIELDS:
+        if field in record and isinstance(record[field], str) and not record[field].strip():
+            errors.append(f"{field} must be a non-empty string")
+    for field in ARRAY_FIELDS:
+        if field in record:
+            values = record[field]
+            if not isinstance(values, list):
+                errors.append(f"{field} must be an array")
+            elif any(not isinstance(item, str) or not item.strip() for item in values):
+                errors.append(f"{field} must contain only non-empty strings")
+    for field in OBJECT_FIELDS:
+        if field in record and not isinstance(record[field], dict):
+            errors.append(f"{field} must be an object")
+
+
+def _validate_enums(record: dict[str, Any], errors: list[str]) -> None:
+    enum_fields = [
+        ("generated_at_policy", GENERATED_AT_POLICY_VALUES),
+        ("platform", PLATFORM_VALUES),
+        ("capture_mode", CAPTURE_MODE_VALUES),
+        ("artifact_policy", ARTIFACT_POLICY_VALUES),
+        ("status", STATUS_VALUES),
+    ]
+    for field, allowed_values in enum_fields:
+        value = record.get(field)
+        if isinstance(value, str) and value not in allowed_values:
+            errors.append(f"{field} must be one of: {', '.join(sorted(allowed_values))}")
+
+
+def _validate_source_of_truth(record: dict[str, Any], errors: list[str]) -> None:
+    note = _stringify(record.get("source_of_truth_note", "")).lower()
+    if "review evidence" not in note:
+        errors.append("source_of_truth_note must state this is review evidence")
+    if "not source of truth" not in note and "non-canonical" not in note:
+        errors.append("source_of_truth_note must state evidence is not source of truth")
+
+    text = _field_text(record)
+    if re.search(r"\bbut\b.{0,40}\boverrides?\b", text):
+        errors.append("screen evidence must not become a source of truth")
+        return
+    for pattern in SOT_AUTHORITY_PATTERNS:
+        for match in re.finditer(pattern, text):
+            if not _has_negation_near(text, match.start()):
+                errors.append("screen evidence must not become a source of truth")
+                return
+
+
+def _validate_components(record: dict[str, Any], repo_root: Path, errors: list[str]) -> None:
+    if not isinstance(record.get("component_ids"), list):
+        return
+    known_ids = _load_component_ids(repo_root)
+    for component_id in record["component_ids"]:
+        if component_id not in known_ids:
+            errors.append(f"unknown PulsePlate component id: {component_id}")
+
+
+def _validate_token_paths(record: dict[str, Any], errors: list[str]) -> None:
+    values = record.get("token_mirror_paths_checked")
+    if not isinstance(values, list):
+        return
+    for value in values:
+        if value not in TOKEN_MIRROR_PATHS:
+            errors.append(f"unknown token mirror path: {value}")
+
+
+def _validate_artifact_paths(record: dict[str, Any], errors: list[str]) -> None:
+    artifact_policy = record.get("artifact_policy")
+    for field in sorted(ARTIFACT_PATH_FIELDS):
+        value = record.get(field)
+        if not isinstance(value, str) or not value:
+            continue
+        candidate = Path(value)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            errors.append(f"{field} must be a repo-relative local artifact path")
+        if any(part in candidate.parts or part in value for part in DISALLOWED_PATH_PARTS):
+            errors.append(f"{field} contains a disallowed local artifact path segment")
+        if artifact_policy == "committed_sample_metadata":
+            errors.append(f"{field} must be empty for committed_sample_metadata")
+        elif not value.startswith(LOCAL_ARTIFACT_PREFIX):
+            errors.append(f"{field} must stay under {LOCAL_ARTIFACT_PREFIX}")
+        if candidate.suffix.lower() in BINARY_ARTIFACT_EXTENSIONS:
+            if artifact_policy == "committed_sample_metadata":
+                errors.append(f"{field} must not reference committed binary artifacts")
+
+
+def _validate_wellness_copy(record: dict[str, Any], errors: list[str]) -> None:
+    text = _stringify(record.get("copy_safety_evidence", "")).lower()
+    for term in WELLNESS_CLAIM_TERMS:
+        for match in re.finditer(re.escape(term), text):
+            if not _has_negation_near(text, match.start()):
+                errors.append(
+                    "copy_safety_evidence must not promote diagnosis, treatment, "
+                    "therapy, emergency, crisis, guaranteed outcome, or medical claims"
+                )
+                return
+
+
+def _dict_has_evidence(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    return any(bool(_stringify(item).strip()) for item in value.values())
+
+
+def _validate_status_requirements(record: dict[str, Any], errors: list[str]) -> None:
+    status = record.get("status")
+    platform = record.get("platform")
+    capture_mode = record.get("capture_mode")
+    if platform == "web" and not _stringify(record.get("route_or_screen", "")).strip():
+        errors.append("platform=web requires route_or_screen")
+    if platform == "ios" and capture_mode == "automated":
+        if not _stringify(record.get("ios_simulator_artifact_path", "")).strip():
+            errors.append("platform=ios automated capture requires ios_simulator_artifact_path")
+    if status == "validated":
+        for field in sorted(OBJECT_FIELDS):
+            if not _dict_has_evidence(record.get(field)):
+                errors.append(f"status=validated requires non-empty {field}")
+        if not record.get("token_mirror_paths_checked"):
+            errors.append("status=validated requires token_mirror_paths_checked")
+
+
+def validate_record(record: dict[str, Any], *, repo_root: Path = REPO_ROOT) -> list[str]:
+    """Return deterministic validation errors for one screen evidence manifest."""
+
+    errors: list[str] = []
+    _validate_required_fields(record, errors)
+    _validate_field_types(record, errors)
+    _validate_enums(record, errors)
+    _validate_source_of_truth(record, errors)
+    _validate_components(record, repo_root, errors)
+    _validate_token_paths(record, errors)
+    _validate_artifact_paths(record, errors)
+    _validate_wellness_copy(record, errors)
+    _validate_status_requirements(record, errors)
+    return sorted(dict.fromkeys(errors))
+
+
+def validate_path(path: str | Path, *, repo_root: Path = REPO_ROOT) -> list[str]:
+    manifest_path = _repo_path(path, repo_root)
+    record = _load_json(manifest_path)
+    return validate_record(record, repo_root=repo_root)
+
+
+def validate_dir(path: str | Path, *, repo_root: Path = REPO_ROOT) -> dict[str, list[str]]:
+    manifest_dir = _repo_path(path, repo_root)
+    manifests = sorted(manifest_dir.rglob("*.json"))
+    if not manifests:
+        return {str(manifest_dir): ["no JSON manifests found"]}
+    results: dict[str, list[str]] = {}
+    for manifest_path in manifests:
+        relative = (
+            manifest_path.relative_to(repo_root)
+            if manifest_path.is_relative_to(repo_root)
+            else manifest_path
+        )
+        results[str(relative)] = validate_path(manifest_path, repo_root=repo_root)
+    return results
+
+
+def summarize_record(record: dict[str, Any]) -> dict[str, Any]:
+    status = _stringify(record.get("status", ""))
+    if status == "rejected":
+        recommendation = "reject"
+    elif status == "validated":
+        recommendation = "validated"
+    elif status == "captured":
+        recommendation = "needs_validation"
+    else:
+        recommendation = "sample_only"
+    return {
+        "artifact_policy": record.get("artifact_policy"),
+        "capture_mode": record.get("capture_mode"),
+        "component_ids": sorted(record.get("component_ids", [])),
+        "evidence_id": record.get("evidence_id"),
+        "evidence_flags": {
+            "accessibility": _dict_has_evidence(record.get("accessibility_evidence")),
+            "copy_safety": _dict_has_evidence(record.get("copy_safety_evidence")),
+            "motion": _dict_has_evidence(record.get("motion_evidence")),
+            "navigation": _dict_has_evidence(record.get("tabbar_or_navigation_evidence")),
+            "overflow": _dict_has_evidence(record.get("overflow_evidence")),
+            "responsive": _dict_has_evidence(record.get("responsive_evidence")),
+        },
+        "platform": record.get("platform"),
+        "recommendation": recommendation,
+        "route_or_screen": record.get("route_or_screen"),
+        "status": status,
+        "surface_id": record.get("surface_id"),
+        "token_mirror_paths_checked": sorted(record.get("token_mirror_paths_checked", [])),
+        "warnings": sorted(record.get("warnings", [])),
+    }
+
+
+def summarize_path(path: str | Path, *, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    manifest_path = _repo_path(path, repo_root)
+    record = _load_json(manifest_path)
+    errors = validate_record(record, repo_root=repo_root)
+    if errors:
+        raise EvidenceManifestError(
+            f"{manifest_path}: cannot summarize invalid manifest: {'; '.join(errors)}"
+        )
+    return summarize_record(record)
+
+
+def _route_slug(route: str) -> str:
+    stripped = route.strip("/")
+    if not stripped:
+        return "root"
+    return re.sub(r"[^a-z0-9]+", "-", stripped.lower()).strip("-")
+
+
+def web_plan(routes: list[str], out_dir: str | Path) -> dict[str, Any]:
+    output_dir = Path(out_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    generated_files = []
+    for route in routes:
+        slug = _route_slug(route)
+        manifest = {
+            "a11y_artifact_path": "",
+            "accessibility_evidence": {
+                "planned": "Capture contrast, focus, keyboard, and landmark evidence later.",
+            },
+            "artifact_policy": "local_only",
+            "capture_mode": "sample",
+            "component_ids": [],
+            "copy_safety_evidence": {
+                "planned": "Review for wellness-only copy; avoid diagnosis, treatment, crisis, medical, and guaranteed outcome claims.",
+            },
+            "dom_artifact_path": "",
+            "evidence_id": f"web-{slug}-screen-evidence-plan",
+            "generated_at_policy": "omitted",
+            "generated_by": "scripts/design/screen_evidence_pack.py web-plan",
+            "ios_simulator_artifact_path": "",
+            "locale": "en-US",
+            "motion_evidence": {
+                "planned": "Capture reduced-motion behavior later if motion is present.",
+            },
+            "overflow_evidence": {
+                "planned": "Capture horizontal overflow evidence later.",
+            },
+            "platform": "web",
+            "responsive_evidence": {
+                "planned": "Capture desktop and mobile viewport metadata later.",
+            },
+            "route_or_screen": route,
+            "screenshot_artifact_path": "",
+            "source_of_truth_note": "Screen evidence is review evidence only, non-canonical, and not source of truth; repo tokens, UI vocabulary, backend/OpenAPI contracts, tests, and runtime code win.",
+            "status": "sample",
+            "storybook_artifact_path": "",
+            "surface_id": f"web:{route}",
+            "surface_name": f"Web {route} review surface",
+            "tabbar_or_navigation_evidence": {
+                "planned": "Capture shell navigation and tabbar visibility later.",
+            },
+            "theme": "repo-default",
+            "token_mirror_paths_checked": [
+                "frontend/src/styles/tokens.css",
+                "frontend/src/styles/tokens.ts",
+            ],
+            "viewport": "desktop-1440x1100",
+            "warnings": [
+                "metadata plan only",
+                "no screenshots captured",
+                "no runtime UI mutation",
+            ],
+        }
+        output_path = output_dir / f"{slug}.screen-evidence.json"
+        output_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        generated_files.append(str(output_path))
+    return {"generated_files": sorted(generated_files), "routes": sorted(routes)}
+
+
+def _print_errors(errors: list[str], *, stderr: TextIO) -> None:
+    for error in errors:
+        print(f"ERROR: {error}", file=stderr)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser("validate", help="validate one evidence manifest")
+    validate_parser.add_argument("path")
+
+    validate_dir_parser = subparsers.add_parser("validate-dir", help="validate evidence manifests")
+    validate_dir_parser.add_argument("dir")
+
+    summarize_parser = subparsers.add_parser("summarize", help="summarize one manifest")
+    summarize_parser.add_argument("path")
+
+    web_plan_parser = subparsers.add_parser(
+        "web-plan", help="write deterministic web evidence plans"
+    )
+    web_plan_parser.add_argument("--routes", nargs="+", required=True)
+    web_plan_parser.add_argument("--out", required=True)
+
+    return parser
+
+
+def run(
+    argv: list[str] | None = None,
+    *,
+    repo_root: Path = REPO_ROOT,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "validate":
+            errors = validate_path(args.path, repo_root=repo_root)
+            if errors:
+                _print_errors(errors, stderr=stderr)
+                return 1
+            return 0
+        if args.command == "validate-dir":
+            results = validate_dir(args.dir, repo_root=repo_root)
+            all_errors = [
+                f"{path}: {error}" for path, errors in results.items() for error in errors
+            ]
+            if all_errors:
+                _print_errors(sorted(all_errors), stderr=stderr)
+                return 1
+            return 0
+        if args.command == "summarize":
+            summary = summarize_path(args.path, repo_root=repo_root)
+            print(json.dumps(summary, indent=2, sort_keys=True), file=stdout)
+            return 0
+        if args.command == "web-plan":
+            summary = web_plan(args.routes, args.out)
+            print(json.dumps(summary, indent=2, sort_keys=True), file=stdout)
+            return 0
+    except EvidenceManifestError as exc:
+        print(f"ERROR: {exc}", file=stderr)
+        return 1
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+def main() -> int:
+    return run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/design/screen_evidence_pack.py
+++ b/scripts/design/screen_evidence_pack.py
@@ -272,7 +272,9 @@ def _validate_source_of_truth(record: dict[str, Any], errors: list[str]) -> None
         return
     for pattern in SOT_AUTHORITY_PATTERNS:
         for match in re.finditer(pattern, text):
-            if not _has_negation_near(text, match.start()):
+            match_text = match.group(0).lower()
+            has_in_match_negation = any(marker in match_text for marker in NEGATION_MARKERS)
+            if not has_in_match_negation and not _has_negation_near(text, match.start()):
                 errors.append("screen evidence must not become a source of truth")
                 return
 
@@ -282,6 +284,8 @@ def _validate_components(record: dict[str, Any], repo_root: Path, errors: list[s
         return
     known_ids = _load_component_ids(repo_root)
     for component_id in record["component_ids"]:
+        if not isinstance(component_id, str):
+            continue
         if component_id not in known_ids:
             errors.append(f"unknown PulsePlate component id: {component_id}")
 

--- a/tests/design/test_screen_evidence_pack.py
+++ b/tests/design/test_screen_evidence_pack.py
@@ -139,6 +139,18 @@ def test_source_of_truth_but_overrides_wording_fails():
     assert "screen evidence must not become a source of truth" in errors
 
 
+def test_negated_source_of_truth_wording_passes():
+    module = load_evidence_module()
+    manifest = valid_manifest(
+        source_of_truth_note=(
+            "Screen evidence is review evidence only and is not source of truth; "
+            "repo runtime code wins."
+        )
+    )
+
+    assert module.validate_record(manifest, repo_root=REPO_ROOT) == []
+
+
 def test_unknown_component_ids_fail():
     module = load_evidence_module()
     manifest = valid_manifest(component_ids=["button", "invented_component"])
@@ -146,6 +158,15 @@ def test_unknown_component_ids_fail():
     errors = module.validate_record(manifest, repo_root=REPO_ROOT)
 
     assert "unknown PulsePlate component id: invented_component" in errors
+
+
+def test_malformed_component_ids_return_validation_errors():
+    module = load_evidence_module()
+    manifest = valid_manifest(component_ids=["button", {}])
+
+    errors = module.validate_record(manifest, repo_root=REPO_ROOT)
+
+    assert "component_ids must contain only non-empty strings" in errors
 
 
 def test_committed_binary_artifact_paths_fail():

--- a/tests/design/test_screen_evidence_pack.py
+++ b/tests/design/test_screen_evidence_pack.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import json
+import runpy
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts/design/screen_evidence_pack.py"
+
+
+def load_evidence_module() -> SimpleNamespace:
+    return SimpleNamespace(**runpy.run_path(str(MODULE_PATH)))
+
+
+def make_temp_repo(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    design_dir = repo_root / "docs/design"
+    design_dir.mkdir(parents=True)
+    shutil.copyfile(
+        REPO_ROOT / "docs/design/ui_component_vocabulary.json",
+        design_dir / "ui_component_vocabulary.json",
+    )
+    return repo_root
+
+
+def valid_manifest(**overrides):
+    manifest = {
+        "a11y_artifact_path": "",
+        "accessibility_evidence": {"focus": "Visible focus evidence captured."},
+        "artifact_policy": "committed_sample_metadata",
+        "capture_mode": "sample",
+        "component_ids": ["button", "card"],
+        "copy_safety_evidence": {
+            "wellness_boundary": "Review evidence only; avoid diagnosis, treatment, therapy, crisis, medical, and guaranteed outcome claims."
+        },
+        "dom_artifact_path": "",
+        "evidence_id": "web-marketing-sample",
+        "generated_at_policy": "omitted",
+        "generated_by": "test fixture",
+        "ios_simulator_artifact_path": "",
+        "locale": "en-US",
+        "motion_evidence": {"reduced_motion": "Reduced-motion behavior reviewed."},
+        "overflow_evidence": {"horizontal": "No horizontal overflow evidence captured."},
+        "platform": "web",
+        "responsive_evidence": {"desktop": "Desktop viewport evidence captured."},
+        "route_or_screen": "/marketing",
+        "screenshot_artifact_path": "",
+        "source_of_truth_note": "Screen evidence is review evidence only, non-canonical, and not source of truth; repo tokens, UI vocabulary, backend/OpenAPI contracts, tests, and runtime code win.",
+        "status": "sample",
+        "storybook_artifact_path": "",
+        "surface_id": "web:/marketing",
+        "surface_name": "Marketing launch shell",
+        "tabbar_or_navigation_evidence": {"navigation": "Navigation evidence captured."},
+        "theme": "repo-default",
+        "token_mirror_paths_checked": [
+            "frontend/src/styles/tokens.css",
+            "frontend/src/styles/tokens.ts",
+        ],
+        "viewport": "desktop-1440x1100",
+        "warnings": ["sample metadata only"],
+    }
+    manifest.update(overrides)
+    return manifest
+
+
+def write_manifest(path: Path, manifest: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_valid_web_sample_manifest_passes():
+    module = load_evidence_module()
+
+    assert module.validate_record(valid_manifest(), repo_root=REPO_ROOT) == []
+
+
+def test_valid_ios_sample_manifest_passes():
+    module = load_evidence_module()
+    manifest = valid_manifest(
+        artifact_policy="committed_sample_metadata",
+        component_ids=["button", "card", "navigation_tab_bar"],
+        platform="ios",
+        route_or_screen="Home",
+        surface_id="ios:home",
+        token_mirror_paths_checked=[
+            "ios/PulsePlate/DesignSystem/DesignTokens.generated.swift",
+        ],
+        viewport="iPhone-template",
+    )
+
+    assert module.validate_record(manifest, repo_root=REPO_ROOT) == []
+
+
+def test_missing_required_field_fails():
+    module = load_evidence_module()
+    manifest = valid_manifest()
+    del manifest["surface_id"]
+
+    errors = module.validate_record(manifest, repo_root=REPO_ROOT)
+
+    assert "missing required field: surface_id" in errors
+
+
+def test_invalid_enum_values_fail():
+    module = load_evidence_module()
+    manifest = valid_manifest(platform="android", status="approved")
+
+    errors = module.validate_record(manifest, repo_root=REPO_ROOT)
+
+    assert "platform must be one of: ios, web" in errors
+    assert "status must be one of: captured, rejected, sample, validated" in errors
+
+
+def test_source_of_truth_wording_fails():
+    module = load_evidence_module()
+    manifest = valid_manifest(
+        source_of_truth_note="Screen evidence is the source of truth for runtime UI."
+    )
+
+    errors = module.validate_record(manifest, repo_root=REPO_ROOT)
+
+    assert "source_of_truth_note must state this is review evidence" in errors
+    assert "screen evidence must not become a source of truth" in errors
+
+
+def test_source_of_truth_but_overrides_wording_fails():
+    module = load_evidence_module()
+    manifest = valid_manifest(
+        source_of_truth_note=(
+            "Screen evidence is review evidence only and not source of truth, "
+            "but overrides repo runtime UI."
+        )
+    )
+
+    errors = module.validate_record(manifest, repo_root=REPO_ROOT)
+
+    assert "screen evidence must not become a source of truth" in errors
+
+
+def test_unknown_component_ids_fail():
+    module = load_evidence_module()
+    manifest = valid_manifest(component_ids=["button", "invented_component"])
+
+    errors = module.validate_record(manifest, repo_root=REPO_ROOT)
+
+    assert "unknown PulsePlate component id: invented_component" in errors
+
+
+def test_committed_binary_artifact_paths_fail():
+    module = load_evidence_module()
+    manifest = valid_manifest(
+        screenshot_artifact_path="artifacts/design/screen_evidence/run/screen.png"
+    )
+
+    errors = module.validate_record(manifest, repo_root=REPO_ROOT)
+
+    assert "screenshot_artifact_path must be empty for committed_sample_metadata" in errors
+    assert "screenshot_artifact_path must not reference committed binary artifacts" in errors
+
+
+def test_disallowed_paths_fail():
+    module = load_evidence_module()
+    manifest = valid_manifest(
+        artifact_policy="local_only",
+        screenshot_artifact_path="artifacts/design/screen_evidence/run/DerivedData/screen.txt",
+        dom_artifact_path="artifacts/design/screen_evidence/run/storybook-static/dom.json",
+        a11y_artifact_path="artifacts/design/screen_evidence/run/node_modules/a11y.json",
+        storybook_artifact_path="artifacts/design/screen_evidence/run/.venv/storybook.json",
+        ios_simulator_artifact_path="artifacts/design/screen_evidence/run/worktrees/ios.json",
+    )
+
+    errors = module.validate_record(manifest, repo_root=REPO_ROOT)
+
+    assert (
+        errors.count("screenshot_artifact_path contains a disallowed local artifact path segment")
+        == 1
+    )
+    assert errors.count("dom_artifact_path contains a disallowed local artifact path segment") == 1
+    assert errors.count("a11y_artifact_path contains a disallowed local artifact path segment") == 1
+    assert (
+        errors.count("storybook_artifact_path contains a disallowed local artifact path segment")
+        == 1
+    )
+    assert (
+        errors.count(
+            "ios_simulator_artifact_path contains a disallowed local artifact path segment"
+        )
+        == 1
+    )
+
+
+def test_copy_safety_medical_claim_fails():
+    module = load_evidence_module()
+    manifest = valid_manifest(
+        copy_safety_evidence={"claim": "This screen supports treatment and guaranteed outcomes."}
+    )
+
+    errors = module.validate_record(manifest, repo_root=REPO_ROOT)
+
+    assert any("copy_safety_evidence must not promote" in error for error in errors)
+
+
+def test_validated_status_requires_non_empty_evidence():
+    module = load_evidence_module()
+    manifest = valid_manifest(
+        accessibility_evidence={},
+        status="validated",
+        token_mirror_paths_checked=[],
+    )
+
+    errors = module.validate_record(manifest, repo_root=REPO_ROOT)
+
+    assert "status=validated requires non-empty accessibility_evidence" in errors
+    assert "status=validated requires token_mirror_paths_checked" in errors
+
+
+def test_ios_automated_capture_requires_ios_artifact_path():
+    module = load_evidence_module()
+    manifest = valid_manifest(platform="ios", capture_mode="automated", route_or_screen="Home")
+
+    errors = module.validate_record(manifest, repo_root=REPO_ROOT)
+
+    assert "platform=ios automated capture requires ios_simulator_artifact_path" in errors
+
+
+def test_validate_dir_validates_examples():
+    module = load_evidence_module()
+
+    results = module.validate_dir("docs/design/screen_evidence/examples", repo_root=REPO_ROOT)
+
+    assert results
+    assert all(errors == [] for errors in results.values())
+
+
+def test_summarize_output_is_deterministic(tmp_path, capsys):
+    module = load_evidence_module()
+    repo_root = make_temp_repo(tmp_path)
+    manifest_path = repo_root / "manifest.json"
+    write_manifest(manifest_path, valid_manifest(warnings=["z warning", "a warning"]))
+
+    first = module.run(["summarize", str(manifest_path)], repo_root=repo_root)
+    first_output = capsys.readouterr().out
+    second = module.run(["summarize", str(manifest_path)], repo_root=repo_root)
+    second_output = capsys.readouterr().out
+
+    assert first == 0
+    assert second == 0
+    assert first_output == second_output
+    assert json.loads(first_output)["warnings"] == ["a warning", "z warning"]
+
+
+def test_web_plan_output_is_deterministic(tmp_path):
+    module = load_evidence_module()
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+
+    first = module.web_plan(["/", "/marketing"], first_dir)
+    second = module.web_plan(["/", "/marketing"], second_dir)
+
+    first_manifests = sorted(path.read_text(encoding="utf-8") for path in first_dir.glob("*.json"))
+    second_manifests = sorted(
+        path.read_text(encoding="utf-8") for path in second_dir.glob("*.json")
+    )
+
+    assert first["routes"] == second["routes"] == ["/", "/marketing"]
+    assert len(first_manifests) == len(second_manifests) == 2
+    assert [json.loads(text)["evidence_id"] for text in first_manifests] == [
+        json.loads(text)["evidence_id"] for text in second_manifests
+    ]
+
+
+def test_web_plan_requires_no_network(monkeypatch, tmp_path):
+    module = load_evidence_module()
+
+    def fail_network(*_args, **_kwargs):  # pragma: no cover - defensive sentinel
+        raise AssertionError("network access is not allowed")
+
+    monkeypatch.setattr("socket.create_connection", fail_network)
+
+    summary = module.web_plan(["/marketing"], tmp_path / "plan")
+
+    assert summary["routes"] == ["/marketing"]


### PR DESCRIPTION
## Summary

Adds screen evidence pack validation and metadata tooling for PulsePlate web and iOS review surfaces.

This PR introduces the Design Evidence Harvester module inside the existing Design Intelligence / Design Runtime system. Evidence packs remain review artifacts only and do not become a source of truth.

## Goal

Let future design scoring and implementation PRs rely on deterministic screen evidence metadata without copying external designs, committing binary artifacts, or mutating runtime UI.

## Business reason

PulsePlate needs design automation that compares actual implemented surfaces against repo contracts. Before scoring or implementation changes, the project needs a safe evidence format for web/iOS review surfaces.

## Scope

- Add deterministic screen evidence pack validation CLI.
- Add sample metadata manifests for web and iOS.
- Add tests for evidence status/path/component/copy-safety rules.
- Add narrow docs/backlog update.

## Split Justification

This PR intentionally exceeds 800 changed lines because PR-3 introduces one new deterministic metadata contract as a coherent unit: the CLI validator, focused tests, schema documentation, synthetic examples, backlog status, and fixed-mapping artifact must land together for the screen evidence pack to be usable and reviewable.

The scope is still bounded to design tooling/docs/tests only, with no runtime frontend, iOS, backend, token mirror, Figma, Canva, screenshot, trace, or scorecard changes. Splitting the schema from the validator/tests would create a temporary non-executable contract and weaken the fail-closed review gate.

## Out of scope

- No web redesign.
- No iOS redesign.
- No Figma writes.
- No Canva writes.
- No external crawler.
- No external asset import.
- No committed screenshots/videos/traces.
- No PR-4 scorecard logic.
- No score thresholds.
- No Storybook config changes.
- No `/tokens` changes.
- No generated token mirror edits.
- No frontend/iOS/backend/OpenAPI/billing/auth changes.

## Source of truth

Repo code/docs/tests, `/tokens`, generated mirrors, UI vocabulary, backend/OpenAPI contracts, and runtime code remain canonical.

Screen evidence packs, external references, Figma, Canva, Storybook, prompt outputs, and DESIGN.md are evidence/reference layers only and do not override repo truth.

## Design automation module classification

Design automation items are modules inside the existing PulsePlate Design Intelligence / Design Runtime system, not standalone plugins.

This PR implements only the Design Evidence Harvester / screen evidence pack module for PR-3.

Other modules remain deferred:
- Component Drift Inspector -> PR-4
- Icon Asset Validator -> release/design asset guard lane
- Launch Copy Compliance Linter -> release/compliance/marketing guard
- Marketing Asset Pack Compiler -> late GTM layer after accepted design/copy truth

## Files changed

- `scripts/design/screen_evidence_pack.py`
- `tests/design/test_screen_evidence_pack.py`
- `docs/design/SCREEN_EVIDENCE_PACK_SCHEMA.md`
- `docs/design/screen_evidence/examples/README.md`
- `docs/design/screen_evidence/examples/web_marketing.sample.json`
- `docs/design/screen_evidence/examples/ios_home.sample.json`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/review/PR_1683_FIXED_MAPPING.md`

## Tests / bounded checks

Do not list full `make verify`.

Commands run:
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/design/screen_evidence_pack.py validate-dir docs/design/screen_evidence/examples`
- `python3 scripts/design/screen_evidence_pack.py summarize docs/design/screen_evidence/examples/web_marketing.sample.json`
- `python3 scripts/design/screen_evidence_pack.py web-plan --routes / /marketing --out /tmp/pulseplate-screen-evidence-plan`
- `. .venv/bin/activate && python -m pytest -q tests/design/test_screen_evidence_pack.py`
- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed`
- `make design-guard`
- `make tokens-check` with root frontend `node_modules` temporarily symlinked and removed after the gate; no token mirror diff remained
- `PATH=.venv/bin:$PATH pre-commit run --all-files`

## Security notes

No secrets, auth, billing, backend, deploy, external integration, crawler, or network access added.

Evidence artifacts are local-only. Committed examples are metadata-only and do not include binary screenshots, videos, traces, or external assets.

## Premortem

Premortem reviewed actual code/docs/tests diff.

- Risk: evidence packs could become a second design source of truth.
  - Finding: validator requires review-evidence and non-canonical wording; a `not source of truth, but overrides repo` wording gap was found during premortem.
  - Fix/decision: fixed in `4e3b34ce4` and covered by `test_source_of_truth_but_overrides_wording_fails` in `cc4a4a8b9`.
  - Evidence: `scripts/design/screen_evidence_pack.py`, `tests/design/test_screen_evidence_pack.py`.
- Risk: committed examples could smuggle binary artifacts or unsafe local paths.
  - Finding: examples use empty artifact paths with `committed_sample_metadata`; validator rejects committed sample artifact paths and disallowed path segments.
  - Fix/decision: enforce fail-closed artifact path rules.
  - Evidence: `docs/design/screen_evidence/examples/*.json`, `tests/design/test_screen_evidence_pack.py`.
- Risk: PR-3 could drift into PR-4 scoring.
  - Finding: no scoring thresholds or scorecard engine added.
  - Fix/decision: schema and PR body defer scoring to PR-4.
  - Evidence: `docs/design/SCREEN_EVIDENCE_PACK_SCHEMA.md`.

## Bug-hunter pass

Checked:
- no second SoT wording permitted
- no committed binary artifact paths
- validation fail-closed checks for required fields, enums, unknown components, unsafe paths, wellness copy claims, validated-status evidence requirements, and iOS automated capture claims
- no token mirror diff
- no runtime frontend/iOS/backend diff
- no plugin architecture introduced
- no scorecard/PR-4 logic introduced

## Deferred / Follow-ups

- PR-4: deterministic design scorecard checks.
- PR-5: web launch shell alignment to accepted design brief.
- PR-6: iOS visual parity audit and bounded sync.
- PR-7: design-agent workflow and PR template.
- PR-8: GEPA-compatible prompt/rubric evolution lane.
- Browser/Playwright `web-capture` remains deferred; PR-3 implements deterministic metadata planning only.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1683_FIXED_MAPPING.md`

## Merge Readiness

Do not mark until CI/review/mapping/wait-window/strict wrapper pass.

## Rollback

Revert this tooling/docs PR. No runtime rollback required.

## DoD

- Screen evidence pack CLI exists.
- Example evidence manifests validate.
- Invalid path/source-of-truth/component/copy-safety states fail closed.
- Tests cover validation rules.
- No committed binary artifacts.
- No runtime code changes.
- No generated token mirror diff.
- Bounded checks pass.
