### PR TITLE
fix(design): validate component evidence paths to prevent repo-escape

### DIFF
--- a/docs/review/PR_1685_FIXED_MAPPING.md
+++ b/docs/review/PR_1685_FIXED_MAPPING.md
@@ -9,6 +9,9 @@ mapping artifact.
 
 ## Discussion Thread Pass
 
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
 - Sourcery overall review:
   https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#pullrequestreview-4236488355
 - Codex inline review thread:
@@ -21,8 +24,19 @@ mapping artifact.
 ## Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#pullrequestreview-4236488355 -> 1ff2f40e7837fa26e29e4f2a4b165b1afa26a71e
+Disposition: FIXED
+Commit: 1ff2f40e7837fa26e29e4f2a4b165b1afa26a71e
+Evidence: `scripts/design/generate_design_md.py:108` resolves `repo_root` once per evidence lookup; `scripts/design/generate_design_md.py:111` returns `invalid-declared-path` before fallback; `scripts/design/generate_design_md.py:100` uses `Path.is_relative_to` without the redundant equality check.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#discussion_r3195828290 -> 1ff2f40e7837fa26e29e4f2a4b165b1afa26a71e
+Disposition: FIXED
+Commit: 1ff2f40e7837fa26e29e4f2a4b165b1afa26a71e
+Evidence: `scripts/design/generate_design_md.py:111` short-circuits invalid declared evidence paths before `RUNTIME_COMPONENT_FALLBACKS`; `tests/design/test_generate_design_md.py:101` proves a `select` fallback path is not rendered when the declared path is invalid.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#pullrequestreview-4236507785 -> d72d352ebdf8e012e6cdda0f0aea7ecf7f1c31ce
+Disposition: FIXED
+Commit: d72d352ebdf8e012e6cdda0f0aea7ecf7f1c31ce
+Evidence: `tests/design/test_generate_design_md.py:145` rejects `docs/design/not_a_component.tsx` as `invalid-declared-path` and renders `none`.
 
 ## Review Dispositions
 

--- a/docs/review/PR_1685_FIXED_MAPPING.md
+++ b/docs/review/PR_1685_FIXED_MAPPING.md
@@ -1,0 +1,120 @@
+# PR 1685 Fixed Mapping
+
+## Summary
+
+PR #1685 hardens `scripts/design/generate_design_md.py` so invalid declared
+component evidence paths fail closed before runtime fallback. The PR remains
+narrowly scoped to the DESIGN.md generator, focused tests, and this review
+mapping artifact.
+
+## Discussion Thread Pass
+
+- Sourcery overall review:
+  https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#pullrequestreview-4236488355
+- Codex inline review thread:
+  https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#discussion_r3195828290
+- CodeRabbit nitpick review:
+  https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#pullrequestreview-4236507785
+- Cubic review:
+  https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#pullrequestreview-4236514753
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#pullrequestreview-4236488355 -> 1ff2f40e7837fa26e29e4f2a4b165b1afa26a71e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#discussion_r3195828290 -> 1ff2f40e7837fa26e29e4f2a4b165b1afa26a71e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#pullrequestreview-4236507785 -> d72d352ebdf8e012e6cdda0f0aea7ecf7f1c31ce
+
+## Review Dispositions
+
+- Disposition: FIXED
+  Source: Sourcery overall review.
+  Commit: 1ff2f40e7837fa26e29e4f2a4b165b1afa26a71e
+  Evidence: `scripts/design/generate_design_md.py:108` resolves `repo_root`
+  once per evidence lookup, `scripts/design/generate_design_md.py:111` returns
+  `invalid-declared-path` before fallback when the declared path is invalid, and
+  `scripts/design/generate_design_md.py:100` relies on `Path.is_relative_to`
+  without the redundant equality check.
+
+- Disposition: FIXED
+  Source: Codex inline review thread on invalid declared paths being masked by
+  runtime fallback.
+  Commit: 1ff2f40e7837fa26e29e4f2a4b165b1afa26a71e
+  Evidence: `scripts/design/generate_design_md.py:111` short-circuits invalid
+  declared evidence paths before `RUNTIME_COMPONENT_FALLBACKS`, and
+  `tests/design/test_generate_design_md.py:101` proves a `select` fallback path
+  is not rendered when the declared path is invalid.
+
+- Disposition: FIXED
+  Source: CodeRabbit nitpick requesting inside-repo but outside allowed-prefix
+  coverage.
+  Commit: d72d352ebdf8e012e6cdda0f0aea7ecf7f1c31ce
+  Evidence: `tests/design/test_generate_design_md.py:145` rejects
+  `docs/design/not_a_component.tsx` as `invalid-declared-path` and renders
+  `none`.
+
+- Disposition: NOT-A-BUG
+  Source: Cubic review.
+  Evidence: Cubic found no issues across the two changed files. No code change
+  or follow-up was required from that review.
+
+## Tests / Bounded Checks
+
+- `python3 scripts/orchestration/check_preflight.py` -> PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS.
+- `python3 scripts/design/generate_design_md.py --check` -> PASS.
+- `python3 -m py_compile scripts/design/generate_design_md.py tests/design/test_generate_design_md.py` -> PASS.
+- `python3 -m pytest -q tests/design/test_generate_design_md.py` -> BLOCKED in system Python by missing `fastapi` import from root `conftest.py`.
+- `.venv/bin/python -m pytest -q tests/design/test_generate_design_md.py` -> PASS, 14 tests.
+- `make validate-changed` -> PASS, selected `tests/design/test_generate_design_md.py`, 14 tests.
+- `make design-guard` -> PASS.
+- `make tokens-check` -> PASS.
+- Token mirror diff check for `frontend/src/styles/tokens.css`,
+  `frontend/src/styles/tokens.ts`, and
+  `ios/PulsePlate/DesignSystem/DesignTokens.generated.swift` -> no diff.
+
+Full local `make verify` was intentionally not run per operator instruction.
+
+## Premortem
+
+It is 48 hours from now and this security hardening made the design governance
+lane worse. The most likely failure would be mapping the review without changing
+the fail-closed order, leaving invalid declared paths masked by runtime fallback.
+The fix changes the decision order before mapping and adds tests for fallback
+masking, absolute paths, traversal paths, and in-repo non-frontend paths.
+
+Checks:
+
+- Absolute paths cannot leak into generated DESIGN.md evidence rows.
+- `..` traversal paths cannot leak into generated DESIGN.md evidence rows.
+- Invalid declarations cannot be masked by runtime fallback.
+- Paths outside repo root are rejected.
+- Paths inside repo but outside allowed frontend prefixes are rejected.
+- Generated token mirrors were not modified.
+- Scope stayed limited to generator/tests plus this review artifact.
+- Mapping was created after code and test fixes existed.
+
+Decision: proceed with bounded governance checks and current-head CI/review
+loop; do not claim merge readiness from local bounded checks alone.
+
+## Bug-hunter pass
+
+- Before mapping, PR diff was limited to
+  `scripts/design/generate_design_md.py` and
+  `tests/design/test_generate_design_md.py`.
+- After mapping, only `docs/review/PR_1685_FIXED_MAPPING.md` is added.
+- No frontend runtime, iOS runtime, backend, OpenAPI, generated token mirror,
+  Figma, or Canva files were changed.
+- Invalid declared paths fail closed before runtime fallback.
+- Focused tests cover the exploit class and CodeRabbit's allowed-prefix gap.
+- PR body must not claim full local `make verify`.
+
+## Merge Readiness
+
+Not claimed by this artifact alone. Merge readiness still requires:
+
+- current-head PR checks complete with required checks passing,
+- no actionable bot comments,
+- no unresolved actionable review threads,
+- PR body mirror aligned with this artifact,
+- mandatory wait-window satisfied,
+- strict `check_merge_ready.py --require-auth` wrapper passing.

--- a/scripts/design/generate_design_md.py
+++ b/scripts/design/generate_design_md.py
@@ -44,6 +44,13 @@ AUTOMATION_MODULES = [
     ),
 ]
 
+ALLOWED_COMPONENT_EVIDENCE_PREFIXES = (
+    Path("frontend/src/components"),
+    Path("frontend/src/features"),
+    Path("frontend/src/pages"),
+)
+
+
 RUNTIME_COMPONENT_FALLBACKS = {
     "alert": "frontend/src/components/ui/Alert.tsx",
     "checkbox": "frontend/src/components/ui/Checkbox.tsx",
@@ -78,10 +85,34 @@ def _load_components(repo_root: Path) -> list[dict[str, object]]:
     return sorted(components, key=lambda item: str(item["id"]))
 
 
+def _is_valid_component_evidence_path(declared_component: str, repo_root: Path) -> bool:
+    declared_path = Path(declared_component)
+    if declared_path.is_absolute() or ".." in declared_path.parts:
+        return False
+
+    candidate = (repo_root / declared_path).resolve(strict=False)
+    resolved_repo_root = repo_root.resolve(strict=False)
+    try:
+        repo_relative_candidate = candidate.relative_to(resolved_repo_root)
+    except ValueError:
+        return False
+
+    return any(
+        repo_relative_candidate == allowed_prefix
+        or repo_relative_candidate.is_relative_to(allowed_prefix)
+        for allowed_prefix in ALLOWED_COMPONENT_EVIDENCE_PREFIXES
+    )
+
+
 def _component_repo_evidence(item: dict[str, object], repo_root: Path) -> tuple[str, str]:
     declared_component = item.get("existing_repo_component")
     declared_status = str(item.get("missing_status", "unknown"))
-    if isinstance(declared_component, str) and declared_component:
+    valid_declared_component = (
+        isinstance(declared_component, str)
+        and bool(declared_component)
+        and _is_valid_component_evidence_path(declared_component, repo_root)
+    )
+    if valid_declared_component:
         if (repo_root / declared_component).exists():
             return declared_status, declared_component
 
@@ -89,8 +120,11 @@ def _component_repo_evidence(item: dict[str, object], repo_root: Path) -> tuple[
     if fallback_path and (repo_root / fallback_path).exists():
         return "existing-runtime-detected", fallback_path
 
-    if isinstance(declared_component, str) and declared_component:
+    if valid_declared_component:
         return "declared-path-missing", declared_component
+
+    if isinstance(declared_component, str) and declared_component:
+        return "invalid-declared-path", "none"
 
     return declared_status, "none"
 

--- a/scripts/design/generate_design_md.py
+++ b/scripts/design/generate_design_md.py
@@ -91,15 +91,13 @@ def _is_valid_component_evidence_path(declared_component: str, repo_root: Path) 
         return False
 
     candidate = (repo_root / declared_path).resolve(strict=False)
-    resolved_repo_root = repo_root.resolve(strict=False)
     try:
-        repo_relative_candidate = candidate.relative_to(resolved_repo_root)
+        repo_relative_candidate = candidate.relative_to(repo_root)
     except ValueError:
         return False
 
     return any(
-        repo_relative_candidate == allowed_prefix
-        or repo_relative_candidate.is_relative_to(allowed_prefix)
+        repo_relative_candidate.is_relative_to(allowed_prefix)
         for allowed_prefix in ALLOWED_COMPONENT_EVIDENCE_PREFIXES
     )
 
@@ -107,24 +105,22 @@ def _is_valid_component_evidence_path(declared_component: str, repo_root: Path) 
 def _component_repo_evidence(item: dict[str, object], repo_root: Path) -> tuple[str, str]:
     declared_component = item.get("existing_repo_component")
     declared_status = str(item.get("missing_status", "unknown"))
-    valid_declared_component = (
-        isinstance(declared_component, str)
-        and bool(declared_component)
-        and _is_valid_component_evidence_path(declared_component, repo_root)
+    resolved_repo_root = repo_root.resolve(strict=False)
+    declared_component_path = (
+        declared_component if isinstance(declared_component, str) and declared_component else None
     )
-    if valid_declared_component:
-        if (repo_root / declared_component).exists():
-            return declared_status, declared_component
+    if declared_component_path:
+        if not _is_valid_component_evidence_path(declared_component_path, resolved_repo_root):
+            return "invalid-declared-path", "none"
+        if (repo_root / declared_component_path).exists():
+            return declared_status, declared_component_path
 
     fallback_path = RUNTIME_COMPONENT_FALLBACKS.get(str(item["id"]))
     if fallback_path and (repo_root / fallback_path).exists():
         return "existing-runtime-detected", fallback_path
 
-    if valid_declared_component:
-        return "declared-path-missing", declared_component
-
-    if isinstance(declared_component, str) and declared_component:
-        return "invalid-declared-path", "none"
+    if declared_component_path:
+        return "declared-path-missing", declared_component_path
 
     return declared_status, "none"
 

--- a/tests/design/test_generate_design_md.py
+++ b/tests/design/test_generate_design_md.py
@@ -103,10 +103,13 @@ def test_declared_absolute_component_path_is_rejected(tmp_path):
     repo_root = make_temp_repo(tmp_path)
     external_component = tmp_path / "external_component.tsx"
     external_component.write_text("export function External() {}\n", encoding="utf-8")
+    fallback_path = repo_root / "frontend/src/components/ui/Select.tsx"
+    fallback_path.parent.mkdir(parents=True)
+    fallback_path.write_text("export function Select() {}\n", encoding="utf-8")
     vocabulary_path = repo_root / "docs/design/ui_component_vocabulary.json"
     vocabulary = json.loads(vocabulary_path.read_text(encoding="utf-8"))
     for item in vocabulary:
-        if item["id"] == "button":
+        if item["id"] == "select":
             item["existing_repo_component"] = str(external_component)
             item["missing_status"] = "existing"
             break
@@ -115,7 +118,8 @@ def test_declared_absolute_component_path_is_rejected(tmp_path):
     output = module.render_design_md(repo_root)
 
     assert str(external_component) not in output
-    assert "| button | button | invalid-declared-path | `none` |" in output
+    assert "frontend/src/components/ui/Select.tsx" not in output
+    assert "| select | select | invalid-declared-path | `none` |" in output
 
 
 def test_declared_traversal_component_path_is_rejected(tmp_path):
@@ -135,6 +139,26 @@ def test_declared_traversal_component_path_is_rejected(tmp_path):
     output = module.render_design_md(repo_root)
 
     assert "../outside_component.tsx" not in output
+    assert "| button | button | invalid-declared-path | `none` |" in output
+
+
+def test_declared_in_repo_non_frontend_component_path_is_rejected(tmp_path):
+    module = load_generator_module()
+    repo_root = make_temp_repo(tmp_path)
+    disallowed_component = repo_root / "docs/design/not_a_component.tsx"
+    disallowed_component.write_text("export const x = 1;\n", encoding="utf-8")
+    vocabulary_path = repo_root / "docs/design/ui_component_vocabulary.json"
+    vocabulary = json.loads(vocabulary_path.read_text(encoding="utf-8"))
+    for item in vocabulary:
+        if item["id"] == "button":
+            item["existing_repo_component"] = "docs/design/not_a_component.tsx"
+            item["missing_status"] = "existing"
+            break
+    vocabulary_path.write_text(json.dumps(vocabulary), encoding="utf-8")
+
+    output = module.render_design_md(repo_root)
+
+    assert "docs/design/not_a_component.tsx" not in output
     assert "| button | button | invalid-declared-path | `none` |" in output
 
 

--- a/tests/design/test_generate_design_md.py
+++ b/tests/design/test_generate_design_md.py
@@ -98,6 +98,46 @@ def test_stale_declared_component_path_uses_runtime_fallback(tmp_path):
     ) in output
 
 
+def test_declared_absolute_component_path_is_rejected(tmp_path):
+    module = load_generator_module()
+    repo_root = make_temp_repo(tmp_path)
+    external_component = tmp_path / "external_component.tsx"
+    external_component.write_text("export function External() {}\n", encoding="utf-8")
+    vocabulary_path = repo_root / "docs/design/ui_component_vocabulary.json"
+    vocabulary = json.loads(vocabulary_path.read_text(encoding="utf-8"))
+    for item in vocabulary:
+        if item["id"] == "button":
+            item["existing_repo_component"] = str(external_component)
+            item["missing_status"] = "existing"
+            break
+    vocabulary_path.write_text(json.dumps(vocabulary), encoding="utf-8")
+
+    output = module.render_design_md(repo_root)
+
+    assert str(external_component) not in output
+    assert "| button | button | invalid-declared-path | `none` |" in output
+
+
+def test_declared_traversal_component_path_is_rejected(tmp_path):
+    module = load_generator_module()
+    repo_root = make_temp_repo(tmp_path)
+    external_component = tmp_path / "outside_component.tsx"
+    external_component.write_text("export function Outside() {}\n", encoding="utf-8")
+    vocabulary_path = repo_root / "docs/design/ui_component_vocabulary.json"
+    vocabulary = json.loads(vocabulary_path.read_text(encoding="utf-8"))
+    for item in vocabulary:
+        if item["id"] == "button":
+            item["existing_repo_component"] = "../outside_component.tsx"
+            item["missing_status"] = "existing"
+            break
+    vocabulary_path.write_text(json.dumps(vocabulary), encoding="utf-8")
+
+    output = module.render_design_md(repo_root)
+
+    assert "../outside_component.tsx" not in output
+    assert "| button | button | invalid-declared-path | `none` |" in output
+
+
 def test_generated_design_md_classifies_automation_as_internal_modules():
     module = load_generator_module()
 


### PR DESCRIPTION
## Summary
Harden DESIGN.md component evidence generation so invalid declared component paths cannot be documented as repo evidence and cannot be masked by runtime fallbacks.

## Goal
Prevent repo-escape and non-frontend component evidence paths from being surfaced in generated DESIGN.md component rows.

## Scope
- Validate declared `existing_repo_component` paths in `scripts/design/generate_design_md.py`.
- Short-circuit invalid declared paths to `invalid-declared-path` with repo evidence `none`.
- Preserve runtime fallback only for entries without invalid declared evidence.
- Add focused tests for absolute paths, parent traversal, runtime fallback masking, and in-repo paths outside allowed frontend prefixes.
- Add canonical review mapping: `docs/review/PR_1685_FIXED_MAPPING.md`.

## Out of scope
- No DESIGN.md generator redesign.
- No reference manifest tooling, screen evidence pack work, scorecard work, or next design epic PR.
- No web/iOS runtime changes, backend/OpenAPI changes, `/tokens` changes, generated token mirror edits, Figma writes, or Canva writes.

## Source of truth
Repo code/docs/tests, `/tokens`, generated token mirrors, UI vocabulary, backend/OpenAPI contracts, and runtime code remain canonical. DESIGN.md, Figma, Canva, Storybook, external references, prompt outputs, reference manifests, and screen evidence packs remain evidence/reference layers only.

## Files changed
- `scripts/design/generate_design_md.py`
- `tests/design/test_generate_design_md.py`
- `docs/review/PR_1685_FIXED_MAPPING.md`

## Tests / bounded checks
Local bounded checks run for this review cycle:
- `python3 scripts/orchestration/check_preflight.py` -> PASS
- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS
- `python3 scripts/design/generate_design_md.py --check` -> PASS
- `python3 -m py_compile scripts/design/generate_design_md.py tests/design/test_generate_design_md.py` -> PASS
- `python3 -m pytest -q tests/design/test_generate_design_md.py` -> BLOCKED in system Python by missing `fastapi` from root `conftest.py`
- `.venv/bin/python -m pytest -q tests/design/test_generate_design_md.py` -> PASS, 14 tests
- `make validate-changed` -> PASS, selected `tests/design/test_generate_design_md.py`, 14 tests
- `make design-guard` -> PASS
- `make tokens-check` -> PASS
- Token mirror diff check for `frontend/src/styles/tokens.css`, `frontend/src/styles/tokens.ts`, and `ios/PulsePlate/DesignSystem/DesignTokens.generated.swift` -> no diff

Full local `make verify` was not run per operator instruction. Merge readiness must come from current-head CI, review governance, and the strict merge wrapper.

## Security notes
Invalid declared component evidence now fails closed before runtime fallback. Absolute paths, `..` traversal paths, resolved paths outside repo root, and in-repo paths outside allowed frontend prefixes are rejected and render `none` instead of external or misleading repo evidence.

## Premortem
Most likely failure was mapping review feedback without changing the fail-closed order, leaving invalid declarations masked by fallback. The implementation now returns `invalid-declared-path` before fallback and adds regression coverage for fallback masking, absolute paths, traversal paths, and non-frontend in-repo paths.

## Bug-hunter pass
- Before mapping, PR diff was limited to `scripts/design/generate_design_md.py` and `tests/design/test_generate_design_md.py`.
- After mapping, only `docs/review/PR_1685_FIXED_MAPPING.md` was added.
- No frontend runtime, iOS runtime, backend, OpenAPI, Figma, Canva, or generated token mirror files were changed.
- Tests cover the exploit class and CodeRabbit's allowed-prefix gap.
- This PR body does not claim full local `make verify`.

## Deferred / Follow-ups
None for this PR.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- Sourcery overall review: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#pullrequestreview-4236488355
- Codex inline review thread: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#discussion_r3195828290
- CodeRabbit nitpick review: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#pullrequestreview-4236507785
- Cubic review: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#pullrequestreview-4236514753

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#pullrequestreview-4236488355 -> 1ff2f40e7837fa26e29e4f2a4b165b1afa26a71e
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#discussion_r3195828290 -> 1ff2f40e7837fa26e29e4f2a4b165b1afa26a71e
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1685#pullrequestreview-4236507785 -> d72d352ebdf8e012e6cdda0f0aea7ecf7f1c31ce

## Merge Readiness
Not claimed from local bounded checks alone. Merge readiness requires current-head PR checks complete, no actionable bot comments, no unresolved actionable review threads, this PR body aligned with `docs/review/PR_1685_FIXED_MAPPING.md`, mandatory wait-window satisfied, and strict `check_merge_ready.py --require-auth` passing.

## Rollback
Revert this PR. It only changes design governance generation/tests/review mapping and does not mutate runtime state, token authoring, generated token mirrors, backend/OpenAPI, iOS runtime, frontend runtime, Figma, or Canva.

## DoD
- Invalid declared component evidence paths fail closed and render `none`.
- Runtime fallback cannot mask invalid declarations.
- Valid frontend evidence and no-declared-path runtime fallback behavior remain covered.
- Bounded local checks and current-head CI/review governance are recorded before merge.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced design MD generator with strict validation for component evidence paths, rejecting invalid or unsafe paths.

* **Tests**
  * Added comprehensive tests validating rejection of invalid component paths.

* **Documentation**
  * Added detailed documentation for design MD generation hardening changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->