### PR TITLE
feat(design): add deterministic design scorecard checks

### DIFF
--- a/docs/design/DESIGN_SCORECARD_CHECKS.md
+++ b/docs/design/DESIGN_SCORECARD_CHECKS.md
@@ -1,0 +1,101 @@
+<!-- markdownlint-disable MD013 -->
+# Design Scorecard Checks
+
+**Status:** Design Intelligence PR-4 contract
+**Purpose:** Define deterministic scorecard checks over PulsePlate screen evidence pack metadata.
+
+## Summary
+
+Design scorecards are review evidence only. They do not become PulsePlate source of truth, product truth, design truth, Figma truth, Storybook truth, App Store truth, or implementation authority.
+
+The repo source of truth remains code, docs, tests, `/tokens`, generated token mirrors, UI vocabulary, backend/OpenAPI contracts, and runtime implementation.
+
+## Hard Rule
+
+Scorecards do not judge subjective visual taste. They do not score whether a screen is beautiful, premium, luxurious, modern, market-ready, visually ready, or persuasive.
+
+Scorecards only summarize deterministic metadata quality from PR-3 screen evidence manifests:
+
+- source-of-truth compliance
+- artifact hygiene
+- component vocabulary integrity
+- token evidence
+- accessibility evidence presence
+- responsive evidence presence
+- copy safety
+- navigation evidence presence
+- overflow evidence presence
+- motion evidence presence
+- platform metadata
+
+## CLI
+
+```bash
+python3 scripts/design/design_scorecard.py score <screen-evidence.json>
+python3 scripts/design/design_scorecard.py score-dir <dir>
+python3 scripts/design/design_scorecard.py validate-score <scorecard.json>
+python3 scripts/design/design_scorecard.py summarize <scorecard.json>
+```
+
+`score` validates the input screen evidence manifest with `scripts/design/screen_evidence_pack.py` before scoring. Invalid evidence fails closed and does not emit a scorecard.
+
+`score-dir` scores all JSON evidence manifests in deterministic path order.
+
+`validate-score` checks generated scorecard shape, deterministic ids, dimensions, score bounds, sorted lists, and forbidden subjective score fields.
+
+`summarize` emits compact deterministic JSON for one valid scorecard.
+
+## Output Contract
+
+Generated scorecards include:
+
+- `scorecard_id`
+- `source_evidence_id`
+- `platform`
+- `surface_id`
+- `route_or_screen`
+- `status`
+- `total_score`
+- `max_score`
+- `normalized_score`
+- `dimensions`
+- `blocking_failures`
+- `warnings`
+- `recommendation`
+- `source_of_truth_note`
+- `generated_by`
+
+No timestamps, random ids, screenshots, browser traces, image analysis results, Figma data, Canva data, Storybook build output, or implementation instructions are included.
+
+## Thresholds
+
+- Invalid evidence manifest: command exits non-zero before scorecard output.
+- Blocking failures: `status=fail`.
+- `normalized_score >= 0.85` with no blocking failures: `status=pass`.
+- `normalized_score >= 0.60` with no blocking failures: `status=warn`.
+- Below `0.60`: `status=fail`.
+
+Recommendations:
+
+- `usable_for_pr5_pr6_brief` means metadata evidence quality is sufficient for a future brief.
+- `needs_evidence` means more evidence metadata is required before future implementation work.
+- `rejected` means the evidence or scorecard cannot inform future implementation.
+
+## Blocking Failures
+
+The scorecard layer relies on PR-3 validation for fail-closed checks such as:
+
+- source-of-truth violations
+- unknown component ids
+- unsafe artifact paths
+- committed binary artifact references
+- copy-safety violations
+- invalid enum values or required fields
+
+The scorecard also treats `status=rejected` evidence as a blocking failure.
+
+## Deferred
+
+PR-4 does not implement visual/pixel scoring, browser capture, Storybook parity, web implementation, iOS parity, App Store screenshot validation, Figma writes, Canva writes, GEPA, or external crawler work.
+
+PR-5 and PR-6 may consume accepted scorecards as review evidence, but scorecards remain non-canonical and cannot override repo truth.

--- a/docs/design/design_scorecard/examples/README.md
+++ b/docs/design/design_scorecard/examples/README.md
@@ -1,0 +1,12 @@
+# Design Scorecard Examples
+
+These files are deterministic sample metadata generated from committed PR-3 screen evidence examples.
+
+They are review evidence only. They do not contain screenshots, videos, traces, Figma data, Canva data, external assets, subjective visual scoring, or implementation instructions.
+
+Regenerate or compare manually with:
+
+```bash
+python3 scripts/design/design_scorecard.py score docs/design/screen_evidence/examples/web_marketing.sample.json
+python3 scripts/design/design_scorecard.py score docs/design/screen_evidence/examples/ios_home.sample.json
+```

--- a/docs/design/design_scorecard/examples/ios_home.scorecard.sample.json
+++ b/docs/design/design_scorecard/examples/ios_home.scorecard.sample.json
@@ -1,0 +1,95 @@
+{
+  "blocking_failures": [],
+  "dimensions": [
+    {
+      "id": "source_truth_compliance",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Evidence source-of-truth note passed PR-3 validation."
+    },
+    {
+      "id": "artifact_hygiene",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Artifact path policy passed PR-3 validation."
+    },
+    {
+      "id": "component_vocabulary_integrity",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Mapped component ids passed PR-3 vocabulary validation."
+    },
+    {
+      "id": "token_evidence",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Platform token mirror evidence is present."
+    },
+    {
+      "id": "accessibility_evidence",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Accessibility evidence metadata is present; this does not claim WCAG pass."
+    },
+    {
+      "id": "responsive_evidence",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Responsive evidence metadata is present."
+    },
+    {
+      "id": "copy_safety",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Copy-safety evidence passed PR-3 wellness validation."
+    },
+    {
+      "id": "navigation_evidence",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Navigation or tabbar evidence metadata is present."
+    },
+    {
+      "id": "overflow_evidence",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Overflow evidence metadata is present."
+    },
+    {
+      "id": "motion_evidence",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Motion or reduced-motion evidence metadata is present."
+    },
+    {
+      "id": "platform_metadata",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "iOS screen and device metadata are present."
+    }
+  ],
+  "generated_by": "scripts/design/design_scorecard.py",
+  "max_score": 110,
+  "normalized_score": 1.0,
+  "platform": "ios",
+  "recommendation": "usable_for_pr5_pr6_brief",
+  "route_or_screen": "Home",
+  "scorecard_id": "design-scorecard::ios-home-sample",
+  "source_evidence_id": "ios-home-sample",
+  "source_of_truth_note": "Design scorecards are deterministic review evidence only, non-canonical, and not source of truth; repo tokens, UI vocabulary, backend/OpenAPI contracts, tests, and runtime code win.",
+  "status": "pass",
+  "surface_id": "ios:home",
+  "total_score": 110,
+  "warnings": []
+}

--- a/docs/design/design_scorecard/examples/web_marketing.scorecard.sample.json
+++ b/docs/design/design_scorecard/examples/web_marketing.scorecard.sample.json
@@ -1,0 +1,95 @@
+{
+  "blocking_failures": [],
+  "dimensions": [
+    {
+      "id": "source_truth_compliance",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Evidence source-of-truth note passed PR-3 validation."
+    },
+    {
+      "id": "artifact_hygiene",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Artifact path policy passed PR-3 validation."
+    },
+    {
+      "id": "component_vocabulary_integrity",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Mapped component ids passed PR-3 vocabulary validation."
+    },
+    {
+      "id": "token_evidence",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Platform token mirror evidence is present."
+    },
+    {
+      "id": "accessibility_evidence",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Accessibility evidence metadata is present; this does not claim WCAG pass."
+    },
+    {
+      "id": "responsive_evidence",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Responsive evidence metadata is present."
+    },
+    {
+      "id": "copy_safety",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Copy-safety evidence passed PR-3 wellness validation."
+    },
+    {
+      "id": "navigation_evidence",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Navigation or tabbar evidence metadata is present."
+    },
+    {
+      "id": "overflow_evidence",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Overflow evidence metadata is present."
+    },
+    {
+      "id": "motion_evidence",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Motion or reduced-motion evidence metadata is present."
+    },
+    {
+      "id": "platform_metadata",
+      "max_score": 10,
+      "score": 10,
+      "status": "pass",
+      "summary": "Web route and viewport metadata are present."
+    }
+  ],
+  "generated_by": "scripts/design/design_scorecard.py",
+  "max_score": 110,
+  "normalized_score": 1.0,
+  "platform": "web",
+  "recommendation": "usable_for_pr5_pr6_brief",
+  "route_or_screen": "/marketing",
+  "scorecard_id": "design-scorecard::web-marketing-sample",
+  "source_evidence_id": "web-marketing-sample",
+  "source_of_truth_note": "Design scorecards are deterministic review evidence only, non-canonical, and not source of truth; repo tokens, UI vocabulary, backend/OpenAPI contracts, tests, and runtime code win.",
+  "status": "pass",
+  "surface_id": "web:/marketing",
+  "total_score": 110,
+  "warnings": []
+}

--- a/docs/review/PR_1686_FIXED_MAPPING.md
+++ b/docs/review/PR_1686_FIXED_MAPPING.md
@@ -65,7 +65,7 @@ Premortem reviewed the actual code/docs/tests diff.
 
 ## Fixed in Commit Mapping
 
-No actionable review threads were present when this artifact was created.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1686_FIXED_MAPPING.md
+++ b/docs/review/PR_1686_FIXED_MAPPING.md
@@ -60,12 +60,17 @@ Premortem reviewed the actual code/docs/tests diff.
 
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
-- No review threads were present when this artifact was created.
-- CodeRabbit/Sourcery/Cubic dispositions: pending post-open bot review.
+- Codex and Cubic actionable review threads were reviewed and fixed in code/tests.
+- CodeRabbit/Sourcery/Cubic dispositions: Cubic actionable fixed; CodeRabbit/Sourcery pending final no-actionables check.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1686#discussion_r3195955116 -> 2f9991e81
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1686#discussion_r3195955128 -> 2f9991e81
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1686#discussion_r3195972169 -> 2f9991e81
+Disposition: FIXED
+Commit: 2f9991e81
+Evidence: `scripts/design/design_scorecard.py` catches PR-3 evidence loader errors and validates aggregate scorecard totals/status/recommendation; `tests/design/test_design_scorecard.py` covers malformed evidence, tampered scorecards, and removes `sys.path.insert`.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1686_FIXED_MAPPING.md
+++ b/docs/review/PR_1686_FIXED_MAPPING.md
@@ -60,14 +60,15 @@ Premortem reviewed the actual code/docs/tests diff.
 
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
-- Codex and Cubic actionable review threads were reviewed and fixed in code/tests.
-- CodeRabbit/Sourcery/Cubic dispositions: Cubic actionable fixed; CodeRabbit/Sourcery pending final no-actionables check.
+- Codex and Cubic actionable review comments were reviewed and fixed in code/tests.
+- CodeRabbit/Sourcery/Cubic dispositions: Cubic actionable fixed; CodeRabbit and Sourcery reported no actionables in current-head checks.
 
 ## Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1686#discussion_r3195955116 -> 2f9991e81
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1686#discussion_r3195955128 -> 2f9991e81
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1686#discussion_r3195972169 -> 2f9991e81
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1686#pullrequestreview-4236668931 -> 2f9991e81
 Disposition: FIXED
 Commit: 2f9991e81
 Evidence: `scripts/design/design_scorecard.py` catches PR-3 evidence loader errors and validates aggregate scorecard totals/status/recommendation; `tests/design/test_design_scorecard.py` covers malformed evidence, tampered scorecards, and removes `sys.path.insert`.

--- a/docs/review/PR_1686_FIXED_MAPPING.md
+++ b/docs/review/PR_1686_FIXED_MAPPING.md
@@ -1,0 +1,86 @@
+# PR 1686 Fixed Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1686
+
+## Summary
+
+Design Intelligence PR-4 adds deterministic scorecard tooling over PR-3 screen evidence metadata.
+
+This mapping artifact is evidence after fixes or explicit review decisions. It is not a substitute for code, docs, or test changes.
+
+## Local Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` -> PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS
+- `python3 scripts/design/screen_evidence_pack.py validate-dir docs/design/screen_evidence/examples` -> PASS
+- `python3 scripts/design/design_scorecard.py score docs/design/screen_evidence/examples/web_marketing.sample.json` -> PASS
+- `python3 scripts/design/design_scorecard.py score-dir docs/design/screen_evidence/examples` -> PASS
+- `python3 scripts/design/design_scorecard.py validate-score docs/design/design_scorecard/examples/web_marketing.scorecard.sample.json` -> PASS
+- `python3 scripts/design/design_scorecard.py summarize docs/design/design_scorecard/examples/web_marketing.scorecard.sample.json` -> PASS
+- `. .venv/bin/activate && python -m pytest -q tests/design/test_design_scorecard.py` -> PASS
+- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed` -> PASS
+- `make design-guard` -> PASS
+- `PATH=.venv/bin:$PATH make tokens-check` with temporary worktree-local `frontend/node_modules` symlink to installed frontend dependencies removed after the command -> PASS
+- `PATH=.venv/bin:$PATH pre-commit run --all-files` -> PASS
+
+## Premortem
+
+Premortem reviewed the actual code/docs/tests diff.
+
+- Risk: scorecards become a second design source of truth.
+  - Decision: Scorecard output and docs state scorecards are non-canonical review evidence only.
+  - Evidence: `scripts/design/design_scorecard.py`, `docs/design/DESIGN_SCORECARD_CHECKS.md`
+- Risk: scorecard logic includes subjective aesthetic judgments.
+  - Decision: Scorecard validation rejects subjective field names and docs forbid visual-taste readiness claims.
+  - Evidence: `tests/design/test_design_scorecard.py`
+- Risk: invalid screen evidence still scores.
+  - Decision: `score` runs PR-3 screen evidence validation before output.
+  - Evidence: `scripts/design/design_scorecard.py`, `tests/design/test_design_scorecard.py`
+- Risk: PR-5/PR-6 implementation leaks into PR-4.
+  - Decision: Diff is docs/tooling/tests only; no runtime, token mirror, frontend, iOS, backend, or binary artifact diff.
+  - Evidence: diff sanity checks listed below.
+
+## Bug-Hunter Pass
+
+- docs/tooling/tests only -> PASS
+- no runtime diff -> PASS
+- no generated token mirror diff -> PASS
+- no committed screenshots/videos/traces -> PASS
+- invalid evidence cannot score as pass -> PASS
+- source-of-truth violations fail closed -> PASS
+- unknown components fail closed through PR-3 validation -> PASS
+- unsafe paths fail closed through PR-3 validation -> PASS
+- no subjective visual scoring -> PASS
+- no Figma/Canva authority drift -> PASS
+- no external network/crawler introduced -> PASS
+- no plugin architecture introduced -> PASS
+- no PR-5/PR-6 implementation introduced -> PASS
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- No review threads were present when this artifact was created.
+- CodeRabbit/Sourcery/Cubic dispositions: pending post-open bot review.
+
+## Fixed in Commit Mapping
+
+No actionable review threads were present when this artifact was created.
+
+## Merge Readiness
+
+Not claimed until current-head CI, review thread disposition, bot no-actionables, wait-window, PR body mirror, this mapping artifact, and strict `check_merge_ready.py --require-auth` pass.
+
+## Deferred / Follow-Ups
+
+- PR-5: web launch shell alignment to accepted design brief.
+- PR-6: iOS visual parity audit and bounded sync.
+- PR-7: design-agent workflow and PR template.
+- PR-8: GEPA-compatible prompt/rubric evolution lane.
+- Browser/Playwright capture remains separate unless later scoped.
+- Storybook parity deep-drift inspection remains separate unless later scoped.
+
+## Diff Sanity
+
+- `git diff -- frontend/src/styles/tokens.css frontend/src/styles/tokens.ts ios/PulsePlate/DesignSystem/DesignTokens.generated.swift` -> no diff
+- binary/local artifact path scan -> no committed artifacts

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1174,8 +1174,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Reference-driven design intelligence wave for web and iOS
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (design / web / iOS / agentic workflow / reference corpus)
-  - Target PR: PR #1671 (`docs(design): open reference-driven design intelligence wave for web and iOS`, branch `docs/design-intelligence-wave-v1`) -> PR #1677 / PR-1 `feat(design): generate PulsePlate DESIGN.md from token and component contracts` -> PR #1680 / PR-2 `feat(design): add external reference manifest and normalization tooling` -> PR-3 `feat(design): add screen evidence pack for web and iOS review surfaces` (`feat/design-screen-evidence-pack-v1`)
-  - Status: PR-0 merged in PR #1671; PR-1 merged in PR #1677 with generated/drift-checked `docs/design/DESIGN.md`; PR-2 merged in PR #1680 with reference manifest validation and normalization tooling; PR-3 active on branch `feat/design-screen-evidence-pack-v1` to add metadata-only screen evidence pack validation for web and iOS review surfaces. Do not close the wave or mark PR-4/PR-5/PR-6/PR-7/PR-8 complete in this PR.
+  - Target PR: PR #1671 (`docs(design): open reference-driven design intelligence wave for web and iOS`, branch `docs/design-intelligence-wave-v1`) -> PR #1677 / PR-1 `feat(design): generate PulsePlate DESIGN.md from token and component contracts` -> PR #1680 / PR-2 `feat(design): add external reference manifest and normalization tooling` -> PR #1683 / PR-3 `feat(design): add screen evidence pack for web and iOS review surfaces` -> PR-4 `feat(design): add deterministic design scorecard checks` (`feat/design-scorecard-checks-v1`)
+  - Status: PR-0 merged in PR #1671; PR-1 merged in PR #1677 with generated/drift-checked `docs/design/DESIGN.md`; PR-2 merged in PR #1680 with reference manifest validation and normalization tooling; PR-3 merged in PR #1683 with metadata-only screen evidence pack validation for web and iOS review surfaces; PR-4 active on branch `feat/design-scorecard-checks-v1` to add deterministic evidence-quality scorecard checks. Do not close the wave or mark PR-5/PR-6/PR-7/PR-8 complete in this PR.
   - Area: design / web / iOS / agentic workflow / reference corpus
   - Finding Type: reference-driven design intelligence bootstrap and governance
   - Anchor: `ledger-p1-design-intelligence-wave`
@@ -1191,6 +1191,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/design/PULSEPLATE_DESIGN_MD_BOOTSTRAP.md`
     - `docs/design/DESIGN.md` (PR-1 generated semantic wrapper; non-canonical)
     - `docs/design/SCREEN_EVIDENCE_PACK_SCHEMA.md` (PR-3 screen evidence metadata schema; non-canonical)
+    - `docs/design/DESIGN_SCORECARD_CHECKS.md` (PR-4 deterministic scorecard checks; non-canonical)
   - DoD:
     - PR-0 runbook and packet exist
     - External reference policy exists

--- a/scripts/design/design_scorecard.py
+++ b/scripts/design/design_scorecard.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python3
+"""Score PulsePlate screen evidence packs with deterministic governance checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, TextIO
+
+import screen_evidence_pack
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+SCORECARD_STATUSES = {"pass", "warn", "fail"}
+RECOMMENDATIONS = {"usable_for_pr5_pr6_brief", "needs_evidence", "rejected"}
+GENERATED_BY = "scripts/design/design_scorecard.py"
+SOURCE_OF_TRUTH_NOTE = (
+    "Design scorecards are deterministic review evidence only, non-canonical, "
+    "and not source of truth; repo tokens, UI vocabulary, backend/OpenAPI "
+    "contracts, tests, and runtime code win."
+)
+
+DIMENSION_IDS = [
+    "source_truth_compliance",
+    "artifact_hygiene",
+    "component_vocabulary_integrity",
+    "token_evidence",
+    "accessibility_evidence",
+    "responsive_evidence",
+    "copy_safety",
+    "navigation_evidence",
+    "overflow_evidence",
+    "motion_evidence",
+    "platform_metadata",
+]
+
+SUBJECTIVE_FIELD_TERMS = {
+    "beautiful",
+    "beauty",
+    "luxury",
+    "luxury_score",
+    "market_appeal",
+    "premium_score",
+    "taste",
+    "taste_score",
+    "visual_ready",
+    "visually_ready",
+}
+
+
+class DesignScorecardError(ValueError):
+    """Raised when scorecard generation or validation fails."""
+
+
+def _repo_path(path: str | Path, repo_root: Path) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return repo_root / candidate
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+    except UnicodeDecodeError as exc:
+        raise DesignScorecardError(f"{path}: invalid UTF-8: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        raise DesignScorecardError(f"{path}: invalid JSON: {exc.msg}") from exc
+    except OSError as exc:
+        raise DesignScorecardError(f"{path}: cannot read JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise DesignScorecardError(f"{path}: expected JSON object")
+    return data
+
+
+def _stringify(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return " ".join(_stringify(item) for item in value)
+    if isinstance(value, dict):
+        return " ".join(_stringify(item) for item in value.values())
+    return str(value)
+
+
+def _dict_has_evidence(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    return any(bool(_stringify(item).strip()) for item in value.values())
+
+
+def _dimension(
+    dimension_id: str,
+    *,
+    score: int,
+    status: str,
+    summary: str,
+    max_score: int = 10,
+) -> dict[str, Any]:
+    return {
+        "id": dimension_id,
+        "max_score": max_score,
+        "score": score,
+        "status": status,
+        "summary": summary,
+    }
+
+
+def _score_presence_dimension(
+    record: dict[str, Any],
+    field: str,
+    dimension_id: str,
+    present_summary: str,
+    missing_summary: str,
+) -> tuple[dict[str, Any], list[str]]:
+    if _dict_has_evidence(record.get(field)):
+        return (
+            _dimension(
+                dimension_id,
+                score=10,
+                status="pass",
+                summary=present_summary,
+            ),
+            [],
+        )
+    return (
+        _dimension(
+            dimension_id,
+            score=0,
+            status="warn",
+            summary=missing_summary,
+        ),
+        [missing_summary],
+    )
+
+
+def _token_evidence_dimension(record: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    platform = record.get("platform")
+    token_paths = set(record.get("token_mirror_paths_checked", []))
+    if platform == "web":
+        expected = {
+            "frontend/src/styles/tokens.css",
+            "frontend/src/styles/tokens.ts",
+        }
+    elif platform == "ios":
+        expected = {
+            "ios/PulsePlate/DesignSystem/DesignTokens.generated.swift",
+        }
+    else:
+        expected = set()
+    if expected and expected.issubset(token_paths):
+        return (
+            _dimension(
+                "token_evidence",
+                score=10,
+                status="pass",
+                summary="Platform token mirror evidence is present.",
+            ),
+            [],
+        )
+    if token_paths:
+        summary = "Token evidence is partial for this platform."
+        return (
+            _dimension("token_evidence", score=6, status="warn", summary=summary),
+            [summary],
+        )
+    summary = "Token evidence is missing."
+    return (
+        _dimension("token_evidence", score=0, status="warn", summary=summary),
+        [summary],
+    )
+
+
+def _component_dimension(record: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    component_ids = record.get("component_ids", [])
+    if component_ids:
+        return (
+            _dimension(
+                "component_vocabulary_integrity",
+                score=10,
+                status="pass",
+                summary="Mapped component ids passed PR-3 vocabulary validation.",
+            ),
+            [],
+        )
+    summary = "No component ids are mapped yet."
+    return (
+        _dimension(
+            "component_vocabulary_integrity",
+            score=6,
+            status="warn",
+            summary=summary,
+        ),
+        [summary],
+    )
+
+
+def _platform_dimension(record: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    platform = record.get("platform")
+    route_or_screen = _stringify(record.get("route_or_screen", "")).strip()
+    viewport = _stringify(record.get("viewport", "")).strip()
+    if platform == "web" and route_or_screen and viewport:
+        return (
+            _dimension(
+                "platform_metadata",
+                score=10,
+                status="pass",
+                summary="Web route and viewport metadata are present.",
+            ),
+            [],
+        )
+    if platform == "ios" and route_or_screen and viewport:
+        return (
+            _dimension(
+                "platform_metadata",
+                score=10,
+                status="pass",
+                summary="iOS screen and device metadata are present.",
+            ),
+            [],
+        )
+    summary = "Platform route/screen or viewport metadata is incomplete."
+    return (
+        _dimension("platform_metadata", score=0, status="warn", summary=summary),
+        [summary],
+    )
+
+
+def _score_record(record: dict[str, Any]) -> dict[str, Any]:
+    dimensions: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    blocking_failures: list[str] = []
+
+    if record.get("status") == "rejected":
+        blocking_failures.append("evidence status is rejected")
+
+    dimensions.append(
+        _dimension(
+            "source_truth_compliance",
+            score=10,
+            status="pass",
+            summary="Evidence source-of-truth note passed PR-3 validation.",
+        )
+    )
+    dimensions.append(
+        _dimension(
+            "artifact_hygiene",
+            score=10,
+            status="pass",
+            summary="Artifact path policy passed PR-3 validation.",
+        )
+    )
+
+    dimension, dimension_warnings = _component_dimension(record)
+    dimensions.append(dimension)
+    warnings.extend(dimension_warnings)
+
+    dimension, dimension_warnings = _token_evidence_dimension(record)
+    dimensions.append(dimension)
+    warnings.extend(dimension_warnings)
+
+    for field, dimension_id, present_summary, missing_summary in [
+        (
+            "accessibility_evidence",
+            "accessibility_evidence",
+            "Accessibility evidence metadata is present; this does not claim WCAG pass.",
+            "Accessibility evidence metadata is missing.",
+        ),
+        (
+            "responsive_evidence",
+            "responsive_evidence",
+            "Responsive evidence metadata is present.",
+            "Responsive evidence metadata is missing.",
+        ),
+        (
+            "copy_safety_evidence",
+            "copy_safety",
+            "Copy-safety evidence passed PR-3 wellness validation.",
+            "Copy-safety evidence metadata is missing.",
+        ),
+        (
+            "tabbar_or_navigation_evidence",
+            "navigation_evidence",
+            "Navigation or tabbar evidence metadata is present.",
+            "Navigation or tabbar evidence metadata is missing.",
+        ),
+        (
+            "overflow_evidence",
+            "overflow_evidence",
+            "Overflow evidence metadata is present.",
+            "Overflow evidence metadata is missing.",
+        ),
+        (
+            "motion_evidence",
+            "motion_evidence",
+            "Motion or reduced-motion evidence metadata is present.",
+            "Motion or reduced-motion evidence metadata is missing.",
+        ),
+    ]:
+        dimension, dimension_warnings = _score_presence_dimension(
+            record,
+            field,
+            dimension_id,
+            present_summary,
+            missing_summary,
+        )
+        dimensions.append(dimension)
+        warnings.extend(dimension_warnings)
+
+    dimension, dimension_warnings = _platform_dimension(record)
+    dimensions.append(dimension)
+    warnings.extend(dimension_warnings)
+
+    ordered_dimensions = [
+        next(item for item in dimensions if item["id"] == item_id) for item_id in DIMENSION_IDS
+    ]
+    total_score = sum(int(item["score"]) for item in ordered_dimensions)
+    max_score = sum(int(item["max_score"]) for item in ordered_dimensions)
+    normalized_score = round(total_score / max_score, 4) if max_score else 0.0
+
+    if blocking_failures:
+        status = "fail"
+    elif normalized_score >= 0.85:
+        status = "pass"
+    elif normalized_score >= 0.60:
+        status = "warn"
+    else:
+        status = "fail"
+
+    if blocking_failures or status == "fail":
+        recommendation = "rejected"
+    elif status == "pass":
+        recommendation = "usable_for_pr5_pr6_brief"
+    else:
+        recommendation = "needs_evidence"
+
+    evidence_id = _stringify(record.get("evidence_id", "")).strip()
+    return {
+        "blocking_failures": sorted(blocking_failures),
+        "dimensions": ordered_dimensions,
+        "generated_by": GENERATED_BY,
+        "max_score": max_score,
+        "normalized_score": normalized_score,
+        "platform": record.get("platform"),
+        "recommendation": recommendation,
+        "route_or_screen": record.get("route_or_screen"),
+        "scorecard_id": f"design-scorecard::{evidence_id}",
+        "source_evidence_id": evidence_id,
+        "source_of_truth_note": SOURCE_OF_TRUTH_NOTE,
+        "status": status,
+        "surface_id": record.get("surface_id"),
+        "total_score": total_score,
+        "warnings": sorted(dict.fromkeys(warnings)),
+    }
+
+
+def score_path(path: str | Path, *, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    evidence_path = _repo_path(path, repo_root)
+    record = screen_evidence_pack._load_json(evidence_path)
+    errors = screen_evidence_pack.validate_record(record, repo_root=repo_root)
+    if errors:
+        raise DesignScorecardError(
+            f"{evidence_path}: cannot score invalid screen evidence: {'; '.join(errors)}"
+        )
+    return _score_record(record)
+
+
+def score_dir(path: str | Path, *, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    evidence_dir = _repo_path(path, repo_root)
+    manifests = sorted(evidence_dir.rglob("*.json"))
+    if not manifests:
+        raise DesignScorecardError(f"{evidence_dir}: no JSON evidence manifests found")
+    scorecards = []
+    for manifest_path in manifests:
+        relative = (
+            manifest_path.relative_to(repo_root)
+            if manifest_path.is_relative_to(repo_root)
+            else manifest_path
+        )
+        scorecards.append(
+            {
+                "path": str(relative),
+                "scorecard": score_path(manifest_path, repo_root=repo_root),
+            }
+        )
+    return {"scorecards": scorecards}
+
+
+def _find_subjective_keys(value: Any, prefix: str = "") -> list[str]:
+    findings: list[str] = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            key_text = str(key)
+            path = f"{prefix}.{key_text}" if prefix else key_text
+            if key_text.lower() in SUBJECTIVE_FIELD_TERMS:
+                findings.append(path)
+            findings.extend(_find_subjective_keys(item, path))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            findings.extend(_find_subjective_keys(item, f"{prefix}[{index}]"))
+    return findings
+
+
+def validate_scorecard_record(record: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    required_fields = {
+        "blocking_failures",
+        "dimensions",
+        "generated_by",
+        "max_score",
+        "normalized_score",
+        "platform",
+        "recommendation",
+        "route_or_screen",
+        "scorecard_id",
+        "source_evidence_id",
+        "source_of_truth_note",
+        "status",
+        "surface_id",
+        "total_score",
+        "warnings",
+    }
+    for field in sorted(required_fields):
+        if field not in record:
+            errors.append(f"missing required field: {field}")
+    if errors:
+        return errors
+
+    if record.get("status") not in SCORECARD_STATUSES:
+        errors.append("status must be one of: fail, pass, warn")
+    if record.get("recommendation") not in RECOMMENDATIONS:
+        errors.append(
+            "recommendation must be one of: needs_evidence, rejected, usable_for_pr5_pr6_brief"
+        )
+    if record.get("generated_by") != GENERATED_BY:
+        errors.append(f"generated_by must be {GENERATED_BY}")
+    if not isinstance(record.get("source_evidence_id"), str) or not record["source_evidence_id"]:
+        errors.append("source_evidence_id must be a non-empty string")
+    expected_scorecard_id = f"design-scorecard::{record.get('source_evidence_id')}"
+    if record.get("scorecard_id") != expected_scorecard_id:
+        errors.append(f"scorecard_id must be {expected_scorecard_id}")
+    if "not source of truth" not in _stringify(record.get("source_of_truth_note", "")).lower():
+        errors.append("source_of_truth_note must state scorecards are not source of truth")
+
+    dimensions = record.get("dimensions")
+    if not isinstance(dimensions, list):
+        errors.append("dimensions must be an array")
+    else:
+        dimension_ids = []
+        for dimension in dimensions:
+            if not isinstance(dimension, dict):
+                errors.append("dimensions must contain objects")
+                continue
+            dimension_ids.append(dimension.get("id"))
+            for field in ["id", "max_score", "score", "status", "summary"]:
+                if field not in dimension:
+                    errors.append(f"dimension missing required field: {field}")
+            if dimension.get("status") not in SCORECARD_STATUSES:
+                errors.append("dimension status must be one of: fail, pass, warn")
+            score = dimension.get("score")
+            max_score = dimension.get("max_score")
+            if not isinstance(score, int) or not isinstance(max_score, int):
+                errors.append("dimension score and max_score must be integers")
+            elif score < 0 or max_score <= 0 or score > max_score:
+                errors.append("dimension score must be between 0 and max_score")
+        if dimension_ids != DIMENSION_IDS:
+            errors.append("dimensions must use the canonical deterministic dimension order")
+
+    for field in ["blocking_failures", "warnings"]:
+        values = record.get(field)
+        if not isinstance(values, list):
+            errors.append(f"{field} must be an array")
+        elif any(not isinstance(item, str) for item in values):
+            errors.append(f"{field} must contain strings")
+        elif values != sorted(values):
+            errors.append(f"{field} must be sorted")
+
+    total_score = record.get("total_score")
+    max_score = record.get("max_score")
+    normalized_score = record.get("normalized_score")
+    if not isinstance(total_score, int) or not isinstance(max_score, int):
+        errors.append("total_score and max_score must be integers")
+    elif total_score < 0 or max_score <= 0 or total_score > max_score:
+        errors.append("total_score must be between 0 and max_score")
+    if not isinstance(normalized_score, (float, int)):
+        errors.append("normalized_score must be numeric")
+    elif normalized_score < 0 or normalized_score > 1:
+        errors.append("normalized_score must be between 0 and 1")
+
+    subjective_keys = _find_subjective_keys(record)
+    for key in subjective_keys:
+        errors.append(f"subjective scorecard field is forbidden: {key}")
+
+    return sorted(dict.fromkeys(errors))
+
+
+def validate_score_path(path: str | Path, *, repo_root: Path = REPO_ROOT) -> list[str]:
+    scorecard_path = _repo_path(path, repo_root)
+    record = _load_json(scorecard_path)
+    return validate_scorecard_record(record)
+
+
+def summarize_scorecard(record: dict[str, Any]) -> dict[str, Any]:
+    errors = validate_scorecard_record(record)
+    if errors:
+        raise DesignScorecardError(f"cannot summarize invalid scorecard: {'; '.join(errors)}")
+    return {
+        "blocking_failures": sorted(record["blocking_failures"]),
+        "normalized_score": record["normalized_score"],
+        "recommendation": record["recommendation"],
+        "scorecard_id": record["scorecard_id"],
+        "source_evidence_id": record["source_evidence_id"],
+        "status": record["status"],
+        "surface_id": record["surface_id"],
+        "warnings": sorted(record["warnings"]),
+    }
+
+
+def summarize_path(path: str | Path, *, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
+    scorecard_path = _repo_path(path, repo_root)
+    return summarize_scorecard(_load_json(scorecard_path))
+
+
+def _print_errors(errors: list[str], *, stderr: TextIO) -> None:
+    for error in errors:
+        print(f"ERROR: {error}", file=stderr)
+
+
+def _print_json(payload: dict[str, Any], *, stdout: TextIO) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True), file=stdout)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    score_parser = subparsers.add_parser("score", help="score one screen evidence manifest")
+    score_parser.add_argument("path")
+
+    score_dir_parser = subparsers.add_parser(
+        "score-dir", help="score every screen evidence manifest in a directory"
+    )
+    score_dir_parser.add_argument("path")
+
+    validate_score_parser = subparsers.add_parser(
+        "validate-score", help="validate one generated scorecard"
+    )
+    validate_score_parser.add_argument("path")
+
+    summarize_parser = subparsers.add_parser("summarize", help="summarize one scorecard")
+    summarize_parser.add_argument("path")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "score":
+            _print_json(score_path(args.path), stdout=sys.stdout)
+            return 0
+        if args.command == "score-dir":
+            _print_json(score_dir(args.path), stdout=sys.stdout)
+            return 0
+        if args.command == "validate-score":
+            errors = validate_score_path(args.path)
+            if errors:
+                _print_errors(errors, stderr=sys.stderr)
+                return 1
+            print(f"OK: {args.path}")
+            return 0
+        if args.command == "summarize":
+            _print_json(summarize_path(args.path), stdout=sys.stdout)
+            return 0
+    except DesignScorecardError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    parser.error(f"unsupported command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/design/design_scorecard.py
+++ b/scripts/design/design_scorecard.py
@@ -4,12 +4,21 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import sys
 from pathlib import Path
 from typing import Any, TextIO
 
-import screen_evidence_pack
+try:
+    import screen_evidence_pack
+except ModuleNotFoundError:
+    screen_evidence_pack_path = Path(__file__).with_name("screen_evidence_pack.py")
+    spec = importlib.util.spec_from_file_location("screen_evidence_pack", screen_evidence_pack_path)
+    if spec is None or spec.loader is None:
+        raise
+    screen_evidence_pack = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(screen_evidence_pack)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -229,6 +238,31 @@ def _platform_dimension(record: dict[str, Any]) -> tuple[dict[str, Any], list[st
     )
 
 
+def _status_and_recommendation(
+    *,
+    total_score: int,
+    max_score: int,
+    blocking_failures: list[str],
+) -> tuple[str, str, float]:
+    normalized_score = round(total_score / max_score, 4) if max_score else 0.0
+    if blocking_failures:
+        status = "fail"
+    elif normalized_score >= 0.85:
+        status = "pass"
+    elif normalized_score >= 0.60:
+        status = "warn"
+    else:
+        status = "fail"
+
+    if blocking_failures or status == "fail":
+        recommendation = "rejected"
+    elif status == "pass":
+        recommendation = "usable_for_pr5_pr6_brief"
+    else:
+        recommendation = "needs_evidence"
+    return status, recommendation, normalized_score
+
+
 def _score_record(record: dict[str, Any]) -> dict[str, Any]:
     dimensions: list[dict[str, Any]] = []
     warnings: list[str] = []
@@ -319,23 +353,11 @@ def _score_record(record: dict[str, Any]) -> dict[str, Any]:
     ]
     total_score = sum(int(item["score"]) for item in ordered_dimensions)
     max_score = sum(int(item["max_score"]) for item in ordered_dimensions)
-    normalized_score = round(total_score / max_score, 4) if max_score else 0.0
-
-    if blocking_failures:
-        status = "fail"
-    elif normalized_score >= 0.85:
-        status = "pass"
-    elif normalized_score >= 0.60:
-        status = "warn"
-    else:
-        status = "fail"
-
-    if blocking_failures or status == "fail":
-        recommendation = "rejected"
-    elif status == "pass":
-        recommendation = "usable_for_pr5_pr6_brief"
-    else:
-        recommendation = "needs_evidence"
+    status, recommendation, normalized_score = _status_and_recommendation(
+        total_score=total_score,
+        max_score=max_score,
+        blocking_failures=blocking_failures,
+    )
 
     evidence_id = _stringify(record.get("evidence_id", "")).strip()
     return {
@@ -359,8 +381,11 @@ def _score_record(record: dict[str, Any]) -> dict[str, Any]:
 
 def score_path(path: str | Path, *, repo_root: Path = REPO_ROOT) -> dict[str, Any]:
     evidence_path = _repo_path(path, repo_root)
-    record = screen_evidence_pack._load_json(evidence_path)
-    errors = screen_evidence_pack.validate_record(record, repo_root=repo_root)
+    try:
+        record = screen_evidence_pack._load_json(evidence_path)
+        errors = screen_evidence_pack.validate_record(record, repo_root=repo_root)
+    except screen_evidence_pack.EvidenceManifestError as exc:
+        raise DesignScorecardError(f"{evidence_path}: cannot score screen evidence: {exc}") from exc
     if errors:
         raise DesignScorecardError(
             f"{evidence_path}: cannot score invalid screen evidence: {'; '.join(errors)}"
@@ -489,6 +514,38 @@ def validate_scorecard_record(record: dict[str, Any]) -> list[str]:
         errors.append("normalized_score must be numeric")
     elif normalized_score < 0 or normalized_score > 1:
         errors.append("normalized_score must be between 0 and 1")
+
+    if isinstance(dimensions, list) and all(isinstance(item, dict) for item in dimensions):
+        if all(isinstance(item.get("score"), int) for item in dimensions) and all(
+            isinstance(item.get("max_score"), int) for item in dimensions
+        ):
+            expected_total = sum(int(item["score"]) for item in dimensions)
+            expected_max = sum(int(item["max_score"]) for item in dimensions)
+            blocking_failures = record.get("blocking_failures")
+            if isinstance(blocking_failures, list) and all(
+                isinstance(item, str) for item in blocking_failures
+            ):
+                (
+                    expected_status,
+                    expected_recommendation,
+                    expected_normalized,
+                ) = _status_and_recommendation(
+                    total_score=expected_total,
+                    max_score=expected_max,
+                    blocking_failures=blocking_failures,
+                )
+                if record.get("total_score") != expected_total:
+                    errors.append("total_score must equal the sum of dimension scores")
+                if record.get("max_score") != expected_max:
+                    errors.append("max_score must equal the sum of dimension max_score values")
+                if record.get("normalized_score") != expected_normalized:
+                    errors.append("normalized_score must match total_score / max_score")
+                if record.get("status") != expected_status:
+                    errors.append("status must match score thresholds and blocking failures")
+                if record.get("recommendation") != expected_recommendation:
+                    errors.append(
+                        "recommendation must match score thresholds and blocking failures"
+                    )
 
     subjective_keys = _find_subjective_keys(record)
     for key in subjective_keys:

--- a/tests/design/test_design_scorecard.py
+++ b/tests/design/test_design_scorecard.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+import runpy
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts/design/design_scorecard.py"
+WEB_SAMPLE = REPO_ROOT / "docs/design/screen_evidence/examples/web_marketing.sample.json"
+IOS_SAMPLE = REPO_ROOT / "docs/design/screen_evidence/examples/ios_home.sample.json"
+
+
+def load_scorecard_module() -> SimpleNamespace:
+    script_dir = str(MODULE_PATH.parent)
+    sys.path.insert(0, script_dir)
+    try:
+        return SimpleNamespace(**runpy.run_path(str(MODULE_PATH)))
+    finally:
+        sys.path.remove(script_dir)
+
+
+def make_temp_repo(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    design_dir = repo_root / "docs/design"
+    design_dir.mkdir(parents=True)
+    shutil.copyfile(
+        REPO_ROOT / "docs/design/ui_component_vocabulary.json",
+        design_dir / "ui_component_vocabulary.json",
+    )
+    return repo_root
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def valid_web_manifest(**overrides):
+    manifest = read_json(WEB_SAMPLE)
+    manifest.update(overrides)
+    return manifest
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(MODULE_PATH), *args],
+        check=False,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_valid_web_screen_evidence_scores_deterministically():
+    module = load_scorecard_module()
+
+    first = module.score_path(WEB_SAMPLE, repo_root=REPO_ROOT)
+    second = module.score_path(WEB_SAMPLE, repo_root=REPO_ROOT)
+
+    assert first == second
+    assert first["scorecard_id"] == "design-scorecard::web-marketing-sample"
+    assert first["status"] == "pass"
+    assert first["recommendation"] == "usable_for_pr5_pr6_brief"
+
+
+def test_valid_ios_screen_evidence_scores_deterministically():
+    module = load_scorecard_module()
+
+    scorecard = module.score_path(IOS_SAMPLE, repo_root=REPO_ROOT)
+
+    assert scorecard["scorecard_id"] == "design-scorecard::ios-home-sample"
+    assert scorecard["platform"] == "ios"
+    assert scorecard["status"] == "pass"
+
+
+def test_invalid_evidence_manifest_fails_before_scoring(tmp_path: Path):
+    manifest_path = tmp_path / "invalid.json"
+    manifest = valid_web_manifest(component_ids=["invented_component"])
+    write_json(manifest_path, manifest)
+
+    result = run_cli("score", str(manifest_path))
+
+    assert result.returncode == 1
+    assert "cannot score invalid screen evidence" in result.stderr
+    assert "unknown PulsePlate component id: invented_component" in result.stderr
+    assert result.stdout == ""
+
+
+def test_source_of_truth_violation_fails_before_scoring(tmp_path: Path):
+    manifest_path = tmp_path / "sot.json"
+    manifest = valid_web_manifest(
+        source_of_truth_note="Screen evidence is the source of truth for runtime UI."
+    )
+    write_json(manifest_path, manifest)
+
+    result = run_cli("score", str(manifest_path))
+
+    assert result.returncode == 1
+    assert "screen evidence must not become a source of truth" in result.stderr
+
+
+def test_unknown_component_ids_fail_before_scoring(tmp_path: Path):
+    manifest_path = tmp_path / "unknown-component.json"
+    write_json(manifest_path, valid_web_manifest(component_ids=["button", "unknown"]))
+
+    result = run_cli("score", str(manifest_path))
+
+    assert result.returncode == 1
+    assert "unknown PulsePlate component id: unknown" in result.stderr
+
+
+def test_unsafe_artifact_paths_fail_before_scoring(tmp_path: Path):
+    manifest_path = tmp_path / "unsafe-path.json"
+    write_json(
+        manifest_path,
+        valid_web_manifest(
+            artifact_policy="local_only",
+            screenshot_artifact_path=(
+                "artifacts/design/screen_evidence/run/DerivedData/evidence.txt"
+            ),
+        ),
+    )
+
+    result = run_cli("score", str(manifest_path))
+
+    assert result.returncode == 1
+    assert "disallowed local artifact path segment" in result.stderr
+
+
+def test_copy_safety_violation_fails_before_scoring(tmp_path: Path):
+    manifest_path = tmp_path / "copy-safety.json"
+    write_json(
+        manifest_path,
+        valid_web_manifest(
+            copy_safety_evidence={"claim": "This screen guarantees treatment outcomes."}
+        ),
+    )
+
+    result = run_cli("score", str(manifest_path))
+
+    assert result.returncode == 1
+    assert "copy_safety_evidence must not promote" in result.stderr
+
+
+def test_rejected_evidence_status_becomes_blocking_failure(tmp_path: Path):
+    module = load_scorecard_module()
+    repo_root = make_temp_repo(tmp_path)
+    manifest_path = repo_root / "evidence.json"
+    write_json(manifest_path, valid_web_manifest(status="rejected"))
+
+    scorecard = module.score_path(manifest_path, repo_root=repo_root)
+
+    assert scorecard["status"] == "fail"
+    assert scorecard["recommendation"] == "rejected"
+    assert scorecard["blocking_failures"] == ["evidence status is rejected"]
+
+
+def test_missing_accessibility_evidence_lowers_score_without_wcag_claim(tmp_path: Path):
+    module = load_scorecard_module()
+    repo_root = make_temp_repo(tmp_path)
+    manifest_path = repo_root / "evidence.json"
+    write_json(manifest_path, valid_web_manifest(accessibility_evidence={}))
+
+    scorecard = module.score_path(manifest_path, repo_root=repo_root)
+    accessibility = next(
+        item for item in scorecard["dimensions"] if item["id"] == "accessibility_evidence"
+    )
+
+    assert accessibility["status"] == "warn"
+    assert accessibility["score"] == 0
+    assert "Accessibility evidence metadata is missing." in scorecard["warnings"]
+    assert "wcag_pass" not in json.dumps(scorecard)
+
+
+def test_missing_responsive_overflow_and_motion_evidence_lowers_score(tmp_path: Path):
+    module = load_scorecard_module()
+    repo_root = make_temp_repo(tmp_path)
+    manifest_path = repo_root / "evidence.json"
+    write_json(
+        manifest_path,
+        valid_web_manifest(
+            motion_evidence={},
+            overflow_evidence={},
+            responsive_evidence={},
+        ),
+    )
+
+    scorecard = module.score_path(manifest_path, repo_root=repo_root)
+    dimensions = {item["id"]: item for item in scorecard["dimensions"]}
+
+    assert dimensions["responsive_evidence"]["score"] == 0
+    assert dimensions["overflow_evidence"]["score"] == 0
+    assert dimensions["motion_evidence"]["score"] == 0
+    assert scorecard["status"] == "warn"
+
+
+def test_score_dir_scores_all_sample_evidence_manifests():
+    module = load_scorecard_module()
+
+    result = module.score_dir("docs/design/screen_evidence/examples", repo_root=REPO_ROOT)
+
+    assert [item["path"] for item in result["scorecards"]] == [
+        "docs/design/screen_evidence/examples/ios_home.sample.json",
+        "docs/design/screen_evidence/examples/web_marketing.sample.json",
+    ]
+
+
+def test_validate_score_validates_generated_scorecard():
+    module = load_scorecard_module()
+    scorecard = module.score_path(WEB_SAMPLE, repo_root=REPO_ROOT)
+
+    assert module.validate_scorecard_record(scorecard) == []
+
+
+def test_validate_score_rejects_subjective_fields():
+    module = load_scorecard_module()
+    scorecard = module.score_path(WEB_SAMPLE, repo_root=REPO_ROOT)
+    scorecard["premium_score"] = 10
+
+    errors = module.validate_scorecard_record(scorecard)
+
+    assert "subjective scorecard field is forbidden: premium_score" in errors
+
+
+def test_validate_score_requires_canonical_dimension_order():
+    module = load_scorecard_module()
+    scorecard = module.score_path(WEB_SAMPLE, repo_root=REPO_ROOT)
+    scorecard["dimensions"] = list(reversed(scorecard["dimensions"]))
+
+    errors = module.validate_scorecard_record(scorecard)
+
+    assert "dimensions must use the canonical deterministic dimension order" in errors
+
+
+def test_summarize_output_is_deterministic(tmp_path: Path):
+    module = load_scorecard_module()
+    scorecard_path = tmp_path / "scorecard.json"
+    write_json(scorecard_path, module.score_path(WEB_SAMPLE, repo_root=REPO_ROOT))
+
+    first = module.summarize_path(scorecard_path, repo_root=REPO_ROOT)
+    second = module.summarize_path(scorecard_path, repo_root=REPO_ROOT)
+
+    assert first == second
+    assert first["scorecard_id"] == "design-scorecard::web-marketing-sample"
+
+
+def test_cli_validate_score_validates_sample_scorecard_fixture():
+    result = run_cli(
+        "validate-score",
+        "docs/design/design_scorecard/examples/web_marketing.scorecard.sample.json",
+    )
+
+    assert result.returncode == 0
+    assert "OK:" in result.stdout
+
+
+def test_no_subjective_visual_scoring_terms_in_generated_output():
+    module = load_scorecard_module()
+    scorecard = module.score_path(WEB_SAMPLE, repo_root=REPO_ROOT)
+    payload = json.dumps(scorecard, sort_keys=True)
+
+    for forbidden in ["beautiful", "premium_score", "luxury_score", "taste_score"]:
+        assert forbidden not in payload
+
+
+def test_cli_does_not_require_network_access():
+    result = run_cli("score", str(WEB_SAMPLE))
+
+    assert result.returncode == 0
+    assert "http://" not in result.stdout
+    assert "https://" not in result.stdout

--- a/tests/design/test_design_scorecard.py
+++ b/tests/design/test_design_scorecard.py
@@ -15,12 +15,7 @@ IOS_SAMPLE = REPO_ROOT / "docs/design/screen_evidence/examples/ios_home.sample.j
 
 
 def load_scorecard_module() -> SimpleNamespace:
-    script_dir = str(MODULE_PATH.parent)
-    sys.path.insert(0, script_dir)
-    try:
-        return SimpleNamespace(**runpy.run_path(str(MODULE_PATH)))
-    finally:
-        sys.path.remove(script_dir)
+    return SimpleNamespace(**runpy.run_path(str(MODULE_PATH)))
 
 
 def make_temp_repo(tmp_path: Path) -> Path:
@@ -92,6 +87,19 @@ def test_invalid_evidence_manifest_fails_before_scoring(tmp_path: Path):
     assert "cannot score invalid screen evidence" in result.stderr
     assert "unknown PulsePlate component id: invented_component" in result.stderr
     assert result.stdout == ""
+
+
+def test_unreadable_evidence_manifest_reports_actionable_error(tmp_path: Path):
+    manifest_path = tmp_path / "malformed.json"
+    manifest_path.write_text("{not-json", encoding="utf-8")
+
+    result = run_cli("score", str(manifest_path))
+
+    assert result.returncode == 1
+    assert "ERROR:" in result.stderr
+    assert "cannot score screen evidence" in result.stderr
+    assert "invalid JSON" in result.stderr
+    assert "Traceback" not in result.stderr
 
 
 def test_source_of_truth_violation_fails_before_scoring(tmp_path: Path):
@@ -228,6 +236,23 @@ def test_validate_score_rejects_subjective_fields():
     errors = module.validate_scorecard_record(scorecard)
 
     assert "subjective scorecard field is forbidden: premium_score" in errors
+
+
+def test_validate_score_rejects_tampered_aggregate_fields():
+    module = load_scorecard_module()
+    scorecard = module.score_path(WEB_SAMPLE, repo_root=REPO_ROOT)
+    scorecard["blocking_failures"] = ["manual failure"]
+    scorecard["status"] = "pass"
+    scorecard["recommendation"] = "usable_for_pr5_pr6_brief"
+    scorecard["total_score"] = 999
+    scorecard["normalized_score"] = 1.0
+
+    errors = module.validate_scorecard_record(scorecard)
+
+    assert "total_score must be between 0 and max_score" in errors
+    assert "total_score must equal the sum of dimension scores" in errors
+    assert "status must match score thresholds and blocking failures" in errors
+    assert "recommendation must match score thresholds and blocking failures" in errors
 
 
 def test_validate_score_requires_canonical_dimension_order():


### PR DESCRIPTION
## Summary

Adds deterministic design scorecard checks for PulsePlate screen evidence packs.

This PR introduces the Component Drift Inspector / deterministic scorecard foundation inside the existing Design Intelligence / Design Runtime system. Scorecards remain review artifacts only and do not become a source of truth.

## Goal

Let future web/iOS design implementation PRs rely on deterministic evidence-quality checks before any visual implementation or parity work begins.

## Business reason

PulsePlate needs market-aware design automation, but design changes must be governed by repo truth, evidence quality, accessibility/copy-safety signals, component vocabulary, and artifact hygiene before implementation PRs.

## Scope

- Add deterministic scorecard CLI.
- Score PR-3 screen evidence manifests.
- Add scorecard schema/docs/examples.
- Add tests for deterministic scoring and fail-closed rules.
- Add narrow docs/backlog update.

## Out of scope

- No web redesign.
- No iOS redesign.
- No Figma writes.
- No Canva writes.
- No screenshots/videos/traces.
- No visual/pixel scoring.
- No subjective aesthetic scoring.
- No PR-5 web implementation.
- No PR-6 iOS parity implementation.
- No `/tokens` changes.
- No generated token mirror edits.
- No frontend/iOS/backend/OpenAPI/billing/auth changes.

## Source of truth

Repo code/docs/tests, `/tokens`, generated mirrors, UI vocabulary, backend/OpenAPI contracts, and runtime code remain canonical.

Scorecards, screen evidence packs, external references, Figma, Canva, Storybook, prompt outputs, and DESIGN.md are evidence/reference layers only and do not override repo truth.

## Design automation module classification

Design automation items are modules inside the existing PulsePlate Design Intelligence / Design Runtime system, not standalone plugins.

This PR implements deterministic scorecard checks as the PR-4 foundation for component/evidence drift inspection.

Other modules remain deferred:
- Icon Asset Validator -> release/design asset guard lane
- Launch Copy Compliance Linter -> release/compliance/marketing guard
- Marketing Asset Pack Compiler -> late GTM layer after accepted design/copy truth

## Files changed

- `scripts/design/design_scorecard.py`
- `tests/design/test_design_scorecard.py`
- `docs/design/DESIGN_SCORECARD_CHECKS.md`
- `docs/design/design_scorecard/examples/README.md`
- `docs/design/design_scorecard/examples/web_marketing.scorecard.sample.json`
- `docs/design/design_scorecard/examples/ios_home.scorecard.sample.json`
- `docs/roadmap/BACKLOG_LEDGER.md`

## Tests / bounded checks

Do not list full `make verify`.

Actual commands run:
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/design/screen_evidence_pack.py validate-dir docs/design/screen_evidence/examples`
- `python3 scripts/design/design_scorecard.py score docs/design/screen_evidence/examples/web_marketing.sample.json`
- `python3 scripts/design/design_scorecard.py score-dir docs/design/screen_evidence/examples`
- `python3 scripts/design/design_scorecard.py validate-score docs/design/design_scorecard/examples/web_marketing.scorecard.sample.json`
- `python3 scripts/design/design_scorecard.py summarize docs/design/design_scorecard/examples/web_marketing.scorecard.sample.json`
- `. .venv/bin/activate && python -m pytest -q tests/design/test_design_scorecard.py`
- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed`
- `make design-guard`
- `PATH=.venv/bin:$PATH make tokens-check` with temporary worktree-local `frontend/node_modules` symlink to installed frontend dependencies removed after the command
- `PATH=.venv/bin:$PATH pre-commit run --all-files`
- `git diff -- frontend/src/styles/tokens.css frontend/src/styles/tokens.ts ios/PulsePlate/DesignSystem/DesignTokens.generated.swift`

## Split Justification

This PR intentionally exceeds the size guard because deterministic scorecard tooling requires one CLI, focused tests, schema/docs, generated sample metadata, backlog status, and the canonical review mapping artifact to land together. Splitting the CLI from its validation fixtures would create an unreviewable or non-executable governance slice. The PR remains bounded to docs/tooling/tests only and does not touch runtime, token mirrors, frontend, iOS, backend, screenshots, Figma, or Canva.

## Security notes

No secrets, auth, billing, backend, deploy, external integration, crawler, or network access added.

Scorecards are deterministic local metadata over committed sample evidence only. No binary artifacts are committed.

## Premortem

Premortem reviewed actual code/docs/tests diff.

Findings / decisions:
- Risk: scorecards could become a second design source of truth. Decision: scorecard docs and output state non-canonical review evidence only.
- Risk: scorecard could drift into subjective visual scoring. Decision: validator rejects subjective fields such as `premium_score`, `luxury_score`, and `taste_score`; docs forbid aesthetic readiness claims.
- Risk: invalid evidence could still score. Decision: `score` runs PR-3 evidence validation first and exits non-zero before scorecard output.
- Risk: PR-5/PR-6 implementation scope could leak in. Decision: PR only adds docs/tooling/tests/examples and no runtime files.

## Bug-hunter pass

Checked:
- no second SoT check
- no subjective scoring check
- invalid evidence fail-closed check
- source-of-truth violation check
- no token mirror diff
- no runtime diff
- no PR-5/PR-6 implementation check

## Deferred / Follow-ups

- PR-5: web launch shell alignment to accepted design brief.
- PR-6: iOS visual parity audit and bounded sync.
- PR-7: design-agent workflow and PR template.
- PR-8: GEPA-compatible prompt/rubric evolution lane.
- Browser/Playwright capture remains separate unless later scoped.
- Storybook parity deep-drift inspection remains separate unless later scoped.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Reviewed and fixed Codex/Cubic actionable review threads in code and tests.

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1686#discussion_r3195955116 -> 2f9991e81
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1686#discussion_r3195955128 -> 2f9991e81
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1686#discussion_r3195972169 -> 2f9991e81

See `docs/review/PR_1686_FIXED_MAPPING.md`.

## Merge Readiness

Do not mark until CI/review/mapping/wait-window/strict wrapper pass.

## Rollback

Revert this tooling/docs PR. No runtime rollback required.

## DoD

- Design scorecard CLI exists.
- Sample scorecards validate.
- Invalid evidence/source-of-truth/component/copy-safety states fail closed.
- Tests cover deterministic scoring rules.
- No subjective visual scoring.
- No runtime code changes.
- No generated token mirror diff.
- Bounded checks pass.
