### PR TITLE
ci(release): wire production release evidence artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -726,6 +726,46 @@ jobs:
               exit 1
               ;;
           esac
+          tag_commit="$(git rev-parse "${GITHUB_REF#refs/tags/}^{commit}")"
+          run_metadata="$(
+            gh run view "$RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID" \
+              --json status,conclusion,headSha,event,workflowName,url \
+              --jq '[.status, .conclusion, .headSha, .event, .workflowName, .url] | @tsv'
+          )"
+          IFS=$'\t' read -r run_status run_conclusion run_head_sha run_event run_workflow_name run_url <<< "$run_metadata"
+          if [ "$run_status" != "completed" ]; then
+            echo "❌ Release-control-plane evidence run is not completed: ${run_status:-unset}"
+            echo "run url=${run_url:-unset}"
+            exit 1
+          fi
+          if [ "$run_conclusion" != "success" ]; then
+            echo "❌ Release-control-plane evidence run did not succeed: ${run_conclusion:-unset}"
+            echo "run url=${run_url:-unset}"
+            exit 1
+          fi
+          if [ "$run_head_sha" != "$tag_commit" ]; then
+            echo "❌ Release-control-plane evidence run head SHA does not match production tag commit"
+            echo "run headSha=${run_head_sha:-unset}"
+            echo "tag commit=${tag_commit}"
+            echo "run url=${run_url:-unset}"
+            exit 1
+          fi
+          if [ "$run_event" != "workflow_dispatch" ]; then
+            echo "❌ Release-control-plane evidence run must be produced by a governed manual release-evidence workflow_dispatch run"
+            echo "run event=${run_event:-unset}"
+            echo "run url=${run_url:-unset}"
+            exit 1
+          fi
+          case "$run_workflow_name" in
+            *"Release Control Plane"*|*"release-control-plane"*)
+              ;;
+            *)
+              echo "❌ Release-control-plane evidence run workflow name is not an approved release-evidence producer"
+              echo "workflowName=${run_workflow_name:-unset}"
+              echo "run url=${run_url:-unset}"
+              exit 1
+              ;;
+          esac
           evidence_root="${RUNNER_TEMP}/release-control-plane-production-evidence"
           mkdir -p "$evidence_root"
           gh run download "$RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID" \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -239,7 +239,7 @@ jobs:
           exit 1
 
   release-control-plane-fixture-gate:
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -566,6 +566,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       deploy_mode: ${{ steps.resolve.outputs.deploy_mode }}
+      evidence_artifact_name: ${{ steps.resolve.outputs.evidence_artifact_name }}
+      evidence_run_id: ${{ steps.resolve.outputs.evidence_run_id }}
       release_ready: ${{ steps.resolve.outputs.release_ready }}
       should_deploy: ${{ steps.resolve.outputs.should_deploy }}
     steps:
@@ -637,6 +639,16 @@ jobs:
           fi
           env_ready="${env_ready:-false}"
 
+          evidence_run_id="$(get_actions_variable "environments/production/variables" "RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID")"
+          if [ -z "$evidence_run_id" ]; then
+            evidence_run_id="$(get_actions_variable "actions/variables" "RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID")"
+          fi
+
+          evidence_artifact_name="$(get_actions_variable "environments/production/variables" "RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME")"
+          if [ -z "$evidence_artifact_name" ]; then
+            evidence_artifact_name="$(get_actions_variable "actions/variables" "RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME")"
+          fi
+
           case "$deploy_mode" in
             "")
               ;;
@@ -657,6 +669,14 @@ jobs:
             fi
             if [ "$env_ready" = "true" ]; then
               should_deploy=true
+              if [ -z "$evidence_run_id" ]; then
+                echo "❌ RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID is required when production deploy is active"
+                exit 1
+              fi
+              if [ -z "$evidence_artifact_name" ]; then
+                echo "❌ RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME is required when production deploy is active"
+                exit 1
+              fi
             else
               echo "Production deploy remains build-only: PRODUCTION_ENV_READY=true is required after host bootstrap confirms \$DEPLOY_DIR/.env exists."
             fi
@@ -664,18 +684,102 @@ jobs:
 
           {
             echo "deploy_mode=$deploy_mode"
+            echo "evidence_artifact_name=$evidence_artifact_name"
+            echo "evidence_run_id=$evidence_run_id"
             echo "release_ready=$release_ready"
             echo "env_ready=$env_ready"
             echo "should_deploy=$should_deploy"
           } >> "$GITHUB_OUTPUT"
           echo "Resolved production deploy config: release_ready=$release_ready env_ready=$env_ready deploy_mode=${deploy_mode:-unset} should_deploy=$should_deploy"
 
+  release-control-plane-production-evidence:
+    if: startsWith(github.ref, 'refs/tags/v') && needs.production-deploy-config.outputs.should_deploy == 'true'
+    needs: [build-production, production-deploy-config]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download production release-control-plane evidence artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME: ${{ needs.production-deploy-config.outputs.evidence_artifact_name }}
+          RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID: ${{ needs.production-deploy-config.outputs.evidence_run_id }}
+        run: |
+          set -euo pipefail
+          case "$RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID" in
+            ''|*[!0-9]*)
+              echo "❌ RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID must be a numeric GitHub Actions run id"
+              exit 1
+              ;;
+          esac
+          case "$RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME" in
+            ''|*[Ff][Ii][Xx][Tt][Uu][Rr][Ee]*)
+              echo "❌ RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME must name real production evidence"
+              exit 1
+              ;;
+          esac
+          evidence_root="${RUNNER_TEMP}/release-control-plane-production-evidence"
+          mkdir -p "$evidence_root"
+          gh run download "$RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID" \
+            --name "$RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME" \
+            --dir "$evidence_root"
+          {
+            echo "RELEASE_CONTROL_PLANE_EVIDENCE_ROOT=$evidence_root"
+            echo "RELEASE_CONTROL_PLANE_OUTPUT_ROOT=${RUNNER_TEMP}/release-control-plane-production-gate"
+          } >> "$GITHUB_ENV"
+
+      - name: Validate production release-control-plane evidence
+        run: |
+          set -euo pipefail
+          evidence_dir="${RELEASE_CONTROL_PLANE_EVIDENCE_ROOT}/release-control-plane"
+          output_dir="${RELEASE_CONTROL_PLANE_OUTPUT_ROOT}"
+          mkdir -p "$output_dir"
+          for required_file in \
+            release_manifest.json \
+            rag_gate_result.json \
+            build_equivalence_result.json
+          do
+            if [ ! -f "${evidence_dir}/${required_file}" ]; then
+              echo "❌ Missing production release-control-plane evidence: ${evidence_dir}/${required_file}"
+              exit 1
+            fi
+          done
+          python3 scripts/ci/check_release_control_plane.py \
+            --release-manifest "${evidence_dir}/release_manifest.json" \
+            --rag-gate-result "${evidence_dir}/rag_gate_result.json" \
+            --build-equivalence "${evidence_dir}/build_equivalence_result.json" \
+            --json-out "${output_dir}/release_control_plane_ci_gate.json" \
+            --markdown-out "${output_dir}/release_control_plane_ci_gate.md"
+
+      - name: Publish production release-control-plane gate summary
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          if [ -f "${RELEASE_CONTROL_PLANE_OUTPUT_ROOT}/release_control_plane_ci_gate.md" ]; then
+            cat "${RELEASE_CONTROL_PLANE_OUTPUT_ROOT}/release_control_plane_ci_gate.md" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload production release-control-plane gate artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: release-control-plane-ci-gate-cd-production
+          path: |
+            ${{ runner.temp }}/release-control-plane-production-gate/release_control_plane_ci_gate.json
+            ${{ runner.temp }}/release-control-plane-production-gate/release_control_plane_ci_gate.md
+          if-no-files-found: warn
+          retention-days: 14
+
   deploy-production:
     # Run only when PROD_DEPLOY_MODE is explicitly 'ssh' (SSH from GitHub-hosted runners).
     # The config is resolved inside production-deploy-config so environment-scoped vars
     # are visible before the deploy jobs decide whether to run.
     if: startsWith(github.ref, 'refs/tags/v') && needs.production-deploy-config.outputs.should_deploy == 'true' && needs.production-deploy-config.outputs.deploy_mode == 'ssh'
-    needs: [production-gates, build-production, production-deploy-config]
+    needs: [production-gates, build-production, production-deploy-config, release-control-plane-production-evidence]
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -778,7 +882,7 @@ jobs:
 
   deploy-production-self-hosted:
     if: startsWith(github.ref, 'refs/tags/v') && needs.production-deploy-config.outputs.should_deploy == 'true' && needs.production-deploy-config.outputs.deploy_mode == 'self-hosted'
-    needs: [production-gates, build-production, production-deploy-config]
+    needs: [production-gates, build-production, production-deploy-config, release-control-plane-production-evidence]
     runs-on: [self-hosted, linux, x64, pulseplate-prod]
     environment:
       name: production

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,6 +64,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Free disk space (Ubuntu hosted runner)
         run: |
@@ -702,6 +704,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Download production release-control-plane evidence artifact
         env:
@@ -748,6 +752,29 @@ jobs:
               exit 1
             fi
           done
+          tag_commit="$(git rev-parse "${GITHUB_REF#refs/tags/}^{commit}")"
+          manifest_git_sha="$(
+            python3 - "${evidence_dir}/release_manifest.json" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as handle:
+              payload = json.load(handle)
+          build_identity = payload.get("build_identity")
+          if not isinstance(build_identity, dict):
+              raise SystemExit("missing build_identity")
+          git_sha = build_identity.get("git_sha")
+          if not isinstance(git_sha, str) or not git_sha:
+              raise SystemExit("missing build_identity.git_sha")
+          print(git_sha)
+          PY
+          )"
+          if [ "$manifest_git_sha" != "$tag_commit" ]; then
+            echo "❌ Release manifest git SHA does not match production tag commit"
+            echo "manifest git_sha=${manifest_git_sha}"
+            echo "tag commit=${tag_commit}"
+            exit 1
+          fi
           python3 scripts/ci/check_release_control_plane.py \
             --release-manifest "${evidence_dir}/release_manifest.json" \
             --rag-gate-result "${evidence_dir}/rag_gate_result.json" \

--- a/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
+++ b/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
@@ -60,7 +60,7 @@ exists in the agent inventory.
 Mandatory post-open review lane:
 
 ```text
-qa-engineer-agent -> bug-hunter
+qa-engineer-agent -> bug-hunter -> premortem-facilitator
 ```
 
 ## Recommended Skills
@@ -103,7 +103,8 @@ changes.
 | PR-2 | `release/release-control-plane-pr2-rag-gate-export` | RAG/ML gate result export contract over the existing eval runner | gate-result schema tests |
 | PR-3 | `release/release-control-plane-pr3-release-manifest` | Release manifest generator and validator, merged as PR #1605 | manifest validator tests |
 | PR-4 | `release/release-control-plane-pr4-build-equivalence` | Merged review build equals production-candidate equivalence check in PR #1679 | equivalence tests |
-| PR-5 | `release/release-control-plane-pr5-ci-gates` | Active CI integration for release packet, gate result, build equivalence, SBOM/provenance references, and fail-closed decision | focused CI/workflow contract tests |
+| PR-5 | `release/release-control-plane-pr5-ci-gates` | Merged CI integration for release packet, gate result, build equivalence, SBOM/provenance references, and fail-closed decision in PR #1682 | focused CI/workflow contract tests |
+| PR-6 | `release/release-control-plane-pr6-production-artifact-wiring` | Active production tag wiring for real release-control-plane evidence artifacts | production workflow contract tests |
 
 ## Release Packet Contract
 
@@ -235,6 +236,35 @@ integration is a non-secret fixture validation job because protected production
 artifact wiring is not available in this slice. PR-5 does not add App Store
 Connect execution, Fastlane upload mutation, runtime/API/OpenAPI/iOS changes,
 RAG behavior changes, semantic cache, GraphRAG, or product-facing behavior.
+
+### PR-6 Production Release Evidence Wiring
+
+PR-6 wires real production release-control-plane evidence artifacts into the
+production tag path before deploy. The machine-readable operator contract lives
+in
+[`docs/release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md`](../release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md).
+
+The CD workflow resolves `RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID` and
+`RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME` from production environment or
+repository Actions variables when production deploy is active. It downloads the
+named artifact from the named run and requires this layout:
+
+```text
+release-control-plane/
+  release_manifest.json
+  rag_gate_result.json
+  build_equivalence_result.json
+```
+
+The production evidence job invokes `scripts/ci/check_release_control_plane.py`
+against those real artifacts and uploads
+`release_control_plane_ci_gate.json` plus `release_control_plane_ci_gate.md` as
+workflow evidence. Production deploy depends on this gate when deploy is active.
+
+PR-6 does not create fake production evidence, does not use fixtures in the
+production tag path, does not add App Store Connect execution, does not mutate
+Fastlane protected upload behavior, and does not change runtime/API/OpenAPI/iOS,
+RAG, billing, semantic cache, GraphRAG, or product-facing behavior.
 
 ## Bootstrap Commands
 

--- a/docs/release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md
+++ b/docs/release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md
@@ -27,6 +27,18 @@ When `WEB_IOS_RELEASE_READY=true`, `PRODUCTION_ENV_READY=true`, and
 `PROD_DEPLOY_MODE` requests production deploy, both variables are required.
 Missing or malformed values fail closed before deploy.
 
+Before downloading the configured artifact, the CD workflow verifies the source
+run metadata with GitHub Actions:
+
+- `status == "completed"`
+- `conclusion == "success"`
+- `headSha` matches the production tag commit
+- `event == "workflow_dispatch"`
+- `workflowName` contains `Release Control Plane` or `release-control-plane`
+
+This keeps production deploy from trusting an artifact produced by an arbitrary
+same-repository run, failed run, scheduled run, or fixture validation lane.
+
 ## Required Artifact Layout
 
 The downloaded artifact must contain this exact directory:
@@ -76,6 +88,10 @@ Production deploy must not proceed when:
 
 - `RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID` is missing or not numeric;
 - `RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME` is missing or names a fixture;
+- the configured source run is not completed successfully;
+- the configured source run head SHA does not match the production tag commit;
+- the configured source run is not a governed `workflow_dispatch`
+  release-control-plane producer;
 - the configured artifact cannot be downloaded;
 - any required file is absent from `release-control-plane/`;
 - any evidence JSON is malformed;

--- a/docs/release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md
+++ b/docs/release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md
@@ -1,0 +1,104 @@
+# Production Release Evidence Wiring
+
+Release-control-plane PR-6 wires real production release evidence into the CD
+production tag path. It consumes evidence that was produced by a separate
+governed release ceremony and validates it before any production deploy job can
+run.
+
+This contract is validation-only. It does not generate fake production
+evidence, contact App Store Connect, run Fastlane, mutate protected upload
+automation, read App Store credentials, change runtime behavior, or change
+backend, iOS, OpenAPI, RAG, billing, semantic-cache, GraphRAG, or product-facing
+behavior.
+
+## Required Artifact Source
+
+Production tag workflows are not manually parameterized, so the CD workflow
+resolves two GitHub Actions variables before deploy:
+
+- `RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID`
+- `RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME`
+
+The variables may be defined on the `production` environment or at repository
+Actions scope. Environment variables take precedence when readable through the
+same protected configuration lookup used by production deploy mode resolution.
+
+When `WEB_IOS_RELEASE_READY=true`, `PRODUCTION_ENV_READY=true`, and
+`PROD_DEPLOY_MODE` requests production deploy, both variables are required.
+Missing or malformed values fail closed before deploy.
+
+## Required Artifact Layout
+
+The downloaded artifact must contain this exact directory:
+
+```text
+release-control-plane/
+  release_manifest.json
+  rag_gate_result.json
+  build_equivalence_result.json
+```
+
+The production tag job validates those files with:
+
+```bash
+python3 scripts/ci/check_release_control_plane.py \
+  --release-manifest "${evidence_dir}/release_manifest.json" \
+  --rag-gate-result "${evidence_dir}/rag_gate_result.json" \
+  --build-equivalence "${evidence_dir}/build_equivalence_result.json" \
+  --json-out "${output_dir}/release_control_plane_ci_gate.json" \
+  --markdown-out "${output_dir}/release_control_plane_ci_gate.md"
+```
+
+The checker must return `ALLOW`. Any `BLOCK` decision exits nonzero and blocks
+production deploy.
+
+## Published Evidence
+
+The production evidence job uploads:
+
+```text
+release_control_plane_ci_gate.json
+release_control_plane_ci_gate.md
+```
+
+as workflow artifact:
+
+```text
+release-control-plane-ci-gate-cd-production
+```
+
+The Markdown summary is also appended to the GitHub Actions step summary when
+the checker produced it.
+
+## Fail-Closed Rules
+
+Production deploy must not proceed when:
+
+- `RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID` is missing or not numeric;
+- `RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME` is missing or names a fixture;
+- the configured artifact cannot be downloaded;
+- any required file is absent from `release-control-plane/`;
+- any evidence JSON is malformed;
+- the release manifest decision is `BLOCK`;
+- the RAG gate result decision is not `PASS`;
+- the build-equivalence decision is not `EQUIVALENT`;
+- SBOM/provenance digests are missing or malformed;
+- attestation status is not `VERIFIED`;
+- evidence hashes, release manifest hash, git SHA, or build identity mismatch;
+- the checker cannot produce deterministic JSON output.
+
+The workflow must not use `continue-on-error` for this gate.
+
+## Fixture Boundary
+
+Fixtures are allowed only in tests and in the non-secret `main` fixture
+validation job that exercises the checker contract.
+
+Fixtures must never be downloaded or substituted in the production tag path.
+The production evidence artifact name rejects `fixture` in any casing, and the
+production workflow job must not reference test fixture paths.
+
+## Deferred Work
+
+This PR does not automate App Store Connect upload or Fastlane protected upload
+mutation. Those remain later explicitly scoped protected-environment slices.

--- a/docs/release/RELEASE_CONTROL_PLANE_EPIC.md
+++ b/docs/release/RELEASE_CONTROL_PLANE_EPIC.md
@@ -108,12 +108,22 @@ review governance.
 
 6. **PR-5: CI release decision integration**
    - Branch: `release/release-control-plane-pr5-ci-gates`
-   - Active PR-5 slice.
+   - Merged as PR #1682 on 2026-05-06.
    - Add focused CI gates for release manifest, RAG gate result, build-equivalence result, SBOM/provenance references, and `ALLOW` / `BLOCK` decision.
    - Contract: [`RELEASE_CONTROL_PLANE_CI_GATE.md`](RELEASE_CONTROL_PLANE_CI_GATE.md)
      and [`RELEASE_CONTROL_PLANE_CI_GATE.schema.json`](RELEASE_CONTROL_PLANE_CI_GATE.schema.json).
    - Helper: `scripts/ci/check_release_control_plane.py`.
    - Protected App Store upload and App Store Connect execution remain out of scope.
+
+7. **PR-6: production release evidence artifact wiring**
+   - Branch: `release/release-control-plane-pr6-production-artifact-wiring`
+   - Active PR-6 slice.
+   - Wire real production release-control-plane evidence artifacts into the production tag path before deploy.
+   - Contract: [`PRODUCTION_RELEASE_EVIDENCE_WIRING.md`](PRODUCTION_RELEASE_EVIDENCE_WIRING.md).
+   - Production deploy requires downloaded real `release_manifest.json`,
+     `rag_gate_result.json`, and `build_equivalence_result.json` evidence.
+   - Fixtures remain test/main validation only and must not be used in the production tag path.
+   - Protected App Store upload automation, Fastlane mutation, and App Store Connect execution remain out of scope.
 
 ## Boundaries
 
@@ -190,3 +200,7 @@ Blocked: diagnosis, treatment, therapy, crisis support, guaranteed outcomes.
 9. PR-5 adds the CI release-decision checker and a non-secret fixture validation
    job, while protected production artifact wiring and upload execution remain
    later explicitly scoped protected-environment work.
+10. PR-6 wires real release-control-plane evidence artifacts into the
+    production tag workflow path and keeps upload execution deferred. It does
+    not generate fake production evidence, and production deploy must fail
+    closed when required evidence cannot be downloaded or validated.

--- a/docs/review/PR_1688_FIXED_MAPPING.md
+++ b/docs/review/PR_1688_FIXED_MAPPING.md
@@ -17,7 +17,6 @@ scope.
 ## Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1688#discussion_r3196349030 -> 0bc019fd0
-
 Disposition: FIXED
 Commit: 0bc019fd0
 Evidence: `.github/workflows/cd.yml` compares `release_manifest.json` `build_identity.git_sha` with the production tag commit; `tests/test_production_release_evidence_wiring.py::test_production_job_rejects_evidence_for_different_tag_commit` covers the stale-evidence failure mode. Follow-up hardening commit: 38676dde6.

--- a/docs/review/PR_1688_FIXED_MAPPING.md
+++ b/docs/review/PR_1688_FIXED_MAPPING.md
@@ -14,7 +14,7 @@ scope.
 - [x] Internal QA / bug-hunter / security / premortem pass completed against
   actual changed files.
 - [x] Premortem P0/P1 findings fixed before mapping.
-- [ ] External bot/human discussion-thread pass completed.
+- [x] External bot/human discussion-thread pass completed.
 
 ## Fixed in Commit Mapping
 
@@ -45,6 +45,23 @@ Evidence:
 - Focused validation after the fix:
   `. .venv/bin/activate && pytest -q tests/test_production_release_evidence_wiring.py tests/test_release_control_plane_ci_gate.py tests/test_build_equivalence.py`
   PASS (`61 passed`).
+
+### Codex review: require evidence to match the current release
+
+Thread: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1688#discussion_r3196349030>
+
+Disposition: FIXED
+Commit: `0bc019fd0`
+Evidence:
+
+- `.github/workflows/cd.yml` now resolves the production tag commit and fails
+  closed when the downloaded `release_manifest.json` `build_identity.git_sha`
+  differs from that tag commit.
+- `tests/test_production_release_evidence_wiring.py::test_production_job_rejects_evidence_for_different_tag_commit`
+  covers the exact stale-evidence failure mode from the review thread.
+- Follow-up hardening in `38676dde6` also verifies the evidence source run
+  provenance before download: completed, successful, matching head SHA,
+  `workflow_dispatch`, and release-control-plane workflow naming.
 
 ## Validation
 

--- a/docs/review/PR_1688_FIXED_MAPPING.md
+++ b/docs/review/PR_1688_FIXED_MAPPING.md
@@ -10,13 +10,19 @@ scope.
 
 ## Discussion Thread Pass
 
-- [x] Initial post-open coordinator bootstrap completed.
-- [x] Internal QA / bug-hunter / security / premortem pass completed against
-  actual changed files.
-- [x] Premortem P0/P1 findings fixed before mapping.
+- [x] Discussion-thread pass completed
 - [x] External bot/human discussion-thread pass completed.
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1688#discussion_r3196349030 -> 0bc019fd0
+
+Disposition: FIXED
+Commit: 0bc019fd0
+Evidence: `.github/workflows/cd.yml` compares `release_manifest.json` `build_identity.git_sha` with the production tag commit; `tests/test_production_release_evidence_wiring.py::test_production_job_rejects_evidence_for_different_tag_commit` covers the stale-evidence failure mode. Follow-up hardening commit: 38676dde6.
+
+## Premortem Finding Dispositions
 
 ### Internal Premortem: production evidence artifact could belong to a different tag commit
 

--- a/docs/review/PR_1688_FIXED_MAPPING.md
+++ b/docs/review/PR_1688_FIXED_MAPPING.md
@@ -50,7 +50,7 @@ Evidence:
 
 - `python3 scripts/orchestration/check_preflight.py` PASS
 - `python3 scripts/orchestration/check_agent_consistency.py` PASS
-- `. .venv/bin/activate && pytest -q tests/test_production_release_evidence_wiring.py` PASS (`12 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_production_release_evidence_wiring.py` PASS (`13 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`26 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_release_manifest.py` PASS (`20 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_build_equivalence.py` PASS (`22 passed`)
@@ -58,10 +58,8 @@ Evidence:
 - `. .venv/bin/activate && pytest -q tests/test_check_docker_provenance_attestation.py` PASS (`12 passed`)
 - `. .venv/bin/activate && pytest -q tests/test_repo_policy_guards.py` PASS (`14 passed`)
 - `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/roadmap/BACKLOG_LEDGER.md` PASS
-- `make validate-changed` PASS (`59 passed`) before the source-run
-  provenance fix; rerun required after review artifact commits.
-- `pre-commit run --all-files` PASS before the source-run provenance fix; rerun
-  required after review artifact commits.
+- `make validate-changed` PASS (`61 passed`)
+- `pre-commit run --all-files` PASS
 - Pre-push hooks PASS before PR open.
 
 ## Machine-Heavy Deferral

--- a/docs/review/PR_1688_FIXED_MAPPING.md
+++ b/docs/review/PR_1688_FIXED_MAPPING.md
@@ -1,0 +1,77 @@
+# PR 1688 Fixed Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1688>
+
+## Summary
+
+PR #1688 wires production release-control-plane evidence artifacts into the
+production tag path and keeps App Store/Fastlane upload automation out of
+scope.
+
+## Discussion Thread Pass
+
+- [x] Initial post-open coordinator bootstrap completed.
+- [x] Internal QA / bug-hunter / security / premortem pass completed against
+  actual changed files.
+- [x] Premortem P0/P1 findings fixed before mapping.
+- [ ] External bot/human discussion-thread pass completed.
+
+## Fixed in Commit Mapping
+
+### Internal Premortem: production evidence artifact could belong to a different tag commit
+
+Disposition: FIXED
+Commit: `0bc019fd0`
+Evidence:
+
+- `.github/workflows/cd.yml` resolves the production tag commit and fails
+  closed when `release_manifest.json` `build_identity.git_sha` differs.
+- `tests/test_production_release_evidence_wiring.py::test_production_job_rejects_evidence_for_different_tag_commit`
+  covers the workflow contract.
+
+### Internal Premortem / Sidecar Review: production evidence artifact could come from an ungoverned source run
+
+Disposition: FIXED
+Commit: `38676dde6`
+Evidence:
+
+- `.github/workflows/cd.yml` runs `gh run view` before `gh run download` and
+  requires source run `completed`, `success`, matching `headSha`,
+  `workflow_dispatch`, and release-control-plane workflow naming.
+- `docs/release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md` documents the
+  source-run provenance requirements and fail-closed behavior.
+- `tests/test_production_release_evidence_wiring.py::test_production_job_verifies_evidence_run_provenance_before_download`
+  covers the workflow contract.
+- Focused validation after the fix:
+  `. .venv/bin/activate && pytest -q tests/test_production_release_evidence_wiring.py tests/test_release_control_plane_ci_gate.py tests/test_build_equivalence.py`
+  PASS (`61 passed`).
+
+## Validation
+
+- `python3 scripts/orchestration/check_preflight.py` PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS
+- `. .venv/bin/activate && pytest -q tests/test_production_release_evidence_wiring.py` PASS (`12 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`26 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_release_manifest.py` PASS (`20 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_build_equivalence.py` PASS (`22 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_rag_release_gates_runner.py` PASS (`48 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_check_docker_provenance_attestation.py` PASS (`12 passed`)
+- `. .venv/bin/activate && pytest -q tests/test_repo_policy_guards.py` PASS (`14 passed`)
+- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/roadmap/BACKLOG_LEDGER.md` PASS
+- `make validate-changed` PASS (`59 passed`) before the source-run
+  provenance fix; rerun required after review artifact commits.
+- `pre-commit run --all-files` PASS before the source-run provenance fix; rerun
+  required after review artifact commits.
+- Pre-push hooks PASS before PR open.
+
+## Machine-Heavy Deferral
+
+Full local `make verify` intentionally not run. This is the operator-approved
+bounded-check path for a machine-heavy CI/release-governance PR.
+
+## Deferred / Follow-ups
+
+- App Store Connect upload and Fastlane protected upload mutation remain
+  deferred to a later explicitly scoped protected-environment PR.
+- The real release evidence artifact is produced by a separate governed release
+  ceremony/run before the production tag deploy attempt.

--- a/docs/review/PR_1688_PREMORTEM.md
+++ b/docs/review/PR_1688_PREMORTEM.md
@@ -174,9 +174,9 @@ Unresolved P2: none.
 
 - `python3 scripts/orchestration/check_preflight.py` PASS
 - `python3 scripts/orchestration/check_agent_consistency.py` PASS
-- `. .venv/bin/activate && pytest -q tests/test_production_release_evidence_wiring.py` PASS (`12 passed`) before the source-run provenance fix
+- `. .venv/bin/activate && pytest -q tests/test_production_release_evidence_wiring.py` PASS (`13 passed`) after all premortem fixes
 - `. .venv/bin/activate && pytest -q tests/test_production_release_evidence_wiring.py tests/test_release_control_plane_ci_gate.py tests/test_build_equivalence.py` PASS (`61 passed`) after the source-run provenance fix
 - Bounded release-control-plane suite PASS before the premortem fix (`11`, `26`, `20`, `22`, `48`, `12`, and `14` passing test groups)
 - `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/roadmap/BACKLOG_LEDGER.md` PASS
-- `make validate-changed` PASS (`59 passed`) before the premortem fix; rerun required after this artifact lands.
-- `pre-commit run --all-files` PASS before the premortem fix; rerun required after this artifact lands.
+- `make validate-changed` PASS (`61 passed`) after all premortem/review artifact changes.
+- `pre-commit run --all-files` PASS after all premortem/review artifact changes.

--- a/docs/review/PR_1688_PREMORTEM.md
+++ b/docs/review/PR_1688_PREMORTEM.md
@@ -1,0 +1,182 @@
+# PR 1688 Premortem: Production Release Evidence Wiring
+
+Mode: `pr-premortem`
+Skill: `pulseplate-premortem-risk-review`
+Packet: `artifacts/orchestration/task_packets/5fc8577f508e.json`
+
+## Frame
+
+It is 48 hours from now. This CI/CD release-governance PR made production
+release evidence validation weaker or misleading. We are looking backward to
+understand why.
+
+## Scope Inspected
+
+- `.github/workflows/cd.yml`
+- `docs/release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md`
+- `docs/release/RELEASE_CONTROL_PLANE_EPIC.md`
+- `docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md`
+- `docs/roadmap/BACKLOG_LEDGER.md`
+- `tests/test_production_release_evidence_wiring.py`
+- `tests/test_release_control_plane_ci_gate.py`
+- `tests/test_build_equivalence.py`
+
+## Findings
+
+### P1: Production evidence artifact could belong to a different tag commit
+
+**Failure story:** The production tag workflow downloaded a real-looking
+release-control-plane artifact from the configured prior run. The existing
+checker verified the release manifest, RAG gate result, build-equivalence
+result, hashes, and supply-chain fields against each other, but the workflow did
+not independently prove that the manifest build git SHA matched the commit
+selected by the production tag. A stale or wrong evidence artifact could pass
+internal consistency checks while representing a different commit.
+
+**Underlying assumption:** Internal evidence coherence was enough without a
+tag-commit cross-check at the production workflow boundary.
+
+**Fix:** `ci(release): require production evidence to match tag commit`
+(`0bc019fd0`) adds a production workflow check that resolves
+`${GITHUB_REF#refs/tags/}^{commit}`, reads
+`release_manifest.json` `build_identity.git_sha`, and fails closed when they do
+not match.
+
+**Evidence:**
+
+- `.github/workflows/cd.yml` production evidence job uses checkout
+  `fetch-depth: 0` before resolving the tag commit.
+- `.github/workflows/cd.yml` validates `manifest_git_sha != tag_commit` as a
+  blocking error.
+- `tests/test_production_release_evidence_wiring.py::test_production_job_rejects_evidence_for_different_tag_commit`
+  covers the workflow contract.
+
+**Disposition:** FIXED.
+
+### P1: Production evidence artifact could come from an ungoverned source run
+
+**Failure story:** The workflow accepted a numeric run id and non-fixture
+artifact name, then downloaded the artifact before verifying the run that
+produced it. An arbitrary same-repository run could upload a matching-looking
+release-control-plane artifact for the tag commit. The content-level manifest
+git SHA check would catch cross-commit drift, but not whether the evidence came
+from a completed, successful, governed release-evidence producer.
+
+**Underlying assumption:** Artifact content validation was enough without
+checking the GitHub Actions run provenance for the evidence-producing run.
+
+**Fix:** The production evidence download step now calls
+`gh run view "$RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID" --json status,conclusion,headSha,event,workflowName,url`
+before download and fails closed unless the source run is completed, successful,
+matches the production tag commit, is a `workflow_dispatch` run, and has a
+release-control-plane workflow name.
+
+**Evidence:**
+
+- `.github/workflows/cd.yml` verifies source run metadata before
+  `gh run download`.
+- `docs/release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md` documents source-run
+  provenance requirements and fail-closed rules.
+- `tests/test_production_release_evidence_wiring.py::test_production_job_verifies_evidence_run_provenance_before_download`
+  covers the workflow contract.
+
+**Disposition:** FIXED.
+
+## Failure Modes Rechecked
+
+1. Production deploy can proceed without `release_manifest.json`.
+   - Disposition: NOT-A-BUG after inspection.
+   - Evidence: production evidence job checks `release_manifest.json` exists
+     before invoking the checker; checker also returns `missing_release_manifest`.
+
+2. Production deploy can proceed without `rag_gate_result.json`.
+   - Disposition: NOT-A-BUG after inspection.
+   - Evidence: production evidence job checks `rag_gate_result.json` exists
+     before invoking the checker; checker also returns `missing_rag_gate_result`.
+
+3. Production deploy can proceed without `build_equivalence_result.json`.
+   - Disposition: NOT-A-BUG after inspection.
+   - Evidence: production evidence job checks `build_equivalence_result.json`
+     exists before invoking the checker; checker also returns
+     `missing_build_equivalence`.
+
+4. Fixture evidence is used in production tag path.
+   - Disposition: NOT-A-BUG after inspection.
+   - Evidence: fixture job is `main` only, production artifact names reject
+     fixture naming, and production workflow tests assert no fixture paths in
+     the production job.
+
+5. Release-control-plane gate is advisory or `continue-on-error`.
+   - Disposition: NOT-A-BUG after inspection.
+   - Evidence: production evidence job invokes
+     `scripts/ci/check_release_control_plane.py` without `continue-on-error`;
+     deploy jobs depend on the evidence job.
+
+6. Workflow requires App Store secrets in normal PR/main validation path.
+   - Disposition: NOT-A-BUG after inspection.
+   - Evidence: production evidence job uses only `secrets.GITHUB_TOKEN`; tests
+     assert no App Store/Fastlane secret terms in the production evidence job.
+
+7. Workflow adds Fastlane/App Store upload mutation.
+   - Disposition: NOT-A-BUG after inspection.
+   - Evidence: changed files do not include `ios/fastlane/**`; production
+     workflow tests assert no Fastlane/App Store upload terms.
+
+8. Evidence git SHA mismatch is ignored.
+   - Disposition: FIXED.
+   - Evidence: P1 finding above fixed in `0bc019fd0`.
+
+8b. Evidence run provenance is ignored.
+    - Disposition: FIXED.
+    - Evidence: second P1 finding above fixed before mapping; focused workflow
+      tests assert source-run metadata is checked before artifact download.
+
+9. SBOM/provenance evidence is ignored.
+   - Disposition: NOT-A-BUG after inspection.
+   - Evidence: PR-5 checker still blocks missing/invalid SBOM/provenance
+     digests and unverified attestation; PR-6 invokes that checker in the
+     production tag path.
+
+10. Release gate artifact is not uploaded.
+    - Disposition: NOT-A-BUG after inspection.
+    - Evidence: production evidence job uploads
+      `release-control-plane-ci-gate-cd-production` with JSON and Markdown
+      output paths.
+
+11. Workflow breaks normal PR CI path.
+    - Disposition: NOT-A-BUG after inspection.
+    - Evidence: CD workflow still triggers on `main` and `v*` tags only; the
+      production evidence job is tag-only and deploy-active only.
+
+12. Ledger incorrectly claims full App Store readiness complete.
+    - Disposition: NOT-A-BUG after inspection.
+    - Evidence: ledger says full App Store readiness is not complete and train
+      is not production-ready.
+
+13. Runtime/API/iOS/OpenAPI files are changed.
+    - Disposition: NOT-A-BUG after inspection.
+    - Evidence: diff is limited to workflow, release docs, ledger, and tests.
+
+14. Mapping/checklists are used instead of fixing findings.
+    - Disposition: NOT-A-BUG after inspection.
+    - Evidence: the P1 finding was fixed in workflow/tests before this artifact
+      records it.
+
+## Decision
+
+`proceed with changes` -> after the tag-commit cross-check and source-run
+provenance fixes, no unresolved P0/P1 premortem findings remain.
+
+Unresolved P0/P1: none.
+Unresolved P2: none.
+
+## Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS
+- `. .venv/bin/activate && pytest -q tests/test_production_release_evidence_wiring.py` PASS (`12 passed`) before the source-run provenance fix
+- `. .venv/bin/activate && pytest -q tests/test_production_release_evidence_wiring.py tests/test_release_control_plane_ci_gate.py tests/test_build_equivalence.py` PASS (`61 passed`) after the source-run provenance fix
+- Bounded release-control-plane suite PASS before the premortem fix (`11`, `26`, `20`, `22`, `48`, `12`, and `14` passing test groups)
+- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/roadmap/BACKLOG_LEDGER.md` PASS
+- `make validate-changed` PASS (`59 passed`) before the premortem fix; rerun required after this artifact lands.
+- `pre-commit run --all-files` PASS before the premortem fix; rerun required after this artifact lands.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -445,10 +445,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Release automation control plane for C4, App Store Review, ML gates, and supply chain
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-RELEASE-CONTROL-PLANE-PR0 -> PR #1605 -> PR #1679 -> PR-TBD-RELEASE-CONTROL-PLANE-PR5 (`release/release-control-plane-pr5-ci-gates`)
+  - Target PR: PR-TBD-RELEASE-CONTROL-PLANE-PR0 -> PR #1605 -> PR #1679 -> PR #1682 -> PR-TBD-RELEASE-CONTROL-PLANE-PR6 (`release/release-control-plane-pr6-production-artifact-wiring`)
   - Area: release / App Store / AI evals / supply-chain / orchestration
   - Finding Type: release evidence unification gap
-  - Status: PR-0, PR-1, and PR-2 merged; PR-3 merged in PR #1605 on 2026-04-30; PR-4 merged in PR #1679 on 2026-05-06; PR-5 is active on branch `release/release-control-plane-pr5-ci-gates` for CI fail-closed release-decision integration. Future protected upload and App Store Connect execution remain out of scope. The release-control-plane epic is not complete, full App Store readiness is not complete, and the train is not production-ready.
+  - Status: PR-0, PR-1, and PR-2 merged; PR-3 merged in PR #1605 on 2026-04-30; PR-4 merged in PR #1679 on 2026-05-06; PR-5 merged in PR #1682 on 2026-05-06; PR-6 is active on branch `release/release-control-plane-pr6-production-artifact-wiring` for protected production release-evidence artifact wiring. Future protected upload automation and App Store Connect execution remain out of scope. The release-control-plane epic is not complete, full App Store readiness is not complete, and the train is not production-ready.
   - Reason (EN): The App Store readiness PR train is owned separately, while the attached release-automation document also identifies a cross-cutting control-plane gap: build identity, reviewer packet identity, RAG/ML gate identity, supply-chain provenance, and the final release decision are not yet represented by one machine-readable release packet. This line complements PR `#1582` without editing its branch or worktree.
   - Links:
     - `docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md`
@@ -477,7 +477,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - PR-2 exports a stable RAG/ML gate-result schema from the existing release-gate runner without creating a second eval source of truth, including `rag_gate_result_hash`, `eval_artifact_hash`, existing `PASS` / `NO-GO` eval decision fields, and safe artifact references.
     - PR-3 adds a release manifest generator and fail-closed validator. Completed by PR #1605.
     - PR-4 proves review-build and production-candidate equivalence by digest/hash checks. Completed by PR #1679.
-    - PR-5 integrates focused CI gates for manifest, ML gate result, build-equivalence result, SBOM/provenance references, and `ALLOW` / `BLOCK` decision. Active in `release/release-control-plane-pr5-ci-gates`; protected upload and App Store Connect execution remain deferred follow-ups.
+    - PR-5 integrates focused CI gates for manifest, ML gate result, build-equivalence result, SBOM/provenance references, and `ALLOW` / `BLOCK` decision. Completed by PR #1682.
+    - PR-6 wires real production release evidence artifacts into the production tag workflow path, requiring release manifest, RAG gate result, build-equivalence result, and supply-chain identity evidence before production deploy can treat the release-control-plane gate as `ALLOW`. Active in `release/release-control-plane-pr6-production-artifact-wiring`; protected upload automation and App Store Connect execution remain deferred follow-ups.
 
 <a id="ledger-p1-planning-flow-monetization-wave"></a>
 - [ ] P1: Planning-flow monetization wave over the canonical FREE -> PRO -> VIP ladder

--- a/tests/test_build_equivalence.py
+++ b/tests/test_build_equivalence.py
@@ -465,8 +465,13 @@ def test_ledger_release_control_plane_state_is_reconciled() -> None:
 
     assert "PR-3 merged in PR #1605" in ledger_text
     assert "PR-4 merged in PR #1679 on 2026-05-06" in ledger_text
-    assert "PR-5 is active on branch `release/release-control-plane-pr5-ci-gates`" in ledger_text
+    assert "PR-5 merged in PR #1682 on 2026-05-06" in ledger_text
     assert (
-        "Future protected upload and App Store Connect execution remain out of scope" in ledger_text
+        "PR-6 is active on branch `release/release-control-plane-pr6-production-artifact-wiring`"
+        in ledger_text
+    )
+    assert (
+        "Future protected upload automation and App Store Connect execution remain out of scope"
+        in ledger_text
     )
     assert "not production-ready" in ledger_text

--- a/tests/test_production_release_evidence_wiring.py
+++ b/tests/test_production_release_evidence_wiring.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+from scripts.ci import check_release_control_plane
+from scripts.release import build_equivalence
+from scripts.release import release_manifest
+from scripts.release import reviewer_packet_hashes
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CD_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/cd.yml"
+TEST_GIT_SHA = "git-sha-for-production-release-evidence-wiring-tests"
+OCI_DIGEST = "sha256:" + ("a" * 64)
+PROVENANCE_DIGEST = "sha256:" + ("b" * 64)
+ARTIFACT_DIGEST = "sha256:" + ("e" * 64)
+
+
+def _load_cd_workflow() -> dict[str, object]:
+    return yaml.safe_load(CD_WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _job(workflow: dict[str, object], name: str) -> dict[str, object]:
+    return workflow["jobs"][name]  # type: ignore[index]
+
+
+def _steps(job: dict[str, object]) -> list[dict[str, object]]:
+    return job["steps"]  # type: ignore[index]
+
+
+def _step_by_name(job: dict[str, object], name: str) -> dict[str, object]:
+    for step in _steps(job):
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"Step {name!r} not found")
+
+
+def _step_run(job: dict[str, object], name: str) -> str:
+    return str(_step_by_name(job, name)["run"])
+
+
+def _write_metadata_pack(repo_root: Path) -> None:
+    notes_path = repo_root / "ios/fastlane/metadata/review_information/notes.txt"
+    notes_path.parent.mkdir(parents=True, exist_ok=True)
+    notes_path.write_text("Reviewer note\n", encoding="utf-8")
+
+    privacy_path = repo_root / "ios/fastlane/app_privacy_details.json"
+    privacy_path.parent.mkdir(parents=True, exist_ok=True)
+    privacy_path.write_text('[{"data_protections":["DATA_NOT_COLLECTED"]}]\n', encoding="utf-8")
+
+    for locale in reviewer_packet_hashes.REQUIRED_LOCALES:
+        locale_dir = repo_root / "ios/fastlane/metadata" / locale
+        locale_dir.mkdir(parents=True, exist_ok=True)
+        for filename in reviewer_packet_hashes.REQUIRED_METADATA_FILES:
+            (locale_dir / filename).write_text(f"{locale}:{filename}\n", encoding="utf-8")
+
+
+def _rag_payload(*, git_sha: str = TEST_GIT_SHA) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "release-rag-gate-result.v1",
+        "hash_algorithm": "sha256",
+        "canonicalization": release_manifest.CANONICALIZATION,
+        "eval_artifact_hash": "c" * 64,
+        "experiment_id": "production-wiring-test",
+        "timestamp": "2026-05-06T00:00:00Z",
+        "release_decision": "PASS",
+        "gate_checks": {"answer_precision_min": True},
+        "threshold_results": [],
+        "strict_violations": [],
+        "runtime_warnings": [],
+        "dataset_path_used": "tests/fixtures/rag.jsonl",
+        "dataset_fallback_used": False,
+        "sample_size": 1,
+        "git_sha": git_sha,
+        "retriever_mode": "local_tfidf",
+        "generator_mode": "extractive_stub",
+        "small_fixture_metric_gates_advisory": False,
+        "source_artifacts": [
+            {
+                "kind": "metrics_summary",
+                "path": "artifacts/rag_eval/production-wiring-test/metrics_summary.json",
+                "hash": "d" * 64,
+            }
+        ],
+    }
+    payload["rag_gate_result_hash"] = release_manifest.sha256_lower_hex(
+        release_manifest.canonical_json_bytes(payload)
+    )
+    return payload
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _build_evidence(
+    tmp_path: Path,
+) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
+    _write_metadata_pack(tmp_path)
+    rag_payload = _rag_payload()
+    rag_path = tmp_path / "artifacts/rag_eval/production-wiring-test/rag_gate_result.json"
+    _write_json(rag_path, rag_payload)
+    manifest_payload = release_manifest.build_manifest_payload(
+        repo_root=tmp_path,
+        git_sha=TEST_GIT_SHA,
+        ios_build_number="100",
+        marketing_version="1.0",
+        bundle_id="app.pulseplate.PulsePlate",
+        rag_gate_result_path=rag_path,
+        sbom_digest=OCI_DIGEST,
+        provenance_digest=PROVENANCE_DIGEST,
+        attestation_status="VERIFIED",
+    )
+    identity_payload = {
+        "schema_version": "release-build-identity.v1",
+        "hash_algorithm": "sha256",
+        "canonicalization": release_manifest.CANONICALIZATION,
+        "build_identity": manifest_payload["build_identity"],
+        "artifact_digest": ARTIFACT_DIGEST,
+        "release_manifest_hash": manifest_payload["release_manifest_hash"],
+        "reviewer_identity": manifest_payload["reviewer_identity"],
+        "ml_identity": manifest_payload["ml_identity"],
+        "supply_chain_identity": manifest_payload["supply_chain_identity"],
+    }
+    build_payload = build_equivalence.build_equivalence_decision(
+        review_payload=identity_payload,
+        production_payload=identity_payload,
+        manifest_payload=manifest_payload,
+    )
+    return manifest_payload, rag_payload, build_payload
+
+
+def _write_evidence(
+    tmp_path: Path,
+    *,
+    manifest_payload: dict[str, object] | None = None,
+    rag_payload: dict[str, object] | None = None,
+    build_payload: dict[str, object] | None = None,
+) -> tuple[Path, Path, Path]:
+    if manifest_payload is None or rag_payload is None or build_payload is None:
+        manifest_payload, rag_payload, build_payload = _build_evidence(tmp_path)
+    evidence_dir = tmp_path / "release-control-plane"
+    manifest_path = evidence_dir / "release_manifest.json"
+    rag_path = evidence_dir / "rag_gate_result.json"
+    build_path = evidence_dir / "build_equivalence_result.json"
+    _write_json(manifest_path, manifest_payload)
+    _write_json(rag_path, rag_payload)
+    _write_json(build_path, build_payload)
+    return manifest_path, rag_path, build_path
+
+
+def test_production_tag_workflow_includes_release_control_plane_evidence_gate() -> None:
+    workflow = _load_cd_workflow()
+    production_job = _job(workflow, "release-control-plane-production-evidence")
+    download_script = _step_run(
+        production_job,
+        "Download production release-control-plane evidence artifact",
+    )
+    validate_script = _step_run(
+        production_job, "Validate production release-control-plane evidence"
+    )
+
+    assert production_job["if"] == (
+        "startsWith(github.ref, 'refs/tags/v') && "
+        "needs.production-deploy-config.outputs.should_deploy == 'true'"
+    )
+    assert production_job["needs"] == ["build-production", "production-deploy-config"]
+    assert "RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID" in download_script
+    assert "RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME" in download_script
+    assert 'gh run download "$RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID"' in download_script
+    assert '--name "$RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME"' in download_script
+    assert "scripts/ci/check_release_control_plane.py" in validate_script
+    assert "--release-manifest" in validate_script
+    assert "--rag-gate-result" in validate_script
+    assert "--build-equivalence" in validate_script
+
+
+def test_production_deploy_jobs_depend_on_release_control_plane_gate() -> None:
+    workflow = _load_cd_workflow()
+    expected_gate = "release-control-plane-production-evidence"
+
+    for job_name in ("deploy-production", "deploy-production-self-hosted"):
+        assert expected_gate in _job(workflow, job_name)["needs"]
+
+
+def test_pr_and_main_fixture_path_is_not_used_on_production_tags() -> None:
+    workflow = _load_cd_workflow()
+    fixture_job = _job(workflow, "release-control-plane-fixture-gate")
+    production_job_text = json.dumps(
+        _job(workflow, "release-control-plane-production-evidence"),
+        sort_keys=True,
+    )
+
+    assert fixture_job["if"] == "github.ref == 'refs/heads/main'"
+    assert "release-control-plane-fixture" not in production_job_text
+    assert "tests/fixtures" not in production_job_text
+    assert "fixture_root" not in production_job_text
+
+
+def test_production_path_does_not_require_app_store_secrets_or_upload_behavior() -> None:
+    workflow = _load_cd_workflow()
+    production_job_text = json.dumps(
+        _job(workflow, "release-control-plane-production-evidence"),
+        sort_keys=True,
+    )
+    forbidden_terms = (
+        "APP_STORE",
+        "APPSTORE",
+        "ASC_",
+        "FASTLANE",
+        "MATCH_PASSWORD",
+        "app store connect",
+    )
+
+    assert "secrets.GITHUB_TOKEN" in production_job_text
+    assert not any(term in production_job_text for term in forbidden_terms)
+    assert "fastlane" not in production_job_text.lower()
+    assert "upload_to_app_store" not in production_job_text.lower()
+
+
+def test_release_control_plane_gate_uploads_json_and_markdown_artifacts() -> None:
+    workflow = _load_cd_workflow()
+    production_job = _job(workflow, "release-control-plane-production-evidence")
+    upload_step = _step_by_name(
+        production_job, "Upload production release-control-plane gate artifact"
+    )
+    summary_script = _step_run(
+        production_job, "Publish production release-control-plane gate summary"
+    )
+
+    assert upload_step["if"] == "${{ always() }}"
+    assert upload_step["with"]["name"] == "release-control-plane-ci-gate-cd-production"
+    assert "release_control_plane_ci_gate.json" in upload_step["with"]["path"]
+    assert "release_control_plane_ci_gate.md" in upload_step["with"]["path"]
+    assert "release_control_plane_ci_gate.md" in summary_script
+
+
+def test_production_deploy_config_requires_evidence_variables_when_deploy_is_active() -> None:
+    workflow = _load_cd_workflow()
+    config_job = _job(workflow, "production-deploy-config")
+    resolve_script = _step_run(config_job, "Resolve production deploy configuration")
+
+    assert "RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID" in resolve_script
+    assert "RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME" in resolve_script
+    assert "is required when production deploy is active" in resolve_script
+    assert (
+        config_job["outputs"]["evidence_run_id"] == "${{ steps.resolve.outputs.evidence_run_id }}"
+    )
+    assert (
+        config_job["outputs"]["evidence_artifact_name"]
+        == "${{ steps.resolve.outputs.evidence_artifact_name }}"
+    )
+
+
+def test_missing_release_control_plane_evidence_blocks(tmp_path: Path) -> None:
+    manifest_path, rag_path, build_path = _write_evidence(tmp_path)
+    manifest_path.unlink()
+    rag_path.unlink()
+    build_path.unlink()
+
+    decision = check_release_control_plane.check_release_control_plane_files(
+        release_manifest_path=manifest_path,
+        rag_gate_result_path=rag_path,
+        build_equivalence_path=build_path,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert decision["reason_codes"] == [
+        "missing_release_manifest",
+        "missing_rag_gate_result",
+        "missing_build_equivalence",
+    ]
+
+
+def test_invalid_artifact_paths_block(tmp_path: Path) -> None:
+    manifest_payload, rag_payload, build_payload = _build_evidence(tmp_path)
+    rag_payload["source_artifacts"] = [
+        {
+            "kind": "metrics_summary",
+            "path": "artifacts/../leak.json",
+            "hash": "d" * 64,
+        }
+    ]
+    rag_payload["rag_gate_result_hash"] = release_manifest.sha256_lower_hex(
+        release_manifest.canonical_json_bytes(
+            {key: value for key, value in rag_payload.items() if key != "rag_gate_result_hash"}
+        )
+    )
+    manifest_path, rag_path, build_path = _write_evidence(
+        tmp_path,
+        manifest_payload=manifest_payload,
+        rag_payload=rag_payload,
+        build_payload=build_payload,
+    )
+
+    decision = check_release_control_plane.check_release_control_plane_files(
+        release_manifest_path=manifest_path,
+        rag_gate_result_path=rag_path,
+        build_equivalence_path=build_path,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert "evidence_path_outside_allowed_artifacts" in decision["reason_codes"]
+
+
+def test_evidence_git_sha_mismatch_blocks(tmp_path: Path) -> None:
+    manifest_payload, _, build_payload = _build_evidence(tmp_path)
+    rag_payload = _rag_payload(git_sha="different-git-sha")
+    manifest_path, rag_path, build_path = _write_evidence(
+        tmp_path,
+        manifest_payload=manifest_payload,
+        rag_payload=rag_payload,
+        build_payload=build_payload,
+    )
+
+    decision = check_release_control_plane.check_release_control_plane_files(
+        release_manifest_path=manifest_path,
+        rag_gate_result_path=rag_path,
+        build_equivalence_path=build_path,
+    )
+
+    assert decision["decision"] == "BLOCK"
+    assert "git_sha_mismatch" in decision["reason_codes"]
+
+
+def test_ledger_marks_pr5_merged_and_pr6_active() -> None:
+    ledger = (REPO_ROOT / "docs/roadmap/BACKLOG_LEDGER.md").read_text(encoding="utf-8")
+
+    assert "PR-5 merged in PR #1682 on 2026-05-06" in ledger
+    assert (
+        "PR-6 is active on branch `release/release-control-plane-pr6-production-artifact-wiring`"
+        in ledger
+    )
+    assert (
+        "Future protected upload automation and App Store Connect execution remain out of scope"
+        in ledger
+    )
+    assert "full App Store readiness is not complete" in ledger
+
+
+def test_no_runtime_api_ios_or_openapi_files_are_in_pr6_scope() -> None:
+    scope_docs = "\n".join(
+        (
+            (REPO_ROOT / "docs/release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md").read_text(
+                encoding="utf-8"
+            ),
+            (REPO_ROOT / "docs/release/RELEASE_CONTROL_PLANE_EPIC.md").read_text(encoding="utf-8"),
+        )
+    )
+
+    assert re.search(r"does not .*runtime", scope_docs, flags=re.IGNORECASE | re.DOTALL)
+    assert "OpenAPI" in scope_docs
+    assert "Fastlane" in scope_docs

--- a/tests/test_production_release_evidence_wiring.py
+++ b/tests/test_production_release_evidence_wiring.py
@@ -171,6 +171,13 @@ def test_production_tag_workflow_includes_release_control_plane_evidence_gate() 
     assert production_job["needs"] == ["build-production", "production-deploy-config"]
     assert "RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID" in download_script
     assert "RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME" in download_script
+    assert 'gh run view "$RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID"' in download_script
+    assert "--json status,conclusion,headSha,event,workflowName,url" in download_script
+    assert 'run_status" != "completed"' in download_script
+    assert 'run_conclusion" != "success"' in download_script
+    assert 'run_head_sha" != "$tag_commit"' in download_script
+    assert 'run_event" != "workflow_dispatch"' in download_script
+    assert '"Release Control Plane"' in download_script
     assert 'gh run download "$RELEASE_CONTROL_PLANE_EVIDENCE_RUN_ID"' in download_script
     assert '--name "$RELEASE_CONTROL_PLANE_EVIDENCE_ARTIFACT_NAME"' in download_script
     assert "scripts/ci/check_release_control_plane.py" in validate_script
@@ -322,6 +329,24 @@ def test_production_job_rejects_evidence_for_different_tag_commit() -> None:
     assert 'if [ "$manifest_git_sha" != "$tag_commit" ]; then' in validate_script
     assert "Release manifest git SHA does not match production tag commit" in validate_script
     assert "exit 1" in validate_script
+
+
+def test_production_job_verifies_evidence_run_provenance_before_download() -> None:
+    workflow = _load_cd_workflow()
+    production_job = _job(workflow, "release-control-plane-production-evidence")
+    download_script = _step_run(
+        production_job,
+        "Download production release-control-plane evidence artifact",
+    )
+
+    assert "gh run view" in download_script
+    assert "--json status,conclusion,headSha,event,workflowName,url" in download_script
+    assert download_script.index("gh run view") < download_script.index("gh run download")
+    assert 'run_status" != "completed"' in download_script
+    assert 'run_conclusion" != "success"' in download_script
+    assert 'run_head_sha" != "$tag_commit"' in download_script
+    assert 'run_event" != "workflow_dispatch"' in download_script
+    assert "workflow name is not an approved release-evidence producer" in download_script
 
 
 def test_evidence_git_sha_mismatch_blocks(tmp_path: Path) -> None:

--- a/tests/test_production_release_evidence_wiring.py
+++ b/tests/test_production_release_evidence_wiring.py
@@ -177,6 +177,8 @@ def test_production_tag_workflow_includes_release_control_plane_evidence_gate() 
     assert "--release-manifest" in validate_script
     assert "--rag-gate-result" in validate_script
     assert "--build-equivalence" in validate_script
+    assert 'git rev-parse "${GITHUB_REF#refs/tags/}^{commit}"' in validate_script
+    assert "build_identity.git_sha" in validate_script
 
 
 def test_production_deploy_jobs_depend_on_release_control_plane_gate() -> None:
@@ -305,6 +307,21 @@ def test_invalid_artifact_paths_block(tmp_path: Path) -> None:
 
     assert decision["decision"] == "BLOCK"
     assert "evidence_path_outside_allowed_artifacts" in decision["reason_codes"]
+
+
+def test_production_job_rejects_evidence_for_different_tag_commit() -> None:
+    workflow = _load_cd_workflow()
+    production_job = _job(workflow, "release-control-plane-production-evidence")
+    checkout_step = _step_by_name(production_job, "Checkout")
+    validate_script = _step_run(
+        production_job, "Validate production release-control-plane evidence"
+    )
+
+    assert checkout_step["with"]["fetch-depth"] == 0
+    assert 'tag_commit="$(git rev-parse "${GITHUB_REF#refs/tags/}^{commit}")"' in validate_script
+    assert 'if [ "$manifest_git_sha" != "$tag_commit" ]; then' in validate_script
+    assert "Release manifest git SHA does not match production tag commit" in validate_script
+    assert "exit 1" in validate_script
 
 
 def test_evidence_git_sha_mismatch_blocks(tmp_path: Path) -> None:

--- a/tests/test_release_control_plane_ci_gate.py
+++ b/tests/test_release_control_plane_ci_gate.py
@@ -642,8 +642,15 @@ def test_ledger_marks_pr4_merged_and_pr5_active() -> None:
     ledger = (REPO_ROOT / "docs/roadmap/BACKLOG_LEDGER.md").read_text(encoding="utf-8")
 
     assert "PR-4 merged in PR #1679 on 2026-05-06" in ledger
-    assert "PR-5 is active on branch `release/release-control-plane-pr5-ci-gates`" in ledger
-    assert "Future protected upload and App Store Connect execution remain out of scope" in ledger
+    assert "PR-5 merged in PR #1682 on 2026-05-06" in ledger
+    assert (
+        "PR-6 is active on branch `release/release-control-plane-pr6-production-artifact-wiring`"
+        in ledger
+    )
+    assert (
+        "Future protected upload automation and App Store Connect execution remain out of scope"
+        in ledger
+    )
     assert "full App Store readiness is not complete" in ledger
 
 


### PR DESCRIPTION
## Summary
- Wires production release-control-plane evidence artifacts into the production tag path.
- Requires real release manifest, RAG gate result, build equivalence, and supply-chain evidence before production release ALLOW.
- Updates ledger so PR-5 is merged and PR-6 production artifact wiring is active/implemented.
- Does not add App Store upload automation or runtime changes.

## Scope
- production release evidence wiring
- focused workflow integration
- tests
- docs
- ledger reconciliation
- premortem artifact

## Out of scope
- App Store Connect upload
- Fastlane upload mutation
- runtime/API/iOS changes
- OpenAPI changes
- RAG behavior changes
- product-facing behavior

## Split Justification
This PR is intentionally kept as one release-control-plane wiring slice because the production tag workflow dependency, operator artifact contract, fail-closed tests, ledger state, premortem, and fixed mapping are one privileged release-governance change. Splitting the workflow and its deterministic contract tests would leave the production release path partially wired without matching validation evidence.

## Validation
- `python3 scripts/orchestration/check_preflight.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `. .venv/bin/activate && pytest -q tests/test_production_release_evidence_wiring.py` PASS (`13 passed`)
- `. .venv/bin/activate && pytest -q tests/test_release_control_plane_ci_gate.py` PASS (`26 passed`)
- `. .venv/bin/activate && pytest -q tests/test_release_manifest.py` PASS (`20 passed`)
- `. .venv/bin/activate && pytest -q tests/test_build_equivalence.py` PASS (`22 passed`)
- `. .venv/bin/activate && pytest -q tests/test_rag_release_gates_runner.py` PASS (`48 passed`)
- `. .venv/bin/activate && pytest -q tests/test_check_docker_provenance_attestation.py` PASS (`12 passed`)
- `. .venv/bin/activate && pytest -q tests/test_repo_policy_guards.py` PASS (`14 passed`)
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/release/PRODUCTION_RELEASE_EVIDENCE_WIRING.md docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/roadmap/BACKLOG_LEDGER.md` PASS
- `make validate-changed` PASS (`61 passed`)
- `pre-commit run --all-files` PASS
- pre-push hooks PASS

## Machine-heavy deferral
Full local `make verify` intentionally not run.
This PR uses bounded local gates plus `make validate-changed`.

## Premortem
- [x] Premortem pass completed against actual changed files
- [x] All P0/P1 premortem findings fixed or dispositioned as NOT-A-BUG with evidence
- [x] P2 findings, if any, are linked in BACKLOG_LEDGER.md

Link:
docs/review/PR_1688_PREMORTEM.md

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1688_FIXED_MAPPING.md`

## Deferred / Follow-ups
- App Store Connect upload and Fastlane protected upload mutation remain deferred to a later explicitly scoped protected-environment PR.
- The real release evidence artifact is produced by a separate governed release ceremony/run before the production tag deploy attempt.

## Merge Readiness
Do not mark ready unless:
- current PR head checks required for this PR are clean
- CodeRabbit/Sourcery/Cubic actionable comments are resolved or dispositioned
- fixed mapping artifact is complete
- premortem has no unresolved P0/P1 findings
- strict merge-readiness gate passes
