### PR TITLE
fix(ci): keep Codecov token out of frontend build

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -166,8 +166,9 @@ jobs:
 
       - name: Build frontend
         env:
-          CODECOV_BUNDLE_ANALYSIS: "true"
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          # Keep bundle analysis off for pull requests and feature/fix branch pushes so
+          # branch-controlled Vite build code never receives Codecov upload credentials.
+          CODECOV_BUNDLE_ANALYSIS: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'true' || 'false' }}
         run: npm run build
 
       - name: Verify Tailwind CSS utilities

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,7 +13,6 @@ export default defineConfig({
       enableBundleAnalysis: enableCodecovBundleAnalysis,
       gitService: "github",
       telemetry: false,
-      uploadToken: process.env.CODECOV_TOKEN,
     }),
   ],
   test: {


### PR DESCRIPTION
### Motivation

- The frontend CI previously injected `CODECOV_TOKEN` into the `npm run build` environment, which made the secret available to branch-controlled Vite config and build-time plugins and created a secret-exfiltration risk. 
- The Vite plugin also forwarded `process.env.CODECOV_TOKEN` via `uploadToken`, directly exposing the token to JavaScript executed during the build.

### Description

- Remove `CODECOV_TOKEN` from the frontend `Build frontend` job environment in `.github/workflows/frontend-ci.yml` and make `CODECOV_BUNDLE_ANALYSIS` evaluate to `true` only for trusted `push` runs on `refs/heads/main`.
- Remove the `uploadToken` option from the Codecov Vite plugin config in `frontend/vite.config.ts` so the config no longer reads `process.env.CODECOV_TOKEN` at build time.
- Commit message: `fix(ci): keep Codecov token out of frontend build` (changes committed to branch).

### Testing

- Ran `python3 scripts/orchestration/check_preflight.py` — PASS.
- Installed frontend deps with `npm ci` and built locally with `npm run build` — PASS (confirmed build completes without reading `CODECOV_TOKEN`).
- Ran pre-commit hooks via `uvx pre-commit run --all-files` (local pre-commit env initialization + hooks) — PASS for changed files.
- Ran `git diff --check` — PASS.
- Note: Full repo `make verify` was not executed because this PR is scoped to frontend CI and Vite configuration; focused local checks above were executed and passed. If required for merge, run full `make verify` per repository hard-gates before claiming merge readiness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5c0cfacc8333b24249b3b01bd5b9)

## Summary by Sourcery

Усилена конфигурация CI и сборки фронтенда, чтобы избежать раскрытия токена загрузки Codecov во время сборок.

Исправления ошибок:
- Прекратить чтение или передачу `CODECOV_TOKEN` из конфигурации плагина Vite Codecov во фронтенде, чтобы предотвратить утечку токена на этапе сборки.

Улучшения:
- Ограничить анализ бандлов Codecov так, чтобы он запускался только для доверенных push-событий в основную ветку в workflow CI фронтенда.

CI:
- Обновить задачу сборки фронтенда в CI так, чтобы она больше не подставляла `CODECOV_TOKEN` в окружение сборки фронтенда и чтобы анализ бандлов Codecov включался условно — только при push в основную ветку.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden frontend CI and build configuration to avoid exposing the Codecov upload token during builds.

Bug Fixes:
- Stop reading or forwarding CODECOV_TOKEN from the frontend Vite Codecov plugin configuration to prevent token exposure at build time.

Enhancements:
- Limit Codecov bundle analysis so it only runs for trusted push events on the main branch in the frontend CI workflow.

CI:
- Update the frontend CI build job to no longer inject CODECOV_TOKEN into the frontend build environment and to conditionally enable Codecov bundle analysis only on pushes to the main branch.

</details>

Исправления ошибок:
- Удалить использование `CODECOV_TOKEN` в конфигурации фронтенд-плагина Vite Codecov, чтобы избежать раскрытия токена во время сборки.

Улучшения:
- Ограничить запуск анализа бандла Codecov так, чтобы он выполнялся только для доверенных push-событий в основную ветку в процессе CI фронтенда.

CI:
- Обновить CI-пайплайн фронтенда, чтобы он перестал внедрять `CODECOV_TOKEN` в окружение сборки фронтенда.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Усилена конфигурация CI и сборки фронтенда, чтобы избежать раскрытия токена загрузки Codecov во время сборок.

Исправления ошибок:
- Прекратить чтение или передачу `CODECOV_TOKEN` из конфигурации плагина Vite Codecov во фронтенде, чтобы предотвратить утечку токена на этапе сборки.

Улучшения:
- Ограничить анализ бандлов Codecov так, чтобы он запускался только для доверенных push-событий в основную ветку в workflow CI фронтенда.

CI:
- Обновить задачу сборки фронтенда в CI так, чтобы она больше не подставляла `CODECOV_TOKEN` в окружение сборки фронтенда и чтобы анализ бандлов Codecov включался условно — только при push в основную ветку.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden frontend CI and build configuration to avoid exposing the Codecov upload token during builds.

Bug Fixes:
- Stop reading or forwarding CODECOV_TOKEN from the frontend Vite Codecov plugin configuration to prevent token exposure at build time.

Enhancements:
- Limit Codecov bundle analysis so it only runs for trusted push events on the main branch in the frontend CI workflow.

CI:
- Update the frontend CI build job to no longer inject CODECOV_TOKEN into the frontend build environment and to conditionally enable Codecov bundle analysis only on pushes to the main branch.

</details>

</details>

Улучшения:
- Прекратить чтение и передачу `CODECOV_TOKEN` из конфигурации Vite Codecov плагина, удалив опцию `uploadToken`.

CI:
- Отключить анализ бандлов Codecov для pull request’ов и пушей в ветки, отличные от `main`, за счёт условной установки `CODECOV_BUNDLE_ANALYSIS` только при доверенных событиях пуша в основную (`main`) ветку.
- Удалить переменную окружения `CODECOV_TOKEN` из задачи сборки фронтенда, чтобы предотвратить передачу секрета в среду сборки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Усилена конфигурация CI и сборки фронтенда, чтобы избежать раскрытия токена загрузки Codecov во время сборок.

Исправления ошибок:
- Прекратить чтение или передачу `CODECOV_TOKEN` из конфигурации плагина Vite Codecov во фронтенде, чтобы предотвратить утечку токена на этапе сборки.

Улучшения:
- Ограничить анализ бандлов Codecov так, чтобы он запускался только для доверенных push-событий в основную ветку в workflow CI фронтенда.

CI:
- Обновить задачу сборки фронтенда в CI так, чтобы она больше не подставляла `CODECOV_TOKEN` в окружение сборки фронтенда и чтобы анализ бандлов Codecov включался условно — только при push в основную ветку.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden frontend CI and build configuration to avoid exposing the Codecov upload token during builds.

Bug Fixes:
- Stop reading or forwarding CODECOV_TOKEN from the frontend Vite Codecov plugin configuration to prevent token exposure at build time.

Enhancements:
- Limit Codecov bundle analysis so it only runs for trusted push events on the main branch in the frontend CI workflow.

CI:
- Update the frontend CI build job to no longer inject CODECOV_TOKEN into the frontend build environment and to conditionally enable Codecov bundle analysis only on pushes to the main branch.

</details>

Исправления ошибок:
- Удалить использование `CODECOV_TOKEN` в конфигурации фронтенд-плагина Vite Codecov, чтобы избежать раскрытия токена во время сборки.

Улучшения:
- Ограничить запуск анализа бандла Codecov так, чтобы он выполнялся только для доверенных push-событий в основную ветку в процессе CI фронтенда.

CI:
- Обновить CI-пайплайн фронтенда, чтобы он перестал внедрять `CODECOV_TOKEN` в окружение сборки фронтенда.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Усилена конфигурация CI и сборки фронтенда, чтобы избежать раскрытия токена загрузки Codecov во время сборок.

Исправления ошибок:
- Прекратить чтение или передачу `CODECOV_TOKEN` из конфигурации плагина Vite Codecov во фронтенде, чтобы предотвратить утечку токена на этапе сборки.

Улучшения:
- Ограничить анализ бандлов Codecov так, чтобы он запускался только для доверенных push-событий в основную ветку в workflow CI фронтенда.

CI:
- Обновить задачу сборки фронтенда в CI так, чтобы она больше не подставляла `CODECOV_TOKEN` в окружение сборки фронтенда и чтобы анализ бандлов Codecov включался условно — только при push в основную ветку.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden frontend CI and build configuration to avoid exposing the Codecov upload token during builds.

Bug Fixes:
- Stop reading or forwarding CODECOV_TOKEN from the frontend Vite Codecov plugin configuration to prevent token exposure at build time.

Enhancements:
- Limit Codecov bundle analysis so it only runs for trusted push events on the main branch in the frontend CI workflow.

CI:
- Update the frontend CI build job to no longer inject CODECOV_TOKEN into the frontend build environment and to conditionally enable Codecov bundle analysis only on pushes to the main branch.

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent secret exposure by keeping `CODECOV_TOKEN` out of the frontend build. Bundle analysis now runs only on trusted pushes to `main`, and the Vite config no longer reads the token.

- **Bug Fixes**
  - `.github/workflows/frontend-ci.yml`: remove `CODECOV_TOKEN` from build env; set `CODECOV_BUNDLE_ANALYSIS` to true only for `push` on `refs/heads/main`.
  - `frontend/vite.config.ts`: remove `uploadToken` from the Codecov plugin so `process.env.CODECOV_TOKEN` is not read at build time.

<sup>Written for commit 38938e599795f9983a2768ac43cde317132cc849. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

