### PR TITLE
fix(design): ignore placeholder scorecard evidence

### DIFF
--- a/docs/review/PR_1693_FIXED_MAPPING.md
+++ b/docs/review/PR_1693_FIXED_MAPPING.md
@@ -23,14 +23,14 @@ GraphQL review-thread inspection found one unresolved Sourcery thread on
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1693#discussion_r3196525841 -> PENDING_FINAL_COMMIT
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1693#discussion_r3196525841 -> 26cf10485157c6533f92d465068b87b98934829f
 Disposition: FIXED
-Commit: PENDING_FINAL_COMMIT
+Commit: 26cf10485157c6533f92d465068b87b98934829f
 Evidence: `_has_meaningful_evidence_value` is centralized in `scripts/design/evidence_utils.py`; both design modules import it; `tests/design/test_design_scorecard.py::test_design_evidence_helper_is_shared` guards against duplicated helper definitions.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1693#pullrequestreview-4238091452 -> PENDING_FINAL_COMMIT
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1693#pullrequestreview-4238091452 -> 26cf10485157c6533f92d465068b87b98934829f
 Disposition: FIXED
-Commit: PENDING_FINAL_COMMIT
+Commit: 26cf10485157c6533f92d465068b87b98934829f
 Evidence: Sourcery's review summary maps to `discussion_r3196525841`, fixed by the shared helper module and duplicate-helper guard test.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1693#issuecomment-4390340906

--- a/docs/review/PR_1693_FIXED_MAPPING.md
+++ b/docs/review/PR_1693_FIXED_MAPPING.md
@@ -1,0 +1,71 @@
+# PR #1693 Fixed Mapping
+
+**PR:** <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1693>
+**Branch:** `codex/fix-scoring-of-placeholder-evidence`
+
+## Summary
+
+PR #1693 rejects placeholder evidence values and centralizes the design evidence
+helper.
+
+## Machine-Heavy Deferral
+
+Full `make verify` intentionally not run per operator-approved batch
+instruction. This PR uses bounded checks and `make validate-changed`.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+GraphQL review-thread inspection found one unresolved Sourcery thread on
+`scripts/design/screen_evidence_pack.py`.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1693#discussion_r3196525841 -> PENDING_FINAL_COMMIT
+Disposition: FIXED
+Commit: PENDING_FINAL_COMMIT
+Evidence: `_has_meaningful_evidence_value` is centralized in `scripts/design/evidence_utils.py`; both design modules import it; `tests/design/test_design_scorecard.py::test_design_evidence_helper_is_shared` guards against duplicated helper definitions.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1693#pullrequestreview-4238091452 -> PENDING_FINAL_COMMIT
+Disposition: FIXED
+Commit: PENDING_FINAL_COMMIT
+Evidence: Sourcery's review summary maps to `discussion_r3196525841`, fixed by the shared helper module and duplicate-helper guard test.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1693#issuecomment-4390340906
+Disposition: NOT-A-BUG
+Evidence: The explicit PR task contract says only non-empty strings count as evidence, and nested list/dict evidence counts only if it contains at least one non-empty string; focused tests preserve that contract.
+Reason: Numeric/boolean scalar evidence is intentionally out of scope for this hotfix.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1693#issuecomment-4390328735
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit provided walkthrough/release-note context without an actionable finding.
+Reason: Bot summary only.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1693#issuecomment-4390328886
+Disposition: NOT-A-BUG
+Evidence: Sourcery reviewer guide context is superseded by the actionable review thread mapped above.
+Reason: Reviewer guide only.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1693#pullrequestreview-4238110234
+Disposition: NOT-A-BUG
+Evidence: Cubic reported no issues across the changed files.
+Reason: No actionable finding.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1693#issuecomment-4390373941
+Disposition: NOT-A-BUG
+Evidence: Codecov reported all modified coverable lines covered.
+Reason: Coverage report only.
+
+## Premortem
+
+- [x] Premortem completed against actual changed files
+- [x] All P0/P1 findings fixed or dispositioned
+- [x] P2 findings linked if deferred
+
+Artifact: [`docs/review/PR_1693_PREMORTEM.md`](PR_1693_PREMORTEM.md)
+
+## Merge Readiness
+
+Strict readiness must be run before merge.

--- a/docs/review/PR_1693_PREMORTEM.md
+++ b/docs/review/PR_1693_PREMORTEM.md
@@ -1,0 +1,50 @@
+# PR #1693 Premortem
+
+Mode: `pr-premortem`
+Coordinator packet: `artifacts/orchestration/task_packets/954153912a69.json`
+
+## Summary
+
+PR #1693 prevents placeholder scalar values from counting as design evidence
+and centralizes the evidence-value helper so scorecard and screen evidence pack
+semantics cannot drift.
+
+Frame: It is 48 hours from now. This design-evidence hotfix made the evidence
+contract weaker. We are looking backward to understand why.
+
+Changed files inspected:
+
+- `scripts/design/evidence_utils.py`
+- `scripts/design/design_scorecard.py`
+- `scripts/design/screen_evidence_pack.py`
+- `tests/design/test_design_scorecard.py`
+- `tests/design/test_screen_evidence_pack.py`
+- `docs/review/PR_1693_PREMORTEM.md`
+- `docs/review/PR_1693_FIXED_MAPPING.md`
+
+## Risk Table
+
+| Priority | Failure mode | Finding | Required fix | Evidence | Disposition |
+| --- | --- | --- | --- | --- | --- |
+| P0 | Placeholder scalar still counts as evidence | `None`, `False`, `0`, blank strings, and whitespace-only strings return false. | Keep helper string-only and recursive. | `scripts/design/evidence_utils.py`; design tests | FIXED |
+| P0 | Nested placeholder list/dict still counts | Nested placeholders return false unless a non-empty string exists. | Add nested placeholder and nested valid string tests. | `tests/design/test_design_scorecard.py`; `tests/design/test_screen_evidence_pack.py` | FIXED |
+| P1 | Helper logic diverges between modules | Helper is centralized in `scripts/design/evidence_utils.py`. | Remove duplicate helper definitions from both modules. | `tests/design/test_design_scorecard.py::test_design_evidence_helper_is_shared` | FIXED |
+| P1 | Circular imports introduced | Both modules import the helper from a standalone utility module with direct-run fallback. | Avoid importing either design module from the other. | Focused design tests and CLI-compatible import fallback | FIXED |
+| P1 | `status=validated` accepts fake evidence | Placeholder-only evidence still triggers validation errors. | Keep `_dict_has_evidence` on shared helper. | `tests/design/test_screen_evidence_pack.py` | FIXED |
+| P1 | Scorecard accepts `False`/`0` as evidence | Placeholder scalar scorecard dimensions stay zero. | Preserve scalar rejection tests. | `tests/design/test_design_scorecard.py` | FIXED |
+| P2 | Tests only cover happy path | Negative and nested-positive cases are covered. | Add targeted negative and nested-positive tests. | Focused design test suite | FIXED |
+
+## Decision
+
+PASS. No unresolved P0/P1 findings remain. The Codex numeric/boolean evidence
+suggestion is NOT-A-BUG for this PR because the explicit task contract requires
+only non-empty strings to count as evidence.
+
+## Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS
+- `. .venv/bin/activate && pytest -q tests/design/test_design_scorecard.py tests/design/test_screen_evidence_pack.py` PASS
+- `. .venv/bin/activate && pytest -q tests/test_repo_policy_guards.py` PASS
+- `make validate-changed` PASS
+- `pre-commit run --all-files` PASS

--- a/scripts/design/design_scorecard.py
+++ b/scripts/design/design_scorecard.py
@@ -95,10 +95,20 @@ def _stringify(value: Any) -> str:
     return str(value)
 
 
+def _has_meaningful_evidence_value(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return any(_has_meaningful_evidence_value(item) for item in value)
+    if isinstance(value, dict):
+        return any(_has_meaningful_evidence_value(item) for item in value.values())
+    return False
+
+
 def _dict_has_evidence(value: Any) -> bool:
     if not isinstance(value, dict):
         return False
-    return any(bool(_stringify(item).strip()) for item in value.values())
+    return any(_has_meaningful_evidence_value(item) for item in value.values())
 
 
 def _dimension(

--- a/scripts/design/design_scorecard.py
+++ b/scripts/design/design_scorecard.py
@@ -95,14 +95,16 @@ def _stringify(value: Any) -> str:
     return str(value)
 
 
-def _has_meaningful_evidence_value(value: Any) -> bool:
-    if isinstance(value, str):
-        return bool(value.strip())
-    if isinstance(value, list):
-        return any(_has_meaningful_evidence_value(item) for item in value)
-    if isinstance(value, dict):
-        return any(_has_meaningful_evidence_value(item) for item in value.values())
-    return False
+try:
+    from evidence_utils import _has_meaningful_evidence_value
+except ModuleNotFoundError:
+    evidence_utils_path = Path(__file__).with_name("evidence_utils.py")
+    spec = importlib.util.spec_from_file_location("evidence_utils", evidence_utils_path)
+    if spec is None or spec.loader is None:
+        raise
+    evidence_utils = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(evidence_utils)
+    _has_meaningful_evidence_value = evidence_utils._has_meaningful_evidence_value
 
 
 def _dict_has_evidence(value: Any) -> bool:

--- a/scripts/design/evidence_utils.py
+++ b/scripts/design/evidence_utils.py
@@ -1,0 +1,17 @@
+"""Shared evidence-value helpers for design review artifacts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _has_meaningful_evidence_value(value: Any) -> bool:
+    """Return True only when evidence contains at least one non-empty string."""
+
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return any(_has_meaningful_evidence_value(item) for item in value)
+    if isinstance(value, dict):
+        return any(_has_meaningful_evidence_value(item) for item in value.values())
+    return False

--- a/scripts/design/screen_evidence_pack.py
+++ b/scripts/design/screen_evidence_pack.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import re
 import sys
@@ -13,6 +14,17 @@ from typing import Any, TextIO
 REPO_ROOT = Path(__file__).resolve().parents[2]
 VOCABULARY_PATH = Path("docs/design/ui_component_vocabulary.json")
 LOCAL_ARTIFACT_PREFIX = "artifacts/design/screen_evidence/"
+
+try:
+    from evidence_utils import _has_meaningful_evidence_value
+except ModuleNotFoundError:
+    evidence_utils_path = Path(__file__).with_name("evidence_utils.py")
+    spec = importlib.util.spec_from_file_location("evidence_utils", evidence_utils_path)
+    if spec is None or spec.loader is None:
+        raise
+    evidence_utils = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(evidence_utils)
+    _has_meaningful_evidence_value = evidence_utils._has_meaningful_evidence_value
 
 REQUIRED_FIELDS = [
     "evidence_id",
@@ -329,16 +341,6 @@ def _validate_wellness_copy(record: dict[str, Any], errors: list[str]) -> None:
                     "therapy, emergency, crisis, guaranteed outcome, or medical claims"
                 )
                 return
-
-
-def _has_meaningful_evidence_value(value: Any) -> bool:
-    if isinstance(value, str):
-        return bool(value.strip())
-    if isinstance(value, list):
-        return any(_has_meaningful_evidence_value(item) for item in value)
-    if isinstance(value, dict):
-        return any(_has_meaningful_evidence_value(item) for item in value.values())
-    return False
 
 
 def _dict_has_evidence(value: Any) -> bool:

--- a/scripts/design/screen_evidence_pack.py
+++ b/scripts/design/screen_evidence_pack.py
@@ -331,10 +331,20 @@ def _validate_wellness_copy(record: dict[str, Any], errors: list[str]) -> None:
                 return
 
 
+def _has_meaningful_evidence_value(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return any(_has_meaningful_evidence_value(item) for item in value)
+    if isinstance(value, dict):
+        return any(_has_meaningful_evidence_value(item) for item in value.values())
+    return False
+
+
 def _dict_has_evidence(value: Any) -> bool:
     if not isinstance(value, dict):
         return False
-    return any(bool(_stringify(item).strip()) for item in value.values())
+    return any(_has_meaningful_evidence_value(item) for item in value.values())
 
 
 def _validate_status_requirements(record: dict[str, Any], errors: list[str]) -> None:

--- a/tests/design/test_design_scorecard.py
+++ b/tests/design/test_design_scorecard.py
@@ -240,6 +240,35 @@ def test_placeholder_scalar_evidence_does_not_receive_presence_credit(tmp_path: 
     assert scorecard["recommendation"] == "rejected"
 
 
+def test_nested_non_empty_string_evidence_receives_presence_credit(tmp_path: Path):
+    module = load_scorecard_module()
+    repo_root = make_temp_repo(tmp_path)
+    manifest_path = repo_root / "nested-evidence.json"
+    write_json(
+        manifest_path,
+        valid_web_manifest(
+            accessibility_evidence={"nested": [None, {"actual": "Focus ring captured"}]},
+        ),
+    )
+
+    scorecard = module.score_path(manifest_path, repo_root=repo_root)
+    dimensions = {item["id"]: item for item in scorecard["dimensions"]}
+
+    assert dimensions["accessibility_evidence"]["score"] == 10
+
+
+def test_design_evidence_helper_is_shared():
+    scorecard_source = MODULE_PATH.read_text(encoding="utf-8")
+    evidence_source = (REPO_ROOT / "scripts/design/screen_evidence_pack.py").read_text(
+        encoding="utf-8"
+    )
+    helper_source = (REPO_ROOT / "scripts/design/evidence_utils.py").read_text(encoding="utf-8")
+
+    assert "def _has_meaningful_evidence_value" not in scorecard_source
+    assert "def _has_meaningful_evidence_value" not in evidence_source
+    assert "def _has_meaningful_evidence_value" in helper_source
+
+
 def test_score_dir_scores_all_sample_evidence_manifests():
     module = load_scorecard_module()
 

--- a/tests/design/test_design_scorecard.py
+++ b/tests/design/test_design_scorecard.py
@@ -210,6 +210,36 @@ def test_missing_responsive_overflow_and_motion_evidence_lowers_score(tmp_path: 
     assert scorecard["status"] == "warn"
 
 
+def test_placeholder_scalar_evidence_does_not_receive_presence_credit(tmp_path: Path):
+    module = load_scorecard_module()
+    repo_root = make_temp_repo(tmp_path)
+    manifest_path = repo_root / "placeholder-evidence.json"
+    write_json(
+        manifest_path,
+        valid_web_manifest(
+            accessibility_evidence={"placeholder": None},
+            copy_safety_evidence={"placeholder": False},
+            motion_evidence={"placeholder": 0},
+            overflow_evidence={"nested": {"placeholder": None}},
+            responsive_evidence={"items": [False, 0, None]},
+            tabbar_or_navigation_evidence={"placeholder": 0},
+        ),
+    )
+
+    scorecard = module.score_path(manifest_path, repo_root=repo_root)
+    dimensions = {item["id"]: item for item in scorecard["dimensions"]}
+
+    assert dimensions["accessibility_evidence"]["status"] == "warn"
+    assert dimensions["accessibility_evidence"]["score"] == 0
+    assert dimensions["responsive_evidence"]["score"] == 0
+    assert dimensions["copy_safety"]["score"] == 0
+    assert dimensions["navigation_evidence"]["score"] == 0
+    assert dimensions["overflow_evidence"]["score"] == 0
+    assert dimensions["motion_evidence"]["score"] == 0
+    assert scorecard["status"] == "fail"
+    assert scorecard["recommendation"] == "rejected"
+
+
 def test_score_dir_scores_all_sample_evidence_manifests():
     module = load_scorecard_module()
 

--- a/tests/design/test_screen_evidence_pack.py
+++ b/tests/design/test_screen_evidence_pack.py
@@ -259,6 +259,18 @@ def test_validated_status_rejects_placeholder_scalar_evidence():
     assert "status=validated requires non-empty tabbar_or_navigation_evidence" in errors
 
 
+def test_validated_status_accepts_nested_non_empty_string_evidence():
+    module = load_evidence_module()
+    manifest = valid_manifest(
+        accessibility_evidence={"nested": [None, {"actual": "Focus ring captured"}]},
+        status="validated",
+    )
+
+    errors = module.validate_record(manifest, repo_root=REPO_ROOT)
+
+    assert "status=validated requires non-empty accessibility_evidence" not in errors
+
+
 def test_ios_automated_capture_requires_ios_artifact_path():
     module = load_evidence_module()
     manifest = valid_manifest(platform="ios", capture_mode="automated", route_or_screen="Home")

--- a/tests/design/test_screen_evidence_pack.py
+++ b/tests/design/test_screen_evidence_pack.py
@@ -237,6 +237,28 @@ def test_validated_status_requires_non_empty_evidence():
     assert "status=validated requires token_mirror_paths_checked" in errors
 
 
+def test_validated_status_rejects_placeholder_scalar_evidence():
+    module = load_evidence_module()
+    manifest = valid_manifest(
+        accessibility_evidence={"placeholder": None},
+        copy_safety_evidence={"placeholder": False},
+        motion_evidence={"placeholder": 0},
+        overflow_evidence={"nested": {"placeholder": None}},
+        responsive_evidence={"items": [False, 0, None]},
+        status="validated",
+        tabbar_or_navigation_evidence={"placeholder": 0},
+    )
+
+    errors = module.validate_record(manifest, repo_root=REPO_ROOT)
+
+    assert "status=validated requires non-empty accessibility_evidence" in errors
+    assert "status=validated requires non-empty copy_safety_evidence" in errors
+    assert "status=validated requires non-empty motion_evidence" in errors
+    assert "status=validated requires non-empty overflow_evidence" in errors
+    assert "status=validated requires non-empty responsive_evidence" in errors
+    assert "status=validated requires non-empty tabbar_or_navigation_evidence" in errors
+
+
 def test_ios_automated_capture_requires_ios_artifact_path():
     module = load_evidence_module()
     manifest = valid_manifest(platform="ios", capture_mode="automated", route_or_screen="Home")


### PR DESCRIPTION
## Summary
Reject placeholder scalar values as design evidence and centralize the shared evidence-value helper.

## Scope
- `scripts/design/evidence_utils.py`: shared `_has_meaningful_evidence_value` helper.
- `scripts/design/design_scorecard.py` and `scripts/design/screen_evidence_pack.py`: import the shared helper without cross-module coupling.
- `tests/design/test_design_scorecard.py` and `tests/design/test_screen_evidence_pack.py`: cover placeholder-only evidence, nested valid string evidence, and duplicate-helper prevention.
- `docs/review/PR_1693_PREMORTEM.md` and `docs/review/PR_1693_FIXED_MAPPING.md`: premortem and fixed mapping evidence.

## Out of scope
No runtime/API/iOS/OpenAPI behavior changes. No Figma writes. No change to the explicit contract that only non-empty strings count as evidence.

## Validation
- `python3 scripts/orchestration/check_preflight.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `. .venv/bin/activate && pytest -q tests/design/test_design_scorecard.py tests/design/test_screen_evidence_pack.py` PASS
- `. .venv/bin/activate && pytest -q tests/test_repo_policy_guards.py` PASS
- `make validate-changed` PASS
- `pre-commit run --all-files` PASS

## Machine-heavy deferral
Full `make verify` intentionally not run. This PR uses bounded checks and `make validate-changed` per the operator-approved alert-batch instructions.

## Premortem
- [x] Premortem completed against actual changed files
- [x] All P0/P1 findings fixed or dispositioned
- [x] P2 findings linked if deferred

Premortem artifact: `docs/review/PR_1693_PREMORTEM.md`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Sourcery duplicate-helper thread is mapped as FIXED. Codex numeric/boolean evidence comment is mapped as NOT-A-BUG because the explicit PR contract says only non-empty strings count as evidence.

### Fixed in Commit Mapping
`docs/review/PR_1693_FIXED_MAPPING.md`

## Merge Readiness
Pending strict merge-readiness wrapper on current head after this body update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to detect and ignore placeholder or empty evidence values, including within nested structures, so they no longer inflate scorecard results.

* **Tests**
  * Added tests ensuring placeholder scalar and nested placeholder evidence are rejected and that validated statuses require non-empty evidence.

* **Documentation**
  * Added review and premortem documentation describing the mapping and validation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->