### PR TITLE
fix(guards): avoid BMI threshold false positive on design scorecard ratios

### DIFF
--- a/docs/review/PR_1695_FIXED_MAPPING.md
+++ b/docs/review/PR_1695_FIXED_MAPPING.md
@@ -20,6 +20,7 @@ Current actionable bot/human review comments have been classified below before a
 Disposition: FIXED
 Commit: 843b66c1e
 Evidence: `tests/test_no_bmi_math_outside_core.py` adds number-before-context and mixed-case BMI threshold examples requested by Sourcery.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#discussion_r3197335778 -> 843b66c1e
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#pullrequestreview-3449071804 -> 843b66c1e
 
 ## Review Dispositions

--- a/docs/review/PR_1695_FIXED_MAPPING.md
+++ b/docs/review/PR_1695_FIXED_MAPPING.md
@@ -8,11 +8,19 @@
 
 Fixes the BMI guard false positive where `normalized_score >= 0.85` in design scorecard tooling was incorrectly detected as BMI/WHR threshold context.
 
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Current actionable bot/human review comments have been classified below before any merge-readiness claim.
+
 ## Fixed in Commit Mapping
 
-- Guard context matching made token-aware and separator-aware: `8f7b2e11b`
-- Regression coverage for design scorecard `normalized_score` false positive and real BMI/WHR threshold examples: `f82ade615`
-- Sourcery mixed-case / number-before-context BMI regression coverage: `843b66c1e`
+Disposition: FIXED
+Commit: 843b66c1e
+Evidence: `tests/test_no_bmi_math_outside_core.py` adds number-before-context and mixed-case BMI threshold examples requested by Sourcery.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#pullrequestreview-3449071804 -> 843b66c1e
 
 ## Review Dispositions
 

--- a/docs/review/PR_1695_FIXED_MAPPING.md
+++ b/docs/review/PR_1695_FIXED_MAPPING.md
@@ -21,7 +21,13 @@ Disposition: FIXED
 Commit: 843b66c1e
 Evidence: `tests/test_no_bmi_math_outside_core.py` adds number-before-context and mixed-case BMI threshold examples requested by Sourcery.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#discussion_r3197335778 -> 843b66c1e
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#pullrequestreview-3449071804 -> 843b66c1e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#pullrequestreview-4239378224 -> 843b66c1e
+
+Disposition: FIXED
+Commit: 120e2c72a
+Evidence: `tests/test_no_bmi_math_outside_core.py` preserves real camelCase/PascalCase BMI/WHR threshold identifiers while keeping `normalizedScore >= 0.85` out of BMI context.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#discussion_r3197336366 -> 120e2c72a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#pullrequestreview-4239379141 -> 120e2c72a
 
 ## Review Dispositions
 
@@ -40,9 +46,12 @@ Evidence: `tests/test_no_bmi_math_outside_core.py` adds number-before-context an
 
 ## Bot Review Findings
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#pullrequestreview-3449071804 -> `843b66c1e`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#pullrequestreview-4239378224 -> `843b66c1e`
   - Disposition: FIXED
   - Evidence: `tests/test_no_bmi_math_outside_core.py` adds number-before-context and mixed-case BMI threshold examples.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#discussion_r3197336366 -> `120e2c72a`
+  - Disposition: FIXED
+  - Evidence: `tests/test_no_bmi_math_outside_core.py` now catches `BMIThreshold = 25.0` and `waistHipRatioThreshold = 0.90`.
 
 ## Validation
 

--- a/docs/review/PR_1695_FIXED_MAPPING.md
+++ b/docs/review/PR_1695_FIXED_MAPPING.md
@@ -1,0 +1,50 @@
+# PR 1695 Fixed in Commit Mapping
+
+## PR
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695
+
+## Summary
+
+Fixes the BMI guard false positive where `normalized_score >= 0.85` in design scorecard tooling was incorrectly detected as BMI/WHR threshold context.
+
+## Fixed in Commit Mapping
+
+- Guard context matching made token-aware and separator-aware: `8f7b2e11b`
+- Regression coverage for design scorecard `normalized_score` false positive and real BMI/WHR threshold examples: `f82ade615`
+
+## Review Dispositions
+
+- Disposition: FIXED
+- Evidence:
+  - `tests/test_no_bmi_math_outside_core.py` now uses explicit BMI/WHR threshold context matching.
+  - `tests/test_no_bmi_math_outside_core.py` covers `normalized_score >= 0.85` as non-BMI scorecard context.
+  - `tests/test_no_bmi_math_outside_core.py` preserves real BMI/WHR examples, including snake_case identifiers.
+
+## Premortem Findings
+
+- Security/QA finding: identifier-style BMI/WHR thresholds such as `BMI_THRESHOLD = 25.0` and `WHR_THRESHOLD: float = 0.90` must not bypass the guard.
+- Disposition: FIXED
+- Commit: `f82ade615`
+- Evidence: focused regression cases in `tests/test_no_bmi_math_outside_core.py`.
+
+## Validation
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `python3 -m pytest -q tests/test_no_bmi_math_outside_core.py::test_no_bmi_thresholds_outside_core` via repo `.venv`
+- `python3 -m pytest -q tests/test_no_bmi_math_outside_core.py` via repo `.venv`
+- `python3 -m pytest -q tests/design/test_design_scorecard.py` via repo `.venv`
+- `python3 scripts/design/design_scorecard.py score docs/design/screen_evidence/examples/web_marketing.sample.json` via repo `.venv`
+- `python3 scripts/design/design_scorecard.py score docs/design/screen_evidence/examples/ios_home.sample.json` via repo `.venv`
+- `make validate-changed`
+- `make design-guard`
+- `make tokens-check`
+- `pre-commit run --all-files`
+
+Full `make verify` was not run for this narrow main-hotfix lane.
+
+## Deferred / Follow-ups
+
+- PR-6 iOS visual parity audit remains separate and must not start until this main fix is merged.
+- Any future BMI guard tuning must preserve the One BMI Engine invariant.

--- a/docs/review/PR_1695_FIXED_MAPPING.md
+++ b/docs/review/PR_1695_FIXED_MAPPING.md
@@ -12,6 +12,7 @@ Fixes the BMI guard false positive where `normalized_score >= 0.85` in design sc
 
 - Guard context matching made token-aware and separator-aware: `8f7b2e11b`
 - Regression coverage for design scorecard `normalized_score` false positive and real BMI/WHR threshold examples: `f82ade615`
+- Sourcery mixed-case / number-before-context BMI regression coverage: `843b66c1e`
 
 ## Review Dispositions
 
@@ -27,6 +28,12 @@ Fixes the BMI guard false positive where `normalized_score >= 0.85` in design sc
 - Disposition: FIXED
 - Commit: `f82ade615`
 - Evidence: focused regression cases in `tests/test_no_bmi_math_outside_core.py`.
+
+## Bot Review Findings
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#pullrequestreview-3449071804 -> `843b66c1e`
+  - Disposition: FIXED
+  - Evidence: `tests/test_no_bmi_math_outside_core.py` adds number-before-context and mixed-case BMI threshold examples.
 
 ## Validation
 

--- a/tests/test_no_bmi_math_outside_core.py
+++ b/tests/test_no_bmi_math_outside_core.py
@@ -487,6 +487,23 @@ def test_bmi_thresholds_re_matches_new_whr_thresholds() -> None:
     ), "Should match 0.85 in waist hip ratio context"
 
 
+def test_bmi_thresholds_re_matches_real_bmi_and_whr_contexts() -> None:
+    """Test that token-aware matching still detects real BMI/WHR thresholds."""
+    matching_cases = (
+        "normal threshold 25.0",
+        "BMI threshold 30.0",
+        "BMI_THRESHOLD = 25.0",
+        "bmi_category_normal = 25.0",
+        "WHR_THRESHOLD: float = 0.90",
+        "whr threshold 0.85",
+        "waist hip ratio 0.90",
+        "waist_hip_ratio = 0.90",
+        "0.85 is the whr threshold",
+    )
+    for case in matching_cases:
+        assert BMI_THRESHOLDS_RE.search(case) is not None, f"Should match: {case}"
+
+
 def test_bmi_thresholds_re_does_not_match_nearby_non_whr_thresholds() -> None:
     """Test that BMI_THRESHOLDS_RE does not match near-miss values (0.89/0.86)."""
     assert (
@@ -518,6 +535,17 @@ def test_bmi_thresholds_re_does_not_match_non_bmi_whr_context() -> None:
     assert (
         BMI_THRESHOLDS_RE.search("value 0.85 is recorded") is None
     ), "Should not match 0.85 without BMI/WHR keyword"
+
+
+def test_bmi_thresholds_re_does_not_match_design_scorecard_normalized_score() -> None:
+    """Test that scorecard normalized_score thresholds are not BMI/WHR context."""
+    non_matching_cases = (
+        "normalized_score >= 0.85",
+        "elif normalized_score >= 0.85:",
+        "scorecard normalized_score 0.85",
+    )
+    for case in non_matching_cases:
+        assert BMI_THRESHOLDS_RE.search(case) is None, f"Should not match: {case}"
 
 
 def test_docstring_tracker_mismatched_quotes_does_not_close() -> None:

--- a/tests/test_no_bmi_math_outside_core.py
+++ b/tests/test_no_bmi_math_outside_core.py
@@ -80,6 +80,7 @@ _NUMERIC_THRESHOLDS = (
 _BMI_THRESHOLD_CONTEXT = (
     r"(?:"
     r"(?<![A-Za-z0-9])bmi(?![A-Za-z0-9])|"
+    r"(?<![A-Za-z0-9])(?:bmi|whr)(?-i:[A-Z])[A-Za-z0-9]*(?![A-Za-z0-9])|"
     r"(?<![A-Za-z0-9])category(?![A-Za-z0-9])|"
     r"(?<![A-Za-z0-9])threshold(?![A-Za-z0-9])|"
     r"(?<![A-Za-z0-9])underweight(?![A-Za-z0-9])|"
@@ -88,6 +89,7 @@ _BMI_THRESHOLD_CONTEXT = (
     r"(?<![A-Za-z0-9])obesity(?![A-Za-z0-9])|"
     r"(?<![A-Za-z0-9])healthy(?![A-Za-z0-9])|"
     r"(?<![A-Za-z0-9])whr(?![A-Za-z0-9])|"
+    r"(?<![A-Za-z0-9])waist(?-i:[A-Z])ip(?:(?-i:[A-Z])[A-Za-z0-9]*)?(?![A-Za-z0-9])|"
     r"(?<![A-Za-z0-9])waist(?![A-Za-z0-9]).*(?<![A-Za-z0-9])hip(?![A-Za-z0-9])"
     r")"
 )
@@ -495,6 +497,8 @@ def test_bmi_thresholds_re_matches_real_bmi_and_whr_contexts() -> None:
         "BMI_THRESHOLD = 25.0",
         "bmi_category_normal = 25.0",
         "WHR_THRESHOLD: float = 0.90",
+        "BMIThreshold = 25.0",
+        "waistHipRatioThreshold = 0.90",
         "whr threshold 0.85",
         "waist hip ratio 0.90",
         "waist_hip_ratio = 0.90",
@@ -546,6 +550,7 @@ def test_bmi_thresholds_re_does_not_match_design_scorecard_normalized_score() ->
         "normalized_score >= 0.85",
         "elif normalized_score >= 0.85:",
         "scorecard normalized_score 0.85",
+        "normalizedScore >= 0.85",
     )
     for case in non_matching_cases:
         assert BMI_THRESHOLDS_RE.search(case) is None, f"Should not match: {case}"

--- a/tests/test_no_bmi_math_outside_core.py
+++ b/tests/test_no_bmi_math_outside_core.py
@@ -77,11 +77,24 @@ _NUMERIC_THRESHOLDS = (
     r")"
 )
 
+_BMI_THRESHOLD_CONTEXT = (
+    r"(?:"
+    r"(?<![A-Za-z0-9])bmi(?![A-Za-z0-9])|"
+    r"(?<![A-Za-z0-9])category(?![A-Za-z0-9])|"
+    r"(?<![A-Za-z0-9])threshold(?![A-Za-z0-9])|"
+    r"(?<![A-Za-z0-9])underweight(?![A-Za-z0-9])|"
+    r"(?<![A-Za-z0-9])normal(?![A-Za-z0-9])|"
+    r"(?<![A-Za-z0-9])overweight(?![A-Za-z0-9])|"
+    r"(?<![A-Za-z0-9])obesity(?![A-Za-z0-9])|"
+    r"(?<![A-Za-z0-9])healthy(?![A-Za-z0-9])|"
+    r"(?<![A-Za-z0-9])whr(?![A-Za-z0-9])|"
+    r"(?<![A-Za-z0-9])waist(?![A-Za-z0-9]).*(?<![A-Za-z0-9])hip(?![A-Za-z0-9])"
+    r")"
+)
+
 BMI_THRESHOLDS_RE = re.compile(
-    rf"(bmi|category|threshold|underweight|normal|overweight|obesity|healthy|whr|waist.*hip).*"
-    rf"\b{_NUMERIC_THRESHOLDS}\b|"
-    rf"\b{_NUMERIC_THRESHOLDS}\b.*"
-    rf"(bmi|category|threshold|underweight|normal|overweight|obesity|healthy|whr|waist.*hip)",
+    rf"{_BMI_THRESHOLD_CONTEXT}.*\b{_NUMERIC_THRESHOLDS}\b|"
+    rf"\b{_NUMERIC_THRESHOLDS}\b.*{_BMI_THRESHOLD_CONTEXT}",
     re.IGNORECASE,
 )
 

--- a/tests/test_no_bmi_math_outside_core.py
+++ b/tests/test_no_bmi_math_outside_core.py
@@ -499,6 +499,9 @@ def test_bmi_thresholds_re_matches_real_bmi_and_whr_contexts() -> None:
         "waist hip ratio 0.90",
         "waist_hip_ratio = 0.90",
         "0.85 is the whr threshold",
+        "25.0 is the normal BMI threshold",
+        "25.0 is the Normal BMI Threshold",
+        "normal Bmi threshold 25.0",
     )
     for case in matching_cases:
         assert BMI_THRESHOLDS_RE.search(case) is not None, f"Should match: {case}"


### PR DESCRIPTION
## Summary

Fixes a false-positive BMI guard failure where `normalized_score >= 0.85` in design scorecard tooling was detected as a BMI/WHR threshold.

## Goal

Restore main by keeping the One BMI Engine guard strict while avoiding substring matches such as `normal` inside `normalized_score`.

## Root cause

The guard matched `normal` inside `normalized_score` and combined it with `0.85`, which is a WHR threshold in BMI context but a deterministic scorecard threshold in design tooling.

## Scope

- Make BMI/WHR threshold context matching token-aware.
- Add regression coverage for `normalized_score >= 0.85`.
- Preserve real BMI/WHR threshold detection, including snake_case and camelCase/PascalCase threshold identifiers.

## Out of scope

- No design scorecard behavior change.
- No BMI engine change.
- No whitelist for design_scorecard.py.
- No frontend/iOS/backend/token changes.
- No design epic progression.
- No full make verify.

## Source of truth

One BMI Engine remains canonical. BMI/WHR math and clinical thresholds belong in `core/bmi/*`.

This PR fixes guard precision only; it does not permit BMI logic outside core.

## Files changed

- `tests/test_no_bmi_math_outside_core.py`
- `docs/review/PR_1695_FIXED_MAPPING.md`

## Tests / bounded checks

Full `make verify` intentionally not run for this narrow main-hotfix lane.

- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 -m pytest -q tests/test_no_bmi_math_outside_core.py::test_no_bmi_thresholds_outside_core` via repo `.venv`
- `python3 -m pytest -q tests/test_no_bmi_math_outside_core.py` via repo `.venv`
- `python3 -m pytest -q tests/design/test_design_scorecard.py` via repo `.venv`
- `python3 scripts/design/design_scorecard.py score docs/design/screen_evidence/examples/web_marketing.sample.json` via repo `.venv`
- `python3 scripts/design/design_scorecard.py score docs/design/screen_evidence/examples/ios_home.sample.json` via repo `.venv`
- `make validate-changed` with temporary worktree `.venv` symlink to repo venv
- `make design-guard`
- `make tokens-check` with temporary worktree `.venv` and `frontend/node_modules` symlinks to repo-local deps, removed after run
- `pre-commit run --all-files` with temporary worktree `.venv` symlink to repo venv, removed after run

## Security notes

No secrets, runtime, auth, billing, backend, deploy, external integrations, Figma, Canva, or token changes.

## Premortem

Premortem reviewed actual code/tests diff and found no remaining blocking defects after the security/QA-identified snake_case guard gap was fixed in code/tests.

Premortem findings must be fixed in code/tests before mapping. Mapping is evidence after fix/decision, not the fix.

## Bug-hunter pass

- Failing guard fixed.
- Real BMI/WHR threshold detection preserved, including snake_case and camelCase/PascalCase identifiers.
- `normalized_score >= 0.85` false positive covered.
- No broad whitelist.
- No runtime diff.
- No generated token mirror diff.
- No design epic scope creep.

## Deferred / Follow-ups

- PR-6 iOS visual parity audit remains separate and must not start until main fix is merged.
- Any future BMI guard tuning must preserve One BMI Engine invariant.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

See docs/review/PR_1695_FIXED_MAPPING.md.

Disposition: FIXED
Commit: 843b66c1e
Evidence: `tests/test_no_bmi_math_outside_core.py` adds number-before-context and mixed-case BMI threshold examples requested by Sourcery.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#discussion_r3197335778 -> 843b66c1e
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#pullrequestreview-4239378224 -> 843b66c1e

Disposition: FIXED
Commit: 120e2c72a
Evidence: `tests/test_no_bmi_math_outside_core.py` preserves camelCase/PascalCase real BMI/WHR threshold detection while keeping `normalizedScore >= 0.85` out of BMI context.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#discussion_r3197336366 -> 120e2c72a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1695#pullrequestreview-4239379141 -> 120e2c72a

## Merge Readiness

Do not mark until CI/review/mapping/wait-window/strict wrapper pass.

## Rollback

Revert this guard-only PR. No runtime rollback required.

## DoD

- Main failing BMI guard test passes.
- Regression test covers `normalized_score >= 0.85`.
- Real BMI/WHR threshold examples still match.
- No whitelist added for design scorecard.
- No runtime files changed.
- Bounded checks pass.
