### PR TITLE
feat(orchestration): add explicit PR lane starter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,23 @@ validate-changed: ## Run tests inferred from changed Python files
 	VENV_PYTHON="$(DEV_PYTHON)" BRANCH_DIFF_MODE=1 bash scripts/run-backend-tests-pre-commit.sh
 	@echo "$(GREEN)✅ Diff-based validation completed$(NC)"
 
+pr-start: ## Start a governed PR lane in an isolated worktree
+	@test -n "$$GOAL" || (printf "$(RED)❌ Set GOAL='<task goal>'.$(NC)\n" && exit 2)
+	@test -n "$$TASK_CLASS" || (printf "$(RED)❌ Set TASK_CLASS='<task class>'.$(NC)\n" && exit 2)
+	@test -n "$$BRANCH" || (printf "$(RED)❌ Set BRANCH='codex/<slug>'.$(NC)\n" && exit 2)
+	@test -n "$$WORKTREE" || (printf "$(RED)❌ Set WORKTREE='worktrees/<slug>'.$(NC)\n" && exit 2)
+	@bash scripts/orchestration/start_pr_lane.sh \
+		--goal "$$GOAL" \
+		--task-class "$$TASK_CLASS" \
+		--branch "$$BRANCH" \
+		--worktree "$$WORKTREE" \
+		$${PATH_ARGS:-} \
+		$${REQUESTED_AGENT_ARGS:-} \
+		$${PLUGIN_ARGS:-} \
+		$${PR_PHASE:+--pr-phase "$$PR_PHASE"} \
+		$${BASE_REF:+--base "$$BASE_REF"} \
+		$${DRY_RUN:+--dry-run}
+
 pr-regression-scan: ## Run temporary PR regression scan (focused + full/main-suite fallback + current-head check)
 	@bash scripts/ci/pr_regression_scan.sh "$${PR_NUMBER:-}" "$${REPO:-$${REPO_NAME:-}}"
 
@@ -583,4 +600,4 @@ dc-smoke: ## Verify tooling inside dev container
 	docker compose -f "$(DEVCONTAINER_COMPOSE)" run --rm devcontainer \
 		bash -lc "python3 --version && node --version && make --version"
 
-.PHONY: all help venv venv-sync setup-automation dev test test-fast validate-min validate-changed pr-regression-scan cov cov-check cov-html lint fmt fmt-check security pre-commit quick-check auto-push safe-push feature sync-main status clean check-all fix-all ci smoke-auto smoke-8000 smoke-8001 docker-build docker-build-dev docker-run docker-run-dev docker-stop docker-clean docker-logs docker-shell bandit-full diff-cov typecheck verify verify-env openapi frontend-install openapi-check ios-test ios-snapshot ios-appstore-validate ios-appstore-upload ios-appstore-upload-privacy ios-appstore-verify icon-silhouette-lock icon-silhouette-check icon-core-validate design-guard tokens-build tokens-check design-validate design-execute design-verify design-list devcontainer-bootstrap dc-up dc-shell dc-down dc-smoke
+.PHONY: all help venv venv-sync setup-automation dev test test-fast validate-min validate-changed pr-start pr-regression-scan cov cov-check cov-html lint fmt fmt-check security pre-commit quick-check auto-push safe-push feature sync-main status clean check-all fix-all ci smoke-auto smoke-8000 smoke-8001 docker-build docker-build-dev docker-run docker-run-dev docker-stop docker-clean docker-logs docker-shell bandit-full diff-cov typecheck verify verify-env openapi frontend-install openapi-check ios-test ios-snapshot ios-appstore-validate ios-appstore-upload ios-appstore-upload-privacy ios-appstore-verify icon-silhouette-lock icon-silhouette-check icon-core-validate design-guard tokens-build tokens-check design-validate design-execute design-verify design-list devcontainer-bootstrap dc-up dc-shell dc-down dc-smoke

--- a/docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md
+++ b/docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md
@@ -10,9 +10,11 @@ Read these in order:
 2. [`docs/ENGINEERING_LESSONS.md`](../ENGINEERING_LESSONS.md)
 3. [`RUNBOOK_AGENT.md`](../../RUNBOOK_AGENT.md)
 4. the nearest scoped `AGENTS.md` for the files you touch
-5. optional machine-local launcher (if installed on your host): see [`LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`](./LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md) — **opt-in only**, not a global default
-6. coordinator bootstrap: `scripts/orchestration/check_preflight.py` then `scripts/orchestration/task_bootstrap.py` (or the printed recipe from `local_session_bootstrap.sh`)
-7. this guide for tool-specific setup notes
+5. for a new PR lane, run the repo-level starter:
+   `scripts/orchestration/start_pr_lane.sh --goal "<goal>" --task-class "<class>" --branch "codex/<slug>" --worktree "worktrees/<slug>"`
+6. optional machine-local launcher (if installed on your host): see [`LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`](./LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md) — **opt-in only**, not a global default
+7. coordinator bootstrap: `scripts/orchestration/check_preflight.py` then `scripts/orchestration/task_bootstrap.py` (or the printed recipe from `local_session_bootstrap.sh`)
+8. this guide for tool-specific setup notes
 
 ## Cursor
 
@@ -31,7 +33,24 @@ Suggested first action in Cursor:
 
 Policy and routing are **deterministic only after** you run the repo entrypoints (`check_preflight.py`, then `task_bootstrap.py`). Markdown and skills do **not** auto-start a coordinator-first session on the host.
 
-Optional first command from repo root:
+Preferred first command for a new PR lane from a clean, synced repo root:
+
+```bash
+scripts/orchestration/start_pr_lane.sh \
+  --goal "<short goal>" \
+  --task-class "<task_class>" \
+  --branch "codex/<slug>" \
+  --worktree "worktrees/<slug>" \
+  --path "<touched-path>"
+```
+
+This creates the isolated worktree, runs analyze preflight, runs
+`task_bootstrap.py`, and prints the non-blocking plugin/runtime checklist plus
+the bootstrap packet summary. It does not push, open a PR, or install host
+plugins.
+
+Optional raw-session helper when you only need preflight plus a printed
+bootstrap recipe:
 
 ```bash
 scripts/orchestration/local_session_bootstrap.sh
@@ -57,6 +76,8 @@ scripts/install_codex_skills.sh --no-cybersec
   `scripts/install_codex_skills.sh --only-cybersec --copy-cybersec`
 - After install or updates, restart Codex so the new skills load
 - Full skill map and policy notes live in [`docs/dev/CODEX_SKILLS.md`](./CODEX_SKILLS.md)
+- Preferred repo-root PR lane starter (isolated worktree + preflight + packet):
+  `scripts/orchestration/start_pr_lane.sh`
 - Optional repo-root helper (preflight analyze + printed `task_bootstrap.py` recipe):
   `scripts/orchestration/local_session_bootstrap.sh`
 - Host-only `~/.codex/config.toml` is outside repo SoT; optional template:

--- a/docs/dev/CODEX_SKILLS.md
+++ b/docs/dev/CODEX_SKILLS.md
@@ -109,9 +109,11 @@ The user should not have to name skills manually for normal project work, but
 that routing comes from the canonical bootstrap/orchestration path, not from
 this document by itself.
 
-**Raw session note:** nothing in this file runs at host session start. Use `scripts/orchestration/local_session_bootstrap.sh` (optional) to run analyze preflight and print the selected `task_bootstrap.py` command, then invoke that command so routing and `recommended_skills` are produced deterministically. Evidence: `scripts/orchestration/local_session_bootstrap.sh:145-147` (analyze preflight) and `scripts/orchestration/local_session_bootstrap.sh:154-166` (printed task bootstrap command).
+**Raw session note:** nothing in this file runs at host session start. For a new PR lane, prefer `scripts/orchestration/start_pr_lane.sh` from a clean checkout synced with `origin/main`; it creates the isolated worktree, runs analyze preflight, invokes `task_bootstrap.py`, and prints the packet summary plus plugin/runtime checklist. Use `scripts/orchestration/local_session_bootstrap.sh` (optional) only when you need analyze preflight and a printed `task_bootstrap.py` command without creating a worktree. Evidence for the weaker helper: `scripts/orchestration/local_session_bootstrap.sh:145-147` (analyze preflight) and `scripts/orchestration/local_session_bootstrap.sh:154-166` (printed task bootstrap command).
 
 **Launcher vs skills:** If you use an opt-in machine launcher (see [`docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`](./LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md)), run preflight/bootstrap **before** relying on installed skills or manual task work. **Skills do not replace** `task_bootstrap.py`; they complement routing after a packet exists.
+
+**Plugins vs skills:** external plugins such as Browser Use, Computer Use, GitHub, Hugging Face, Life Science Research, Plugin Eval, and CodeRabbit are operator/runtime checklist items. The repo starter may print them to make availability explicit, but it does not install them, fail closed when they are unavailable, or treat them as product/runtime truth. Repo-native skill selection still comes from `task_bootstrap.py` `recommended_skills`.
 
 **Non-interference contract:** skills remain passive/discovery-only helpers. They do not:
 

--- a/docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md
+++ b/docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md
@@ -13,6 +13,9 @@ developers or CI. Repository markdown and templates do not auto-start sessions o
 **Canonical example (sanitized):** [`docs/templates/pulseplate-coordinator-launch.example.sh`](../templates/pulseplate-coordinator-launch.example.sh)
 
 **Related SoT:** [`docs/orchestration/AUTOMATION_READINESS_MATRIX.md`](../orchestration/AUTOMATION_READINESS_MATRIX.md),
+[`scripts/orchestration/start_pr_lane.sh`](../../scripts/orchestration/start_pr_lane.sh)
+(repo PR-lane starter; creates an isolated worktree and invokes the canonical
+preflight/bootstrap flow when the operator runs it),
 [`scripts/orchestration/local_session_bootstrap.sh`](../../scripts/orchestration/local_session_bootstrap.sh)
 (repo bridge; runs analyze preflight and prints the selected bootstrap recipe only).
 
@@ -43,6 +46,20 @@ than by an ephemeral PR packet path.
 into the repository.
 
 ## Use
+
+For ordinary manual repo work, prefer the repo-level PR lane starter first:
+
+```bash
+scripts/orchestration/start_pr_lane.sh \
+  --goal "Close machine-local launcher gap for coordinator-first startup" \
+  --task-class "pr_governance" \
+  --branch "codex/local-launcher-rollout" \
+  --worktree "worktrees/local-launcher-rollout" \
+  --path docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md
+```
+
+This repo starter is still operator-invoked. It does not install host plugins,
+edit `~/.codex/config.toml`, push branches, or open pull requests.
 
 Run from any directory inside the repo (so `git rev-parse --show-toplevel` resolves), or set
 `PULSEPLATE_REPO_ROOT` to the clone root and run from elsewhere.
@@ -81,6 +98,22 @@ Run these **before** opening the docs companion PR (or re-run after template cha
 Expect: preflight exit 0, bootstrap writes task packet under gitignored `artifacts/orchestration/task_packets/`.
 
 ## Repo bridge smoke
+
+### PR lane starter smoke
+
+```bash
+scripts/orchestration/start_pr_lane.sh \
+  --goal "Close machine-local launcher gap for coordinator-first startup" \
+  --task-class "pr_governance" \
+  --branch "codex/local-launcher-rollout-smoke" \
+  --worktree "worktrees/local-launcher-rollout-smoke" \
+  --path docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md \
+  --dry-run
+```
+
+Expect: dry-run output lists the `git worktree add`, `check_preflight.py`, and
+`task_bootstrap.py` commands plus the plugin/runtime checklist. Remove
+`--dry-run` only from a clean checkout synced to `origin/main`.
 
 The repo helper is intentionally weaker than the installed host wrapper: it does not execute
 `task_bootstrap.py`, but it can validate the selected options and print the exact command to run
@@ -183,6 +216,7 @@ recreate; do not touch tracked repo files except through intentional PR changes.
 ## Known limits
 
 - **Bash 3.2 / `set -u`:** the canonical template uses `${ARRAY[@]+"${ARRAY[@]}"}` so empty `--path` / `--requested-agent` lists do not trip unbound-variable errors.
+- **Repo PR starter:** `scripts/orchestration/start_pr_lane.sh` is a repo command, not a host startup hook. It must be run explicitly and treats plugin availability as an operator checklist, not a fail-closed dependency.
 - **Bash-only** in the canonical template; zsh/fish parity is a follow-up if needed.
 - **No Windows launcher** in this slice; parity is deferred unless documented separately.
 - **No CI enforcement:** hosts opt in individually.

--- a/docs/orchestration/AUTOMATION_READINESS_MATRIX.md
+++ b/docs/orchestration/AUTOMATION_READINESS_MATRIX.md
@@ -43,13 +43,15 @@ new Codex session to start with bootstrap logic before the first response.
 
 Owned by repo-tracked scripts:
 
+- `scripts/orchestration/start_pr_lane.sh`
 - `scripts/orchestration/task_bootstrap.py`
 - `scripts/orchestration/skill_router.py`
 - `scripts/orchestration/native_subagent_bridge.py`
 - related deterministic tests
 
-This layer can provide canonical task packets and explainable routing once it is
-invoked, but it still depends on an execution surface calling it.
+This layer can create an operator-invoked PR lane worktree and provide
+canonical task packets plus explainable routing once it is invoked, but it
+still depends on an execution surface calling it.
 
 ### Local launcher / wrapper layer
 
@@ -61,6 +63,9 @@ Owned outside repo source of truth:
 
 Optional **repo companion** (operator-invoked only; not host auto-start):
 
+- `scripts/orchestration/start_pr_lane.sh` creates an isolated PR worktree, runs
+  analyze preflight, invokes `task_bootstrap.py`, and prints a non-blocking
+  plugin/runtime checklist when the operator explicitly runs it.
 - `scripts/orchestration/local_session_bootstrap.sh` runs `check_preflight.py --mode analyze` and prints the next step to invoke `task_bootstrap.py` (see script output and `--help`).
 
 This is the layer that can actually make coordinator-first bootstrap happen at
@@ -85,6 +90,7 @@ unconditionally guaranteed by Markdown alone.
 | Capability | Repo policy | Repo engine | Local launcher needed | Host/runtime dependency | Current truth |
 |------------|-------------|-------------|------------------------|-------------------------|---------------|
 | Coordinator-first task handling | Yes | Partial | Usually yes | Yes | Policy-required, not guaranteed raw-session auto-start |
+| PR lane worktree + bootstrap start | Yes | Yes | No for manual invocation; yes for raw-session auto-start | Low | Repo wrapper-enforced once `start_pr_lane.sh` is invoked |
 | Bootstrap task packet generation | Yes | Yes | No for manual invocation; yes for auto-start | Low | Deterministic once invoked |
 | Skill auto-selection | Yes | Yes | Yes for raw-session auto-start | Medium | Automatic after bootstrap, not at raw chat start |
 | Mandatory post-open bug-hunter pass | Yes | Yes | No | Medium | Deterministic once invoked via PR phase packet; not globally event-triggered |
@@ -111,6 +117,8 @@ Current approved wording:
 - Coordinator-first is **policy-required**.
 - Manual `agent-coordinator` invocation remains mandatory when launcher/runtime
   auto-capture is unavailable.
+- PR lane worktree startup is **repo wrapper-enforced once invoked** through
+  `scripts/orchestration/start_pr_lane.sh`; it is not raw-session auto-start.
 - Bootstrap packet generation is **deterministic once invoked**.
 - Skill routing is **automatic after bootstrap**, not automatic at raw chat start.
 - Bug-hunter post-open pass is **deterministic once invoked** via
@@ -231,8 +239,9 @@ Out:
 
 Operator path today (repo companion, **not** a guarantee of raw-session auto-start):
 
-1. (Optional) `scripts/orchestration/local_session_bootstrap.sh` from repo root — preflight analyze + printed `task_bootstrap` recipe. Evidence: `scripts/orchestration/local_session_bootstrap.sh:145-147` runs analyze preflight and `scripts/orchestration/local_session_bootstrap.sh:154-166` renders the follow-up command without executing it. For flag-specific option handling, use the script's `--help` output.
-2. `python3 scripts/orchestration/task_bootstrap.py ...` — deterministic packet + routing metadata once invoked.
+1. `scripts/orchestration/start_pr_lane.sh --goal "<goal>" --task-class "<class>" --branch "codex/<slug>" --worktree "worktrees/<slug>" --path "<scope>"` from a clean checkout synced with `origin/main` — creates the isolated PR worktree, runs analyze preflight, invokes `task_bootstrap.py`, and prints the plugin/runtime checklist plus packet summary.
+2. (Optional) `scripts/orchestration/local_session_bootstrap.sh` from repo root — preflight analyze + printed `task_bootstrap` recipe. Evidence: `scripts/orchestration/local_session_bootstrap.sh:145-147` runs analyze preflight and `scripts/orchestration/local_session_bootstrap.sh:154-166` renders the follow-up command without executing it. For flag-specific option handling, use the script's `--help` output.
+3. `python3 scripts/orchestration/task_bootstrap.py ...` — deterministic packet + routing metadata once invoked.
 
 In:
 
@@ -242,6 +251,8 @@ In:
 
 Out:
 
+- host plugin installation or raw-session auto-start guarantees from repo
+  scripts alone.
 - repo source-of-truth mutation used as a substitute for launcher/runtime
   support.
 

--- a/docs/review/PR_1696_FIXED_MAPPING.md
+++ b/docs/review/PR_1696_FIXED_MAPPING.md
@@ -12,12 +12,55 @@ Canonical fixed/disposition mapping for
 - [x] Post-open review bootstrap packet generated:
   `artifacts/orchestration/task_packets/b8b8644d7480.json` (local,
   gitignored evidence).
-- [ ] Re-run if any human, CodeRabbit, Sourcery, Cubic, or GitHub bot review
-  event appears before merge readiness.
+- [x] Post-open Sourcery, Codex, and Cubic bot review comments inspected and
+  dispositioned below.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1696#pullrequestreview-4239509630 -> 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Disposition: FIXED
+Commit: 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Evidence: scripts/orchestration/start_pr_lane.sh:212, scripts/orchestration/start_pr_lane.sh:282, tests/test_start_pr_lane.py:161
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1696#discussion_r3197445963 -> 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Disposition: FIXED
+Commit: 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Evidence: scripts/orchestration/start_pr_lane.sh:212, tests/test_start_pr_lane.py:224
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1696#discussion_r3197445985 -> 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Disposition: FIXED
+Commit: 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Evidence: tests/test_start_pr_lane.py:161
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1696#discussion_r3197445994 -> 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Disposition: FIXED
+Commit: 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Evidence: tests/test_start_pr_lane.py:178
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1696#pullrequestreview-4239523980 -> 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Disposition: FIXED
+Commit: 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Evidence: scripts/orchestration/start_pr_lane.sh:74, tests/test_start_pr_lane.py:150
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1696#discussion_r3197458660 -> 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Disposition: FIXED
+Commit: 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Evidence: scripts/orchestration/start_pr_lane.sh:74, tests/test_start_pr_lane.py:150
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1696#pullrequestreview-4239530694 -> 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Disposition: FIXED
+Commit: 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Evidence: scripts/orchestration/start_pr_lane.sh:282, scripts/orchestration/start_pr_lane.sh:288
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1696#discussion_r3197464600 -> 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Disposition: FIXED
+Commit: 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Evidence: scripts/orchestration/start_pr_lane.sh:288, scripts/orchestration/start_pr_lane.sh:300
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1696#discussion_r3197464603 -> 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Disposition: FIXED
+Commit: 38b3f6f46d1fbdf52245f57150b7e05691347ca1
+Evidence: scripts/orchestration/start_pr_lane.sh:282, scripts/orchestration/start_pr_lane.sh:286
 
 ## Merge Readiness
 

--- a/docs/review/PR_1696_FIXED_MAPPING.md
+++ b/docs/review/PR_1696_FIXED_MAPPING.md
@@ -1,0 +1,27 @@
+# PR 1696 Fixed in Commit Mapping
+
+Canonical fixed/disposition mapping for
+<https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1696>.
+
+## Discussion Thread Pass
+
+- [x] PR opened; no human or bot review threads were present when this artifact
+  was created.
+- [x] Post-open review bootstrap packet generated:
+  `artifacts/orchestration/task_packets/b8b8644d7480.json` (local,
+  gitignored evidence).
+- [ ] Re-run if any human, CodeRabbit, Sourcery, Cubic, or GitHub bot review
+  event appears before merge readiness.
+
+## Fixed in Commit Mapping
+
+No review threads yet.
+
+## Merge Readiness
+
+- [ ] Current-head CI must be inspected after the latest push.
+- [ ] If CodeRabbit, Sourcery, or Cubic posts on this PR, it must be PASS /
+  no-actionables before merge readiness.
+- [ ] Required checks must be PASS with no pending required jobs.
+- [ ] Strict merge-readiness wrapper must pass before any ready/mergeable claim:
+  `python3 scripts/orchestration/check_merge_ready.py --pr-number 1696 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`

--- a/docs/review/PR_1696_FIXED_MAPPING.md
+++ b/docs/review/PR_1696_FIXED_MAPPING.md
@@ -5,6 +5,8 @@ Canonical fixed/disposition mapping for
 
 ## Discussion Thread Pass
 
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 - [x] PR opened; no human or bot review threads were present when this artifact
   was created.
 - [x] Post-open review bootstrap packet generated:
@@ -15,7 +17,7 @@ Canonical fixed/disposition mapping for
 
 ## Fixed in Commit Mapping
 
-No review threads yet.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/scripts/orchestration/start_pr_lane.sh
+++ b/scripts/orchestration/start_pr_lane.sh
@@ -71,7 +71,7 @@ normalize_scope_path() {
         ""|"."|".."|../*|*/../*|*/..|/*)
             die_usage "--path must stay inside the repo without parent traversal: ${raw_path}"
             ;;
-        artifacts/agent_runs|artifacts/agent_runs/*|artifacts/orchestration|artifacts/orchestration/*|artifacts/security_lab|artifacts/security_lab/*|worktrees|worktrees/*|.venv|.venv/*|.pytest_cache|.pytest_cache/*|.mypy_cache|.mypy_cache/*|.ruff_cache|.ruff_cache/*|node_modules|node_modules/*|dist|dist/*|build|build/*)
+        artifacts/agent_runs|artifacts/agent_runs/*|artifacts/orchestration|artifacts/orchestration/*|artifacts/security_lab|artifacts/security_lab/*|worktrees|worktrees/*|.venv|.venv/*|.pytest_cache|.pytest_cache/*|.mypy_cache|.mypy_cache/*|.ruff_cache|.ruff_cache/*|node_modules|node_modules/*|dist|dist/*|build|build/*|.DS_Store|.coverage|coverage.*)
             die_usage "--path points at a local-only artifact/cache surface: ${raw_path}"
             ;;
     esac
@@ -209,11 +209,12 @@ if [[ -z "${TASK_CLASS}" ]]; then die_usage "--task-class is required"; fi
 if [[ -z "${BRANCH}" ]]; then die_usage "--branch is required"; fi
 if [[ -z "${WORKTREE_REL}" ]]; then die_usage "--worktree is required"; fi
 
-case "${BRANCH}" in
-    main|master|origin/*|refs/*|""|*..*|*~*|*^*|*:*)
-        die_usage "--branch must be a new local branch name, got: ${BRANCH}"
-        ;;
-esac
+if [[ "${BRANCH}" == "main" || "${BRANCH}" == "master" || "${BRANCH}" == origin/* || "${BRANCH}" == refs/* ]]; then
+    die_usage "--branch must be a new local branch name, got: ${BRANCH}"
+fi
+if ! git check-ref-format --branch "${BRANCH}" >/dev/null; then
+    die_usage "--branch must be a valid branch name, got: ${BRANCH}"
+fi
 
 WORKTREE_ABS="${REPO_ROOT}/${WORKTREE_REL}"
 
@@ -278,15 +279,25 @@ git worktree add -b "${BRANCH}" "${WORKTREE_REL}" "${BASE_REF}"
 
 (
     cd "${WORKTREE_ABS}"
-    python3 scripts/orchestration/check_preflight.py --mode analyze ${PATH_ARGS[@]+"${PATH_ARGS[@]}"}
-    BOOTSTRAP_OUTPUT="$(
-        python3 scripts/orchestration/task_bootstrap.py \
-            --goal "${GOAL}" \
-            --task-class "${TASK_CLASS}" \
-            --pr-phase "${PR_PHASE}" \
-            ${PATH_ARGS[@]+"${PATH_ARGS[@]}"} \
-            ${REQUESTED_ARGS[@]+"${REQUESTED_ARGS[@]}"}
-    )"
+    preflight_cmd=(python3 scripts/orchestration/check_preflight.py --mode analyze)
+    if ((${#PATH_ARGS[@]})); then
+        preflight_cmd+=("${PATH_ARGS[@]}")
+    fi
+    "${preflight_cmd[@]}"
+
+    bootstrap_cmd=(
+        python3 scripts/orchestration/task_bootstrap.py
+        --goal "${GOAL}"
+        --task-class "${TASK_CLASS}"
+        --pr-phase "${PR_PHASE}"
+    )
+    if ((${#PATH_ARGS[@]})); then
+        bootstrap_cmd+=("${PATH_ARGS[@]}")
+    fi
+    if ((${#REQUESTED_ARGS[@]})); then
+        bootstrap_cmd+=("${REQUESTED_ARGS[@]}")
+    fi
+    BOOTSTRAP_OUTPUT="$("${bootstrap_cmd[@]}")"
     echo "${BOOTSTRAP_OUTPUT}"
     echo ""
     BOOTSTRAP_OUTPUT="${BOOTSTRAP_OUTPUT}" python3 - <<'PY'

--- a/scripts/orchestration/start_pr_lane.sh
+++ b/scripts/orchestration/start_pr_lane.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# Repo-level PR lane starter for coordinator-first PulsePlate work.
+# Creates an isolated worktree, runs analyze preflight, and emits a bootstrap packet.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+DEFAULT_PLUGINS=(
+    "Browser Use"
+    "Computer Use"
+    "GitHub"
+    "Hugging Face"
+    "Life Science Research"
+    "Plugin Eval"
+    "CodeRabbit"
+)
+
+usage() {
+    cat <<'EOF'
+Usage:
+  scripts/orchestration/start_pr_lane.sh --goal <text> --task-class <class> --branch <name> --worktree <path> [options]
+
+Required:
+  --goal <text>              Goal for task_bootstrap.py.
+  --task-class <class>       Task class for task_bootstrap.py.
+  --branch <name>            New branch to create for the PR lane.
+  --worktree <path>          New isolated worktree path, repo-relative or under repo root.
+
+Options:
+  --path <path>              Repeatable; task scope path for preflight/bootstrap.
+  --requested-agent <slug>   Repeatable; forwarded to task_bootstrap.py.
+  --plugin <name>            Repeatable; operator/runtime plugin checklist item.
+  --pr-phase <phase>         One of: pre_open, post_open_review, merge_ready, none. Default: pre_open.
+  --base <ref>               Base ref for worktree creation. Default: origin/main.
+  --dry-run                  Validate args and print the planned commands without mutating git state.
+  -h, --help                 Show this help.
+
+The plugin list is a checklist only. Missing host/runtime plugins do not fail repo startup.
+EOF
+}
+
+die_usage() {
+    echo "ERROR: $1" >&2
+    echo "Run scripts/orchestration/start_pr_lane.sh --help for usage." >&2
+    exit 2
+}
+
+die() {
+    echo "ERROR: $1" >&2
+    exit 1
+}
+
+normalize_scope_path() {
+    local raw_path="$1"
+    local repo_prefix="${REPO_ROOT}/"
+    local rel_path
+
+    case "${raw_path}" in
+        "${repo_prefix}"*) rel_path="${raw_path#"${repo_prefix}"}" ;;
+        /*) die_usage "--path must be repo-relative or under repo root: ${raw_path}" ;;
+        *) rel_path="${raw_path}" ;;
+    esac
+
+    while [[ "${rel_path}" == ./* ]]; do
+        rel_path="${rel_path#./}"
+    done
+
+    case "${rel_path}" in
+        ""|"."|".."|../*|*/../*|*/..|/*)
+            die_usage "--path must stay inside the repo without parent traversal: ${raw_path}"
+            ;;
+        artifacts/agent_runs|artifacts/agent_runs/*|artifacts/orchestration|artifacts/orchestration/*|artifacts/security_lab|artifacts/security_lab/*|worktrees|worktrees/*|.venv|.venv/*|.pytest_cache|.pytest_cache/*|.mypy_cache|.mypy_cache/*|.ruff_cache|.ruff_cache/*|node_modules|node_modules/*|dist|dist/*|build|build/*)
+            die_usage "--path points at a local-only artifact/cache surface: ${raw_path}"
+            ;;
+    esac
+
+    printf "%s" "${rel_path}"
+}
+
+normalize_worktree_path() {
+    local raw_path="$1"
+    local repo_prefix="${REPO_ROOT}/"
+    local rel_path
+
+    case "${raw_path}" in
+        "${repo_prefix}"*) rel_path="${raw_path#"${repo_prefix}"}" ;;
+        /*) die_usage "--worktree must be repo-relative or under repo root: ${raw_path}" ;;
+        *) rel_path="${raw_path}" ;;
+    esac
+
+    while [[ "${rel_path}" == ./* ]]; do
+        rel_path="${rel_path#./}"
+    done
+
+    case "${rel_path}" in
+        ""|"."|".."|../*|*/../*|*/..|/*)
+            die_usage "--worktree must stay inside the repo without parent traversal: ${raw_path}"
+            ;;
+        worktrees/*) ;;
+        *)
+            die_usage "--worktree must be under worktrees/: ${raw_path}"
+            ;;
+    esac
+
+    printf "%s" "${rel_path}"
+}
+
+for arg in "$@"; do
+    if [[ "${arg}" == "-h" || "${arg}" == "--help" ]]; then
+        usage
+        exit 0
+    fi
+done
+
+if ! command -v python3 >/dev/null 2>&1; then
+    die "python3 not found in PATH"
+fi
+
+PREFLIGHT_PY="${REPO_ROOT}/scripts/orchestration/check_preflight.py"
+TASK_BOOTSTRAP_PY="${REPO_ROOT}/scripts/orchestration/task_bootstrap.py"
+if [[ ! -f "${PREFLIGHT_PY}" ]]; then
+    die "missing ${PREFLIGHT_PY}"
+fi
+if [[ ! -f "${TASK_BOOTSTRAP_PY}" ]]; then
+    die "missing ${TASK_BOOTSTRAP_PY}"
+fi
+
+GOAL=""
+TASK_CLASS=""
+BRANCH=""
+WORKTREE_REL=""
+PR_PHASE="pre_open"
+BASE_REF="origin/main"
+DRY_RUN=0
+PATH_ARGS=()
+REQUESTED_ARGS=(--requested-agent "agent-coordinator")
+PLUGIN_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --goal)
+            if [[ $# -lt 2 ]]; then die_usage "--goal requires a value"; fi
+            GOAL="$2"
+            shift 2
+            ;;
+        --task-class)
+            if [[ $# -lt 2 ]]; then die_usage "--task-class requires a value"; fi
+            TASK_CLASS="$2"
+            shift 2
+            ;;
+        --branch)
+            if [[ $# -lt 2 ]]; then die_usage "--branch requires a value"; fi
+            BRANCH="$2"
+            shift 2
+            ;;
+        --worktree)
+            if [[ $# -lt 2 ]]; then die_usage "--worktree requires a value"; fi
+            WORKTREE_REL="$(normalize_worktree_path "$2")"
+            shift 2
+            ;;
+        --path)
+            if [[ $# -lt 2 ]]; then die_usage "--path requires a value"; fi
+            PATH_ARGS+=(--path "$(normalize_scope_path "$2")")
+            shift 2
+            ;;
+        --requested-agent)
+            if [[ $# -lt 2 ]]; then die_usage "--requested-agent requires a value"; fi
+            REQUESTED_ARGS+=(--requested-agent "$2")
+            shift 2
+            ;;
+        --plugin)
+            if [[ $# -lt 2 ]]; then die_usage "--plugin requires a value"; fi
+            PLUGIN_ARGS+=("$2")
+            shift 2
+            ;;
+        --pr-phase)
+            if [[ $# -lt 2 ]]; then die_usage "--pr-phase requires a value"; fi
+            PR_PHASE="$2"
+            shift 2
+            ;;
+        --base)
+            if [[ $# -lt 2 ]]; then die_usage "--base requires a value"; fi
+            BASE_REF="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        *)
+            die_usage "unknown arg: $1"
+            ;;
+    esac
+done
+
+case "${PR_PHASE}" in
+    pre_open|post_open_review|merge_ready|none) ;;
+    *) die_usage "--pr-phase must be one of: pre_open, post_open_review, merge_ready, none" ;;
+esac
+
+if [[ -z "${GOAL}" ]]; then die_usage "--goal is required"; fi
+if [[ -z "${TASK_CLASS}" ]]; then die_usage "--task-class is required"; fi
+if [[ -z "${BRANCH}" ]]; then die_usage "--branch is required"; fi
+if [[ -z "${WORKTREE_REL}" ]]; then die_usage "--worktree is required"; fi
+
+case "${BRANCH}" in
+    main|master|origin/*|refs/*|""|*..*|*~*|*^*|*:*)
+        die_usage "--branch must be a new local branch name, got: ${BRANCH}"
+        ;;
+esac
+
+WORKTREE_ABS="${REPO_ROOT}/${WORKTREE_REL}"
+
+if [[ "${DRY_RUN}" -eq 0 ]]; then
+    if [[ -e "${WORKTREE_ABS}" ]]; then
+        die "worktree path already exists: ${WORKTREE_REL}"
+    fi
+    if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+        die "branch already exists: ${BRANCH}"
+    fi
+    if [[ -n "$(git status --porcelain)" ]]; then
+        die "current checkout must be clean before starting a new PR lane"
+    fi
+    git fetch --prune origin
+    if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+        die "base ref not found: ${BASE_REF}"
+    fi
+    if [[ "${BASE_REF}" == "origin/main" ]]; then
+        ahead_behind="$(git rev-list --left-right --count HEAD...origin/main)"
+        if [[ "${ahead_behind}" != "0	0" ]]; then
+            die "current checkout must be synced with origin/main before lane start; got ${ahead_behind}"
+        fi
+    fi
+fi
+
+if [[ "${#PLUGIN_ARGS[@]}" -eq 0 ]]; then
+    PLUGIN_ARGS=("${DEFAULT_PLUGINS[@]}")
+fi
+
+echo "PulsePlate PR lane start"
+echo "  branch: ${BRANCH}"
+echo "  worktree: ${WORKTREE_REL}"
+echo "  base: ${BASE_REF}"
+echo "  pr_phase: ${PR_PHASE}"
+echo ""
+echo "Plugin/runtime checklist (operator-confirmed, non-blocking):"
+for plugin in "${PLUGIN_ARGS[@]}"; do
+    echo "  - ${plugin}"
+done
+echo ""
+
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+    echo "DRY RUN: no git worktree, preflight, or bootstrap commands were executed."
+    printf "Would run: git worktree add -b %q %q %q\n" "${BRANCH}" "${WORKTREE_REL}" "${BASE_REF}"
+    printf "Would run in worktree: python3 scripts/orchestration/check_preflight.py --mode analyze"
+    for ((i = 0; i < ${#PATH_ARGS[@]}; i += 2)); do
+        printf " %q %q" "${PATH_ARGS[i]}" "${PATH_ARGS[i + 1]}"
+    done
+    printf "\n"
+    printf "Would run in worktree: python3 scripts/orchestration/task_bootstrap.py --goal %q --task-class %q --pr-phase %q" "${GOAL}" "${TASK_CLASS}" "${PR_PHASE}"
+    for ((i = 0; i < ${#PATH_ARGS[@]}; i += 2)); do
+        printf " %q %q" "${PATH_ARGS[i]}" "${PATH_ARGS[i + 1]}"
+    done
+    for ((i = 0; i < ${#REQUESTED_ARGS[@]}; i += 2)); do
+        printf " %q %q" "${REQUESTED_ARGS[i]}" "${REQUESTED_ARGS[i + 1]}"
+    done
+    printf "\n"
+    exit 0
+fi
+
+git worktree add -b "${BRANCH}" "${WORKTREE_REL}" "${BASE_REF}"
+
+(
+    cd "${WORKTREE_ABS}"
+    python3 scripts/orchestration/check_preflight.py --mode analyze ${PATH_ARGS[@]+"${PATH_ARGS[@]}"}
+    BOOTSTRAP_OUTPUT="$(
+        python3 scripts/orchestration/task_bootstrap.py \
+            --goal "${GOAL}" \
+            --task-class "${TASK_CLASS}" \
+            --pr-phase "${PR_PHASE}" \
+            ${PATH_ARGS[@]+"${PATH_ARGS[@]}"} \
+            ${REQUESTED_ARGS[@]+"${REQUESTED_ARGS[@]}"}
+    )"
+    echo "${BOOTSTRAP_OUTPUT}"
+    echo ""
+    BOOTSTRAP_OUTPUT="${BOOTSTRAP_OUTPUT}" python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["BOOTSTRAP_OUTPUT"])
+print("Coordinator packet summary:")
+print(f"  output: {payload['output']}")
+print(f"  primary_agent: {payload['primary_agent']}")
+print(f"  reviewer: {payload['reviewer']}")
+print("  recommended_skills:")
+for skill in payload["recommended_skills"]:
+    print(f"    - {skill}")
+PY
+)
+
+echo ""
+echo "Next steps:"
+echo "  1. cd ${WORKTREE_REL}"
+echo "  2. Follow the generated task packet before implementation."
+echo "  3. Do not push or open the PR until local validation and PR body/mapping are ready."

--- a/tests/test_start_pr_lane.py
+++ b/tests/test_start_pr_lane.py
@@ -1,0 +1,193 @@
+"""Regression tests for the repo-level PR lane starter."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+START_SCRIPT = REPO_ROOT / "scripts/orchestration/start_pr_lane.sh"
+
+
+def run_start(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    """Run the PR lane starter with captured output."""
+
+    bash_path = shutil.which("bash")
+    if bash_path is None:
+        raise RuntimeError("bash executable not found on PATH")
+
+    return subprocess.run(
+        [bash_path, str(START_SCRIPT), *args],
+        cwd=cwd or REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=60,
+    )
+
+
+def _required_args() -> tuple[str, ...]:
+    return (
+        "--goal",
+        "Start governed PR lane",
+        "--task-class",
+        "pr_governance",
+        "--branch",
+        "codex/example-pr-lane",
+        "--worktree",
+        "worktrees/example-pr-lane",
+    )
+
+
+def test_start_pr_lane_help_is_non_mutating() -> None:
+    """Help should not run git or bootstrap commands."""
+
+    result = run_start("--help")
+
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "--branch <name>" in result.stdout
+    assert "PulsePlate PR lane start" not in result.stdout
+
+
+def test_start_pr_lane_requires_core_lane_fields() -> None:
+    """Goal, class, branch, and worktree are all required before mutation."""
+
+    required_error_by_args = {
+        "--goal is required": (),
+        "--task-class is required": ("--goal", "Start governed PR lane"),
+        "--branch is required": (
+            "--goal",
+            "Start governed PR lane",
+            "--task-class",
+            "pr_governance",
+        ),
+        "--worktree is required": (
+            "--goal",
+            "Start governed PR lane",
+            "--task-class",
+            "pr_governance",
+            "--branch",
+            "codex/example-pr-lane",
+        ),
+    }
+
+    for expected_error, args in required_error_by_args.items():
+        result = run_start(*args)
+
+        assert result.returncode == 2
+        assert expected_error in result.stderr
+        assert "PulsePlate PR lane start" not in result.stdout
+
+
+def test_start_pr_lane_dry_run_prints_stable_commands_and_plugins() -> None:
+    """Dry-run should expose the full start recipe without mutating git state."""
+
+    result = run_start(
+        *_required_args(),
+        "--path",
+        "docs/dev/CODEX_SKILLS.md",
+        "--path",
+        "scripts/orchestration/start_pr_lane.sh",
+        "--requested-agent",
+        "qa-engineer-agent",
+        "--plugin",
+        "GitHub",
+        "--plugin",
+        "CodeRabbit",
+        "--dry-run",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "DRY RUN: no git worktree, preflight, or bootstrap commands were executed." in (
+        result.stdout
+    )
+    assert "Would run: git worktree add -b codex/example-pr-lane" in result.stdout
+    assert "Would run in worktree: python3 scripts/orchestration/check_preflight.py" in (
+        result.stdout
+    )
+    assert "Would run in worktree: python3 scripts/orchestration/task_bootstrap.py" in (
+        result.stdout
+    )
+    assert "--path docs/dev/CODEX_SKILLS.md" in result.stdout
+    assert "--path scripts/orchestration/start_pr_lane.sh" in result.stdout
+    assert "--requested-agent agent-coordinator" in result.stdout
+    assert "--requested-agent qa-engineer-agent" in result.stdout
+    assert "Plugin/runtime checklist (operator-confirmed, non-blocking):" in result.stdout
+    assert result.stdout.index("  - GitHub") < result.stdout.index("  - CodeRabbit")
+
+
+def test_start_pr_lane_dry_run_uses_default_plugin_checklist() -> None:
+    """The default plugin checklist should be stable and non-blocking."""
+
+    result = run_start(*_required_args(), "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    default_plugins = (
+        "Browser Use",
+        "Computer Use",
+        "GitHub",
+        "Hugging Face",
+        "Life Science Research",
+        "Plugin Eval",
+        "CodeRabbit",
+    )
+    for plugin in default_plugins:
+        assert f"  - {plugin}" in result.stdout
+    assert result.stdout.index("  - Browser Use") < result.stdout.index("  - CodeRabbit")
+
+
+def test_start_pr_lane_rejects_local_only_scope_paths() -> None:
+    """Task scope must not include local-only artifacts or worktrees."""
+
+    for blocked_path in (
+        "artifacts/agent_runs/session.json",
+        "artifacts/orchestration/task_packets/demo.json",
+        "artifacts/security_lab/report.json",
+        ".venv/bin/python",
+        "worktrees/other-lane",
+    ):
+        result = run_start(*_required_args(), "--path", blocked_path, "--dry-run")
+
+        assert result.returncode == 2
+        assert "local-only artifact/cache surface" in result.stderr
+        assert "PulsePlate PR lane start" not in result.stdout
+
+
+def test_start_pr_lane_rejects_bad_worktree_paths() -> None:
+    """The lane worktree itself must be inside repo worktrees/."""
+
+    result = run_start(
+        "--goal",
+        "Start governed PR lane",
+        "--task-class",
+        "pr_governance",
+        "--branch",
+        "codex/example-pr-lane",
+        "--worktree",
+        "tmp/example-pr-lane",
+        "--dry-run",
+    )
+
+    assert result.returncode == 2
+    assert "--worktree must be under worktrees/" in result.stderr
+
+
+def test_start_pr_lane_rejects_branch_ref_like_names() -> None:
+    """The branch must be a new local branch name, not a remote or ref expression."""
+
+    result = run_start(
+        "--goal",
+        "Start governed PR lane",
+        "--task-class",
+        "pr_governance",
+        "--branch",
+        "origin/main",
+        "--worktree",
+        "worktrees/example-pr-lane",
+        "--dry-run",
+    )
+
+    assert result.returncode == 2
+    assert "--branch must be a new local branch name" in result.stderr

--- a/tests/test_start_pr_lane.py
+++ b/tests/test_start_pr_lane.py
@@ -147,6 +147,9 @@ def test_start_pr_lane_rejects_local_only_scope_paths() -> None:
         "artifacts/security_lab/report.json",
         ".venv/bin/python",
         "worktrees/other-lane",
+        ".DS_Store",
+        ".coverage",
+        "coverage.xml",
     ):
         result = run_start(*_required_args(), "--path", blocked_path, "--dry-run")
 
@@ -155,23 +158,48 @@ def test_start_pr_lane_rejects_local_only_scope_paths() -> None:
         assert "PulsePlate PR lane start" not in result.stdout
 
 
+def test_start_pr_lane_rejects_parent_traversal_scope_paths() -> None:
+    """Task scope paths must stay inside tracked repo surfaces."""
+
+    blocked_path_errors = {
+        "../secrets.json": "--path must stay inside the repo without parent traversal",
+        "../../outside-repo": "--path must stay inside the repo without parent traversal",
+        "/tmp/session.json": "--path must be repo-relative or under repo root",
+    }
+
+    for blocked_path, expected_error in blocked_path_errors.items():
+        result = run_start(*_required_args(), "--path", blocked_path, "--dry-run")
+
+        assert result.returncode == 2
+        assert expected_error in result.stderr
+        assert "PulsePlate PR lane start" not in result.stdout
+
+
 def test_start_pr_lane_rejects_bad_worktree_paths() -> None:
     """The lane worktree itself must be inside repo worktrees/."""
 
-    result = run_start(
-        "--goal",
-        "Start governed PR lane",
-        "--task-class",
-        "pr_governance",
-        "--branch",
-        "codex/example-pr-lane",
-        "--worktree",
-        "tmp/example-pr-lane",
-        "--dry-run",
-    )
+    blocked_worktree_errors = {
+        "tmp/example-pr-lane": "--worktree must be under worktrees/",
+        "../example-pr-lane": "--worktree must stay inside the repo without parent traversal",
+        "../../outside-repo/example-pr-lane": "--worktree must stay inside the repo without parent traversal",
+        "/tmp/example-pr-lane": "--worktree must be repo-relative or under repo root",
+    }
 
-    assert result.returncode == 2
-    assert "--worktree must be under worktrees/" in result.stderr
+    for blocked_worktree, expected_error in blocked_worktree_errors.items():
+        result = run_start(
+            "--goal",
+            "Start governed PR lane",
+            "--task-class",
+            "pr_governance",
+            "--branch",
+            "codex/example-pr-lane",
+            "--worktree",
+            blocked_worktree,
+            "--dry-run",
+        )
+
+        assert result.returncode == 2
+        assert expected_error in result.stderr
 
 
 def test_start_pr_lane_rejects_branch_ref_like_names() -> None:
@@ -191,3 +219,22 @@ def test_start_pr_lane_rejects_branch_ref_like_names() -> None:
 
     assert result.returncode == 2
     assert "--branch must be a new local branch name" in result.stderr
+
+
+def test_start_pr_lane_rejects_git_invalid_branch_names() -> None:
+    """Branch validation should match git refname rules."""
+
+    result = run_start(
+        "--goal",
+        "Start governed PR lane",
+        "--task-class",
+        "pr_governance",
+        "--branch",
+        "bad branch name",
+        "--worktree",
+        "worktrees/example-pr-lane",
+        "--dry-run",
+    )
+
+    assert result.returncode == 2
+    assert "--branch must be a valid branch name" in result.stderr


### PR DESCRIPTION
## Goal
Make every new PulsePlate PR lane start through an explicit repo command that preserves coordinator-first preflight/bootstrap and isolated worktree discipline.

## Business reason
Reduce repeated operator reminders and missed orchestration startup steps by giving agents a deterministic repo-level PR-start path.

## Scope
- Add `scripts/orchestration/start_pr_lane.sh` to create an isolated worktree, run analyze preflight, invoke `task_bootstrap.py`, and print packet/plugin checklist output.
- Add `make pr-start` as the Make entrypoint for the wrapper.
- Update onboarding, launcher, Codex skills, and automation-readiness docs to make the repo wrapper the preferred manual PR lane start path.
- Add focused regression tests for non-mutating help/dry-run and fail-closed argument/path behavior.
- Add canonical mapping artifact: `docs/review/PR_1696_FIXED_MAPPING.md`.

## Out of scope
- No host plugin installation.
- No edits to real `~/.codex/config.toml`.
- No raw-session/global Codex runtime auto-start claim.
- No automatic PR push/open inside the lane starter.

## Files changed / likely touched
- `scripts/orchestration/start_pr_lane.sh`
- `tests/test_start_pr_lane.py`
- `Makefile`
- `docs/review/PR_1696_FIXED_MAPPING.md`
- `docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md`
- `docs/dev/CODEX_SKILLS.md`
- `docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md`
- `docs/orchestration/AUTOMATION_READINESS_MATRIX.md`

## Key decisions
- Plugin handling is checklist-only and non-blocking: Browser Use, Computer Use, GitHub, Hugging Face, Life Science Research, Plugin Eval, and CodeRabbit are operator/runtime availability checks, not repo fail-closed dependencies.
- The wrapper defaults to `--pr-phase pre_open`, base `origin/main`, and requested `agent-coordinator`.
- The wrapper creates branch/worktree only after validating a clean checkout synced to `origin/main`.
- `--dry-run` exists for deterministic testing and operator inspection without mutating git state.

## Tests / validation
- `bash -n scripts/orchestration/start_pr_lane.sh` PASS
- `python3 scripts/orchestration/check_preflight.py --mode analyze --path scripts/orchestration/start_pr_lane.sh --path docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md --path docs/dev/LOCAL_COORDINATOR_LAUNCHER_ROLLOUT.md --path docs/orchestration/AUTOMATION_READINESS_MATRIX.md --path docs/dev/CODEX_SKILLS.md --path tests/test_start_pr_lane.py --path Makefile` PASS
- `python3 scripts/orchestration/check_preflight.py --mode analyze --path scripts/orchestration/start_pr_lane.sh --path tests/test_start_pr_lane.py` PASS after bot-feedback fix
- `python3 scripts/orchestration/check_preflight.py --mode analyze --path docs/review/PR_1696_FIXED_MAPPING.md` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_start_pr_lane.py` PASS (`9 passed`)
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_local_session_bootstrap.py tests/test_start_pr_lane.py` PASS (`18 passed`)
- `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` PASS
- `pre-commit run --all-files` PASS
- Push/pre-push hooks PASS: backend pre-push, full Bandit, pip-audit; docker build test passed on the implementation push and was skipped on docs-only mapping push

## Security notes
- No secrets or host-local config are written.
- Plugin availability is printed as an operator checklist only; no external plugin probing or network plugin installation is added.
- Worktree creation rejects local-only task scope paths, coverage/OS artifacts, absolute escapes, and parent traversal.

## Risks / rollback
- Risk: agents may treat the wrapper as raw-session auto-start. Mitigation: docs explicitly classify it as repo wrapper-enforced only once invoked.
- Risk: local fresh worktrees may lack `.venv`. Mitigation: validation documented the worktree-local `.venv` symlink need; the wrapper itself does not create or commit env artifacts.
- Rollback: remove `scripts/orchestration/start_pr_lane.sh`, `make pr-start`, tests, mapping scaffold, and doc references; existing `local_session_bootstrap.sh` and direct `task_bootstrap.py` flows remain intact.

## Deferred / follow-ups
- Host launcher installation remains operator-owned and opt-in.
- Raw-session/global auto-start remains host-runtime constrained and out of scope.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Sourcery, Codex, and Cubic post-open bot review comments inspected and dispositioned in `docs/review/PR_1696_FIXED_MAPPING.md`.
- [x] Post-open review bootstrap packet generated locally: `artifacts/orchestration/task_packets/b8b8644d7480.json`.

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1696_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Current-head CI must be inspected after the latest push.
- [ ] If CodeRabbit, Sourcery, or Cubic posts again on this PR, it must be PASS / no-actionables before merge readiness.
- [ ] Required checks must be PASS with no pending required jobs.
- [ ] Strict merge-readiness wrapper must pass before any ready/mergeable claim: `python3 scripts/orchestration/check_merge_ready.py --pr-number 1696 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`
