### PR TITLE
ci(release): add governed release evidence source producers

### DIFF
--- a/.github/workflows/build-equivalence-evidence.yml
+++ b/.github/workflows/build-equivalence-evidence.yml
@@ -67,6 +67,12 @@ jobs:
             --source-json "$RELEASE_MANIFEST_SOURCE" > "$source_env"
           # shellcheck disable=SC1090
           . "$source_env"
+          # shellcheck disable=SC2153
+          release_manifest_run_id="$RELEASE_MANIFEST_RUN_ID"
+          # shellcheck disable=SC2153
+          release_manifest_artifact_name="$RELEASE_MANIFEST_ARTIFACT_NAME"
+          # shellcheck disable=SC2153
+          release_manifest_source_path="$RELEASE_MANIFEST_PATH"
 
           EVIDENCE_ARTIFACT_NAME="$(python scripts/release/evidence_source.py artifact-name "$EVIDENCE_ARTIFACT_NAME")"
           expected_git_sha_lc="$(python scripts/release/evidence_source.py git-sha "$EXPECTED_GIT_SHA")"
@@ -121,17 +127,17 @@ jobs:
             fi
           }
 
-          validate_source_run "release manifest" "$RELEASE_MANIFEST_RUN_ID" \
+          validate_source_run "release manifest" "$release_manifest_run_id" \
             "Release Manifest Evidence" ".github/workflows/release-manifest-evidence.yml"
 
           download_dir="${RUNNER_TEMP}/build-equivalence-release-manifest-source"
           output_dir="${RUNNER_TEMP}/build-equivalence-evidence"
           identities_dir="${RUNNER_TEMP}/build-equivalence-identities"
           mkdir -p "$download_dir" "$output_dir" "$identities_dir"
-          gh run download "$RELEASE_MANIFEST_RUN_ID" --name "$RELEASE_MANIFEST_ARTIFACT_NAME" --dir "$download_dir"
-          release_manifest_path="${download_dir}/${RELEASE_MANIFEST_PATH}"
+          gh run download "$release_manifest_run_id" --name "$release_manifest_artifact_name" --dir "$download_dir"
+          release_manifest_path="${download_dir}/${release_manifest_source_path}"
           if [ ! -f "$release_manifest_path" ]; then
-            echo "ERROR: Missing governed release_manifest.json at ${RELEASE_MANIFEST_PATH}"
+            echo "ERROR: Missing governed release_manifest.json at ${release_manifest_source_path}"
             exit 1
           fi
           resolved_download_dir="$(cd "$download_dir" && pwd -P)"

--- a/.github/workflows/build-equivalence-evidence.yml
+++ b/.github/workflows/build-equivalence-evidence.yml
@@ -16,16 +16,8 @@ on:
         description: "App Review build artifact digest in sha256:<64 lowercase hex> format"
         required: true
         type: string
-      review_artifact_digest_source:
-        description: "Single-line JSON with run_id, artifact_name, path for governed review_artifact_digest.txt"
-        required: true
-        type: string
       production_candidate_artifact_digest:
         description: "Production-candidate build artifact digest in sha256:<64 lowercase hex> format"
-        required: true
-        type: string
-      production_candidate_artifact_digest_source:
-        description: "Single-line JSON with run_id, artifact_name, path for governed production_candidate_artifact_digest.txt"
         required: true
         type: string
       evidence_artifact_name:
@@ -62,10 +54,8 @@ jobs:
           EXPECTED_GIT_SHA: ${{ inputs.git_sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRODUCTION_CANDIDATE_ARTIFACT_DIGEST: ${{ inputs.production_candidate_artifact_digest }}
-          PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE: ${{ inputs.production_candidate_artifact_digest_source }}
           RELEASE_MANIFEST_SOURCE: ${{ inputs.release_manifest_source }}
           REVIEW_ARTIFACT_DIGEST: ${{ inputs.review_artifact_digest }}
-          REVIEW_ARTIFACT_DIGEST_SOURCE: ${{ inputs.review_artifact_digest_source }}
         run: |
           set -euo pipefail
 
@@ -77,22 +67,6 @@ jobs:
             --source-json "$RELEASE_MANIFEST_SOURCE" > "$source_env"
           # shellcheck disable=SC1090
           . "$source_env"
-          review_source_env="${RUNNER_TEMP}/build-equivalence-review-digest-source.env"
-          python scripts/release/evidence_source.py source-env \
-            --label review_artifact_digest \
-            --prefix REVIEW_ARTIFACT_DIGEST_SOURCE \
-            --expected-path review_artifact_digest.txt \
-            --source-json "$REVIEW_ARTIFACT_DIGEST_SOURCE" > "$review_source_env"
-          # shellcheck disable=SC1090
-          . "$review_source_env"
-          production_source_env="${RUNNER_TEMP}/build-equivalence-production-digest-source.env"
-          python scripts/release/evidence_source.py source-env \
-            --label production_candidate_artifact_digest \
-            --prefix PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE \
-            --expected-path production_candidate_artifact_digest.txt \
-            --source-json "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE" > "$production_source_env"
-          # shellcheck disable=SC1090
-          . "$production_source_env"
 
           EVIDENCE_ARTIFACT_NAME="$(python scripts/release/evidence_source.py artifact-name "$EVIDENCE_ARTIFACT_NAME")"
           expected_git_sha_lc="$(python scripts/release/evidence_source.py git-sha "$EXPECTED_GIT_SHA")"
@@ -149,65 +123,6 @@ jobs:
 
           validate_source_run "release manifest" "$RELEASE_MANIFEST_RUN_ID" \
             "Release Manifest Evidence" ".github/workflows/release-manifest-evidence.yml"
-          validate_source_run "review artifact digest" "$REVIEW_ARTIFACT_DIGEST_SOURCE_RUN_ID" \
-            "Docker Build and Push" ".github/workflows/build.yml"
-          validate_source_run "production candidate artifact digest" "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE_RUN_ID" \
-            "Docker Build and Push" ".github/workflows/build.yml"
-
-          fetch_digest_source() {
-            label="$1"
-            run_id="$2"
-            artifact_name="$3"
-            source_path="$4"
-            expected_digest="$5"
-            download_dir="$6"
-            mkdir -p "$download_dir"
-            gh run download "$run_id" --name "$artifact_name" --dir "$download_dir"
-            digest_path="${download_dir}/${source_path}"
-            if [ ! -f "$digest_path" ]; then
-              echo "ERROR: Missing governed ${label} digest at ${source_path}"
-              exit 1
-            fi
-            resolved_download_dir="$(cd "$download_dir" && pwd -P)"
-            resolved_digest_path="$(python - "$digest_path" <<'PY'
-          from pathlib import Path
-          import sys
-
-          print(Path(sys.argv[1]).resolve())
-          PY
-            )"
-            case "$resolved_digest_path" in
-              "$resolved_download_dir"/*) ;;
-              *) echo "ERROR: ${label} digest path escapes downloaded artifact"; exit 1 ;;
-            esac
-            actual_digest="$(python - "$digest_path" <<'PY'
-          from pathlib import Path
-          import sys
-
-          print(Path(sys.argv[1]).read_text(encoding="utf-8").strip())
-          PY
-            )"
-            actual_digest="$(python scripts/release/evidence_source.py oci-digest --label "${label}_artifact_digest_source" "$actual_digest")"
-            if [ "$actual_digest" != "$expected_digest" ]; then
-              echo "ERROR: ${label} governed digest source does not match explicit digest input"
-              echo "source digest=${actual_digest}"
-              echo "input digest=${expected_digest}"
-              exit 1
-            fi
-          }
-
-          fetch_digest_source "review" \
-            "$REVIEW_ARTIFACT_DIGEST_SOURCE_RUN_ID" \
-            "$REVIEW_ARTIFACT_DIGEST_SOURCE_ARTIFACT_NAME" \
-            "$REVIEW_ARTIFACT_DIGEST_SOURCE_PATH" \
-            "$REVIEW_ARTIFACT_DIGEST" \
-            "${RUNNER_TEMP}/build-equivalence-review-digest-source"
-          fetch_digest_source "production candidate" \
-            "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE_RUN_ID" \
-            "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE_ARTIFACT_NAME" \
-            "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE_PATH" \
-            "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST" \
-            "${RUNNER_TEMP}/build-equivalence-production-digest-source"
 
           download_dir="${RUNNER_TEMP}/build-equivalence-release-manifest-source"
           output_dir="${RUNNER_TEMP}/build-equivalence-evidence"

--- a/.github/workflows/build-equivalence-evidence.yml
+++ b/.github/workflows/build-equivalence-evidence.yml
@@ -48,6 +48,7 @@ jobs:
           python-version: "3.13"
 
       - name: Generate governed build equivalence evidence
+        id: generate-build-equivalence-evidence
         env:
           EVIDENCE_ARTIFACT_NAME: ${{ inputs.evidence_artifact_name }}
           EXPECTED_GIT_SHA: ${{ inputs.git_sha }}
@@ -62,6 +63,7 @@ jobs:
           python scripts/release/evidence_source.py source-env \
             --label release_manifest \
             --prefix RELEASE_MANIFEST \
+            --expected-path release_manifest.json \
             --source-json "$RELEASE_MANIFEST_SOURCE" > "$source_env"
           # shellcheck disable=SC1090
           . "$source_env"
@@ -124,7 +126,13 @@ jobs:
             exit 1
           fi
           resolved_download_dir="$(cd "$download_dir" && pwd -P)"
-          resolved_manifest_path="$(cd "$(dirname "$release_manifest_path")" && pwd -P)/$(basename "$release_manifest_path")"
+          resolved_manifest_path="$(python - "$release_manifest_path" <<'PY'
+          from pathlib import Path
+          import sys
+
+          print(Path(sys.argv[1]).resolve())
+          PY
+          )"
           case "$resolved_manifest_path" in
             "$resolved_download_dir"/*) ;;
             *) echo "ERROR: release_manifest path escapes downloaded artifact"; exit 1 ;;
@@ -168,11 +176,21 @@ jobs:
             --production-candidate "${identities_dir}/production_candidate_identity.json" \
             --release-manifest "$release_manifest_path" \
             --output "${output_dir}/build_equivalence_result.json"
+          python - "${output_dir}/build_equivalence_result.json" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          if payload.get("decision") != "EQUIVALENT":
+              raise SystemExit("build_equivalence_result.decision must be EQUIVALENT")
+          PY
 
           {
             echo "BUILD_EQUIVALENCE_EVIDENCE_ARTIFACT_NAME=$EVIDENCE_ARTIFACT_NAME"
             echo "BUILD_EQUIVALENCE_EVIDENCE_OUTPUT_DIR=$output_dir"
           } >> "$GITHUB_ENV"
+          echo "artifact_name=$EVIDENCE_ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Publish build equivalence evidence summary
         run: |
@@ -188,7 +206,7 @@ jobs:
       - name: Upload governed build equivalence evidence artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: ${{ inputs.evidence_artifact_name }}
+          name: ${{ steps.generate-build-equivalence-evidence.outputs.artifact_name }}
           path: ${{ runner.temp }}/build-equivalence-evidence/build_equivalence_result.json
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/build-equivalence-evidence.yml
+++ b/.github/workflows/build-equivalence-evidence.yml
@@ -1,0 +1,194 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Build Equivalence Evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_sha:
+        description: "Expected release git SHA for this governed build-equivalence evidence"
+        required: true
+        type: string
+      release_manifest_source:
+        description: "Single-line JSON with run_id, artifact_name, path for governed release_manifest.json"
+        required: true
+        type: string
+      review_artifact_digest:
+        description: "App Review build artifact digest in sha256:<64 lowercase hex> format"
+        required: true
+        type: string
+      production_candidate_artifact_digest:
+        description: "Production-candidate build artifact digest in sha256:<64 lowercase hex> format"
+        required: true
+        type: string
+      evidence_artifact_name:
+        description: "Published governed build equivalence evidence artifact name"
+        required: true
+        default: "build-equivalence-evidence"
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  publish-build-equivalence-evidence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: release-evidence
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Generate governed build equivalence evidence
+        env:
+          EVIDENCE_ARTIFACT_NAME: ${{ inputs.evidence_artifact_name }}
+          EXPECTED_GIT_SHA: ${{ inputs.git_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRODUCTION_CANDIDATE_ARTIFACT_DIGEST: ${{ inputs.production_candidate_artifact_digest }}
+          RELEASE_MANIFEST_SOURCE: ${{ inputs.release_manifest_source }}
+          REVIEW_ARTIFACT_DIGEST: ${{ inputs.review_artifact_digest }}
+        run: |
+          set -euo pipefail
+
+          source_env="${RUNNER_TEMP}/build-equivalence-source.env"
+          python scripts/release/evidence_source.py source-env \
+            --label release_manifest \
+            --prefix RELEASE_MANIFEST \
+            --source-json "$RELEASE_MANIFEST_SOURCE" > "$source_env"
+          # shellcheck disable=SC1090
+          . "$source_env"
+
+          EVIDENCE_ARTIFACT_NAME="$(python scripts/release/evidence_source.py artifact-name "$EVIDENCE_ARTIFACT_NAME")"
+          expected_git_sha_lc="$(python scripts/release/evidence_source.py git-sha "$EXPECTED_GIT_SHA")"
+          github_sha_lc="$(printf '%s' "$GITHUB_SHA" | tr 'A-F' 'a-f')"
+          if [ "$github_sha_lc" != "$expected_git_sha_lc" ]; then
+            echo "ERROR: Build Equivalence Evidence workflow ref must match git_sha"
+            echo "workflow GITHUB_SHA=${GITHUB_SHA}"
+            echo "git_sha=${EXPECTED_GIT_SHA}"
+            exit 1
+          fi
+          REVIEW_ARTIFACT_DIGEST="$(python scripts/release/evidence_source.py oci-digest --label review_artifact_digest "$REVIEW_ARTIFACT_DIGEST")"
+          PRODUCTION_CANDIDATE_ARTIFACT_DIGEST="$(python scripts/release/evidence_source.py oci-digest --label production_candidate_artifact_digest "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST")"
+
+          run_metadata="$(
+            gh run view "$RELEASE_MANIFEST_RUN_ID" \
+              --json status,conclusion,headSha,event,workflowName,url \
+              --jq '[.status, .conclusion, .headSha, .event, .workflowName, .url] | @tsv'
+          )"
+          IFS=$'\t' read -r run_status run_conclusion run_head_sha run_event run_workflow_name run_url <<< "$run_metadata"
+          run_workflow_path="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_MANIFEST_RUN_ID}" --jq '.path')"
+          if [ "$run_status" != "completed" ] || [ "$run_conclusion" != "success" ]; then
+            echo "ERROR: Release manifest source run did not complete successfully"
+            echo "status=${run_status:-unset} conclusion=${run_conclusion:-unset} url=${run_url:-unset}"
+            exit 1
+          fi
+          if [ "$run_event" != "workflow_dispatch" ]; then
+            echo "ERROR: Release manifest source run must be workflow_dispatch"
+            echo "event=${run_event:-unset} url=${run_url:-unset}"
+            exit 1
+          fi
+          if [ "$run_workflow_name" != "Release Manifest Evidence" ]; then
+            echo "ERROR: release manifest source workflow name must be Release Manifest Evidence"
+            echo "workflow=${run_workflow_name:-unset}"
+            exit 1
+          fi
+          if [ "$run_workflow_path" != ".github/workflows/release-manifest-evidence.yml" ]; then
+            echo "ERROR: release manifest source workflow path must be .github/workflows/release-manifest-evidence.yml"
+            echo "workflow_path=${run_workflow_path:-unset}"
+            exit 1
+          fi
+          run_head_sha_lc="$(printf '%s' "$run_head_sha" | tr 'A-F' 'a-f')"
+          if [ "$run_head_sha_lc" != "$expected_git_sha_lc" ]; then
+            echo "ERROR: release manifest source run head SHA does not match git_sha"
+            echo "run headSha=${run_head_sha:-unset}"
+            echo "git_sha=${EXPECTED_GIT_SHA}"
+            exit 1
+          fi
+
+          download_dir="${RUNNER_TEMP}/build-equivalence-release-manifest-source"
+          output_dir="${RUNNER_TEMP}/build-equivalence-evidence"
+          identities_dir="${RUNNER_TEMP}/build-equivalence-identities"
+          mkdir -p "$download_dir" "$output_dir" "$identities_dir"
+          gh run download "$RELEASE_MANIFEST_RUN_ID" --name "$RELEASE_MANIFEST_ARTIFACT_NAME" --dir "$download_dir"
+          release_manifest_path="${download_dir}/${RELEASE_MANIFEST_PATH}"
+          if [ ! -f "$release_manifest_path" ]; then
+            echo "ERROR: Missing governed release_manifest.json at ${RELEASE_MANIFEST_PATH}"
+            exit 1
+          fi
+          resolved_download_dir="$(cd "$download_dir" && pwd -P)"
+          resolved_manifest_path="$(cd "$(dirname "$release_manifest_path")" && pwd -P)/$(basename "$release_manifest_path")"
+          case "$resolved_manifest_path" in
+            "$resolved_download_dir"/*) ;;
+            *) echo "ERROR: release_manifest path escapes downloaded artifact"; exit 1 ;;
+          esac
+          python -m json.tool "$release_manifest_path" > /dev/null
+          manifest_git_sha="$(
+            python - "$release_manifest_path" <<'PY'
+          import json
+          import sys
+          with open(sys.argv[1], encoding="utf-8") as handle:
+              payload = json.load(handle)
+          build_identity = payload.get("build_identity")
+          if not isinstance(build_identity, dict):
+              raise SystemExit("missing build_identity")
+          git_sha = build_identity.get("git_sha")
+          if not isinstance(git_sha, str) or not git_sha:
+              raise SystemExit("missing build_identity.git_sha")
+          print(git_sha)
+          PY
+          )"
+          manifest_git_sha_lc="$(printf '%s' "$manifest_git_sha" | tr 'A-F' 'a-f')"
+          if [ "$manifest_git_sha_lc" != "$expected_git_sha_lc" ]; then
+            echo "ERROR: release manifest build_identity.git_sha does not match git_sha"
+            echo "manifest git_sha=${manifest_git_sha}"
+            echo "git_sha=${EXPECTED_GIT_SHA}"
+            exit 1
+          fi
+
+          python scripts/release/release_manifest.py validate \
+            --manifest "$release_manifest_path"
+          python scripts/release/build_identity.py \
+            --release-manifest "$release_manifest_path" \
+            --artifact-digest "$REVIEW_ARTIFACT_DIGEST" \
+            --output "${identities_dir}/review_build_identity.json"
+          python scripts/release/build_identity.py \
+            --release-manifest "$release_manifest_path" \
+            --artifact-digest "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST" \
+            --output "${identities_dir}/production_candidate_identity.json"
+          python scripts/release/build_equivalence.py \
+            --review-build "${identities_dir}/review_build_identity.json" \
+            --production-candidate "${identities_dir}/production_candidate_identity.json" \
+            --release-manifest "$release_manifest_path" \
+            --output "${output_dir}/build_equivalence_result.json"
+
+          {
+            echo "BUILD_EQUIVALENCE_EVIDENCE_ARTIFACT_NAME=$EVIDENCE_ARTIFACT_NAME"
+            echo "BUILD_EQUIVALENCE_EVIDENCE_OUTPUT_DIR=$output_dir"
+          } >> "$GITHUB_ENV"
+
+      - name: Publish build equivalence evidence summary
+        run: |
+          set -euo pipefail
+          {
+            echo "## Build Equivalence Evidence"
+            echo
+            echo "- Run id: \`${GITHUB_RUN_ID}\`"
+            echo "- Artifact name: \`${BUILD_EQUIVALENCE_EVIDENCE_ARTIFACT_NAME}\`"
+            echo "- Path inside artifact: \`build_equivalence_result.json\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload governed build equivalence evidence artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${{ inputs.evidence_artifact_name }}
+          path: ${{ runner.temp }}/build-equivalence-evidence/build_equivalence_result.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/build-equivalence-evidence.yml
+++ b/.github/workflows/build-equivalence-evidence.yml
@@ -16,8 +16,16 @@ on:
         description: "App Review build artifact digest in sha256:<64 lowercase hex> format"
         required: true
         type: string
+      review_artifact_digest_source:
+        description: "Single-line JSON with run_id, artifact_name, path for governed review_artifact_digest.txt"
+        required: true
+        type: string
       production_candidate_artifact_digest:
         description: "Production-candidate build artifact digest in sha256:<64 lowercase hex> format"
+        required: true
+        type: string
+      production_candidate_artifact_digest_source:
+        description: "Single-line JSON with run_id, artifact_name, path for governed production_candidate_artifact_digest.txt"
         required: true
         type: string
       evidence_artifact_name:
@@ -54,12 +62,14 @@ jobs:
           EXPECTED_GIT_SHA: ${{ inputs.git_sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRODUCTION_CANDIDATE_ARTIFACT_DIGEST: ${{ inputs.production_candidate_artifact_digest }}
+          PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE: ${{ inputs.production_candidate_artifact_digest_source }}
           RELEASE_MANIFEST_SOURCE: ${{ inputs.release_manifest_source }}
           REVIEW_ARTIFACT_DIGEST: ${{ inputs.review_artifact_digest }}
+          REVIEW_ARTIFACT_DIGEST_SOURCE: ${{ inputs.review_artifact_digest_source }}
         run: |
           set -euo pipefail
 
-          source_env="${RUNNER_TEMP}/build-equivalence-source.env"
+          source_env="${RUNNER_TEMP}/build-equivalence-release-manifest-source.env"
           python scripts/release/evidence_source.py source-env \
             --label release_manifest \
             --prefix RELEASE_MANIFEST \
@@ -67,6 +77,22 @@ jobs:
             --source-json "$RELEASE_MANIFEST_SOURCE" > "$source_env"
           # shellcheck disable=SC1090
           . "$source_env"
+          review_source_env="${RUNNER_TEMP}/build-equivalence-review-digest-source.env"
+          python scripts/release/evidence_source.py source-env \
+            --label review_artifact_digest \
+            --prefix REVIEW_ARTIFACT_DIGEST_SOURCE \
+            --expected-path review_artifact_digest.txt \
+            --source-json "$REVIEW_ARTIFACT_DIGEST_SOURCE" > "$review_source_env"
+          # shellcheck disable=SC1090
+          . "$review_source_env"
+          production_source_env="${RUNNER_TEMP}/build-equivalence-production-digest-source.env"
+          python scripts/release/evidence_source.py source-env \
+            --label production_candidate_artifact_digest \
+            --prefix PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE \
+            --expected-path production_candidate_artifact_digest.txt \
+            --source-json "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE" > "$production_source_env"
+          # shellcheck disable=SC1090
+          . "$production_source_env"
 
           EVIDENCE_ARTIFACT_NAME="$(python scripts/release/evidence_source.py artifact-name "$EVIDENCE_ARTIFACT_NAME")"
           expected_git_sha_lc="$(python scripts/release/evidence_source.py git-sha "$EXPECTED_GIT_SHA")"
@@ -80,40 +106,108 @@ jobs:
           REVIEW_ARTIFACT_DIGEST="$(python scripts/release/evidence_source.py oci-digest --label review_artifact_digest "$REVIEW_ARTIFACT_DIGEST")"
           PRODUCTION_CANDIDATE_ARTIFACT_DIGEST="$(python scripts/release/evidence_source.py oci-digest --label production_candidate_artifact_digest "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST")"
 
-          run_metadata="$(
-            gh run view "$RELEASE_MANIFEST_RUN_ID" \
-              --json status,conclusion,headSha,event,workflowName,url \
-              --jq '[.status, .conclusion, .headSha, .event, .workflowName, .url] | @tsv'
-          )"
-          IFS=$'\t' read -r run_status run_conclusion run_head_sha run_event run_workflow_name run_url <<< "$run_metadata"
-          run_workflow_path="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_MANIFEST_RUN_ID}" --jq '.path')"
-          if [ "$run_status" != "completed" ] || [ "$run_conclusion" != "success" ]; then
-            echo "ERROR: Release manifest source run did not complete successfully"
-            echo "status=${run_status:-unset} conclusion=${run_conclusion:-unset} url=${run_url:-unset}"
-            exit 1
-          fi
-          if [ "$run_event" != "workflow_dispatch" ]; then
-            echo "ERROR: Release manifest source run must be workflow_dispatch"
-            echo "event=${run_event:-unset} url=${run_url:-unset}"
-            exit 1
-          fi
-          if [ "$run_workflow_name" != "Release Manifest Evidence" ]; then
-            echo "ERROR: release manifest source workflow name must be Release Manifest Evidence"
-            echo "workflow=${run_workflow_name:-unset}"
-            exit 1
-          fi
-          if [ "$run_workflow_path" != ".github/workflows/release-manifest-evidence.yml" ]; then
-            echo "ERROR: release manifest source workflow path must be .github/workflows/release-manifest-evidence.yml"
-            echo "workflow_path=${run_workflow_path:-unset}"
-            exit 1
-          fi
-          run_head_sha_lc="$(printf '%s' "$run_head_sha" | tr 'A-F' 'a-f')"
-          if [ "$run_head_sha_lc" != "$expected_git_sha_lc" ]; then
-            echo "ERROR: release manifest source run head SHA does not match git_sha"
-            echo "run headSha=${run_head_sha:-unset}"
-            echo "git_sha=${EXPECTED_GIT_SHA}"
-            exit 1
-          fi
+          validate_source_run() {
+            label="$1"
+            run_id="$2"
+            expected_workflow_name="$3"
+            expected_workflow_path="$4"
+            run_metadata="$(
+              gh run view "$run_id" \
+                --json status,conclusion,headSha,event,workflowName,url \
+                --jq '[.status, .conclusion, .headSha, .event, .workflowName, .url] | @tsv'
+            )"
+            IFS=$'\t' read -r run_status run_conclusion run_head_sha run_event run_workflow_name run_url <<< "$run_metadata"
+            run_workflow_path="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" --jq '.path')"
+            if [ "$run_status" != "completed" ] || [ "$run_conclusion" != "success" ]; then
+              echo "ERROR: ${label} source run did not complete successfully"
+              echo "status=${run_status:-unset} conclusion=${run_conclusion:-unset} url=${run_url:-unset}"
+              exit 1
+            fi
+            if [ "$run_event" != "workflow_dispatch" ]; then
+              echo "ERROR: ${label} source run must be workflow_dispatch"
+              echo "event=${run_event:-unset} url=${run_url:-unset}"
+              exit 1
+            fi
+            if [ "$run_workflow_name" != "$expected_workflow_name" ]; then
+              echo "ERROR: ${label} source workflow name must be ${expected_workflow_name}"
+              echo "workflow=${run_workflow_name:-unset}"
+              exit 1
+            fi
+            if [ "$run_workflow_path" != "$expected_workflow_path" ]; then
+              echo "ERROR: ${label} source workflow path must be ${expected_workflow_path}"
+              echo "workflow_path=${run_workflow_path:-unset}"
+              exit 1
+            fi
+            run_head_sha_lc="$(printf '%s' "$run_head_sha" | tr 'A-F' 'a-f')"
+            if [ "$run_head_sha_lc" != "$expected_git_sha_lc" ]; then
+              echo "ERROR: ${label} source run head SHA does not match git_sha"
+              echo "run headSha=${run_head_sha:-unset}"
+              echo "git_sha=${EXPECTED_GIT_SHA}"
+              exit 1
+            fi
+          }
+
+          validate_source_run "release manifest" "$RELEASE_MANIFEST_RUN_ID" \
+            "Release Manifest Evidence" ".github/workflows/release-manifest-evidence.yml"
+          validate_source_run "review artifact digest" "$REVIEW_ARTIFACT_DIGEST_SOURCE_RUN_ID" \
+            "Docker Build and Push" ".github/workflows/build.yml"
+          validate_source_run "production candidate artifact digest" "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE_RUN_ID" \
+            "Docker Build and Push" ".github/workflows/build.yml"
+
+          fetch_digest_source() {
+            label="$1"
+            run_id="$2"
+            artifact_name="$3"
+            source_path="$4"
+            expected_digest="$5"
+            download_dir="$6"
+            mkdir -p "$download_dir"
+            gh run download "$run_id" --name "$artifact_name" --dir "$download_dir"
+            digest_path="${download_dir}/${source_path}"
+            if [ ! -f "$digest_path" ]; then
+              echo "ERROR: Missing governed ${label} digest at ${source_path}"
+              exit 1
+            fi
+            resolved_download_dir="$(cd "$download_dir" && pwd -P)"
+            resolved_digest_path="$(python - "$digest_path" <<'PY'
+          from pathlib import Path
+          import sys
+
+          print(Path(sys.argv[1]).resolve())
+          PY
+            )"
+            case "$resolved_digest_path" in
+              "$resolved_download_dir"/*) ;;
+              *) echo "ERROR: ${label} digest path escapes downloaded artifact"; exit 1 ;;
+            esac
+            actual_digest="$(python - "$digest_path" <<'PY'
+          from pathlib import Path
+          import sys
+
+          print(Path(sys.argv[1]).read_text(encoding="utf-8").strip())
+          PY
+            )"
+            actual_digest="$(python scripts/release/evidence_source.py oci-digest --label "${label}_artifact_digest_source" "$actual_digest")"
+            if [ "$actual_digest" != "$expected_digest" ]; then
+              echo "ERROR: ${label} governed digest source does not match explicit digest input"
+              echo "source digest=${actual_digest}"
+              echo "input digest=${expected_digest}"
+              exit 1
+            fi
+          }
+
+          fetch_digest_source "review" \
+            "$REVIEW_ARTIFACT_DIGEST_SOURCE_RUN_ID" \
+            "$REVIEW_ARTIFACT_DIGEST_SOURCE_ARTIFACT_NAME" \
+            "$REVIEW_ARTIFACT_DIGEST_SOURCE_PATH" \
+            "$REVIEW_ARTIFACT_DIGEST" \
+            "${RUNNER_TEMP}/build-equivalence-review-digest-source"
+          fetch_digest_source "production candidate" \
+            "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE_RUN_ID" \
+            "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE_ARTIFACT_NAME" \
+            "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE_PATH" \
+            "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST" \
+            "${RUNNER_TEMP}/build-equivalence-production-digest-source"
 
           download_dir="${RUNNER_TEMP}/build-equivalence-release-manifest-source"
           output_dir="${RUNNER_TEMP}/build-equivalence-evidence"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -321,7 +321,9 @@ jobs:
     if: github.event_name != 'pull_request'
     permissions:
       actions: write
+      attestations: write
       contents: write
+      id-token: write
       packages: write # write implies read; required for GHCR push/pull
       security-events: write
 
@@ -443,17 +445,42 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
 
+      - name: Attest Docker image provenance
+        id: attest-build-provenance
+        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
+          subject-digest: ${{ steps.docker-build-push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest Docker image SBOM
+        id: attest-build-sbom
+        uses: actions/attest@281a49d4cbb0a72c9575a50d18f6deb515a11deb # v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}
+          subject-digest: ${{ steps.docker-build-push.outputs.digest }}
+          sbom-path: sbom.spdx.json
+          push-to-registry: true
+
+      - name: Verify Docker image attestations
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check_docker_provenance_attestation.py \
+            --image-name "${{ env.REGISTRY }}/${{ steps.image-name.outputs.image_name }}" \
+            --digest "${{ steps.docker-build-push.outputs.digest }}" \
+            --repo "${{ github.repository }}" \
+            --signer-workflow "${{ github.repository }}/.github/workflows/build.yml" \
+            --source-ref "${{ github.ref }}" \
+            --json-out docker-provenance-attestation-check.json \
+            --markdown-out docker-provenance-attestation-check.md
+
       - name: Prepare release-control-plane build digest sources
         run: |
           set -euo pipefail
           mkdir -p release-control-plane-build-sources
-          image_digest="${{ steps.docker-build-push.outputs.digest }}"
-          case "$image_digest" in
-            sha256:????????????????????????????????????????????????????????????????) ;;
-            *) echo "ERROR: Docker build output digest is not sha256:<64 hex>"; exit 1 ;;
-          esac
-          printf '%s\n' "$image_digest" > release-control-plane-build-sources/review_artifact_digest.txt
-          printf '%s\n' "$image_digest" > release-control-plane-build-sources/production_candidate_artifact_digest.txt
           python3 - <<'PY'
           import hashlib
           import json
@@ -461,21 +488,20 @@ jobs:
 
           source_dir = Path("release-control-plane-build-sources")
           sbom = Path("sbom.spdx.json")
+          attestation = Path("docker-provenance-attestation-check.json")
           if not sbom.is_file():
               raise SystemExit("ERROR: sbom.spdx.json is missing")
+          if not attestation.is_file():
+              raise SystemExit("ERROR: docker-provenance-attestation-check.json is missing")
+          attestation_payload = json.loads(attestation.read_text(encoding="utf-8"))
+          if attestation_payload.get("passed") is not True:
+              raise SystemExit("ERROR: Docker provenance/SBOM attestations are not verified")
           (source_dir / "sbom_digest.txt").write_text(
               f"sha256:{hashlib.sha256(sbom.read_bytes()).hexdigest()}\n",
               encoding="utf-8",
           )
-
-          metadata = ${{ toJSON(steps.docker-build-push.outputs.metadata) }}
-          metadata_path = source_dir / "docker_build_metadata.json"
-          metadata_path.write_text(
-              json.dumps(json.loads(metadata), sort_keys=True, separators=(",", ":")) + "\n",
-              encoding="utf-8",
-          )
           (source_dir / "provenance_digest.txt").write_text(
-              f"sha256:{hashlib.sha256(metadata_path.read_bytes()).hexdigest()}\n",
+              f"sha256:{hashlib.sha256(attestation.read_bytes()).hexdigest()}\n",
               encoding="utf-8",
           )
           (source_dir / "attestation_status.txt").write_text("VERIFIED\n", encoding="utf-8")
@@ -486,12 +512,11 @@ jobs:
         with:
           name: release-control-plane-build-sources
           path: |
-            release-control-plane-build-sources/review_artifact_digest.txt
-            release-control-plane-build-sources/production_candidate_artifact_digest.txt
             release-control-plane-build-sources/sbom_digest.txt
             release-control-plane-build-sources/provenance_digest.txt
             release-control-plane-build-sources/attestation_status.txt
-            release-control-plane-build-sources/docker_build_metadata.json
+            docker-provenance-attestation-check.json
+            docker-provenance-attestation-check.md
           if-no-files-found: error
           retention-days: 14
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -373,6 +373,7 @@ jobs:
 
 
       - name: Build and push Docker image
+        id: docker-build-push
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
@@ -441,6 +442,58 @@ jobs:
           image: ${{ steps.image-ref.outputs.ref }}
           format: spdx-json
           output-file: sbom.spdx.json
+
+      - name: Prepare release-control-plane build digest sources
+        run: |
+          set -euo pipefail
+          mkdir -p release-control-plane-build-sources
+          image_digest="${{ steps.docker-build-push.outputs.digest }}"
+          case "$image_digest" in
+            sha256:????????????????????????????????????????????????????????????????) ;;
+            *) echo "ERROR: Docker build output digest is not sha256:<64 hex>"; exit 1 ;;
+          esac
+          printf '%s\n' "$image_digest" > release-control-plane-build-sources/review_artifact_digest.txt
+          printf '%s\n' "$image_digest" > release-control-plane-build-sources/production_candidate_artifact_digest.txt
+          python3 - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          source_dir = Path("release-control-plane-build-sources")
+          sbom = Path("sbom.spdx.json")
+          if not sbom.is_file():
+              raise SystemExit("ERROR: sbom.spdx.json is missing")
+          (source_dir / "sbom_digest.txt").write_text(
+              f"sha256:{hashlib.sha256(sbom.read_bytes()).hexdigest()}\n",
+              encoding="utf-8",
+          )
+
+          metadata = ${{ toJSON(steps.docker-build-push.outputs.metadata) }}
+          metadata_path = source_dir / "docker_build_metadata.json"
+          metadata_path.write_text(
+              json.dumps(json.loads(metadata), sort_keys=True, separators=(",", ":")) + "\n",
+              encoding="utf-8",
+          )
+          (source_dir / "provenance_digest.txt").write_text(
+              f"sha256:{hashlib.sha256(metadata_path.read_bytes()).hexdigest()}\n",
+              encoding="utf-8",
+          )
+          (source_dir / "attestation_status.txt").write_text("VERIFIED\n", encoding="utf-8")
+          PY
+
+      - name: Upload release-control-plane build digest sources
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: release-control-plane-build-sources
+          path: |
+            release-control-plane-build-sources/review_artifact_digest.txt
+            release-control-plane-build-sources/production_candidate_artifact_digest.txt
+            release-control-plane-build-sources/sbom_digest.txt
+            release-control-plane-build-sources/provenance_digest.txt
+            release-control-plane-build-sources/attestation_status.txt
+            release-control-plane-build-sources/docker_build_metadata.json
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Upload SBOM
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/release-manifest-evidence.yml
+++ b/.github/workflows/release-manifest-evidence.yml
@@ -24,8 +24,16 @@ on:
         description: "Verified SBOM digest in sha256:<64 lowercase hex> format"
         required: true
         type: string
+      sbom_digest_source:
+        description: "Single-line JSON with run_id, artifact_name, path for governed sbom_digest.txt"
+        required: true
+        type: string
       provenance_digest:
         description: "Verified provenance digest in sha256:<64 lowercase hex> format"
+        required: true
+        type: string
+      provenance_digest_source:
+        description: "Single-line JSON with run_id, artifact_name, path for governed provenance_digest.txt"
         required: true
         type: string
       attestation_status:
@@ -37,6 +45,10 @@ on:
           - FAILED
           - MISSING
           - PENDING
+      attestation_status_source:
+        description: "Single-line JSON with run_id, artifact_name, path for governed attestation_status.txt"
+        required: true
+        type: string
       rag_gate_result_source:
         description: "Single-line JSON with run_id, artifact_name, path for governed rag_gate_result.json"
         required: true
@@ -79,12 +91,15 @@ jobs:
           IOS_BUILD_NUMBER: ${{ inputs.ios_build_number }}
           MARKETING_VERSION: ${{ inputs.marketing_version }}
           PROVENANCE_DIGEST: ${{ inputs.provenance_digest }}
+          PROVENANCE_DIGEST_SOURCE: ${{ inputs.provenance_digest_source }}
           RAG_GATE_RESULT_SOURCE: ${{ inputs.rag_gate_result_source }}
           SBOM_DIGEST: ${{ inputs.sbom_digest }}
+          SBOM_DIGEST_SOURCE: ${{ inputs.sbom_digest_source }}
+          ATTESTATION_STATUS_SOURCE: ${{ inputs.attestation_status_source }}
         run: |
           set -euo pipefail
 
-          source_env="${RUNNER_TEMP}/release-manifest-source.env"
+          source_env="${RUNNER_TEMP}/release-manifest-rag-source.env"
           python scripts/release/evidence_source.py source-env \
             --label rag_gate_result \
             --prefix RAG_GATE_RESULT \
@@ -92,6 +107,30 @@ jobs:
             --source-json "$RAG_GATE_RESULT_SOURCE" > "$source_env"
           # shellcheck disable=SC1090
           . "$source_env"
+          sbom_source_env="${RUNNER_TEMP}/release-manifest-sbom-source.env"
+          python scripts/release/evidence_source.py source-env \
+            --label sbom_digest \
+            --prefix SBOM_DIGEST_SOURCE \
+            --expected-path sbom_digest.txt \
+            --source-json "$SBOM_DIGEST_SOURCE" > "$sbom_source_env"
+          # shellcheck disable=SC1090
+          . "$sbom_source_env"
+          provenance_source_env="${RUNNER_TEMP}/release-manifest-provenance-source.env"
+          python scripts/release/evidence_source.py source-env \
+            --label provenance_digest \
+            --prefix PROVENANCE_DIGEST_SOURCE \
+            --expected-path provenance_digest.txt \
+            --source-json "$PROVENANCE_DIGEST_SOURCE" > "$provenance_source_env"
+          # shellcheck disable=SC1090
+          . "$provenance_source_env"
+          attestation_source_env="${RUNNER_TEMP}/release-manifest-attestation-source.env"
+          python scripts/release/evidence_source.py source-env \
+            --label attestation_status \
+            --prefix ATTESTATION_STATUS_SOURCE \
+            --expected-path attestation_status.txt \
+            --source-json "$ATTESTATION_STATUS_SOURCE" > "$attestation_source_env"
+          # shellcheck disable=SC1090
+          . "$attestation_source_env"
 
           EVIDENCE_ARTIFACT_NAME="$(python scripts/release/evidence_source.py artifact-name "$EVIDENCE_ARTIFACT_NAME")"
           expected_git_sha_lc="$(python scripts/release/evidence_source.py git-sha "$EXPECTED_GIT_SHA")"
@@ -110,40 +149,123 @@ jobs:
             exit 1
           fi
 
-          run_metadata="$(
-            gh run view "$RAG_GATE_RESULT_RUN_ID" \
-              --json status,conclusion,headSha,event,workflowName,url \
-              --jq '[.status, .conclusion, .headSha, .event, .workflowName, .url] | @tsv'
-          )"
-          IFS=$'\t' read -r run_status run_conclusion run_head_sha run_event run_workflow_name run_url <<< "$run_metadata"
-          run_workflow_path="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RAG_GATE_RESULT_RUN_ID}" --jq '.path')"
-          if [ "$run_status" != "completed" ] || [ "$run_conclusion" != "success" ]; then
-            echo "ERROR: RAG source run did not complete successfully"
-            echo "status=${run_status:-unset} conclusion=${run_conclusion:-unset} url=${run_url:-unset}"
-            exit 1
-          fi
-          if [ "$run_event" != "workflow_dispatch" ]; then
-            echo "ERROR: RAG source run must be workflow_dispatch"
-            echo "event=${run_event:-unset} url=${run_url:-unset}"
-            exit 1
-          fi
-          if [ "$run_workflow_name" != "RAG Release Gates" ]; then
-            echo "ERROR: RAG source workflow name must be RAG Release Gates"
-            echo "workflow=${run_workflow_name:-unset}"
-            exit 1
-          fi
-          if [ "$run_workflow_path" != ".github/workflows/rag-release-gates.yml" ]; then
-            echo "ERROR: RAG source workflow path must be .github/workflows/rag-release-gates.yml"
-            echo "workflow_path=${run_workflow_path:-unset}"
-            exit 1
-          fi
-          run_head_sha_lc="$(printf '%s' "$run_head_sha" | tr 'A-F' 'a-f')"
-          if [ "$run_head_sha_lc" != "$expected_git_sha_lc" ]; then
-            echo "ERROR: RAG source run head SHA does not match git_sha"
-            echo "run headSha=${run_head_sha:-unset}"
-            echo "git_sha=${EXPECTED_GIT_SHA}"
-            exit 1
-          fi
+          validate_source_run() {
+            label="$1"
+            run_id="$2"
+            expected_workflow_name="$3"
+            expected_workflow_path="$4"
+            run_metadata="$(
+              gh run view "$run_id" \
+                --json status,conclusion,headSha,event,workflowName,url \
+                --jq '[.status, .conclusion, .headSha, .event, .workflowName, .url] | @tsv'
+            )"
+            IFS=$'\t' read -r run_status run_conclusion run_head_sha run_event run_workflow_name run_url <<< "$run_metadata"
+            run_workflow_path="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" --jq '.path')"
+            if [ "$run_status" != "completed" ] || [ "$run_conclusion" != "success" ]; then
+              echo "ERROR: ${label} source run did not complete successfully"
+              echo "status=${run_status:-unset} conclusion=${run_conclusion:-unset} url=${run_url:-unset}"
+              exit 1
+            fi
+            if [ "$run_event" != "workflow_dispatch" ]; then
+              echo "ERROR: ${label} source run must be workflow_dispatch"
+              echo "event=${run_event:-unset} url=${run_url:-unset}"
+              exit 1
+            fi
+            if [ "$run_workflow_name" != "$expected_workflow_name" ]; then
+              echo "ERROR: ${label} source workflow name must be ${expected_workflow_name}"
+              echo "workflow=${run_workflow_name:-unset}"
+              exit 1
+            fi
+            if [ "$run_workflow_path" != "$expected_workflow_path" ]; then
+              echo "ERROR: ${label} source workflow path must be ${expected_workflow_path}"
+              echo "workflow_path=${run_workflow_path:-unset}"
+              exit 1
+            fi
+            run_head_sha_lc="$(printf '%s' "$run_head_sha" | tr 'A-F' 'a-f')"
+            if [ "$run_head_sha_lc" != "$expected_git_sha_lc" ]; then
+              echo "ERROR: ${label} source run head SHA does not match git_sha"
+              echo "run headSha=${run_head_sha:-unset}"
+              echo "git_sha=${EXPECTED_GIT_SHA}"
+              exit 1
+            fi
+          }
+
+          validate_source_run "RAG" "$RAG_GATE_RESULT_RUN_ID" \
+            "RAG Release Gates" ".github/workflows/rag-release-gates.yml"
+          validate_source_run "SBOM digest" "$SBOM_DIGEST_SOURCE_RUN_ID" \
+            "Docker Build and Push" ".github/workflows/build.yml"
+          validate_source_run "provenance digest" "$PROVENANCE_DIGEST_SOURCE_RUN_ID" \
+            "Docker Build and Push" ".github/workflows/build.yml"
+          validate_source_run "attestation status" "$ATTESTATION_STATUS_SOURCE_RUN_ID" \
+            "Docker Build and Push" ".github/workflows/build.yml"
+
+          fetch_text_source() {
+            label="$1"
+            run_id="$2"
+            artifact_name="$3"
+            source_path="$4"
+            expected_value="$5"
+            download_dir="$6"
+            mkdir -p "$download_dir"
+            gh run download "$run_id" --name "$artifact_name" --dir "$download_dir"
+            source_file="${download_dir}/${source_path}"
+            if [ ! -f "$source_file" ]; then
+              echo "ERROR: Missing governed ${label} at ${source_path}"
+              exit 1
+            fi
+            resolved_download_dir="$(cd "$download_dir" && pwd -P)"
+            resolved_source_file="$(python - "$source_file" <<'PY'
+          from pathlib import Path
+          import sys
+
+          print(Path(sys.argv[1]).resolve())
+          PY
+            )"
+            case "$resolved_source_file" in
+              "$resolved_download_dir"/*) ;;
+              *) echo "ERROR: ${label} path escapes downloaded artifact"; exit 1 ;;
+            esac
+            actual_value="$(python - "$source_file" <<'PY'
+          from pathlib import Path
+          import sys
+
+          print(Path(sys.argv[1]).read_text(encoding="utf-8").strip())
+          PY
+            )"
+            if [ "$label" = "attestation status" ]; then
+              if [ "$actual_value" != "VERIFIED" ]; then
+                echo "ERROR: governed attestation status source must be VERIFIED"
+                exit 1
+              fi
+            else
+              actual_value="$(python scripts/release/evidence_source.py oci-digest --label "${label}_source" "$actual_value")"
+            fi
+            if [ "$actual_value" != "$expected_value" ]; then
+              echo "ERROR: governed ${label} source does not match explicit input"
+              echo "source value=${actual_value}"
+              echo "input value=${expected_value}"
+              exit 1
+            fi
+          }
+
+          fetch_text_source "SBOM digest" \
+            "$SBOM_DIGEST_SOURCE_RUN_ID" \
+            "$SBOM_DIGEST_SOURCE_ARTIFACT_NAME" \
+            "$SBOM_DIGEST_SOURCE_PATH" \
+            "$SBOM_DIGEST" \
+            "${RUNNER_TEMP}/release-manifest-sbom-source"
+          fetch_text_source "provenance digest" \
+            "$PROVENANCE_DIGEST_SOURCE_RUN_ID" \
+            "$PROVENANCE_DIGEST_SOURCE_ARTIFACT_NAME" \
+            "$PROVENANCE_DIGEST_SOURCE_PATH" \
+            "$PROVENANCE_DIGEST" \
+            "${RUNNER_TEMP}/release-manifest-provenance-source"
+          fetch_text_source "attestation status" \
+            "$ATTESTATION_STATUS_SOURCE_RUN_ID" \
+            "$ATTESTATION_STATUS_SOURCE_ARTIFACT_NAME" \
+            "$ATTESTATION_STATUS_SOURCE_PATH" \
+            "$ATTESTATION_STATUS" \
+            "${RUNNER_TEMP}/release-manifest-attestation-source"
 
           download_dir="${RUNNER_TEMP}/release-manifest-rag-source"
           output_dir="${RUNNER_TEMP}/release-manifest-evidence"

--- a/.github/workflows/release-manifest-evidence.yml
+++ b/.github/workflows/release-manifest-evidence.yml
@@ -1,0 +1,236 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Release Manifest Evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_sha:
+        description: "Expected release git SHA for this governed release manifest evidence"
+        required: true
+        type: string
+      ios_build_number:
+        description: "iOS build number for release_manifest.v1 build_identity"
+        required: true
+        type: string
+      marketing_version:
+        description: "Marketing version for release_manifest.v1 build_identity"
+        required: true
+        type: string
+      bundle_id:
+        description: "Bundle ID for release_manifest.v1 build_identity"
+        required: true
+        type: string
+      sbom_digest:
+        description: "Verified SBOM digest in sha256:<64 lowercase hex> format"
+        required: true
+        type: string
+      provenance_digest:
+        description: "Verified provenance digest in sha256:<64 lowercase hex> format"
+        required: true
+        type: string
+      attestation_status:
+        description: "Supply-chain attestation status"
+        required: true
+        type: choice
+        options:
+          - VERIFIED
+          - FAILED
+          - MISSING
+          - PENDING
+      rag_gate_result_source:
+        description: "Single-line JSON with run_id, artifact_name, path for governed rag_gate_result.json"
+        required: true
+        type: string
+      evidence_artifact_name:
+        description: "Published governed release manifest evidence artifact name"
+        required: true
+        default: "release-manifest-evidence"
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  publish-release-manifest-evidence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: release-evidence
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Generate governed release manifest evidence
+        env:
+          ATTESTATION_STATUS: ${{ inputs.attestation_status }}
+          BUNDLE_ID: ${{ inputs.bundle_id }}
+          EVIDENCE_ARTIFACT_NAME: ${{ inputs.evidence_artifact_name }}
+          EXPECTED_GIT_SHA: ${{ inputs.git_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IOS_BUILD_NUMBER: ${{ inputs.ios_build_number }}
+          MARKETING_VERSION: ${{ inputs.marketing_version }}
+          PROVENANCE_DIGEST: ${{ inputs.provenance_digest }}
+          RAG_GATE_RESULT_SOURCE: ${{ inputs.rag_gate_result_source }}
+          SBOM_DIGEST: ${{ inputs.sbom_digest }}
+        run: |
+          set -euo pipefail
+
+          source_env="${RUNNER_TEMP}/release-manifest-source.env"
+          python scripts/release/evidence_source.py source-env \
+            --label rag_gate_result \
+            --prefix RAG_GATE_RESULT \
+            --source-json "$RAG_GATE_RESULT_SOURCE" > "$source_env"
+          # shellcheck disable=SC1090
+          . "$source_env"
+
+          EVIDENCE_ARTIFACT_NAME="$(python scripts/release/evidence_source.py artifact-name "$EVIDENCE_ARTIFACT_NAME")"
+          expected_git_sha_lc="$(python scripts/release/evidence_source.py git-sha "$EXPECTED_GIT_SHA")"
+          github_sha_lc="$(printf '%s' "$GITHUB_SHA" | tr 'A-F' 'a-f')"
+          if [ "$github_sha_lc" != "$expected_git_sha_lc" ]; then
+            echo "ERROR: Release Manifest Evidence workflow ref must match git_sha"
+            echo "workflow GITHUB_SHA=${GITHUB_SHA}"
+            echo "git_sha=${EXPECTED_GIT_SHA}"
+            exit 1
+          fi
+
+          SBOM_DIGEST="$(python scripts/release/evidence_source.py oci-digest --label sbom_digest "$SBOM_DIGEST")"
+          PROVENANCE_DIGEST="$(python scripts/release/evidence_source.py oci-digest --label provenance_digest "$PROVENANCE_DIGEST")"
+          if [ "$ATTESTATION_STATUS" != "VERIFIED" ]; then
+            echo "ERROR: attestation_status must be VERIFIED for governed production release manifest evidence"
+            exit 1
+          fi
+
+          run_metadata="$(
+            gh run view "$RAG_GATE_RESULT_RUN_ID" \
+              --json status,conclusion,headSha,event,workflowName,url \
+              --jq '[.status, .conclusion, .headSha, .event, .workflowName, .url] | @tsv'
+          )"
+          IFS=$'\t' read -r run_status run_conclusion run_head_sha run_event run_workflow_name run_url <<< "$run_metadata"
+          run_workflow_path="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RAG_GATE_RESULT_RUN_ID}" --jq '.path')"
+          if [ "$run_status" != "completed" ] || [ "$run_conclusion" != "success" ]; then
+            echo "ERROR: RAG source run did not complete successfully"
+            echo "status=${run_status:-unset} conclusion=${run_conclusion:-unset} url=${run_url:-unset}"
+            exit 1
+          fi
+          if [ "$run_event" != "workflow_dispatch" ]; then
+            echo "ERROR: RAG source run must be workflow_dispatch"
+            echo "event=${run_event:-unset} url=${run_url:-unset}"
+            exit 1
+          fi
+          if [ "$run_workflow_name" != "RAG Release Gates" ]; then
+            echo "ERROR: RAG source workflow name must be RAG Release Gates"
+            echo "workflow=${run_workflow_name:-unset}"
+            exit 1
+          fi
+          if [ "$run_workflow_path" != ".github/workflows/rag-release-gates.yml" ]; then
+            echo "ERROR: RAG source workflow path must be .github/workflows/rag-release-gates.yml"
+            echo "workflow_path=${run_workflow_path:-unset}"
+            exit 1
+          fi
+          run_head_sha_lc="$(printf '%s' "$run_head_sha" | tr 'A-F' 'a-f')"
+          if [ "$run_head_sha_lc" != "$expected_git_sha_lc" ]; then
+            echo "ERROR: RAG source run head SHA does not match git_sha"
+            echo "run headSha=${run_head_sha:-unset}"
+            echo "git_sha=${EXPECTED_GIT_SHA}"
+            exit 1
+          fi
+
+          download_dir="${RUNNER_TEMP}/release-manifest-rag-source"
+          output_dir="${RUNNER_TEMP}/release-manifest-evidence"
+          repo_source_dir="${GITHUB_WORKSPACE}/artifacts/release_control_plane_sources"
+          mkdir -p "$download_dir" "$output_dir" "$repo_source_dir"
+          gh run download "$RAG_GATE_RESULT_RUN_ID" --name "$RAG_GATE_RESULT_ARTIFACT_NAME" --dir "$download_dir"
+          rag_gate_result_path="${download_dir}/${RAG_GATE_RESULT_PATH}"
+          if [ ! -f "$rag_gate_result_path" ]; then
+            echo "ERROR: Missing governed rag_gate_result.json at ${RAG_GATE_RESULT_PATH}"
+            exit 1
+          fi
+          resolved_download_dir="$(cd "$download_dir" && pwd -P)"
+          resolved_rag_path="$(cd "$(dirname "$rag_gate_result_path")" && pwd -P)/$(basename "$rag_gate_result_path")"
+          case "$resolved_rag_path" in
+            "$resolved_download_dir"/*) ;;
+            *) echo "ERROR: rag_gate_result path escapes downloaded artifact"; exit 1 ;;
+          esac
+          python -m json.tool "$rag_gate_result_path" > /dev/null
+          python - "$rag_gate_result_path" <<'PY'
+          import json
+          import re
+          import sys
+          from pathlib import Path
+          from typing import Any
+
+          path = Path(sys.argv[1])
+          payload = json.loads(path.read_text(encoding="utf-8"))
+          sentinel_hash = re.compile(r"^(?:sha256:)?([0-9a-f])\1{63}$")
+          forbidden = ("tests/fixtures", "fixture", "sample", "example", "placeholder", "fake", "fallback")
+
+          def walk(value: Any, pointer: str) -> None:
+              if isinstance(value, dict):
+                  for key, child in value.items():
+                      walk(child, f"{pointer}.{key}" if pointer else str(key))
+              elif isinstance(value, list):
+                  for index, child in enumerate(value):
+                      walk(child, f"{pointer}[{index}]")
+              elif isinstance(value, str):
+                  lowered = value.lower().replace("\\", "/")
+                  if sentinel_hash.fullmatch(lowered):
+                      raise SystemExit(f"sentinel placeholder digest/hash rejected at {pointer}")
+                  if any(token in lowered for token in forbidden):
+                      raise SystemExit(f"fixture/sample/fallback evidence rejected at {pointer}")
+
+          walk(payload, "rag_gate_result")
+          if payload.get("release_decision") != "PASS":
+              raise SystemExit("rag_gate_result.release_decision must be PASS")
+          if payload.get("dataset_fallback_used") is not False:
+              raise SystemExit("rag_gate_result.dataset_fallback_used must be false")
+          if payload.get("small_fixture_metric_gates_advisory") is not False:
+              raise SystemExit("rag_gate_result.small_fixture_metric_gates_advisory must be false")
+          PY
+
+          cp "$rag_gate_result_path" "${repo_source_dir}/rag_gate_result.json"
+
+          python scripts/release/release_manifest.py generate \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --git-sha "$EXPECTED_GIT_SHA" \
+            --ios-build-number "$IOS_BUILD_NUMBER" \
+            --marketing-version "$MARKETING_VERSION" \
+            --bundle-id "$BUNDLE_ID" \
+            --rag-gate-result "${repo_source_dir}/rag_gate_result.json" \
+            --sbom-digest "$SBOM_DIGEST" \
+            --provenance-digest "$PROVENANCE_DIGEST" \
+            --attestation-status "$ATTESTATION_STATUS" \
+            --output "${output_dir}/release_manifest.json"
+          python scripts/release/release_manifest.py validate \
+            --manifest "${output_dir}/release_manifest.json"
+
+          {
+            echo "RELEASE_MANIFEST_EVIDENCE_ARTIFACT_NAME=$EVIDENCE_ARTIFACT_NAME"
+            echo "RELEASE_MANIFEST_EVIDENCE_OUTPUT_DIR=$output_dir"
+          } >> "$GITHUB_ENV"
+
+      - name: Publish release manifest evidence summary
+        run: |
+          set -euo pipefail
+          {
+            echo "## Release Manifest Evidence"
+            echo
+            echo "- Run id: \`${GITHUB_RUN_ID}\`"
+            echo "- Artifact name: \`${RELEASE_MANIFEST_EVIDENCE_ARTIFACT_NAME}\`"
+            echo "- Path inside artifact: \`release_manifest.json\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload governed release manifest evidence artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${{ inputs.evidence_artifact_name }}
+          path: ${{ runner.temp }}/release-manifest-evidence/release_manifest.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/release-manifest-evidence.yml
+++ b/.github/workflows/release-manifest-evidence.yml
@@ -69,6 +69,7 @@ jobs:
           python-version: "3.13"
 
       - name: Generate governed release manifest evidence
+        id: generate-release-manifest-evidence
         env:
           ATTESTATION_STATUS: ${{ inputs.attestation_status }}
           BUNDLE_ID: ${{ inputs.bundle_id }}
@@ -87,6 +88,7 @@ jobs:
           python scripts/release/evidence_source.py source-env \
             --label rag_gate_result \
             --prefix RAG_GATE_RESULT \
+            --expected-path rag_gate_result.json \
             --source-json "$RAG_GATE_RESULT_SOURCE" > "$source_env"
           # shellcheck disable=SC1090
           . "$source_env"
@@ -154,13 +156,19 @@ jobs:
             exit 1
           fi
           resolved_download_dir="$(cd "$download_dir" && pwd -P)"
-          resolved_rag_path="$(cd "$(dirname "$rag_gate_result_path")" && pwd -P)/$(basename "$rag_gate_result_path")"
+          resolved_rag_path="$(python - "$rag_gate_result_path" <<'PY'
+          from pathlib import Path
+          import sys
+
+          print(Path(sys.argv[1]).resolve())
+          PY
+          )"
           case "$resolved_rag_path" in
             "$resolved_download_dir"/*) ;;
             *) echo "ERROR: rag_gate_result path escapes downloaded artifact"; exit 1 ;;
           esac
           python -m json.tool "$rag_gate_result_path" > /dev/null
-          python - "$rag_gate_result_path" <<'PY'
+          python - "$rag_gate_result_path" "$expected_git_sha_lc" <<'PY'
           import json
           import re
           import sys
@@ -168,7 +176,13 @@ jobs:
           from typing import Any
 
           path = Path(sys.argv[1])
+          expected_git_sha = sys.argv[2]
           payload = json.loads(path.read_text(encoding="utf-8"))
+          git_sha = payload.get("git_sha")
+          if not isinstance(git_sha, str) or not re.fullmatch(r"[0-9a-fA-F]{40}", git_sha):
+              raise SystemExit("rag_gate_result.git_sha must be a full 40-character hexadecimal SHA")
+          if git_sha.lower() != expected_git_sha:
+              raise SystemExit("rag_gate_result.git_sha must match git_sha")
           sentinel_hash = re.compile(r"^(?:sha256:)?([0-9a-f])\1{63}$")
           forbidden = ("tests/fixtures", "fixture", "sample", "example", "placeholder", "fake", "fallback")
 
@@ -215,6 +229,7 @@ jobs:
             echo "RELEASE_MANIFEST_EVIDENCE_ARTIFACT_NAME=$EVIDENCE_ARTIFACT_NAME"
             echo "RELEASE_MANIFEST_EVIDENCE_OUTPUT_DIR=$output_dir"
           } >> "$GITHUB_ENV"
+          echo "artifact_name=$EVIDENCE_ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Publish release manifest evidence summary
         run: |
@@ -230,7 +245,7 @@ jobs:
       - name: Upload governed release manifest evidence artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: ${{ inputs.evidence_artifact_name }}
+          name: ${{ steps.generate-release-manifest-evidence.outputs.artifact_name }}
           path: ${{ runner.temp }}/release-manifest-evidence/release_manifest.json
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/release-manifest-evidence.yml
+++ b/.github/workflows/release-manifest-evidence.yml
@@ -148,6 +148,16 @@ jobs:
             echo "ERROR: attestation_status must be VERIFIED for governed production release manifest evidence"
             exit 1
           fi
+          if [ "$SBOM_DIGEST_SOURCE_RUN_ID" != "$PROVENANCE_DIGEST_SOURCE_RUN_ID" ] \
+            || [ "$SBOM_DIGEST_SOURCE_RUN_ID" != "$ATTESTATION_STATUS_SOURCE_RUN_ID" ]; then
+            echo "ERROR: SBOM, provenance, and attestation status sources must come from the same Docker Build and Push run"
+            exit 1
+          fi
+          if [ "$SBOM_DIGEST_SOURCE_ARTIFACT_NAME" != "$PROVENANCE_DIGEST_SOURCE_ARTIFACT_NAME" ] \
+            || [ "$SBOM_DIGEST_SOURCE_ARTIFACT_NAME" != "$ATTESTATION_STATUS_SOURCE_ARTIFACT_NAME" ]; then
+            echo "ERROR: SBOM, provenance, and attestation status sources must come from the same artifact"
+            exit 1
+          fi
 
           validate_source_run() {
             label="$1"

--- a/.github/workflows/release-manifest-evidence.yml
+++ b/.github/workflows/release-manifest-evidence.yml
@@ -24,16 +24,8 @@ on:
         description: "Verified SBOM digest in sha256:<64 lowercase hex> format"
         required: true
         type: string
-      sbom_digest_source:
-        description: "Single-line JSON with run_id, artifact_name, path for governed sbom_digest.txt"
-        required: true
-        type: string
       provenance_digest:
         description: "Verified provenance digest in sha256:<64 lowercase hex> format"
-        required: true
-        type: string
-      provenance_digest_source:
-        description: "Single-line JSON with run_id, artifact_name, path for governed provenance_digest.txt"
         required: true
         type: string
       attestation_status:
@@ -45,8 +37,8 @@ on:
           - FAILED
           - MISSING
           - PENDING
-      attestation_status_source:
-        description: "Single-line JSON with run_id, artifact_name, path for governed attestation_status.txt"
+      supply_chain_source:
+        description: "Single-line JSON with run_id, artifact_name, path=release-control-plane-build-sources"
         required: true
         type: string
       rag_gate_result_source:
@@ -91,11 +83,9 @@ jobs:
           IOS_BUILD_NUMBER: ${{ inputs.ios_build_number }}
           MARKETING_VERSION: ${{ inputs.marketing_version }}
           PROVENANCE_DIGEST: ${{ inputs.provenance_digest }}
-          PROVENANCE_DIGEST_SOURCE: ${{ inputs.provenance_digest_source }}
           RAG_GATE_RESULT_SOURCE: ${{ inputs.rag_gate_result_source }}
           SBOM_DIGEST: ${{ inputs.sbom_digest }}
-          SBOM_DIGEST_SOURCE: ${{ inputs.sbom_digest_source }}
-          ATTESTATION_STATUS_SOURCE: ${{ inputs.attestation_status_source }}
+          SUPPLY_CHAIN_SOURCE: ${{ inputs.supply_chain_source }}
         run: |
           set -euo pipefail
 
@@ -107,30 +97,26 @@ jobs:
             --source-json "$RAG_GATE_RESULT_SOURCE" > "$source_env"
           # shellcheck disable=SC1090
           . "$source_env"
-          sbom_source_env="${RUNNER_TEMP}/release-manifest-sbom-source.env"
+          # shellcheck disable=SC2153
+          rag_gate_result_run_id="$RAG_GATE_RESULT_RUN_ID"
+          # shellcheck disable=SC2153
+          rag_gate_result_artifact_name="$RAG_GATE_RESULT_ARTIFACT_NAME"
+          # shellcheck disable=SC2153
+          rag_gate_result_source_path="$RAG_GATE_RESULT_PATH"
+          supply_chain_source_env="${RUNNER_TEMP}/release-manifest-supply-chain-source.env"
           python scripts/release/evidence_source.py source-env \
-            --label sbom_digest \
-            --prefix SBOM_DIGEST_SOURCE \
-            --expected-path sbom_digest.txt \
-            --source-json "$SBOM_DIGEST_SOURCE" > "$sbom_source_env"
+            --label supply_chain \
+            --prefix SUPPLY_CHAIN \
+            --expected-path release-control-plane-build-sources \
+            --source-json "$SUPPLY_CHAIN_SOURCE" > "$supply_chain_source_env"
           # shellcheck disable=SC1090
-          . "$sbom_source_env"
-          provenance_source_env="${RUNNER_TEMP}/release-manifest-provenance-source.env"
-          python scripts/release/evidence_source.py source-env \
-            --label provenance_digest \
-            --prefix PROVENANCE_DIGEST_SOURCE \
-            --expected-path provenance_digest.txt \
-            --source-json "$PROVENANCE_DIGEST_SOURCE" > "$provenance_source_env"
-          # shellcheck disable=SC1090
-          . "$provenance_source_env"
-          attestation_source_env="${RUNNER_TEMP}/release-manifest-attestation-source.env"
-          python scripts/release/evidence_source.py source-env \
-            --label attestation_status \
-            --prefix ATTESTATION_STATUS_SOURCE \
-            --expected-path attestation_status.txt \
-            --source-json "$ATTESTATION_STATUS_SOURCE" > "$attestation_source_env"
-          # shellcheck disable=SC1090
-          . "$attestation_source_env"
+          . "$supply_chain_source_env"
+          # shellcheck disable=SC2153
+          supply_chain_run_id="$SUPPLY_CHAIN_RUN_ID"
+          # shellcheck disable=SC2153
+          supply_chain_artifact_name="$SUPPLY_CHAIN_ARTIFACT_NAME"
+          # shellcheck disable=SC2153
+          supply_chain_source_path="$SUPPLY_CHAIN_PATH"
 
           EVIDENCE_ARTIFACT_NAME="$(python scripts/release/evidence_source.py artifact-name "$EVIDENCE_ARTIFACT_NAME")"
           expected_git_sha_lc="$(python scripts/release/evidence_source.py git-sha "$EXPECTED_GIT_SHA")"
@@ -146,16 +132,6 @@ jobs:
           PROVENANCE_DIGEST="$(python scripts/release/evidence_source.py oci-digest --label provenance_digest "$PROVENANCE_DIGEST")"
           if [ "$ATTESTATION_STATUS" != "VERIFIED" ]; then
             echo "ERROR: attestation_status must be VERIFIED for governed production release manifest evidence"
-            exit 1
-          fi
-          if [ "$SBOM_DIGEST_SOURCE_RUN_ID" != "$PROVENANCE_DIGEST_SOURCE_RUN_ID" ] \
-            || [ "$SBOM_DIGEST_SOURCE_RUN_ID" != "$ATTESTATION_STATUS_SOURCE_RUN_ID" ]; then
-            echo "ERROR: SBOM, provenance, and attestation status sources must come from the same Docker Build and Push run"
-            exit 1
-          fi
-          if [ "$SBOM_DIGEST_SOURCE_ARTIFACT_NAME" != "$PROVENANCE_DIGEST_SOURCE_ARTIFACT_NAME" ] \
-            || [ "$SBOM_DIGEST_SOURCE_ARTIFACT_NAME" != "$ATTESTATION_STATUS_SOURCE_ARTIFACT_NAME" ]; then
-            echo "ERROR: SBOM, provenance, and attestation status sources must come from the same artifact"
             exit 1
           fi
 
@@ -200,24 +176,17 @@ jobs:
             fi
           }
 
-          validate_source_run "RAG" "$RAG_GATE_RESULT_RUN_ID" \
+          validate_source_run "RAG" "$rag_gate_result_run_id" \
             "RAG Release Gates" ".github/workflows/rag-release-gates.yml"
-          validate_source_run "SBOM digest" "$SBOM_DIGEST_SOURCE_RUN_ID" \
-            "Docker Build and Push" ".github/workflows/build.yml"
-          validate_source_run "provenance digest" "$PROVENANCE_DIGEST_SOURCE_RUN_ID" \
-            "Docker Build and Push" ".github/workflows/build.yml"
-          validate_source_run "attestation status" "$ATTESTATION_STATUS_SOURCE_RUN_ID" \
+          validate_source_run "supply chain" "$supply_chain_run_id" \
             "Docker Build and Push" ".github/workflows/build.yml"
 
           fetch_text_source() {
             label="$1"
-            run_id="$2"
-            artifact_name="$3"
-            source_path="$4"
-            expected_value="$5"
-            download_dir="$6"
+            source_path="$2"
+            download_dir="$3"
+            expected_value="$4"
             mkdir -p "$download_dir"
-            gh run download "$run_id" --name "$artifact_name" --dir "$download_dir"
             source_file="${download_dir}/${source_path}"
             if [ ! -f "$source_file" ]; then
               echo "ERROR: Missing governed ${label} at ${source_path}"
@@ -258,33 +227,30 @@ jobs:
             fi
           }
 
+          supply_chain_download_dir="${RUNNER_TEMP}/release-manifest-supply-chain-source"
+          mkdir -p "$supply_chain_download_dir"
+          gh run download "$supply_chain_run_id" --name "$supply_chain_artifact_name" --dir "$supply_chain_download_dir"
           fetch_text_source "SBOM digest" \
-            "$SBOM_DIGEST_SOURCE_RUN_ID" \
-            "$SBOM_DIGEST_SOURCE_ARTIFACT_NAME" \
-            "$SBOM_DIGEST_SOURCE_PATH" \
-            "$SBOM_DIGEST" \
-            "${RUNNER_TEMP}/release-manifest-sbom-source"
+            "${supply_chain_source_path}/sbom_digest.txt" \
+            "$supply_chain_download_dir" \
+            "$SBOM_DIGEST"
           fetch_text_source "provenance digest" \
-            "$PROVENANCE_DIGEST_SOURCE_RUN_ID" \
-            "$PROVENANCE_DIGEST_SOURCE_ARTIFACT_NAME" \
-            "$PROVENANCE_DIGEST_SOURCE_PATH" \
-            "$PROVENANCE_DIGEST" \
-            "${RUNNER_TEMP}/release-manifest-provenance-source"
+            "${supply_chain_source_path}/provenance_digest.txt" \
+            "$supply_chain_download_dir" \
+            "$PROVENANCE_DIGEST"
           fetch_text_source "attestation status" \
-            "$ATTESTATION_STATUS_SOURCE_RUN_ID" \
-            "$ATTESTATION_STATUS_SOURCE_ARTIFACT_NAME" \
-            "$ATTESTATION_STATUS_SOURCE_PATH" \
-            "$ATTESTATION_STATUS" \
-            "${RUNNER_TEMP}/release-manifest-attestation-source"
+            "${supply_chain_source_path}/attestation_status.txt" \
+            "$supply_chain_download_dir" \
+            "$ATTESTATION_STATUS"
 
           download_dir="${RUNNER_TEMP}/release-manifest-rag-source"
           output_dir="${RUNNER_TEMP}/release-manifest-evidence"
           repo_source_dir="${GITHUB_WORKSPACE}/artifacts/release_control_plane_sources"
           mkdir -p "$download_dir" "$output_dir" "$repo_source_dir"
-          gh run download "$RAG_GATE_RESULT_RUN_ID" --name "$RAG_GATE_RESULT_ARTIFACT_NAME" --dir "$download_dir"
-          rag_gate_result_path="${download_dir}/${RAG_GATE_RESULT_PATH}"
+          gh run download "$rag_gate_result_run_id" --name "$rag_gate_result_artifact_name" --dir "$download_dir"
+          rag_gate_result_path="${download_dir}/${rag_gate_result_source_path}"
           if [ ! -f "$rag_gate_result_path" ]; then
-            echo "ERROR: Missing governed rag_gate_result.json at ${RAG_GATE_RESULT_PATH}"
+            echo "ERROR: Missing governed rag_gate_result.json at ${rag_gate_result_source_path}"
             exit 1
           fi
           resolved_download_dir="$(cd "$download_dir" && pwd -P)"

--- a/.github/workflows/release-manifest-evidence.yml
+++ b/.github/workflows/release-manifest-evidence.yml
@@ -168,52 +168,15 @@ jobs:
             *) echo "ERROR: rag_gate_result path escapes downloaded artifact"; exit 1 ;;
           esac
           python -m json.tool "$rag_gate_result_path" > /dev/null
-          python - "$rag_gate_result_path" "$expected_git_sha_lc" <<'PY'
-          import json
-          import re
-          import sys
-          from pathlib import Path
-          from typing import Any
-
-          path = Path(sys.argv[1])
-          expected_git_sha = sys.argv[2]
-          payload = json.loads(path.read_text(encoding="utf-8"))
-          git_sha = payload.get("git_sha")
-          if not isinstance(git_sha, str) or not re.fullmatch(r"[0-9a-fA-F]{40}", git_sha):
-              raise SystemExit("rag_gate_result.git_sha must be a full 40-character hexadecimal SHA")
-          if git_sha.lower() != expected_git_sha:
-              raise SystemExit("rag_gate_result.git_sha must match git_sha")
-          sentinel_hash = re.compile(r"^(?:sha256:)?([0-9a-f])\1{63}$")
-          forbidden = ("tests/fixtures", "fixture", "sample", "example", "placeholder", "fake", "fallback")
-
-          def walk(value: Any, pointer: str) -> None:
-              if isinstance(value, dict):
-                  for key, child in value.items():
-                      walk(child, f"{pointer}.{key}" if pointer else str(key))
-              elif isinstance(value, list):
-                  for index, child in enumerate(value):
-                      walk(child, f"{pointer}[{index}]")
-              elif isinstance(value, str):
-                  lowered = value.lower().replace("\\", "/")
-                  if sentinel_hash.fullmatch(lowered):
-                      raise SystemExit(f"sentinel placeholder digest/hash rejected at {pointer}")
-                  if any(token in lowered for token in forbidden):
-                      raise SystemExit(f"fixture/sample/fallback evidence rejected at {pointer}")
-
-          walk(payload, "rag_gate_result")
-          if payload.get("release_decision") != "PASS":
-              raise SystemExit("rag_gate_result.release_decision must be PASS")
-          if payload.get("dataset_fallback_used") is not False:
-              raise SystemExit("rag_gate_result.dataset_fallback_used must be false")
-          if payload.get("small_fixture_metric_gates_advisory") is not False:
-              raise SystemExit("rag_gate_result.small_fixture_metric_gates_advisory must be false")
-          PY
+          python scripts/release/evidence_source.py rag-gate-result \
+            --expected-git-sha "$expected_git_sha_lc" \
+            "$rag_gate_result_path"
 
           cp "$rag_gate_result_path" "${repo_source_dir}/rag_gate_result.json"
 
           python scripts/release/release_manifest.py generate \
             --repo-root "$GITHUB_WORKSPACE" \
-            --git-sha "$EXPECTED_GIT_SHA" \
+            --git-sha "$expected_git_sha_lc" \
             --ios-build-number "$IOS_BUILD_NUMBER" \
             --marketing-version "$MARKETING_VERSION" \
             --bundle-id "$BUNDLE_ID" \

--- a/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
+++ b/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
@@ -309,14 +309,14 @@ must be `workflow_dispatch` only, validate source run provenance and matching
 paths (`release_manifest.json` and `build_equivalence_result.json`), and avoid
 App Store Connect execution, Fastlane upload mutation, runtime/API/iOS, RAG
 behavior, billing, semantic cache, GraphRAG, or product-facing behavior.
-Build-equivalence publication also requires governed same-SHA digest source
-objects for `review_artifact_digest.txt` and
-`production_candidate_artifact_digest.txt`; digest strings alone are not
-sufficient release evidence.
+Build-equivalence publication keeps App Review and production-candidate
+artifact digests as explicit protected dispatch inputs; this slice must not
+self-certify those App Store build identities from Docker image digests.
 Release-manifest publication similarly requires governed same-SHA supply-chain
 source objects for `sbom_digest.txt`, `provenance_digest.txt`, and
 `attestation_status.txt`, emitted by the `Docker Build and Push` publish lane in
-the `release-control-plane-build-sources` artifact.
+the `release-control-plane-build-sources` artifact only after exact-digest
+provenance/SBOM attestation verification passes.
 
 ## Bootstrap Commands
 

--- a/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
+++ b/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
@@ -309,6 +309,10 @@ must be `workflow_dispatch` only, validate source run provenance and matching
 paths (`release_manifest.json` and `build_equivalence_result.json`), and avoid
 App Store Connect execution, Fastlane upload mutation, runtime/API/iOS, RAG
 behavior, billing, semantic cache, GraphRAG, or product-facing behavior.
+Build-equivalence publication also requires governed same-SHA digest source
+objects for `review_artifact_digest.txt` and
+`production_candidate_artifact_digest.txt`; digest strings alone are not
+sufficient release evidence.
 
 ## Bootstrap Commands
 

--- a/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
+++ b/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
@@ -313,6 +313,10 @@ Build-equivalence publication also requires governed same-SHA digest source
 objects for `review_artifact_digest.txt` and
 `production_candidate_artifact_digest.txt`; digest strings alone are not
 sufficient release evidence.
+Release-manifest publication similarly requires governed same-SHA supply-chain
+source objects for `sbom_digest.txt`, `provenance_digest.txt`, and
+`attestation_status.txt`, emitted by the `Docker Build and Push` publish lane in
+the `release-control-plane-build-sources` artifact.
 
 ## Bootstrap Commands
 

--- a/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
+++ b/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
@@ -105,7 +105,8 @@ changes.
 | PR-4 | `release/release-control-plane-pr4-build-equivalence` | Merged review build equals production-candidate equivalence check in PR #1679 | equivalence tests |
 | PR-5 | `release/release-control-plane-pr5-ci-gates` | Merged CI integration for release packet, gate result, build equivalence, SBOM/provenance references, and fail-closed decision in PR #1682 | focused CI/workflow contract tests |
 | PR-6 | `release/release-control-plane-pr6-production-artifact-wiring` | Merged production tag wiring for real release-control-plane evidence artifacts in PR #1688 | production workflow contract tests |
-| Post-#1692 | `ci/release-control-plane-evidence-publication` | Active governed manual publication workflow for the production evidence artifact required by CD | evidence publication workflow contract tests |
+| Post-#1692 | `ci/release-control-plane-evidence-publication` | Merged governed manual publication workflow for the production evidence artifact required by CD in PR #1699 | evidence publication workflow contract tests |
+| Post-#1699 | `ci/release-control-plane-source-producers` | Active governed source producers for `Release Manifest Evidence` and `Build Equivalence Evidence` | source producer workflow contract tests |
 
 ## Release Packet Contract
 
@@ -292,6 +293,22 @@ create release truth, use fixtures as production evidence, perform App Store
 Connect execution, mutate Fastlane protected upload behavior, or change
 runtime/API/iOS, RAG, billing, semantic cache, GraphRAG, or product-facing
 behavior.
+
+### Post-PR-1699 Governed Source Producers
+
+After PR #1699, the publisher has a governed manual publication lane but still
+needs repo-owned source producers for release manifest and build-equivalence
+evidence. The `ci/release-control-plane-source-producers` follow-up adds:
+
+- `Release Manifest Evidence` at `.github/workflows/release-manifest-evidence.yml`
+- `Build Equivalence Evidence` at `.github/workflows/build-equivalence-evidence.yml`
+
+`RAG Release Gates` remains the existing RAG/ML producer. The source producers
+must be `workflow_dispatch` only, validate source run provenance and matching
+`git_sha`, reject fixtures/placeholders/fallbacks, publish stable root artifact
+paths (`release_manifest.json` and `build_equivalence_result.json`), and avoid
+App Store Connect execution, Fastlane upload mutation, runtime/API/iOS, RAG
+behavior, billing, semantic cache, GraphRAG, or product-facing behavior.
 
 ## Bootstrap Commands
 

--- a/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
+++ b/docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md
@@ -312,11 +312,12 @@ behavior, billing, semantic cache, GraphRAG, or product-facing behavior.
 Build-equivalence publication keeps App Review and production-candidate
 artifact digests as explicit protected dispatch inputs; this slice must not
 self-certify those App Store build identities from Docker image digests.
-Release-manifest publication similarly requires governed same-SHA supply-chain
-source objects for `sbom_digest.txt`, `provenance_digest.txt`, and
-`attestation_status.txt`, emitted by the `Docker Build and Push` publish lane in
-the `release-control-plane-build-sources` artifact only after exact-digest
-provenance/SBOM attestation verification passes.
+Release-manifest publication similarly requires one governed same-SHA
+supply-chain source object pointing to the `release-control-plane-build-sources`
+artifact root, emitted by the `Docker Build and Push` publish lane only after
+exact-digest provenance/SBOM attestation verification passes. That artifact must
+contain `sbom_digest.txt`, `provenance_digest.txt`, and
+`attestation_status.txt`.
 
 ## Bootstrap Commands
 

--- a/docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md
+++ b/docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md
@@ -96,6 +96,13 @@ Do not run production publication or set production CD evidence variables from
 ad hoc workflow runs, fixture artifacts, manually assembled JSON, or
 operator-supplied workflow names.
 
+`Build Equivalence Evidence` also requires governed source objects for the App
+Review and production-candidate artifact digest text files:
+`review_artifact_digest.txt` and `production_candidate_artifact_digest.txt`.
+Those source runs must be successful `workflow_dispatch` runs for the same
+`git_sha` before the workflow will generate build identity JSON. Raw digest
+strings alone are not enough to publish build-equivalence evidence.
+
 If a governed source producer is missing, do not run production publication or
 set production CD evidence variables; create the missing producer workflow in a
 separate reviewed PR first.

--- a/docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md
+++ b/docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md
@@ -103,6 +103,13 @@ Those source runs must be successful `workflow_dispatch` runs for the same
 `git_sha` before the workflow will generate build identity JSON. Raw digest
 strings alone are not enough to publish build-equivalence evidence.
 
+`Release Manifest Evidence` requires governed source objects for supply-chain
+identity as well: `sbom_digest.txt`, `provenance_digest.txt`, and
+`attestation_status.txt`. The existing `Docker Build and Push` workflow publishes
+these files in the `release-control-plane-build-sources` artifact from its
+non-PR publish job. The manifest producer compares those same-SHA source files
+against the explicit dispatch inputs before writing `release_manifest.json`.
+
 If a governed source producer is missing, do not run production publication or
 set production CD evidence variables; create the missing producer workflow in a
 separate reviewed PR first.

--- a/docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md
+++ b/docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md
@@ -102,13 +102,14 @@ App Store Connect upload execution, Fastlane upload mutation, or an App Review
 binary artifact producer, so the Docker build workflow must not self-certify
 those App Store build identities.
 
-`Release Manifest Evidence` requires governed source objects for supply-chain
-identity as well: `sbom_digest.txt`, `provenance_digest.txt`, and
-`attestation_status.txt`. The existing `Docker Build and Push` workflow publishes
-these files in the `release-control-plane-build-sources` artifact from its
-non-PR publish job only after exact-digest provenance/SBOM attestation
-verification passes. The manifest producer compares those same-SHA source files
-against the explicit dispatch inputs before writing `release_manifest.json`.
+`Release Manifest Evidence` requires one governed supply-chain source object
+that points to the `release-control-plane-build-sources` artifact root. The
+artifact must contain `sbom_digest.txt`, `provenance_digest.txt`, and
+`attestation_status.txt`. The existing `Docker Build and Push` workflow
+publishes these files from its non-PR publish job only after exact-digest
+provenance/SBOM attestation verification passes. The manifest producer compares
+those same-SHA source files against the explicit dispatch inputs before writing
+`release_manifest.json`.
 
 If a governed source producer is missing, do not run production publication or
 set production CD evidence variables; create the missing producer workflow in a

--- a/docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md
+++ b/docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md
@@ -85,12 +85,20 @@ Current repo-owned producer names:
 - RAG gate result: `RAG Release Gates`
 - build equivalence: `Build Equivalence Evidence`
 
-The current repo-defined producer that exists today is `RAG Release Gates`.
-`Release Manifest Evidence` and `Build Equivalence Evidence` are reserved
-fail-closed producer identities for the next governed producer-workflow PRs. If
-no governed source workflow exists for a required evidence type, do not run
-production publication or set production CD evidence variables; create the
-missing producer workflow in a separate reviewed PR first.
+The repo-defined producers are:
+
+- `Release Manifest Evidence` at `.github/workflows/release-manifest-evidence.yml`
+- `RAG Release Gates` at `.github/workflows/rag-release-gates.yml`
+- `Build Equivalence Evidence` at `.github/workflows/build-equivalence-evidence.yml`
+
+The publication workflow accepts only these governed source workflow identities.
+Do not run production publication or set production CD evidence variables from
+ad hoc workflow runs, fixture artifacts, manually assembled JSON, or
+operator-supplied workflow names.
+
+If a governed source producer is missing, do not run production publication or
+set production CD evidence variables; create the missing producer workflow in a
+separate reviewed PR first.
 
 The publication workflow itself must be dispatched on the release commit or ref:
 its workflow ref must match `git_sha`.
@@ -130,6 +138,8 @@ The publication workflow blocks when:
 - a source run was not triggered by `workflow_dispatch`;
 - a source run workflow name does not match the repo-owned expected producer
   workflow name for that evidence type;
+- a source run workflow path does not match the repo-owned expected producer
+  workflow path for that evidence type;
 - source run `headSha` does not match `git_sha`;
 - release manifest `build_identity.git_sha` does not match `git_sha`;
 - any evidence JSON contains a sentinel placeholder digest or hash such as a

--- a/docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md
+++ b/docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md
@@ -96,18 +96,18 @@ Do not run production publication or set production CD evidence variables from
 ad hoc workflow runs, fixture artifacts, manually assembled JSON, or
 operator-supplied workflow names.
 
-`Build Equivalence Evidence` also requires governed source objects for the App
-Review and production-candidate artifact digest text files:
-`review_artifact_digest.txt` and `production_candidate_artifact_digest.txt`.
-Those source runs must be successful `workflow_dispatch` runs for the same
-`git_sha` before the workflow will generate build identity JSON. Raw digest
-strings alone are not enough to publish build-equivalence evidence.
+`Build Equivalence Evidence` keeps the App Review and production-candidate
+artifact digests as explicit protected dispatch inputs. This PR does not add
+App Store Connect upload execution, Fastlane upload mutation, or an App Review
+binary artifact producer, so the Docker build workflow must not self-certify
+those App Store build identities.
 
 `Release Manifest Evidence` requires governed source objects for supply-chain
 identity as well: `sbom_digest.txt`, `provenance_digest.txt`, and
 `attestation_status.txt`. The existing `Docker Build and Push` workflow publishes
 these files in the `release-control-plane-build-sources` artifact from its
-non-PR publish job. The manifest producer compares those same-SHA source files
+non-PR publish job only after exact-digest provenance/SBOM attestation
+verification passes. The manifest producer compares those same-SHA source files
 against the explicit dispatch inputs before writing `release_manifest.json`.
 
 If a governed source producer is missing, do not run production publication or

--- a/docs/release/RELEASE_CONTROL_PLANE_EPIC.md
+++ b/docs/release/RELEASE_CONTROL_PLANE_EPIC.md
@@ -127,7 +127,7 @@ review governance.
 
 8. **Post-PR-1692: governed release evidence publication**
    - Branch: `ci/release-control-plane-evidence-publication`
-   - Active follow-up after PR #1692.
+   - Merged as PR #1699 on 2026-05-07 after PR #1692 closed the production gate bypass.
    - Add the manual governed workflow that publishes the production evidence artifact expected by CD.
    - Contract: [`PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md`](PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md).
    - Published artifact layout:
@@ -135,6 +135,16 @@ review governance.
      `release-control-plane/rag_gate_result.json`, and
      `release-control-plane/build_equivalence_result.json`.
    - Source evidence must come from successful `workflow_dispatch` source runs for the same git SHA.
+   - App Store Connect upload execution, Fastlane upload mutation, runtime changes, and fake production fixtures remain out of scope.
+
+9. **Post-PR-1699: governed source evidence producers**
+   - Branch: `ci/release-control-plane-source-producers`
+   - Active follow-up after PR #1699.
+   - Add the governed manual source producers consumed by the PR #1699 publisher:
+     `Release Manifest Evidence` and `Build Equivalence Evidence`.
+   - The existing `RAG Release Gates` workflow remains the RAG/ML producer and is not redefined here.
+   - Source producer artifacts use stable paths: `release_manifest.json` and
+     `build_equivalence_result.json`.
    - App Store Connect upload execution, Fastlane upload mutation, runtime changes, and fake production fixtures remain out of scope.
 
 ## Boundaries

--- a/docs/review/PR_1703_FIXED_MAPPING.md
+++ b/docs/review/PR_1703_FIXED_MAPPING.md
@@ -1,0 +1,50 @@
+# PR #1703 Fixed In Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1703
+Branch: `ci/release-control-plane-source-producers`
+
+## Discussion Thread Pass
+
+Status: Pending external review.
+
+No GitHub review threads were resolved before this artifact was created. New CodeRabbit/Sourcery/Cubic/human comments must be fixed or dispositioned here before thread resolution.
+
+## Fixed In Commit Mapping
+
+Internal pre-open review findings fixed before PR open:
+
+- Raw upload artifact name bypassed validation -> `1876e231b`
+- Missing `rag_gate_result.git_sha` validation -> `1876e231b`
+- Downloaded artifact symlink target escape -> `1876e231b`
+- Noncanonical source object paths -> `1876e231b`
+- Generic test paths accepted inside RAG payload -> `9a4b5f666`
+- Uppercase `git_sha` propagated into manifest generation -> `9a4b5f666`
+- Build equivalence could upload non-`EQUIVALENT` result -> `1876e231b`
+- Manual supply-chain assertions -> `f43d6c1ec`
+- Mixed supply-chain source runs/artifacts -> `e1f454cb9`
+- Docker build self-certified App Review / production-candidate digests -> `f43d6c1ec`
+
+## NOT-A-BUG
+
+- Suggested `artifact-metadata: write` permission.
+  - Evidence: `check-github-workflows` rejects `artifact-metadata` in the current schema. Valid permissions retained: `attestations: write`, `id-token: write`, `packages: write`.
+  - Guard: `tests/test_release_manifest_evidence_workflow.py` asserts `artifact-metadata` is absent.
+
+## DEFERRED
+
+- App Store build identity truth remains separate from this release-control-plane source-producer PR.
+  - Backlog: `docs/roadmap/BACKLOG_LEDGER.md`
+  - Reason: App Store Connect upload execution, Fastlane protected upload mutation, and App Review binary artifact production are explicitly out of scope for PR #1703.
+
+## Validation
+
+- `.venv/bin/python scripts/orchestration/check_preflight.py` -> PASS
+- `.venv/bin/python scripts/orchestration/check_agent_consistency.py` -> PASS
+- `.venv/bin/python -m pytest -q tests/test_release_manifest_evidence_workflow.py tests/test_build_equivalence_evidence_workflow.py tests/test_release_control_plane_evidence_publication_workflow.py tests/test_release_manifest.py tests/test_build_equivalence.py tests/test_release_control_plane_ci_gate.py tests/test_production_release_evidence_wiring.py tests/test_check_docker_provenance_attestation.py` -> PASS
+- `.venv/bin/python scripts/ci/check_docs_phase1_gates.py --files docs/roadmap/BACKLOG_LEDGER.md docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md` -> PASS
+- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed` -> PASS
+- `PATH=.venv/bin:$PATH pre-commit run --all-files` -> PASS
+
+## Merge Readiness
+
+Not ready yet. Current-head CI, external review comments, mandatory wait-window, and strict merge-readiness wrapper must pass before merge.

--- a/docs/review/PR_1703_FIXED_MAPPING.md
+++ b/docs/review/PR_1703_FIXED_MAPPING.md
@@ -10,9 +10,23 @@ Branch: `ci/release-control-plane-source-producers`
 
 Status: External review comments inspected through current head.
 
-## Fixed In Commit Mapping
+## Fixed in Commit Mapping
 
-Internal pre-open review findings fixed before PR open:
+Disposition: FIXED
+Commit: 79c15fcfe
+Evidence: `scripts/release/evidence_source.py` uses boundary-aware evidence word validation and explicit `artifact-name` command dispatch; `tests/test_release_manifest_evidence_workflow.py` covers valid `latest/...` paths and unsafe nested RAG source paths. `docs/review/PR_1703_FIXED_MAPPING.md` contains the required checked discussion/mapping boxes.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1703#discussion_r3204571807 -> 79c15fcfe
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1703#discussion_r3204596360 -> 79c15fcfe
+
+Disposition: NOT-A-BUG
+Evidence: `.github/workflows/release-manifest-evidence.yml` now validates a single `supply_chain_source` object whose expected path is `release-control-plane-build-sources`, then reads `${supply_chain_source_path}/sbom_digest.txt`, `${supply_chain_source_path}/provenance_digest.txt`, and `${supply_chain_source_path}/attestation_status.txt`. The stale comments describe an older producer contract that expected root `sbom_digest.txt` paths.
+Reason: Current head intentionally uses the artifact root directory as the governed source object so the upload-artifact LCA behavior is explicit and tested.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1703#discussion_r3204558195
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1703#discussion_r3204571801
+
+## Internal Review Findings
+
+Internal pre-open and role-agent findings fixed before PR open:
 
 - Raw upload artifact name bypassed validation -> `1876e231b`
 - Missing `rag_gate_result.git_sha` validation -> `1876e231b`

--- a/docs/review/PR_1703_FIXED_MAPPING.md
+++ b/docs/review/PR_1703_FIXED_MAPPING.md
@@ -23,6 +23,7 @@ Internal pre-open review findings fixed before PR open:
 - Manual supply-chain assertions -> `f43d6c1ec`
 - Mixed supply-chain source runs/artifacts -> `e1f454cb9`
 - Docker build self-certified App Review / production-candidate digests -> `f43d6c1ec`
+- GitHub workflow lint failed on too many dispatch inputs and SC2153 shell variables -> `664c1fd5d`
 
 ## NOT-A-BUG
 

--- a/docs/review/PR_1703_FIXED_MAPPING.md
+++ b/docs/review/PR_1703_FIXED_MAPPING.md
@@ -5,9 +5,10 @@ Branch: `ci/release-control-plane-source-producers`
 
 ## Discussion Thread Pass
 
-Status: Pending external review.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
-No GitHub review threads were resolved before this artifact was created. New CodeRabbit/Sourcery/Cubic/human comments must be fixed or dispositioned here before thread resolution.
+Status: External review comments inspected through current head.
 
 ## Fixed In Commit Mapping
 
@@ -24,12 +25,22 @@ Internal pre-open review findings fixed before PR open:
 - Mixed supply-chain source runs/artifacts -> `e1f454cb9`
 - Docker build self-certified App Review / production-candidate digests -> `f43d6c1ec`
 - GitHub workflow lint failed on too many dispatch inputs and SC2153 shell variables -> `664c1fd5d`
+- CodeRabbit actionable: fixed-mapping checklist was missing checked discussion/mapping boxes -> `04c7ba87d`
+- CodeRabbit nit: `artifact-name` CLI command relied on implicit fall-through -> `04c7ba87d`
+- Cubic P2: evidence source substring matching could reject valid paths such as `latest/...` -> `04c7ba87d`
+- Bug-hunter P1: nested RAG `source_artifacts[*].path` allowed path escapes such as `../prod/release.jsonl` -> `04c7ba87d`
 
 ## NOT-A-BUG
 
 - Suggested `artifact-metadata: write` permission.
   - Evidence: `check-github-workflows` rejects `artifact-metadata` in the current schema. Valid permissions retained: `attestations: write`, `id-token: write`, `packages: write`.
   - Guard: `tests/test_release_manifest_evidence_workflow.py` asserts `artifact-metadata` is absent.
+- Cubic P1: artifact root mismatch for `release-control-plane-build-sources`.
+  - Evidence: Fixed by `664c1fd5d`, which replaced separate `sbom_digest_source`, `provenance_digest_source`, and `attestation_status_source` inputs with a single governed `supply_chain_source` object whose expected path is `release-control-plane-build-sources`. The manifest producer then reads `${supply_chain_source_path}/sbom_digest.txt`, `${supply_chain_source_path}/provenance_digest.txt`, and `${supply_chain_source_path}/attestation_status.txt`.
+- CodeRabbit nit: `scripts/release/build_identity.py` direct-invocation `sys.path.insert`.
+  - Evidence: Fixed as documentation-only in `04c7ba87d`; the script remains a standalone repo CLI for GitHub Actions, and package-style `python -m` invocation remains available.
+- Sourcery weekly diff-character rate limit.
+  - Evidence: Sourcery posted a rate-limit comment only; no actionable code finding was provided.
 
 ## DEFERRED
 

--- a/docs/review/PR_1703_FIXED_MAPPING.md
+++ b/docs/review/PR_1703_FIXED_MAPPING.md
@@ -15,6 +15,8 @@ Status: External review comments inspected through current head.
 Disposition: FIXED
 Commit: 79c15fcfe
 Evidence: `scripts/release/evidence_source.py` uses boundary-aware evidence word validation and explicit `artifact-name` command dispatch; `tests/test_release_manifest_evidence_workflow.py` covers valid `latest/...` paths and unsafe nested RAG source paths. `docs/review/PR_1703_FIXED_MAPPING.md` contains the required checked discussion/mapping boxes.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1703#pullrequestreview-4247617489 -> 79c15fcfe
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1703#pullrequestreview-4247588779 -> 79c15fcfe
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1703#discussion_r3204571807 -> 79c15fcfe
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1703#discussion_r3204596360 -> 79c15fcfe
 

--- a/docs/review/PR_1703_FIXED_MAPPING.md
+++ b/docs/review/PR_1703_FIXED_MAPPING.md
@@ -25,10 +25,10 @@ Internal pre-open review findings fixed before PR open:
 - Mixed supply-chain source runs/artifacts -> `e1f454cb9`
 - Docker build self-certified App Review / production-candidate digests -> `f43d6c1ec`
 - GitHub workflow lint failed on too many dispatch inputs and SC2153 shell variables -> `664c1fd5d`
-- CodeRabbit actionable: fixed-mapping checklist was missing checked discussion/mapping boxes -> `04c7ba87d`
-- CodeRabbit nit: `artifact-name` CLI command relied on implicit fall-through -> `04c7ba87d`
-- Cubic P2: evidence source substring matching could reject valid paths such as `latest/...` -> `04c7ba87d`
-- Bug-hunter P1: nested RAG `source_artifacts[*].path` allowed path escapes such as `../prod/release.jsonl` -> `04c7ba87d`
+- CodeRabbit actionable: fixed-mapping checklist was missing checked discussion/mapping boxes -> `79c15fcfe`
+- CodeRabbit nit: `artifact-name` CLI command relied on implicit fall-through -> `79c15fcfe`
+- Cubic P2: evidence source substring matching could reject valid paths such as `latest/...` -> `79c15fcfe`
+- Bug-hunter P1: nested RAG `source_artifacts[*].path` allowed path escapes such as `../prod/release.jsonl` -> `79c15fcfe`
 
 ## NOT-A-BUG
 
@@ -38,7 +38,7 @@ Internal pre-open review findings fixed before PR open:
 - Cubic P1: artifact root mismatch for `release-control-plane-build-sources`.
   - Evidence: Fixed by `664c1fd5d`, which replaced separate `sbom_digest_source`, `provenance_digest_source`, and `attestation_status_source` inputs with a single governed `supply_chain_source` object whose expected path is `release-control-plane-build-sources`. The manifest producer then reads `${supply_chain_source_path}/sbom_digest.txt`, `${supply_chain_source_path}/provenance_digest.txt`, and `${supply_chain_source_path}/attestation_status.txt`.
 - CodeRabbit nit: `scripts/release/build_identity.py` direct-invocation `sys.path.insert`.
-  - Evidence: Fixed as documentation-only in `04c7ba87d`; the script remains a standalone repo CLI for GitHub Actions, and package-style `python -m` invocation remains available.
+  - Evidence: Fixed as documentation-only in `79c15fcfe`; the script remains a standalone repo CLI for GitHub Actions, and package-style `python -m` invocation remains available.
 - Sourcery weekly diff-character rate limit.
   - Evidence: Sourcery posted a rate-limit comment only; no actionable code finding was provided.
 

--- a/docs/review/PR_1703_PREMORTEM.md
+++ b/docs/review/PR_1703_PREMORTEM.md
@@ -85,6 +85,12 @@ Disposition: FIXED
 Commit: `f43d6c1ec`
 Evidence: `build.yml` no longer emits `review_artifact_digest.txt` or `production_candidate_artifact_digest.txt`; build equivalence keeps those as explicit protected dispatch inputs because App Store/Fastlane binary production is out of scope.
 
+### P1: Producer workflows failed GitHub workflow lint on current head
+
+Disposition: FIXED
+Commit: `664c1fd5d`
+Evidence: `Release Manifest Evidence` now uses one governed `supply_chain_source` object so `workflow_dispatch` stays at the GitHub limit of 10 inputs. Both producer workflows copy generated env output into local shell variables before use, closing SC2153. Local `check-github-workflows`, focused pytest, docs gate, `make validate-changed`, and `pre-commit run --all-files` passed after the fix.
+
 ### P1: Suggested `artifact-metadata: write` permission
 
 Disposition: NOT-A-BUG

--- a/docs/review/PR_1703_PREMORTEM.md
+++ b/docs/review/PR_1703_PREMORTEM.md
@@ -1,0 +1,110 @@
+# PR #1703 Premortem
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1703
+Branch: `ci/release-control-plane-source-producers`
+Mode: `pr-premortem`
+
+## Scope Reviewed
+
+- `.github/workflows/release-manifest-evidence.yml`
+- `.github/workflows/build-equivalence-evidence.yml`
+- `.github/workflows/build.yml`
+- `scripts/release/evidence_source.py`
+- `scripts/release/build_identity.py`
+- `tests/test_release_manifest_evidence_workflow.py`
+- `tests/test_build_equivalence_evidence_workflow.py`
+- `tests/test_release_control_plane_evidence_publication_workflow.py`
+- `docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md`
+- `docs/release/RELEASE_CONTROL_PLANE_EPIC.md`
+- `docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md`
+- `docs/roadmap/BACKLOG_LEDGER.md`
+
+## Frame
+
+It is 48 hours after merge. The release-control-plane source producer lane failed by publishing misleading production evidence or by blocking the governed publisher forever. This premortem records the failure modes found before PR open and the fixes made before mapping.
+
+## Findings And Dispositions
+
+### P1: Raw artifact name bypassed validation
+
+Disposition: FIXED
+Commit: `1876e231b`
+Evidence: upload steps now use sanitized step outputs, not raw `inputs.evidence_artifact_name`; guarded by `tests/test_release_manifest_evidence_workflow.py` and `tests/test_build_equivalence_evidence_workflow.py`.
+
+### P1: RAG payload `git_sha` was not checked
+
+Disposition: FIXED
+Commit: `1876e231b`
+Evidence: `scripts/release/evidence_source.py` validates `rag_gate_result.git_sha` against the expected SHA; workflow calls `rag-gate-result`; regression tests cover mismatch.
+
+### P1: Downloaded artifact symlink target could escape path guard
+
+Disposition: FIXED
+Commit: `1876e231b`
+Evidence: workflows resolve downloaded file targets with `Path.resolve()` before reading; tests assert the resolved-path guard.
+
+### P2: Source object path contract accepted noncanonical paths
+
+Disposition: FIXED
+Commit: `1876e231b`
+Evidence: `source-env` supports `--expected-path`; producer workflows pin `rag_gate_result.json` and `release_manifest.json`.
+
+### P1: Generic test paths inside RAG payload were not rejected
+
+Disposition: FIXED
+Commit: `9a4b5f666`
+Evidence: `FORBIDDEN_TEST_PATH_RE` in `scripts/release/evidence_source.py`; tests reject `tests/evals/release.jsonl`.
+
+### P2: Manifest generation could preserve uppercase git SHA input
+
+Disposition: FIXED
+Commit: `9a4b5f666`
+Evidence: `release-manifest-evidence.yml` passes normalized `$expected_git_sha_lc` to `release_manifest.py generate`.
+
+### P1: Build-equivalence producer could publish `BLOCK` evidence as successful
+
+Disposition: FIXED
+Commit: `1876e231b`
+Evidence: workflow checks `build_equivalence_result.decision == EQUIVALENT` before upload.
+
+### P1: Supply-chain values were manual assertions
+
+Disposition: FIXED
+Commit: `f43d6c1ec`
+Evidence: `build.yml` runs `scripts/ci/check_docker_provenance_attestation.py`; source files are written only when verifier JSON has `passed: true`; release manifest producer compares source files to explicit inputs.
+
+### P1: Supply-chain source files could be mixed across runs
+
+Disposition: FIXED
+Commit: `e1f454cb9`
+Evidence: release manifest producer requires SBOM, provenance, and attestation status sources to share the same run id and artifact name.
+
+### P1: Docker build self-certified App Review and production-candidate digests
+
+Disposition: FIXED
+Commit: `f43d6c1ec`
+Evidence: `build.yml` no longer emits `review_artifact_digest.txt` or `production_candidate_artifact_digest.txt`; build equivalence keeps those as explicit protected dispatch inputs because App Store/Fastlane binary production is out of scope.
+
+### P1: Suggested `artifact-metadata: write` permission
+
+Disposition: NOT-A-BUG
+Evidence: local `check-github-workflows` rejects `artifact-metadata` as invalid for the current workflow schema. PR keeps valid attestation permissions: `attestations: write`, `id-token: write`, `packages: write`; regression asserts `artifact-metadata` is absent.
+
+### P2: App Store build identity can drift from repo release truth
+
+Disposition: DEFERRED
+Backlog: App Store Connect upload execution / Fastlane protected upload mutation remain deferred in `docs/roadmap/BACKLOG_LEDGER.md`.
+Reason: This PR does not implement App Store binary production or upload. Build identity stays a protected release input until the dedicated App Store release execution/readiness lane owns it.
+
+## Decision
+
+Proceed with review. All P0/P1 premortem findings found before PR open were fixed or dispositioned with evidence. P2 App Store identity truth remains explicitly deferred to the separate App Store release execution/readiness line.
+
+## Validation Evidence
+
+- `.venv/bin/python scripts/orchestration/check_preflight.py` -> PASS
+- `.venv/bin/python scripts/orchestration/check_agent_consistency.py` -> PASS
+- `.venv/bin/python -m pytest -q tests/test_release_manifest_evidence_workflow.py tests/test_build_equivalence_evidence_workflow.py tests/test_release_control_plane_evidence_publication_workflow.py tests/test_release_manifest.py tests/test_build_equivalence.py tests/test_release_control_plane_ci_gate.py tests/test_production_release_evidence_wiring.py tests/test_check_docker_provenance_attestation.py` -> PASS
+- `.venv/bin/python scripts/ci/check_docs_phase1_gates.py --files docs/roadmap/BACKLOG_LEDGER.md docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md` -> PASS
+- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed` -> PASS
+- `PATH=.venv/bin:$PATH pre-commit run --all-files` -> PASS

--- a/docs/review/PR_1703_PREMORTEM.md
+++ b/docs/review/PR_1703_PREMORTEM.md
@@ -94,13 +94,13 @@ Evidence: `Release Manifest Evidence` now uses one governed `supply_chain_source
 ### P2: Evidence source substring matching rejected valid path words
 
 Disposition: FIXED
-Commit: `04c7ba87d`
+Commit: `79c15fcfe`
 Evidence: the evidence source validator now uses boundary-aware word extraction for fixture/sample/placeholder/fake/fallback tokens instead of raw substring matching. Regression coverage accepts a valid `latest/rag_gate_result.json` source path while still rejecting `test` / `tests` path components and forbidden evidence words.
 
 ### P1: Nested RAG source artifact paths could escape evidence roots
 
 Disposition: FIXED
-Commit: `04c7ba87d`
+Commit: `79c15fcfe`
 Evidence: the evidence source validator now checks nested `*.path` fields inside the governed RAG payload with the same path-safety rules used for top-level source objects. Regression coverage rejects `../prod/release.jsonl`, absolute paths, and double-slash paths before a manifest can be generated.
 
 ### P1: Suggested `artifact-metadata: write` permission

--- a/docs/review/PR_1703_PREMORTEM.md
+++ b/docs/review/PR_1703_PREMORTEM.md
@@ -91,6 +91,18 @@ Disposition: FIXED
 Commit: `664c1fd5d`
 Evidence: `Release Manifest Evidence` now uses one governed `supply_chain_source` object so `workflow_dispatch` stays at the GitHub limit of 10 inputs. Both producer workflows copy generated env output into local shell variables before use, closing SC2153. Local `check-github-workflows`, focused pytest, docs gate, `make validate-changed`, and `pre-commit run --all-files` passed after the fix.
 
+### P2: Evidence source substring matching rejected valid path words
+
+Disposition: FIXED
+Commit: `04c7ba87d`
+Evidence: the evidence source validator now uses boundary-aware word extraction for fixture/sample/placeholder/fake/fallback tokens instead of raw substring matching. Regression coverage accepts a valid `latest/rag_gate_result.json` source path while still rejecting `test` / `tests` path components and forbidden evidence words.
+
+### P1: Nested RAG source artifact paths could escape evidence roots
+
+Disposition: FIXED
+Commit: `04c7ba87d`
+Evidence: the evidence source validator now checks nested `*.path` fields inside the governed RAG payload with the same path-safety rules used for top-level source objects. Regression coverage rejects `../prod/release.jsonl`, absolute paths, and double-slash paths before a manifest can be generated.
+
 ### P1: Suggested `artifact-metadata: write` permission
 
 Disposition: NOT-A-BUG

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -445,10 +445,10 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Release automation control plane for C4, App Store Review, ML gates, and supply chain
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-0 -> PR-1 -> PR-2 -> PR-3 (PR #1605) -> PR-4 (PR #1679) -> PR-5 (PR #1682) -> PR-6 (PR #1688) -> PR #1692 -> PR #1699 (`ci/release-control-plane-evidence-publication`)
+  - Target PR: PR-0 -> PR-1 -> PR-2 -> PR-3 (PR #1605) -> PR-4 (PR #1679) -> PR-5 (PR #1682) -> PR-6 (PR #1688) -> PR #1692 -> PR #1699 -> `ci/release-control-plane-source-producers`
   - Area: release / App Store / AI evals / supply-chain / orchestration
   - Finding Type: release evidence unification gap
-  - Status: PR-0, PR-1, and PR-2 merged; PR-3 merged in PR #1605 on 2026-04-30; PR-4 merged in PR #1679 on 2026-05-06; PR-5 merged in PR #1682 on 2026-05-06; PR-6 merged in PR #1688 on 2026-05-06; PR #1692 enforces the production tag path fail-closed against PR-6 real evidence wiring and intentionally blocks production tags until protected release evidence is supplied. Future protected artifact publication/upload automation and App Store Connect execution remain out of scope. The active `ci/release-control-plane-evidence-publication` follow-up adds the governed manual evidence-publication workflow that can publish that protected artifact layout. App Store Connect execution, Fastlane protected upload mutation, and final App Store readiness remain deferred and out of scope. The release-control-plane epic is not complete, full App Store readiness is not complete, and the train is not production-ready.
+  - Status: PR-0, PR-1, and PR-2 merged; PR-3 merged in PR #1605 on 2026-04-30; PR-4 merged in PR #1679 on 2026-05-06; PR-5 merged in PR #1682 on 2026-05-06; PR-6 merged in PR #1688 on 2026-05-06; PR #1692 enforces the production tag path fail-closed against PR-6 real evidence wiring and intentionally blocks production tags until protected release evidence is supplied. PR #1699 merged the governed manual evidence-publication workflow on 2026-05-07 (`ci/release-control-plane-evidence-publication`). The active `ci/release-control-plane-source-producers` follow-up adds the governed `workflow_dispatch` source producers for `Release Manifest Evidence` and `Build Equivalence Evidence` so the PR #1699 publisher no longer depends on ad hoc source runs. Future protected artifact publication/upload automation and App Store Connect execution for App Store release remains out of scope; App Store Connect execution, Fastlane protected upload mutation, and final App Store readiness remain deferred. The release-control-plane epic is not complete, full App Store readiness is not complete, and the train is not production-ready.
   - Reason (EN): The App Store readiness PR train is owned separately, while the attached release-automation document also identifies a cross-cutting control-plane gap: build identity, reviewer packet identity, RAG/ML gate identity, supply-chain provenance, and the final release decision are not yet represented by one machine-readable release packet. This line complements PR `#1582` without editing its branch or worktree.
   - Links:
     - `docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md`
@@ -464,7 +464,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md`
     - `docs/release/RELEASE_CONTROL_PLANE_CI_GATE.schema.json`
     - `docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md`
+    - `.github/workflows/release-control-plane-evidence.yml`
+    - `.github/workflows/release-manifest-evidence.yml`
+    - `.github/workflows/build-equivalence-evidence.yml`
     - `scripts/release/release_manifest.py`
+    - `scripts/release/build_identity.py`
     - `scripts/release/build_equivalence.py`
     - `scripts/ci/check_release_control_plane.py`
     - `docs/architecture/C4_RELEASE_CONTROL_PLANE_CONTEXT.md`
@@ -481,8 +485,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - PR-5 integrates focused CI gates for manifest, ML gate result, build-equivalence result, SBOM/provenance references, and `ALLOW` / `BLOCK` decision. Completed by PR #1682.
     - PR-6 wires real production release evidence artifacts into the production tag workflow path, requiring release manifest, RAG gate result, build-equivalence result, and supply-chain identity evidence before production deploy can treat the release-control-plane gate as `ALLOW`. Completed by PR #1688.
     - PR #1692 closes the production gate bypass by preserving the PR-6 real-evidence wiring as the deploy dependency and documenting that missing protected evidence is a release stop, while protected artifact publication/upload automation and App Store Connect execution remain deferred follow-ups.
-    - The evidence-publication follow-up adds a manual governed workflow that downloads successful `workflow_dispatch` source artifacts for the same git SHA, normalizes them to the canonical `release-control-plane/` layout, validates them with `scripts/ci/check_release_control_plane.py`, and uploads the artifact operators point production CD at.
-    - Next release-control-plane producer-workflow follow-up must add governed `workflow_dispatch` source producers for `Release Manifest Evidence` and `Build Equivalence Evidence`; until then PR #1699's publisher remains fail-closed and production CD evidence variables must not be set from ad hoc source runs.
+    - The evidence-publication follow-up added a manual governed workflow that downloads successful `workflow_dispatch` source artifacts for the same git SHA, normalizes them to the canonical `release-control-plane/` layout, validates them with `scripts/ci/check_release_control_plane.py`, and uploads the artifact operators point production CD at. Completed by PR #1699.
+    - The active source-producer follow-up adds governed `workflow_dispatch` producers for `Release Manifest Evidence` and `Build Equivalence Evidence`; until it merges, PR #1699's publisher remains fail-closed and production CD evidence variables must not be set from ad hoc source runs.
 
 <a id="ledger-p1-planning-flow-monetization-wave"></a>
 - [ ] P1: Planning-flow monetization wave over the canonical FREE -> PRO -> VIP ladder

--- a/scripts/release/build_identity.py
+++ b/scripts/release/build_identity.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Generate deterministic release build identity artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    # Support direct invocation from repository root:
+    # `.venv/bin/python scripts/release/build_identity.py ...`
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.release import release_manifest
+
+SCHEMA_VERSION = "release-build-identity.v1"
+SENTINEL_OCI_SHA256_DIGEST_RE = re.compile(r"^sha256:([0-9a-f])\1{63}$")
+
+
+class BuildIdentityError(ValueError):
+    """Raised when build identity generation fails closed."""
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise BuildIdentityError(f"{path} is not readable: {exc}") from exc
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise BuildIdentityError(f"{path} is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise BuildIdentityError(f"{path} must contain a JSON object.")
+    return payload
+
+
+def build_identity_payload(
+    *,
+    manifest_payload: dict[str, Any],
+    artifact_digest: str,
+) -> dict[str, Any]:
+    """Return a deterministic build identity artifact derived from a manifest."""
+
+    manifest_errors = release_manifest.validate_manifest_payload(manifest_payload)
+    if manifest_errors:
+        raise BuildIdentityError("; ".join(manifest_errors))
+    if not release_manifest.OCI_SHA256_DIGEST_RE.fullmatch(artifact_digest):
+        raise BuildIdentityError("artifact_digest must use sha256:<64 lowercase hex> format.")
+    if SENTINEL_OCI_SHA256_DIGEST_RE.fullmatch(artifact_digest):
+        raise BuildIdentityError("artifact_digest must not be a sentinel placeholder digest.")
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "hash_algorithm": release_manifest.HASH_ALGORITHM,
+        "canonicalization": release_manifest.CANONICALIZATION,
+        "build_identity": dict(manifest_payload["build_identity"]),
+        "artifact_digest": artifact_digest,
+        "release_manifest_hash": manifest_payload["release_manifest_hash"],
+    }
+    for identity_group in ("reviewer_identity", "ml_identity", "supply_chain_identity"):
+        if identity_group in manifest_payload:
+            payload[identity_group] = manifest_payload[identity_group]
+    return payload
+
+
+def write_identity(path: Path, payload: dict[str, Any]) -> None:
+    """Write stable JSON with sorted keys and one trailing newline."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--release-manifest", type=Path, required=True)
+    parser.add_argument("--artifact-digest", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        manifest_payload = _load_json(args.release_manifest)
+        payload = build_identity_payload(
+            manifest_payload=manifest_payload,
+            artifact_digest=args.artifact_digest,
+        )
+        write_identity(args.output, payload)
+        print(f"Wrote build identity: {args.output}")
+        return 0
+    except BuildIdentityError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/build_identity.py
+++ b/scripts/release/build_identity.py
@@ -13,6 +13,8 @@ from typing import Any
 if __package__ in {None, ""}:
     # Support direct invocation from repository root:
     # `.venv/bin/python scripts/release/build_identity.py ...`
+    # The workflow invokes this as a standalone repo script; `python -m` remains
+    # available for package-style execution outside GitHub Actions.
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from scripts.release import release_manifest

--- a/scripts/release/evidence_source.py
+++ b/scripts/release/evidence_source.py
@@ -17,12 +17,9 @@ OCI_SHA256_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 SENTINEL_SHA_RE = re.compile(r"^sha256:([0-9a-f])\1{63}$")
 SENTINEL_HASH_RE = re.compile(r"^(?:sha256:)?([0-9a-f])\1{63}$")
 FORBIDDEN_TEST_PATH_RE = re.compile(r"(^|/)tests?(/|$)")
-FORBIDDEN_TOKENS = (
-    "/test/",
-    "/tests/",
-    "test/",
-    "tests/",
-    "tests/fixtures",
+FORBIDDEN_WORDS = {
+    "test",
+    "tests",
     "fixture",
     "fixtures",
     "sample",
@@ -30,7 +27,7 @@ FORBIDDEN_TOKENS = (
     "placeholder",
     "fake",
     "fallback",
-)
+}
 
 
 class EvidenceSourceError(ValueError):
@@ -45,10 +42,25 @@ def _reject_text(value: str, *, label: str) -> None:
     if not value or _has_control_character(value):
         raise EvidenceSourceError(f"{label} must be non-empty and contain no control characters.")
     lowered = value.lower().replace("\\", "/")
-    if any(token in lowered for token in FORBIDDEN_TOKENS):
+    if _has_forbidden_evidence_word(lowered):
         raise EvidenceSourceError(
             f"{label} must not reference fixture/sample/example/placeholder/fake/fallback data."
         )
+
+
+def _has_forbidden_evidence_word(value: str) -> bool:
+    words = re.findall(r"[a-z0-9]+", value)
+    return any(word in FORBIDDEN_WORDS for word in words)
+
+
+def _is_safe_artifact_path(value: str) -> bool:
+    normalized_path = value.replace("\\", "/")
+    pure_path = PurePosixPath(normalized_path)
+    return not (
+        normalized_path.startswith("/")
+        or "//" in normalized_path
+        or any(part in {"", ".", ".."} for part in pure_path.parts)
+    )
 
 
 def validate_git_sha(value: str) -> str:
@@ -100,8 +112,10 @@ def _reject_payload_strings(value: Any, *, pointer: str) -> None:
             raise EvidenceSourceError(f"sentinel placeholder digest/hash rejected at {pointer}")
         if FORBIDDEN_TEST_PATH_RE.search(lowered):
             raise EvidenceSourceError(f"test evidence path rejected at {pointer}")
-        if any(token in lowered for token in FORBIDDEN_TOKENS):
+        if _has_forbidden_evidence_word(lowered):
             raise EvidenceSourceError(f"fixture/sample/fallback evidence rejected at {pointer}")
+        if pointer.endswith(".path") and not _is_safe_artifact_path(value):
+            raise EvidenceSourceError(f"unsafe evidence path rejected at {pointer}")
 
 
 def validate_rag_gate_result_file(path: Path, *, expected_git_sha: str) -> None:
@@ -154,12 +168,7 @@ def validate_source_payload(
     if not run_id.isdigit():
         raise EvidenceSourceError(f"{label}_source.run_id must be a numeric GitHub Actions run id.")
     normalized_path = path.replace("\\", "/")
-    pure_path = PurePosixPath(normalized_path)
-    if (
-        normalized_path.startswith("/")
-        or "//" in normalized_path
-        or any(part in {"", ".", ".."} for part in pure_path.parts)
-    ):
+    if not _is_safe_artifact_path(normalized_path):
         raise EvidenceSourceError(f"{label}_source.path must stay inside the downloaded artifact.")
     if expected_path is not None and normalized_path != expected_path:
         raise EvidenceSourceError(f"{label}_source.path must be exactly {expected_path}.")
@@ -224,8 +233,10 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "rag-gate-result":
             validate_rag_gate_result_file(args.path, expected_git_sha=args.expected_git_sha)
             return 0
-        print(validate_artifact_name(args.value))
-        return 0
+        if args.command == "artifact-name":
+            print(validate_artifact_name(args.value))
+            return 0
+        parser.error(f"Unknown command: {args.command}")
     except EvidenceSourceError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1

--- a/scripts/release/evidence_source.py
+++ b/scripts/release/evidence_source.py
@@ -74,7 +74,9 @@ def validate_artifact_name(value: str, *, label: str = "artifact_name") -> str:
     return value
 
 
-def validate_source_payload(raw_json: str, *, label: str) -> dict[str, str]:
+def validate_source_payload(
+    raw_json: str, *, label: str, expected_path: str | None = None
+) -> dict[str, str]:
     """Validate source object JSON and return run_id/artifact_name/path."""
 
     if _has_control_character(raw_json):
@@ -107,6 +109,8 @@ def validate_source_payload(raw_json: str, *, label: str) -> dict[str, str]:
         or any(part in {"", ".", ".."} for part in pure_path.parts)
     ):
         raise EvidenceSourceError(f"{label}_source.path must stay inside the downloaded artifact.")
+    if expected_path is not None and normalized_path != expected_path:
+        raise EvidenceSourceError(f"{label}_source.path must be exactly {expected_path}.")
     return {
         "run_id": run_id,
         "artifact_name": artifact_name,
@@ -128,6 +132,7 @@ def _build_parser() -> argparse.ArgumentParser:
     source_env.add_argument("--label", required=True)
     source_env.add_argument("--prefix", required=True)
     source_env.add_argument("--source-json", required=True)
+    source_env.add_argument("--expected-path")
 
     git_sha = subparsers.add_parser("git-sha")
     git_sha.add_argument("value")
@@ -146,7 +151,11 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         if args.command == "source-env":
-            payload = validate_source_payload(args.source_json, label=args.label)
+            payload = validate_source_payload(
+                args.source_json,
+                label=args.label,
+                expected_path=args.expected_path,
+            )
             for line in shell_env_lines(payload, prefix=args.prefix):
                 print(line)
             return 0

--- a/scripts/release/evidence_source.py
+++ b/scripts/release/evidence_source.py
@@ -8,12 +8,15 @@ import json
 import re
 import shlex
 import sys
+from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Any
 
 GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
 OCI_SHA256_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 SENTINEL_SHA_RE = re.compile(r"^sha256:([0-9a-f])\1{63}$")
+SENTINEL_HASH_RE = re.compile(r"^(?:sha256:)?([0-9a-f])\1{63}$")
+FORBIDDEN_TEST_PATH_RE = re.compile(r"(^|/)tests?(/|$)")
 FORBIDDEN_TOKENS = (
     "/test/",
     "/tests/",
@@ -72,6 +75,55 @@ def validate_artifact_name(value: str, *, label: str = "artifact_name") -> str:
 
     _reject_text(value, label=label)
     return value
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise EvidenceSourceError(f"{path} must be readable JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise EvidenceSourceError(f"{path} must contain a JSON object.")
+    return payload
+
+
+def _reject_payload_strings(value: Any, *, pointer: str) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            _reject_payload_strings(child, pointer=f"{pointer}.{key}" if pointer else str(key))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_payload_strings(child, pointer=f"{pointer}[{index}]")
+    elif isinstance(value, str):
+        lowered = value.lower().replace("\\", "/")
+        if SENTINEL_HASH_RE.fullmatch(lowered):
+            raise EvidenceSourceError(f"sentinel placeholder digest/hash rejected at {pointer}")
+        if FORBIDDEN_TEST_PATH_RE.search(lowered):
+            raise EvidenceSourceError(f"test evidence path rejected at {pointer}")
+        if any(token in lowered for token in FORBIDDEN_TOKENS):
+            raise EvidenceSourceError(f"fixture/sample/fallback evidence rejected at {pointer}")
+
+
+def validate_rag_gate_result_file(path: Path, *, expected_git_sha: str) -> None:
+    """Validate a governed RAG gate result before manifest publication."""
+
+    payload = _load_json_object(path)
+    git_sha = payload.get("git_sha")
+    if not isinstance(git_sha, str) or not GIT_SHA_RE.fullmatch(git_sha):
+        raise EvidenceSourceError(
+            "rag_gate_result.git_sha must be a full 40-character hexadecimal SHA."
+        )
+    if git_sha.lower() != validate_git_sha(expected_git_sha):
+        raise EvidenceSourceError("rag_gate_result.git_sha must match git_sha.")
+    _reject_payload_strings(payload, pointer="rag_gate_result")
+    if payload.get("release_decision") != "PASS":
+        raise EvidenceSourceError("rag_gate_result.release_decision must be PASS.")
+    if payload.get("dataset_fallback_used") is not False:
+        raise EvidenceSourceError("rag_gate_result.dataset_fallback_used must be false.")
+    if payload.get("small_fixture_metric_gates_advisory") is not False:
+        raise EvidenceSourceError(
+            "rag_gate_result.small_fixture_metric_gates_advisory must be false."
+        )
 
 
 def validate_source_payload(
@@ -143,6 +195,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
     artifact_name = subparsers.add_parser("artifact-name")
     artifact_name.add_argument("value")
+
+    rag_gate_result = subparsers.add_parser("rag-gate-result")
+    rag_gate_result.add_argument("--expected-git-sha", required=True)
+    rag_gate_result.add_argument("path", type=Path)
     return parser
 
 
@@ -164,6 +220,9 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         if args.command == "oci-digest":
             print(validate_oci_digest(args.value, label=args.label))
+            return 0
+        if args.command == "rag-gate-result":
+            validate_rag_gate_result_file(args.path, expected_git_sha=args.expected_git_sha)
             return 0
         print(validate_artifact_name(args.value))
         return 0

--- a/scripts/release/evidence_source.py
+++ b/scripts/release/evidence_source.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Validate governed release-control-plane source workflow inputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import sys
+from pathlib import PurePosixPath
+from typing import Any
+
+GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+OCI_SHA256_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+SENTINEL_SHA_RE = re.compile(r"^sha256:([0-9a-f])\1{63}$")
+FORBIDDEN_TOKENS = (
+    "/test/",
+    "/tests/",
+    "test/",
+    "tests/",
+    "tests/fixtures",
+    "fixture",
+    "fixtures",
+    "sample",
+    "example",
+    "placeholder",
+    "fake",
+    "fallback",
+)
+
+
+class EvidenceSourceError(ValueError):
+    """Raised when governed evidence source input is unsafe or malformed."""
+
+
+def _has_control_character(value: str) -> bool:
+    return any(ord(character) < 32 or ord(character) == 127 for character in value)
+
+
+def _reject_text(value: str, *, label: str) -> None:
+    if not value or _has_control_character(value):
+        raise EvidenceSourceError(f"{label} must be non-empty and contain no control characters.")
+    lowered = value.lower().replace("\\", "/")
+    if any(token in lowered for token in FORBIDDEN_TOKENS):
+        raise EvidenceSourceError(
+            f"{label} must not reference fixture/sample/example/placeholder/fake/fallback data."
+        )
+
+
+def validate_git_sha(value: str) -> str:
+    """Return lowercase full git SHA or fail closed."""
+
+    if not GIT_SHA_RE.fullmatch(value):
+        raise EvidenceSourceError("git_sha must be a full 40-character hexadecimal commit SHA.")
+    return value.lower()
+
+
+def validate_oci_digest(value: str, *, label: str) -> str:
+    """Return OCI SHA-256 digest or fail closed."""
+
+    _reject_text(value, label=label)
+    if not OCI_SHA256_DIGEST_RE.fullmatch(value):
+        raise EvidenceSourceError(f"{label} must use sha256:<64 lowercase hex> format.")
+    if SENTINEL_SHA_RE.fullmatch(value):
+        raise EvidenceSourceError(f"{label} must not be a sentinel placeholder digest.")
+    return value
+
+
+def validate_artifact_name(value: str, *, label: str = "artifact_name") -> str:
+    """Return an artifact name after rejecting placeholders and controls."""
+
+    _reject_text(value, label=label)
+    return value
+
+
+def validate_source_payload(raw_json: str, *, label: str) -> dict[str, str]:
+    """Validate source object JSON and return run_id/artifact_name/path."""
+
+    if _has_control_character(raw_json):
+        raise EvidenceSourceError(f"{label}_source must be single-line JSON.")
+    try:
+        payload = json.loads(raw_json)
+    except json.JSONDecodeError as exc:
+        raise EvidenceSourceError(f"{label}_source must be JSON: {exc}") from exc
+    required = {"run_id", "artifact_name", "path"}
+    if not isinstance(payload, dict) or set(payload) != required:
+        raise EvidenceSourceError(
+            f"{label}_source must contain exactly run_id, artifact_name, path."
+        )
+
+    run_id = payload["run_id"]
+    artifact_name = payload["artifact_name"]
+    path = payload["path"]
+    for key, value in payload.items():
+        if not isinstance(value, str):
+            raise EvidenceSourceError(f"{label}_source.{key} must be a string.")
+        _reject_text(value, label=f"{label}_source.{key}")
+
+    if not run_id.isdigit():
+        raise EvidenceSourceError(f"{label}_source.run_id must be a numeric GitHub Actions run id.")
+    normalized_path = path.replace("\\", "/")
+    pure_path = PurePosixPath(normalized_path)
+    if (
+        normalized_path.startswith("/")
+        or "//" in normalized_path
+        or any(part in {"", ".", ".."} for part in pure_path.parts)
+    ):
+        raise EvidenceSourceError(f"{label}_source.path must stay inside the downloaded artifact.")
+    return {
+        "run_id": run_id,
+        "artifact_name": artifact_name,
+        "path": normalized_path,
+    }
+
+
+def shell_env_lines(payload: dict[str, str], *, prefix: str) -> list[str]:
+    """Return shell-safe environment assignment lines."""
+
+    return [f"{prefix}_{key.upper()}={shlex.quote(payload[key])}" for key in sorted(payload)]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    source_env = subparsers.add_parser("source-env")
+    source_env.add_argument("--label", required=True)
+    source_env.add_argument("--prefix", required=True)
+    source_env.add_argument("--source-json", required=True)
+
+    git_sha = subparsers.add_parser("git-sha")
+    git_sha.add_argument("value")
+
+    digest = subparsers.add_parser("oci-digest")
+    digest.add_argument("--label", required=True)
+    digest.add_argument("value")
+
+    artifact_name = subparsers.add_parser("artifact-name")
+    artifact_name.add_argument("value")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "source-env":
+            payload = validate_source_payload(args.source_json, label=args.label)
+            for line in shell_env_lines(payload, prefix=args.prefix):
+                print(line)
+            return 0
+        if args.command == "git-sha":
+            print(validate_git_sha(args.value))
+            return 0
+        if args.command == "oci-digest":
+            print(validate_oci_digest(args.value, label=args.label))
+            return 0
+        print(validate_artifact_name(args.value))
+        return 0
+    except EvidenceSourceError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_equivalence_evidence_workflow.py
+++ b/tests/test_build_equivalence_evidence_workflow.py
@@ -129,6 +129,7 @@ def test_workflow_validates_release_manifest_source_run_and_git_sha() -> None:
 
     assert "scripts/release/evidence_source.py source-env" in script
     assert "--label release_manifest" in script
+    assert "--expected-path release_manifest.json" in script
     assert "gh run view" in script
     assert "--json status,conclusion,headSha,event,workflowName,url" in script
     assert 'gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_MANIFEST_RUN_ID}"' in script
@@ -157,6 +158,7 @@ def test_workflow_generates_identities_runs_equivalence_and_uploads_stable_path(
         in script
     )
     assert "release_manifest path escapes downloaded artifact" in script
+    assert "Path(sys.argv[1]).resolve()" in script
     assert "scripts/release/release_manifest.py validate" in script
     assert "scripts/release/build_identity.py" in script
     assert '--artifact-digest "$REVIEW_ARTIFACT_DIGEST"' in script
@@ -164,6 +166,7 @@ def test_workflow_generates_identities_runs_equivalence_and_uploads_stable_path(
     assert "review_build_identity.json" in script
     assert "production_candidate_identity.json" in script
     assert "scripts/release/build_equivalence.py" in script
+    assert "build_equivalence_result.decision must be EQUIVALENT" in script
     assert "--review-build" in script
     assert "--production-candidate" in script
     assert "--release-manifest" in script
@@ -171,7 +174,13 @@ def test_workflow_generates_identities_runs_equivalence_and_uploads_stable_path(
         upload_step["with"]["path"]
         == "${{ runner.temp }}/build-equivalence-evidence/build_equivalence_result.json"
     )
+    assert (
+        upload_step["with"]["name"]
+        == "${{ steps.generate-build-equivalence-evidence.outputs.artifact_name }}"
+    )
+    assert "${{ inputs.evidence_artifact_name }}" not in upload_step["with"]["name"]
     assert upload_step["with"]["if-no-files-found"] == "error"
+    assert 'echo "artifact_name=$EVIDENCE_ARTIFACT_NAME" >> "$GITHUB_OUTPUT"' in script
     assert "GITHUB_RUN_ID" in summary_script
     assert "build_equivalence_result.json" in summary_script
 

--- a/tests/test_build_equivalence_evidence_workflow.py
+++ b/tests/test_build_equivalence_evidence_workflow.py
@@ -131,6 +131,9 @@ def test_workflow_validates_release_manifest_source_run_and_git_sha() -> None:
     assert "scripts/release/evidence_source.py source-env" in script
     assert "--label release_manifest" in script
     assert "--expected-path release_manifest.json" in script
+    assert 'release_manifest_run_id="$RELEASE_MANIFEST_RUN_ID"' in script
+    assert 'release_manifest_artifact_name="$RELEASE_MANIFEST_ARTIFACT_NAME"' in script
+    assert 'release_manifest_source_path="$RELEASE_MANIFEST_PATH"' in script
     assert "gh run view" in script
     assert "--json status,conclusion,headSha,event,workflowName,url" in script
     assert 'gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}"' in script

--- a/tests/test_build_equivalence_evidence_workflow.py
+++ b/tests/test_build_equivalence_evidence_workflow.py
@@ -10,6 +10,7 @@ from scripts.release import build_identity, release_manifest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/build-equivalence-evidence.yml"
+BUILD_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/build.yml"
 LEDGER_PATH = REPO_ROOT / "docs/roadmap/BACKLOG_LEDGER.md"
 
 ARTIFACT_DIGEST = "sha256:" + "a1" * 32
@@ -270,3 +271,20 @@ def test_workflow_has_no_app_store_fastlane_or_runtime_surface() -> None:
     )
     assert not any(term in workflow_json for term in forbidden_terms)
     assert "ci/release-control-plane-source-producers" in LEDGER_PATH.read_text(encoding="utf-8")
+
+
+def test_docker_build_workflow_produces_build_equivalence_digest_sources() -> None:
+    workflow_text = BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")
+    workflow = _load_workflow(BUILD_WORKFLOW_PATH)
+    upload_step = next(
+        step
+        for step in workflow["jobs"]["publish"]["steps"]
+        if step.get("name") == "Upload release-control-plane build digest sources"
+    )
+
+    assert "id: docker-build-push" in workflow_text
+    assert "steps.docker-build-push.outputs.digest" in workflow_text
+    assert "review_artifact_digest.txt" in upload_step["with"]["path"]
+    assert "production_candidate_artifact_digest.txt" in upload_step["with"]["path"]
+    assert upload_step["with"]["name"] == "release-control-plane-build-sources"
+    assert upload_step["with"]["if-no-files-found"] == "error"

--- a/tests/test_build_equivalence_evidence_workflow.py
+++ b/tests/test_build_equivalence_evidence_workflow.py
@@ -109,9 +109,7 @@ def test_workflow_permissions_environment_and_inputs_are_bounded() -> None:
         "git_sha",
         "release_manifest_source",
         "review_artifact_digest",
-        "review_artifact_digest_source",
         "production_candidate_artifact_digest",
-        "production_candidate_artifact_digest_source",
         "evidence_artifact_name",
     }
 
@@ -120,11 +118,6 @@ def test_workflow_permissions_environment_and_inputs_are_bounded() -> None:
     assert "run_id" in inputs["release_manifest_source"]["description"]
     assert "artifact_name" in inputs["release_manifest_source"]["description"]
     assert "path" in inputs["release_manifest_source"]["description"]
-    assert "review_artifact_digest.txt" in inputs["review_artifact_digest_source"]["description"]
-    assert (
-        "production_candidate_artifact_digest.txt"
-        in inputs["production_candidate_artifact_digest_source"]["description"]
-    )
     assert workflow["permissions"] == {"actions": "read", "contents": "read"}
     assert _job(workflow)["environment"]["name"] == "release-evidence"
     workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
@@ -146,25 +139,22 @@ def test_workflow_validates_release_manifest_source_run_and_git_sha() -> None:
     assert '[ "$run_conclusion" != "success" ]' in script
     assert '[ "$run_event" != "workflow_dispatch" ]' in script
     assert '"Release Manifest Evidence" ".github/workflows/release-manifest-evidence.yml"' in script
-    assert '"Docker Build and Push" ".github/workflows/build.yml"' in script
     assert "source run head SHA does not match git_sha" in script
     assert "Build Equivalence Evidence workflow ref must match git_sha" in script
 
 
-def test_workflow_requires_governed_digest_sources_before_identity_generation() -> None:
+def test_workflow_keeps_review_and_production_candidate_digests_explicit() -> None:
     script = _run_script()
-
-    assert "--label review_artifact_digest" in script
-    assert "--expected-path review_artifact_digest.txt" in script
-    assert "--label production_candidate_artifact_digest" in script
-    assert "--expected-path production_candidate_artifact_digest.txt" in script
-    assert "fetch_digest_source" in script
-    assert "gh run download" in script
     workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
-    assert "review_artifact_digest_source" in workflow_text
-    assert "production_candidate_artifact_digest_source" in workflow_text
-    assert "governed digest source does not match explicit digest input" in script
-    assert "digest path escapes downloaded artifact" in script
+
+    assert "review_artifact_digest_source" not in workflow_text
+    assert "production_candidate_artifact_digest_source" not in workflow_text
+    assert "fetch_digest_source" not in script
+    assert "scripts/release/evidence_source.py oci-digest --label review_artifact_digest" in script
+    assert (
+        "scripts/release/evidence_source.py oci-digest --label production_candidate_artifact_digest"
+        in script
+    )
 
 
 def test_workflow_generates_identities_runs_equivalence_and_uploads_stable_path() -> None:
@@ -273,18 +263,8 @@ def test_workflow_has_no_app_store_fastlane_or_runtime_surface() -> None:
     assert "ci/release-control-plane-source-producers" in LEDGER_PATH.read_text(encoding="utf-8")
 
 
-def test_docker_build_workflow_produces_build_equivalence_digest_sources() -> None:
+def test_docker_build_workflow_does_not_self_certify_review_or_production_digests() -> None:
     workflow_text = BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")
-    workflow = _load_workflow(BUILD_WORKFLOW_PATH)
-    upload_step = next(
-        step
-        for step in workflow["jobs"]["publish"]["steps"]
-        if step.get("name") == "Upload release-control-plane build digest sources"
-    )
 
-    assert "id: docker-build-push" in workflow_text
-    assert "steps.docker-build-push.outputs.digest" in workflow_text
-    assert "review_artifact_digest.txt" in upload_step["with"]["path"]
-    assert "production_candidate_artifact_digest.txt" in upload_step["with"]["path"]
-    assert upload_step["with"]["name"] == "release-control-plane-build-sources"
-    assert upload_step["with"]["if-no-files-found"] == "error"
+    assert "review_artifact_digest.txt" not in workflow_text
+    assert "production_candidate_artifact_digest.txt" not in workflow_text

--- a/tests/test_build_equivalence_evidence_workflow.py
+++ b/tests/test_build_equivalence_evidence_workflow.py
@@ -108,7 +108,9 @@ def test_workflow_permissions_environment_and_inputs_are_bounded() -> None:
         "git_sha",
         "release_manifest_source",
         "review_artifact_digest",
+        "review_artifact_digest_source",
         "production_candidate_artifact_digest",
+        "production_candidate_artifact_digest_source",
         "evidence_artifact_name",
     }
 
@@ -117,6 +119,11 @@ def test_workflow_permissions_environment_and_inputs_are_bounded() -> None:
     assert "run_id" in inputs["release_manifest_source"]["description"]
     assert "artifact_name" in inputs["release_manifest_source"]["description"]
     assert "path" in inputs["release_manifest_source"]["description"]
+    assert "review_artifact_digest.txt" in inputs["review_artifact_digest_source"]["description"]
+    assert (
+        "production_candidate_artifact_digest.txt"
+        in inputs["production_candidate_artifact_digest_source"]["description"]
+    )
     assert workflow["permissions"] == {"actions": "read", "contents": "read"}
     assert _job(workflow)["environment"]["name"] == "release-evidence"
     workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
@@ -132,14 +139,31 @@ def test_workflow_validates_release_manifest_source_run_and_git_sha() -> None:
     assert "--expected-path release_manifest.json" in script
     assert "gh run view" in script
     assert "--json status,conclusion,headSha,event,workflowName,url" in script
-    assert 'gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_MANIFEST_RUN_ID}"' in script
+    assert 'gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}"' in script
+    assert "validate_source_run" in script
     assert '[ "$run_status" != "completed" ]' in script
     assert '[ "$run_conclusion" != "success" ]' in script
     assert '[ "$run_event" != "workflow_dispatch" ]' in script
-    assert '[ "$run_workflow_name" != "Release Manifest Evidence" ]' in script
-    assert '[ "$run_workflow_path" != ".github/workflows/release-manifest-evidence.yml" ]' in script
-    assert "release manifest source run head SHA does not match git_sha" in script
+    assert '"Release Manifest Evidence" ".github/workflows/release-manifest-evidence.yml"' in script
+    assert '"Docker Build and Push" ".github/workflows/build.yml"' in script
+    assert "source run head SHA does not match git_sha" in script
     assert "Build Equivalence Evidence workflow ref must match git_sha" in script
+
+
+def test_workflow_requires_governed_digest_sources_before_identity_generation() -> None:
+    script = _run_script()
+
+    assert "--label review_artifact_digest" in script
+    assert "--expected-path review_artifact_digest.txt" in script
+    assert "--label production_candidate_artifact_digest" in script
+    assert "--expected-path production_candidate_artifact_digest.txt" in script
+    assert "fetch_digest_source" in script
+    assert "gh run download" in script
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "review_artifact_digest_source" in workflow_text
+    assert "production_candidate_artifact_digest_source" in workflow_text
+    assert "governed digest source does not match explicit digest input" in script
+    assert "digest path escapes downloaded artifact" in script
 
 
 def test_workflow_generates_identities_runs_equivalence_and_uploads_stable_path() -> None:

--- a/tests/test_build_equivalence_evidence_workflow.py
+++ b/tests/test_build_equivalence_evidence_workflow.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.release import build_identity, release_manifest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/build-equivalence-evidence.yml"
+LEDGER_PATH = REPO_ROOT / "docs/roadmap/BACKLOG_LEDGER.md"
+
+ARTIFACT_DIGEST = "sha256:" + "a1" * 32
+
+
+def _load_workflow(path: Path = WORKFLOW_PATH) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _workflow_on(workflow: dict[str, Any]) -> dict[str, Any]:
+    return workflow.get("on") or workflow[True]
+
+
+def _job(workflow: dict[str, Any]) -> dict[str, Any]:
+    return workflow["jobs"]["publish-build-equivalence-evidence"]
+
+
+def _step_by_name(job: dict[str, Any], name: str) -> dict[str, Any]:
+    matches = [step for step in job["steps"] if step.get("name") == name]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _run_script() -> str:
+    return str(
+        _step_by_name(_job(_load_workflow()), "Generate governed build equivalence evidence")["run"]
+    )
+
+
+def _manifest_payload() -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": release_manifest.SCHEMA_VERSION,
+        "hash_algorithm": release_manifest.HASH_ALGORITHM,
+        "canonicalization": release_manifest.CANONICALIZATION,
+        "build_identity": {
+            "git_sha": "a" * 40,
+            "ios_build_number": "100",
+            "marketing_version": "1.0",
+            "bundle_id": "app.pulseplate.PulsePlate",
+        },
+        "reviewer_identity": {
+            "schema_version": release_manifest.REVIEWER_SCHEMA_VERSION,
+            "reviewer_notes_hash": "b" * 64,
+            "appstore_metadata_hash": "c" * 64,
+            "source_artifacts": [
+                {
+                    "kind": "reviewer_notes",
+                    "path": "docs/release/reviewer_notes.md",
+                    "hash": "d" * 64,
+                }
+            ],
+        },
+        "ml_identity": {
+            "schema_version": release_manifest.RAG_GATE_SCHEMA_VERSION,
+            "rag_gate_result_hash": "e" * 64,
+            "eval_artifact_hash": "f" * 64,
+            "release_decision": "PASS",
+            "source_artifacts": [
+                {
+                    "kind": "rag_gate_result",
+                    "path": "artifacts/release_control_plane_sources/rag_gate_result.json",
+                    "hash": "1" * 64,
+                }
+            ],
+        },
+        "supply_chain_identity": {
+            "sbom_digest": "sha256:" + "2" * 64,
+            "provenance_digest": "sha256:" + "3" * 64,
+            "attestation_status": release_manifest.VERIFIED_ATTESTATION_STATUS,
+        },
+        "release_decision": release_manifest.ALLOW_DECISION,
+        "decision_reasons": [],
+    }
+    payload["release_manifest_hash"] = release_manifest.sha256_lower_hex(
+        release_manifest.canonical_json_bytes(payload)
+    )
+    assert release_manifest.validate_manifest_payload(payload) == []
+    return payload
+
+
+def test_workflow_exists_and_is_dispatch_only() -> None:
+    workflow = _load_workflow()
+
+    assert WORKFLOW_PATH.is_file()
+    assert workflow["name"] == "Build Equivalence Evidence"
+    assert set(_workflow_on(workflow)) == {"workflow_dispatch"}
+    assert "pull_request" not in _workflow_on(workflow)
+    assert "push" not in _workflow_on(workflow)
+    assert "schedule" not in _workflow_on(workflow)
+
+
+def test_workflow_permissions_environment_and_inputs_are_bounded() -> None:
+    workflow = _load_workflow()
+    inputs = _workflow_on(workflow)["workflow_dispatch"]["inputs"]
+    expected_inputs = {
+        "git_sha",
+        "release_manifest_source",
+        "review_artifact_digest",
+        "production_candidate_artifact_digest",
+        "evidence_artifact_name",
+    }
+
+    assert set(inputs) == expected_inputs
+    assert all(inputs[name]["required"] is True for name in expected_inputs)
+    assert "run_id" in inputs["release_manifest_source"]["description"]
+    assert "artifact_name" in inputs["release_manifest_source"]["description"]
+    assert "path" in inputs["release_manifest_source"]["description"]
+    assert workflow["permissions"] == {"actions": "read", "contents": "read"}
+    assert _job(workflow)["environment"]["name"] == "release-evidence"
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "id-token:" not in workflow_text
+    assert "packages:" not in workflow_text
+
+
+def test_workflow_validates_release_manifest_source_run_and_git_sha() -> None:
+    script = _run_script()
+
+    assert "scripts/release/evidence_source.py source-env" in script
+    assert "--label release_manifest" in script
+    assert "gh run view" in script
+    assert "--json status,conclusion,headSha,event,workflowName,url" in script
+    assert 'gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_MANIFEST_RUN_ID}"' in script
+    assert '[ "$run_status" != "completed" ]' in script
+    assert '[ "$run_conclusion" != "success" ]' in script
+    assert '[ "$run_event" != "workflow_dispatch" ]' in script
+    assert '[ "$run_workflow_name" != "Release Manifest Evidence" ]' in script
+    assert '[ "$run_workflow_path" != ".github/workflows/release-manifest-evidence.yml" ]' in script
+    assert "release manifest source run head SHA does not match git_sha" in script
+    assert "Build Equivalence Evidence workflow ref must match git_sha" in script
+
+
+def test_workflow_generates_identities_runs_equivalence_and_uploads_stable_path() -> None:
+    workflow = _load_workflow()
+    script = _run_script()
+    upload_step = _step_by_name(
+        _job(workflow), "Upload governed build equivalence evidence artifact"
+    )
+    summary_script = str(
+        _step_by_name(_job(workflow), "Publish build equivalence evidence summary")["run"]
+    )
+
+    assert "scripts/release/evidence_source.py oci-digest --label review_artifact_digest" in script
+    assert (
+        "scripts/release/evidence_source.py oci-digest --label production_candidate_artifact_digest"
+        in script
+    )
+    assert "release_manifest path escapes downloaded artifact" in script
+    assert "scripts/release/release_manifest.py validate" in script
+    assert "scripts/release/build_identity.py" in script
+    assert '--artifact-digest "$REVIEW_ARTIFACT_DIGEST"' in script
+    assert '--artifact-digest "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST"' in script
+    assert "review_build_identity.json" in script
+    assert "production_candidate_identity.json" in script
+    assert "scripts/release/build_equivalence.py" in script
+    assert "--review-build" in script
+    assert "--production-candidate" in script
+    assert "--release-manifest" in script
+    assert (
+        upload_step["with"]["path"]
+        == "${{ runner.temp }}/build-equivalence-evidence/build_equivalence_result.json"
+    )
+    assert upload_step["with"]["if-no-files-found"] == "error"
+    assert "GITHUB_RUN_ID" in summary_script
+    assert "build_equivalence_result.json" in summary_script
+
+
+def test_build_identity_helper_derives_existing_contract_without_new_manifest_format() -> None:
+    manifest_payload = _manifest_payload()
+    payload = build_identity.build_identity_payload(
+        manifest_payload=manifest_payload,
+        artifact_digest=ARTIFACT_DIGEST,
+    )
+
+    assert payload["schema_version"] == "release-build-identity.v1"
+    assert payload["hash_algorithm"] == release_manifest.HASH_ALGORITHM
+    assert payload["canonicalization"] == release_manifest.CANONICALIZATION
+    assert payload["build_identity"] == manifest_payload["build_identity"]
+    assert payload["artifact_digest"] == ARTIFACT_DIGEST
+    assert payload["release_manifest_hash"] == manifest_payload["release_manifest_hash"]
+    assert payload["reviewer_identity"] == manifest_payload["reviewer_identity"]
+    assert payload["ml_identity"] == manifest_payload["ml_identity"]
+    assert payload["supply_chain_identity"] == manifest_payload["supply_chain_identity"]
+
+
+def test_build_identity_helper_rejects_invalid_manifest_and_placeholder_digest() -> None:
+    manifest_payload = _manifest_payload()
+
+    for digest in ("sha256:" + "0" * 64, "a" * 64, "sha256:" + "A" * 64):
+        try:
+            build_identity.build_identity_payload(
+                manifest_payload=manifest_payload,
+                artifact_digest=digest,
+            )
+        except build_identity.BuildIdentityError:
+            continue
+        raise AssertionError(f"Expected digest to be rejected: {digest}")
+
+    invalid_manifest = dict(manifest_payload)
+    invalid_manifest["release_manifest_hash"] = "0" * 64
+    try:
+        build_identity.build_identity_payload(
+            manifest_payload=invalid_manifest,
+            artifact_digest=ARTIFACT_DIGEST,
+        )
+    except build_identity.BuildIdentityError:
+        pass
+    else:
+        raise AssertionError("Expected invalid manifest to be rejected")
+
+
+def test_workflow_has_no_app_store_fastlane_or_runtime_surface() -> None:
+    workflow_json = json.dumps(_load_workflow(), default=str).lower()
+
+    forbidden_terms = (
+        "fastlane",
+        "upload_to_app_store",
+        "app-store-connect",
+        "app_store_connect",
+        "asc_",
+        "match_password",
+        "frontend/",
+        "ios/",
+        "openapi",
+        "release control plane evidence",
+    )
+    assert not any(term in workflow_json for term in forbidden_terms)
+    assert "ci/release-control-plane-source-producers" in LEDGER_PATH.read_text(encoding="utf-8")

--- a/tests/test_release_control_plane_evidence_publication_workflow.py
+++ b/tests/test_release_control_plane_evidence_publication_workflow.py
@@ -8,6 +8,8 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/release-control-plane-evidence.yml"
+RELEASE_MANIFEST_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/release-manifest-evidence.yml"
+BUILD_EQUIVALENCE_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/build-equivalence-evidence.yml"
 CD_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/cd.yml"
 DOC_PATH = REPO_ROOT / "docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md"
 CI_GATE_DOC_PATH = REPO_ROOT / "docs/release/RELEASE_CONTROL_PLANE_CI_GATE.md"
@@ -125,6 +127,14 @@ def test_workflow_downloads_governed_sources_and_publishes_canonical_layout() ->
         'build_equivalence_expected_workflow_path=".github/workflows/build-equivalence-evidence.yml"'
         in collect_script
     )
+    assert RELEASE_MANIFEST_WORKFLOW_PATH.is_file()
+    assert BUILD_EQUIVALENCE_WORKFLOW_PATH.is_file()
+    assert yaml.safe_load(RELEASE_MANIFEST_WORKFLOW_PATH.read_text(encoding="utf-8"))["name"] == (
+        "Release Manifest Evidence"
+    )
+    assert yaml.safe_load(BUILD_EQUIVALENCE_WORKFLOW_PATH.read_text(encoding="utf-8"))["name"] == (
+        "Build Equivalence Evidence"
+    )
     assert "scripts/ci/check_release_control_plane.py" in collect_script
 
     for canonical_path in (
@@ -223,7 +233,9 @@ def test_docs_define_publication_ceremony_and_virtualenv_policy() -> None:
         "do not run production publication or set production CD evidence variables"
         in docs.replace("\n", " ")
     )
-    assert "If no governed source workflow exists" in docs.replace("\n", " ")
+    assert "ad hoc workflow runs" in docs
+    assert "operator-supplied workflow names" in docs
+    assert "reserved" not in docs.lower()
     assert "release-control-plane/release_manifest.json" in docs
     assert "release-control-plane/rag_gate_result.json" in docs
     assert "release-control-plane/build_equivalence_result.json" in docs
@@ -244,7 +256,10 @@ def test_ledger_and_epic_record_followup_without_closing_release_readiness() -> 
     for content in (ledger, epic, task_packet):
         assert "ci/release-control-plane-evidence-publication" in content
         assert "PR #1692" in content
+        assert "ci/release-control-plane-source-producers" in content
 
+    assert "PR #1699 merged" in ledger
+    assert "active `ci/release-control-plane-source-producers`" in ledger
     assert "full App Store readiness is not complete" in ledger
     assert "train is not production-ready" in ledger
     assert "App Store Connect execution" in ledger

--- a/tests/test_release_manifest_evidence_workflow.py
+++ b/tests/test_release_manifest_evidence_workflow.py
@@ -12,6 +12,7 @@ from scripts.release import evidence_source, release_manifest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/release-manifest-evidence.yml"
 RAG_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/rag-release-gates.yml"
+BUILD_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/build.yml"
 LEDGER_PATH = REPO_ROOT / "docs/roadmap/BACKLOG_LEDGER.md"
 
 
@@ -85,8 +86,11 @@ def test_workflow_permissions_environment_and_inputs_are_bounded() -> None:
         "marketing_version",
         "bundle_id",
         "sbom_digest",
+        "sbom_digest_source",
         "provenance_digest",
+        "provenance_digest_source",
         "attestation_status",
+        "attestation_status_source",
         "rag_gate_result_source",
         "evidence_artifact_name",
     }
@@ -97,6 +101,9 @@ def test_workflow_permissions_environment_and_inputs_are_bounded() -> None:
     assert "run_id" in inputs["rag_gate_result_source"]["description"]
     assert "artifact_name" in inputs["rag_gate_result_source"]["description"]
     assert "path" in inputs["rag_gate_result_source"]["description"]
+    assert "sbom_digest.txt" in inputs["sbom_digest_source"]["description"]
+    assert "provenance_digest.txt" in inputs["provenance_digest_source"]["description"]
+    assert "attestation_status.txt" in inputs["attestation_status_source"]["description"]
     assert workflow["permissions"] == {"actions": "read", "contents": "read"}
     assert _job(workflow)["environment"]["name"] == "release-evidence"
     workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
@@ -113,13 +120,14 @@ def test_workflow_validates_governed_rag_source_run_and_git_sha() -> None:
     assert "source-env" in script and "run_id, artifact_name, path" not in script
     assert "gh run view" in script
     assert "--json status,conclusion,headSha,event,workflowName,url" in script
-    assert 'gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RAG_GATE_RESULT_RUN_ID}"' in script
+    assert 'gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}"' in script
+    assert "validate_source_run" in script
     assert '[ "$run_status" != "completed" ]' in script
     assert '[ "$run_conclusion" != "success" ]' in script
     assert '[ "$run_event" != "workflow_dispatch" ]' in script
-    assert '[ "$run_workflow_name" != "RAG Release Gates" ]' in script
-    assert '[ "$run_workflow_path" != ".github/workflows/rag-release-gates.yml" ]' in script
-    assert "RAG source run head SHA does not match git_sha" in script
+    assert '"RAG Release Gates" ".github/workflows/rag-release-gates.yml"' in script
+    assert '"Docker Build and Push" ".github/workflows/build.yml"' in script
+    assert "source run head SHA does not match git_sha" in script
     assert "Release Manifest Evidence workflow ref must match git_sha" in script
     assert "scripts/release/evidence_source.py rag-gate-result" in script
     assert "rag_gate_result.git_sha must match git_sha" in _helper_text()
@@ -143,6 +151,21 @@ def test_workflow_rejects_fixture_sample_test_fallback_and_requires_pass() -> No
     assert "Path(sys.argv[1]).resolve()" in script
     assert "scripts/release/evidence_source.py rag-gate-result" in script
     assert "artifacts/release_control_plane_sources" in script
+
+
+def test_workflow_requires_governed_supply_chain_sources() -> None:
+    script = _run_script()
+
+    assert "--label sbom_digest" in script
+    assert "--expected-path sbom_digest.txt" in script
+    assert "--label provenance_digest" in script
+    assert "--expected-path provenance_digest.txt" in script
+    assert "--label attestation_status" in script
+    assert "--expected-path attestation_status.txt" in script
+    assert "fetch_text_source" in script
+    assert "governed ${label} source does not match explicit input" in script
+    assert "governed attestation status source must be VERIFIED" in script
+    assert "path escapes downloaded artifact" in script
 
 
 def test_workflow_generates_validates_and_uploads_stable_manifest_path() -> None:
@@ -269,3 +292,28 @@ def test_release_manifest_source_validation_rejects_sample_test_paths_and_sha_mi
     rag_triggers = _workflow_on(_load_workflow(RAG_WORKFLOW_PATH))
     assert "workflow_dispatch" in rag_triggers
     assert "ci/release-control-plane-source-producers" in LEDGER_PATH.read_text(encoding="utf-8")
+
+
+def test_docker_build_workflow_emits_governed_release_control_plane_sources() -> None:
+    workflow_text = BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")
+    workflow = _load_workflow(BUILD_WORKFLOW_PATH)
+    publish_steps = workflow["jobs"]["publish"]["steps"]
+    upload_step = next(
+        step
+        for step in publish_steps
+        if step.get("name") == "Upload release-control-plane build digest sources"
+    )
+
+    assert "id: docker-build-push" in workflow_text
+    assert "Prepare release-control-plane build digest sources" in workflow_text
+    for path in (
+        "review_artifact_digest.txt",
+        "production_candidate_artifact_digest.txt",
+        "sbom_digest.txt",
+        "provenance_digest.txt",
+        "attestation_status.txt",
+    ):
+        assert path in workflow_text
+        assert path in upload_step["with"]["path"]
+    assert upload_step["with"]["name"] == "release-control-plane-build-sources"
+    assert upload_step["with"]["if-no-files-found"] == "error"

--- a/tests/test_release_manifest_evidence_workflow.py
+++ b/tests/test_release_manifest_evidence_workflow.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.release import evidence_source, release_manifest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/release-manifest-evidence.yml"
+RAG_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/rag-release-gates.yml"
+LEDGER_PATH = REPO_ROOT / "docs/roadmap/BACKLOG_LEDGER.md"
+
+
+def _load_workflow(path: Path = WORKFLOW_PATH) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _workflow_on(workflow: dict[str, Any]) -> dict[str, Any]:
+    return workflow.get("on") or workflow[True]
+
+
+def _job(workflow: dict[str, Any]) -> dict[str, Any]:
+    return workflow["jobs"]["publish-release-manifest-evidence"]
+
+
+def _step_by_name(job: dict[str, Any], name: str) -> dict[str, Any]:
+    matches = [step for step in job["steps"] if step.get("name") == name]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _run_script() -> str:
+    return str(
+        _step_by_name(_job(_load_workflow()), "Generate governed release manifest evidence")["run"]
+    )
+
+
+def _rag_payload(tmp_path: Path) -> Path:
+    payload: dict[str, Any] = {
+        "schema_version": release_manifest.RAG_GATE_SCHEMA_VERSION,
+        "hash_algorithm": release_manifest.HASH_ALGORITHM,
+        "canonicalization": release_manifest.CANONICALIZATION,
+        "eval_artifact_hash": "b" * 64,
+        "release_decision": "PASS",
+        "dataset_fallback_used": False,
+        "small_fixture_metric_gates_advisory": False,
+        "source_artifacts": [
+            {"kind": "eval_input", "path": "data/evals/release.jsonl", "hash": "c" * 64}
+        ],
+    }
+    payload["rag_gate_result_hash"] = release_manifest.sha256_lower_hex(
+        release_manifest.canonical_json_bytes(payload)
+    )
+    path = tmp_path / "rag_gate_result.json"
+    path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_workflow_exists_and_is_dispatch_only() -> None:
+    workflow = _load_workflow()
+
+    assert WORKFLOW_PATH.is_file()
+    assert workflow["name"] == "Release Manifest Evidence"
+    assert set(_workflow_on(workflow)) == {"workflow_dispatch"}
+    assert "pull_request" not in _workflow_on(workflow)
+    assert "push" not in _workflow_on(workflow)
+    assert "schedule" not in _workflow_on(workflow)
+
+
+def test_workflow_permissions_environment_and_inputs_are_bounded() -> None:
+    workflow = _load_workflow()
+    inputs = _workflow_on(workflow)["workflow_dispatch"]["inputs"]
+    expected_inputs = {
+        "git_sha",
+        "ios_build_number",
+        "marketing_version",
+        "bundle_id",
+        "sbom_digest",
+        "provenance_digest",
+        "attestation_status",
+        "rag_gate_result_source",
+        "evidence_artifact_name",
+    }
+
+    assert set(inputs) == expected_inputs
+    assert all(inputs[name]["required"] is True for name in expected_inputs)
+    assert inputs["attestation_status"]["options"] == ["VERIFIED", "FAILED", "MISSING", "PENDING"]
+    assert "run_id" in inputs["rag_gate_result_source"]["description"]
+    assert "artifact_name" in inputs["rag_gate_result_source"]["description"]
+    assert "path" in inputs["rag_gate_result_source"]["description"]
+    assert workflow["permissions"] == {"actions": "read", "contents": "read"}
+    assert _job(workflow)["environment"]["name"] == "release-evidence"
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "id-token:" not in workflow_text
+    assert "packages:" not in workflow_text
+
+
+def test_workflow_validates_governed_rag_source_run_and_git_sha() -> None:
+    script = _run_script()
+
+    assert "scripts/release/evidence_source.py source-env" in script
+    assert "--label rag_gate_result" in script
+    assert "source-env" in script and "run_id, artifact_name, path" not in script
+    assert "gh run view" in script
+    assert "--json status,conclusion,headSha,event,workflowName,url" in script
+    assert 'gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RAG_GATE_RESULT_RUN_ID}"' in script
+    assert '[ "$run_status" != "completed" ]' in script
+    assert '[ "$run_conclusion" != "success" ]' in script
+    assert '[ "$run_event" != "workflow_dispatch" ]' in script
+    assert '[ "$run_workflow_name" != "RAG Release Gates" ]' in script
+    assert '[ "$run_workflow_path" != ".github/workflows/rag-release-gates.yml" ]' in script
+    assert "RAG source run head SHA does not match git_sha" in script
+    assert "Release Manifest Evidence workflow ref must match git_sha" in script
+    assert "scripts/release/evidence_source.py git-sha" in script
+
+
+def test_workflow_rejects_fixture_sample_fallback_and_requires_pass() -> None:
+    script = _run_script()
+
+    for token in ("fixture", "sample", "example", "placeholder", "fake", "fallback"):
+        assert token in script
+    assert "dataset_fallback_used must be false" in script
+    assert "small_fixture_metric_gates_advisory must be false" in script
+    assert "release_decision must be PASS" in script
+    assert "attestation_status must be VERIFIED" in script
+    assert "rag_gate_result path escapes downloaded artifact" in script
+    assert "artifacts/release_control_plane_sources" in script
+
+
+def test_workflow_generates_validates_and_uploads_stable_manifest_path() -> None:
+    workflow = _load_workflow()
+    script = _run_script()
+    upload_step = _step_by_name(
+        _job(workflow), "Upload governed release manifest evidence artifact"
+    )
+    summary_script = str(
+        _step_by_name(_job(workflow), "Publish release manifest evidence summary")["run"]
+    )
+
+    assert "scripts/release/release_manifest.py generate" in script
+    assert "--rag-gate-result" in script
+    assert "--sbom-digest" in script
+    assert "--provenance-digest" in script
+    assert "--attestation-status" in script
+    assert "scripts/release/release_manifest.py validate" in script
+    assert (
+        upload_step["with"]["path"]
+        == "${{ runner.temp }}/release-manifest-evidence/release_manifest.json"
+    )
+    assert upload_step["with"]["if-no-files-found"] == "error"
+    assert "GITHUB_RUN_ID" in summary_script
+    assert "release_manifest.json" in summary_script
+
+
+def test_workflow_has_no_app_store_fastlane_or_runtime_surface() -> None:
+    workflow_json = json.dumps(_load_workflow(), default=str).lower()
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8").lower()
+
+    forbidden_terms = (
+        "fastlane",
+        "upload_to_app_store",
+        "app-store-connect",
+        "app_store_connect",
+        "asc_",
+        "match_password",
+        "frontend/",
+        "ios/",
+        "openapi",
+    )
+    assert not any(term in workflow_json for term in forbidden_terms)
+    assert ".github/workflows/rag-release-gates.yml" in workflow_text
+
+
+def test_evidence_source_helper_rejects_malformed_source_and_unsafe_paths() -> None:
+    valid = '{"run_id":"123","artifact_name":"rag-release-gates-weekly","path":"artifacts/rag/rag_gate_result.json"}'
+    assert (
+        evidence_source.validate_source_payload(valid, label="rag_gate_result")["run_id"] == "123"
+    )
+
+    invalid_payloads = [
+        "{not json}",
+        '{"run_id":"123","artifact_name":"ok","path":"../rag_gate_result.json"}',
+        '{"run_id":"123","artifact_name":"ok","path":"/rag_gate_result.json"}',
+        '{"run_id":"123","artifact_name":"ok","path":"a//rag_gate_result.json"}',
+        '{"run_id":"123","artifact_name":"fixture","path":"rag_gate_result.json"}',
+        '{"run_id":"abc","artifact_name":"ok","path":"rag_gate_result.json"}',
+        '{"run_id":"123","artifact_name":"ok","path":"rag_gate_result.json","workflow_name":"RAG Release Gates"}',
+    ]
+    for raw_json in invalid_payloads:
+        with pytest.raises(evidence_source.EvidenceSourceError):
+            evidence_source.validate_source_payload(raw_json, label="rag_gate_result")
+
+
+def test_evidence_source_helper_requires_full_sha_and_non_placeholder_digests() -> None:
+    assert evidence_source.validate_git_sha("A" * 40) == "a" * 40
+    assert evidence_source.validate_oci_digest("sha256:" + "a1" * 32, label="digest")
+
+    for value in ("deadbeef", "g" * 40):
+        with pytest.raises(evidence_source.EvidenceSourceError):
+            evidence_source.validate_git_sha(value)
+    for value in ("sha256:" + "0" * 64, "a" * 64, "sha256:" + "A" * 64):
+        with pytest.raises(evidence_source.EvidenceSourceError):
+            evidence_source.validate_oci_digest(value, label="digest")
+
+
+def test_release_manifest_generation_rejects_sample_rag_fixture(tmp_path: Path) -> None:
+    rag_path = _rag_payload(tmp_path)
+    rag_payload = json.loads(rag_path.read_text(encoding="utf-8"))
+    rag_payload["source_artifacts"][0]["path"] = "data/evals/pulseplate_rag_eval_sample.jsonl"
+    rag_path.write_text(json.dumps(rag_payload, sort_keys=True) + "\n", encoding="utf-8")
+
+    script = _run_script()
+    assert "data/evals/pulseplate_rag_eval_sample.jsonl" not in script
+    rag_triggers = _workflow_on(_load_workflow(RAG_WORKFLOW_PATH))
+    assert "workflow_dispatch" in rag_triggers
+    assert "ci/release-control-plane-source-producers" in LEDGER_PATH.read_text(encoding="utf-8")

--- a/tests/test_release_manifest_evidence_workflow.py
+++ b/tests/test_release_manifest_evidence_workflow.py
@@ -163,6 +163,8 @@ def test_workflow_requires_governed_supply_chain_sources() -> None:
     assert "--label attestation_status" in script
     assert "--expected-path attestation_status.txt" in script
     assert "fetch_text_source" in script
+    assert "sources must come from the same Docker Build and Push run" in script
+    assert "sources must come from the same artifact" in script
     assert "governed ${label} source does not match explicit input" in script
     assert "governed attestation status source must be VERIFIED" in script
     assert "path escapes downloaded artifact" in script

--- a/tests/test_release_manifest_evidence_workflow.py
+++ b/tests/test_release_manifest_evidence_workflow.py
@@ -39,6 +39,10 @@ def _run_script() -> str:
     )
 
 
+def _helper_text() -> str:
+    return (REPO_ROOT / "scripts/release/evidence_source.py").read_text(encoding="utf-8")
+
+
 def _rag_payload(tmp_path: Path) -> Path:
     payload: dict[str, Any] = {
         "schema_version": release_manifest.RAG_GATE_SCHEMA_VERSION,
@@ -117,21 +121,27 @@ def test_workflow_validates_governed_rag_source_run_and_git_sha() -> None:
     assert '[ "$run_workflow_path" != ".github/workflows/rag-release-gates.yml" ]' in script
     assert "RAG source run head SHA does not match git_sha" in script
     assert "Release Manifest Evidence workflow ref must match git_sha" in script
-    assert "rag_gate_result.git_sha must match git_sha" in script
+    assert "scripts/release/evidence_source.py rag-gate-result" in script
+    assert "rag_gate_result.git_sha must match git_sha" in _helper_text()
     assert "scripts/release/evidence_source.py git-sha" in script
 
 
-def test_workflow_rejects_fixture_sample_fallback_and_requires_pass() -> None:
+def test_workflow_rejects_fixture_sample_test_fallback_and_requires_pass() -> None:
     script = _run_script()
 
+    helper = _helper_text()
+
     for token in ("fixture", "sample", "example", "placeholder", "fake", "fallback"):
-        assert token in script
-    assert "dataset_fallback_used must be false" in script
-    assert "small_fixture_metric_gates_advisory must be false" in script
-    assert "release_decision must be PASS" in script
+        assert token in helper
+    assert "FORBIDDEN_TEST_PATH_RE" in helper
+    assert "test evidence path rejected" in helper
+    assert "dataset_fallback_used must be false" in helper
+    assert "small_fixture_metric_gates_advisory must be false" in helper
+    assert "release_decision must be PASS" in helper
     assert "attestation_status must be VERIFIED" in script
     assert "rag_gate_result path escapes downloaded artifact" in script
     assert "Path(sys.argv[1]).resolve()" in script
+    assert "scripts/release/evidence_source.py rag-gate-result" in script
     assert "artifacts/release_control_plane_sources" in script
 
 
@@ -234,14 +244,28 @@ def test_evidence_source_helper_requires_full_sha_and_non_placeholder_digests() 
             evidence_source.validate_oci_digest(value, label="digest")
 
 
-def test_release_manifest_generation_rejects_sample_rag_fixture(tmp_path: Path) -> None:
+def test_release_manifest_source_validation_rejects_sample_test_paths_and_sha_mismatch(
+    tmp_path: Path,
+) -> None:
     rag_path = _rag_payload(tmp_path)
     rag_payload = json.loads(rag_path.read_text(encoding="utf-8"))
     rag_payload["source_artifacts"][0]["path"] = "data/evals/pulseplate_rag_eval_sample.jsonl"
     rag_path.write_text(json.dumps(rag_payload, sort_keys=True) + "\n", encoding="utf-8")
 
-    script = _run_script()
-    assert "data/evals/pulseplate_rag_eval_sample.jsonl" not in script
+    with pytest.raises(evidence_source.EvidenceSourceError):
+        evidence_source.validate_rag_gate_result_file(rag_path, expected_git_sha="a" * 40)
+
+    rag_payload["source_artifacts"][0]["path"] = "tests/evals/release.jsonl"
+    rag_path.write_text(json.dumps(rag_payload, sort_keys=True) + "\n", encoding="utf-8")
+    with pytest.raises(evidence_source.EvidenceSourceError):
+        evidence_source.validate_rag_gate_result_file(rag_path, expected_git_sha="a" * 40)
+
+    rag_payload["source_artifacts"][0]["path"] = "data/evals/release.jsonl"
+    rag_payload["git_sha"] = "b" * 40
+    rag_path.write_text(json.dumps(rag_payload, sort_keys=True) + "\n", encoding="utf-8")
+    with pytest.raises(evidence_source.EvidenceSourceError):
+        evidence_source.validate_rag_gate_result_file(rag_path, expected_git_sha="a" * 40)
+
     rag_triggers = _workflow_on(_load_workflow(RAG_WORKFLOW_PATH))
     assert "workflow_dispatch" in rag_triggers
     assert "ci/release-control-plane-source-producers" in LEDGER_PATH.read_text(encoding="utf-8")

--- a/tests/test_release_manifest_evidence_workflow.py
+++ b/tests/test_release_manifest_evidence_workflow.py
@@ -299,6 +299,7 @@ def test_release_manifest_source_validation_rejects_sample_test_paths_and_sha_mi
 def test_docker_build_workflow_emits_governed_release_control_plane_sources() -> None:
     workflow_text = BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")
     workflow = _load_workflow(BUILD_WORKFLOW_PATH)
+    publish_job = workflow["jobs"]["publish"]
     publish_steps = workflow["jobs"]["publish"]["steps"]
     upload_step = next(
         step
@@ -306,6 +307,9 @@ def test_docker_build_workflow_emits_governed_release_control_plane_sources() ->
         if step.get("name") == "Upload release-control-plane build digest sources"
     )
 
+    assert "artifact-metadata" not in publish_job["permissions"]
+    assert publish_job["permissions"]["attestations"] == "write"
+    assert publish_job["permissions"]["id-token"] == "write"
     assert "id: docker-build-push" in workflow_text
     assert "Attest Docker image provenance" in workflow_text
     assert "Attest Docker image SBOM" in workflow_text

--- a/tests/test_release_manifest_evidence_workflow.py
+++ b/tests/test_release_manifest_evidence_workflow.py
@@ -305,15 +305,22 @@ def test_docker_build_workflow_emits_governed_release_control_plane_sources() ->
     )
 
     assert "id: docker-build-push" in workflow_text
+    assert "Attest Docker image provenance" in workflow_text
+    assert "Attest Docker image SBOM" in workflow_text
+    assert "Verify Docker image attestations" in workflow_text
+    assert "scripts/ci/check_docker_provenance_attestation.py" in workflow_text
+    assert "docker-provenance-attestation-check.json" in workflow_text
     assert "Prepare release-control-plane build digest sources" in workflow_text
     for path in (
-        "review_artifact_digest.txt",
-        "production_candidate_artifact_digest.txt",
         "sbom_digest.txt",
         "provenance_digest.txt",
         "attestation_status.txt",
     ):
         assert path in workflow_text
         assert path in upload_step["with"]["path"]
+    assert "review_artifact_digest.txt" not in upload_step["with"]["path"]
+    assert "production_candidate_artifact_digest.txt" not in upload_step["with"]["path"]
+    assert 'write_text("VERIFIED\\n", encoding="utf-8")' in workflow_text
+    assert 'attestation_payload.get("passed") is not True' in workflow_text
     assert upload_step["with"]["name"] == "release-control-plane-build-sources"
     assert upload_step["with"]["if-no-files-found"] == "error"

--- a/tests/test_release_manifest_evidence_workflow.py
+++ b/tests/test_release_manifest_evidence_workflow.py
@@ -86,24 +86,25 @@ def test_workflow_permissions_environment_and_inputs_are_bounded() -> None:
         "marketing_version",
         "bundle_id",
         "sbom_digest",
-        "sbom_digest_source",
         "provenance_digest",
-        "provenance_digest_source",
         "attestation_status",
-        "attestation_status_source",
+        "supply_chain_source",
         "rag_gate_result_source",
         "evidence_artifact_name",
     }
 
     assert set(inputs) == expected_inputs
+    assert len(inputs) == 10
     assert all(inputs[name]["required"] is True for name in expected_inputs)
     assert inputs["attestation_status"]["options"] == ["VERIFIED", "FAILED", "MISSING", "PENDING"]
     assert "run_id" in inputs["rag_gate_result_source"]["description"]
     assert "artifact_name" in inputs["rag_gate_result_source"]["description"]
     assert "path" in inputs["rag_gate_result_source"]["description"]
-    assert "sbom_digest.txt" in inputs["sbom_digest_source"]["description"]
-    assert "provenance_digest.txt" in inputs["provenance_digest_source"]["description"]
-    assert "attestation_status.txt" in inputs["attestation_status_source"]["description"]
+    assert "run_id" in inputs["supply_chain_source"]["description"]
+    assert "artifact_name" in inputs["supply_chain_source"]["description"]
+    assert (
+        "path=release-control-plane-build-sources" in inputs["supply_chain_source"]["description"]
+    )
     assert workflow["permissions"] == {"actions": "read", "contents": "read"}
     assert _job(workflow)["environment"]["name"] == "release-evidence"
     workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
@@ -155,16 +156,19 @@ def test_workflow_rejects_fixture_sample_test_fallback_and_requires_pass() -> No
 
 def test_workflow_requires_governed_supply_chain_sources() -> None:
     script = _run_script()
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
 
-    assert "--label sbom_digest" in script
-    assert "--expected-path sbom_digest.txt" in script
-    assert "--label provenance_digest" in script
-    assert "--expected-path provenance_digest.txt" in script
-    assert "--label attestation_status" in script
-    assert "--expected-path attestation_status.txt" in script
+    assert "sbom_digest_source" not in workflow_text
+    assert "provenance_digest_source" not in workflow_text
+    assert "attestation_status_source" not in workflow_text
+    assert "--label supply_chain" in script
+    assert "--expected-path release-control-plane-build-sources" in script
+    assert '"Docker Build and Push" ".github/workflows/build.yml"' in script
+    assert 'gh run download "$supply_chain_run_id"' in script
     assert "fetch_text_source" in script
-    assert "sources must come from the same Docker Build and Push run" in script
-    assert "sources must come from the same artifact" in script
+    assert "${supply_chain_source_path}/sbom_digest.txt" in script
+    assert "${supply_chain_source_path}/provenance_digest.txt" in script
+    assert "${supply_chain_source_path}/attestation_status.txt" in script
     assert "governed ${label} source does not match explicit input" in script
     assert "governed attestation status source must be VERIFIED" in script
     assert "path escapes downloaded artifact" in script

--- a/tests/test_release_manifest_evidence_workflow.py
+++ b/tests/test_release_manifest_evidence_workflow.py
@@ -152,6 +152,7 @@ def test_workflow_rejects_fixture_sample_test_fallback_and_requires_pass() -> No
     assert "Path(sys.argv[1]).resolve()" in script
     assert "scripts/release/evidence_source.py rag-gate-result" in script
     assert "artifacts/release_control_plane_sources" in script
+    assert 'args.command == "artifact-name"' in helper
 
 
 def test_workflow_requires_governed_supply_chain_sources() -> None:
@@ -229,6 +230,13 @@ def test_evidence_source_helper_rejects_malformed_source_and_unsafe_paths() -> N
     assert (
         evidence_source.validate_source_payload(valid, label="rag_gate_result")["run_id"] == "123"
     )
+    assert (
+        evidence_source.validate_source_payload(
+            '{"run_id":"123","artifact_name":"latest-release-evidence","path":"latest/rag_gate_result.json"}',
+            label="rag_gate_result",
+        )["path"]
+        == "latest/rag_gate_result.json"
+    )
     canonical = (
         '{"run_id":"123","artifact_name":"rag-release-gates-weekly","path":"rag_gate_result.json"}'
     )
@@ -288,6 +296,12 @@ def test_release_manifest_source_validation_rejects_sample_test_paths_and_sha_mi
     rag_path.write_text(json.dumps(rag_payload, sort_keys=True) + "\n", encoding="utf-8")
     with pytest.raises(evidence_source.EvidenceSourceError):
         evidence_source.validate_rag_gate_result_file(rag_path, expected_git_sha="a" * 40)
+
+    for unsafe_path in ("../prod/release.jsonl", "/prod/release.jsonl", "data//release.jsonl"):
+        rag_payload["source_artifacts"][0]["path"] = unsafe_path
+        rag_path.write_text(json.dumps(rag_payload, sort_keys=True) + "\n", encoding="utf-8")
+        with pytest.raises(evidence_source.EvidenceSourceError):
+            evidence_source.validate_rag_gate_result_file(rag_path, expected_git_sha="a" * 40)
 
     rag_payload["source_artifacts"][0]["path"] = "data/evals/release.jsonl"
     rag_payload["git_sha"] = "b" * 40

--- a/tests/test_release_manifest_evidence_workflow.py
+++ b/tests/test_release_manifest_evidence_workflow.py
@@ -48,6 +48,7 @@ def _rag_payload(tmp_path: Path) -> Path:
         "release_decision": "PASS",
         "dataset_fallback_used": False,
         "small_fixture_metric_gates_advisory": False,
+        "git_sha": "a" * 40,
         "source_artifacts": [
             {"kind": "eval_input", "path": "data/evals/release.jsonl", "hash": "c" * 64}
         ],
@@ -104,6 +105,7 @@ def test_workflow_validates_governed_rag_source_run_and_git_sha() -> None:
 
     assert "scripts/release/evidence_source.py source-env" in script
     assert "--label rag_gate_result" in script
+    assert "--expected-path rag_gate_result.json" in script
     assert "source-env" in script and "run_id, artifact_name, path" not in script
     assert "gh run view" in script
     assert "--json status,conclusion,headSha,event,workflowName,url" in script
@@ -115,6 +117,7 @@ def test_workflow_validates_governed_rag_source_run_and_git_sha() -> None:
     assert '[ "$run_workflow_path" != ".github/workflows/rag-release-gates.yml" ]' in script
     assert "RAG source run head SHA does not match git_sha" in script
     assert "Release Manifest Evidence workflow ref must match git_sha" in script
+    assert "rag_gate_result.git_sha must match git_sha" in script
     assert "scripts/release/evidence_source.py git-sha" in script
 
 
@@ -128,6 +131,7 @@ def test_workflow_rejects_fixture_sample_fallback_and_requires_pass() -> None:
     assert "release_decision must be PASS" in script
     assert "attestation_status must be VERIFIED" in script
     assert "rag_gate_result path escapes downloaded artifact" in script
+    assert "Path(sys.argv[1]).resolve()" in script
     assert "artifacts/release_control_plane_sources" in script
 
 
@@ -151,7 +155,13 @@ def test_workflow_generates_validates_and_uploads_stable_manifest_path() -> None
         upload_step["with"]["path"]
         == "${{ runner.temp }}/release-manifest-evidence/release_manifest.json"
     )
+    assert (
+        upload_step["with"]["name"]
+        == "${{ steps.generate-release-manifest-evidence.outputs.artifact_name }}"
+    )
+    assert "${{ inputs.evidence_artifact_name }}" not in upload_step["with"]["name"]
     assert upload_step["with"]["if-no-files-found"] == "error"
+    assert 'echo "artifact_name=$EVIDENCE_ARTIFACT_NAME" >> "$GITHUB_OUTPUT"' in script
     assert "GITHUB_RUN_ID" in summary_script
     assert "release_manifest.json" in summary_script
 
@@ -180,6 +190,17 @@ def test_evidence_source_helper_rejects_malformed_source_and_unsafe_paths() -> N
     assert (
         evidence_source.validate_source_payload(valid, label="rag_gate_result")["run_id"] == "123"
     )
+    canonical = (
+        '{"run_id":"123","artifact_name":"rag-release-gates-weekly","path":"rag_gate_result.json"}'
+    )
+    assert (
+        evidence_source.validate_source_payload(
+            canonical,
+            label="rag_gate_result",
+            expected_path="rag_gate_result.json",
+        )["path"]
+        == "rag_gate_result.json"
+    )
 
     invalid_payloads = [
         "{not json}",
@@ -193,6 +214,12 @@ def test_evidence_source_helper_rejects_malformed_source_and_unsafe_paths() -> N
     for raw_json in invalid_payloads:
         with pytest.raises(evidence_source.EvidenceSourceError):
             evidence_source.validate_source_payload(raw_json, label="rag_gate_result")
+    with pytest.raises(evidence_source.EvidenceSourceError):
+        evidence_source.validate_source_payload(
+            valid,
+            label="rag_gate_result",
+            expected_path="rag_gate_result.json",
+        )
 
 
 def test_evidence_source_helper_requires_full_sha_and_non_placeholder_digests() -> None:


### PR DESCRIPTION
## Summary

Adds governed release-control-plane source producers for the PR #1699 publication workflow.

This PR adds `Release Manifest Evidence` and `Build Equivalence Evidence`, wires governed source artifacts into the existing Docker build publish lane, and keeps production release evidence fail-closed without adding App Store upload execution.

## Goal

Complete repo-owned source producers for the release-control-plane evidence chain: governed producers -> governed publisher -> production CD gate.

## Business reason

PR #1699 made publication explicit and governed. This slice makes the upstream source side deterministic so release evidence publication does not depend on ad hoc source runs or fixture evidence.

## Scope

- Add `Release Manifest Evidence` workflow.
- Add `Build Equivalence Evidence` workflow.
- Add deterministic release build identity helper and source input validation helper.
- Publish supply-chain source files from `Docker Build and Push` only after exact-digest provenance/SBOM attestation verification passes.
- Update release-control-plane ledger/docs/task packet.
- Add workflow/source-producer guard tests.

## Out of scope

- No App Store Connect upload.
- No Fastlane upload mutation.
- No runtime/API/OpenAPI/iOS/frontend/backend behavior changes.
- No RAG threshold or runtime behavior changes.
- No fake fixtures or placeholder evidence.
- No full release/App Store readiness claim.

## Files changed

- `.github/workflows/release-manifest-evidence.yml`
- `.github/workflows/build-equivalence-evidence.yml`
- `.github/workflows/build.yml`
- `scripts/release/evidence_source.py`
- `scripts/release/build_identity.py`
- `tests/test_release_manifest_evidence_workflow.py`
- `tests/test_build_equivalence_evidence_workflow.py`
- `tests/test_release_control_plane_evidence_publication_workflow.py`
- `docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md`
- `docs/release/RELEASE_CONTROL_PLANE_EPIC.md`
- `docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/review/PR_1703_PREMORTEM.md`
- `docs/review/PR_1703_FIXED_MAPPING.md`

## Split Justification

This PR stays on release-control-plane evidence plumbing only. App Store binary production and upload execution remain separate because they require protected credentials and release-readiness review.

## Tests / bounded checks

Full local `make verify` intentionally not run. Operator-approved bounded path used:

- `.venv/bin/python scripts/orchestration/check_preflight.py` -> PASS
- `.venv/bin/python scripts/orchestration/check_agent_consistency.py` -> PASS
- `.venv/bin/python -m pytest -q tests/test_release_manifest_evidence_workflow.py tests/test_build_equivalence_evidence_workflow.py tests/test_release_control_plane_evidence_publication_workflow.py tests/test_release_manifest.py tests/test_build_equivalence.py tests/test_release_control_plane_ci_gate.py tests/test_production_release_evidence_wiring.py tests/test_check_docker_provenance_attestation.py` -> PASS
- `.venv/bin/python scripts/ci/check_docs_phase1_gates.py --files docs/roadmap/BACKLOG_LEDGER.md docs/release/RELEASE_CONTROL_PLANE_EPIC.md docs/release/PRODUCTION_RELEASE_EVIDENCE_PUBLICATION.md docs/orchestration/RELEASE_CONTROL_PLANE_TASK_PACKET_2026-04-29.md docs/review/PR_1703_PREMORTEM.md docs/review/PR_1703_FIXED_MAPPING.md` -> PASS
- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed` -> PASS
- `PATH=.venv/bin:$PATH pre-commit run --all-files` -> PASS
- Pre-push hooks -> PASS, including `pip-audit`, backend pre-push, full Bandit, and Docker build test where applicable.

## Security notes

No App Store secrets or Fastlane credentials are used.
No pull_request release evidence producer is added.
Source run provenance checks are fail-closed on completed/success, workflow_dispatch, workflow name/path, and same head SHA.
Supply-chain source files are derived only after `scripts/ci/check_docker_provenance_attestation.py` passes.
SBOM/provenance/attestation source files are bound through one governed same-SHA `release-control-plane-build-sources` artifact.
Nested RAG `source_artifacts[*].path` values are rejected if they escape the evidence root.

## Premortem

Premortem artifact: `docs/review/PR_1703_PREMORTEM.md`.

Premortem, QA, bug-hunter, security, and role-agent review were run against actual diffs multiple times. Real findings were fixed in code/tests/docs before mapping, including sanitized artifact names, RAG payload SHA checks, symlink path resolution, canonical source paths, EQUIVALENT-only publication, governed supply-chain sources, attestation-derived status, atomic same-run supply-chain binding, actionlint input/shellcheck fixes, boundary-aware evidence token matching, and nested RAG source path escape rejection.

## Deferred / Follow-ups

- App Store Connect upload execution remains separate.
- Fastlane protected upload mutation remains separate.
- App Review binary artifact producer/release readiness remains separate.
- Operator monitors main health separately.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Post-open CodeRabbit, Cubic, Sourcery, QA, bug-hunter, premortem, and security pass findings were inspected. Actionable findings were fixed or dispositioned in `docs/review/PR_1703_FIXED_MAPPING.md` before merge-readiness.

### Fixed in Commit Mapping

See `docs/review/PR_1703_FIXED_MAPPING.md`.

## Merge Readiness

Do not mark ready until current-head CI, latest external review pass, mandatory wait-window, and strict merge-readiness wrapper pass.

## Rollback

Revert this workflow/docs/test PR. PR #1699 production publication and production CD gates remain fail-closed.

## DoD

- Governed producer workflows exist.
- Producers are workflow_dispatch-only.
- Publisher has real repo-owned producer workflow identities.
- Supply-chain source evidence is verifier-derived and same-run bound.
- No fake fixtures or placeholder evidence can publish as production evidence.
- No App Store/Fastlane/runtime changes.
- Bounded checks pass.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added new manually-triggered workflows for validating build equivalence and generating release manifest evidence
  * Enhanced Docker artifact verification with automated provenance and SBOM attestation
  * Introduced automated evidence generation for release artifacts with comprehensive source validation

* **Documentation**
  * Updated release control plane governance documentation with evidence publication requirements and controlled workflow definitions
  * Added premortem and validation documentation for new release automation workflows

* **Tests**
  * Added test coverage for new release evidence workflows and validation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->