### PR TITLE
feat(ai-runtime): add bounded /insight semantic-cache experiment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,6 +630,7 @@ jobs:
               route_contract_safety)
                 add_suite \
                   tests/test_api.py \
+                  tests/core/ai/test_bounded_insight_semantic_cache.py \
                   tests/core/ai/test_cache_observability.py \
                   tests/core/ai/test_exact_fuzzy_cache.py \
                   tests/test_app_endpoints_combined.py \
@@ -644,6 +645,7 @@ jobs:
                   tests/test_metrics.py \
                   tests/test_paywall_exposure_ledger_api.py \
                   tests/test_paywall_exposure_ledger_service.py \
+                  tests/test_semantic_cache_bounded_insight_experiment_contract.py \
                   tests/test_semantic_cache_observability_contract.py \
                   tests/test_semantic_cache_scaffold_contract.py
                 ;;
@@ -875,6 +877,7 @@ jobs:
               route_contract_safety)
                 add_suite \
                   tests/test_api.py \
+                  tests/core/ai/test_bounded_insight_semantic_cache.py \
                   tests/core/ai/test_cache_observability.py \
                   tests/core/ai/test_exact_fuzzy_cache.py \
                   tests/test_app_endpoints_combined.py \
@@ -889,6 +892,7 @@ jobs:
                   tests/test_metrics.py \
                   tests/test_paywall_exposure_ledger_api.py \
                   tests/test_paywall_exposure_ledger_service.py \
+                  tests/test_semantic_cache_bounded_insight_experiment_contract.py \
                   tests/test_semantic_cache_observability_contract.py \
                   tests/test_semantic_cache_scaffold_contract.py
                 ;;

--- a/core/ai/bounded_insight_semantic_cache.py
+++ b/core/ai/bounded_insight_semantic_cache.py
@@ -484,36 +484,43 @@ def _candidate_reasons(
     if (
         candidate.lookup_request.source_fingerprints != request.source_fingerprints
         or candidate.record.lineage.source_fingerprints != request.source_fingerprints
+        or candidate.audit_event.source_fingerprints != request.source_fingerprints
     ):
         reasons.append(REASON_SOURCE_FINGERPRINT_MISMATCH)
     if (
         candidate.lookup_request.policy_version != request.policy_version
         or candidate.record.lineage.policy_version != request.policy_version
+        or candidate.audit_event.policy_version != request.policy_version
     ):
         reasons.append(REASON_POLICY_MISMATCH)
     if (
         candidate.lookup_request.provider_key != request.provider_key
         or candidate.record.provider_key != request.provider_key
+        or candidate.audit_event.provider_key != request.provider_key
     ):
         reasons.append(REASON_PROVIDER_MISMATCH)
     if (
         candidate.lookup_request.model_key != request.model_key
         or candidate.record.model_key != request.model_key
+        or candidate.audit_event.model_key != request.model_key
     ):
         reasons.append(REASON_MODEL_MISMATCH)
     if (
         candidate.lookup_request.context_fingerprint != request.context_fingerprint
         or candidate.record.context_fingerprint != request.context_fingerprint
+        or candidate.audit_event.context_fingerprint != request.context_fingerprint
     ):
         reasons.append(REASON_CONTEXT_MISMATCH)
     if (
         candidate.lookup_request.user_tier != request.user_tier
         or candidate.record.user_tier != request.user_tier
+        or candidate.audit_event.user_tier != request.user_tier
     ):
         reasons.append(REASON_USER_TIER_MISMATCH)
     if (
         candidate.lookup_request.transparency_notice_id != request.transparency_notice_id
         or candidate.record.transparency_notice_id != request.transparency_notice_id
+        or candidate.audit_event.transparency_notice_id != request.transparency_notice_id
     ):
         reasons.append(REASON_TRANSPARENCY_NOTICE_MISMATCH)
     if not candidate.admission_allowed:
@@ -580,6 +587,8 @@ def _is_missing_evidence_linkage(request: BoundedInsightExperimentRequest) -> bo
     return (
         request.admission_decision_id is None
         or not request.eval_event_ids
+        or not request.promotion_ids
+        or not request.replay_entry_ids
         or not request.source_fingerprints
         or not request.safety_flags
     )
@@ -590,9 +599,13 @@ def _is_missing_candidate_linkage(candidate: BoundedInsightExperimentCandidate) 
     return (
         lineage.admission_decision_id is None
         or not lineage.eval_event_ids
+        or not lineage.promotion_ids
+        or not lineage.replay_entry_ids
         or not lineage.source_fingerprints
         or candidate.audit_event.admission_decision_id is None
         or not candidate.audit_event.eval_event_ids
+        or not candidate.audit_event.promotion_ids
+        or not candidate.audit_event.replay_entry_ids
     )
 
 

--- a/core/ai/bounded_insight_semantic_cache.py
+++ b/core/ai/bounded_insight_semantic_cache.py
@@ -1,0 +1,696 @@
+"""Offline SC-G4 bounded insight semantic-cache experiment contracts.
+
+This module models an off-by-default eligibility decision for a future bounded
+`/insight` semantic-cache experiment. It does not wire routes, serve cached
+answers, persist payloads, read environment variables, call providers, or select
+cache backends.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import hashlib
+import json
+import math
+import re
+from types import MappingProxyType
+from typing import TypeAlias
+
+from core.ai.cache_observability import (
+    CacheLookupAuditEvent,
+    CacheObservabilityMetrics,
+    CacheStopDecision,
+    FalseHitHarnessEvaluation,
+    KillSwitchSnapshot,
+)
+from core.ai.exact_fuzzy_cache import (
+    MATCH_DECISION_HIT,
+    ExactFuzzyCacheLookupRequest,
+    ExactFuzzyCacheLookupResult,
+    ExactFuzzyCacheRecord,
+)
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+
+ALLOWED_SURFACE = "insight"
+
+DECISION_EXPERIMENT_ELIGIBLE = "experiment_eligible"
+DECISION_FALLBACK = "fallback"
+
+REASON_EXPERIMENT_ELIGIBLE = "experiment_eligible"
+REASON_ENVIRONMENT_FLAG_DISABLED = "environment_flag_disabled"
+REASON_RUNTIME_FLAG_DISABLED = "runtime_flag_disabled"
+REASON_REQUEST_NOT_OPTED_IN = "request_not_opted_in"
+REASON_REQUEST_DISABLED = "request_disabled"
+REASON_KILL_SWITCH_DISABLED = "kill_switch_disabled"
+REASON_UNSUPPORTED_SURFACE = "unsupported_surface"
+REASON_CANDIDATE_MISSING = "candidate_missing"
+REASON_LOOKUP_MISS = "lookup_miss"
+REASON_MATCHED_RECORD_MISMATCH = "matched_record_mismatch"
+REASON_RESPONSE_FINGERPRINT_MISMATCH = "response_fingerprint_mismatch"
+REASON_SOURCE_FINGERPRINT_MISMATCH = "source_fingerprint_mismatch"
+REASON_POLICY_MISMATCH = "policy_mismatch"
+REASON_PROVIDER_MISMATCH = "provider_mismatch"
+REASON_MODEL_MISMATCH = "model_mismatch"
+REASON_CONTEXT_MISMATCH = "context_mismatch"
+REASON_USER_TIER_MISMATCH = "user_tier_mismatch"
+REASON_TRANSPARENCY_NOTICE_MISMATCH = "transparency_notice_mismatch"
+REASON_EVIDENCE_LINKAGE_MISSING = "evidence_linkage_missing"
+REASON_ADMISSION_BLOCKED = "admission_blocked"
+REASON_FALSE_HIT_BLOCKED = "false_hit_blocked"
+REASON_STOP_RULE_BLOCKED = "stop_rule_blocked"
+REASON_BLOCKED_SURFACE = "blocked_surface"
+
+BLOCKED_SURFACE_LABELS = (
+    "account_truth",
+    "advisory_wiki",
+    "auth",
+    "billing",
+    "compliance",
+    "entitlement",
+    "healthkit_sensitive",
+    "legal",
+    "workforce_memory",
+)
+
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
+_PATH_RE = re.compile(r"(?:^|[\s=])(?:/|~[/\\]|[A-Za-z]:[\\/]|\\\\)")
+_UNSAFE_METADATA_RE = re.compile(
+    r"raw[_ -]?(?:query|prompt|response|answer)"
+    r"|normalized[_ -]?query"
+    r"|prompt"
+    r"|response"
+    r"|answer"
+    r"|provider[_ -]?payload"
+    r"|secret"
+    r"|credential"
+    r"|authorization"
+    r"|api[_ -]?key"
+    r"|bearer"
+    r"|basic [a-z0-9+/=]+"
+    r"|cookie"
+    r"|set-cookie"
+    r"|session[_ -]?id"
+    r"|x-api-key"
+    r"|private[_ -]?key"
+    r"|sk-[a-z0-9]"
+    r"|[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}"
+    r"|\+?\d[\d ()-]{7,}\d"
+    r"|healthkit"
+    r"|diagnosis"
+    r"|symptom"
+    r"|medical"
+    r"|account[_ -]?(?:id|truth)"
+    r"|billing"
+    r"|entitlement"
+    r"|legal"
+    r"|compliance"
+    r"|advisory[_ -]?wiki"
+    r"|workforce[_ -]?memory"
+    r"|coaching[_ -]?state"
+    r"|user[_ -]?health",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class BoundedInsightExperimentFlags:
+    """Explicit fail-closed flags for the bounded SC-G4 experiment."""
+
+    environment_enabled: bool
+    runtime_enabled: bool
+    request_opt_in: bool
+    request_disable: bool
+    kill_switch_snapshot: KillSwitchSnapshot
+
+    def __post_init__(self) -> None:
+        _validate_bool("environment_enabled", self.environment_enabled)
+        _validate_bool("runtime_enabled", self.runtime_enabled)
+        _validate_bool("request_opt_in", self.request_opt_in)
+        _validate_bool("request_disable", self.request_disable)
+        if not isinstance(self.kill_switch_snapshot, KillSwitchSnapshot):
+            raise ValueError("kill_switch_snapshot must be KillSwitchSnapshot")
+
+
+@dataclass(frozen=True)
+class BoundedInsightExperimentRequest:
+    """Safe request metadata for the bounded `/insight` experiment."""
+
+    surface: str
+    request_fingerprint: str
+    context_fingerprint: str
+    source_fingerprints: tuple[str, ...]
+    policy_version: str
+    provider_key: str
+    model_key: str
+    user_tier: str
+    transparency_notice_id: str
+    eval_event_ids: tuple[str, ...]
+    admission_decision_id: str | None
+    promotion_ids: tuple[str, ...]
+    replay_entry_ids: tuple[str, ...]
+    safety_flags: tuple[str, ...]
+    metadata: Mapping[str, JsonValue]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "surface", _validate_token("surface", self.surface))
+        object.__setattr__(
+            self,
+            "request_fingerprint",
+            _validate_token("request_fingerprint", self.request_fingerprint),
+        )
+        object.__setattr__(
+            self,
+            "context_fingerprint",
+            _validate_token("context_fingerprint", self.context_fingerprint),
+        )
+        object.__setattr__(
+            self,
+            "source_fingerprints",
+            _normalize_required_unique_tokens("source_fingerprints", self.source_fingerprints),
+        )
+        object.__setattr__(
+            self,
+            "policy_version",
+            _validate_token("policy_version", self.policy_version),
+        )
+        object.__setattr__(self, "provider_key", _validate_token("provider_key", self.provider_key))
+        object.__setattr__(self, "model_key", _validate_token("model_key", self.model_key))
+        object.__setattr__(self, "user_tier", _validate_token("user_tier", self.user_tier))
+        object.__setattr__(
+            self,
+            "transparency_notice_id",
+            _validate_token("transparency_notice_id", self.transparency_notice_id),
+        )
+        object.__setattr__(
+            self,
+            "eval_event_ids",
+            _normalize_required_unique_tokens("eval_event_ids", self.eval_event_ids),
+        )
+        if self.admission_decision_id is not None:
+            object.__setattr__(
+                self,
+                "admission_decision_id",
+                _validate_token("admission_decision_id", self.admission_decision_id),
+            )
+        object.__setattr__(
+            self,
+            "promotion_ids",
+            _normalize_unique_tokens("promotion_ids", self.promotion_ids),
+        )
+        object.__setattr__(
+            self,
+            "replay_entry_ids",
+            _normalize_unique_tokens("replay_entry_ids", self.replay_entry_ids),
+        )
+        object.__setattr__(
+            self,
+            "safety_flags",
+            _normalize_required_unique_tokens("safety_flags", self.safety_flags),
+        )
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+
+@dataclass(frozen=True)
+class BoundedInsightExperimentCandidate:
+    """Candidate metadata from SC-G2/SC-G3 contracts, never a cached payload."""
+
+    lookup_request: ExactFuzzyCacheLookupRequest
+    lookup_result: ExactFuzzyCacheLookupResult
+    record: ExactFuzzyCacheRecord
+    audit_event: CacheLookupAuditEvent
+    false_hit_evaluation: FalseHitHarnessEvaluation
+    metrics: CacheObservabilityMetrics
+    stop_decision: CacheStopDecision
+    response_fingerprint: str
+    blocked_surface: bool
+    admission_allowed: bool
+    metadata: Mapping[str, JsonValue]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.lookup_request, ExactFuzzyCacheLookupRequest):
+            raise ValueError("lookup_request must be ExactFuzzyCacheLookupRequest")
+        if not isinstance(self.lookup_result, ExactFuzzyCacheLookupResult):
+            raise ValueError("lookup_result must be ExactFuzzyCacheLookupResult")
+        if not isinstance(self.record, ExactFuzzyCacheRecord):
+            raise ValueError("record must be ExactFuzzyCacheRecord")
+        if not isinstance(self.audit_event, CacheLookupAuditEvent):
+            raise ValueError("audit_event must be CacheLookupAuditEvent")
+        if not isinstance(self.false_hit_evaluation, FalseHitHarnessEvaluation):
+            raise ValueError("false_hit_evaluation must be FalseHitHarnessEvaluation")
+        if not isinstance(self.metrics, CacheObservabilityMetrics):
+            raise ValueError("metrics must be CacheObservabilityMetrics")
+        if not isinstance(self.stop_decision, CacheStopDecision):
+            raise ValueError("stop_decision must be CacheStopDecision")
+        object.__setattr__(
+            self,
+            "response_fingerprint",
+            _validate_token("response_fingerprint", self.response_fingerprint),
+        )
+        _validate_bool("blocked_surface", self.blocked_surface)
+        _validate_bool("admission_allowed", self.admission_allowed)
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+
+@dataclass(frozen=True)
+class BoundedInsightExperimentDecision:
+    """Safe metadata-only decision for SC-G4 eligibility."""
+
+    decision_id: str
+    decision: str
+    surface: str
+    candidate_record_id: str | None
+    response_fingerprint: str | None
+    match_mode: str | None
+    score_bps: int | None
+    request_fingerprint: str
+    source_fingerprints: tuple[str, ...]
+    policy_version: str
+    provider_key: str
+    model_key: str
+    user_tier: str
+    context_fingerprint: str
+    transparency_notice_id: str
+    eval_event_ids: tuple[str, ...]
+    admission_decision_id: str | None
+    promotion_ids: tuple[str, ...]
+    replay_entry_ids: tuple[str, ...]
+    safety_flags: tuple[str, ...]
+    reason_codes: tuple[str, ...]
+    metadata: Mapping[str, JsonValue]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "decision_id", _validate_token("decision_id", self.decision_id))
+        if self.decision not in {DECISION_EXPERIMENT_ELIGIBLE, DECISION_FALLBACK}:
+            raise ValueError(f"unsupported decision: {self.decision!r}")
+        object.__setattr__(self, "surface", _validate_token("surface", self.surface))
+        if self.candidate_record_id is not None:
+            object.__setattr__(
+                self,
+                "candidate_record_id",
+                _validate_token("candidate_record_id", self.candidate_record_id),
+            )
+        if self.response_fingerprint is not None:
+            object.__setattr__(
+                self,
+                "response_fingerprint",
+                _validate_token("response_fingerprint", self.response_fingerprint),
+            )
+        if self.match_mode is not None:
+            object.__setattr__(self, "match_mode", _validate_token("match_mode", self.match_mode))
+        if self.score_bps is not None:
+            _validate_bps("score_bps", self.score_bps)
+        object.__setattr__(
+            self,
+            "request_fingerprint",
+            _validate_token("request_fingerprint", self.request_fingerprint),
+        )
+        object.__setattr__(
+            self,
+            "source_fingerprints",
+            _normalize_required_unique_tokens("source_fingerprints", self.source_fingerprints),
+        )
+        object.__setattr__(
+            self,
+            "policy_version",
+            _validate_token("policy_version", self.policy_version),
+        )
+        object.__setattr__(self, "provider_key", _validate_token("provider_key", self.provider_key))
+        object.__setattr__(self, "model_key", _validate_token("model_key", self.model_key))
+        object.__setattr__(self, "user_tier", _validate_token("user_tier", self.user_tier))
+        object.__setattr__(
+            self,
+            "context_fingerprint",
+            _validate_token("context_fingerprint", self.context_fingerprint),
+        )
+        object.__setattr__(
+            self,
+            "transparency_notice_id",
+            _validate_token("transparency_notice_id", self.transparency_notice_id),
+        )
+        object.__setattr__(
+            self,
+            "eval_event_ids",
+            _normalize_required_unique_tokens("eval_event_ids", self.eval_event_ids),
+        )
+        if self.admission_decision_id is not None:
+            object.__setattr__(
+                self,
+                "admission_decision_id",
+                _validate_token("admission_decision_id", self.admission_decision_id),
+            )
+        object.__setattr__(
+            self,
+            "promotion_ids",
+            _normalize_unique_tokens("promotion_ids", self.promotion_ids),
+        )
+        object.__setattr__(
+            self,
+            "replay_entry_ids",
+            _normalize_unique_tokens("replay_entry_ids", self.replay_entry_ids),
+        )
+        object.__setattr__(
+            self,
+            "safety_flags",
+            _normalize_required_unique_tokens("safety_flags", self.safety_flags),
+        )
+        object.__setattr__(
+            self,
+            "reason_codes",
+            _normalize_required_unique_tokens("reason_codes", self.reason_codes),
+        )
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+
+def evaluate_bounded_insight_experiment(
+    *,
+    flags: BoundedInsightExperimentFlags,
+    request: BoundedInsightExperimentRequest,
+    candidate: BoundedInsightExperimentCandidate | None,
+) -> BoundedInsightExperimentDecision:
+    """Evaluate SC-G4 experiment eligibility without serving cached output."""
+
+    if not isinstance(flags, BoundedInsightExperimentFlags):
+        raise ValueError("flags must be BoundedInsightExperimentFlags")
+    if not isinstance(request, BoundedInsightExperimentRequest):
+        raise ValueError("request must be BoundedInsightExperimentRequest")
+
+    reasons = _flag_reasons(flags)
+    if request.surface != ALLOWED_SURFACE:
+        reasons.append(REASON_UNSUPPORTED_SURFACE)
+    if _is_missing_evidence_linkage(request):
+        reasons.append(REASON_EVIDENCE_LINKAGE_MISSING)
+
+    if candidate is None:
+        reasons.append(REASON_CANDIDATE_MISSING)
+        return _build_decision(request=request, candidate=None, reasons=reasons)
+    if not isinstance(candidate, BoundedInsightExperimentCandidate):
+        raise ValueError("candidate must be BoundedInsightExperimentCandidate")
+
+    reasons.extend(_candidate_reasons(request=request, candidate=candidate))
+    return _build_decision(request=request, candidate=candidate, reasons=reasons)
+
+
+def to_stable_mapping(value: object) -> Mapping[str, JsonValue]:
+    """Return deterministic safe JSON-ready mappings for SC-G4 contracts."""
+
+    if isinstance(value, BoundedInsightExperimentDecision):
+        return _freeze_mapping(
+            {
+                "admission_decision_id": value.admission_decision_id,
+                "candidate_record_id": value.candidate_record_id,
+                "context_fingerprint": value.context_fingerprint,
+                "decision": value.decision,
+                "decision_id": value.decision_id,
+                "eval_event_ids": list(value.eval_event_ids),
+                "match_mode": value.match_mode,
+                "metadata": _json_safe_copy(value.metadata),
+                "model_key": value.model_key,
+                "policy_version": value.policy_version,
+                "promotion_ids": list(value.promotion_ids),
+                "provider_key": value.provider_key,
+                "reason_codes": list(value.reason_codes),
+                "replay_entry_ids": list(value.replay_entry_ids),
+                "request_fingerprint": value.request_fingerprint,
+                "response_fingerprint": value.response_fingerprint,
+                "safety_flags": list(value.safety_flags),
+                "score_bps": value.score_bps,
+                "source_fingerprints": list(value.source_fingerprints),
+                "surface": value.surface,
+                "transparency_notice_id": value.transparency_notice_id,
+                "user_tier": value.user_tier,
+            }
+        )
+    if isinstance(value, BoundedInsightExperimentFlags):
+        return _freeze_mapping(
+            {
+                "environment_enabled": value.environment_enabled,
+                "kill_switch_snapshot": _json_safe_copy(
+                    dict(
+                        {
+                            "bypass_forced": value.kill_switch_snapshot.bypass_forced,
+                            "environment_enabled": value.kill_switch_snapshot.environment_enabled,
+                            "request_disabled": value.kill_switch_snapshot.request_disabled,
+                            "runtime_enabled": value.kill_switch_snapshot.runtime_enabled,
+                        }
+                    )
+                ),
+                "request_disable": value.request_disable,
+                "request_opt_in": value.request_opt_in,
+                "runtime_enabled": value.runtime_enabled,
+            }
+        )
+    raise ValueError(f"unsupported stable mapping value: {type(value).__name__}")
+
+
+def _flag_reasons(flags: BoundedInsightExperimentFlags) -> list[str]:
+    reasons: list[str] = []
+    if not flags.environment_enabled:
+        reasons.append(REASON_ENVIRONMENT_FLAG_DISABLED)
+    if not flags.runtime_enabled:
+        reasons.append(REASON_RUNTIME_FLAG_DISABLED)
+    if not flags.request_opt_in:
+        reasons.append(REASON_REQUEST_NOT_OPTED_IN)
+    if flags.request_disable:
+        reasons.append(REASON_REQUEST_DISABLED)
+    if flags.kill_switch_snapshot.disables_hypothetical_serving:
+        reasons.append(REASON_KILL_SWITCH_DISABLED)
+    return reasons
+
+
+def _candidate_reasons(
+    *,
+    request: BoundedInsightExperimentRequest,
+    candidate: BoundedInsightExperimentCandidate,
+) -> list[str]:
+    reasons: list[str] = []
+    if candidate.lookup_result.decision != MATCH_DECISION_HIT:
+        reasons.append(REASON_LOOKUP_MISS)
+    if candidate.lookup_result.matched_record_id != candidate.record.record_id:
+        reasons.append(REASON_MATCHED_RECORD_MISMATCH)
+    if candidate.record.response_fingerprint != candidate.response_fingerprint:
+        reasons.append(REASON_RESPONSE_FINGERPRINT_MISMATCH)
+    if candidate.audit_event.candidate_record_id != candidate.record.record_id:
+        reasons.append(REASON_MATCHED_RECORD_MISMATCH)
+    if candidate.audit_event.candidate_response_fingerprint != candidate.response_fingerprint:
+        reasons.append(REASON_RESPONSE_FINGERPRINT_MISMATCH)
+    if (
+        candidate.lookup_request.surface != request.surface
+        or candidate.record.surface != request.surface
+    ):
+        reasons.append(REASON_UNSUPPORTED_SURFACE)
+    if (
+        candidate.lookup_request.source_fingerprints != request.source_fingerprints
+        or candidate.record.lineage.source_fingerprints != request.source_fingerprints
+    ):
+        reasons.append(REASON_SOURCE_FINGERPRINT_MISMATCH)
+    if (
+        candidate.lookup_request.policy_version != request.policy_version
+        or candidate.record.lineage.policy_version != request.policy_version
+    ):
+        reasons.append(REASON_POLICY_MISMATCH)
+    if (
+        candidate.lookup_request.provider_key != request.provider_key
+        or candidate.record.provider_key != request.provider_key
+    ):
+        reasons.append(REASON_PROVIDER_MISMATCH)
+    if (
+        candidate.lookup_request.model_key != request.model_key
+        or candidate.record.model_key != request.model_key
+    ):
+        reasons.append(REASON_MODEL_MISMATCH)
+    if (
+        candidate.lookup_request.context_fingerprint != request.context_fingerprint
+        or candidate.record.context_fingerprint != request.context_fingerprint
+    ):
+        reasons.append(REASON_CONTEXT_MISMATCH)
+    if (
+        candidate.lookup_request.user_tier != request.user_tier
+        or candidate.record.user_tier != request.user_tier
+    ):
+        reasons.append(REASON_USER_TIER_MISMATCH)
+    if (
+        candidate.lookup_request.transparency_notice_id != request.transparency_notice_id
+        or candidate.record.transparency_notice_id != request.transparency_notice_id
+    ):
+        reasons.append(REASON_TRANSPARENCY_NOTICE_MISMATCH)
+    if not candidate.admission_allowed:
+        reasons.append(REASON_ADMISSION_BLOCKED)
+    if candidate.blocked_surface:
+        reasons.append(REASON_BLOCKED_SURFACE)
+    if candidate.false_hit_evaluation.is_false_hit or not candidate.false_hit_evaluation.allowed:
+        reasons.append(REASON_FALSE_HIT_BLOCKED)
+    if candidate.stop_decision.stop_serving or candidate.stop_decision.rollback_required:
+        reasons.append(REASON_STOP_RULE_BLOCKED)
+    if _is_missing_candidate_linkage(candidate):
+        reasons.append(REASON_EVIDENCE_LINKAGE_MISSING)
+    return reasons
+
+
+def _build_decision(
+    *,
+    request: BoundedInsightExperimentRequest,
+    candidate: BoundedInsightExperimentCandidate | None,
+    reasons: list[str],
+) -> BoundedInsightExperimentDecision:
+    normalized_reasons = _normalize_unique_tokens("reason_codes", list(dict.fromkeys(reasons)))
+    decision = DECISION_FALLBACK
+    if not normalized_reasons and candidate is not None:
+        normalized_reasons = (REASON_EXPERIMENT_ELIGIBLE,)
+        decision = DECISION_EXPERIMENT_ELIGIBLE
+    elif not normalized_reasons:
+        normalized_reasons = (REASON_CANDIDATE_MISSING,)
+    payload: JsonValue = {
+        "candidate_record_id": candidate.record.record_id if candidate is not None else None,
+        "decision": decision,
+        "policy_version": request.policy_version,
+        "reason_codes": list(normalized_reasons),
+        "request_fingerprint": request.request_fingerprint,
+        "surface": request.surface,
+    }
+    return BoundedInsightExperimentDecision(
+        decision_id=f"bounded-insight-cache:{_fingerprint_payload(payload)[:24]}",
+        decision=decision,
+        surface=request.surface,
+        candidate_record_id=candidate.record.record_id if candidate is not None else None,
+        response_fingerprint=candidate.response_fingerprint if candidate is not None else None,
+        match_mode=candidate.lookup_result.match_mode if candidate is not None else None,
+        score_bps=candidate.lookup_result.score_bps if candidate is not None else None,
+        request_fingerprint=request.request_fingerprint,
+        source_fingerprints=request.source_fingerprints,
+        policy_version=request.policy_version,
+        provider_key=request.provider_key,
+        model_key=request.model_key,
+        user_tier=request.user_tier,
+        context_fingerprint=request.context_fingerprint,
+        transparency_notice_id=request.transparency_notice_id,
+        eval_event_ids=request.eval_event_ids,
+        admission_decision_id=request.admission_decision_id,
+        promotion_ids=request.promotion_ids,
+        replay_entry_ids=request.replay_entry_ids,
+        safety_flags=request.safety_flags,
+        reason_codes=normalized_reasons,
+        metadata={"decision_scope": "metadata_only", "serves_cached_payload": False},
+    )
+
+
+def _is_missing_evidence_linkage(request: BoundedInsightExperimentRequest) -> bool:
+    return (
+        request.admission_decision_id is None
+        or not request.eval_event_ids
+        or not request.source_fingerprints
+        or not request.safety_flags
+    )
+
+
+def _is_missing_candidate_linkage(candidate: BoundedInsightExperimentCandidate) -> bool:
+    lineage = candidate.record.lineage
+    return (
+        lineage.admission_decision_id is None
+        or not lineage.eval_event_ids
+        or not lineage.source_fingerprints
+        or candidate.audit_event.admission_decision_id is None
+        or not candidate.audit_event.eval_event_ids
+    )
+
+
+def _fingerprint_payload(payload: JsonValue) -> str:
+    raw = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _freeze_metadata(value: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
+    copied = _json_safe_copy(value)
+    if not isinstance(copied, dict):
+        raise ValueError("metadata must be a mapping")
+    _validate_metadata_is_safe(copied)
+    return _freeze_mapping(copied)
+
+
+def _freeze_mapping(value: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
+    return MappingProxyType(dict(sorted(value.items())))
+
+
+def _json_safe_copy(value: JsonValue | Mapping[str, JsonValue]) -> JsonValue:
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe_copy(item) for key, item in sorted(value.items())}
+    if isinstance(value, list):
+        return [_json_safe_copy(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_safe_copy(item) for item in value]
+    if isinstance(value, bool) or value is None or isinstance(value, str):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("metadata contains non-finite number")
+        return value
+    raise ValueError(f"metadata contains unsupported value: {type(value).__name__}")
+
+
+def _validate_metadata_is_safe(value: JsonValue, *, path: str = "metadata") -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _validate_safe_metadata_string(f"{path}.key", key)
+            _validate_metadata_is_safe(item, path=f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_metadata_is_safe(item, path=f"{path}[{index}]")
+    elif isinstance(value, str):
+        _validate_safe_metadata_string(path, value)
+
+
+def _validate_safe_metadata_string(name: str, value: str) -> None:
+    if _UNSAFE_METADATA_RE.search(value) or _PATH_RE.search(value):
+        raise ValueError(f"{name} contains unsafe metadata")
+
+
+def _normalize_required_unique_tokens(name: str, values: tuple[str, ...]) -> tuple[str, ...]:
+    normalized = _normalize_unique_tokens(name, values)
+    if not normalized:
+        raise ValueError(f"{name} must be non-empty")
+    return normalized
+
+
+def _normalize_unique_tokens(name: str, values: tuple[str, ...] | list[str]) -> tuple[str, ...]:
+    normalized_values: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = _validate_token(name, value)
+        if normalized in seen:
+            raise ValueError(f"{name} contains duplicate entries")
+        seen.add(normalized)
+        normalized_values.append(normalized)
+    return tuple(sorted(normalized_values))
+
+
+def _validate_token(name: str, value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{name} must be non-empty")
+    if any(char.isspace() for char in normalized):
+        raise ValueError(f"{name} must not contain whitespace")
+    if not _TOKEN_RE.match(normalized):
+        raise ValueError(f"{name} contains unsupported characters")
+    return normalized
+
+
+def _validate_bps(name: str, value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer")
+    if value < 0 or value > 10000:
+        raise ValueError(f"{name} must be between 0 and 10000")
+
+
+def _validate_bool(name: str, value: bool) -> None:
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} must be bool")

--- a/core/ai/bounded_insight_semantic_cache.py
+++ b/core/ai/bounded_insight_semantic_cache.py
@@ -49,6 +49,7 @@ REASON_UNSUPPORTED_SURFACE = "unsupported_surface"
 REASON_CANDIDATE_MISSING = "candidate_missing"
 REASON_LOOKUP_MISS = "lookup_miss"
 REASON_MATCHED_RECORD_MISMATCH = "matched_record_mismatch"
+REASON_REQUEST_FINGERPRINT_MISMATCH = "request_fingerprint_mismatch"
 REASON_RESPONSE_FINGERPRINT_MISMATCH = "response_fingerprint_mismatch"
 REASON_SOURCE_FINGERPRINT_MISMATCH = "source_fingerprint_mismatch"
 REASON_POLICY_MISMATCH = "policy_mismatch"
@@ -477,6 +478,8 @@ def _candidate_reasons(
         reasons.append(REASON_MATCHED_RECORD_MISMATCH)
     if candidate.audit_event.candidate_response_fingerprint != candidate.response_fingerprint:
         reasons.append(REASON_RESPONSE_FINGERPRINT_MISMATCH)
+    if candidate.audit_event.request_fingerprint != request.request_fingerprint:
+        reasons.append(REASON_REQUEST_FINGERPRINT_MISMATCH)
     if (
         candidate.lookup_request.surface != request.surface
         or candidate.record.surface != request.surface

--- a/core/ai/bounded_insight_semantic_cache.py
+++ b/core/ai/bounded_insight_semantic_cache.py
@@ -558,8 +558,9 @@ def _build_decision(
         decision = DECISION_EXPERIMENT_ELIGIBLE
     elif not normalized_reasons:
         normalized_reasons = (REASON_CANDIDATE_MISSING,)
+    eligible_candidate = candidate if decision == DECISION_EXPERIMENT_ELIGIBLE else None
     payload: JsonValue = {
-        "candidate_record_id": _eligible_candidate_record_id(candidate),
+        "candidate_record_id": _eligible_candidate_record_id(eligible_candidate),
         "decision": decision,
         "policy_version": request.policy_version,
         "reason_codes": list(normalized_reasons),
@@ -570,10 +571,10 @@ def _build_decision(
         decision_id=f"bounded-insight-cache:{_fingerprint_payload(payload)[:24]}",
         decision=decision,
         surface=request.surface,
-        candidate_record_id=_eligible_candidate_record_id(candidate),
-        response_fingerprint=_eligible_candidate_response_fingerprint(candidate),
-        match_mode=_eligible_match_mode(candidate),
-        score_bps=_eligible_score_bps(candidate),
+        candidate_record_id=_eligible_candidate_record_id(eligible_candidate),
+        response_fingerprint=_eligible_candidate_response_fingerprint(eligible_candidate),
+        match_mode=_eligible_match_mode(eligible_candidate),
+        score_bps=_eligible_score_bps(eligible_candidate),
         request_fingerprint=request.request_fingerprint,
         source_fingerprints=request.source_fingerprints,
         policy_version=request.policy_version,

--- a/core/ai/bounded_insight_semantic_cache.py
+++ b/core/ai/bounded_insight_semantic_cache.py
@@ -607,7 +607,8 @@ def _eligible_candidate_record_id(
 ) -> str | None:
     if candidate is None or not _has_bound_hit_candidate(candidate):
         return None
-    return candidate.record.record_id
+    record_id: str = candidate.record.record_id
+    return record_id
 
 
 def _eligible_candidate_response_fingerprint(
@@ -621,13 +622,15 @@ def _eligible_candidate_response_fingerprint(
 def _eligible_match_mode(candidate: BoundedInsightExperimentCandidate | None) -> str | None:
     if candidate is None or not _has_bound_hit_candidate(candidate):
         return None
-    return candidate.lookup_result.match_mode
+    match_mode: str | None = candidate.lookup_result.match_mode
+    return match_mode
 
 
 def _eligible_score_bps(candidate: BoundedInsightExperimentCandidate | None) -> int | None:
     if candidate is None or not _has_bound_hit_candidate(candidate):
         return None
-    return candidate.lookup_result.score_bps
+    score_bps: int | None = candidate.lookup_result.score_bps
+    return score_bps
 
 
 def _is_missing_evidence_linkage(request: BoundedInsightExperimentRequest) -> bool:

--- a/core/ai/bounded_insight_semantic_cache.py
+++ b/core/ai/bounded_insight_semantic_cache.py
@@ -58,6 +58,7 @@ REASON_CONTEXT_MISMATCH = "context_mismatch"
 REASON_USER_TIER_MISMATCH = "user_tier_mismatch"
 REASON_TRANSPARENCY_NOTICE_MISMATCH = "transparency_notice_mismatch"
 REASON_EVIDENCE_LINKAGE_MISSING = "evidence_linkage_missing"
+REASON_EVIDENCE_LINKAGE_MISMATCH = "evidence_linkage_mismatch"
 REASON_ADMISSION_BLOCKED = "admission_blocked"
 REASON_FALSE_HIT_BLOCKED = "false_hit_blocked"
 REASON_STOP_RULE_BLOCKED = "stop_rule_blocked"
@@ -523,6 +524,8 @@ def _candidate_reasons(
         or candidate.audit_event.transparency_notice_id != request.transparency_notice_id
     ):
         reasons.append(REASON_TRANSPARENCY_NOTICE_MISMATCH)
+    if _has_evidence_linkage_mismatch(request=request, candidate=candidate):
+        reasons.append(REASON_EVIDENCE_LINKAGE_MISMATCH)
     if not candidate.admission_allowed:
         reasons.append(REASON_ADMISSION_BLOCKED)
     if candidate.blocked_surface:
@@ -606,6 +609,25 @@ def _is_missing_candidate_linkage(candidate: BoundedInsightExperimentCandidate) 
         or not candidate.audit_event.eval_event_ids
         or not candidate.audit_event.promotion_ids
         or not candidate.audit_event.replay_entry_ids
+    )
+
+
+def _has_evidence_linkage_mismatch(
+    *,
+    request: BoundedInsightExperimentRequest,
+    candidate: BoundedInsightExperimentCandidate,
+) -> bool:
+    lineage = candidate.record.lineage
+    audit_event = candidate.audit_event
+    return (
+        lineage.eval_event_ids != request.eval_event_ids
+        or lineage.admission_decision_id != request.admission_decision_id
+        or lineage.promotion_ids != request.promotion_ids
+        or lineage.replay_entry_ids != request.replay_entry_ids
+        or audit_event.eval_event_ids != request.eval_event_ids
+        or audit_event.admission_decision_id != request.admission_decision_id
+        or audit_event.promotion_ids != request.promotion_ids
+        or audit_event.replay_entry_ids != request.replay_entry_ids
     )
 
 

--- a/core/ai/bounded_insight_semantic_cache.py
+++ b/core/ai/bounded_insight_semantic_cache.py
@@ -719,7 +719,7 @@ def _freeze_json_value(value: JsonValue) -> JsonValue:
 
 
 def _stable_json_mapping(value: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
-    return MappingProxyType({key: _json_safe_copy(item) for key, item in sorted(value.items())})
+    return {key: _json_safe_copy(item) for key, item in sorted(value.items())}
 
 
 def _json_safe_copy(value: JsonValue | Mapping[str, JsonValue]) -> JsonValue:

--- a/core/ai/bounded_insight_semantic_cache.py
+++ b/core/ai/bounded_insight_semantic_cache.py
@@ -619,16 +619,17 @@ def _has_evidence_linkage_mismatch(
 ) -> bool:
     lineage = candidate.record.lineage
     audit_event = candidate.audit_event
-    return (
-        lineage.eval_event_ids != request.eval_event_ids
-        or lineage.admission_decision_id != request.admission_decision_id
-        or lineage.promotion_ids != request.promotion_ids
-        or lineage.replay_entry_ids != request.replay_entry_ids
-        or audit_event.eval_event_ids != request.eval_event_ids
-        or audit_event.admission_decision_id != request.admission_decision_id
-        or audit_event.promotion_ids != request.promotion_ids
-        or audit_event.replay_entry_ids != request.replay_entry_ids
+    mismatches = (
+        bool(lineage.eval_event_ids != request.eval_event_ids),
+        bool(lineage.admission_decision_id != request.admission_decision_id),
+        bool(lineage.promotion_ids != request.promotion_ids),
+        bool(lineage.replay_entry_ids != request.replay_entry_ids),
+        bool(audit_event.eval_event_ids != request.eval_event_ids),
+        bool(audit_event.admission_decision_id != request.admission_decision_id),
+        bool(audit_event.promotion_ids != request.promotion_ids),
+        bool(audit_event.replay_entry_ids != request.replay_entry_ids),
     )
+    return any(mismatches)
 
 
 def _fingerprint_payload(payload: JsonValue) -> str:

--- a/core/ai/bounded_insight_semantic_cache.py
+++ b/core/ai/bounded_insight_semantic_cache.py
@@ -562,8 +562,6 @@ def _build_decision(
     if not normalized_reasons and candidate is not None:
         normalized_reasons = (REASON_EXPERIMENT_ELIGIBLE,)
         decision = DECISION_EXPERIMENT_ELIGIBLE
-    elif not normalized_reasons:
-        normalized_reasons = (REASON_CANDIDATE_MISSING,)
     eligible_candidate = candidate if decision == DECISION_EXPERIMENT_ELIGIBLE else None
     payload: JsonValue = {
         "candidate_record_id": _eligible_candidate_record_id(eligible_candidate),
@@ -746,9 +744,6 @@ def _validate_metadata_is_safe(value: JsonValue, *, path: str = "metadata") -> N
             _validate_safe_metadata_string(f"{path}.key", key)
             _validate_metadata_is_safe(item, path=f"{path}.{key}")
     elif isinstance(value, list):
-        for index, item in enumerate(value):
-            _validate_metadata_is_safe(item, path=f"{path}[{index}]")
-    elif isinstance(value, tuple):
         for index, item in enumerate(value):
             _validate_metadata_is_safe(item, path=f"{path}[{index}]")
     elif isinstance(value, str):

--- a/core/ai/bounded_insight_semantic_cache.py
+++ b/core/ai/bounded_insight_semantic_cache.py
@@ -32,7 +32,13 @@ from core.ai.exact_fuzzy_cache import (
 )
 
 JsonScalar: TypeAlias = str | int | float | bool | None
-JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+JsonValue: TypeAlias = (
+    JsonScalar
+    | list["JsonValue"]
+    | tuple["JsonValue", ...]
+    | dict[str, "JsonValue"]
+    | Mapping[str, "JsonValue"]
+)
 
 ALLOWED_SURFACE = "insight"
 
@@ -400,7 +406,7 @@ def to_stable_mapping(value: object) -> Mapping[str, JsonValue]:
     """Return deterministic safe JSON-ready mappings for SC-G4 contracts."""
 
     if isinstance(value, BoundedInsightExperimentDecision):
-        return _freeze_mapping(
+        return _stable_json_mapping(
             {
                 "admission_decision_id": value.admission_decision_id,
                 "candidate_record_id": value.candidate_record_id,
@@ -427,7 +433,7 @@ def to_stable_mapping(value: object) -> Mapping[str, JsonValue]:
             }
         )
     if isinstance(value, BoundedInsightExperimentFlags):
-        return _freeze_mapping(
+        return _stable_json_mapping(
             {
                 "environment_enabled": value.environment_enabled,
                 "kill_switch_snapshot": _json_safe_copy(
@@ -598,6 +604,7 @@ def _has_bound_hit_candidate(candidate: BoundedInsightExperimentCandidate | None
         candidate is not None
         and candidate.lookup_result.decision == MATCH_DECISION_HIT
         and candidate.lookup_result.matched_record_id == candidate.record.record_id
+        and candidate.response_fingerprint == candidate.record.response_fingerprint
         and candidate.audit_event.candidate_record_id == candidate.record.record_id
         and candidate.audit_event.candidate_response_fingerprint == candidate.response_fingerprint
     )
@@ -700,7 +707,19 @@ def _freeze_metadata(value: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
 
 
 def _freeze_mapping(value: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
-    return MappingProxyType(dict(sorted(value.items())))
+    return MappingProxyType({key: _freeze_json_value(item) for key, item in sorted(value.items())})
+
+
+def _freeze_json_value(value: JsonValue) -> JsonValue:
+    if isinstance(value, Mapping):
+        return _freeze_mapping(value)
+    if isinstance(value, list | tuple):
+        return tuple(_freeze_json_value(item) for item in value)
+    return value
+
+
+def _stable_json_mapping(value: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
+    return MappingProxyType({key: _json_safe_copy(item) for key, item in sorted(value.items())})
 
 
 def _json_safe_copy(value: JsonValue | Mapping[str, JsonValue]) -> JsonValue:
@@ -727,6 +746,9 @@ def _validate_metadata_is_safe(value: JsonValue, *, path: str = "metadata") -> N
             _validate_safe_metadata_string(f"{path}.key", key)
             _validate_metadata_is_safe(item, path=f"{path}.{key}")
     elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_metadata_is_safe(item, path=f"{path}[{index}]")
+    elif isinstance(value, tuple):
         for index, item in enumerate(value):
             _validate_metadata_is_safe(item, path=f"{path}[{index}]")
     elif isinstance(value, str):
@@ -758,6 +780,8 @@ def _normalize_unique_tokens(name: str, values: tuple[str, ...] | list[str]) -> 
 
 
 def _validate_token(name: str, value: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string")
     normalized = value.strip()
     if not normalized:
         raise ValueError(f"{name} must be non-empty")

--- a/core/ai/bounded_insight_semantic_cache.py
+++ b/core/ai/bounded_insight_semantic_cache.py
@@ -60,6 +60,7 @@ REASON_USER_TIER_MISMATCH = "user_tier_mismatch"
 REASON_TRANSPARENCY_NOTICE_MISMATCH = "transparency_notice_mismatch"
 REASON_EVIDENCE_LINKAGE_MISSING = "evidence_linkage_missing"
 REASON_EVIDENCE_LINKAGE_MISMATCH = "evidence_linkage_mismatch"
+REASON_SAFETY_FLAGS_MISMATCH = "safety_flags_mismatch"
 REASON_ADMISSION_BLOCKED = "admission_blocked"
 REASON_FALSE_HIT_BLOCKED = "false_hit_blocked"
 REASON_STOP_RULE_BLOCKED = "stop_rule_blocked"
@@ -527,6 +528,8 @@ def _candidate_reasons(
         or candidate.audit_event.transparency_notice_id != request.transparency_notice_id
     ):
         reasons.append(REASON_TRANSPARENCY_NOTICE_MISMATCH)
+    if candidate.record.safety_flags != request.safety_flags:
+        reasons.append(REASON_SAFETY_FLAGS_MISMATCH)
     if _has_evidence_linkage_mismatch(request=request, candidate=candidate):
         reasons.append(REASON_EVIDENCE_LINKAGE_MISMATCH)
     if not candidate.admission_allowed:
@@ -556,7 +559,7 @@ def _build_decision(
     elif not normalized_reasons:
         normalized_reasons = (REASON_CANDIDATE_MISSING,)
     payload: JsonValue = {
-        "candidate_record_id": candidate.record.record_id if candidate is not None else None,
+        "candidate_record_id": _eligible_candidate_record_id(candidate),
         "decision": decision,
         "policy_version": request.policy_version,
         "reason_codes": list(normalized_reasons),
@@ -567,10 +570,10 @@ def _build_decision(
         decision_id=f"bounded-insight-cache:{_fingerprint_payload(payload)[:24]}",
         decision=decision,
         surface=request.surface,
-        candidate_record_id=candidate.record.record_id if candidate is not None else None,
-        response_fingerprint=candidate.response_fingerprint if candidate is not None else None,
-        match_mode=candidate.lookup_result.match_mode if candidate is not None else None,
-        score_bps=candidate.lookup_result.score_bps if candidate is not None else None,
+        candidate_record_id=_eligible_candidate_record_id(candidate),
+        response_fingerprint=_eligible_candidate_response_fingerprint(candidate),
+        match_mode=_eligible_match_mode(candidate),
+        score_bps=_eligible_score_bps(candidate),
         request_fingerprint=request.request_fingerprint,
         source_fingerprints=request.source_fingerprints,
         policy_version=request.policy_version,
@@ -587,6 +590,44 @@ def _build_decision(
         reason_codes=normalized_reasons,
         metadata={"decision_scope": "metadata_only", "serves_cached_payload": False},
     )
+
+
+def _has_bound_hit_candidate(candidate: BoundedInsightExperimentCandidate | None) -> bool:
+    return (
+        candidate is not None
+        and candidate.lookup_result.decision == MATCH_DECISION_HIT
+        and candidate.lookup_result.matched_record_id == candidate.record.record_id
+        and candidate.audit_event.candidate_record_id == candidate.record.record_id
+        and candidate.audit_event.candidate_response_fingerprint == candidate.response_fingerprint
+    )
+
+
+def _eligible_candidate_record_id(
+    candidate: BoundedInsightExperimentCandidate | None,
+) -> str | None:
+    if candidate is None or not _has_bound_hit_candidate(candidate):
+        return None
+    return candidate.record.record_id
+
+
+def _eligible_candidate_response_fingerprint(
+    candidate: BoundedInsightExperimentCandidate | None,
+) -> str | None:
+    if candidate is None or not _has_bound_hit_candidate(candidate):
+        return None
+    return candidate.response_fingerprint
+
+
+def _eligible_match_mode(candidate: BoundedInsightExperimentCandidate | None) -> str | None:
+    if candidate is None or not _has_bound_hit_candidate(candidate):
+        return None
+    return candidate.lookup_result.match_mode
+
+
+def _eligible_score_bps(candidate: BoundedInsightExperimentCandidate | None) -> int | None:
+    if candidate is None or not _has_bound_hit_candidate(candidate):
+        return None
+    return candidate.lookup_result.score_bps
 
 
 def _is_missing_evidence_linkage(request: BoundedInsightExperimentRequest) -> bool:

--- a/core/ai/cache_observability.py
+++ b/core/ai/cache_observability.py
@@ -79,9 +79,18 @@ _UNSAFE_METADATA_RE = re.compile(
     r"|answer"
     r"|secret"
     r"|credential"
+    r"|authorization"
+    r"|api[_ -]?key"
     r"|bearer"
+    r"|basic [a-z0-9+/=]+"
+    r"|cookie"
+    r"|set-cookie"
+    r"|session[_ -]?id"
+    r"|x-api-key"
     r"|private[_ -]?key"
     r"|sk-[a-z0-9]"
+    r"|[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}"
+    r"|\+?\d[\d ()-]{7,}\d"
     r"|healthkit"
     r"|diagnosis"
     r"|symptom"
@@ -164,6 +173,8 @@ class CacheLookupAuditEvent:
             self.candidate_record_id is not None or self.candidate_response_fingerprint is not None
         ):
             raise ValueError("miss audit events must not carry candidate fields")
+        elif self.match_mode is not None:
+            raise ValueError("miss audit events must not carry match_mode")
         object.__setattr__(
             self, "policy_version", _validate_token("policy_version", self.policy_version)
         )
@@ -586,7 +597,7 @@ def evaluate_false_hit_case(
         and case.fresh_response_fingerprint != case.audit_event.candidate_response_fingerprint
     ):
         blocking_reasons.append(REASON_RESPONSE_FINGERPRINT_MISMATCH)
-    if case.negative_control and case.expected_action == EXPECTED_ACTION_FALLBACK:
+    if case.negative_control:
         reason_codes.append(REASON_NEGATIVE_CONTROL)
         if candidate_hit:
             blocking_reasons.append(REASON_FALLBACK_REQUIRED)

--- a/docs/orchestration/contracts/SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.md
+++ b/docs/orchestration/contracts/SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.md
@@ -1,0 +1,251 @@
+# Semantic Cache Bounded Insight Experiment Contract
+
+## Purpose
+
+SC-G4 bounded `/insight` semantic-cache experiment defines a deterministic,
+metadata-only decision layer for a future product AI runtime experiment. It does
+not open the semantic-cache gate. It does not enable runtime caching. It does
+not enable `/insight` serving.
+
+SC-G4 does not open the semantic-cache gate.
+SC-G4 does not enable `/insight` serving.
+
+Gate remains closed.
+
+- Gate status: closed.
+- Runtime allowed: false.
+- Implementation allowed: false.
+- Experiment default: off by default.
+- Allowed surface: bounded `/insight`-style product AI only.
+- Backend selection: SC-G5 remains future.
+
+## Position In Rollout
+
+Required rollout order remains:
+
+1. SC-G1 rollout gate contract.
+2. SC-G2 exact/fuzzy cache scaffold.
+3. SC-G3 observability and false-hit harness.
+4. SC-G4 bounded `/insight` semantic-cache experiment.
+5. SC-G5 backend selection.
+
+SC-G4 may evaluate whether a future bounded `/insight` cache candidate is
+eligible for an experiment, but it remains non-serving. A decision of
+`experiment_eligible` is safe metadata only. It is not a cached answer, not a
+runtime route, and not global semantic-cache approval.
+
+## Required Flag Semantics
+
+The experiment is off by default and requires all of these explicit signals:
+
+- environment flag enabled;
+- runtime flag snapshot enabled;
+- explicit request opt-in;
+- request disable is false;
+- kill switch snapshot permits the hypothetical experiment;
+- no bypass is forced.
+
+Fail-closed fallback is mandatory when any signal is absent or disabled:
+
+- environment flag disabled;
+- runtime flag disabled;
+- request not opted in;
+- request disable;
+- kill switch disabled;
+- bypass forced.
+
+Disable means provider fresh path or stable fallback only. Disable never means
+serving a cached answer.
+
+## Required Evidence Graph Linkage
+
+Every SC-G4 decision must carry safe IDs and fingerprints only:
+
+- source fingerprints;
+- eval event IDs;
+- admission decision ID;
+- promotion IDs;
+- replay entry IDs;
+- policy version;
+- provider key as non-secret provider/version reference;
+- model key as non-secret model/version reference;
+- context fingerprint;
+- user tier;
+- transparency notice id;
+- response fingerprint;
+- safety flags;
+- request fingerprint.
+
+Missing Evidence Graph linkage forces fallback. Source fingerprint mismatch
+forces fallback. Policy mismatch, provider mismatch, model mismatch, context
+mismatch, user tier mismatch, transparency notice mismatch, admission blocked,
+false-hit blocked, stop-rule blocked, and blocked surface all force fallback.
+
+## Blocked Payloads And Surfaces
+
+SC-G4 must not contain or persist:
+
+- raw prompts;
+- raw queries;
+- normalized queries;
+- raw model responses;
+- raw answers;
+- provider payloads;
+- secrets, credentials, authorization headers, cookies, or API keys;
+- local paths;
+- HealthKit-derived sensitive payloads;
+- diagnosis-like health data;
+- highly personalized coaching state;
+- user-account truth.
+
+SC-G4 must not use these as product cache sources or surfaces:
+
+- advisory wiki;
+- workforce memory;
+- billing/auth/entitlement;
+- legal/compliance outputs;
+- account truth;
+- GraphRAG or knowledge graph runtime output.
+
+Advisory wiki pages are not product cache truth and may not seed product cache
+entries.
+
+## Blocked Runtime And Backend Scope
+
+SC-G4 blocks:
+
+- FastAPI;
+- OpenAPI;
+- DB writes;
+- migrations;
+- provider calls;
+- runtime wiring;
+- Redis;
+- GPTCache;
+- vector search;
+- embeddings;
+- semantic similarity backends;
+- raw payload storage;
+- cache backend selection.
+
+SC-G5 backend selection remains future and may consider Redis/GPTCache only
+after safety evidence, rollback proof, current-head CI governance, and human
+approval exist.
+
+## Observability And Rollback
+
+SC-G4 consumes SC-G2 and SC-G3 contracts:
+
+- SC-G2 exact/fuzzy lookup request, lookup result, and candidate record;
+- SC-G3 audit event;
+- SC-G3 false-hit evaluation;
+- SC-G3 observability metrics;
+- SC-G3 stop decision;
+- SC-G3 kill switch snapshot.
+
+SC-G4 does not duplicate matching logic and does not implement semantic
+inference. `semantic_false_positive` remains an SC-G3 risk label only.
+
+Required rollback and stop proof:
+
+- no-cache fallback path;
+- purge/invalidation path documented for later serving PRs;
+- stop rules for false-hit rate, stale-source hit, policy mismatch, model
+  mismatch, context leakage, and blocked surfaces;
+- rollback thresholds;
+- kill switch snapshot;
+- deterministic disabled-state tests.
+
+## Machine-Readable State
+
+```json
+{
+  "acceptance_criteria": [
+    "gate remains closed",
+    "off by default",
+    "request disable forces fallback",
+    "kill switch forces fallback",
+    "missing Evidence Graph linkage forces fallback",
+    "no raw payload persistence",
+    "SC-G5 backend selection remains future"
+  ],
+  "allowed_surface": "bounded_insight_style_product_ai",
+  "blocked_backends": [
+    "Redis",
+    "GPTCache",
+    "embeddings",
+    "vector search",
+    "semantic similarity backend"
+  ],
+  "blocked_payload_fields": [
+    "raw prompts",
+    "raw queries",
+    "normalized queries",
+    "raw model responses",
+    "raw answers",
+    "provider payloads",
+    "secrets",
+    "authorization headers",
+    "cookies",
+    "API keys"
+  ],
+  "blocked_surfaces": [
+    "advisory wiki",
+    "workforce memory",
+    "billing/auth/entitlement",
+    "legal/compliance outputs",
+    "account truth",
+    "HealthKit-derived sensitive payloads",
+    "GraphRAG"
+  ],
+  "default_state": "off",
+  "feature_flag_sources": [
+    "environment flag",
+    "runtime flag snapshot",
+    "explicit request opt-in",
+    "request disable",
+    "kill switch snapshot"
+  ],
+  "gate_status": "closed",
+  "implementation_allowed": false,
+  "required_decision_fields": [
+    "decision",
+    "reason_codes",
+    "source_fingerprints",
+    "policy_version",
+    "provider_key",
+    "model_key",
+    "context_fingerprint",
+    "user_tier",
+    "transparency_notice_id",
+    "response_fingerprint",
+    "request_fingerprint"
+  ],
+  "required_evidence_linkage_fields": [
+    "source_fingerprints",
+    "eval_event_ids",
+    "admission_decision_id",
+    "promotion_ids",
+    "replay_entry_ids",
+    "policy_version"
+  ],
+  "rollout_phase": "SC-G4",
+  "runtime_allowed": false
+}
+```
+
+## Premortem Closure
+
+- Accidental gate open: checker requires closed gate and rejects active/open
+  wording.
+- Default enabled drift: code and contract require off by default and explicit
+  opt-in.
+- Hidden runtime serving path: import guards reject runtime/provider/backend
+  imports and app-side cache wiring while the gate is closed.
+- Cross-context leakage: context, tier, source, policy, provider, model, and
+  transparency mismatches force fallback.
+- Raw prompt/response persistence: metadata validators and contract checker
+  reject raw prompt/query/response/answer payloads.
+- Advisory wiki cache source: blocked surface and checker anchors reject
+  advisory wiki product cache truth.
+- Redis/GPTCache drift: SC-G5 backend selection remains future.

--- a/docs/orchestration/contracts/SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.schema.json
+++ b/docs/orchestration/contracts/SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "acceptance_criteria": {
+      "items": { "type": "string" },
+      "minItems": 7,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "allowed_surface": { "const": "bounded_insight_style_product_ai" },
+    "blocked_backends": {
+      "items": {
+        "enum": [
+          "Redis",
+          "GPTCache",
+          "embeddings",
+          "vector search",
+          "semantic similarity backend"
+        ]
+      },
+      "minItems": 5,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "blocked_payload_fields": {
+      "items": { "type": "string" },
+      "minItems": 9,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "blocked_surfaces": {
+      "items": { "type": "string" },
+      "minItems": 7,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "default_state": { "const": "off" },
+    "feature_flag_sources": {
+      "items": {
+        "enum": [
+          "environment flag",
+          "runtime flag snapshot",
+          "explicit request opt-in",
+          "request disable",
+          "kill switch snapshot"
+        ]
+      },
+      "minItems": 5,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "gate_status": { "const": "closed" },
+    "implementation_allowed": { "const": false },
+    "required_decision_fields": {
+      "items": {
+        "enum": [
+          "decision",
+          "reason_codes",
+          "source_fingerprints",
+          "policy_version",
+          "provider_key",
+          "model_key",
+          "context_fingerprint",
+          "user_tier",
+          "transparency_notice_id",
+          "response_fingerprint",
+          "request_fingerprint"
+        ]
+      },
+      "minItems": 11,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "required_evidence_linkage_fields": {
+      "items": {
+        "enum": [
+          "source_fingerprints",
+          "eval_event_ids",
+          "admission_decision_id",
+          "promotion_ids",
+          "replay_entry_ids",
+          "policy_version"
+        ]
+      },
+      "minItems": 6,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "rollout_phase": { "const": "SC-G4" },
+    "runtime_allowed": { "const": false }
+  },
+  "required": [
+    "gate_status",
+    "runtime_allowed",
+    "implementation_allowed",
+    "rollout_phase",
+    "allowed_surface",
+    "default_state",
+    "feature_flag_sources",
+    "required_evidence_linkage_fields",
+    "required_decision_fields",
+    "blocked_payload_fields",
+    "blocked_surfaces",
+    "blocked_backends",
+    "acceptance_criteria"
+  ],
+  "type": "object"
+}

--- a/docs/orchestration/contracts/SEMANTIC_CACHE_ROLLOUT_GATE.md
+++ b/docs/orchestration/contracts/SEMANTIC_CACHE_ROLLOUT_GATE.md
@@ -75,7 +75,10 @@ which keeps SC-G3 offline only and non-serving.
 
 SC-G4 is the first bounded semantic-cache experiment. It must stay
 feature-flagged, off by default, and limited to the `/insight`-style product AI
-surface.
+surface. The phase-specific SC-G4 contract is
+[`SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.md`](./SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.md),
+which keeps SC-G4 metadata-only, fail-closed, and non-serving while the global
+semantic-cache gate remains closed.
 
 SC-G5 may consider Redis/GPTCache only after safety evidence, rollback proof,
 and current-head CI governance exist.

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -72,7 +72,7 @@ Evidence: `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bound
 | Deep-freeze nested metadata without breaking JSON-ready stable mappings | FIXED | Commit `014017e6a`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
 | Reject non-string token inputs with `ValueError` instead of `AttributeError` | FIXED | Commit `014017e6a`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
 | Return plain JSON-ready stable mappings from `to_stable_mapping()` | FIXED | Commit `2f0692a67`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
-| Include SC-G4 tests in CI coverage selection | FIXED | Commit `c1fc167cd`; `.github/workflows/ci.yml`; focused pytest, mypy, changed-files pre-commit, and `make validate-changed` PASS |
+| Include SC-G4 tests in CI coverage selection | FIXED | Commit `c1fc167cd`; GitHub Actions workflow coverage lane; focused pytest, mypy, changed-files pre-commit, and `make validate-changed` PASS |
 | Close remaining SC-G4 diff coverage gaps | FIXED | Commit `11311d937`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; local diff-cover 100% PASS |
 
 ## Premortem Finding Mapping

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -16,6 +16,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 - Follow-up commit: `b25a370b2` `fix(ai-runtime): omit rejected bounded insight candidate payloads`
 - Follow-up commit: `014017e6a` `fix(ai-runtime): harden bounded insight metadata contracts`
 - Follow-up commit: `2f0692a67` `fix(ai-runtime): return json-ready bounded insight mappings`
+- Follow-up commit: `c1fc167cd` `fix(ci): include bounded insight tests in coverage lane`
 - `python scripts/orchestration/check_preflight.py` PASS
 - `python scripts/orchestration/check_agent_consistency.py` PASS
 - `python scripts/ci/check_semantic_cache_gate.py` PASS
@@ -23,7 +24,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 - Focused semantic-cache pytest bundle PASS
 - Narrow mypy PASS
 - `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed` PASS
-- `PATH=.venv/bin:$PATH pre-commit run --all-files` PASS
+- `PATH=.venv/bin:$PATH pre-commit run --from-ref origin/main --to-ref HEAD` PASS
 
 ## Discussion Thread Pass
 
@@ -32,7 +33,19 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 3e5f9ca6f, 014017e6a, 2f0692a67
+Evidence: `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`, `docs/review/PR_1705_FIXED_MAPPING.md`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#pullrequestreview-4250807388 -> 3e5f9ca6f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207440778 -> 3e5f9ca6f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207440785 -> 3e5f9ca6f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207480050 -> 3e5f9ca6f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#pullrequestreview-4250851460 -> 3e5f9ca6f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#pullrequestreview-4251227882 -> 014017e6a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207798992 -> 014017e6a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207799842 -> 014017e6a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207799846 -> 2f0692a67
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#pullrequestreview-4251228938 -> 2f0692a67
 
 ## Post-Open Agent Finding Mapping
 
@@ -54,6 +67,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 | Deep-freeze nested metadata without breaking JSON-ready stable mappings | FIXED | Commit `014017e6a`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
 | Reject non-string token inputs with `ValueError` instead of `AttributeError` | FIXED | Commit `014017e6a`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
 | Return plain JSON-ready stable mappings from `to_stable_mapping()` | FIXED | Commit `2f0692a67`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
+| Include SC-G4 tests in CI coverage selection | FIXED | Commit `c1fc167cd`; `.github/workflows/ci.yml`; focused pytest, mypy, changed-files pre-commit, and `make validate-changed` PASS |
 
 ## Premortem Finding Mapping
 

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -7,7 +7,8 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 ## Local Evidence
 
 - Commit: `250a1f856` `feat(ai-runtime): add bounded insight semantic-cache experiment`
-- Follow-up commit: pending post-open QA fixes for linkage, audit partition validation, and Phase2 artifact format
+- Follow-up commit: `e388863c4` `fix(ai-runtime): close bounded insight review gaps`
+- Follow-up commit: `83c372b1f` `fix(ai-runtime): harden bounded insight linkage guards`
 - `python scripts/orchestration/check_preflight.py` PASS
 - `python scripts/orchestration/check_agent_consistency.py` PASS
 - `python scripts/ci/check_semantic_cache_gate.py` PASS
@@ -30,9 +31,11 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 
 | Finding | Disposition | Evidence |
 | --- | --- | --- |
-| Require promotion/replay linkage before eligibility | FIXED | `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
-| Validate audit event partition fields | FIXED | `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
-| Fix Phase2 mapping artifact format | FIXED | `docs/review/PR_1705_FIXED_MAPPING.md`, PR body mirror |
+| Require promotion/replay linkage before eligibility | FIXED | Commit `e388863c4`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
+| Validate audit event partition fields | FIXED | Commit `e388863c4`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
+| Fix Phase2 mapping artifact format | FIXED | Commit `e388863c4`; `docs/review/PR_1705_FIXED_MAPPING.md`, PR body mirror |
+| Require Evidence Graph ID equality across request, record, and audit event | FIXED | Commit `83c372b1f`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
+| Harden SC-G4 checker against unsafe bare backend/raw-payload wording | FIXED | Commit `83c372b1f`; `scripts/ci/check_semantic_cache_gate.py`, `tests/test_semantic_cache_bounded_insight_experiment_contract.py` |
 
 ## Premortem Finding Mapping
 

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -10,6 +10,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 - Follow-up commit: `e388863c4` `fix(ai-runtime): close bounded insight review gaps`
 - Follow-up commit: `83c372b1f` `fix(ai-runtime): harden bounded insight linkage guards`
 - Follow-up commit: `18a333152` `fix(ai-runtime): keep linkage mismatch typing explicit`
+- Follow-up commit: `878b316a6` `fix(ai-runtime): bind bounded insight audit fingerprints`
 - `python scripts/orchestration/check_preflight.py` PASS
 - `python scripts/orchestration/check_agent_consistency.py` PASS
 - `python scripts/ci/check_semantic_cache_gate.py` PASS
@@ -38,6 +39,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 | Require Evidence Graph ID equality across request, record, and audit event | FIXED | Commit `83c372b1f`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
 | Harden SC-G4 checker against unsafe bare backend/raw-payload wording | FIXED | Commit `83c372b1f`; `scripts/ci/check_semantic_cache_gate.py`, `tests/test_semantic_cache_bounded_insight_experiment_contract.py` |
 | Keep pre-push mypy strict on linkage mismatch helper | FIXED | Commit `18a333152`; `core/ai/bounded_insight_semantic_cache.py`; `python -m mypy ...` PASS |
+| Bind SC-G4 decisions to audited request fingerprint | FIXED | Commit `878b316a6`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
 
 ## Premortem Finding Mapping
 

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -18,6 +18,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 - Follow-up commit: `2f0692a67` `fix(ai-runtime): return json-ready bounded insight mappings`
 - Follow-up commit: `c1fc167cd` `fix(ci): include bounded insight tests in coverage lane`
 - Follow-up commit: `d8af82a6e` `docs(review): map bounded insight bot findings`
+- Follow-up commit: `11311d937` `fix(ai-runtime): close bounded insight diff coverage gaps`
 - `python scripts/orchestration/check_preflight.py` PASS
 - `python scripts/orchestration/check_agent_consistency.py` PASS
 - `python scripts/ci/check_semantic_cache_gate.py` PASS
@@ -71,6 +72,7 @@ Evidence: `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bound
 | Reject non-string token inputs with `ValueError` instead of `AttributeError` | FIXED | Commit `014017e6a`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
 | Return plain JSON-ready stable mappings from `to_stable_mapping()` | FIXED | Commit `2f0692a67`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
 | Include SC-G4 tests in CI coverage selection | FIXED | Commit `c1fc167cd`; `.github/workflows/ci.yml`; focused pytest, mypy, changed-files pre-commit, and `make validate-changed` PASS |
+| Close remaining SC-G4 diff coverage gaps | FIXED | Commit `11311d937`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; local diff-cover 100% PASS |
 
 ## Premortem Finding Mapping
 

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -14,6 +14,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 - Follow-up commit: `3e5f9ca6f` `fix(ai-runtime): close bounded insight bot findings`
 - Follow-up commit: `153c65302` `fix(ai-runtime): keep bounded insight helper typing strict`
 - Follow-up commit: `b25a370b2` `fix(ai-runtime): omit rejected bounded insight candidate payloads`
+- Follow-up commit: `014017e6a` `fix(ai-runtime): harden bounded insight metadata contracts`
 - `python scripts/orchestration/check_preflight.py` PASS
 - `python scripts/orchestration/check_agent_consistency.py` PASS
 - `python scripts/ci/check_semantic_cache_gate.py` PASS
@@ -48,6 +49,9 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 | Replace `Phase2` spelling with `Phase 2` | FIXED | Commit `3e5f9ca6f`; `docs/review/PR_1705_FIXED_MAPPING.md` |
 | Keep strict mypy compatibility for eligible candidate helper returns | FIXED | Commit `153c65302`; `core/ai/bounded_insight_semantic_cache.py`; `python -m mypy ...` PASS |
 | Omit candidate identifiers and response fingerprints on all rejected fallback decisions | FIXED | Commit `b25a370b2`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
+| Require candidate response fingerprint parity before bound-hit metadata eligibility | FIXED | Commit `014017e6a`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
+| Deep-freeze nested metadata without breaking JSON-ready stable mappings | FIXED | Commit `014017e6a`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
+| Reject non-string token inputs with `ValueError` instead of `AttributeError` | FIXED | Commit `014017e6a`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
 
 ## Premortem Finding Mapping
 

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -11,6 +11,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 - Follow-up commit: `83c372b1f` `fix(ai-runtime): harden bounded insight linkage guards`
 - Follow-up commit: `18a333152` `fix(ai-runtime): keep linkage mismatch typing explicit`
 - Follow-up commit: `878b316a6` `fix(ai-runtime): bind bounded insight audit fingerprints`
+- Follow-up commit: `3e5f9ca6f` `fix(ai-runtime): close bounded insight bot findings`
 - `python scripts/orchestration/check_preflight.py` PASS
 - `python scripts/orchestration/check_agent_consistency.py` PASS
 - `python scripts/ci/check_semantic_cache_gate.py` PASS
@@ -40,6 +41,9 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 | Harden SC-G4 checker against unsafe bare backend/raw-payload wording | FIXED | Commit `83c372b1f`; `scripts/ci/check_semantic_cache_gate.py`, `tests/test_semantic_cache_bounded_insight_experiment_contract.py` |
 | Keep pre-push mypy strict on linkage mismatch helper | FIXED | Commit `18a333152`; `core/ai/bounded_insight_semantic_cache.py`; `python -m mypy ...` PASS |
 | Bind SC-G4 decisions to audited request fingerprint | FIXED | Commit `878b316a6`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
+| Require safety flag parity before eligibility | FIXED | Commit `3e5f9ca6f`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
+| Do not attach candidate record/response metadata on lookup miss | FIXED | Commit `3e5f9ca6f`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
+| Replace `Phase2` spelling with `Phase 2` | FIXED | Commit `3e5f9ca6f`; `docs/review/PR_1705_FIXED_MAPPING.md` |
 
 ## Premortem Finding Mapping
 

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -13,6 +13,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 - Follow-up commit: `878b316a6` `fix(ai-runtime): bind bounded insight audit fingerprints`
 - Follow-up commit: `3e5f9ca6f` `fix(ai-runtime): close bounded insight bot findings`
 - Follow-up commit: `153c65302` `fix(ai-runtime): keep bounded insight helper typing strict`
+- Follow-up commit: `b25a370b2` `fix(ai-runtime): omit rejected bounded insight candidate payloads`
 - `python scripts/orchestration/check_preflight.py` PASS
 - `python scripts/orchestration/check_agent_consistency.py` PASS
 - `python scripts/ci/check_semantic_cache_gate.py` PASS
@@ -46,6 +47,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 | Do not attach candidate record/response metadata on lookup miss | FIXED | Commit `3e5f9ca6f`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
 | Replace `Phase2` spelling with `Phase 2` | FIXED | Commit `3e5f9ca6f`; `docs/review/PR_1705_FIXED_MAPPING.md` |
 | Keep strict mypy compatibility for eligible candidate helper returns | FIXED | Commit `153c65302`; `core/ai/bounded_insight_semantic_cache.py`; `python -m mypy ...` PASS |
+| Omit candidate identifiers and response fingerprints on all rejected fallback decisions | FIXED | Commit `b25a370b2`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
 
 ## Premortem Finding Mapping
 

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -19,6 +19,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 - Follow-up commit: `c1fc167cd` `fix(ci): include bounded insight tests in coverage lane`
 - Follow-up commit: `d8af82a6e` `docs(review): map bounded insight bot findings`
 - Follow-up commit: `11311d937` `fix(ai-runtime): close bounded insight diff coverage gaps`
+- Follow-up commit: `aa0204417` `docs(review): map bounded insight coverage fix`
 - `python scripts/orchestration/check_preflight.py` PASS
 - `python scripts/orchestration/check_agent_consistency.py` PASS
 - `python scripts/ci/check_semantic_cache_gate.py` PASS

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -35,7 +35,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 | --- | --- | --- |
 | Require promotion/replay linkage before eligibility | FIXED | Commit `e388863c4`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
 | Validate audit event partition fields | FIXED | Commit `e388863c4`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
-| Fix Phase2 mapping artifact format | FIXED | Commit `e388863c4`; `docs/review/PR_1705_FIXED_MAPPING.md`, PR body mirror |
+| Fix Phase 2 mapping artifact format | FIXED | Commit `e388863c4`; `docs/review/PR_1705_FIXED_MAPPING.md`, PR body mirror |
 | Require Evidence Graph ID equality across request, record, and audit event | FIXED | Commit `83c372b1f`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
 | Harden SC-G4 checker against unsafe bare backend/raw-payload wording | FIXED | Commit `83c372b1f`; `scripts/ci/check_semantic_cache_gate.py`, `tests/test_semantic_cache_bounded_insight_experiment_contract.py` |
 | Keep pre-push mypy strict on linkage mismatch helper | FIXED | Commit `18a333152`; `core/ai/bounded_insight_semantic_cache.py`; `python -m mypy ...` PASS |

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -17,6 +17,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 - Follow-up commit: `014017e6a` `fix(ai-runtime): harden bounded insight metadata contracts`
 - Follow-up commit: `2f0692a67` `fix(ai-runtime): return json-ready bounded insight mappings`
 - Follow-up commit: `c1fc167cd` `fix(ci): include bounded insight tests in coverage lane`
+- Follow-up commit: `d8af82a6e` `docs(review): map bounded insight bot findings`
 - `python scripts/orchestration/check_preflight.py` PASS
 - `python scripts/orchestration/check_agent_consistency.py` PASS
 - `python scripts/ci/check_semantic_cache_gate.py` PASS
@@ -39,6 +40,8 @@ Evidence: `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bound
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#pullrequestreview-4250807388 -> 3e5f9ca6f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207440778 -> 3e5f9ca6f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207440785 -> 3e5f9ca6f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207399328 -> 3e5f9ca6f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207399336 -> e388863c4
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207480050 -> 3e5f9ca6f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#pullrequestreview-4250851460 -> 3e5f9ca6f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#pullrequestreview-4251227882 -> 014017e6a

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -7,6 +7,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 ## Local Evidence
 
 - Commit: `250a1f856` `feat(ai-runtime): add bounded insight semantic-cache experiment`
+- Follow-up commit: pending post-open QA fixes for linkage, audit partition validation, and Phase2 artifact format
 - `python scripts/orchestration/check_preflight.py` PASS
 - `python scripts/orchestration/check_agent_consistency.py` PASS
 - `python scripts/ci/check_semantic_cache_gate.py` PASS
@@ -18,14 +19,20 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 
 ## Discussion Thread Pass
 
-- [ ] Awaiting CodeRabbit/Sourcery/Cubic/human review.
-- [ ] Post-open `qa-engineer-agent -> bug-hunter -> security-auditor` lane pending.
-- [ ] Codex Security threat-model/security-scan/validation pending.
-- [ ] No unresolved actionable review threads before merge readiness.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments yet.
+- No actionable review comments
+
+## Post-Open Agent Finding Mapping
+
+| Finding | Disposition | Evidence |
+| --- | --- | --- |
+| Require promotion/replay linkage before eligibility | FIXED | `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
+| Validate audit event partition fields | FIXED | `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
+| Fix Phase2 mapping artifact format | FIXED | `docs/review/PR_1705_FIXED_MAPPING.md`, PR body mirror |
 
 ## Premortem Finding Mapping
 

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -39,8 +39,9 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
-Commit: 3e5f9ca6f, 014017e6a, 2f0692a67
+Commit: see mapping entries below
 Evidence: `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`, `docs/review/PR_1705_FIXED_MAPPING.md`
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#pullrequestreview-4250807388 -> 3e5f9ca6f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207440778 -> 3e5f9ca6f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207440785 -> 3e5f9ca6f

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -20,6 +20,8 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 - Follow-up commit: `d8af82a6e` `docs(review): map bounded insight bot findings`
 - Follow-up commit: `11311d937` `fix(ai-runtime): close bounded insight diff coverage gaps`
 - Follow-up commit: `aa0204417` `docs(review): map bounded insight coverage fix`
+- Follow-up commit: `844e1416b` `docs(review): record bounded insight coverage mapping`
+- Follow-up commit: `613abbb68` `docs(review): fix bounded insight GitHub wording`
 - `python scripts/orchestration/check_preflight.py` PASS
 - `python scripts/orchestration/check_agent_consistency.py` PASS
 - `python scripts/ci/check_semantic_cache_gate.py` PASS
@@ -51,6 +53,8 @@ Evidence: `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bound
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207799842 -> 014017e6a
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3207799846 -> 2f0692a67
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#pullrequestreview-4251228938 -> 2f0692a67
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#discussion_r3208706618 -> 613abbb68
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1705#pullrequestreview-4252289237 -> 613abbb68
 
 ## Post-Open Agent Finding Mapping
 

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -1,0 +1,43 @@
+# PR 1705 Fixed Mapping
+
+## Summary
+
+SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic, metadata-only, off-by-default decision layer and machine-checkable contract while keeping the global semantic-cache gate closed.
+
+## Local Evidence
+
+- Commit: `250a1f856` `feat(ai-runtime): add bounded insight semantic-cache experiment`
+- `python scripts/orchestration/check_preflight.py` PASS
+- `python scripts/orchestration/check_agent_consistency.py` PASS
+- `python scripts/ci/check_semantic_cache_gate.py` PASS
+- `python scripts/ci/check_docs_phase1_gates.py --files docs/orchestration/contracts/SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.md docs/orchestration/contracts/SEMANTIC_CACHE_OBSERVABILITY_FALSE_HIT_HARNESS.md docs/orchestration/contracts/EXACT_FUZZY_CACHE_SCAFFOLD.md docs/roadmap/PulsePlate_Semantic_Cache_Gate_and_Plan.md` PASS
+- Focused semantic-cache pytest bundle PASS
+- Narrow mypy PASS
+- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed` PASS
+- `PATH=.venv/bin:$PATH pre-commit run --all-files` PASS
+
+## Discussion Thread Pass
+
+- [ ] Awaiting CodeRabbit/Sourcery/Cubic/human review.
+- [ ] Post-open `qa-engineer-agent -> bug-hunter -> security-auditor` lane pending.
+- [ ] Codex Security threat-model/security-scan/validation pending.
+- [ ] No unresolved actionable review threads before merge readiness.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments yet.
+
+## Premortem Finding Mapping
+
+| Finding | Disposition | Evidence |
+| --- | --- | --- |
+| SC-G4 could imply gate-open or serving | FIXED | `scripts/ci/check_semantic_cache_gate.py`, `tests/test_semantic_cache_bounded_insight_experiment_contract.py` |
+| Default-on experiment | FIXED | `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
+| Hidden runtime import path | FIXED | `tests/test_semantic_cache_bounded_insight_experiment_contract.py` side-door guard |
+| Negative controls becoming safe hits | FIXED | `core/ai/cache_observability.py`, `tests/core/ai/test_cache_observability.py` |
+| Miss audit event with hit-like mode | FIXED | `core/ai/cache_observability.py`, `tests/core/ai/test_cache_observability.py` |
+| Raw auth/header metadata leakage | FIXED | `core/ai/cache_observability.py`, `core/ai/bounded_insight_semantic_cache.py`, focused tests |
+
+## Merge Readiness
+
+Not merge-ready yet. Await current-head CI, bot/human review disposition, Codex Security pass, strict merge-readiness wrapper, unresolved-thread check, and mandatory wait-window.

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -12,6 +12,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 - Follow-up commit: `18a333152` `fix(ai-runtime): keep linkage mismatch typing explicit`
 - Follow-up commit: `878b316a6` `fix(ai-runtime): bind bounded insight audit fingerprints`
 - Follow-up commit: `3e5f9ca6f` `fix(ai-runtime): close bounded insight bot findings`
+- Follow-up commit: `153c65302` `fix(ai-runtime): keep bounded insight helper typing strict`
 - `python scripts/orchestration/check_preflight.py` PASS
 - `python scripts/orchestration/check_agent_consistency.py` PASS
 - `python scripts/ci/check_semantic_cache_gate.py` PASS
@@ -44,6 +45,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 | Require safety flag parity before eligibility | FIXED | Commit `3e5f9ca6f`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
 | Do not attach candidate record/response metadata on lookup miss | FIXED | Commit `3e5f9ca6f`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
 | Replace `Phase2` spelling with `Phase 2` | FIXED | Commit `3e5f9ca6f`; `docs/review/PR_1705_FIXED_MAPPING.md` |
+| Keep strict mypy compatibility for eligible candidate helper returns | FIXED | Commit `153c65302`; `core/ai/bounded_insight_semantic_cache.py`; `python -m mypy ...` PASS |
 
 ## Premortem Finding Mapping
 

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -15,6 +15,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 - Follow-up commit: `153c65302` `fix(ai-runtime): keep bounded insight helper typing strict`
 - Follow-up commit: `b25a370b2` `fix(ai-runtime): omit rejected bounded insight candidate payloads`
 - Follow-up commit: `014017e6a` `fix(ai-runtime): harden bounded insight metadata contracts`
+- Follow-up commit: `2f0692a67` `fix(ai-runtime): return json-ready bounded insight mappings`
 - `python scripts/orchestration/check_preflight.py` PASS
 - `python scripts/orchestration/check_agent_consistency.py` PASS
 - `python scripts/ci/check_semantic_cache_gate.py` PASS
@@ -52,6 +53,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 | Require candidate response fingerprint parity before bound-hit metadata eligibility | FIXED | Commit `014017e6a`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
 | Deep-freeze nested metadata without breaking JSON-ready stable mappings | FIXED | Commit `014017e6a`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
 | Reject non-string token inputs with `ValueError` instead of `AttributeError` | FIXED | Commit `014017e6a`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
+| Return plain JSON-ready stable mappings from `to_stable_mapping()` | FIXED | Commit `2f0692a67`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py`; focused pytest + mypy PASS |
 
 ## Premortem Finding Mapping
 

--- a/docs/review/PR_1705_FIXED_MAPPING.md
+++ b/docs/review/PR_1705_FIXED_MAPPING.md
@@ -9,6 +9,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 - Commit: `250a1f856` `feat(ai-runtime): add bounded insight semantic-cache experiment`
 - Follow-up commit: `e388863c4` `fix(ai-runtime): close bounded insight review gaps`
 - Follow-up commit: `83c372b1f` `fix(ai-runtime): harden bounded insight linkage guards`
+- Follow-up commit: `18a333152` `fix(ai-runtime): keep linkage mismatch typing explicit`
 - `python scripts/orchestration/check_preflight.py` PASS
 - `python scripts/orchestration/check_agent_consistency.py` PASS
 - `python scripts/ci/check_semantic_cache_gate.py` PASS
@@ -36,6 +37,7 @@ SC-G4 bounded `/insight` semantic-cache experiment. The PR adds a deterministic,
 | Fix Phase2 mapping artifact format | FIXED | Commit `e388863c4`; `docs/review/PR_1705_FIXED_MAPPING.md`, PR body mirror |
 | Require Evidence Graph ID equality across request, record, and audit event | FIXED | Commit `83c372b1f`; `core/ai/bounded_insight_semantic_cache.py`, `tests/core/ai/test_bounded_insight_semantic_cache.py` |
 | Harden SC-G4 checker against unsafe bare backend/raw-payload wording | FIXED | Commit `83c372b1f`; `scripts/ci/check_semantic_cache_gate.py`, `tests/test_semantic_cache_bounded_insight_experiment_contract.py` |
+| Keep pre-push mypy strict on linkage mismatch helper | FIXED | Commit `18a333152`; `core/ai/bounded_insight_semantic_cache.py`; `python -m mypy ...` PASS |
 
 ## Premortem Finding Mapping
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2323,7 +2323,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Evidence Graph Runtime umbrella
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (AI runtime governance / evidence lineage)
-  - Target PR: PR-E0 (`codex/evidence-graph-runtime-umbrella`) -> PR-E1/E2/E3/E4/E5; current follow-up: `feat/ai-runtime-cache-observability-false-hit-harness`
+  - Target PR: PR-E0 (`codex/evidence-graph-runtime-umbrella`) -> PR-E1/E2/E3/E4/E5; current follow-up: `feat/ai-runtime-bounded-insight-semantic-cache-experiment`
   - Area: AI runtime / RAG / evals / knowledge promotion / advisory memory
   - Finding Type: asset-lineage and replay-governance gap
   - Status: PR-E5 advisory wiki evidence bridge merged; E0/E1/E2/E3/E4/E5 are baseline, #1666/#1667 eval-sidecar hardening is baseline, #1676 source-artifact path hardening is baseline, and semantic cache remains blocked behind a dedicated gate with machine-checkable closed markers
@@ -2352,6 +2352,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - SC-G1 semantic-cache rollout gate contract defines the future gate-open criteria, rollout sequence, false-hit risk model, observability, kill switch, and blocked surfaces while keeping semantic-cache markers closed
     - SC-G2 exact/fuzzy cache scaffold adds deterministic lexical matching contracts and guards while preserving closed semantic-cache markers, with no runtime serving, embeddings, Redis/GPTCache, vector search, provider changes, `/insight` wiring, DB, FastAPI, or OpenAPI changes
     - SC-G3 cache observability and false-hit harness adds offline audit events, negative controls, metric contracts, stop rules, rollback thresholds, and kill-switch modeling while preserving closed semantic-cache markers, with no runtime serving, embeddings, Redis/GPTCache, vector search, provider changes, `/insight` wiring, DB, FastAPI, or OpenAPI changes
+    - SC-G4 bounded `/insight` semantic-cache experiment adds a deterministic, metadata-only, off-by-default, request-disableable, kill-switchable decision layer while preserving closed semantic-cache markers, with no runtime serving, Redis/GPTCache, embeddings, vector search, provider calls, DB, FastAPI, OpenAPI, or `/insight` route wiring changes
 
 <a id="ledger-p1-apple-server-api-migration"></a>
 - [ ] P1: Apple receipt verification migration to App Store Server API

--- a/docs/roadmap/PulsePlate_Semantic_Cache_Gate_and_Plan.md
+++ b/docs/roadmap/PulsePlate_Semantic_Cache_Gate_and_Plan.md
@@ -38,6 +38,12 @@ That contract is offline only and non-serving; it adds audit-event,
 negative-control, metric, stop-rule, rollback-threshold, and kill-switch
 contracts without opening the gate or wiring runtime cache behavior.
 
+The SC-G4 bounded `/insight` experiment contract is defined in
+[`SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.md`](../orchestration/contracts/SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.md).
+That contract is metadata-only, off by default, request-disableable,
+kill-switchable, fail-closed, and non-serving; it does not open the global
+semantic-cache gate, wire `/insight`, or approve any backend.
+
 Current `main` already contains:
 - merged `A1` fallback/readiness runtime truth
 - landed PRO/VIP tier-aware monthly quota machinery
@@ -108,6 +114,11 @@ Any future semantic cache record must include:
 - TTL
 - model/version key
 - safety/classification flags
+
+For SC-G4 specifically, the current decision layer must use safe fingerprints,
+IDs, reason codes, and metadata only. It must not store raw prompts, raw
+queries, normalized queries, raw model responses, raw answers, or provider
+payloads.
 
 Minimum metrics:
 - eligible_hit_rate

--- a/scripts/ci/check_docs_phase1_gates.py
+++ b/scripts/ci/check_docs_phase1_gates.py
@@ -25,6 +25,9 @@ EXACT_FUZZY_CACHE_SCAFFOLD_DOC = "docs/orchestration/contracts/EXACT_FUZZY_CACHE
 SEMANTIC_CACHE_OBSERVABILITY_CONTRACT_DOC = (
     "docs/orchestration/contracts/SEMANTIC_CACHE_OBSERVABILITY_FALSE_HIT_HARNESS.md"
 )
+SEMANTIC_CACHE_BOUNDED_INSIGHT_CONTRACT_DOC = (
+    "docs/orchestration/contracts/SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.md"
+)
 SemanticCacheGateValidator = Callable[[str], list[str]]
 
 
@@ -54,6 +57,10 @@ def _load_exact_fuzzy_scaffold_validator() -> SemanticCacheGateValidator:
 
 def _load_semantic_cache_observability_validator() -> SemanticCacheGateValidator:
     return _load_validator("validate_semantic_cache_observability_contract")
+
+
+def _load_semantic_cache_bounded_insight_validator() -> SemanticCacheGateValidator:
+    return _load_validator("validate_semantic_cache_bounded_insight_experiment_contract")
 
 
 def _read_text(relpath: str) -> str:
@@ -106,6 +113,12 @@ def check_docs_phase1_guards(markdown_files: list[str]) -> list[str]:
             validate_observability_contract = _load_semantic_cache_observability_validator()
             errors.extend(
                 f"{relpath}: {error}" for error in validate_observability_contract(content)
+            )
+
+        if relpath == SEMANTIC_CACHE_BOUNDED_INSIGHT_CONTRACT_DOC:
+            validate_bounded_insight_contract = _load_semantic_cache_bounded_insight_validator()
+            errors.extend(
+                f"{relpath}: {error}" for error in validate_bounded_insight_contract(content)
             )
 
     return errors

--- a/scripts/ci/check_semantic_cache_gate.py
+++ b/scripts/ci/check_semantic_cache_gate.py
@@ -23,6 +23,13 @@ DEFAULT_OBSERVABILITY_CONTRACT = (
     / "contracts"
     / "SEMANTIC_CACHE_OBSERVABILITY_FALSE_HIT_HARNESS.md"
 )
+DEFAULT_BOUNDED_INSIGHT_CONTRACT = (
+    REPO_ROOT
+    / "docs"
+    / "orchestration"
+    / "contracts"
+    / "SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.md"
+)
 
 REQUIRED_MARKERS = {
     "SEMANTIC_CACHE_GATE_STATUS": "closed",
@@ -394,6 +401,95 @@ OBSERVABILITY_FORBIDDEN_PATTERNS = (
     ("cache raw responses", re.compile(r"\bcache\s+raw\s+(?:model\s+)?responses?\b")),
 )
 
+BOUNDED_INSIGHT_REQUIRED_ANCHORS = (
+    ("SC-G4 bounded insight", re.compile(r"\bsc-g4 bounded /insight semantic-cache experiment\b")),
+    ("does not open gate", re.compile(r"\bdoes not open (?:the )?semantic-cache gate\b")),
+    ("does not enable runtime caching", re.compile(r"\bdoes not enable runtime caching\b")),
+    ("does not enable insight serving", re.compile(r"\bdoes not enable /insight serving\b")),
+    ("gate remains closed", re.compile(r"\bgate remains closed\b")),
+    ("runtime allowed false", re.compile(r"\bruntime allowed:\s*false\b")),
+    ("implementation allowed false", re.compile(r"\bimplementation allowed:\s*false\b")),
+    ("off by default", re.compile(r"\boff by default\b")),
+    ("environment flag", re.compile(r"\benvironment flag\b")),
+    ("runtime flag snapshot", re.compile(r"\bruntime flag snapshot\b")),
+    ("explicit request opt-in", re.compile(r"\bexplicit request opt-in\b")),
+    ("request disable", re.compile(r"\brequest disable\b")),
+    ("kill switch snapshot", re.compile(r"\bkill switch snapshot\b")),
+    ("fallback", re.compile(r"\bfallback\b")),
+    ("source fingerprints", re.compile(r"\bsource fingerprints\b")),
+    ("eval event IDs", re.compile(r"\beval event ids\b")),
+    ("admission decision ID", re.compile(r"\badmission decision id\b")),
+    ("promotion IDs", re.compile(r"\bpromotion ids\b")),
+    ("replay entry IDs", re.compile(r"\breplay entry ids\b")),
+    ("policy version", re.compile(r"\bpolicy version\b")),
+    ("provider key", re.compile(r"\bprovider key\b")),
+    ("model key", re.compile(r"\bmodel key\b")),
+    ("context fingerprint", re.compile(r"\bcontext fingerprint\b")),
+    ("user tier", re.compile(r"\buser tier\b")),
+    ("transparency notice id", re.compile(r"\btransparency notice id\b")),
+    ("response fingerprint", re.compile(r"\bresponse fingerprint\b")),
+    ("no raw prompts", re.compile(r"\braw prompts\b")),
+    ("no raw queries", re.compile(r"\braw queries\b")),
+    ("no raw model responses", re.compile(r"\braw model responses\b")),
+    ("no raw answers", re.compile(r"\braw answers\b")),
+    ("advisory wiki blocked", re.compile(r"\badvisory wiki\b")),
+    ("no Redis", re.compile(r"\bredis\b")),
+    ("no GPTCache", re.compile(r"\bgptcache\b")),
+    ("no embeddings", re.compile(r"\bembeddings\b")),
+    ("no vector search", re.compile(r"\bvector search\b")),
+    ("no provider calls", re.compile(r"\bprovider calls\b")),
+    ("SC-G5 remains future", re.compile(r"\bsc-g5 backend selection remains future\b")),
+)
+
+BOUNDED_INSIGHT_FORBIDDEN_PATTERNS = (
+    (
+        "semantic cache active",
+        re.compile(r"\bsemantic\s+cache\s+(?:is\s+)?(?:active|enabled|open)\b"),
+    ),
+    (
+        "semantic cache can serve insight",
+        re.compile(r"\bsemantic\s+cache\s+can\s+serve\s+/insight\s+responses\b"),
+    ),
+    ("SC-G4 opens gate", re.compile(r"\bsc-g4\s+opens\s+(?:the\s+)?gate\b")),
+    (
+        "SC-G4 enables insight serving",
+        re.compile(r"\bsc-g4\s+enables\s+/insight\s+serving\b"),
+    ),
+    (
+        "SC-G4 allows embeddings",
+        re.compile(r"\bsc-g4\s+(?:allows|approves|enables|permits)\s+embeddings\b"),
+    ),
+    (
+        "SC-G4 allows vector search",
+        re.compile(r"\bsc-g4\s+(?:allows|approves|enables|permits)\s+vector\s+search\b"),
+    ),
+    (
+        "SC-G4 approves Redis/GPTCache",
+        re.compile(
+            r"\bsc-g4\s+(?:allows|approves|enables|permits|supports)\s+"
+            r"(?:redis|gptcache|redis/gptcache)\b"
+        ),
+    ),
+    ("SC-G4 allows Redis", re.compile(r"\bsc-g4\s+(?:allows|enables|permits)\s+redis\b")),
+    ("SC-G4 allows GPTCache", re.compile(r"\bsc-g4\s+(?:allows|enables|permits)\s+gptcache\b")),
+    (
+        "SC-G4 allows provider calls",
+        re.compile(r"\bsc-g4\s+(?:allows|approves|enables|permits)\s+provider\s+calls\b"),
+    ),
+    (
+        "default-on experiment",
+        re.compile(r"\b(?:default on|default-on|on by default)\b"),
+    ),
+    ("cache raw prompts", re.compile(r"\bcache(?:s)?\s+raw\s+prompts?\b")),
+    ("cache raw queries", re.compile(r"\bcache(?:s)?\s+raw\s+quer(?:y|ies)\b")),
+    ("cache raw responses", re.compile(r"\bcache(?:s)?\s+raw\s+(?:model\s+)?responses?\b")),
+    ("cache raw answers", re.compile(r"\bcache(?:s)?\s+raw\s+answers?\b")),
+    (
+        "advisory wiki seeds product cache",
+        re.compile(r"\badvisory\s+wiki\s+(?:may\s+seed|can\s+seed|seeds)\s+product\s+cache\b"),
+    ),
+)
+
 MARKER_RE = re.compile(r"<!--\s*(?P<key>SEMANTIC_CACHE_[A-Z_]+):\s*(?P<value>.*?)\s*-->")
 
 
@@ -571,6 +667,36 @@ def validate_semantic_cache_observability_contract(text: str) -> list[str]:
     return errors
 
 
+def validate_semantic_cache_bounded_insight_experiment_contract(text: str) -> list[str]:
+    """Return stable validation errors for unsafe SC-G4 bounded experiment contracts."""
+    errors: list[str] = []
+    normalized = _normalize_text(text)
+
+    for label, pattern in BOUNDED_INSIGHT_REQUIRED_ANCHORS:
+        if not pattern.search(normalized):
+            errors.append(f"bounded insight contract missing anchor: {label}")
+
+    rollout_section_index = normalized.find("required rollout order remains:")
+    rollout_section = (
+        normalized[rollout_section_index:] if rollout_section_index != -1 else normalized
+    )
+    errors.extend(
+        _validate_rollout_order(
+            rollout_section,
+            missing_prefix="bounded insight contract missing phase",
+            out_of_order_prefix="bounded insight contract phase out of order",
+        )
+    )
+    errors.extend(_forbidden_claim_errors(text))
+    errors.extend(
+        f"forbidden bounded insight contract claim: {label}"
+        for label, pattern in BOUNDED_INSIGHT_FORBIDDEN_PATTERNS
+        if pattern.search(normalized)
+    )
+
+    return errors
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Check semantic-cache gate markers.")
     parser.add_argument(
@@ -596,6 +722,12 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         default=DEFAULT_OBSERVABILITY_CONTRACT,
         help="SC-G3 observability false-hit harness markdown document to validate.",
+    )
+    parser.add_argument(
+        "--bounded-insight-contract",
+        type=Path,
+        default=DEFAULT_BOUNDED_INSIGHT_CONTRACT,
+        help="SC-G4 bounded insight experiment markdown document to validate.",
     )
     args = parser.parse_args(argv)
 
@@ -625,6 +757,14 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
+    bounded_insight_contract = args.bounded_insight_contract
+    if not bounded_insight_contract.exists():
+        print(
+            f"ERROR: bounded insight experiment contract missing: {bounded_insight_contract}",
+            file=sys.stderr,
+        )
+        return 1
+
     errors = validate_semantic_cache_gate(doc.read_text(encoding="utf-8"))
     errors.extend(validate_semantic_cache_rollout_contract(contract.read_text(encoding="utf-8")))
     errors.extend(
@@ -633,6 +773,11 @@ def main(argv: list[str] | None = None) -> int:
     errors.extend(
         validate_semantic_cache_observability_contract(
             observability_contract.read_text(encoding="utf-8")
+        )
+    )
+    errors.extend(
+        validate_semantic_cache_bounded_insight_experiment_contract(
+            bounded_insight_contract.read_text(encoding="utf-8")
         )
     )
     if errors:
@@ -644,6 +789,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"semantic-cache rollout contract closed: {contract}")
     print(f"exact/fuzzy scaffold contract closed: {scaffold_contract}")
     print(f"cache observability contract closed: {observability_contract}")
+    print(f"bounded insight experiment contract closed: {bounded_insight_contract}")
     return 0
 
 

--- a/scripts/ci/check_semantic_cache_gate.py
+++ b/scripts/ci/check_semantic_cache_gate.py
@@ -428,16 +428,30 @@ BOUNDED_INSIGHT_REQUIRED_ANCHORS = (
     ("user tier", re.compile(r"\buser tier\b")),
     ("transparency notice id", re.compile(r"\btransparency notice id\b")),
     ("response fingerprint", re.compile(r"\bresponse fingerprint\b")),
-    ("no raw prompts", re.compile(r"\braw prompts\b")),
-    ("no raw queries", re.compile(r"\braw queries\b")),
-    ("no raw model responses", re.compile(r"\braw model responses\b")),
-    ("no raw answers", re.compile(r"\braw answers\b")),
+    (
+        "no raw prompts",
+        re.compile(r"\b(?:must not contain or persist|blocked payload fields).*raw prompts\b"),
+    ),
+    (
+        "no raw queries",
+        re.compile(r"\b(?:must not contain or persist|blocked payload fields).*raw queries\b"),
+    ),
+    (
+        "no raw model responses",
+        re.compile(
+            r"\b(?:must not contain or persist|blocked payload fields).*raw model responses\b"
+        ),
+    ),
+    (
+        "no raw answers",
+        re.compile(r"\b(?:must not contain or persist|blocked payload fields).*raw answers\b"),
+    ),
     ("advisory wiki blocked", re.compile(r"\badvisory wiki\b")),
-    ("no Redis", re.compile(r"\bredis\b")),
-    ("no GPTCache", re.compile(r"\bgptcache\b")),
-    ("no embeddings", re.compile(r"\bembeddings\b")),
-    ("no vector search", re.compile(r"\bvector search\b")),
-    ("no provider calls", re.compile(r"\bprovider calls\b")),
+    ("no Redis", re.compile(r"\bsc-g4 blocks:.*redis\b")),
+    ("no GPTCache", re.compile(r"\bsc-g4 blocks:.*gptcache\b")),
+    ("no embeddings", re.compile(r"\bsc-g4 blocks:.*embeddings\b")),
+    ("no vector search", re.compile(r"\bsc-g4 blocks:.*vector search\b")),
+    ("no provider calls", re.compile(r"\bsc-g4 blocks:.*provider calls\b")),
     ("SC-G5 remains future", re.compile(r"\bsc-g5 backend selection remains future\b")),
 )
 
@@ -473,6 +487,14 @@ BOUNDED_INSIGHT_FORBIDDEN_PATTERNS = (
     ("SC-G4 allows Redis", re.compile(r"\bsc-g4\s+(?:allows|enables|permits)\s+redis\b")),
     ("SC-G4 allows GPTCache", re.compile(r"\bsc-g4\s+(?:allows|enables|permits)\s+gptcache\b")),
     (
+        "Redis allowed",
+        re.compile(r"\bredis\s+(?:is\s+)?(?:allowed|approved|enabled|supported)\b"),
+    ),
+    (
+        "GPTCache supported",
+        re.compile(r"\bgptcache\s+(?:is\s+)?(?:allowed|approved|enabled|supported)\b"),
+    ),
+    (
         "SC-G4 allows provider calls",
         re.compile(r"\bsc-g4\s+(?:allows|approves|enables|permits)\s+provider\s+calls\b"),
     ),
@@ -484,6 +506,24 @@ BOUNDED_INSIGHT_FORBIDDEN_PATTERNS = (
     ("cache raw queries", re.compile(r"\bcache(?:s)?\s+raw\s+quer(?:y|ies)\b")),
     ("cache raw responses", re.compile(r"\bcache(?:s)?\s+raw\s+(?:model\s+)?responses?\b")),
     ("cache raw answers", re.compile(r"\bcache(?:s)?\s+raw\s+answers?\b")),
+    (
+        "raw payload allowed",
+        re.compile(
+            r"\braw\s+(?:prompts?|quer(?:y|ies)|(?:model\s+)?responses?|answers?)\s+"
+            r"(?:are\s+)?(?:allowed|approved|enabled|supported|stored|persisted)\b"
+        ),
+    ),
+    (
+        "SC-G4 may store raw payloads",
+        re.compile(
+            r"\bsc-g4\s+(?:may|can)\s+(?:store|persist|cache)\s+raw\s+"
+            r"(?:prompts?|quer(?:y|ies)|(?:model\s+)?responses?|answers?)\b"
+        ),
+    ),
+    (
+        "provider payloads for replay",
+        re.compile(r"\bprovider\s+payloads?\s+(?:for|in|to)\s+replay\b"),
+    ),
     (
         "advisory wiki seeds product cache",
         re.compile(r"\badvisory\s+wiki\s+(?:may\s+seed|can\s+seed|seeds)\s+product\s+cache\b"),

--- a/tests/core/ai/test_bounded_insight_semantic_cache.py
+++ b/tests/core/ai/test_bounded_insight_semantic_cache.py
@@ -587,7 +587,7 @@ def test_decision_identity_and_serialization_are_deterministic_and_safe() -> Non
 
     assert first.decision_id == second.decision_id
     assert to_stable_mapping(first) == to_stable_mapping(second)
-    serialized = json.dumps(dict(to_stable_mapping(first)), sort_keys=True)
+    serialized = json.dumps(to_stable_mapping(first), sort_keys=True)
     assert "Plan protein breakfast" not in serialized
     assert "raw_query" not in serialized
     assert "normalized_query" not in serialized

--- a/tests/core/ai/test_bounded_insight_semantic_cache.py
+++ b/tests/core/ai/test_bounded_insight_semantic_cache.py
@@ -28,6 +28,7 @@ from core.ai.bounded_insight_semantic_cache import (
     REASON_REQUEST_NOT_OPTED_IN,
     REASON_RESPONSE_FINGERPRINT_MISMATCH,
     REASON_RUNTIME_FLAG_DISABLED,
+    REASON_SAFETY_FLAGS_MISMATCH,
     REASON_SOURCE_FINGERPRINT_MISMATCH,
     REASON_STOP_RULE_BLOCKED,
     REASON_TRANSPARENCY_NOTICE_MISMATCH,
@@ -358,6 +359,15 @@ def test_missing_candidate_and_lookup_miss_fallback() -> None:
 
     assert miss.decision == DECISION_FALLBACK
     assert REASON_LOOKUP_MISS in miss.reason_codes
+    assert miss.candidate_record_id is None
+    assert miss.response_fingerprint is None
+    assert miss.match_mode is None
+    assert miss.score_bps is None
+    serialized = dict(to_stable_mapping(miss))
+    assert serialized["candidate_record_id"] is None
+    assert serialized["response_fingerprint"] is None
+    assert serialized["match_mode"] is None
+    assert serialized["score_bps"] is None
 
 
 @pytest.mark.parametrize(
@@ -430,6 +440,15 @@ def test_audit_event_request_fingerprint_mismatch_fallback() -> None:
 
     assert decision.decision == DECISION_FALLBACK
     assert REASON_REQUEST_FINGERPRINT_MISMATCH in decision.reason_codes
+
+
+def test_record_safety_flags_mismatch_fallback() -> None:
+    record = replace(_record(), safety_flags=("legacy-policy",))
+
+    decision = _decision(candidate=_candidate(record=record))
+
+    assert decision.decision == DECISION_FALLBACK
+    assert REASON_SAFETY_FLAGS_MISMATCH in decision.reason_codes
 
 
 def test_response_fingerprint_admission_stop_and_blocked_surface_fallback() -> None:

--- a/tests/core/ai/test_bounded_insight_semantic_cache.py
+++ b/tests/core/ai/test_bounded_insight_semantic_cache.py
@@ -1,0 +1,531 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import replace
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from core.ai.bounded_insight_semantic_cache import (
+    DECISION_EXPERIMENT_ELIGIBLE,
+    DECISION_FALLBACK,
+    REASON_ADMISSION_BLOCKED,
+    REASON_BLOCKED_SURFACE,
+    REASON_CONTEXT_MISMATCH,
+    REASON_ENVIRONMENT_FLAG_DISABLED,
+    REASON_EVIDENCE_LINKAGE_MISSING,
+    REASON_EXPERIMENT_ELIGIBLE,
+    REASON_KILL_SWITCH_DISABLED,
+    REASON_LOOKUP_MISS,
+    REASON_MODEL_MISMATCH,
+    REASON_POLICY_MISMATCH,
+    REASON_PROVIDER_MISMATCH,
+    REASON_REQUEST_DISABLED,
+    REASON_REQUEST_NOT_OPTED_IN,
+    REASON_RESPONSE_FINGERPRINT_MISMATCH,
+    REASON_RUNTIME_FLAG_DISABLED,
+    REASON_SOURCE_FINGERPRINT_MISMATCH,
+    REASON_STOP_RULE_BLOCKED,
+    REASON_TRANSPARENCY_NOTICE_MISMATCH,
+    REASON_UNSUPPORTED_SURFACE,
+    REASON_USER_TIER_MISMATCH,
+    BoundedInsightExperimentCandidate,
+    BoundedInsightExperimentDecision,
+    BoundedInsightExperimentFlags,
+    BoundedInsightExperimentRequest,
+    JsonValue,
+    evaluate_bounded_insight_experiment,
+    to_stable_mapping,
+)
+from core.ai.cache_observability import (
+    EXPECTED_ACTION_SAFE_HIT,
+    CacheLookupAuditEvent,
+    CacheObservabilityMetrics,
+    CacheStopDecision,
+    CacheStopRules,
+    FalseHitHarnessCase,
+    FalseHitHarnessEvaluation,
+    KillSwitchSnapshot,
+    build_cache_lookup_audit_event,
+    compute_cache_observability_metrics,
+    evaluate_cache_stop_rules,
+    evaluate_false_hit_case,
+)
+from core.ai.exact_fuzzy_cache import (
+    ExactFuzzyCacheLookupRequest,
+    ExactFuzzyCacheLookupResult,
+    ExactFuzzyCacheRecord,
+    ExactFuzzyMatchPolicy,
+    build_exact_fuzzy_lineage,
+    create_exact_fuzzy_cache_record,
+    match_exact_fuzzy_records,
+)
+from tests.helpers.semantic_cache_import_guard import (
+    assert_no_forbidden_semantic_cache_calls,
+    assert_no_forbidden_semantic_cache_imports,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE = REPO_ROOT / "core" / "ai" / "bounded_insight_semantic_cache.py"
+PRODUCED_AT = "2026-05-08T12:00:00Z"
+
+
+def _record() -> ExactFuzzyCacheRecord:
+    lineage = build_exact_fuzzy_lineage(
+        eval_event_ids=("eval:bounded:1",),
+        admission_decision_id="admission:bounded:1",
+        promotion_ids=("promotion:bounded:1",),
+        replay_entry_ids=("replay:bounded:1",),
+        source_fingerprints=("sha256:source-a", "sha256:source-b"),
+        policy_version="semantic-cache-sc-g4-v1",
+    )
+    return create_exact_fuzzy_cache_record(
+        surface="insight",
+        raw_query="Plan protein breakfast",
+        context_fingerprint="sha256:context",
+        provider_key="provider:test",
+        model_key="model:test",
+        user_tier="pro",
+        transparency_notice_id="notice:insight:v1",
+        lineage=lineage,
+        response_fingerprint="sha256:response",
+        safety_flags=("wellness-only",),
+    )
+
+
+def _lookup_request(raw_query: str = "Plan protein breakfast") -> ExactFuzzyCacheLookupRequest:
+    return ExactFuzzyCacheLookupRequest(
+        surface="insight",
+        raw_query=raw_query,
+        context_fingerprint="sha256:context",
+        source_fingerprints=("sha256:source-a", "sha256:source-b"),
+        policy_version="semantic-cache-sc-g4-v1",
+        provider_key="provider:test",
+        model_key="model:test",
+        user_tier="pro",
+        transparency_notice_id="notice:insight:v1",
+    )
+
+
+def _policy() -> ExactFuzzyMatchPolicy:
+    return ExactFuzzyMatchPolicy(
+        policy_version="semantic-cache-sc-g4-v1",
+        token_jaccard_min_bps=5000,
+        sequence_ratio_min_bps=5000,
+        max_token_count_delta=1,
+    )
+
+
+def _request(
+    *,
+    surface: str = "insight",
+    request_fingerprint: str = "cache-request:bounded",
+    context_fingerprint: str = "sha256:context",
+    source_fingerprints: tuple[str, ...] = ("sha256:source-a", "sha256:source-b"),
+    policy_version: str = "semantic-cache-sc-g4-v1",
+    provider_key: str = "provider:test",
+    model_key: str = "model:test",
+    user_tier: str = "pro",
+    transparency_notice_id: str = "notice:insight:v1",
+    eval_event_ids: tuple[str, ...] = ("eval:bounded:1",),
+    admission_decision_id: str | None = "admission:bounded:1",
+    promotion_ids: tuple[str, ...] = ("promotion:bounded:1",),
+    replay_entry_ids: tuple[str, ...] = ("replay:bounded:1",),
+    safety_flags: tuple[str, ...] = ("wellness-only",),
+    metadata: Mapping[str, JsonValue] | None = None,
+) -> BoundedInsightExperimentRequest:
+    return BoundedInsightExperimentRequest(
+        surface=surface,
+        request_fingerprint=request_fingerprint,
+        context_fingerprint=context_fingerprint,
+        source_fingerprints=source_fingerprints,
+        policy_version=policy_version,
+        provider_key=provider_key,
+        model_key=model_key,
+        user_tier=user_tier,
+        transparency_notice_id=transparency_notice_id,
+        eval_event_ids=eval_event_ids,
+        admission_decision_id=admission_decision_id,
+        promotion_ids=promotion_ids,
+        replay_entry_ids=replay_entry_ids,
+        safety_flags=safety_flags,
+        metadata={"scope": "sc-g4"} if metadata is None else metadata,
+    )
+
+
+def _flags(
+    *,
+    environment_enabled: bool = True,
+    runtime_enabled: bool = True,
+    request_opt_in: bool = True,
+    request_disable: bool = False,
+    kill_switch_snapshot: KillSwitchSnapshot | None = None,
+) -> BoundedInsightExperimentFlags:
+    return BoundedInsightExperimentFlags(
+        environment_enabled=environment_enabled,
+        runtime_enabled=runtime_enabled,
+        request_opt_in=request_opt_in,
+        request_disable=request_disable,
+        kill_switch_snapshot=(
+            KillSwitchSnapshot(True, True, False, False)
+            if kill_switch_snapshot is None
+            else kill_switch_snapshot
+        ),
+    )
+
+
+def _candidate(
+    *,
+    lookup_request: ExactFuzzyCacheLookupRequest | None = None,
+    lookup_result: ExactFuzzyCacheLookupResult | None = None,
+    record: ExactFuzzyCacheRecord | None = None,
+    audit_event: CacheLookupAuditEvent | None = None,
+    false_hit_evaluation: FalseHitHarnessEvaluation | None = None,
+    metrics: CacheObservabilityMetrics | None = None,
+    stop_decision: CacheStopDecision | None = None,
+    response_fingerprint: str | None = None,
+    blocked_surface: bool = False,
+    admission_allowed: bool = True,
+    metadata: Mapping[str, JsonValue] | None = None,
+) -> BoundedInsightExperimentCandidate:
+    record = _record() if record is None else record
+    lookup_request = _lookup_request() if lookup_request is None else lookup_request
+    lookup_result = (
+        match_exact_fuzzy_records(
+            request=lookup_request,
+            candidate_records=(record,),
+            policy=_policy(),
+        )
+        if lookup_result is None
+        else lookup_result
+    )
+    audit_event = (
+        build_cache_lookup_audit_event(
+            request=lookup_request,
+            lookup_result=lookup_result,
+            candidate_record=record if lookup_result.decision == "hit" else None,
+            produced_at=PRODUCED_AT,
+            metadata={"scope": "sc-g4"},
+        )
+        if audit_event is None
+        else audit_event
+    )
+    false_hit_case = FalseHitHarnessCase(
+        case_id="case:bounded",
+        risk_class="exact_duplicate_hit",
+        audit_event=audit_event,
+        expected_action=EXPECTED_ACTION_SAFE_HIT,
+        fresh_response_fingerprint=record.response_fingerprint,
+        current_source_fingerprints=record.lineage.source_fingerprints,
+        current_policy_version=record.lineage.policy_version,
+        current_model_key=record.model_key,
+        current_user_tier=record.user_tier,
+        current_context_fingerprint=record.context_fingerprint,
+        admission_allowed=True,
+        blocked_surface=False,
+        negative_control=False,
+        metadata={"scope": "sc-g4"},
+    )
+    evaluation = (
+        evaluate_false_hit_case(case=false_hit_case, produced_at=PRODUCED_AT)
+        if false_hit_evaluation is None
+        else false_hit_evaluation
+    )
+    metrics = (
+        compute_cache_observability_metrics(
+            evaluations=(evaluation,),
+            produced_at=PRODUCED_AT,
+        )
+        if metrics is None
+        else metrics
+    )
+    stop_decision = (
+        evaluate_cache_stop_rules(
+            metrics=metrics,
+            stop_rules=CacheStopRules(
+                policy_version="semantic-cache-sc-g4-v1",
+                max_false_hit_rate_bps=0,
+                max_stale_answer_rate_bps=0,
+                max_policy_mismatch_hits=0,
+                max_model_mismatch_hits=0,
+                max_context_leakage_hits=0,
+                allow_blocked_surface_hits=False,
+            ),
+            produced_at=PRODUCED_AT,
+        )
+        if stop_decision is None
+        else stop_decision
+    )
+    return BoundedInsightExperimentCandidate(
+        lookup_request=lookup_request,
+        lookup_result=lookup_result,
+        record=record,
+        audit_event=audit_event,
+        false_hit_evaluation=evaluation,
+        metrics=metrics,
+        stop_decision=stop_decision,
+        response_fingerprint=(
+            record.response_fingerprint if response_fingerprint is None else response_fingerprint
+        ),
+        blocked_surface=blocked_surface,
+        admission_allowed=admission_allowed,
+        metadata={"scope": "sc-g4"} if metadata is None else metadata,
+    )
+
+
+def _decision(
+    *,
+    flags: BoundedInsightExperimentFlags | None = None,
+    request: BoundedInsightExperimentRequest | None = None,
+    candidate: BoundedInsightExperimentCandidate | None = None,
+) -> BoundedInsightExperimentDecision:
+    return evaluate_bounded_insight_experiment(
+        flags=_flags() if flags is None else flags,
+        request=_request() if request is None else request,
+        candidate=_candidate() if candidate is None else candidate,
+    )
+
+
+def test_experiment_eligible_requires_all_flags_and_safe_candidate() -> None:
+    decision = _decision()
+
+    assert decision.decision == DECISION_EXPERIMENT_ELIGIBLE
+    assert decision.reason_codes == (REASON_EXPERIMENT_ELIGIBLE,)
+    assert decision.candidate_record_id == _record().record_id
+    assert decision.response_fingerprint == "sha256:response"
+    assert dict(to_stable_mapping(decision))["metadata"] == {
+        "decision_scope": "metadata_only",
+        "serves_cached_payload": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("flags", "reason"),
+    [
+        (_flags(environment_enabled=False), REASON_ENVIRONMENT_FLAG_DISABLED),
+        (_flags(runtime_enabled=False), REASON_RUNTIME_FLAG_DISABLED),
+        (_flags(request_opt_in=False), REASON_REQUEST_NOT_OPTED_IN),
+        (_flags(request_disable=True), REASON_REQUEST_DISABLED),
+        (
+            _flags(kill_switch_snapshot=KillSwitchSnapshot(True, True, False, True)),
+            REASON_KILL_SWITCH_DISABLED,
+        ),
+    ],
+)
+def test_flags_default_off_and_fail_closed(
+    flags: BoundedInsightExperimentFlags,
+    reason: str,
+) -> None:
+    decision = _decision(flags=flags)
+
+    assert decision.decision == DECISION_FALLBACK
+    assert reason in decision.reason_codes
+
+
+def test_missing_candidate_and_lookup_miss_fallback() -> None:
+    missing = evaluate_bounded_insight_experiment(
+        flags=_flags(),
+        request=_request(),
+        candidate=None,
+    )
+
+    assert missing.decision == DECISION_FALLBACK
+    assert "candidate_missing" in missing.reason_codes
+
+    lookup_request = _lookup_request("different query")
+    lookup_result = match_exact_fuzzy_records(
+        request=lookup_request,
+        candidate_records=(),
+        policy=_policy(),
+    )
+    miss_candidate = _candidate(
+        lookup_request=lookup_request,
+        lookup_result=lookup_result,
+        audit_event=build_cache_lookup_audit_event(
+            request=lookup_request,
+            lookup_result=lookup_result,
+            candidate_record=None,
+            produced_at=PRODUCED_AT,
+            metadata={"scope": "sc-g4"},
+        ),
+    )
+    miss = _decision(candidate=miss_candidate)
+
+    assert miss.decision == DECISION_FALLBACK
+    assert REASON_LOOKUP_MISS in miss.reason_codes
+
+
+@pytest.mark.parametrize(
+    ("experiment_request", "reason"),
+    [
+        (_request(surface="settings"), REASON_UNSUPPORTED_SURFACE),
+        (
+            _request(source_fingerprints=("sha256:source-a", "sha256:source-next")),
+            REASON_SOURCE_FINGERPRINT_MISMATCH,
+        ),
+        (_request(policy_version="semantic-cache-sc-g4-v2"), REASON_POLICY_MISMATCH),
+        (_request(provider_key="provider:next"), REASON_PROVIDER_MISMATCH),
+        (_request(model_key="model:next"), REASON_MODEL_MISMATCH),
+        (_request(context_fingerprint="sha256:context-next"), REASON_CONTEXT_MISMATCH),
+        (_request(user_tier="free"), REASON_USER_TIER_MISMATCH),
+        (
+            _request(transparency_notice_id="notice:insight:v2"),
+            REASON_TRANSPARENCY_NOTICE_MISMATCH,
+        ),
+    ],
+)
+def test_partition_and_surface_mismatches_fallback(
+    experiment_request: BoundedInsightExperimentRequest,
+    reason: str,
+) -> None:
+    decision = _decision(request=experiment_request)
+
+    assert decision.decision == DECISION_FALLBACK
+    assert reason in decision.reason_codes
+
+
+def test_response_fingerprint_admission_stop_and_blocked_surface_fallback() -> None:
+    response_mismatch = _decision(
+        candidate=_candidate(response_fingerprint="sha256:other-response")
+    )
+    assert response_mismatch.decision == DECISION_FALLBACK
+    assert REASON_RESPONSE_FINGERPRINT_MISMATCH in response_mismatch.reason_codes
+
+    admission_blocked = _decision(candidate=_candidate(admission_allowed=False))
+    assert admission_blocked.decision == DECISION_FALLBACK
+    assert REASON_ADMISSION_BLOCKED in admission_blocked.reason_codes
+
+    blocked_surface = _decision(candidate=_candidate(blocked_surface=True))
+    assert blocked_surface.decision == DECISION_FALLBACK
+    assert REASON_BLOCKED_SURFACE in blocked_surface.reason_codes
+
+    stop_decision = replace(_candidate().stop_decision, stop_serving=True, rollback_required=True)
+    stop_blocked = _decision(candidate=_candidate(stop_decision=stop_decision))
+    assert stop_blocked.decision == DECISION_FALLBACK
+    assert REASON_STOP_RULE_BLOCKED in stop_blocked.reason_codes
+
+
+def test_missing_evidence_linkage_fallback() -> None:
+    request = _request(admission_decision_id=None)
+    decision = _decision(request=request)
+
+    assert decision.decision == DECISION_FALLBACK
+    assert REASON_EVIDENCE_LINKAGE_MISSING in decision.reason_codes
+
+    record = create_exact_fuzzy_cache_record(
+        surface="insight",
+        raw_query="Plan protein breakfast",
+        context_fingerprint="sha256:context",
+        provider_key="provider:test",
+        model_key="model:test",
+        user_tier="pro",
+        transparency_notice_id="notice:insight:v1",
+        lineage=build_exact_fuzzy_lineage(
+            eval_event_ids=("eval:bounded:1",),
+            admission_decision_id=None,
+            promotion_ids=("promotion:bounded:1",),
+            replay_entry_ids=("replay:bounded:1",),
+            source_fingerprints=("sha256:source-a", "sha256:source-b"),
+            policy_version="semantic-cache-sc-g4-v1",
+        ),
+        response_fingerprint="sha256:response",
+        safety_flags=("wellness-only",),
+    )
+    decision = _decision(candidate=_candidate(record=record))
+    assert decision.decision == DECISION_FALLBACK
+    assert REASON_EVIDENCE_LINKAGE_MISSING in decision.reason_codes
+
+
+def test_decision_identity_and_serialization_are_deterministic_and_safe() -> None:
+    first = _decision()
+    second = _decision()
+
+    assert first.decision_id == second.decision_id
+    assert to_stable_mapping(first) == to_stable_mapping(second)
+    serialized = json.dumps(dict(to_stable_mapping(first)), sort_keys=True)
+    assert "Plan protein breakfast" not in serialized
+    assert "raw_query" not in serialized
+    assert "normalized_query" not in serialized
+    assert "raw_prompt" not in serialized
+    with pytest.raises(ValueError, match="unsupported stable mapping"):
+        to_stable_mapping({"not": "a contract"})
+
+
+def test_metadata_is_defensively_copied_and_raw_payloads_are_rejected() -> None:
+    metadata: dict[str, JsonValue] = {"labels": ["sc-g4"]}
+    request = _request(metadata=metadata)
+    metadata["labels"] = ["mutated"]
+
+    assert request.metadata["labels"] == ["sc-g4"]
+    for unsafe in (
+        {"raw_prompt": "never"},
+        {"note": "cache raw response"},
+        {"authorization": "Basic abc"},
+        {"artifact": "/tmp/cache.txt"},
+        {"healthkit": "steps"},
+    ):
+        with pytest.raises(ValueError, match="unsafe metadata"):
+            _request(metadata=unsafe)
+
+
+def test_contracts_reject_invalid_types() -> None:
+    with pytest.raises(ValueError, match="kill_switch_snapshot must be KillSwitchSnapshot"):
+        _flags(kill_switch_snapshot=cast(KillSwitchSnapshot, "not-kill-switch"))
+    base = _candidate()
+    with pytest.raises(ValueError, match="lookup_request must be ExactFuzzyCacheLookupRequest"):
+        BoundedInsightExperimentCandidate(
+            lookup_request=cast(ExactFuzzyCacheLookupRequest, "not-request"),
+            lookup_result=base.lookup_result,
+            record=base.record,
+            audit_event=base.audit_event,
+            false_hit_evaluation=base.false_hit_evaluation,
+            metrics=base.metrics,
+            stop_decision=base.stop_decision,
+            response_fingerprint=base.response_fingerprint,
+            blocked_surface=False,
+            admission_allowed=True,
+            metadata={},
+        )
+    with pytest.raises(ValueError, match="lookup_result must be ExactFuzzyCacheLookupResult"):
+        BoundedInsightExperimentCandidate(
+            lookup_request=base.lookup_request,
+            lookup_result=cast(ExactFuzzyCacheLookupResult, "not-result"),
+            record=base.record,
+            audit_event=base.audit_event,
+            false_hit_evaluation=base.false_hit_evaluation,
+            metrics=base.metrics,
+            stop_decision=base.stop_decision,
+            response_fingerprint=base.response_fingerprint,
+            blocked_surface=False,
+            admission_allowed=True,
+            metadata={},
+        )
+    with pytest.raises(ValueError, match="record must be ExactFuzzyCacheRecord"):
+        BoundedInsightExperimentCandidate(
+            lookup_request=base.lookup_request,
+            lookup_result=base.lookup_result,
+            record=cast(ExactFuzzyCacheRecord, "not-record"),
+            audit_event=base.audit_event,
+            false_hit_evaluation=base.false_hit_evaluation,
+            metrics=base.metrics,
+            stop_decision=base.stop_decision,
+            response_fingerprint=base.response_fingerprint,
+            blocked_surface=False,
+            admission_allowed=True,
+            metadata={},
+        )
+
+
+def test_module_has_no_forbidden_imports_or_nondeterministic_calls() -> None:
+    assert_no_forbidden_semantic_cache_imports(MODULE)
+    assert_no_forbidden_semantic_cache_calls(MODULE)
+
+
+def test_sc_g4_is_not_exported_from_core_ai_facade() -> None:
+    init_path = REPO_ROOT / "core" / "ai" / "__init__.py"
+    content = init_path.read_text(encoding="utf-8")
+
+    assert "bounded_insight_semantic_cache" not in content
+    assert "BoundedInsight" not in content

--- a/tests/core/ai/test_bounded_insight_semantic_cache.py
+++ b/tests/core/ai/test_bounded_insight_semantic_cache.py
@@ -16,6 +16,7 @@ from core.ai.bounded_insight_semantic_cache import (
     REASON_CONTEXT_MISMATCH,
     REASON_ENVIRONMENT_FLAG_DISABLED,
     REASON_EVIDENCE_LINKAGE_MISSING,
+    REASON_EVIDENCE_LINKAGE_MISMATCH,
     REASON_EXPERIMENT_ELIGIBLE,
     REASON_KILL_SWITCH_DISABLED,
     REASON_LOOKUP_MISS,
@@ -497,6 +498,51 @@ def test_missing_evidence_linkage_fallback() -> None:
     decision = _decision(candidate=_candidate(record=missing_replay_record))
     assert decision.decision == DECISION_FALLBACK
     assert REASON_EVIDENCE_LINKAGE_MISSING in decision.reason_codes
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        replace(
+            _record(),
+            lineage=replace(_record().lineage, eval_event_ids=("eval:bounded:other",)),
+        ),
+        replace(
+            _record(), lineage=replace(_record().lineage, admission_decision_id="admission:other")
+        ),
+        replace(
+            _record(),
+            lineage=replace(_record().lineage, promotion_ids=("promotion:bounded:other",)),
+        ),
+        replace(
+            _record(),
+            lineage=replace(_record().lineage, replay_entry_ids=("replay:bounded:other",)),
+        ),
+    ],
+)
+def test_record_evidence_graph_id_mismatches_fallback(record: ExactFuzzyCacheRecord) -> None:
+    decision = _decision(candidate=_candidate(record=record))
+
+    assert decision.decision == DECISION_FALLBACK
+    assert REASON_EVIDENCE_LINKAGE_MISMATCH in decision.reason_codes
+
+
+@pytest.mark.parametrize(
+    "audit_event",
+    [
+        replace(_candidate().audit_event, eval_event_ids=("eval:bounded:other",)),
+        replace(_candidate().audit_event, admission_decision_id="admission:other"),
+        replace(_candidate().audit_event, promotion_ids=("promotion:bounded:other",)),
+        replace(_candidate().audit_event, replay_entry_ids=("replay:bounded:other",)),
+    ],
+)
+def test_audit_event_evidence_graph_id_mismatches_fallback(
+    audit_event: CacheLookupAuditEvent,
+) -> None:
+    decision = _decision(candidate=_candidate(audit_event=audit_event))
+
+    assert decision.decision == DECISION_FALLBACK
+    assert REASON_EVIDENCE_LINKAGE_MISMATCH in decision.reason_codes
 
 
 def test_decision_identity_and_serialization_are_deterministic_and_safe() -> None:

--- a/tests/core/ai/test_bounded_insight_semantic_cache.py
+++ b/tests/core/ai/test_bounded_insight_semantic_cache.py
@@ -386,6 +386,40 @@ def test_partition_and_surface_mismatches_fallback(
     assert reason in decision.reason_codes
 
 
+@pytest.mark.parametrize(
+    ("audit_event", "reason"),
+    [
+        (
+            replace(_candidate().audit_event, source_fingerprints=("sha256:source-a",)),
+            REASON_SOURCE_FINGERPRINT_MISMATCH,
+        ),
+        (
+            replace(_candidate().audit_event, policy_version="semantic-cache-sc-g4-v2"),
+            REASON_POLICY_MISMATCH,
+        ),
+        (replace(_candidate().audit_event, provider_key="provider:next"), REASON_PROVIDER_MISMATCH),
+        (replace(_candidate().audit_event, model_key="model:next"), REASON_MODEL_MISMATCH),
+        (
+            replace(_candidate().audit_event, context_fingerprint="sha256:context-next"),
+            REASON_CONTEXT_MISMATCH,
+        ),
+        (replace(_candidate().audit_event, user_tier="free"), REASON_USER_TIER_MISMATCH),
+        (
+            replace(_candidate().audit_event, transparency_notice_id="notice:insight:v2"),
+            REASON_TRANSPARENCY_NOTICE_MISMATCH,
+        ),
+    ],
+)
+def test_audit_event_partition_mismatches_fallback(
+    audit_event: CacheLookupAuditEvent,
+    reason: str,
+) -> None:
+    decision = _decision(candidate=_candidate(audit_event=audit_event))
+
+    assert decision.decision == DECISION_FALLBACK
+    assert reason in decision.reason_codes
+
+
 def test_response_fingerprint_admission_stop_and_blocked_surface_fallback() -> None:
     response_mismatch = _decision(
         candidate=_candidate(response_fingerprint="sha256:other-response")
@@ -408,11 +442,15 @@ def test_response_fingerprint_admission_stop_and_blocked_surface_fallback() -> N
 
 
 def test_missing_evidence_linkage_fallback() -> None:
-    request = _request(admission_decision_id=None)
-    decision = _decision(request=request)
+    for request in (
+        _request(admission_decision_id=None),
+        _request(promotion_ids=()),
+        _request(replay_entry_ids=()),
+    ):
+        decision = _decision(request=request)
 
-    assert decision.decision == DECISION_FALLBACK
-    assert REASON_EVIDENCE_LINKAGE_MISSING in decision.reason_codes
+        assert decision.decision == DECISION_FALLBACK
+        assert REASON_EVIDENCE_LINKAGE_MISSING in decision.reason_codes
 
     record = create_exact_fuzzy_cache_record(
         surface="insight",
@@ -434,6 +472,29 @@ def test_missing_evidence_linkage_fallback() -> None:
         safety_flags=("wellness-only",),
     )
     decision = _decision(candidate=_candidate(record=record))
+    assert decision.decision == DECISION_FALLBACK
+    assert REASON_EVIDENCE_LINKAGE_MISSING in decision.reason_codes
+
+    missing_replay_record = create_exact_fuzzy_cache_record(
+        surface="insight",
+        raw_query="Plan protein breakfast",
+        context_fingerprint="sha256:context",
+        provider_key="provider:test",
+        model_key="model:test",
+        user_tier="pro",
+        transparency_notice_id="notice:insight:v1",
+        lineage=build_exact_fuzzy_lineage(
+            eval_event_ids=("eval:bounded:1",),
+            admission_decision_id="admission:bounded:1",
+            promotion_ids=("promotion:bounded:1",),
+            replay_entry_ids=(),
+            source_fingerprints=("sha256:source-a", "sha256:source-b"),
+            policy_version="semantic-cache-sc-g4-v1",
+        ),
+        response_fingerprint="sha256:response",
+        safety_flags=("wellness-only",),
+    )
+    decision = _decision(candidate=_candidate(record=missing_replay_record))
     assert decision.decision == DECISION_FALLBACK
     assert REASON_EVIDENCE_LINKAGE_MISSING in decision.reason_codes
 

--- a/tests/core/ai/test_bounded_insight_semantic_cache.py
+++ b/tests/core/ai/test_bounded_insight_semantic_cache.py
@@ -4,7 +4,7 @@ import json
 from collections.abc import Mapping
 from dataclasses import replace
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -597,11 +597,23 @@ def test_decision_identity_and_serialization_are_deterministic_and_safe() -> Non
 
 
 def test_metadata_is_defensively_copied_and_raw_payloads_are_rejected() -> None:
-    metadata: dict[str, JsonValue] = {"labels": ["sc-g4"]}
+    metadata: dict[str, JsonValue] = {"labels": ["sc-g4"], "nested": {"values": ["stable"]}}
     request = _request(metadata=metadata)
     metadata["labels"] = ["mutated"]
+    cast(dict[str, JsonValue], metadata["nested"])["values"] = ["mutated"]
 
-    assert request.metadata["labels"] == ["sc-g4"]
+    assert request.metadata["labels"] == ("sc-g4",)
+    assert cast(Mapping[str, JsonValue], request.metadata["nested"])["values"] == ("stable",)
+    with pytest.raises(TypeError):
+        cast(dict[str, JsonValue], request.metadata)["new"] = "blocked"
+    with pytest.raises(TypeError):
+        cast(dict[str, JsonValue], request.metadata["nested"])["values"] = ["blocked"]
+    with pytest.raises(AttributeError):
+        cast(list[str], cast(Mapping[str, JsonValue], request.metadata["nested"])["values"]).append(
+            "blocked"
+        )
+    stable_metadata = cast(Mapping[str, JsonValue], to_stable_mapping(_decision())["metadata"])
+    assert stable_metadata == {"decision_scope": "metadata_only", "serves_cached_payload": False}
     for unsafe in (
         {"raw_prompt": "never"},
         {"note": "cache raw response"},
@@ -616,6 +628,8 @@ def test_metadata_is_defensively_copied_and_raw_payloads_are_rejected() -> None:
 def test_contracts_reject_invalid_types() -> None:
     with pytest.raises(ValueError, match="kill_switch_snapshot must be KillSwitchSnapshot"):
         _flags(kill_switch_snapshot=cast(KillSwitchSnapshot, "not-kill-switch"))
+    with pytest.raises(ValueError, match="surface must be a string"):
+        _request(surface=cast(Any, 123))
     base = _candidate()
     with pytest.raises(ValueError, match="lookup_request must be ExactFuzzyCacheLookupRequest"):
         BoundedInsightExperimentCandidate(

--- a/tests/core/ai/test_bounded_insight_semantic_cache.py
+++ b/tests/core/ai/test_bounded_insight_semantic_cache.py
@@ -23,6 +23,7 @@ from core.ai.bounded_insight_semantic_cache import (
     REASON_MODEL_MISMATCH,
     REASON_POLICY_MISMATCH,
     REASON_PROVIDER_MISMATCH,
+    REASON_REQUEST_FINGERPRINT_MISMATCH,
     REASON_REQUEST_DISABLED,
     REASON_REQUEST_NOT_OPTED_IN,
     REASON_RESPONSE_FINGERPRINT_MISMATCH,
@@ -71,6 +72,7 @@ from tests.helpers.semantic_cache_import_guard import (
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MODULE = REPO_ROOT / "core" / "ai" / "bounded_insight_semantic_cache.py"
 PRODUCED_AT = "2026-05-08T12:00:00Z"
+DEFAULT_REQUEST_FINGERPRINT = "cache-request:02e1e0ba21a97b15e01c4e3f"
 
 
 def _record() -> ExactFuzzyCacheRecord:
@@ -122,7 +124,7 @@ def _policy() -> ExactFuzzyMatchPolicy:
 def _request(
     *,
     surface: str = "insight",
-    request_fingerprint: str = "cache-request:bounded",
+    request_fingerprint: str = DEFAULT_REQUEST_FINGERPRINT,
     context_fingerprint: str = "sha256:context",
     source_fingerprints: tuple[str, ...] = ("sha256:source-a", "sha256:source-b"),
     policy_version: str = "semantic-cache-sc-g4-v1",
@@ -419,6 +421,15 @@ def test_audit_event_partition_mismatches_fallback(
 
     assert decision.decision == DECISION_FALLBACK
     assert reason in decision.reason_codes
+
+
+def test_audit_event_request_fingerprint_mismatch_fallback() -> None:
+    audit_event = replace(_candidate().audit_event, request_fingerprint="cache-request:other")
+
+    decision = _decision(candidate=_candidate(audit_event=audit_event))
+
+    assert decision.decision == DECISION_FALLBACK
+    assert REASON_REQUEST_FINGERPRINT_MISMATCH in decision.reason_codes
 
 
 def test_response_fingerprint_admission_stop_and_blocked_surface_fallback() -> None:

--- a/tests/core/ai/test_bounded_insight_semantic_cache.py
+++ b/tests/core/ai/test_bounded_insight_semantic_cache.py
@@ -292,6 +292,16 @@ def _decision(
     )
 
 
+def _assert_fallback_omits_candidate_payload(
+    decision: BoundedInsightExperimentDecision,
+) -> None:
+    assert decision.decision == DECISION_FALLBACK
+    assert decision.candidate_record_id is None
+    assert decision.response_fingerprint is None
+    assert decision.match_mode is None
+    assert decision.score_bps is None
+
+
 def test_experiment_eligible_requires_all_flags_and_safe_candidate() -> None:
     decision = _decision()
 
@@ -357,12 +367,8 @@ def test_missing_candidate_and_lookup_miss_fallback() -> None:
     )
     miss = _decision(candidate=miss_candidate)
 
-    assert miss.decision == DECISION_FALLBACK
+    _assert_fallback_omits_candidate_payload(miss)
     assert REASON_LOOKUP_MISS in miss.reason_codes
-    assert miss.candidate_record_id is None
-    assert miss.response_fingerprint is None
-    assert miss.match_mode is None
-    assert miss.score_bps is None
     serialized = dict(to_stable_mapping(miss))
     assert serialized["candidate_record_id"] is None
     assert serialized["response_fingerprint"] is None
@@ -438,7 +444,7 @@ def test_audit_event_request_fingerprint_mismatch_fallback() -> None:
 
     decision = _decision(candidate=_candidate(audit_event=audit_event))
 
-    assert decision.decision == DECISION_FALLBACK
+    _assert_fallback_omits_candidate_payload(decision)
     assert REASON_REQUEST_FINGERPRINT_MISMATCH in decision.reason_codes
 
 
@@ -447,7 +453,7 @@ def test_record_safety_flags_mismatch_fallback() -> None:
 
     decision = _decision(candidate=_candidate(record=record))
 
-    assert decision.decision == DECISION_FALLBACK
+    _assert_fallback_omits_candidate_payload(decision)
     assert REASON_SAFETY_FLAGS_MISMATCH in decision.reason_codes
 
 
@@ -455,20 +461,20 @@ def test_response_fingerprint_admission_stop_and_blocked_surface_fallback() -> N
     response_mismatch = _decision(
         candidate=_candidate(response_fingerprint="sha256:other-response")
     )
-    assert response_mismatch.decision == DECISION_FALLBACK
+    _assert_fallback_omits_candidate_payload(response_mismatch)
     assert REASON_RESPONSE_FINGERPRINT_MISMATCH in response_mismatch.reason_codes
 
     admission_blocked = _decision(candidate=_candidate(admission_allowed=False))
-    assert admission_blocked.decision == DECISION_FALLBACK
+    _assert_fallback_omits_candidate_payload(admission_blocked)
     assert REASON_ADMISSION_BLOCKED in admission_blocked.reason_codes
 
     blocked_surface = _decision(candidate=_candidate(blocked_surface=True))
-    assert blocked_surface.decision == DECISION_FALLBACK
+    _assert_fallback_omits_candidate_payload(blocked_surface)
     assert REASON_BLOCKED_SURFACE in blocked_surface.reason_codes
 
     stop_decision = replace(_candidate().stop_decision, stop_serving=True, rollback_required=True)
     stop_blocked = _decision(candidate=_candidate(stop_decision=stop_decision))
-    assert stop_blocked.decision == DECISION_FALLBACK
+    _assert_fallback_omits_candidate_payload(stop_blocked)
     assert REASON_STOP_RULE_BLOCKED in stop_blocked.reason_codes
 
 

--- a/tests/core/ai/test_bounded_insight_semantic_cache.py
+++ b/tests/core/ai/test_bounded_insight_semantic_cache.py
@@ -592,6 +592,10 @@ def test_decision_identity_and_serialization_are_deterministic_and_safe() -> Non
     assert "raw_query" not in serialized
     assert "normalized_query" not in serialized
     assert "raw_prompt" not in serialized
+    flags_mapping = dict(to_stable_mapping(_flags()))
+    assert flags_mapping["environment_enabled"] is True
+    assert flags_mapping["runtime_enabled"] is True
+    assert flags_mapping["request_opt_in"] is True
     with pytest.raises(ValueError, match="unsupported stable mapping"):
         to_stable_mapping({"not": "a contract"})
 
@@ -623,6 +627,32 @@ def test_metadata_is_defensively_copied_and_raw_payloads_are_rejected() -> None:
     ):
         with pytest.raises(ValueError, match="unsafe metadata"):
             _request(metadata=unsafe)
+    request_with_tuple = _request(metadata=cast(Mapping[str, JsonValue], {"labels": ("tuple",)}))
+    assert request_with_tuple.metadata["labels"] == ("tuple",)
+    request_with_float = _request(metadata={"score": 1.25})
+    assert request_with_float.metadata["score"] == 1.25
+    with pytest.raises(ValueError, match="non-finite number"):
+        _request(metadata={"score": float("inf")})
+    with pytest.raises(ValueError, match="unsupported value"):
+        _request(metadata=cast(Mapping[str, JsonValue], {"bad": object()}))
+    with pytest.raises(ValueError, match="metadata must be a mapping"):
+        BoundedInsightExperimentRequest(
+            surface="insight",
+            request_fingerprint=DEFAULT_REQUEST_FINGERPRINT,
+            context_fingerprint="sha256:context",
+            source_fingerprints=("sha256:source-a",),
+            policy_version="semantic-cache-sc-g4-v1",
+            provider_key="provider:test",
+            model_key="model:test",
+            user_tier="pro",
+            transparency_notice_id="notice:insight:v1",
+            eval_event_ids=("eval:bounded:1",),
+            admission_decision_id="admission:bounded:1",
+            promotion_ids=("promotion:bounded:1",),
+            replay_entry_ids=("replay:bounded:1",),
+            safety_flags=("wellness-only",),
+            metadata=cast(Mapping[str, JsonValue], ["not-mapping"]),
+        )
 
 
 def test_contracts_reject_invalid_types() -> None:
@@ -673,6 +703,100 @@ def test_contracts_reject_invalid_types() -> None:
             admission_allowed=True,
             metadata={},
         )
+    with pytest.raises(ValueError, match="audit_event must be CacheLookupAuditEvent"):
+        BoundedInsightExperimentCandidate(
+            lookup_request=base.lookup_request,
+            lookup_result=base.lookup_result,
+            record=base.record,
+            audit_event=cast(CacheLookupAuditEvent, "not-audit"),
+            false_hit_evaluation=base.false_hit_evaluation,
+            metrics=base.metrics,
+            stop_decision=base.stop_decision,
+            response_fingerprint=base.response_fingerprint,
+            blocked_surface=False,
+            admission_allowed=True,
+            metadata={},
+        )
+    with pytest.raises(ValueError, match="false_hit_evaluation must be FalseHitHarnessEvaluation"):
+        BoundedInsightExperimentCandidate(
+            lookup_request=base.lookup_request,
+            lookup_result=base.lookup_result,
+            record=base.record,
+            audit_event=base.audit_event,
+            false_hit_evaluation=cast(FalseHitHarnessEvaluation, "not-evaluation"),
+            metrics=base.metrics,
+            stop_decision=base.stop_decision,
+            response_fingerprint=base.response_fingerprint,
+            blocked_surface=False,
+            admission_allowed=True,
+            metadata={},
+        )
+    with pytest.raises(ValueError, match="metrics must be CacheObservabilityMetrics"):
+        BoundedInsightExperimentCandidate(
+            lookup_request=base.lookup_request,
+            lookup_result=base.lookup_result,
+            record=base.record,
+            audit_event=base.audit_event,
+            false_hit_evaluation=base.false_hit_evaluation,
+            metrics=cast(CacheObservabilityMetrics, "not-metrics"),
+            stop_decision=base.stop_decision,
+            response_fingerprint=base.response_fingerprint,
+            blocked_surface=False,
+            admission_allowed=True,
+            metadata={},
+        )
+    with pytest.raises(ValueError, match="stop_decision must be CacheStopDecision"):
+        BoundedInsightExperimentCandidate(
+            lookup_request=base.lookup_request,
+            lookup_result=base.lookup_result,
+            record=base.record,
+            audit_event=base.audit_event,
+            false_hit_evaluation=base.false_hit_evaluation,
+            metrics=base.metrics,
+            stop_decision=cast(CacheStopDecision, "not-stop"),
+            response_fingerprint=base.response_fingerprint,
+            blocked_surface=False,
+            admission_allowed=True,
+            metadata={},
+        )
+    with pytest.raises(ValueError, match="blocked_surface must be bool"):
+        replace(base, blocked_surface=cast(bool, "false"))
+    with pytest.raises(ValueError, match="admission_allowed must be bool"):
+        replace(base, admission_allowed=cast(bool, "true"))
+    with pytest.raises(ValueError, match="flags must be BoundedInsightExperimentFlags"):
+        evaluate_bounded_insight_experiment(
+            flags=cast(BoundedInsightExperimentFlags, "not-flags"),
+            request=_request(),
+            candidate=base,
+        )
+    with pytest.raises(ValueError, match="request must be BoundedInsightExperimentRequest"):
+        evaluate_bounded_insight_experiment(
+            flags=_flags(),
+            request=cast(BoundedInsightExperimentRequest, "not-request"),
+            candidate=base,
+        )
+    with pytest.raises(ValueError, match="candidate must be BoundedInsightExperimentCandidate"):
+        evaluate_bounded_insight_experiment(
+            flags=_flags(),
+            request=_request(),
+            candidate=cast(BoundedInsightExperimentCandidate, "not-candidate"),
+        )
+    with pytest.raises(ValueError, match="unsupported decision"):
+        replace(_decision(), decision="serve")
+    with pytest.raises(ValueError, match="score_bps must be an integer"):
+        replace(_decision(), score_bps=cast(int, 1.5))
+    with pytest.raises(ValueError, match="score_bps must be between 0 and 10000"):
+        replace(_decision(), score_bps=10001)
+    with pytest.raises(ValueError, match="safety_flags must be non-empty"):
+        _request(safety_flags=())
+    with pytest.raises(ValueError, match="source_fingerprints contains duplicate entries"):
+        _request(source_fingerprints=("sha256:source-a", "sha256:source-a"))
+    with pytest.raises(ValueError, match="policy_version must be non-empty"):
+        _request(policy_version=" ")
+    with pytest.raises(ValueError, match="model_key must not contain whitespace"):
+        _request(model_key="model test")
+    with pytest.raises(ValueError, match="provider_key contains unsupported characters"):
+        _request(provider_key="provider@test")
 
 
 def test_module_has_no_forbidden_imports_or_nondeterministic_calls() -> None:

--- a/tests/core/ai/test_cache_observability.py
+++ b/tests/core/ai/test_cache_observability.py
@@ -270,6 +270,36 @@ def test_miss_audit_event_rejects_candidate_fields() -> None:
         )
 
 
+def test_miss_audit_event_rejects_hit_like_match_mode() -> None:
+    audit = _miss_audit_event()
+
+    with pytest.raises(ValueError, match="miss audit events must not carry match_mode"):
+        CacheLookupAuditEvent(
+            audit_event_id="audit:miss-mode",
+            idempotency_key="idempotency:miss-mode",
+            surface=audit.surface,
+            request_fingerprint=audit.request_fingerprint,
+            candidate_record_id=None,
+            candidate_response_fingerprint=None,
+            lookup_decision=audit.lookup_decision,
+            match_mode="exact",
+            policy_version=audit.policy_version,
+            provider_key=audit.provider_key,
+            model_key=audit.model_key,
+            user_tier=audit.user_tier,
+            context_fingerprint=audit.context_fingerprint,
+            transparency_notice_id=audit.transparency_notice_id,
+            source_fingerprints=audit.source_fingerprints,
+            eval_event_ids=audit.eval_event_ids,
+            admission_decision_id=audit.admission_decision_id,
+            promotion_ids=audit.promotion_ids,
+            replay_entry_ids=audit.replay_entry_ids,
+            reason_codes=audit.reason_codes,
+            produced_at=PRODUCED_AT,
+            metadata={},
+        )
+
+
 def test_build_audit_event_rejects_mismatched_or_malformed_inputs() -> None:
     result = match_exact_fuzzy_records(
         request=_request(),
@@ -439,6 +469,23 @@ def test_candidate_miss_with_fallback_action_remains_fallback() -> None:
     assert evaluation.allowed is False
     assert evaluation.is_false_hit is False
     assert evaluation.outcome_class == "fallback"
+
+
+def test_negative_control_blocks_safe_hit_even_if_expected_safe() -> None:
+    evaluation = evaluate_false_hit_case(
+        case=_case(
+            case_id="case:negative-safe",
+            risk_class="semantic_false_positive",
+            expected_action=EXPECTED_ACTION_SAFE_HIT,
+            negative_control=True,
+        ),
+        produced_at=PRODUCED_AT,
+    )
+
+    assert evaluation.allowed is False
+    assert evaluation.is_false_hit is True
+    assert evaluation.outcome_class == "false_hit"
+    assert "fallback_required" in evaluation.blocking_reasons
 
 
 def test_negative_control_case_ordering_is_deterministic() -> None:
@@ -737,6 +784,26 @@ def test_unsafe_metadata_fails_closed() -> None:
             negative_control=True,
             metadata={"artifact": "/tmp/raw-response.txt"},
         )
+    for metadata in (
+        {"authorization": "Basic abc"},
+        {"header": "Bearer secret"},
+        {"api-key": "sk-test"},
+        {"cookie": "session=abc"},
+        {"contact": "user@example.com"},
+        {"phone": "+1 555 123 4567"},
+    ):
+        with pytest.raises(ValueError, match="unsafe metadata"):
+            build_cache_lookup_audit_event(
+                request=_request(),
+                lookup_result=match_exact_fuzzy_records(
+                    request=_request(),
+                    candidate_records=(_record(),),
+                    policy=_policy(),
+                ),
+                candidate_record=_record(),
+                produced_at=PRODUCED_AT,
+                metadata=metadata,
+            )
 
 
 def test_metadata_accepts_safe_nested_json_and_rejects_bad_shapes() -> None:

--- a/tests/helpers/semantic_cache_import_guard.py
+++ b/tests/helpers/semantic_cache_import_guard.py
@@ -27,7 +27,10 @@ FORBIDDEN_SEMANTIC_CACHE_IMPORT_PREFIXES = (
     "openai",
     "anthropic",
 )
-ALLOWED_SEMANTIC_CACHE_IMPORTS = ("core.ai.exact_fuzzy_cache",)
+ALLOWED_SEMANTIC_CACHE_IMPORTS = (
+    "core.ai.cache_observability",
+    "core.ai.exact_fuzzy_cache",
+)
 
 FORBIDDEN_SEMANTIC_CACHE_CALLS = (
     "datetime.now",

--- a/tests/test_semantic_cache_bounded_insight_experiment_contract.py
+++ b/tests/test_semantic_cache_bounded_insight_experiment_contract.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+
+from scripts.ci.check_docs_phase1_gates import check_docs_phase1_guards
+from scripts.ci.check_semantic_cache_gate import (
+    validate_semantic_cache_bounded_insight_experiment_contract,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = (
+    REPO_ROOT
+    / "docs"
+    / "orchestration"
+    / "contracts"
+    / "SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.md"
+)
+SCHEMA = CONTRACT.with_suffix(".schema.json")
+REL_CONTRACT = "docs/orchestration/contracts/SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.md"
+
+
+def _contract_text() -> str:
+    return CONTRACT.read_text(encoding="utf-8")
+
+
+def test_sc_g4_contract_exists_and_keeps_gate_closed_off_by_default() -> None:
+    text = _contract_text().lower()
+
+    assert "sc-g4 bounded `/insight` semantic-cache experiment" in text
+    assert "does not open the semantic-cache gate" in text
+    assert "does not enable runtime caching" in text
+    assert "does not enable `/insight` serving" in text
+    assert "gate remains closed" in text
+    assert "runtime allowed: false" in text
+    assert "implementation allowed: false" in text
+    assert "off by default" in text
+
+
+def test_checker_passes_current_bounded_insight_contract() -> None:
+    assert validate_semantic_cache_bounded_insight_experiment_contract(_contract_text()) == []
+
+
+def test_checker_fails_if_contract_implies_live_serving_or_gate_open() -> None:
+    bad_text = _contract_text() + "\nSC-G4 opens the gate.\n"
+    errors = validate_semantic_cache_bounded_insight_experiment_contract(bad_text)
+    assert any("SC-G4 opens gate" in error for error in errors)
+
+    bad_text = _contract_text() + "\nSC-G4 enables /insight serving.\n"
+    errors = validate_semantic_cache_bounded_insight_experiment_contract(bad_text)
+    assert any("SC-G4 enables insight serving" in error for error in errors)
+
+    bad_text = _contract_text() + "\nSemantic cache can serve /insight responses.\n"
+    errors = validate_semantic_cache_bounded_insight_experiment_contract(bad_text)
+    assert any("semantic cache can serve insight" in error for error in errors)
+
+
+def test_checker_fails_if_required_fail_closed_anchors_are_missing() -> None:
+    text = _contract_text()
+    for phrase in (
+        "off by default",
+        "request disable",
+        "kill switch snapshot",
+        "source fingerprints",
+        "admission decision ID",
+        "response fingerprint",
+        "SC-G5 backend selection remains future",
+    ):
+        broken = re.sub(re.escape(phrase), "", text, flags=re.IGNORECASE)
+        errors = validate_semantic_cache_bounded_insight_experiment_contract(broken)
+        assert errors
+
+
+def test_checker_fails_if_backends_or_raw_payloads_are_approved() -> None:
+    bad_text = (
+        _contract_text()
+        + "\nSC-G4 allows embeddings.\n"
+        + "SC-G4 enables vector search.\n"
+        + "SC-G4 approves Redis/GPTCache.\n"
+        + "SC-G4 allows Redis.\n"
+        + "SC-G4 permits GPTCache.\n"
+        + "SC-G4 allows provider calls.\n"
+        + "SC-G4 caches raw prompts.\n"
+        + "SC-G4 caches raw responses.\n"
+        + "Advisory wiki may seed product cache.\n"
+    )
+    errors = validate_semantic_cache_bounded_insight_experiment_contract(bad_text)
+
+    assert any("SC-G4 allows embeddings" in error for error in errors)
+    assert any("SC-G4 allows vector search" in error for error in errors)
+    assert any("SC-G4 approves Redis/GPTCache" in error for error in errors)
+    assert any("SC-G4 allows provider calls" in error for error in errors)
+    assert any("cache raw prompts" in error for error in errors)
+    assert any("cache raw responses" in error for error in errors)
+    assert any("advisory wiki seeds product cache" in error for error in errors)
+
+
+def test_schema_required_keys_match_sc_g4_intent() -> None:
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+
+    assert schema["required"] == [
+        "gate_status",
+        "runtime_allowed",
+        "implementation_allowed",
+        "rollout_phase",
+        "allowed_surface",
+        "default_state",
+        "feature_flag_sources",
+        "required_evidence_linkage_fields",
+        "required_decision_fields",
+        "blocked_payload_fields",
+        "blocked_surfaces",
+        "blocked_backends",
+        "acceptance_criteria",
+    ]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["gate_status"]["const"] == "closed"
+    assert schema["properties"]["runtime_allowed"]["const"] is False
+    assert schema["properties"]["implementation_allowed"]["const"] is False
+    assert schema["properties"]["rollout_phase"]["const"] == "SC-G4"
+    assert schema["properties"]["default_state"]["const"] == "off"
+    assert "Redis" in schema["properties"]["blocked_backends"]["items"]["enum"]
+    assert (
+        "response_fingerprint" in schema["properties"]["required_decision_fields"]["items"]["enum"]
+    )
+
+
+def test_docs_phase1_gate_includes_sc_g4_contract() -> None:
+    assert check_docs_phase1_guards([REL_CONTRACT]) == []
+
+
+def test_closed_gate_blocks_runtime_side_door_imports() -> None:
+    forbidden_fragments = (
+        "core.ai.exact_fuzzy_cache",
+        "core.ai.cache_observability",
+        "core.ai.bounded_insight_semantic_cache",
+    )
+    scanned_paths = [
+        *(REPO_ROOT / "app").rglob("*.py"),
+        REPO_ROOT / "legacy_app.py",
+    ]
+    offenders: list[str] = []
+    for path in scanned_paths:
+        if not path.exists():
+            continue
+        content = path.read_text(encoding="utf-8")
+        for fragment in forbidden_fragments:
+            if fragment in content:
+                offenders.append(f"{path.relative_to(REPO_ROOT)} imports {fragment}")
+
+    assert offenders == []

--- a/tests/test_semantic_cache_bounded_insight_experiment_contract.py
+++ b/tests/test_semantic_cache_bounded_insight_experiment_contract.py
@@ -83,6 +83,11 @@ def test_checker_fails_if_backends_or_raw_payloads_are_approved() -> None:
         + "SC-G4 allows provider calls.\n"
         + "SC-G4 caches raw prompts.\n"
         + "SC-G4 caches raw responses.\n"
+        + "SC-G4 may store raw prompts.\n"
+        + "Redis is allowed.\n"
+        + "GPTCache is supported.\n"
+        + "provider payloads for replay.\n"
+        + "Raw answers are allowed.\n"
         + "Advisory wiki may seed product cache.\n"
     )
     errors = validate_semantic_cache_bounded_insight_experiment_contract(bad_text)
@@ -93,6 +98,11 @@ def test_checker_fails_if_backends_or_raw_payloads_are_approved() -> None:
     assert any("SC-G4 allows provider calls" in error for error in errors)
     assert any("cache raw prompts" in error for error in errors)
     assert any("cache raw responses" in error for error in errors)
+    assert any("SC-G4 may store raw payloads" in error for error in errors)
+    assert any("Redis allowed" in error for error in errors)
+    assert any("GPTCache supported" in error for error in errors)
+    assert any("provider payloads for replay" in error for error in errors)
+    assert any("raw payload allowed" in error for error in errors)
     assert any("advisory wiki seeds product cache" in error for error in errors)
 
 


### PR DESCRIPTION
## Summary

Adds SC-G4 bounded `/insight` semantic-cache experiment contracts as a deterministic, metadata-only, off-by-default decision layer over the landed SC-G2 exact/fuzzy scaffold and SC-G3 observability/false-hit harness.

This PR keeps the global semantic-cache gate closed. It does not add `/insight` wiring, provider calls, DB writes, FastAPI/OpenAPI, Redis/GPTCache, embeddings, vector search, or raw payload persistence.

## Goal

Define and test the bounded SC-G4 experiment decision layer that can evaluate safe metadata eligibility for a future `/insight`-style experiment while preserving fail-closed gate behavior.

## Business reason

This reduces future AI runtime rollout risk by forcing default-off flags, kill-switch behavior, Evidence Graph lineage, false-hit harness evidence, and blocked-surface checks before any semantic-cache serving can be considered.

## Scope

| In scope | Out of scope |
| --- | --- |
| Pure `core/ai` SC-G4 decision contracts | Runtime cache serving |
| SC-G4 contract doc + schema | `/insight` route/service wiring |
| Semantic-cache checker/docs phase integration | Redis/GPTCache/backend selection |
| Focused unit/contract/import guard tests | Embeddings/vector search/provider calls |
| Narrow roadmap/backlog updates | DB/FastAPI/OpenAPI/frontend/iOS changes |
| Premortem-driven SC-G3 guard fixes | Raw prompt/query/response storage |

## Out of scope

No global gate-open marker changes, public runtime rollout, provider or DB integration, backend selection, Redis/GPTCache, embeddings/vector retrieval, raw payload persistence, advisory wiki product-truth behavior, or App Store/frontend/iOS changes.


## Split Justification

This PR is intentionally kept as one SC-G4 slice because the decision contract, checker anchors, schema, docs, and focused tests must change together to prove the bounded experiment remains off by default and fail-closed. Splitting code from checker/docs would temporarily allow wording or guard drift around a semantic-cache safety gate. Runtime wiring, provider/backend selection, Redis/GPTCache, embeddings, DB/OpenAPI, frontend, and iOS remain deferred to later PRs.

## Files touched

| File | Purpose |
| --- | --- |
| `core/ai/bounded_insight_semantic_cache.py` | SC-G4 pure deterministic metadata-only decision layer |
| `core/ai/cache_observability.py` | Premortem fix: stricter negative-control, miss-event, and metadata safety guards |
| `docs/orchestration/contracts/SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.md` | Machine-checkable SC-G4 contract |
| `docs/orchestration/contracts/SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.schema.json` | SC-G4 schema shape |
| `scripts/ci/check_semantic_cache_gate.py` | SC-G4 contract validator and CLI option |
| `scripts/ci/check_docs_phase1_gates.py` | Docs Phase1 SC-G4 validation |
| `tests/core/ai/test_bounded_insight_semantic_cache.py` | SC-G4 unit/import/facade tests |
| `tests/test_semantic_cache_bounded_insight_experiment_contract.py` | SC-G4 docs/schema/checker tests |
| Existing SC-G3/docs/ledger files | Narrow linkage and regression guard updates |

## Tests / bounded checks

- `python scripts/orchestration/check_preflight.py`
- `python scripts/orchestration/check_agent_consistency.py`
- `python scripts/ci/check_semantic_cache_gate.py`
- `python scripts/ci/check_docs_phase1_gates.py --files docs/orchestration/contracts/SEMANTIC_CACHE_BOUNDED_INSIGHT_EXPERIMENT.md docs/orchestration/contracts/SEMANTIC_CACHE_OBSERVABILITY_FALSE_HIT_HARNESS.md docs/orchestration/contracts/EXACT_FUZZY_CACHE_SCAFFOLD.md docs/roadmap/PulsePlate_Semantic_Cache_Gate_and_Plan.md`
- `python -m pytest -q tests/core/ai/test_bounded_insight_semantic_cache.py tests/core/ai/test_exact_fuzzy_cache.py tests/core/ai/test_cache_observability.py tests/test_semantic_cache_bounded_insight_experiment_contract.py tests/test_semantic_cache_gate.py tests/test_semantic_cache_rollout_gate.py tests/test_semantic_cache_observability_contract.py tests/test_docs_phase1_gates.py tests/test_repo_policy_guards.py`
- `python -m mypy --no-incremental --cache-dir=/dev/null core/ai/bounded_insight_semantic_cache.py tests/core/ai/test_bounded_insight_semantic_cache.py scripts/ci/check_semantic_cache_gate.py scripts/ci/check_docs_phase1_gates.py`
- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed`
- `PATH=.venv/bin:$PATH pre-commit run --from-ref origin/main --to-ref HEAD`
- Pre-push hooks also passed, including changed-file mypy, backend tests, full-repo Bandit, and docker build test.

## Security notes

- No raw prompt/query/normalized query/answer/model response/provider payload fields are introduced.
- Decisions carry only fingerprints, IDs, reason codes, policy/model/provider references, and safe metadata.
- Request disable, kill-switch snapshot, missing lineage, source/policy/provider/model/context/tier/transparency mismatch, admission block, false-hit block, stop-rule block, and blocked surfaces force fallback.
- Import/call guards reject runtime/provider/cache/RAG/eval/vector/embedding imports and nondeterministic calls.
- `core/ai/__init__.py` remains unchanged; SC-G4 is not eagerly exported.

## Premortem

| Failure mode | Mitigation | Evidence |
| --- | --- | --- |
| Accidental gate open | Markers unchanged; checker validates closed state | `check_semantic_cache_gate.py`, gate doc |
| Default-on experiment | Flags require env + runtime + opt-in and no disable/kill-switch | SC-G4 unit tests |
| Hidden runtime serving path | No app/runtime files touched; side-door import guard added | contract tests |
| Cross-context leakage | source/policy/provider/model/context/tier/transparency mismatches fallback | SC-G4 unit tests |
| Raw payload persistence | metadata validators and docs checker reject raw payload terms | SC-G4 + SC-G3 tests |
| Advisory wiki as cache source | blocked in contract/checker | contract tests |
| Redis/GPTCache drift | SC-G5 remains future; checker rejects approval wording | contract tests |
| Negative controls becoming safe hits | SC-G3 bug-hunter finding fixed | `test_negative_control_blocks_safe_hit_even_if_expected_safe` |
| Miss audit event with hit-like mode | SC-G3 bug-hunter finding fixed | `test_miss_audit_event_rejects_hit_like_match_mode` |
| Evidence Graph ID drift across request/record/audit event | SC-G4 decision now checks eval/admission/promotion/replay equality | `test_record_evidence_graph_id_mismatches_fallback`, `test_audit_event_evidence_graph_id_mismatches_fallback` |
| Unsafe bare wording in SC-G4 contract checker | Checker now rejects bare Redis/GPTCache/raw payload allowance claims | `test_checker_fails_if_backends_or_raw_payloads_are_approved` |
| Request identity drift between request and audit event | SC-G4 now requires audit request fingerprint equality before eligibility | `test_audit_event_request_fingerprint_mismatch_fallback` |
| Safety flag drift | SC-G4 now requires candidate record safety flags to match current request safety flags | `test_record_safety_flags_mismatch_fallback` |
| Miss fallback metadata leakage | Miss decisions now omit candidate record/response/match metadata | `test_missing_candidate_and_lookup_miss_fallback` |
| Rejected fallback metadata leakage | Fallback decisions now omit candidate record/response/match metadata for request/audit fingerprint mismatch, safety flag mismatch, admission block, blocked surface, response mismatch, and stop-rule block | `test_audit_event_request_fingerprint_mismatch_fallback`, `test_record_safety_flags_mismatch_fallback`, `test_response_fingerprint_admission_stop_and_blocked_surface_fallback` |
| Bound-hit response drift | Bound-hit candidate metadata now also requires candidate response fingerprint parity with the record response fingerprint | `test_response_fingerprint_admission_stop_and_blocked_surface_fallback` |
| Nested metadata mutation | Metadata is deeply frozen internally while `to_stable_mapping()` remains JSON-ready | `test_metadata_is_defensively_copied_and_raw_payloads_are_rejected`, `test_decision_identity_and_serialization_are_deterministic_and_safe` |
| Non-string token inputs | Token validation now fails closed with `ValueError` instead of leaking `AttributeError` | `test_contracts_reject_invalid_types` |
| Stable mapping serialization | `to_stable_mapping()` returns plain JSON-ready dict/list structures instead of requiring wrapper conversion | `test_decision_identity_and_serialization_are_deterministic_and_safe` |
| CI coverage lane omitted SC-G4 tests | CI contract-risk coverage selection now includes bounded insight module and contract tests | `.github/workflows/ci.yml`, diff-coverage rerun |
| SC-G4 diff coverage below threshold | Removed unreachable private fallback branch and added focused fail-closed validator tests | local diff-cover 100% |

## Rollback / risks

Rollback is low risk: revert this docs/core/test-only PR. No migrations, storage, routes, providers, feature flags, or product behavior are added.

Residual risk is review/governance drift: this PR must not be interpreted as global semantic-cache approval. The checker and docs keep the gate closed.

## DoD

- [x] SC-G4 contract exists.
- [x] Experiment remains off by default.
- [x] Request disable and kill switch are deterministic.
- [x] Evidence Graph linkage fields are mandatory.
- [x] No raw payload storage.
- [x] No FastAPI/OpenAPI/DB/provider/Redis/GPTCache changes.
- [x] Global semantic-cache gate markers remain closed.
- [x] Checker/docs gates pass.
- [x] Focused tests pass.
- [x] PR opened as non-draft.

## Commit breakdown

- `250a1f856` `feat(ai-runtime): add bounded insight semantic-cache experiment`
- `94ed8e8d9` `docs(review): add PR 1705 fixed mapping`
- `e388863c4` `fix(ai-runtime): close bounded insight review gaps`
- `83c372b1f` `fix(ai-runtime): harden bounded insight linkage guards`
- `3b2370847` `docs(review): map bounded insight follow-up fixes`
- `18a333152` `fix(ai-runtime): keep linkage mismatch typing explicit`
- `6d28cae6b` `docs(review): map bounded insight typing fix`
- `878b316a6` `fix(ai-runtime): bind bounded insight audit fingerprints`
- `85506a6fd` `docs(review): map bounded insight security fix`
- `3e5f9ca6f` `fix(ai-runtime): close bounded insight bot findings`
- `8466cffc0` `docs(review): map bounded insight bot fixes`
- `153c65302` `fix(ai-runtime): keep bounded insight helper typing strict`
- `018711888` `docs(review): map bounded insight typing follow-up`
- `b25a370b2` `fix(ai-runtime): omit rejected bounded insight candidate payloads`
- `5c48257e4` `docs(review): map rejected candidate payload fix`
- `014017e6a` `fix(ai-runtime): harden bounded insight metadata contracts`
- `603b14da6` `docs(review): map bounded insight metadata fixes`
- `2f0692a67` `fix(ai-runtime): return json-ready bounded insight mappings`
- `fdbfa8b3f` `docs(review): map bounded insight stable mapping fix`
- `c1fc167cd` `fix(ci): include bounded insight tests in coverage lane`
- `d8af82a6e` `docs(review): map bounded insight bot findings`
- `85e38b8ec` `docs(review): map bounded insight codex findings`
- `11311d937` `fix(ai-runtime): close bounded insight diff coverage gaps`
- `aa0204417` `docs(review): map bounded insight coverage fix`
- `844e1416b` `docs(review): record bounded insight coverage mapping`
- `613abbb68` `docs(review): fix bounded insight GitHub wording`
- `2f0692a67` `fix(ai-runtime): return json-ready bounded insight mappings`

## Pre-push checklist

- [x] Coordinator-first bootstrap completed.
- [x] Premortem findings converted into code/test/docs guards.
- [x] Bounded local validation passed.
- [x] Pre-commit passed.
- [x] Branch pushed without force-push.

## Post-merge checklist

- Sync local `main` via fetch + ff-only merge.
- Confirm `git rev-list --left-right --count HEAD...origin/main` is `0 0`.
- Run post-merge `check_preflight.py` and `check_agent_consistency.py`.
- Remove only the SC-G4 worktree, local branch, slice-local caches/temp/generated artifacts.
- Do not start SC-G5 automatically.

## AGENTS updates

No AGENTS.md updates.

## Deferred / Follow-ups

SC-G5 backend selection remains future and blocked until explicit operator selection, safety evidence, rollback proof, current-head CI governance, and human approval.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_1705_FIXED_MAPPING.md`

## Merge Readiness

Not merge-ready yet. Required before merge: current-head CI clean, CodeRabbit/Sourcery/Cubic no actionables or dispositions, Codex Security clean/dispositioned, strict merge-readiness wrapper pass, no unresolved review threads, mandatory wait-window observed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a metadata-only semantic cache experiment for the `/insight` surface with fail-closed behavior and strict safety eligibility validation.

* **Documentation**
  * Added experiment contract specifications defining required behavior, constraints, and safety requirements.

* **Tests**
  * Enhanced observability detection for sensitive data patterns and added comprehensive experiment validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->