### PR TITLE
docs(orchestration): add design-epic PR prompt protocol v2026-05-08

### DIFF
--- a/docs/orchestration/DESIGN_AGENT_PR_TEMPLATE.md
+++ b/docs/orchestration/DESIGN_AGENT_PR_TEMPLATE.md
@@ -3,6 +3,8 @@
 
 Use this template for design-impacting PRs. It is a repo-governed process layer and does not make design evidence canonical.
 
+For future design-epic PR prompts, apply `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md` before filling this template.
+
 ## Summary
 
 Describe the design-impacting change and the surface it governs.
@@ -61,7 +63,7 @@ Use repo `.venv`:
 - `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make tokens-check`
 - `PATH=.venv/bin:$PATH pre-commit run --all-files`
 
-Add targeted evidence/tooling/runtime checks for touched surfaces only.
+Add targeted evidence/tooling/runtime checks for touched surfaces only. Generated future design-epic PR prompts use the narrower prompt bundle in `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md` unless a coordinator packet explicitly supersedes it.
 
 ## Security notes
 
@@ -73,9 +75,13 @@ Premortem must review the actual docs/code/tests diff. Real findings must be fix
 
 Mapping is evidence after fix or decision; mapping is not the fix.
 
+For future design-epic PR prompts, premortem runs before PR opening and again after the first bot-review cycle.
+
 ## Bug-hunter pass
 
 Confirm no second source of truth, no manual generated mirror edits, no runtime drift outside scope, no unsupported wellness claims, and no hidden binary artifacts.
+
+For future design-epic PR prompts, post-open review must include `qa-engineer-agent`, `bug-hunter`, `security-auditor`, and Codex Security. After the first bot review, repeat `agent-coordinator`, `qa-engineer-agent`, `bug-hunter`, `security-auditor`, and premortem on the updated diff.
 
 ## Deferred / Follow-ups
 

--- a/docs/orchestration/DESIGN_AGENT_WORKFLOW.md
+++ b/docs/orchestration/DESIGN_AGENT_WORKFLOW.md
@@ -7,6 +7,8 @@ This workflow governs future design-impacting PulsePlate PRs after the Design In
 
 It is a process layer only. Repo code, tests, `/tokens` as token authoring truth, generated mirrors as derived runtime artifacts, UI vocabulary, backend/OpenAPI contracts, and implemented runtime components remain governed by repo truth.
 
+Future design-epic PR prompts must follow `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md` for clean worktree startup, actual-diff premortem execution, coordinator-expanded role order, post-open review chains, and fixed-mapping-after-fix governance.
+
 ## 1. Start Gate
 
 Before edits, design-impacting PRs must:
@@ -115,6 +117,8 @@ Do not resolve review threads without explicit disposition evidence. Do not upda
 ## 9. Merge Readiness
 
 Design-impacting PRs use bounded local checks and current-head PR checks.
+
+The command bundle below is general merge-readiness evidence for design-impacting PRs. Generated future design-epic PR prompts use the narrower bounded prompt bundle in `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md` unless a coordinator packet explicitly supersedes it.
 
 Use `.venv/bin/python` for repo Python commands and:
 

--- a/docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md
+++ b/docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md
@@ -20,7 +20,7 @@ Future design-epic PR prompts must:
 - list `make validate-changed` as the only default `make` target in generated prompt command blocks;
 - state that bounded local checks are evidence only and do not prove merge readiness;
 - require PR body, checkbox, fixed-mapping, review-governance, and merge-readiness docs to be read before PR opening;
-- keep Figma, Canva, Storybook, Browser Use, Slack, Hugging Face, Supabase, and research connectors as evidence or reference layers unless the coordinator packet explicitly scopes stronger authority.
+- keep Figma, Canva, Storybook, Browser Use, Slack, Hugging Face, Supabase, and research connectors as evidence or reference layers unless a separate repo-reviewed contract promotes a narrower authority.
 
 Future design-epic PR prompts must not:
 

--- a/docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md
+++ b/docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md
@@ -118,7 +118,7 @@ DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed
 PATH=.venv/bin:$PATH pre-commit run --all-files
 ```
 
-Use `check_preflight.py --mode execute --path <path>` for the final pre-open validation pass after edits and before push.
+Use `check_preflight.py --mode execute --primary <primary-agent> --reviewer <reviewer-agent> --path <path>` for the final pre-open validation pass after edits and before push. Include `--secondary <agent>` when the coordinator packet declares secondary agents.
 
 Additional targeted commands are allowed only when they are not `make` targets and are tied to the touched surface. Environment setup target `make venv-sync` is allowed in startup only; it is not validation evidence.
 

--- a/docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md
+++ b/docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md
@@ -1,0 +1,140 @@
+<!-- markdownlint-disable MD013 -->
+# Design Epic PR Prompt Protocol v2026-05-08
+
+## Summary
+
+This protocol governs future PulsePlate design-epic PR prompts after the merged post-PR-8 design automation decision.
+
+It is support infrastructure for the design epic. It does not replace `docs/design/NEXT_DESIGN_AUTOMATION_MODULE_DECISION.md`, does not rewrite the post-PR-8 next-lane packet, and does not make prompt outputs a product or design source of truth.
+
+## Prompt Contract
+
+Future design-epic PR prompts must:
+
+- start from a clean worktree created directly from `origin/main`;
+- open a normal review PR only after local narrow evidence exists;
+- create a worktree-local virtual environment with `python3.13 -m venv .venv --copies`;
+- refresh locked repo dependencies inside that environment with `make venv-sync`;
+- use repo-local Python commands through `.venv/bin/python`;
+- include all touched paths as repeated `--path` arguments in preflight and bootstrap commands;
+- list `make validate-changed` as the only default `make` target in generated prompt command blocks;
+- state that bounded local checks are evidence only and do not prove merge readiness;
+- require PR body, checkbox, fixed-mapping, review-governance, and merge-readiness docs to be read before PR opening;
+- keep Figma, Canva, Storybook, Browser Use, Slack, Hugging Face, Supabase, and research connectors as evidence or reference layers unless the coordinator packet explicitly scopes stronger authority.
+
+Future design-epic PR prompts must not:
+
+- instruct agents to switch the root checkout;
+- include provisional PR-state wording;
+- include the full local root verification bundle as a prompt command;
+- list stale design-lane `make` targets in generated prompt command blocks;
+- delegate post-merge local main synchronization to the agent prompt;
+- treat skills, plugins, browser state, design files, prompt outputs, scorecards, or evidence packs as source of truth.
+
+## Required Startup Flow
+
+The generated prompt must require this order before edits:
+
+```bash
+git fetch --prune origin
+git worktree add -b <branch> <worktree-path> origin/main
+cd <worktree-path>
+python3.13 -m venv .venv --copies
+DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make venv-sync
+.venv/bin/python scripts/orchestration/check_preflight.py --path <path>
+.venv/bin/python scripts/orchestration/check_agent_consistency.py
+.venv/bin/python scripts/orchestration/task_bootstrap.py \
+  --goal "<goal>" \
+  --task-class "<class>" \
+  --pr-phase pre_open \
+  --path <path> \
+  --requested-agent agent-coordinator \
+  --requested-agent cursor-specialist-agent \
+  --requested-agent architecture-specialist \
+  --requested-agent security-auditor \
+  --requested-agent creative-designer \
+  --requested-agent qa-engineer-agent \
+  --requested-agent bug-hunter
+```
+
+Use repeated `--path` arguments for every touched file or directory that matters for scoped `AGENTS.md` resolution.
+
+## Required Execution Chain
+
+The minimum pre-open execution chain is:
+
+1. `agent-coordinator`
+2. `cursor-specialist-agent`
+3. `architecture-specialist`
+4. `security-auditor`
+5. `creative-designer`
+6. `qa-engineer-agent`
+7. `bug-hunter`
+
+If `task_bootstrap.py` or `agent-coordinator` expands the role order, the expanded order becomes mandatory for the lane. No declared role agent may be skipped without a coordinator update to the lane packet or runbook; the PR body may mirror that decision but cannot replace it.
+
+## Premortem Requirement
+
+Premortem is mandatory before PR opening and again after the first bot-review cycle.
+
+The premortem must inspect the actual diff across docs, tests, scripts, and code in scope. Reviewing only the PR body, checkboxes, or fixed-mapping artifact is insufficient.
+
+Every premortem finding must close before readiness:
+
+- `FIXED`: change docs, tests, scripts, or code and cite file plus command evidence.
+- `NOT-A-BUG`: coordinator records why the finding does not apply, with repo evidence.
+- `DEFERRED`: coordinator records the backlog anchor and PR-body follow-up.
+
+If a finding is real, fix the underlying issue first, rerun the targeted gate, then update `docs/review/PR_<N>_FIXED_MAPPING.md`.
+
+## Post-Open And Bot-Review Chain
+
+After opening the PR, run:
+
+1. `qa-engineer-agent`
+2. `bug-hunter`
+3. `security-auditor`
+4. Codex Security plugin diff scan
+
+After the first bot review, run:
+
+1. `agent-coordinator`
+2. `qa-engineer-agent`
+3. `bug-hunter`
+4. `security-auditor`
+5. premortem rerun on the actual updated diff
+
+Findings from these passes follow the same fix-before-mapping rule as human and bot review threads.
+
+## Bounded Validation Prompt
+
+The generated prompt may include this local validation bundle:
+
+```bash
+.venv/bin/python scripts/orchestration/check_preflight.py --path <path>
+.venv/bin/python scripts/orchestration/check_agent_consistency.py
+.venv/bin/python -m pytest -q <targeted-test-file>
+DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed
+PATH=.venv/bin:$PATH pre-commit run --all-files
+```
+
+Use `check_preflight.py --mode execute --path <path>` for the final pre-open validation pass after edits and before push.
+
+Additional targeted commands are allowed only when they are not `make` targets and are tied to the touched surface. Environment setup target `make venv-sync` is allowed in startup only; it is not validation evidence.
+
+## Review Governance
+
+After the PR number exists:
+
+- create `docs/review/PR_<N>_FIXED_MAPPING.md`;
+- keep the PR body as a mirror of the canonical artifact;
+- record mapping only after the underlying fix or formal decision exists;
+- never use mapping as a substitute for fixing a real defect.
+
+Merge readiness still depends on current-head CI, review dispositions, fixed mapping, mandatory wait-window, and the strict merge wrapper. Local bounded checks alone do not prove readiness.
+
+## Design-Epic Boundary
+
+This protocol does not authorize runtime web, iOS, backend, OpenAPI, billing, auth, StoreKit, HealthKit, `/tokens`, generated mirrors, Figma, Canva, Storybook config, screenshots, videos, traces, binary assets, or external asset generation.
+
+It supports future design-epic PR prompts only. The selected future design automation lane remains the Icon Asset Validator / App Store asset guard lane recorded by the merged post-PR-8 decision packet.

--- a/docs/review/PR_1710_FIXED_MAPPING.md
+++ b/docs/review/PR_1710_FIXED_MAPPING.md
@@ -31,29 +31,29 @@ Disposition: FIXED
 Commit: 320e257471ec5af546391bfdd8ad4d507fcbb4d5
 Evidence: Cubic review summary reported the execute-mode preflight finding mapped above at `discussion_r3209085108` and fixed by the same commit.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#discussion_r3209166947 -> c9f2427890dc2b3f95b6ddf1b8f5f41b6be252dd
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#discussion_r3209166947 -> c9f2427898eb4ccde0120fa91a1a75ffa0b8dae9
 Disposition: FIXED
-Commit: c9f2427890dc2b3f95b6ddf1b8f5f41b6be252dd
+Commit: c9f2427898eb4ccde0120fa91a1a75ffa0b8dae9
 Evidence: `docs/roadmap/BACKLOG_LEDGER.md` now uses `Target PR: #1710` for the design-epic PR-prompt protocol tracking entry.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#pullrequestreview-4252800795 -> c9f2427890dc2b3f95b6ddf1b8f5f41b6be252dd
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#pullrequestreview-4252800795 -> c9f2427898eb4ccde0120fa91a1a75ffa0b8dae9
 Disposition: FIXED
-Commit: c9f2427890dc2b3f95b6ddf1b8f5f41b6be252dd
+Commit: c9f2427898eb4ccde0120fa91a1a75ffa0b8dae9
 Evidence: CodeRabbit review summary reported one actionable ledger finding, mapped above at `discussion_r3209166947` and fixed by the same commit.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#discussion_r3209249327 -> 7603bda253f6b53a03f721ee53b4c6f9a61e4fe2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#discussion_r3209249327 -> 7603bda25a840335a55406ad0e849efe6c3c8939
 Disposition: FIXED
-Commit: 7603bda253f6b53a03f721ee53b4c6f9a61e4fe2
+Commit: 7603bda25a840335a55406ad0e849efe6c3c8939
 Evidence: the pre-merge checklist in this artifact now uses unchecked checkbox syntax for each checklist item.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#pullrequestreview-4252891670 -> 7603bda253f6b53a03f721ee53b4c6f9a61e4fe2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#pullrequestreview-4252891670 -> 7603bda25a840335a55406ad0e849efe6c3c8939
 Disposition: FIXED
-Commit: 7603bda253f6b53a03f721ee53b4c6f9a61e4fe2
+Commit: 7603bda25a840335a55406ad0e849efe6c3c8939
 Evidence: CodeRabbit review summary reported the checklist syntax finding mapped above at `discussion_r3209249327` and fixed by the same commit.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#pullrequestreview-4252916551 -> 7603bda253f6b53a03f721ee53b4c6f9a61e4fe2
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#pullrequestreview-4252916551 -> 7603bda25a840335a55406ad0e849efe6c3c8939
 Disposition: FIXED
-Commit: 7603bda253f6b53a03f721ee53b4c6f9a61e4fe2
+Commit: 7603bda25a840335a55406ad0e849efe6c3c8939
 Evidence: later CodeRabbit review summary duplicated the checklist syntax finding and is covered by the same checklist fix.
 
 ## Internal Findings Closed Before Mapping

--- a/docs/review/PR_1710_FIXED_MAPPING.md
+++ b/docs/review/PR_1710_FIXED_MAPPING.md
@@ -31,6 +31,11 @@ Disposition: FIXED
 Commit: c9f2427890dc2b3f95b6ddf1b8f5f41b6be252dd
 Evidence: `docs/roadmap/BACKLOG_LEDGER.md` now uses `Target PR: #1710` for the design-epic PR-prompt protocol tracking entry.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#pullrequestreview-4252800795 -> c9f2427890dc2b3f95b6ddf1b8f5f41b6be252dd
+Disposition: FIXED
+Commit: c9f2427890dc2b3f95b6ddf1b8f5f41b6be252dd
+Evidence: CodeRabbit review summary reported one actionable ledger finding, mapped above at `discussion_r3209166947` and fixed by the same commit.
+
 ## Internal Findings Closed Before Mapping
 
 - Pre-open finding: future prompt guard scanned the full backlog ledger and matched unrelated historical `draft PR` text.

--- a/docs/review/PR_1710_FIXED_MAPPING.md
+++ b/docs/review/PR_1710_FIXED_MAPPING.md
@@ -98,12 +98,12 @@ Decision: proceed with changes. The required changes were applied before PR open
 
 Pre-merge checklist for this PR:
 
-- Confirm the protocol is framed as design-epic support docs, not a standalone prompt-canon lane.
-- Confirm PR #1707 historical next-lane truth remains intact.
-- Confirm generated prompt command blocks reject root checkout switching, provisional PR-state wording, full local root verification bundle commands, and stale prompt make targets.
-- Confirm generic design workflow gates remain separate from generated prompt protocol commands.
-- Confirm mapping remains evidence after fix/decision.
-- Confirm no runtime, token, generated mirror, Figma, Canva, Storybook, asset, web, iOS, or backend files are changed.
+- [ ] Confirm the protocol is framed as design-epic support docs, not a standalone prompt-canon lane.
+- [ ] Confirm PR #1707 historical next-lane truth remains intact.
+- [ ] Confirm generated prompt command blocks reject root checkout switching, provisional PR-state wording, full local root verification bundle commands, and stale prompt make targets.
+- [ ] Confirm generic design workflow gates remain separate from generated prompt protocol commands.
+- [ ] Confirm mapping remains evidence after fix/decision.
+- [ ] Confirm no runtime, token, generated mirror, Figma, Canva, Storybook, asset, web, iOS, or backend files are changed.
 
 ## Agent Run Summary
 

--- a/docs/review/PR_1710_FIXED_MAPPING.md
+++ b/docs/review/PR_1710_FIXED_MAPPING.md
@@ -62,12 +62,12 @@ This artifact records evidence after fixes or formal decisions. It is not a subs
 
 - Post-open finding: final execute-mode preflight command was not copy-paste runnable because it omitted the required routing flags.
   - Disposition: FIXED
-  - Commit: `a319925fb46d5d80ac13815dc702c184f452e0e3`
+  - Commit: `320e257471ec5af546391bfdd8ad4d507fcbb4d5`
   - Evidence: `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md` now requires `--primary`, `--reviewer`, `--path`, and `--secondary` for coordinator-declared secondary agents; `.venv/bin/python scripts/orchestration/check_preflight.py --mode execute --primary agent-coordinator --secondary cursor-specialist-agent --reviewer architecture-specialist --path docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md --path docs/orchestration/DESIGN_AGENT_WORKFLOW.md --path docs/orchestration/DESIGN_AGENT_PR_TEMPLATE.md --path tests/test_design_automation_next_lane_docs.py --path docs/roadmap/BACKLOG_LEDGER.md` passed after staging.
 
 - Post-open finding: canonical mapping artifact used an invalid heading and mixed prose bullets inside the parser-owned mapping section.
   - Disposition: FIXED
-  - Commit: `a319925fb46d5d80ac13815dc702c184f452e0e3`
+  - Commit: `320e257471ec5af546391bfdd8ad4d507fcbb4d5`
   - Evidence: this file now uses the exact `## Fixed in Commit Mapping` heading and keeps internal non-GitHub findings outside the parser-owned section.
 
 ## Premortem Evidence

--- a/docs/review/PR_1710_FIXED_MAPPING.md
+++ b/docs/review/PR_1710_FIXED_MAPPING.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD013 -->
-# PR 1710 Fixed In Commit Mapping
+# PR 1710 Fixed in Commit Mapping
 
 ## Scope
 
@@ -11,9 +11,14 @@ This artifact records evidence after fixes or formal decisions. It is not a subs
 
 ## Discussion Thread Pass
 
-Pre-open role-agent and premortem review found actionable docs/test issues before PR opening. They were fixed before this mapping file was created.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
-## Fixed In Commit Mapping
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Internal Findings Closed Before Mapping
 
 - Pre-open finding: future prompt guard scanned the full backlog ledger and matched unrelated historical `draft PR` text.
   - Disposition: FIXED
@@ -49,6 +54,21 @@ Pre-open role-agent and premortem review found actionable docs/test issues befor
   - Disposition: FIXED
   - Commit: `5a3ced20a22bf2757bc525c7e6eb9ec2ecd6dc42`
   - Evidence: `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md` requires `check_preflight.py --mode execute --path <path>` for final pre-open validation.
+
+- Post-open finding: external-tool authority wording allowed a coordinator packet alone to grant stronger authority.
+  - Disposition: FIXED
+  - Commit: `8fb9e62e27f096390aa76f700ecc7aa91ad7a2a1`
+  - Evidence: `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md` now requires a separate repo-reviewed contract to promote any narrower authority, and `tests/test_design_automation_next_lane_docs.py` guards against the old wording.
+
+- Post-open finding: final execute-mode preflight command was not copy-paste runnable because it omitted the required routing flags.
+  - Disposition: FIXED
+  - Commit: `a319925fb46d5d80ac13815dc702c184f452e0e3`
+  - Evidence: `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md` now requires `--primary`, `--reviewer`, `--path`, and `--secondary` for coordinator-declared secondary agents; `.venv/bin/python scripts/orchestration/check_preflight.py --mode execute --primary agent-coordinator --secondary cursor-specialist-agent --reviewer architecture-specialist --path docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md --path docs/orchestration/DESIGN_AGENT_WORKFLOW.md --path docs/orchestration/DESIGN_AGENT_PR_TEMPLATE.md --path tests/test_design_automation_next_lane_docs.py --path docs/roadmap/BACKLOG_LEDGER.md` passed after staging.
+
+- Post-open finding: canonical mapping artifact used an invalid heading and mixed prose bullets inside the parser-owned mapping section.
+  - Disposition: FIXED
+  - Commit: `a319925fb46d5d80ac13815dc702c184f452e0e3`
+  - Evidence: this file now uses the exact `## Fixed in Commit Mapping` heading and keeps internal non-GitHub findings outside the parser-owned section.
 
 ## Premortem Evidence
 

--- a/docs/review/PR_1710_FIXED_MAPPING.md
+++ b/docs/review/PR_1710_FIXED_MAPPING.md
@@ -16,7 +16,20 @@ This artifact records evidence after fixes or formal decisions. It is not a subs
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#discussion_r3209064923 -> 320e257471ec5af546391bfdd8ad4d507fcbb4d5
+Disposition: FIXED
+Commit: 320e257471ec5af546391bfdd8ad4d507fcbb4d5
+Evidence: `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md` requires execute-mode `check_preflight.py` with `--primary`, `--reviewer`, and scoped `--path`; `tests/test_design_automation_next_lane_docs.py` asserts the command wording.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#discussion_r3209085108 -> 320e257471ec5af546391bfdd8ad4d507fcbb4d5
+Disposition: FIXED
+Commit: 320e257471ec5af546391bfdd8ad4d507fcbb4d5
+Evidence: same execute-mode routing fix as above; Cubic marked the finding addressed in commit `320e257`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#discussion_r3209166947 -> c9f2427890dc2b3f95b6ddf1b8f5f41b6be252dd
+Disposition: FIXED
+Commit: c9f2427890dc2b3f95b6ddf1b8f5f41b6be252dd
+Evidence: `docs/roadmap/BACKLOG_LEDGER.md` now uses `Target PR: #1710` for the design-epic PR-prompt protocol tracking entry.
 
 ## Internal Findings Closed Before Mapping
 

--- a/docs/review/PR_1710_FIXED_MAPPING.md
+++ b/docs/review/PR_1710_FIXED_MAPPING.md
@@ -26,6 +26,11 @@ Disposition: FIXED
 Commit: 320e257471ec5af546391bfdd8ad4d507fcbb4d5
 Evidence: same execute-mode routing fix as above; Cubic marked the finding addressed in commit `320e257`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#pullrequestreview-4252710283 -> 320e257471ec5af546391bfdd8ad4d507fcbb4d5
+Disposition: FIXED
+Commit: 320e257471ec5af546391bfdd8ad4d507fcbb4d5
+Evidence: Cubic review summary reported the execute-mode preflight finding mapped above at `discussion_r3209085108` and fixed by the same commit.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#discussion_r3209166947 -> c9f2427890dc2b3f95b6ddf1b8f5f41b6be252dd
 Disposition: FIXED
 Commit: c9f2427890dc2b3f95b6ddf1b8f5f41b6be252dd

--- a/docs/review/PR_1710_FIXED_MAPPING.md
+++ b/docs/review/PR_1710_FIXED_MAPPING.md
@@ -1,0 +1,102 @@
+<!-- markdownlint-disable MD013 -->
+# PR 1710 Fixed In Commit Mapping
+
+## Scope
+
+PR: `docs(orchestration): add design-epic PR prompt protocol v2026-05-08`
+
+Branch: `codex/design-epic-pr-prompt-protocol-v2026-05-08`
+
+This artifact records evidence after fixes or formal decisions. It is not a substitute for fixing real defects.
+
+## Discussion Thread Pass
+
+Pre-open role-agent and premortem review found actionable docs/test issues before PR opening. They were fixed before this mapping file was created.
+
+## Fixed In Commit Mapping
+
+- Pre-open finding: future prompt guard scanned the full backlog ledger and matched unrelated historical `draft PR` text.
+  - Disposition: FIXED
+  - Commit: `5a3ced20a22bf2757bc525c7e6eb9ec2ecd6dc42`
+  - Evidence: `tests/test_design_automation_next_lane_docs.py` now scopes `_future_prompt_corpus()` to the actual future prompt surface.
+
+- Pre-open finding: review-chain guard used brittle exact casing instead of the governing protocol/template wording.
+  - Disposition: FIXED
+  - Commit: `5a3ced20a22bf2757bc525c7e6eb9ec2ecd6dc42`
+  - Evidence: `tests/test_design_automation_next_lane_docs.py` now checks the post-open and post-first-bot-review chain phrases as written in the docs.
+
+- Pre-open finding: generic design PR template gates were weakened by removing `make design-guard` and `make tokens-check`.
+  - Disposition: FIXED
+  - Commit: `5a3ced20a22bf2757bc525c7e6eb9ec2ecd6dc42`
+  - Evidence: `docs/orchestration/DESIGN_AGENT_PR_TEMPLATE.md` keeps the generic design gates and points generated future design-epic PR prompts to the narrower protocol bundle.
+
+- Pre-open finding: protocol wording allowed PR body text to supersede coordinator-declared role order.
+  - Disposition: FIXED
+  - Commit: `5a3ced20a22bf2757bc525c7e6eb9ec2ecd6dc42`
+  - Evidence: `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md` now requires coordinator updates to the lane packet or runbook; the PR body may mirror but cannot replace that decision.
+
+- Pre-open finding: workflow generic gates and generated prompt protocol were ambiguous.
+  - Disposition: FIXED
+  - Commit: `5a3ced20a22bf2757bc525c7e6eb9ec2ecd6dc42`
+  - Evidence: `docs/orchestration/DESIGN_AGENT_WORKFLOW.md` separates general merge-readiness evidence from the narrower generated prompt bundle, and `tests/test_design_automation_next_lane_docs.py` asserts that boundary.
+
+- Pre-open finding: copied worktree-local venv setup omitted dependency sync.
+  - Disposition: FIXED
+  - Commit: `5a3ced20a22bf2757bc525c7e6eb9ec2ecd6dc42`
+  - Evidence: `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md` includes startup-only `make venv-sync`.
+
+- Pre-open finding: final validation preflight did not name execute mode.
+  - Disposition: FIXED
+  - Commit: `5a3ced20a22bf2757bc525c7e6eb9ec2ecd6dc42`
+  - Evidence: `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md` requires `check_preflight.py --mode execute --path <path>` for final pre-open validation.
+
+## Premortem Evidence
+
+Premortem mode: `pr-premortem`, pre-open.
+
+Frame: It is six months from now. The design epic failed because future PR prompts skipped coordinator-expanded role order, actual-diff premortem, dependency setup, post-open reviews, or fixed-mapping-after-fix governance.
+
+Decision: proceed with changes. The required changes were applied before PR opening and validated locally.
+
+Pre-merge checklist for this PR:
+
+- Confirm the protocol is framed as design-epic support docs, not a standalone prompt-canon lane.
+- Confirm PR #1707 historical next-lane truth remains intact.
+- Confirm generated prompt command blocks reject root checkout switching, provisional PR-state wording, full local root verification bundle commands, and stale prompt make targets.
+- Confirm generic design workflow gates remain separate from generated prompt protocol commands.
+- Confirm mapping remains evidence after fix/decision.
+- Confirm no runtime, token, generated mirror, Figma, Canva, Storybook, asset, web, iOS, or backend files are changed.
+
+## Agent Run Summary
+
+Coordinator bootstrap evidence:
+
+- `.venv/bin/python scripts/orchestration/check_preflight.py --path ...` passed with scoped AGENTS resolved.
+- `.venv/bin/python scripts/orchestration/check_agent_consistency.py` passed.
+- `.venv/bin/python scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open --path ... --requested-agent ...` passed and emitted task packet `fe672e424219`.
+
+Declared pre-open role order:
+
+1. `agent-coordinator`
+2. `cursor-specialist-agent`
+3. `architecture-specialist`
+4. `security-auditor`
+5. `creative-designer`
+6. `qa-engineer-agent`
+7. `bug-hunter`
+
+## Security Review
+
+Codex Security plugin diff-scoped review found no reportable runtime candidate. The diff changes docs/tests/governance only and introduces no auth, secret, subprocess, network, CI workflow, suppression, or fail-open runtime path.
+
+## Validation Evidence
+
+- `.venv/bin/python -m pytest -q tests/test_design_automation_next_lane_docs.py` passed: 14 passed.
+- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed` passed; command output reported no changed Python files, so targeted pytest is the primary guard evidence for the changed test file.
+- `PATH=.venv/bin:$PATH pre-commit run --all-files` passed.
+- `.venv/bin/python scripts/orchestration/check_preflight.py --mode execute --primary agent-coordinator --secondary cursor-specialist-agent --reviewer architecture-specialist --path ...` passed after staging.
+- Commit and push hooks passed, including pre-push backend tests and full-repo Bandit.
+
+## Merge Readiness
+
+Not claimed. Merge readiness still depends on current-head CI, post-open role passes, post-first-bot-review passes, review dispositions, this mapping artifact, wait-window, and strict merge wrapper.

--- a/docs/review/PR_1710_FIXED_MAPPING.md
+++ b/docs/review/PR_1710_FIXED_MAPPING.md
@@ -36,6 +36,21 @@ Disposition: FIXED
 Commit: c9f2427890dc2b3f95b6ddf1b8f5f41b6be252dd
 Evidence: CodeRabbit review summary reported one actionable ledger finding, mapped above at `discussion_r3209166947` and fixed by the same commit.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#discussion_r3209249327 -> 7603bda253f6b53a03f721ee53b4c6f9a61e4fe2
+Disposition: FIXED
+Commit: 7603bda253f6b53a03f721ee53b4c6f9a61e4fe2
+Evidence: the pre-merge checklist in this artifact now uses unchecked checkbox syntax for each checklist item.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#pullrequestreview-4252891670 -> 7603bda253f6b53a03f721ee53b4c6f9a61e4fe2
+Disposition: FIXED
+Commit: 7603bda253f6b53a03f721ee53b4c6f9a61e4fe2
+Evidence: CodeRabbit review summary reported the checklist syntax finding mapped above at `discussion_r3209249327` and fixed by the same commit.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1710#pullrequestreview-4252916551 -> 7603bda253f6b53a03f721ee53b4c6f9a61e4fe2
+Disposition: FIXED
+Commit: 7603bda253f6b53a03f721ee53b4c6f9a61e4fe2
+Evidence: later CodeRabbit review summary duplicated the checklist syntax finding and is covered by the same checklist fix.
+
 ## Internal Findings Closed Before Mapping
 
 - Pre-open finding: future prompt guard scanned the full backlog ledger and matched unrelated historical `draft PR` text.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1252,6 +1252,13 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Reason: PR-8 intentionally stopped before any automatic implementation lane. The next safe step is a coordinator-owned decision packet that selects the next module while preserving repo truth and requiring a separate future implementation packet.
     - Links: `docs/orchestration/DESIGN_INTELLIGENCE_WEB_IOS_RUNBOOK.md`, `docs/orchestration/DESIGN_AGENT_WORKFLOW.md`, `docs/design/NEXT_DESIGN_AUTOMATION_MODULE_DECISION.md`, `docs/orchestration/DESIGN_AUTOMATION_NEXT_LANE_PACKET_2026-05-08.md`
     - DoD: Decision packet selects the next design automation module, records deferred lanes, defines future implementation boundaries, and keeps runtime, token, generated mirror, Figma, Canva, Storybook, screenshots, and asset implementation out of scope.
+  - Design-epic PR-prompt protocol tracking:
+    - Owner: @katsiaryna_kavaleuskaya
+    - Priority: P1
+    - Target PR: `docs(orchestration): add design-epic PR prompt protocol v2026-05-08`, branch `codex/design-epic-pr-prompt-protocol-v2026-05-08`
+    - Reason: Future design-epic PR prompts need a guarded protocol for clean worktree startup, worktree-local Python setup, coordinator-expanded mandatory agents, premortem execution on the actual diff, post-open and post-bot review passes, fixed mapping after fix/decision, and operator-owned post-merge local main synchronization.
+    - Links: `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md`, `docs/orchestration/DESIGN_AGENT_WORKFLOW.md`, `docs/orchestration/DESIGN_AGENT_PR_TEMPLATE.md`
+    - DoD: Protocol doc exists, workflow/template point future design-epic prompts at it, deterministic docs guards reject stale prompt patterns, and the lane remains docs/tests/governance only without rewriting the merged post-PR-8 next-lane decision.
   - Deferred design automation lane: `design-automation-deferred-launch-copy-linter`
     - Owner: @katsiaryna_kavaleuskaya
     - Priority: P1

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -1255,7 +1255,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Design-epic PR-prompt protocol tracking:
     - Owner: @katsiaryna_kavaleuskaya
     - Priority: P1
-    - Target PR: `docs(orchestration): add design-epic PR prompt protocol v2026-05-08`, branch `codex/design-epic-pr-prompt-protocol-v2026-05-08`
+    - Target PR: `#1710`
     - Reason: Future design-epic PR prompts need a guarded protocol for clean worktree startup, worktree-local Python setup, coordinator-expanded mandatory agents, premortem execution on the actual diff, post-open and post-bot review passes, fixed mapping after fix/decision, and operator-owned post-merge local main synchronization.
     - Links: `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md`, `docs/orchestration/DESIGN_AGENT_WORKFLOW.md`, `docs/orchestration/DESIGN_AGENT_PR_TEMPLATE.md`
     - DoD: Protocol doc exists, workflow/template point future design-epic prompts at it, deterministic docs guards reject stale prompt patterns, and the lane remains docs/tests/governance only without rewriting the merged post-PR-8 next-lane decision.

--- a/tests/test_design_automation_next_lane_docs.py
+++ b/tests/test_design_automation_next_lane_docs.py
@@ -266,6 +266,9 @@ def test_design_epic_pr_prompt_protocol_requires_review_chains() -> None:
     for phrase in required:
         assert phrase in corpus
 
+    assert "separate repo-reviewed contract promotes a narrower authority" in corpus
+    assert "coordinator packet explicitly scopes stronger authority" not in corpus
+
 
 def test_design_epic_pr_prompt_protocol_keeps_next_lane_truth_historical() -> None:
     """Keep the merged post-PR-8 next-lane decision as the design-epic vector."""

--- a/tests/test_design_automation_next_lane_docs.py
+++ b/tests/test_design_automation_next_lane_docs.py
@@ -7,6 +7,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 DECISION = REPO_ROOT / "docs/design/NEXT_DESIGN_AUTOMATION_MODULE_DECISION.md"
 PACKET = REPO_ROOT / "docs/orchestration/DESIGN_AUTOMATION_NEXT_LANE_PACKET_2026-05-08.md"
+PROTOCOL = REPO_ROOT / "docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md"
+WORKFLOW = REPO_ROOT / "docs/orchestration/DESIGN_AGENT_WORKFLOW.md"
+TEMPLATE = REPO_ROOT / "docs/orchestration/DESIGN_AGENT_PR_TEMPLATE.md"
 LEDGER = REPO_ROOT / "docs/roadmap/BACKLOG_LEDGER.md"
 
 
@@ -18,6 +21,16 @@ def _read(path: Path) -> str:
 def _combined() -> str:
     """Return the decision, packet, and ledger text as one searchable corpus."""
     return "\n".join([_read(DECISION), _read(PACKET), _read(LEDGER)])
+
+
+def _future_prompt_corpus() -> str:
+    """Return docs that govern future design-epic PR prompts."""
+    return "\n".join([_read(PROTOCOL), _read(TEMPLATE)])
+
+
+def _command_blocks(text: str) -> str:
+    """Extract shell-like command blocks from markdown."""
+    return "\n".join(re.findall(r"```(?:bash|sh|shell|zsh)\n(.*?)```", text, flags=re.DOTALL))
 
 
 def test_next_design_automation_decision_required_sections() -> None:
@@ -151,3 +164,115 @@ def test_next_design_automation_requires_premortem_fix_before_mapping() -> None:
 
     for phrase in required:
         assert phrase in packet
+
+
+def test_design_epic_pr_prompt_protocol_required_sections() -> None:
+    """Require the design-epic prompt protocol to stay complete."""
+    text = _read(PROTOCOL)
+
+    required = [
+        "# Design Epic PR Prompt Protocol v2026-05-08",
+        "## Prompt Contract",
+        "## Required Startup Flow",
+        "## Required Execution Chain",
+        "## Premortem Requirement",
+        "## Post-Open And Bot-Review Chain",
+        "## Bounded Validation Prompt",
+        "## Review Governance",
+        "## Design-Epic Boundary",
+        "python3.13 -m venv .venv --copies",
+        "make venv-sync",
+        "make validate-changed",
+        "agent-coordinator",
+        "cursor-specialist-agent",
+        "architecture-specialist",
+        "security-auditor",
+        "creative-designer",
+        "qa-engineer-agent",
+        "bug-hunter",
+        "Codex Security plugin",
+    ]
+
+    for phrase in required:
+        assert phrase in text
+
+
+def test_design_epic_pr_prompt_protocol_is_referenced_by_workflow_and_template() -> None:
+    """Require workflow and template to point future design-epic prompts at the protocol."""
+    protocol_path = "docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md"
+
+    assert protocol_path in _read(WORKFLOW)
+    assert protocol_path in _read(TEMPLATE)
+
+
+def test_design_workflow_general_gates_do_not_replace_prompt_protocol() -> None:
+    """Keep generic design gates separate from generated prompt commands."""
+    workflow = _read(WORKFLOW)
+
+    assert "general merge-readiness evidence for design-impacting PRs" in workflow
+    assert "future design-epic PR prompts use the narrower bounded prompt bundle" in workflow
+    assert "DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make design-guard" in workflow
+    assert "DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make tokens-check" in workflow
+
+
+def test_design_epic_pr_prompt_protocol_rejects_stale_prompt_commands() -> None:
+    """Reject stale generated-prompt command patterns from future prompt docs."""
+    corpus = _future_prompt_corpus()
+    commands = _command_blocks(corpus)
+
+    forbidden_commands = [
+        r"(?m)^\s*git\s+checkout\s+main\b",
+        r"(?m)^\s*git\s+merge\s+--ff-only\s+origin/main\b",
+        r"(?m)^\s*make\s+verify\b",
+        r"(?m)^\s*DEV_PYTHON=.*\bmake\s+(?!(?:venv-sync|validate-changed)\b)[A-Za-z0-9_-]+\b",
+    ]
+
+    for pattern in forbidden_commands:
+        assert re.search(pattern, commands) is None, pattern
+
+    assert "draft PR" not in corpus
+    assert "open as draft" not in corpus.lower()
+
+
+def test_design_epic_pr_prompt_protocol_allows_only_default_make_target() -> None:
+    """Generated future prompt command blocks may name only setup plus validate-changed."""
+    commands = _command_blocks(_future_prompt_corpus())
+    targets = set(re.findall(r"\bmake\s+([A-Za-z0-9_-]+)", commands))
+
+    assert targets == {"venv-sync", "validate-changed"}
+
+
+def test_design_epic_pr_prompt_protocol_requires_execute_mode_preflight() -> None:
+    """Require execute-mode preflight before final pre-open validation."""
+    text = _read(PROTOCOL)
+
+    assert "Use `check_preflight.py --mode execute --path <path>`" in text
+    assert "Environment setup target `make venv-sync` is allowed in startup only" in text
+
+
+def test_design_epic_pr_prompt_protocol_requires_review_chains() -> None:
+    """Require actual-diff premortem and both post-open review chains."""
+    corpus = _future_prompt_corpus()
+
+    required = [
+        "Premortem is mandatory before PR opening and again after the first bot-review cycle.",
+        "The premortem must inspect the actual diff",
+        "If `task_bootstrap.py` or `agent-coordinator` expands the role order, the expanded order becomes mandatory",
+        "post-open review must include `qa-engineer-agent`, `bug-hunter`, `security-auditor`, and Codex Security.",
+        "After the first bot review, repeat `agent-coordinator`, `qa-engineer-agent`, `bug-hunter`, `security-auditor`, and premortem on the updated diff.",
+        "mapping only after the underlying fix or formal decision exists",
+    ]
+
+    for phrase in required:
+        assert phrase in corpus
+
+
+def test_design_epic_pr_prompt_protocol_keeps_next_lane_truth_historical() -> None:
+    """Keep the merged post-PR-8 next-lane decision as the design-epic vector."""
+    combined = _combined()
+    protocol = _read(PROTOCOL)
+
+    assert "docs/design-automation-next-lane-decision-v1" in combined
+    assert "Icon Asset Validator / App Store asset guard lane" in combined
+    assert "Icon Asset Validator / App Store asset guard lane" in protocol
+    assert "does not replace `docs/design/NEXT_DESIGN_AUTOMATION_MODULE_DECISION.md`" in protocol

--- a/tests/test_design_automation_next_lane_docs.py
+++ b/tests/test_design_automation_next_lane_docs.py
@@ -246,7 +246,14 @@ def test_design_epic_pr_prompt_protocol_requires_execute_mode_preflight() -> Non
     """Require execute-mode preflight before final pre-open validation."""
     text = _read(PROTOCOL)
 
-    assert "Use `check_preflight.py --mode execute --path <path>`" in text
+    assert (
+        "check_preflight.py --mode execute --primary <primary-agent> --reviewer <reviewer-agent> --path <path>"
+        in text
+    )
+    assert (
+        "Include `--secondary <agent>` when the coordinator packet declares secondary agents."
+        in text
+    )
     assert "Environment setup target `make venv-sync` is allowed in startup only" in text
 
 


### PR DESCRIPTION
## Goal
Add a docs/test-only design-epic PR-prompt protocol for v2026-05-08 so future PulsePlate design-epic PR prompts start and execute consistently without turning the prompt rules into a standalone product lane.

## Business reason
The design epic needs a stable operating protocol for the next design automation PRs after PR #1707. This keeps the selected future lane, Icon Asset Validator / App Store asset guard, as the design vector while preventing repeated prompt drift around coordinator routing, premortem, review chains, fixed mapping, and operator-owned post-merge sync.

## Scope
- Add `docs/orchestration/DESIGN_EPIC_PR_PROMPT_PROTOCOL_2026_05_08.md`.
- Add small references from the design workflow and generic design PR template.
- Track the protocol in the design intelligence backlog entry.
- Extend `tests/test_design_automation_next_lane_docs.py` with deterministic guards for future design-epic prompt instructions.

## Out of scope
No runtime web, iOS, backend, OpenAPI, billing, auth, StoreKit, HealthKit, `/tokens`, generated mirrors, Figma, Canva, Storybook config, screenshots, videos, traces, binary assets, external asset generation, or Icon Asset Validator implementation.

This PR intentionally does not rewrite the merged post-PR-8 next-lane decision packet. PR #1707 remains the historical design-epic vector.

## Carryover / replacement note
PR #1709 was closed as mis-scoped because it over-framed this work as a standalone prompt-canon lane. This PR is the corrected docs PR: the protocol supports future design-epic PR prompts and preserves the design epic as the product vector.

## Agent chain
Pre-open startup ran with scoped paths through:

- `check_preflight.py --path ...`
- `check_agent_consistency.py`
- `task_bootstrap.py --pr-phase pre_open --path ...`

Coordinator-declared role order used for pre-open review:

1. `agent-coordinator`
2. `cursor-specialist-agent`
3. `architecture-specialist`
4. `security-auditor`
5. `creative-designer`
6. `qa-engineer-agent`
7. `bug-hunter`

Post-open review chain started with `qa-engineer-agent -> bug-hunter -> security-auditor -> Codex Security` and fixed the actionable docs/governance findings before updating mapping evidence.

## Premortem / review findings
Premortem and role-agent review inspected the actual docs/tests diff. Findings were fixed before PR opening or before readiness evidence was updated:

- FIXED: initial guards scanned the full ledger and failed on unrelated historical draft-PR text. The prompt guard now scans the actual future prompt surface.
- FIXED: exact review-chain assertion was brittle. The guard now matches the protocol/template wording actually governing future prompts.
- FIXED: generic design PR template gates were temporarily weakened. `make design-guard` and `make tokens-check` are restored for generic design PR evidence.
- FIXED: protocol wording allowed PR body to supersede coordinator role order. It now requires lane packet/runbook updates; PR body is mirror only.
- FIXED: workflow generic gates and generated prompt protocol were ambiguous. Workflow now explicitly separates general merge-readiness evidence from the narrower generated prompt bundle, and tests guard that boundary.
- FIXED: fresh copied venv setup omitted dependency sync. Protocol now includes startup-only `make venv-sync`.
- FIXED: execute-mode preflight command omitted required routing flags. Protocol now includes `--primary`, `--reviewer`, `--path`, and `--secondary` for coordinator-declared secondary agents.
- FIXED: canonical mapping artifact format mixed internal findings inside the parser-owned mapping section. The mapping section now remains parser-valid and internal findings live in a separate section.

Codex Security diff-scoped review found no reportable runtime security candidate: this diff changes docs/tests/governance only and introduces no auth, secret, subprocess, network, CI workflow, suppression, or fail-open runtime path.

## Tests / validation
- `.venv/bin/python scripts/orchestration/check_preflight.py --path ...` PASS with scoped AGENTS resolved.
- `.venv/bin/python scripts/orchestration/check_agent_consistency.py` PASS.
- `.venv/bin/python scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open --path ... --requested-agent ...` PASS, packet `fe672e424219`.
- `.venv/bin/python scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review --path ... --requested-agent ...` PASS, packet `c243dacfdd7f`.
- `.venv/bin/python -m pytest -q tests/test_design_automation_next_lane_docs.py` PASS: 14 passed.
- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed` PASS.
- `.venv/bin/python scripts/ci/check_pr_body_phase2_gates.py --pr-number 1710` PASS for the canonical mapping artifact.
- `PATH=.venv/bin:$PATH pre-commit run --all-files` PASS.
- `.venv/bin/python scripts/orchestration/check_preflight.py --mode execute --primary agent-coordinator --secondary cursor-specialist-agent --reviewer architecture-specialist --path ...` PASS after staging.
- Commit and push hooks PASS, including pre-push backend tests and full-repo Bandit.

## Security notes
No secrets, auth, billing, backend, deploy, external write integrations, or runtime product truth changed. Figma/Canva/Storybook/connectors remain evidence/reference layers unless separately scoped.

## Risks / rollback
Risk: future agents could over-apply the prompt bundle to generic design PR merge-readiness and skip design/token guards. Mitigation: workflow/template now separate general design gates from generated prompt protocol, and tests assert that boundary.

Rollback: revert this docs/tests PR. No runtime rollback is required.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1710_FIXED_MAPPING.md`

## Deferred / follow-ups
- After the next current-head bot-review cycle, rerun `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor -> premortem` before any readiness claim.

## Merge Readiness
Not claimed. Merge readiness still depends on current-head CI, bot/human review dispositions, fixed mapping, wait-window, and strict merge wrapper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new design-epic PR prompt protocol and updated workflow/template to require it; clarifies setup, bounded prompt defaults, execute-mode preflight/validation, premortem timing (pre-open and after first bot review), review-chain rules, merge-readiness scope limits, PR evidence mapping, and a backlog tracking entry plus a fixed-mapping evidence doc.

* **Tests**
  * Added tests and helpers to validate the protocol is referenced, contains required sections and setup/validation commands, extracts command blocks, enforces allowed default targets, and enforces preflight, review-chain, and premortem rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->