### PR TITLE
docs(readme): harden public repo presentation and licensing boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,442 +1,72 @@
 # PulsePlate
 
 [![CI](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/workflows/ci.yml/badge.svg)](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/Katsiarynakavaleuskaya/PulsePlate/graph/badge.svg?token=HE8BHRB7Q9)](https://codecov.io/gh/Katsiarynakavaleuskaya/PulsePlate)
-[![Food data: USDA + OFF](https://img.shields.io/badge/Food%20data-USDA%20%2B%20OFF-brightgreen)](docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Katsiarynakavaleuskaya/PulsePlate)
-
-Operational signals:
-- `CI` shows the main backend/shared validation lane.
-- `codecov` shows the latest published repository coverage snapshot.
-- Runtime probes live at `/health`, `/ready`, and `/metrics`; see `docs/deploy/OPERATIONAL_SIGNALS.md`.
-- OpenTelemetry tracing is bootstrap-gated by `OTEL_*` env vars plus `PULSE_OBS_HMAC_KEY`.
-- In-process request telemetry exists for local/runtime diagnostics; centralized error reporting is still a follow-up gap.
+[![codecov](https://codecov.io/gh/Katsiarynakavaleuskaya/PulsePlate/graph/badge.svg?token=HE8BHRB709)](https://codecov.io/gh/Katsiarynakavaleuskaya/PulsePlate)
 
 > **PulsePlate turns body-metric check-ins into practical meal decisions.**
->
-> It is a planning-first wellness product built around one continuous flow:
->
-> **check-in -> targets -> daily plate -> weekly plan -> shopping list**
+
+It is a planning-first wellness product built around one continuous flow:
+
+**check-in -> targets -> daily plate -> weekly plan -> shopping list**
 
 PulsePlate is designed as a **wellness and meal-planning product**, not as a diagnosis, treatment, therapy, crisis-support, or emergency-care system. BMI and related outputs are informational wellness tools only, and the product should not replace clinician guidance for diagnosed conditions, pregnancy, eating disorders, medically prescribed diets, or emergencies.
 
-PulsePlate is currently in a **private staged rollout**. This repository is the clearest technical and product snapshot of the platform today.
+PulsePlate is currently in a **private staged rollout**. This repository is a technical and product snapshot of the platform.
 
-## Developer And Contributor Entrypoint
+## What PulsePlate Does
 
-If you are here to build, review, or deploy rather than evaluate the product story first, start here:
+PulsePlate is built for people who want structured nutrition planning without the guesswork. It takes body-metric check-ins and turns them into actionable meal decisions.
 
-- `AGENTS.md` for repository-wide engineering rules and merge-governance policy
-- `RUNBOOK_AGENT.md` for CI triage, merge-readiness, and post-merge cleanup flow
-- `docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md` for Cursor / Codex / Claude startup guidance
-- `docs/deploy/README.md` for deployment navigation
-- `docs/deploy/OPERATIONAL_SIGNALS.md` for runtime probes, metrics, tracing, and current gaps
-- `docs/contracts/API_CANONICAL_MAP.md` for the canonical public API surface
+**Core capabilities:**
 
-If you need the shortest docs-only path first, you can contribute safely in Markdown without depending on the full maintainer-only backend bootstrap.
+- **BMI & nutrition targets** — baseline wellness metrics and daily nutrition guidance
+- **Meal planning** — daily plate suggestions and weekly plan generation
+- **Food database** — merged local catalog built from USDA and Open Food Facts inputs
+- **Shopping list** — auto-generated grocery lists from your weekly plan
+- **AI-assisted planning** — retrieval-augmented support for consistency checks and planning value, used only where it adds real structure to the flow
 
-### Local development with Dev Container (recommended)
+**Product tiers:**
 
-The recommended path for backend, web, docs, and orchestration work is the
-Docker Dev Container.  It eliminates `.venv` fragility across worktrees, cloud
-agents, and different operating systems.
+| Tier | What you get |
+|------|-------------|
+| **FREE** | BMI check-ins, baseline wellness metrics |
+| **PRO** | Nutrition targets, daily plate, weekly planning |
+| **VIP** | Higher-end planning, menu flows, recipes, shopping/export |
 
-**Requirements:** Docker Desktop (or Docker Engine) + VS Code Dev Containers extension (or `docker compose` CLI) + `.env` copied from `.env.example` (must contain `PULSEPLATE_PYTHON_INDEX_URL` pointing to the approved private package proxy).
-
-**VS Code path:**
-
-```bash
-cp .env.example .env          # one-time; edit to set real proxy URL
-# then: Cmd/Ctrl+Shift+P -> "Dev Containers: Reopen in Container"
-# bootstrap runs automatically on first open; re-run only if deps change:
-#   make devcontainer-bootstrap
-make dev
-```
-
-**CLI path:**
-
-```bash
-cp .env.example .env
-make dc-up
-make dc-shell
-make devcontainer-bootstrap
-make dev
-```
-
-**Common commands (work in both container and host .venv):**
-
-```bash
-make test-fast        # deterministic smoke subset
-make validate-min     # guards + smoke
-make lint             # flake8
-make typecheck        # mypy
-make openapi          # regenerate OpenAPI + TS types
-pre-commit run --all-files
-```
-
-Generic developer targets use `DEV_PYTHON`, which resolves to `.venv/bin/python`
-when present or `python3` inside containers.
-
-**CI:** A lightweight Devcontainer Smoke workflow verifies the tooling image and
-base developer tools on PRs that touch `.devcontainer/` or related scripts.  It
-does not run `make devcontainer-bootstrap` or require secrets.
-
-**Legacy fallback (host-native .venv):**
-
-```bash
-make venv
-source .venv/bin/activate
-make dev
-```
-
-`make venv` remains supported as a rollback/fallback path.
-
-**Note:** iOS/Xcode development remains host-native on macOS.  The Linux devcontainer is not an Xcode replacement.
-
-## From Metrics To Meals
-
-Most nutrition apps stop at logging. PulsePlate is being built to keep going:
-
-1. Start from simple body-metric and nutrition inputs.
-2. Turn them into practical targets and daily plate guidance.
-3. Extend that into weekly planning and grocery workflows.
-4. Layer in AI-assisted support only where it adds real planning value.
-
-The goal is straightforward: **less tracking noise, less decision fatigue, more repeatable nutrition planning**.
-
-## Who PulsePlate Is For
-
-PulsePlate is aimed first at people who want nutrition planning to feel more actionable:
-
-- users who want a clearer path from simple check-ins to actual meal decisions
-- people who want less decision friction around meals and groceries
-- users who want planning help, not just another calorie log
-
-### A concrete PulsePlate moment
-
-The target PulsePlate experience is simple: a user starts with a quick body-metric check-in, gets practical targets, sees what today's plate should look like, turns that into a weekly plan, and finishes with a shopping workflow. That is the product shape PulsePlate is optimizing for.
+**Client surfaces:** web interface and iOS client in development.
 
 ## Why PulsePlate Stands Out
 
-### 1. It is planning-first, not logging-first
+- **Planning-first, not logging-first** — structured around execution, not retrospective tracking. The flow is `check-in -> targets -> plate -> weekly plan -> groceries`.
+- **Domain logic combined with product workflows** — BMI/nutrition logic is integrated directly into the planning pipeline, not siloed as a separate calculation.
+- **Snapshot-first food-data model** — local merged USDA + Open Food Facts catalog, no external API dependency for core food lookups.
+- **AI is staged, not decorative** — retrieval-augmented support, consistency and contradiction checks. AI is used only where it increases planning value.
 
-PulsePlate is structured around execution, not just record-keeping. The product thesis is that users need help moving from inputs to action:
+## Current Status
 
-- `check-in -> targets -> plate -> weekly plan -> groceries`
+PulsePlate is in a **private staged rollout**.
 
-### 2. It combines domain logic with product workflows
+- **Backend API**: active — FastAPI-based backend with nutrition and BMI logic
+- **Food-data pipeline**: active — USDA + Open Food Facts ingestion
+- **Web client**: in development
+- **iOS client**: in development
+- **Monetization / selective rollout**: hardening in progress
+- **Full self-hosted setup**: not available publicly
 
-This repository already contains the core layers needed for a serious nutrition product:
+Production components require authorized access.
 
-- a backend/domain core for BMI and nutrition logic
-- planning surfaces for daily and weekly decision-making
-- shopping/export flows
-- thin web and iOS client layers
-- a food-data foundation that can support richer planning over time
+## Access and Licensing
 
-### 3. It uses a snapshot-first food-data model
+PulsePlate is **proprietary software**. All rights reserved.
 
-Instead of relying on live third-party lookups for every request, PulsePlate is built around a local merged catalog strategy. That supports lower latency, more stable lookups, and future enrichment on top of a controlled data foundation.
+This public repository is a product and technical snapshot for evaluation, collaboration, and licensing discussions. It is **not** a public self-hosting distribution.
 
-### 4. Its AI direction is staged, not decorative
+Full backend bootstrap, private packages, deployment runbooks, production configuration, internal AI-runtime tooling, and release operations require **explicit written authorization**.
 
-PulsePlate has a real AI research and product direction, but it is being rolled out carefully. Current and planned work explores:
+Unauthorized copying, distribution, modification, commercial use, or derivative work creation is prohibited without prior written permission.
 
-- retrieval-augmented support
-- consistency and contradiction checks
-- optional planning assistance
-- progressively stronger planning assistance
+For licensing, partnership, or access inquiries: **pulseplate@pm.me**
 
-Not all of these capabilities are user-facing, enabled by default, or fully deployed in production today.
+---
 
-## What Exists Today
-
-| Layer | Current reality |
-|---|---|
-| FREE | BMI-based wellness check-ins and basic lookup surfaces |
-| PRO | Nutrition targets, daily nutrition guidance, planning and payment flows |
-| VIP | Higher-end planning, menu flows, recipes, export/shopping-list surfaces |
-| Data foundation | Local merged food catalog built from USDA and Open Food Facts inputs |
-| Clients | Active web and iOS codebases over a FastAPI backend |
-
-### Live and staged surfaces
-
-- **Live core:** backend API, domain logic, food-data pipeline, PRO/VIP planning surfaces
-- **Selective rollout:** release packaging, monetization closure, and deploy/runtime polish
-- **Feature-gated exceptions:** `/api/v1/insight*` and `/api/v1/insight/fitchef*`
-
-## Where The Product Stands
-
-PulsePlate is already **substantial at the backend/domain level**. Today the strongest parts are the planning core and the data foundation; advanced assistance and release packaging are being rolled out selectively around that base.
-
-At a high level, treat PulsePlate as an **active product platform in staged rollout**: the planning foundation is real today, while some packaging, monetization, and advanced assistance layers are still being tightened.
-
-| Area | Status |
-|---|---|
-| Backend API and domain core | Active and substantially implemented |
-| Food-data pipeline | Active and substantially implemented |
-| Web app | Active |
-| iOS app | Active |
-| Monetization and entitlement closure | Selective rollout / hardening |
-| Release packaging and deployment polish | Selective rollout / hardening |
-| Advanced assistance surfaces | Partial / feature-gated |
-
-## For Contributors And Integrators
-
-If you are reading this README primarily as a product visitor, the sections above are the main story. Everything below is contributor and integration context.
-
-If you are here primarily as a contributor, reviewer, or integration partner, use the paths below.
-
-### Fastest first-success path
-
-Most new contributors should start here first.
-
-If you do not already have access to the approved Python package proxy, treat the backend bootstrap as maintainer-only for now and use this newcomer path:
-
-- docs-only contributions
-- frontend work in `frontend/`
-- iOS exploration in `ios/`
-
-That path gets you to a first successful contribution without depending on the full backend bootstrap.
-
-Move to the maintainer setup below only when you explicitly need backend access and the approved proxy path.
-
-## Maintainer Setup
-
-### Prerequisites
-
-- Python `3.13.x`
-- Node `22.22.1` for the web client
-- Xcode for the iOS project in `ios/PulsePlate.xcodeproj`
-- Access to the approved Python package proxy for full backend bootstrap
-
-If you do **not** have access to the approved package proxy, stop here and use the first-success path above. Full backend bootstrap is currently maintainer-oriented.
-
-If you need full backend access, coordinate with the maintainer before attempting backend/bootstrap work.
-
-### 1. Backend
-
-Bootstrap environment values first:
-
-```bash
-cp .env.example .env
-```
-
-For local contributor setup, make sure `.env` contains at least:
-
-- `PULSEPLATE_PYTHON_INDEX_URL` for `make`-driven bootstrap targets
-- `SERVER_SALT` for app startup validation; replace the `.env.example` placeholder with a strong local value before boot
-
-Important:
-
-- the copied `.env.example` default `DATABASE_URL=...@postgres:5432/...` is compose-network only
-- it does **not** work unchanged for a host-native `alembic upgrade head` or `make dev` flow on your laptop
-
-Before running `alembic upgrade head`, choose the right database host for your local path:
-
-- Docker Compose / shared container path: keep `postgres` in `DATABASE_URL`
-- Native local Postgres path: switch `DATABASE_URL` to `localhost`
-- Local-only SQLite fallback: use the commented SQLite example for dev/test-only work
-- Hybrid path warning: this repo does not publish the compose Postgres port to the host by default, so "Postgres in Compose + app on the Mac" is not a ready-made path unless you add your own port mapping or run a separate local Postgres
-
-Additional secrets are only required for specific features or production-like environments:
-
-- `APPLE_SHARED_SECRET` for Apple receipt verification in production/staging-like setups
-- `EXPORT_TOKEN_SECRET` when `PRIVATE_EXPORTS_ENABLED=true` in production/staging-like setups
-
-For local-only boot, non-empty placeholder values remain acceptable for `APPLE_SHARED_SECRET` and `EXPORT_TOKEN_SECRET` unless you are actively testing those flows.
-
-Export the env into your current shell, then run the supported bootstrap path:
-
-```bash
-set -a && source .env && set +a
-make venv
-source .venv/bin/activate
-alembic upgrade head
-make dev
-```
-
-Verify the API from another terminal:
-
-```bash
-curl http://127.0.0.1:8001/health
-```
-
-Preferred health surface:
-
-- use `/health` for the canonical liveness check
-- `/api/v1/health` remains a compatibility alias used by some scripts/tests
-
-Port note:
-
-- Native local development uses `make dev` on `http://127.0.0.1:8001`
-- Raw `uvicorn` is only equivalent when you also pass `--host 0.0.0.0 --port 8001`
-
-### 2. Web app
-
-```bash
-cd frontend
-nvm use
-npm ci
-npm run dev
-```
-
-`nvm use` reads the repo-root `.nvmrc` and selects Node `22.22.1`.
-
-### 3. iOS app
-
-Open `ios/PulsePlate.xcodeproj` in Xcode and run the `PulsePlate` scheme on a simulator.
-
-### 4. Docker
-
-Docker build also expects the approved Python package proxy and runtime env values that satisfy startup guards:
-
-```bash
-set -a && source .env && set +a
-make docker-build
-docker compose up -d
-curl http://localhost:8000/health
-```
-
-Docker port note:
-
-- The container listens on `8000`
-- If you use `docker compose`, verify the published host port from `docker-compose.yaml` before reusing the native-local `8001` curl example
-
-Quick mode matrix:
-
-| Mode | Host port | Preferred health URL |
-| --- | --- | --- |
-| Native `make dev` | `8001` | `http://127.0.0.1:8001/health` |
-| Raw `uvicorn ... --port 8001` | `8001` | `http://127.0.0.1:8001/health` |
-| Default `docker compose up` | `8000` | `http://127.0.0.1:8000/health` |
-| `docker compose --profile dev up` | _see compose mapping_ | verify the published host port in `docker-compose.yaml` before curling |
-
-## Architecture At A Glance
-
-```mermaid
-flowchart LR
-    CLIENTS["Web + iOS + API consumers"] --> APP["FastAPI platform<br/>app.main:app"]
-
-    APP --> FREE["FREE<br/>/api/v1/bmi/*"]
-    APP --> PRO["PRO<br/>/api/v1/pro/*"]
-    APP --> VIP["VIP<br/>/api/v1/vip/*"]
-    APP --> INSIGHT["Insight<br/>/api/v1/insight*"]
-
-    FREE --> DOMAIN["Core domain logic"]
-    PRO --> DOMAIN
-    VIP --> DOMAIN
-    INSIGHT --> AI["Feature-gated AI surfaces"]
-
-    DOMAIN --> DATA["Local food catalog + planning data"]
-    AI --> DATA
-    SOURCES["USDA + Open Food Facts inputs"] --> DATA
-```
-
-### Working rule of thumb
-
-- `app/` orchestrates HTTP/runtime behavior
-- `core/` owns domain logic
-- clients stay thin over backend truth
-- backend OpenAPI is the contract baseline
-
-## Product Tiers
-
-| Tier | Purpose | Typical surface |
-|---|---|---|
-| **FREE** | Entry point into the product | BMI-based check-ins, lookup, simple planning inputs |
-| **PRO** | Core planning value | Targets, daily nutrition, weekly planning, payment activation |
-| **VIP** | Advanced planning and AI-assisted surfaces | Weekly menu flows, recipes, shop/export, insight and FitChef lanes |
-
-## Canonical Product Surfaces
-
-For new backend or client work, the main canonical route families are:
-
-- `/api/v1/bmi/*`
-- `/api/v1/pro/*`
-- `/api/v1/vip/*`
-
-Important canonical exceptions also exist:
-
-- `/api/v1/insight*`
-- `/api/v1/insight/fitchef*`
-- `/api/v1/billing/apple/verify-receipt`
-
-Legacy `/api/v1/premium/*` routes remain compatibility surfaces only and should not be treated as the canonical namespace for new client work.
-
-## Repository Layout
-
-```text
-PulsePlate/
-├── app/            # FastAPI app layer: routers, middleware, schemas, services
-├── core/           # Domain engines and shared business logic
-├── frontend/       # React + TypeScript + Vite web client
-├── ios/            # SwiftUI iOS client
-├── providers/      # LLM/provider integrations
-├── data/           # Local food snapshots, merge outputs, recipe templates
-├── docs/           # Contracts, specs, runbooks, roadmap, architecture
-├── tests/          # Backend, client, and policy guard tests
-├── scripts/        # CI, ops, orchestration, and utility scripts
-└── alembic/        # Database migrations
-```
-
-## Data Foundation
-
-PulsePlate's food-data layer is built around reviewed local snapshots and merge workflows rather than a live-request dependency for every lookup.
-
-- Sources include **USDA FoodData Central** and **Open Food Facts**
-- Merge outputs live in `data/`
-- Architecture direction: `docs/architecture/FOOD_DATABASE_PLATFORM_STRATEGY_v1.md`
-- Source-policy boundaries: `docs/legal/EXTERNAL_FOOD_SOURCE_OPERATING_POLICY.md`
-
-Food data can be incomplete or vary by market, manufacturer, and packaging updates. Critical nutrition information should always be verified against official labels or source records.
-
-## Go Deeper
-
-- `docs/architecture/system_overview.md` - system-level product and runtime map
-- `docs/contracts/API_CANONICAL_MAP.md` - canonical route map and namespace rules
-- `docs/contracts/PRODUCT_TIER_MAP.md` - FREE / PRO / VIP semantics
-- `docs/deploy/README.md` - deployment and infrastructure guidance
-- `docs/runbooks/ENGINEER_QUICKPATH.md` - operator quick path
-
-## Interested In PulsePlate?
-
-For demo, collaboration, integration, or licensing conversations:
-
-- email: [pulseplate@pm.me](mailto:pulseplate@pm.me)
-- topic examples: product demo, API/integration discussion, partnership, private rollout access
-
-## Contributing
-
-Before changing code:
-
-1. Required reading:
-   - `AGENTS.md`
-   - `docs/ENGINEERING_LESSONS.md`
-   - `RUNBOOK_AGENT.md`
-   - the nearest scoped `AGENTS.md` for the files you touch
-2. Use the checks that match your surface:
-
-- docs / copy changes: follow the relevant docs guidance and keep the PR docs-only
-- frontend-only changes: run the frontend-local checks for `frontend/`
-- iOS-only changes: run the iOS-local checks for `ios/`
-- backend local iteration (maintainer/proxy-approved path):
-  - `make validate-min` for the cheap deterministic guard + smoke bundle
-  - `make validate-changed` for diff-based Python test selection on your current branch
-  - targeted `pytest` when narrowing a specific backend change
-- maintainer full-stack/backend changes: run:
-
-```bash
-pre-commit run --all-files
-make verify
-```
-
-Public deployments should also ship with clear privacy and data-use notices for health-related inputs and any third-party services involved in processing them.
-
-## License
-
-This project is **proprietary software**. All rights reserved.
-
-Unauthorized copying, distribution, modification, or use of this code is prohibited without prior written permission from the author.
-
-For commercial or licensing inquiries: [pulseplate@pm.me](mailto:pulseplate@pm.me)
+Copyright (c) 2025 Katsiaryna Kavaleuskaya. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PulsePlate
 
 [![CI](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/workflows/ci.yml/badge.svg)](https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/Katsiarynakavaleuskaya/PulsePlate/graph/badge.svg?token=HE8BHRB709)](https://codecov.io/gh/Katsiarynakavaleuskaya/PulsePlate)
+[![codecov](https://codecov.io/gh/Katsiarynakavaleuskaya/PulsePlate/graph/badge.svg)](https://codecov.io/gh/Katsiarynakavaleuskaya/PulsePlate)
 
 > **PulsePlate turns body-metric check-ins into practical meal decisions.**
 
@@ -55,11 +55,17 @@ PulsePlate is in a **private staged rollout**.
 
 Production components require authorized access.
 
+## Developer Entrypoint
+
+Authorized maintainers and reviewers should start with [`AGENTS.md`](./AGENTS.md), [`RUNBOOK_AGENT.md`](./RUNBOOK_AGENT.md), and [`docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md`](./docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md). Those files are the repo-governed entrypoint for contribution, review, and merge-readiness work without exposing public bootstrap or deployment instructions here.
+
 ## Access and Licensing
 
 PulsePlate is **proprietary software**. All rights reserved.
 
-This public repository is a product and technical snapshot for evaluation, collaboration, and licensing discussions. It is **not** a public self-hosting distribution.
+The authoritative license text is [`LICENSE`](./LICENSE). This README summarizes the access boundary only; if there is any conflict, `LICENSE` controls.
+
+This public repository is a product and technical snapshot for evaluation, collaboration, and licensing discussions. It is **not** a public self-hosting distribution, and repository code is not offered as a public library or SDK unless a separate written license says so.
 
 Full backend bootstrap, private packages, deployment runbooks, production configuration, internal AI-runtime tooling, and release operations require **explicit written authorization**.
 

--- a/docs/review/PR_1714_FIXED_MAPPING.md
+++ b/docs/review/PR_1714_FIXED_MAPPING.md
@@ -32,6 +32,14 @@ Evidence: README.md anchors licensing precedence to LICENSE and clarifies that t
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS
 - `python3 scripts/orchestration/task_bootstrap.py ... --path README.md --requested-agent agent-coordinator --pr-phase merge_ready` - PASS, packet `2024817f65aa`
 - `git diff --check` - PASS before mapping artifact creation
+- `python3 - <<'PY' ... validate_mapping_artifact_text(read_mapping_artifact(1714)) ... PY` - PASS
+- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1714 --body "$(gh pr view 1714 --repo Katsiarynakavaleuskaya/PulsePlate --json body -q .body)"` - PASS
+- `pre-commit run --all-files` - PASS
+- `make validate-changed` - PASS, no Python files changed on the current branch
+
+## Full Verify Deferral
+
+Full local `make verify` was intentionally stopped by operator direction after the run passed `verify-env`, lint, mypy, and `test-fast`, then entered the long full coverage/diff-cover segment. Operator direction for this docs-only PR is to use `make validate-changed` to avoid timeout, then rely on current-head CI and strict merge-readiness governance before merge.
 
 ## Security Notes
 

--- a/docs/review/PR_1714_FIXED_MAPPING.md
+++ b/docs/review/PR_1714_FIXED_MAPPING.md
@@ -1,0 +1,49 @@
+<!-- markdownlint-disable MD013 MD034 -->
+# PR 1714 Fixed In Commit Mapping
+
+- PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1714>
+- Branch: `docs/public-repo-hardening-readme`
+- Title: `docs(readme): harden public repo presentation and licensing boundary`
+- Initial reviewed head: `3d06c9b87029b7cebe65a40ccb55816d80e22878`
+- Review-fix commit: `f64bd06b3`
+- Status: docs-only PR, not draft.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Open review-bot actionables were reviewed before mapping. GitHub review threads must remain unresolved until this artifact, the PR-body mirror, and current-head validation agree.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1714#pullrequestreview-4255329404 -> f64bd06b3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1714#pullrequestreview-4255336698 -> f64bd06b3
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1714#discussion_r3211320859 -> f64bd06b3
+Disposition: FIXED
+Commit: f64bd06b3
+Evidence: README.md removes the token parameter from the Codecov badge URL.
+Evidence: README.md adds a maintainer/reviewer entrypoint to AGENTS.md, RUNBOOK_AGENT.md, and docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md without restoring public bootstrap or deployment instructions.
+Evidence: README.md anchors licensing precedence to LICENSE and clarifies that the repository is not a public self-hosting distribution, library, or SDK without separate written license.
+
+## Local Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py --path README.md` - PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` - PASS
+- `python3 scripts/orchestration/task_bootstrap.py ... --path README.md --requested-agent agent-coordinator --pr-phase merge_ready` - PASS, packet `2024817f65aa`
+- `git diff --check` - PASS before mapping artifact creation
+
+## Security Notes
+
+- Docs-only change. No runtime, auth, billing, entitlement, data, deploy, or CI behavior changes.
+- Public README no longer exposes a tokenized Codecov badge URL.
+- README licensing language is non-authoritative summary text; LICENSE remains authoritative.
+
+## Risks / Rollback
+
+- Risk: public README may under-serve external developers looking for setup details. Mitigation: authorized maintainers and reviewers are pointed to repo-governed AGENTS/RUNBOOK onboarding.
+- Rollback: revert the README and mapping commits from PR #1714 if the public-facing positioning needs to be replaced.
+
+## Deferred / Follow-Ups
+
+- No deferred runtime or governance work in this PR.


### PR DESCRIPTION
## Goal

Harden the public README so it reads as a product-facing PulsePlate snapshot instead of a public deployment or self-hosting guide.

## Business Reason

Reduce exposure of internal bootstrap/deploy details while keeping the public repository useful for product evaluation, collaboration, and licensing conversations.

## Scope

- Rewrite README as a public-facing product page.
- Remove deploy/bootstrap/quick-start/env setup instructions from the public README layer.
- Remove DeepWiki link that exposed repo structure.
- Retain wellness-only disclaimer, product flow, features, tiers, and rollout status.
- Address review feedback: tokenless Codecov badge, maintainer/reviewer entrypoint, LICENSE precedence, and hosted-service/library-SDK boundary.

## Out Of Scope

- No runtime code changes.
- No deploy, CI, backend, frontend, iOS, or OpenAPI behavior changes.
- No public self-hosting instructions.

## Files Changed

- `README.md`
- `docs/review/PR_1714_FIXED_MAPPING.md`

## Key Decisions

- Keep the public README product-focused and omit backend bootstrap/deploy instructions.
- Point authorized maintainers and reviewers to `AGENTS.md`, `RUNBOOK_AGENT.md`, and `docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md` for repo-governed work.
- Treat `LICENSE` as the authoritative license text; README licensing language is a non-authoritative summary.
- Clarify that repository code is not offered as a public library or SDK unless separately licensed in writing.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_1714_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1714#pullrequestreview-4255329404 -> f64bd06b3
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1714#pullrequestreview-4255336698 -> f64bd06b3
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1714#discussion_r3211320859 -> f64bd06b3

## Tests / Validation

Local evidence:

- `python3 scripts/orchestration/check_preflight.py --path README.md` - PASS
- `python3 scripts/orchestration/check_agent_consistency.py` - PASS
- `python3 scripts/orchestration/task_bootstrap.py ... --path README.md --requested-agent agent-coordinator --pr-phase merge_ready` - PASS, packet `2024817f65aa`
- `git diff --check` - PASS
- `python3 - <<'PY' ... validate_mapping_artifact_text(read_mapping_artifact(1714)) ... PY` - PASS
- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1714 --body "$(gh pr view 1714 --repo Katsiarynakavaleuskaya/PulsePlate --json body -q .body)"` - PASS
- `pre-commit run --all-files` - PASS
- `make validate-changed` - PASS, no Python files changed on the current branch

Full local `make verify` was intentionally stopped by operator direction after it passed `verify-env`, lint, mypy, and `test-fast`, then entered the long coverage/diff-cover segment. For this docs-only PR, merge readiness must rely on the narrow local bundle above plus current-head CI and strict merge-readiness governance.

Pending before merge-readiness claim:

- current-head CI after push
- `python3 scripts/orchestration/check_merge_ready.py --pr-number 1714 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`

## Security Notes

Docs-only change. No auth, billing, entitlement, data, deploy, CI, or runtime behavior changes. The README no longer includes a tokenized Codecov badge URL.

## Risks / Rollback

Risk: public README gives less setup detail to external readers. Mitigation: authorized maintainers and reviewers have explicit repo-governed entrypoints.

Rollback: revert the README and mapping commits from PR #1714.

## Deferred / Follow-Ups

No deferred runtime or governance work in this PR.
