### PR TITLE
feat(design): add icon asset validator lock-mode and guard tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,8 @@ TOKEN_PARITY_TESTS := tests/test_design_token_parity.py tests/test_design_invari
 
 ## Validate icon core v1.0 folder structure
 icon-core-validate:
-	python3 scripts/validate_icon_core_v1.py
+	$(DEV_PYTHON) scripts/validate_icon_core_v1.py
+	$(DEV_PYTHON) scripts/validate_icon_core_v1.py --strict
 
 ## Enforce design invariant manifest, palette, and lock hashes
 design-guard:
@@ -560,6 +561,7 @@ ios-appstore-upload-privacy: ## Upload App Privacy answers (requires Apple ID se
 
 ios-appstore-verify: ## Verify App Store submission readiness (repo-local, no upload)
 	@echo "$(YELLOW)Verifying iOS App Store submission readiness...$(NC)"
+	$(DEV_PYTHON) scripts/validate_icon_core_v1.py --strict
 	$(DEV_PYTHON) scripts/release/check_ios_appstore_verify.py
 	$(DEV_PYTHON) -m pytest -q tests/ios/
 	$(DEV_PYTHON) -m pytest -q tests/guards/test_wellness_language_blockers_guard.py

--- a/assets/brand/icon/core/v1.0/README.md
+++ b/assets/brand/icon/core/v1.0/README.md
@@ -1,26 +1,39 @@
 # PulsePlate App Icon Core v1.0 (Dual-master)
 
-This directory contains the **canonical, production-locked masters** for the
-PulsePlate App Icon Core v1.0.
+This directory is the **canonical, repo-owned icon core contract folder** for
+PulsePlate App Icon Core v1.0. It may remain in a pre-lock state until the
+canonical masters and hash fields are confirmed by a dedicated asset-lock PR.
 
-**Source of truth (design):** Figma Design (see `meta.json` + lock docs).
-**Repo truth (masters):** This folder only.
+**Design reference:** Figma Design metadata recorded in `meta.json` after lock.
+**Repo truth:** this folder plus the repo validators and lock docs.
 
 ---
 
-## Canonical files (must exist)
+## Canonical files
 
 - `icon_core_v1.svg` — **master SVG**
 - `icon_core_v1_1024.png` — **master PNG (1024)**
 - `icon_core_v1_60.png` — **control PNG (60)**
+- `icon_core_v1_120.png` — derived PNG (120)
+- `icon_core_v1_32.png` — derived PNG (32)
+- `icon_core_v1_24.png` — derived PNG (24)
 - `meta.json` — contract metadata (winner + figma fields + hashes)
+
+Until lock completion, `README.md` and `meta.json` may be the only files
+present. `make icon-core-validate` enforces folder shape and metadata schema.
+Use explicit lock gates only when the repo-owned values are confirmed:
+
+```bash
+python3 scripts/validate_icon_core_v1.py --require-lock-values
+python3 scripts/validate_icon_core_v1.py --require-canonical-masters
+```
 
 ---
 
 ## Rules (6)
 
 1) **Do not commit exports here.**
-   Only canonical masters listed above belong in this folder.
+   Only canonical files listed above belong in this folder.
 
 2) **No extra variants.**
    Do not add `light/dark/mono`, `v2`, `final_final`, `tmp`, `draft`, etc.
@@ -31,8 +44,8 @@ PulsePlate App Icon Core v1.0.
 4) **Figma Make is not SoT.**
    Only Figma Design URL/key/node stored in `meta.json` is considered design SoT.
 
-5) **L4 gates are mandatory.**
-   Before updating any file in this folder:
+5) **L4 gates are mandatory for lock updates.**
+   Before adding or updating canonical asset files in this folder:
    - run `make icon-core-validate`
    - run `make icon-silhouette-lock`
    - update lock docs
@@ -45,9 +58,9 @@ PulsePlate App Icon Core v1.0.
 
 ---
 
-## Quick checklist (before PR)
+## Quick checklist (before asset-lock PR)
 
-- [ ] Files match the canonical set (no extras)
+- [ ] Files match the canonical allowed set (no extras)
 - [ ] `make icon-core-validate` passes
 - [ ] `make icon-silhouette-check` passes
 - [ ] `docs/design/EMBLEM_CORE_v1.0_LOCK.md` updated

--- a/docs/design/NEXT_DESIGN_AUTOMATION_MODULE_DECISION.md
+++ b/docs/design/NEXT_DESIGN_AUTOMATION_MODULE_DECISION.md
@@ -9,10 +9,11 @@ The selected next lane is the **Icon Asset Validator / App Store asset guard lan
 
 This document is a process decision only. It does not implement the selected lane, does not create an undocumented PR-9 implementation train, and does not mutate runtime web, runtime iOS, backend, OpenAPI, `/tokens`, generated mirrors, Figma, Canva, Storybook config, screenshots, videos, traces, or external assets.
 
-## Current PR-6 Status (for implementation planning)
+## Active Implementation Status
 
-- This PR implements the **Icon Asset Validator / App Store asset guard lane** implementation slice only.
-- Scope is deliberately limited to repo-local validation, tests, and governance updates.
+- The active implementation slice is `feat/design-icon-asset-validator-v1`.
+- Its scope is deliberately limited to repo-local validation, tests, and governance updates.
+- It establishes process, repo-local validation, tests, and governance for the Icon Asset Validator / App Store asset guard lane, including pre-lock metadata-shape validation and explicit opt-in lock/master checks; it does not provide final locked icon masters or confirmed hash values (no runtime or delivery implementation).
 - No runtime UI, screenshot generation, StoreKit changes, network uploads, or asset uploads are included.
 - Figma/Canva/Storybook are evidence/reference only unless explicitly promoted by a future packet.
 
@@ -26,7 +27,7 @@ The Design Intelligence wave has landed through PR-8:
 - PR-7 added the repeatable design-agent workflow and PR template.
 - PR-8 added a GEPA-compatible prompt/rubric evolution lane as research/eval/process-only.
 
-The runbook says the Design Intelligence wave does not imply an undocumented design-runtime PR-9 or runtime ownership without a later packet. Therefore the next action is a coordinator-owned selection packet, not an implementation PR.
+The runbook says the Design Intelligence wave does not imply an undocumented design-runtime PR-9 or runtime ownership without a later packet. This decision packet selects the next lane and records the boundary that the active implementation slice follows.
 
 Repo code/docs/tests, `/tokens` as token authoring truth, generated mirrors as derived artifacts, UI vocabulary, backend/OpenAPI contracts, and runtime code remain canonical. DESIGN.md, decision packets, research docs, Figma, Canva, Storybook, evidence packs, scorecards, templates, and prompt outputs remain evidence/reference/process layers only.
 
@@ -48,7 +49,7 @@ The candidates come from the landed design-agent workflow module classification:
 
 The selected next lane is **Icon Asset Validator / App Store asset guard lane**.
 
-The future implementation PR should be a release/design asset guard PR, not a generic Design Intelligence PR-9 and not a broad App Store release implementation.
+The implementation PR should be a release/design asset guard PR, not a generic Design Intelligence PR-9 and not a broad App Store release implementation.
 
 Suggested future branch shape:
 
@@ -58,7 +59,7 @@ Suggested future title shape:
 
 - `feat(design): add icon asset validator guard`
 
-Exact future branch/title must still be confirmed by its own coordinator packet.
+Exact branch/title must still be confirmed by its own coordinator packet.
 
 ## Why This Lane Is Next
 
@@ -83,7 +84,7 @@ Deferral does not mean rejection. It means these lanes are not first after PR-8 
 
 ## Future Implementation Boundary
 
-A future Icon Asset Validator implementation PR may touch only explicitly scoped release/design asset governance surfaces, such as:
+An Icon Asset Validator implementation PR may touch only explicitly scoped release/design asset governance surfaces, such as:
 
 - App icon or release asset manifest validation docs.
 - Deterministic validator scripts or tests for repo-owned asset metadata.
@@ -110,7 +111,7 @@ It must not touch:
 
 Controls:
 
-- This PR remains docs/test-only.
+- The active validator slice remains repo-local tooling/docs/tests/governance only.
 - The selected lane requires a separate future packet and PR.
 - Repo truth and `/tokens` precedence are restated here and guarded by tests.
 - Deferred lanes are explicit.

--- a/docs/design/NEXT_DESIGN_AUTOMATION_MODULE_DECISION.md
+++ b/docs/design/NEXT_DESIGN_AUTOMATION_MODULE_DECISION.md
@@ -9,6 +9,13 @@ The selected next lane is the **Icon Asset Validator / App Store asset guard lan
 
 This document is a process decision only. It does not implement the selected lane, does not create an undocumented PR-9 implementation train, and does not mutate runtime web, runtime iOS, backend, OpenAPI, `/tokens`, generated mirrors, Figma, Canva, Storybook config, screenshots, videos, traces, or external assets.
 
+## Current PR-6 Status (for implementation planning)
+
+- This PR implements the **Icon Asset Validator / App Store asset guard lane** implementation slice only.
+- Scope is deliberately limited to repo-local validation, tests, and governance updates.
+- No runtime UI, screenshot generation, StoreKit changes, network uploads, or asset uploads are included.
+- Figma/Canva/Storybook are evidence/reference only unless explicitly promoted by a future packet.
+
 ## Current Repo Truth
 
 The Design Intelligence wave has landed through PR-8:

--- a/docs/release/APPSTORE_SCREENSHOT_ASSET_GATE.md
+++ b/docs/release/APPSTORE_SCREENSHOT_ASSET_GATE.md
@@ -25,9 +25,20 @@ gated, not deleted.
 | `docs/release/APPSTORE_FEATURE_ASSET_MATRIX.md` | Feature-to-asset mapping with release flags and privacy |
 | `ios/PulsePlate/AppStore/AppStoreScreenshotContext.swift` | Canonical screenshot scenario enum (`AppStoreScreenshotScenario`) |
 | `ios/PulsePlate/Assets.xcassets/AppIcon.appiconset/Contents.json` | AppIcon asset catalog with `ios-marketing` 1024x1024 entry |
+| `scripts/validate_icon_core_v1.py` | Repo-local icon core validator contract and lock-mode checks |
 | `docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md` | Protected upload procedure and evidence requirements |
 | `ios/fastlane/Fastfile` | Fastlane snapshot, validation, and upload lanes |
 | `ios/fastlane/metadata/review_information/notes.txt` | Reviewer notes (current state on main) |
+
+Repo-local validator scripts are enforcement-only and must remain:
+- deterministic,
+- network-free,
+- and without mutation of app store assets, metadata, App Store Connect state, or Figma/Canva payloads.
+
+For this lane:
+- `Figma`, `Canva`, and `Storybook` are evidence/reference layers only.
+- App Store Connect is operational proof during protected upload only; it is not repo logic.
+- `scripts/validate_icon_core_v1.py` enforces local gate correctness and never uploads or generates assets.
 
 Root `AGENTS.md` section `App Store release readiness gates` remains the
 hard-gate source of truth for release readiness checks. This gate document
@@ -205,6 +216,8 @@ This document does not:
 - Change the validator script or release validation implementation
 - Change billing, subscription, or entitlement logic
 - Change AI provider configuration
+- Generate, export, capture, or replace icon/App Store binaries in this lane
+- Create network uploads or protected App Store Connect dispatches in this lane
 
 ## Blockers
 

--- a/docs/release/APPSTORE_SCREENSHOT_ASSET_GATE.md
+++ b/docs/release/APPSTORE_SCREENSHOT_ASSET_GATE.md
@@ -25,7 +25,7 @@ gated, not deleted.
 | `docs/release/APPSTORE_FEATURE_ASSET_MATRIX.md` | Feature-to-asset mapping with release flags and privacy |
 | `ios/PulsePlate/AppStore/AppStoreScreenshotContext.swift` | Canonical screenshot scenario enum (`AppStoreScreenshotScenario`) |
 | `ios/PulsePlate/Assets.xcassets/AppIcon.appiconset/Contents.json` | AppIcon asset catalog with `ios-marketing` 1024x1024 entry |
-| `scripts/validate_icon_core_v1.py` | Repo-local icon core validator contract and lock-mode checks |
+| `scripts/validate_icon_core_v1.py` | Repo-local icon core validator contract, strict metadata checks, and opt-in lock-mode checks |
 | `docs/runbooks/IOS_APPSTORE_ASSETS_ROLLOUT.md` | Protected upload procedure and evidence requirements |
 | `ios/fastlane/Fastfile` | Fastlane snapshot, validation, and upload lanes |
 | `ios/fastlane/metadata/review_information/notes.txt` | Reviewer notes (current state on main) |
@@ -33,12 +33,12 @@ gated, not deleted.
 Repo-local validator scripts are enforcement-only and must remain:
 - deterministic,
 - network-free,
-- and without mutation of app store assets, metadata, App Store Connect state, or Figma/Canva payloads.
+- and without mutation of App Store assets, metadata, App Store Connect state, or Figma/Canva payloads.
 
 For this lane:
 - `Figma`, `Canva`, and `Storybook` are evidence/reference layers only.
 - App Store Connect is operational proof during protected upload only; it is not repo logic.
-- `scripts/validate_icon_core_v1.py` enforces local gate correctness and never uploads or generates assets.
+- `scripts/validate_icon_core_v1.py` enforces local gate correctness and never uploads or generates assets. Default and strict metadata checks run repo-locally; lock-value and canonical-master enforcement remain explicit opt-in modes until the repo-owned lock values and masters are confirmed.
 
 Root `AGENTS.md` section `App Store release readiness gates` remains the
 hard-gate source of truth for release readiness checks. This gate document
@@ -213,7 +213,7 @@ This document does not:
 - Access MCP, Figma, or App Store Connect API
 - Introduce network or provider calls
 - Add secrets or environment variable requirements
-- Change the validator script or release validation implementation
+- Generate assets or change protected upload/release mutation implementation
 - Change billing, subscription, or entitlement logic
 - Change AI provider configuration
 - Generate, export, capture, or replace icon/App Store binaries in this lane
@@ -321,12 +321,16 @@ reclassified to `SUBMIT_READY`. Each links to backlog or the epic PR train.
 
 ## Validation Commands
 
-Commands that should pass for this docs/release PR:
+Commands that should pass for the icon asset validator guard lane:
 
 ```bash
 python3 scripts/orchestration/check_preflight.py
 python3 scripts/orchestration/check_agent_consistency.py
-pre-commit run --all-files
-python3 scripts/release/check_ios_appstore_verify.py
-! git diff --name-only origin/main...HEAD | rg -q -v '^docs/.*\.md$|^ios/fastlane/metadata/review_information/notes\.txt$'
+.venv/bin/python scripts/validate_icon_core_v1.py
+.venv/bin/python scripts/validate_icon_core_v1.py --strict
+DEV_PYTHON=.venv/bin/python make icon-core-validate
+DEV_PYTHON=.venv/bin/python make ios-appstore-verify
+.venv/bin/python -m pytest -q tests/test_icon_core_validator.py
+PATH=.venv/bin:$PATH pre-commit run --files <touched-files>
+DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed
 ```

--- a/docs/review/PR_1715_FIXED_MAPPING.md
+++ b/docs/review/PR_1715_FIXED_MAPPING.md
@@ -25,6 +25,7 @@ Open review-bot actionables were triaged against current head. This artifact is 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#discussion_r3212900480 -> 8f1eb0999
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#pullrequestreview-4257495522 -> 8f1eb0999
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#pullrequestreview-4257497445 -> 8f1eb0999
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#pullrequestreview-4258427610 -> 3374e3a88
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#discussion_r3213807371 -> 3374e3a88
 
 Disposition: FIXED
@@ -39,7 +40,7 @@ Evidence: `docs/release/APPSTORE_SCREENSHOT_ASSET_GATE.md` uses “App Store ass
 
 Evidence: Aggregated Sourcery and CodeRabbit review threads (`#pullrequestreview-4257495522`, `#pullrequestreview-4257497445`) are dispositioned to the same implementation commit; inline discussion URLs above cover file-level feedback.
 
-Evidence: Cubic P2 (`discussion_r3213807371`): `--require-canonical-masters` must enforce `CANONICAL_MASTER_SET` only; derived PNGs stay optional on disk; regression test renamed to `test_require_canonical_masters_does_not_require_derived_files`.
+Evidence: Cubic aggregated review `#pullrequestreview-4258427610` (P2 canonical-masters vs derived files) dispositioned to `3374e3a88` (same fix as `discussion_r3213807371`).
 
 Evidence: `183bc1b5d` removes duplicate “missing meta.json” line when `meta.json` is already listed in `missing required governance files`; covered by `test_missing_meta_json_is_single_governance_error`.
 

--- a/docs/review/PR_1715_FIXED_MAPPING.md
+++ b/docs/review/PR_1715_FIXED_MAPPING.md
@@ -22,6 +22,8 @@ Open review-bot actionables were triaged against current head. This artifact is 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#discussion_r3212898589 -> 8f1eb0999
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#discussion_r3212899779 -> 8f1eb0999
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#discussion_r3212900480 -> 8f1eb0999
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#pullrequestreview-4257495522 -> 8f1eb0999
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#pullrequestreview-4257497445 -> 8f1eb0999
 
 Disposition: FIXED
 
@@ -33,7 +35,7 @@ Evidence: `tests/test_icon_core_validator.py` adds strict-mode coverage for miss
 
 Evidence: `docs/release/APPSTORE_SCREENSHOT_ASSET_GATE.md` uses “App Store assets” for consistency with App Store Connect naming.
 
-Evidence: `docs/design/NEXT_DESIGN_AUTOMATION_MODULE_DECISION.md` reconciles active slice wording as process/governance-only (no runtime or delivery implementation).
+Evidence: Aggregated Sourcery and CodeRabbit review threads (`#pullrequestreview-4257495522`, `#pullrequestreview-4257497445`) are dispositioned to the same implementation commit; inline discussion URLs above cover file-level feedback.
 
 ## Local Validation Evidence
 

--- a/docs/review/PR_1715_FIXED_MAPPING.md
+++ b/docs/review/PR_1715_FIXED_MAPPING.md
@@ -1,0 +1,54 @@
+<!-- markdownlint-disable MD013 MD034 -->
+# PR 1715 Fixed In Commit Mapping
+
+- PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715>
+- Branch: `feat/design-icon-asset-validator-v1`
+- Title: `feat(design): add icon asset validator lock-mode and guard tests`
+- Initial reviewed head: `9cd0bc9305f1432d94777b5ff18ceca239911728`
+- Review-fix commit: `8f1eb0999`
+- Status: addressed Sourcery/CodeRabbit/Cubic inline threads; canonical Phase2 artifact.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Open review-bot actionables were triaged against current head. This artifact is the source of truth for Fixed in Commit Mapping; PR body mirrors the Phase2 checklists per repo policy.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#discussion_r3212898584 -> 8f1eb0999
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#discussion_r3212898587 -> 8f1eb0999
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#discussion_r3212898589 -> 8f1eb0999
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#discussion_r3212899779 -> 8f1eb0999
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#discussion_r3212900480 -> 8f1eb0999
+
+Disposition: FIXED
+
+Commit: 8f1eb0999
+
+Evidence: `scripts/validate_icon_core_v1.py` gates `assets`/`hashes` shape checks behind key presence to avoid duplicate errors with top-level required-field validation.
+
+Evidence: `tests/test_icon_core_validator.py` adds strict-mode coverage for missing meta fields, missing asset keys, and non-object `assets`/`hashes`; aligns lock-placeholder fixture path typo to `icon_core_v1_60.png`.
+
+Evidence: `docs/release/APPSTORE_SCREENSHOT_ASSET_GATE.md` uses “App Store assets” for consistency with App Store Connect naming.
+
+Evidence: `docs/design/NEXT_DESIGN_AUTOMATION_MODULE_DECISION.md` reconciles active slice wording as process/governance-only (no runtime or delivery implementation).
+
+## Local Validation Evidence
+
+- `python3 -m pytest tests/test_icon_core_validator.py` - PASS (venv)
+- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1715 --body "$(gh pr view 1715 --repo Katsiarynakavaleuskaya/PulsePlate --json body -q .body)"` - intended PASS after artifact commit and body checkbox update
+
+## Security Notes
+
+- Validator remains network-free and deterministic; changes are meta-shape and test coverage only.
+
+## Risks / Rollback
+
+- Risk: stricter strict-mode aggregation may omit shape errors when top-level keys are missing until keys are present. Mitigation: top-level required set still requires `assets`/`hashes` names.
+- Rollback: revert commit `8f1eb0999` and remove this artifact if the gate contract must be relaxed.
+
+## Deferred / Follow-ups
+
+- None for this mapping cycle.

--- a/docs/review/PR_1715_FIXED_MAPPING.md
+++ b/docs/review/PR_1715_FIXED_MAPPING.md
@@ -5,7 +5,7 @@
 - Branch: `feat/design-icon-asset-validator-v1`
 - Title: `feat(design): add icon asset validator lock-mode and guard tests`
 - Initial reviewed head: `9cd0bc9305f1432d94777b5ff18ceca239911728`
-- Review-fix commit: `183bc1b5d` (+ `3374e3a88`, `8f1eb0999`)
+- Review-fix commit: `474c8f0f5` (tips this branch; includes `183bc1b5d`, `3374e3a88`, `8f1eb0999`)
 - Status: addressed Sourcery/CodeRabbit/Cubic inline threads; canonical Phase2 artifact.
 
 ## Discussion Thread Pass
@@ -28,7 +28,7 @@ Open review-bot actionables were triaged against current head. This artifact is 
 
 Disposition: FIXED
 
-Commit: 183bc1b5d
+Commit: 474c8f0f5
 
 Evidence: `scripts/validate_icon_core_v1.py` gates `assets`/`hashes` shape checks behind key presence to avoid duplicate errors with top-level required-field validation.
 

--- a/docs/review/PR_1715_FIXED_MAPPING.md
+++ b/docs/review/PR_1715_FIXED_MAPPING.md
@@ -5,7 +5,7 @@
 - Branch: `feat/design-icon-asset-validator-v1`
 - Title: `feat(design): add icon asset validator lock-mode and guard tests`
 - Initial reviewed head: `9cd0bc9305f1432d94777b5ff18ceca239911728`
-- Review-fix commit: `474c8f0f5` (tips this branch; includes `183bc1b5d`, `3374e3a88`, `8f1eb0999`)
+- Review-fix commit: `f16886190` (branch tip; includes `474c8f0f5`, `183bc1b5d`, `3374e3a88`, `8f1eb0999`)
 - Status: addressed Sourcery/CodeRabbit/Cubic inline threads; canonical Phase2 artifact.
 
 ## Discussion Thread Pass
@@ -28,7 +28,7 @@ Open review-bot actionables were triaged against current head. This artifact is 
 
 Disposition: FIXED
 
-Commit: 474c8f0f5
+Commit: f16886190
 
 Evidence: `scripts/validate_icon_core_v1.py` gates `assets`/`hashes` shape checks behind key presence to avoid duplicate errors with top-level required-field validation.
 

--- a/docs/review/PR_1715_FIXED_MAPPING.md
+++ b/docs/review/PR_1715_FIXED_MAPPING.md
@@ -5,7 +5,8 @@
 - Branch: `feat/design-icon-asset-validator-v1`
 - Title: `feat(design): add icon asset validator lock-mode and guard tests`
 - Initial reviewed head: `9cd0bc9305f1432d94777b5ff18ceca239911728`
-- Review-fix commit: `f16886190` (branch tip; includes `474c8f0f5`, `183bc1b5d`, `3374e3a88`, `8f1eb0999`)
+- Review-fix commit: `f16886190` (includes `474c8f0f5`, `183bc1b5d`, `3374e3a88`, `8f1eb0999`; review-bot / Cubic threads)
+- Premortem / security-auditor hardening: see **Premortem / security-auditor closure** below (commit \`fix(validate): anchor repo root and harden meta.json handling\` on this branch)
 - Status: addressed Sourcery/CodeRabbit/Cubic inline threads; canonical Phase2 artifact.
 
 ## Discussion Thread Pass
@@ -42,19 +43,32 @@ Evidence: Cubic P2 (`discussion_r3213807371`): `--require-canonical-masters` mus
 
 Evidence: `183bc1b5d` removes duplicate “missing meta.json” line when `meta.json` is already listed in `missing required governance files`; covered by `test_missing_meta_json_is_single_governance_error`.
 
+### Premortem / security-auditor closure
+
+Disposition: FIXED
+
+Evidence: `scripts/validate_icon_core_v1.py` adds `_default_repo_root()` / `_resolve_repo_root()`, `ICON_CORE_SUBPATH`, and `validate(..., repo_root=)`. Resolved `core_dir` must satisfy `core_dir.relative_to(root.resolve())` or validation fails fast (path containment; blocks symlink / `--repo-root` escape).
+
+Evidence: CLI `--repo-root` for non-repo cwd; `META_JSON_MAX_BYTES` (256 KiB) enforced via `stat` before `json.load`; `JSONDecodeError` reported as `line` / `column` only (no full exception string).
+
+Evidence: `tests/test_icon_core_validator.py` — `test_meta_json_size_cap`, `test_symlinked_core_dir_outside_repo_rejected` (skip if symlinks unsupported), `test_cli_accepts_repo_root`; `test_malformed_meta_json_is_detected` asserts `JSON parse error at line` prefix; `_run_validator` uses `repo_root=tmp_root` instead of patching `CORE_DIR`.
+
 ## Local Validation Evidence
 
+- `python3 -m pytest tests/test_icon_core_validator.py -q --noconftest` — PASS
 - `python3 -m pytest tests/test_icon_core_validator.py` - PASS (venv / `--noconftest` when root conftest deps absent)
 - `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1715 --body "$(gh pr view 1715 --repo Katsiarynakavaleuskaya/PulsePlate --json body -q .body)"` - intended PASS after artifact commit and body checkbox update
 
 ## Security Notes
 
-- Validator remains network-free and deterministic; changes are meta-shape and test coverage only.
+- Validator remains network-free and deterministic.
+- Repo-root anchoring and `meta.json` size cap reduce abuse of the gate script on shared runners or pathological inputs; no guard weakening.
 
 ## Risks / Rollback
 
 - Risk: stricter strict-mode aggregation may omit shape errors when top-level keys are missing until keys are present. Mitigation: top-level required set still requires `assets`/`hashes` names.
-- Rollback: revert commits `183bc1b5d` / `3374e3a88` (and prior `8f1eb0999` if needed) and remove this artifact if the gate contract must be relaxed.
+- Risk: very large `meta.json` on disk could spike memory on `json.load` before strict contracts apply. Mitigation: 256 KiB cap rejects oversize files before parse.
+- Rollback: revert premortem hardening commit for `validate_icon_core_v1` / tests / this artifact; revert earlier `183bc1b5d` / `3374e3a88` (and prior `8f1eb0999` if needed) only if the broader gate contract must be relaxed.
 
 ## Deferred / Follow-ups
 

--- a/docs/review/PR_1715_FIXED_MAPPING.md
+++ b/docs/review/PR_1715_FIXED_MAPPING.md
@@ -5,7 +5,7 @@
 - Branch: `feat/design-icon-asset-validator-v1`
 - Title: `feat(design): add icon asset validator lock-mode and guard tests`
 - Initial reviewed head: `9cd0bc9305f1432d94777b5ff18ceca239911728`
-- Review-fix commit: `3374e3a88` (+ prior `8f1eb0999`)
+- Review-fix commit: `183bc1b5d` (+ `3374e3a88`, `8f1eb0999`)
 - Status: addressed Sourcery/CodeRabbit/Cubic inline threads; canonical Phase2 artifact.
 
 ## Discussion Thread Pass
@@ -28,7 +28,7 @@ Open review-bot actionables were triaged against current head. This artifact is 
 
 Disposition: FIXED
 
-Commit: 3374e3a88
+Commit: 183bc1b5d
 
 Evidence: `scripts/validate_icon_core_v1.py` gates `assets`/`hashes` shape checks behind key presence to avoid duplicate errors with top-level required-field validation.
 
@@ -39,6 +39,8 @@ Evidence: `docs/release/APPSTORE_SCREENSHOT_ASSET_GATE.md` uses “App Store ass
 Evidence: Aggregated Sourcery and CodeRabbit review threads (`#pullrequestreview-4257495522`, `#pullrequestreview-4257497445`) are dispositioned to the same implementation commit; inline discussion URLs above cover file-level feedback.
 
 Evidence: Cubic P2 (`discussion_r3213807371`): `--require-canonical-masters` must enforce `CANONICAL_MASTER_SET` only; derived PNGs stay optional on disk; regression test renamed to `test_require_canonical_masters_does_not_require_derived_files`.
+
+Evidence: `183bc1b5d` removes duplicate “missing meta.json” line when `meta.json` is already listed in `missing required governance files`; covered by `test_missing_meta_json_is_single_governance_error`.
 
 ## Local Validation Evidence
 
@@ -52,7 +54,7 @@ Evidence: Cubic P2 (`discussion_r3213807371`): `--require-canonical-masters` mus
 ## Risks / Rollback
 
 - Risk: stricter strict-mode aggregation may omit shape errors when top-level keys are missing until keys are present. Mitigation: top-level required set still requires `assets`/`hashes` names.
-- Rollback: revert commit `3374e3a88` (and prior `8f1eb0999` if needed) and remove this artifact if the gate contract must be relaxed.
+- Rollback: revert commits `183bc1b5d` / `3374e3a88` (and prior `8f1eb0999` if needed) and remove this artifact if the gate contract must be relaxed.
 
 ## Deferred / Follow-ups
 

--- a/docs/review/PR_1715_FIXED_MAPPING.md
+++ b/docs/review/PR_1715_FIXED_MAPPING.md
@@ -6,7 +6,7 @@
 - Title: `feat(design): add icon asset validator lock-mode and guard tests`
 - Initial reviewed head: `9cd0bc9305f1432d94777b5ff18ceca239911728`
 - Review-fix commit: `f16886190` (includes `474c8f0f5`, `183bc1b5d`, `3374e3a88`, `8f1eb0999`; review-bot / Cubic threads)
-- Premortem / security-auditor hardening: see **Premortem / security-auditor closure** below (commit \`fix(validate): anchor repo root and harden meta.json handling\` on this branch)
+- Premortem / security-auditor hardening: see Evidence lines at end of **Fixed in Commit Mapping** (commit \`fix(validate): anchor repo root and harden meta.json handling\` on this branch)
 - Status: addressed Sourcery/CodeRabbit/Cubic inline threads; canonical Phase2 artifact.
 
 ## Discussion Thread Pass
@@ -43,15 +43,11 @@ Evidence: Cubic P2 (`discussion_r3213807371`): `--require-canonical-masters` mus
 
 Evidence: `183bc1b5d` removes duplicate “missing meta.json” line when `meta.json` is already listed in `missing required governance files`; covered by `test_missing_meta_json_is_single_governance_error`.
 
-### Premortem / security-auditor closure
+Evidence: Premortem / security-auditor closure — disposition FIXED. `scripts/validate_icon_core_v1.py` adds `_default_repo_root()` / `_resolve_repo_root()`, `ICON_CORE_SUBPATH`, and `validate(..., repo_root=)`. Resolved `core_dir` must satisfy `core_dir.relative_to(root.resolve())` or validation fails fast (path containment; blocks symlink / `--repo-root` escape).
 
-Disposition: FIXED
+Evidence: Premortem / security-auditor closure — CLI `--repo-root` for non-repo cwd; `META_JSON_MAX_BYTES` (256 KiB) enforced via `stat` before `json.load`; `JSONDecodeError` reported as `line` / `column` only (no full exception string).
 
-Evidence: `scripts/validate_icon_core_v1.py` adds `_default_repo_root()` / `_resolve_repo_root()`, `ICON_CORE_SUBPATH`, and `validate(..., repo_root=)`. Resolved `core_dir` must satisfy `core_dir.relative_to(root.resolve())` or validation fails fast (path containment; blocks symlink / `--repo-root` escape).
-
-Evidence: CLI `--repo-root` for non-repo cwd; `META_JSON_MAX_BYTES` (256 KiB) enforced via `stat` before `json.load`; `JSONDecodeError` reported as `line` / `column` only (no full exception string).
-
-Evidence: `tests/test_icon_core_validator.py` — `test_meta_json_size_cap`, `test_symlinked_core_dir_outside_repo_rejected` (skip if symlinks unsupported), `test_cli_accepts_repo_root`; `test_malformed_meta_json_is_detected` asserts `JSON parse error at line` prefix; `_run_validator` uses `repo_root=tmp_root` instead of patching `CORE_DIR`.
+Evidence: Premortem / security-auditor closure — `tests/test_icon_core_validator.py`: `test_meta_json_size_cap`, `test_symlinked_core_dir_outside_repo_rejected` (skip if symlinks unsupported), `test_cli_accepts_repo_root`; `test_malformed_meta_json_is_detected` asserts `JSON parse error at line` prefix; `_run_validator` uses `repo_root=tmp_root` instead of patching `CORE_DIR`.
 
 ## Local Validation Evidence
 

--- a/docs/review/PR_1715_FIXED_MAPPING.md
+++ b/docs/review/PR_1715_FIXED_MAPPING.md
@@ -5,7 +5,7 @@
 - Branch: `feat/design-icon-asset-validator-v1`
 - Title: `feat(design): add icon asset validator lock-mode and guard tests`
 - Initial reviewed head: `9cd0bc9305f1432d94777b5ff18ceca239911728`
-- Review-fix commit: `8f1eb0999`
+- Review-fix commit: `3374e3a88` (+ prior `8f1eb0999`)
 - Status: addressed Sourcery/CodeRabbit/Cubic inline threads; canonical Phase2 artifact.
 
 ## Discussion Thread Pass
@@ -24,10 +24,11 @@ Open review-bot actionables were triaged against current head. This artifact is 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#discussion_r3212900480 -> 8f1eb0999
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#pullrequestreview-4257495522 -> 8f1eb0999
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#pullrequestreview-4257497445 -> 8f1eb0999
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1715#discussion_r3213807371 -> 3374e3a88
 
 Disposition: FIXED
 
-Commit: 8f1eb0999
+Commit: 3374e3a88
 
 Evidence: `scripts/validate_icon_core_v1.py` gates `assets`/`hashes` shape checks behind key presence to avoid duplicate errors with top-level required-field validation.
 
@@ -37,9 +38,11 @@ Evidence: `docs/release/APPSTORE_SCREENSHOT_ASSET_GATE.md` uses “App Store ass
 
 Evidence: Aggregated Sourcery and CodeRabbit review threads (`#pullrequestreview-4257495522`, `#pullrequestreview-4257497445`) are dispositioned to the same implementation commit; inline discussion URLs above cover file-level feedback.
 
+Evidence: Cubic P2 (`discussion_r3213807371`): `--require-canonical-masters` must enforce `CANONICAL_MASTER_SET` only; derived PNGs stay optional on disk; regression test renamed to `test_require_canonical_masters_does_not_require_derived_files`.
+
 ## Local Validation Evidence
 
-- `python3 -m pytest tests/test_icon_core_validator.py` - PASS (venv)
+- `python3 -m pytest tests/test_icon_core_validator.py` - PASS (venv / `--noconftest` when root conftest deps absent)
 - `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1715 --body "$(gh pr view 1715 --repo Katsiarynakavaleuskaya/PulsePlate --json body -q .body)"` - intended PASS after artifact commit and body checkbox update
 
 ## Security Notes
@@ -49,7 +52,7 @@ Evidence: Aggregated Sourcery and CodeRabbit review threads (`#pullrequestreview
 ## Risks / Rollback
 
 - Risk: stricter strict-mode aggregation may omit shape errors when top-level keys are missing until keys are present. Mitigation: top-level required set still requires `assets`/`hashes` names.
-- Rollback: revert commit `8f1eb0999` and remove this artifact if the gate contract must be relaxed.
+- Rollback: revert commit `3374e3a88` (and prior `8f1eb0999` if needed) and remove this artifact if the gate contract must be relaxed.
 
 ## Deferred / Follow-ups
 

--- a/scripts/orchestration/check_preflight.py
+++ b/scripts/orchestration/check_preflight.py
@@ -54,8 +54,8 @@ def _run(cmd: list[str], cwd: Path | None = None) -> tuple[int, str]:
         text=True,
         check=False,
     )
-    out = (r.stdout or "").strip() + "\n" + (r.stderr or "").strip()
-    return r.returncode, out.strip()
+    out = (r.stdout or "") + ("\n" + r.stderr if r.stderr else "")
+    return r.returncode, out.rstrip()
 
 
 def _parse_dirty_paths(status_output: str) -> list[str]:
@@ -100,7 +100,7 @@ def check_worktrees_untracked() -> bool:
         print("FAIL: git ls-files worktrees failed")
         print(out)
         return False
-    lines = [ln.strip() for ln in out.splitlines() if ln.strip()]
+    lines = [ln for ln in out.splitlines() if ln.strip()]
     if lines:
         print("FAIL: worktrees/ must not be tracked. Tracked paths:")
         for p in lines[:20]:

--- a/scripts/validate_icon_core_v1.py
+++ b/scripts/validate_icon_core_v1.py
@@ -143,7 +143,7 @@ def validate(
         errors.append(f"missing required governance files: {', '.join(missing_governance)}")
 
     if require_canonical_masters:
-        missing_masters = sorted((CANONICAL_MASTER_SET | CANONICAL_DERIVED_SET) - file_set)
+        missing_masters = sorted(CANONICAL_MASTER_SET - file_set)
         if missing_masters:
             errors.append(
                 "missing canonical masters (require-canonical-masters mode): "

--- a/scripts/validate_icon_core_v1.py
+++ b/scripts/validate_icon_core_v1.py
@@ -203,9 +203,6 @@ def validate(
                 errors.append("meta.json lock placeholders found: " + ", ".join(placeholders))
         return errors
 
-    else:
-        errors.append("missing required governance file: meta.json")
-
     return errors
 
 

--- a/scripts/validate_icon_core_v1.py
+++ b/scripts/validate_icon_core_v1.py
@@ -24,10 +24,64 @@ CANONICAL_MASTER_SET = {
     "icon_core_v1_60.png",
 }
 
+REQUIRED_META_TOP_LEVEL_FIELDS = {
+    "contract_id",
+    "version",
+    "master_policy",
+    "figma_source_type",
+    "figma_design_url",
+    "figma_file_key",
+    "figma_node_id",
+    "assets",
+    "hashes",
+}
+
+LOCK_PLACEHOLDER_VALUE = "TBD_AFTER_WINNER_LOCK"
+
+
 ALLOWED_FILES = GOVERNANCE_REQUIRED | CANONICAL_MASTER_SET
+REQUIRED_ASSET_KEYS = {
+    "svg_master",
+    "png_master_1024",
+    "png_master_60",
+    "png_derived_120",
+    "png_derived_32",
+    "png_derived_24",
+}
+REQUIRED_HASH_KEYS = {
+    "master_svg_sha256",
+    "master_png_1024_sha256",
+    "master_png_60_sha256",
+    "silhouette_mask_sha256_1024",
+    "silhouette_mask_sha256_60",
+}
 
 
-def validate(strict: bool) -> list[str]:
+def _find_placeholder_values(data: dict[str, object]) -> list[str]:
+    """Return flattened placeholder-like values from known lock fields."""
+
+    placeholders: list[str] = []
+    for key in ("figma_design_url", "figma_file_key", "figma_node_id"):
+        value = data.get(key)
+        if value == LOCK_PLACEHOLDER_VALUE:
+            placeholders.append(f"{key}={LOCK_PLACEHOLDER_VALUE}")
+
+    assets = data.get("assets")
+    if isinstance(assets, dict):
+        for key, value in assets.items():
+            if value == LOCK_PLACEHOLDER_VALUE:
+                placeholders.append(f"assets.{key}={LOCK_PLACEHOLDER_VALUE}")
+
+    hashes = data.get("hashes")
+    if isinstance(hashes, dict):
+        for key, value in hashes.items():
+            if value == LOCK_PLACEHOLDER_VALUE:
+                placeholders.append(f"hashes.{key}={LOCK_PLACEHOLDER_VALUE}")
+
+    return placeholders
+
+
+def validate(strict: bool, *, require_lock_values: bool = False) -> list[str]:
     errors: list[str] = []
 
     if not CORE_DIR.exists():
@@ -58,8 +112,45 @@ def validate(strict: bool) -> list[str]:
                 meta = json.load(f)
             if not isinstance(meta, dict):
                 errors.append("meta.json must be a JSON object")
+                return errors
         except json.JSONDecodeError as exc:
             errors.append(f"invalid meta.json: {exc}")
+            return errors
+
+        missing_meta_fields = sorted(REQUIRED_META_TOP_LEVEL_FIELDS - set(meta.keys()))
+        if missing_meta_fields:
+            errors.append(
+                f"meta.json missing required top-level fields: {', '.join(missing_meta_fields)}"
+            )
+
+        assets = meta.get("assets")
+        if not isinstance(assets, dict):
+            errors.append("meta.json must define assets as an object")
+        else:
+            missing_asset_keys = sorted(REQUIRED_ASSET_KEYS - set(assets.keys()))
+            if missing_asset_keys:
+                errors.append(
+                    f"meta.json assets missing required keys: {', '.join(missing_asset_keys)}"
+                )
+
+        hashes = meta.get("hashes")
+        if not isinstance(hashes, dict):
+            errors.append("meta.json must define hashes as an object")
+        else:
+            missing_hash_keys = sorted(REQUIRED_HASH_KEYS - set(hashes.keys()))
+            if missing_hash_keys:
+                errors.append(
+                    f"meta.json hashes missing required keys: {', '.join(missing_hash_keys)}"
+                )
+
+        if require_lock_values:
+            placeholders = _find_placeholder_values(meta)
+            if placeholders:
+                errors.append("meta.json lock placeholders found: " + ", ".join(placeholders))
+        return errors
+
+    else:
+        errors.append("missing required governance file: meta.json")
 
     return errors
 
@@ -71,9 +162,14 @@ def main() -> None:
         action="store_true",
         help="Require canonical master files to exist.",
     )
+    parser.add_argument(
+        "--require-lock-values",
+        action="store_true",
+        help="Require TBD lock placeholders to be replaced with concrete values.",
+    )
     args = parser.parse_args()
 
-    errors = validate(strict=args.strict)
+    errors = validate(strict=args.strict, require_lock_values=args.require_lock_values)
     if errors:
         for line in errors:
             print(line)

--- a/scripts/validate_icon_core_v1.py
+++ b/scripts/validate_icon_core_v1.py
@@ -5,7 +5,9 @@ Default mode is intentionally lightweight:
 - fail on unexpected files in core/v1.0
 - require governance files (README.md + meta.json)
 
-Strict mode additionally requires canonical masters to exist.
+Strict mode validates required metadata fields and canonical asset paths.
+Canonical files and confirmed lock values are required only when explicitly
+requested because the current repo contract may still be pre-lock.
 """
 
 from __future__ import annotations
@@ -23,6 +25,11 @@ CANONICAL_MASTER_SET = {
     "icon_core_v1_1024.png",
     "icon_core_v1_60.png",
 }
+CANONICAL_DERIVED_SET = {
+    "icon_core_v1_120.png",
+    "icon_core_v1_32.png",
+    "icon_core_v1_24.png",
+}
 
 REQUIRED_META_TOP_LEVEL_FIELDS = {
     "contract_id",
@@ -37,9 +44,17 @@ REQUIRED_META_TOP_LEVEL_FIELDS = {
 }
 
 LOCK_PLACEHOLDER_VALUE = "TBD_AFTER_WINNER_LOCK"
+PLACEHOLDER_VALUES = {
+    "",
+    "TBD",
+    "TODO",
+    "UNKNOWN",
+    "UNSPECIFIED",
+    LOCK_PLACEHOLDER_VALUE,
+}
 
 
-ALLOWED_FILES = GOVERNANCE_REQUIRED | CANONICAL_MASTER_SET
+ALLOWED_FILES = GOVERNANCE_REQUIRED | CANONICAL_MASTER_SET | CANONICAL_DERIVED_SET
 REQUIRED_ASSET_KEYS = {
     "svg_master",
     "png_master_1024",
@@ -47,6 +62,14 @@ REQUIRED_ASSET_KEYS = {
     "png_derived_120",
     "png_derived_32",
     "png_derived_24",
+}
+REQUIRED_ASSET_PATHS = {
+    "svg_master": "assets/brand/icon/core/v1.0/icon_core_v1.svg",
+    "png_master_1024": "assets/brand/icon/core/v1.0/icon_core_v1_1024.png",
+    "png_master_60": "assets/brand/icon/core/v1.0/icon_core_v1_60.png",
+    "png_derived_120": "assets/brand/icon/core/v1.0/icon_core_v1_120.png",
+    "png_derived_32": "assets/brand/icon/core/v1.0/icon_core_v1_32.png",
+    "png_derived_24": "assets/brand/icon/core/v1.0/icon_core_v1_24.png",
 }
 REQUIRED_HASH_KEYS = {
     "master_svg_sha256",
@@ -63,25 +86,44 @@ def _find_placeholder_values(data: dict[str, object]) -> list[str]:
     placeholders: list[str] = []
     for key in ("figma_design_url", "figma_file_key", "figma_node_id"):
         value = data.get(key)
-        if value == LOCK_PLACEHOLDER_VALUE:
-            placeholders.append(f"{key}={LOCK_PLACEHOLDER_VALUE}")
+        if not _is_concrete_lock_value(value):
+            placeholders.append(f"{key}={value!r}")
 
     assets = data.get("assets")
     if isinstance(assets, dict):
         for key, value in assets.items():
-            if value == LOCK_PLACEHOLDER_VALUE:
-                placeholders.append(f"assets.{key}={LOCK_PLACEHOLDER_VALUE}")
+            if not _is_concrete_lock_value(value):
+                placeholders.append(f"assets.{key}={value!r}")
 
     hashes = data.get("hashes")
     if isinstance(hashes, dict):
         for key, value in hashes.items():
-            if value == LOCK_PLACEHOLDER_VALUE:
-                placeholders.append(f"hashes.{key}={LOCK_PLACEHOLDER_VALUE}")
+            if not _is_concrete_hash_value(value):
+                placeholders.append(f"hashes.{key}={value!r}")
 
     return placeholders
 
 
-def validate(strict: bool, *, require_lock_values: bool = False) -> list[str]:
+def _is_concrete_lock_value(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    normalized = value.strip()
+    return bool(normalized) and normalized.upper() not in PLACEHOLDER_VALUES
+
+
+def _is_concrete_hash_value(value: object) -> bool:
+    if not _is_concrete_lock_value(value):
+        return False
+    normalized = str(value).strip()
+    return normalized.startswith("sha256:") and len(normalized) > len("sha256:")
+
+
+def validate(
+    *,
+    strict: bool = False,
+    require_lock_values: bool = False,
+    require_canonical_masters: bool = False,
+) -> list[str]:
     errors: list[str] = []
 
     if not CORE_DIR.exists():
@@ -100,10 +142,13 @@ def validate(strict: bool, *, require_lock_values: bool = False) -> list[str]:
     if missing_governance:
         errors.append(f"missing required governance files: {', '.join(missing_governance)}")
 
-    if strict:
-        missing_masters = sorted(CANONICAL_MASTER_SET - file_set)
+    if require_canonical_masters:
+        missing_masters = sorted((CANONICAL_MASTER_SET | CANONICAL_DERIVED_SET) - file_set)
         if missing_masters:
-            errors.append(f"missing canonical masters (strict mode): {', '.join(missing_masters)}")
+            errors.append(
+                "missing canonical masters (require-canonical-masters mode): "
+                + ", ".join(missing_masters)
+            )
 
     meta_path = CORE_DIR / "meta.json"
     if meta_path.exists():
@@ -117,31 +162,40 @@ def validate(strict: bool, *, require_lock_values: bool = False) -> list[str]:
             errors.append(f"invalid meta.json: {exc}")
             return errors
 
-        missing_meta_fields = sorted(REQUIRED_META_TOP_LEVEL_FIELDS - set(meta.keys()))
-        if missing_meta_fields:
-            errors.append(
-                f"meta.json missing required top-level fields: {', '.join(missing_meta_fields)}"
-            )
-
-        assets = meta.get("assets")
-        if not isinstance(assets, dict):
-            errors.append("meta.json must define assets as an object")
-        else:
-            missing_asset_keys = sorted(REQUIRED_ASSET_KEYS - set(assets.keys()))
-            if missing_asset_keys:
+        validate_meta_contract = strict or require_lock_values
+        if validate_meta_contract:
+            missing_meta_fields = sorted(REQUIRED_META_TOP_LEVEL_FIELDS - set(meta.keys()))
+            if missing_meta_fields:
                 errors.append(
-                    f"meta.json assets missing required keys: {', '.join(missing_asset_keys)}"
+                    "meta.json missing required top-level fields: " + ", ".join(missing_meta_fields)
                 )
 
-        hashes = meta.get("hashes")
-        if not isinstance(hashes, dict):
-            errors.append("meta.json must define hashes as an object")
-        else:
-            missing_hash_keys = sorted(REQUIRED_HASH_KEYS - set(hashes.keys()))
-            if missing_hash_keys:
-                errors.append(
-                    f"meta.json hashes missing required keys: {', '.join(missing_hash_keys)}"
-                )
+            if "assets" in meta:
+                assets = meta["assets"]
+                if not isinstance(assets, dict):
+                    errors.append("meta.json must define assets as an object")
+                else:
+                    missing_asset_keys = sorted(REQUIRED_ASSET_KEYS - set(assets.keys()))
+                    if missing_asset_keys:
+                        errors.append(
+                            "meta.json assets missing required keys: "
+                            + ", ".join(missing_asset_keys)
+                        )
+                    for key, expected_path in sorted(REQUIRED_ASSET_PATHS.items()):
+                        if assets.get(key) != expected_path:
+                            errors.append(f"meta.json assets.{key} must be {expected_path}")
+
+            if "hashes" in meta:
+                hashes = meta["hashes"]
+                if not isinstance(hashes, dict):
+                    errors.append("meta.json must define hashes as an object")
+                else:
+                    missing_hash_keys = sorted(REQUIRED_HASH_KEYS - set(hashes.keys()))
+                    if missing_hash_keys:
+                        errors.append(
+                            "meta.json hashes missing required keys: "
+                            + ", ".join(missing_hash_keys)
+                        )
 
         if require_lock_values:
             placeholders = _find_placeholder_values(meta)
@@ -160,7 +214,12 @@ def main() -> None:
     parser.add_argument(
         "--strict",
         action="store_true",
-        help="Require canonical master files to exist.",
+        help="Validate required metadata fields and canonical asset paths.",
+    )
+    parser.add_argument(
+        "--require-canonical-masters",
+        action="store_true",
+        help="Require canonical master asset files to exist.",
     )
     parser.add_argument(
         "--require-lock-values",
@@ -169,7 +228,11 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    errors = validate(strict=args.strict, require_lock_values=args.require_lock_values)
+    errors = validate(
+        strict=args.strict,
+        require_lock_values=args.require_lock_values,
+        require_canonical_masters=args.require_canonical_masters,
+    )
     if errors:
         for line in errors:
             print(line)

--- a/scripts/validate_icon_core_v1.py
+++ b/scripts/validate_icon_core_v1.py
@@ -8,6 +8,11 @@ Default mode is intentionally lightweight:
 Strict mode validates required metadata fields and canonical asset paths.
 Canonical files and confirmed lock values are required only when explicitly
 requested because the current repo contract may still be pre-lock.
+
+Repository root defaults to the parent of ``scripts/`` (stable in CI regardless
+of process cwd). Pass ``--repo-root`` / ``repo_root=`` to override. The
+resolved icon core directory must stay under that root (blocks symlink escape).
+``meta.json`` larger than ``META_JSON_MAX_BYTES`` is rejected before parsing.
 """
 
 from __future__ import annotations
@@ -16,7 +21,23 @@ import argparse
 import json
 from pathlib import Path
 
-CORE_DIR = Path("assets/brand/icon/core/v1.0")
+ICON_CORE_SUBPATH = Path("assets") / "brand" / "icon" / "core" / "v1.0"
+META_JSON_MAX_BYTES = 256 * 1024
+
+
+def _default_repo_root() -> Path:
+    """Repository root when the script lives in scripts/."""
+
+    return Path(__file__).resolve().parent.parent
+
+
+def _resolve_repo_root(repo_root: Path | str | None) -> Path:
+    if repo_root is None:
+        return _default_repo_root()
+    return Path(repo_root).expanduser().resolve()
+
+
+CORE_DIR = (_default_repo_root() / ICON_CORE_SUBPATH).resolve()
 
 GOVERNANCE_REQUIRED = {"README.md", "meta.json"}
 
@@ -123,20 +144,28 @@ def validate(
     strict: bool = False,
     require_lock_values: bool = False,
     require_canonical_masters: bool = False,
+    repo_root: Path | str | None = None,
 ) -> list[str]:
     errors: list[str] = []
 
-    if not CORE_DIR.exists():
-        return [f"missing directory: {CORE_DIR}"]
-    if not CORE_DIR.is_dir():
-        return [f"not a directory: {CORE_DIR}"]
+    root = _resolve_repo_root(repo_root)
+    core_dir = (root / ICON_CORE_SUBPATH).resolve()
+    try:
+        core_dir.relative_to(root.resolve())
+    except ValueError:
+        return [f"icon core directory resolves outside repo root: {core_dir}"]
 
-    files = sorted(p.name for p in CORE_DIR.iterdir() if p.is_file())
+    if not core_dir.exists():
+        return [f"missing directory: {core_dir}"]
+    if not core_dir.is_dir():
+        return [f"not a directory: {core_dir}"]
+
+    files = sorted(p.name for p in core_dir.iterdir() if p.is_file())
     file_set = set(files)
 
     unexpected = sorted(file_set - ALLOWED_FILES)
     if unexpected:
-        errors.append(f"unexpected files in {CORE_DIR}: {', '.join(unexpected)}")
+        errors.append(f"unexpected files in {core_dir}: {', '.join(unexpected)}")
 
     missing_governance = sorted(GOVERNANCE_REQUIRED - file_set)
     if missing_governance:
@@ -150,8 +179,18 @@ def validate(
                 + ", ".join(missing_masters)
             )
 
-    meta_path = CORE_DIR / "meta.json"
+    meta_path = core_dir / "meta.json"
     if meta_path.exists():
+        try:
+            meta_size = meta_path.stat().st_size
+        except OSError as exc:
+            errors.append(f"cannot stat meta.json: {exc}")
+            return errors
+        if meta_size > META_JSON_MAX_BYTES:
+            errors.append(
+                f"meta.json exceeds max size ({META_JSON_MAX_BYTES} bytes): {meta_size} bytes"
+            )
+            return errors
         try:
             with meta_path.open("r", encoding="utf-8") as f:
                 meta = json.load(f)
@@ -159,7 +198,9 @@ def validate(
                 errors.append("meta.json must be a JSON object")
                 return errors
         except json.JSONDecodeError as exc:
-            errors.append(f"invalid meta.json: {exc}")
+            errors.append(
+                f"invalid meta.json: JSON parse error at line {exc.lineno} column {exc.colno}"
+            )
             return errors
 
         validate_meta_contract = strict or require_lock_values
@@ -223,12 +264,19 @@ def main() -> None:
         action="store_true",
         help="Require TBD lock placeholders to be replaced with concrete values.",
     )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (default: parent of scripts/). Use when cwd is not the repo root.",
+    )
     args = parser.parse_args()
 
     errors = validate(
         strict=args.strict,
         require_lock_values=args.require_lock_values,
         require_canonical_masters=args.require_canonical_masters,
+        repo_root=args.repo_root,
     )
     if errors:
         for line in errors:

--- a/tests/test_icon_core_validator.py
+++ b/tests/test_icon_core_validator.py
@@ -100,8 +100,9 @@ def _run_validator(
     include_meta: bool = True,
     unexpected_files: list[str] | None = None,
     meta_payload: dict | str | None = None,
+    repo_root: pathlib.Path | None = None,
 ) -> list[str]:
-    core_dir = _write_icon_core_fixture(
+    _write_icon_core_fixture(
         tmp_root,
         include_masters=include_masters,
         include_derived=include_derived,
@@ -109,11 +110,12 @@ def _run_validator(
         unexpected_files=unexpected_files,
         meta_payload=meta_payload,
     )
-    monkeypatch.setattr(validator, "CORE_DIR", core_dir)
+    root = repo_root if repo_root is not None else tmp_root
     return validator.validate(
         strict=strict,
         require_lock_values=require_lock_values,
         require_canonical_masters=require_canonical_masters,
+        repo_root=root,
     )
 
 
@@ -177,6 +179,60 @@ def test_malformed_meta_json_is_detected(
         meta_payload='{"contract_id": "bad", "assets": ',
     )
     assert any("invalid meta.json" in err for err in errors)
+    assert any("JSON parse error at line" in err for err in errors)
+
+
+def test_meta_json_size_cap(tmp_path: pathlib.Path) -> None:
+    """Very large meta.json must fail without feeding megabytes to json.load."""
+
+    core = _write_icon_core_fixture(
+        tmp_path,
+        include_masters=True,
+        include_meta=False,
+    )
+    (core / "meta.json").write_bytes(b"x" * (validator.META_JSON_MAX_BYTES + 1))
+    errors = validator.validate(repo_root=tmp_path)
+    assert any("meta.json exceeds max size" in e for e in errors)
+
+
+def test_symlinked_core_dir_outside_repo_rejected(tmp_path: pathlib.Path) -> None:
+    """Resolved icon core path must stay under repo root (symlink escape)."""
+
+    if not hasattr(pathlib.Path, "symlink_to"):
+        pytest.skip("symlink_to not available")
+
+    outside = tmp_path / "outside"
+    outside.mkdir(parents=True)
+    (outside / "README.md").write_text("outside\n", encoding="utf-8")
+
+    repo = tmp_path / "repo"
+    link_parent = repo / "assets" / "brand" / "icon" / "core"
+    link_parent.mkdir(parents=True)
+    link = link_parent / "v1.0"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("cannot create symlink in this environment")
+
+    errors = validator.validate(repo_root=repo)
+    assert any("resolves outside repo root" in e for e in errors)
+
+
+def test_cli_accepts_repo_root(tmp_path: pathlib.Path) -> None:
+    """CLI --repo-root must validate a subtree without cwd being that repo."""
+
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    _write_icon_core_fixture(tmp_path, include_masters=True)
+    script = repo / "scripts" / "validate_icon_core_v1.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--repo-root", str(tmp_path)],
+        cwd="/",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "OK: icon core v1.0 structure valid" in result.stdout
 
 
 def test_asset_paths_must_match_canonical_names(

--- a/tests/test_icon_core_validator.py
+++ b/tests/test_icon_core_validator.py
@@ -16,6 +16,7 @@ def _write_icon_core_fixture(
     tmp_root: pathlib.Path,
     *,
     include_masters: bool,
+    include_derived: bool = False,
     include_meta: bool = True,
     unexpected_files: list[str] | None = None,
     meta_payload: dict | str | None = None,
@@ -32,6 +33,14 @@ def _write_icon_core_fixture(
             "icon_core_v1.svg",
             "icon_core_v1_1024.png",
             "icon_core_v1_60.png",
+        ):
+            (core_dir / name).write_text(f"{name}\n", encoding="utf-8")
+
+    if include_derived:
+        for name in (
+            "icon_core_v1_120.png",
+            "icon_core_v1_32.png",
+            "icon_core_v1_24.png",
         ):
             (core_dir / name).write_text(f"{name}\n", encoding="utf-8")
 
@@ -54,11 +63,11 @@ def _write_icon_core_fixture(
                     "figma_node_id": "1024:2048",
                     "assets": {
                         "svg_master": "assets/brand/icon/core/v1.0/icon_core_v1.svg",
-                        "png_master_1024": "assets/brand/icon/core/v1.0/icon_core_1024.png",
-                        "png_master_60": "assets/brand/icon/core/v1.0/icon_core_60.png",
-                        "png_derived_120": "assets/brand/icon/core/v1.0/icon_core_120.png",
-                        "png_derived_32": "assets/brand/icon/core/v1.0/icon_core_32.png",
-                        "png_derived_24": "assets/brand/icon/core/v1.0/icon_core_24.png",
+                        "png_master_1024": "assets/brand/icon/core/v1.0/icon_core_v1_1024.png",
+                        "png_master_60": "assets/brand/icon/core/v1.0/icon_core_v1_60.png",
+                        "png_derived_120": "assets/brand/icon/core/v1.0/icon_core_v1_120.png",
+                        "png_derived_32": "assets/brand/icon/core/v1.0/icon_core_v1_32.png",
+                        "png_derived_24": "assets/brand/icon/core/v1.0/icon_core_v1_24.png",
                     },
                     "hashes": {
                         "master_svg_sha256": "sha256:svg",
@@ -85,7 +94,9 @@ def _run_validator(
     *,
     strict: bool = False,
     require_lock_values: bool = False,
+    require_canonical_masters: bool = False,
     include_masters: bool = True,
+    include_derived: bool = False,
     include_meta: bool = True,
     unexpected_files: list[str] | None = None,
     meta_payload: dict | str | None = None,
@@ -93,12 +104,17 @@ def _run_validator(
     core_dir = _write_icon_core_fixture(
         tmp_root,
         include_masters=include_masters,
+        include_derived=include_derived,
         include_meta=include_meta,
         unexpected_files=unexpected_files,
         meta_payload=meta_payload,
     )
     monkeypatch.setattr(validator, "CORE_DIR", core_dir)
-    return validator.validate(strict=strict, require_lock_values=require_lock_values)
+    return validator.validate(
+        strict=strict,
+        require_lock_values=require_lock_values,
+        require_canonical_masters=require_canonical_masters,
+    )
 
 
 def test_default_validator_passes_current_repo_fixture() -> None:
@@ -116,18 +132,21 @@ def test_default_validator_passes_current_repo_fixture() -> None:
     assert "OK: icon core v1.0 structure valid (default mode)" in result.stdout
 
 
-def test_strict_catches_missing_masters(
+def test_require_canonical_masters_catches_missing_masters(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Strict mode should fail when canonical masters are missing."""
+    """Master enforcement mode should fail when canonical masters are missing."""
 
     errors = _run_validator(
         monkeypatch,
         tmp_path,
-        strict=True,
+        require_canonical_masters=True,
         include_masters=False,
     )
-    assert any(err.startswith("missing canonical masters (strict mode)") for err in errors)
+    assert any(
+        err.startswith("missing canonical masters (require-canonical-masters mode)")
+        for err in errors
+    )
 
 
 def test_malformed_meta_json_is_detected(
@@ -142,6 +161,68 @@ def test_malformed_meta_json_is_detected(
         meta_payload='{"contract_id": "bad", "assets": ',
     )
     assert any("invalid meta.json" in err for err in errors)
+
+
+def test_asset_paths_must_match_canonical_names(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Metadata asset paths must point at canonical icon-core filenames."""
+
+    bad_meta = {
+        "contract_id": "EMBLEM_CORE_v1.0_LOCK",
+        "version": "v1.0",
+        "master_policy": "dual-master-svg-png",
+        "figma_source_type": "design",
+        "figma_design_url": "spec://design-url",
+        "figma_file_key": "design-file-key",
+        "figma_node_id": "1024:2048",
+        "assets": {
+            "svg_master": "assets/brand/icon/core/v1.0/icon_core_v1.svg",
+            "png_master_1024": "assets/brand/icon/core/v1.0/icon_core_1024.png",
+            "png_master_60": "assets/brand/icon/core/v1.0/icon_core_60.png",
+            "png_derived_120": "assets/brand/icon/core/v1.0/icon_core_v1_120.png",
+            "png_derived_32": "assets/brand/icon/core/v1.0/icon_core_v1_32.png",
+            "png_derived_24": "assets/brand/icon/core/v1.0/icon_core_v1_24.png",
+        },
+        "hashes": {
+            "master_svg_sha256": "sha256:svg",
+            "master_png_1024_sha256": "sha256:png1024",
+            "master_png_60_sha256": "sha256:png60",
+            "silhouette_mask_sha256_1024": "sha256:mask1024",
+            "silhouette_mask_sha256_60": "sha256:mask60",
+        },
+    }
+
+    errors = _run_validator(
+        monkeypatch,
+        tmp_path,
+        strict=True,
+        include_masters=True,
+        meta_payload=bad_meta,
+    )
+    assert (
+        "meta.json assets.png_master_1024 must be assets/brand/icon/core/v1.0/icon_core_v1_1024.png"
+        in errors
+    )
+    assert (
+        "meta.json assets.png_master_60 must be assets/brand/icon/core/v1.0/icon_core_v1_60.png"
+        in errors
+    )
+
+
+def test_canonical_derived_files_are_allowed(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repo-owned derived icon files should be allowed when they are later added."""
+
+    errors = _run_validator(
+        monkeypatch,
+        tmp_path,
+        strict=True,
+        include_masters=True,
+        include_derived=True,
+    )
+    assert errors == []
 
 
 def test_unexpected_file_is_detected(
@@ -174,7 +255,7 @@ def test_require_lock_values_rejects_placeholders(
         "assets": {
             "svg_master": "assets/brand/icon/core/v1.0/icon_core_v1.svg",
             "png_master_1024": "assets/brand/icon/core/v1.0/icon_core_v1_1024.png",
-            "png_master_60": "assets/brand/icon/core/v1.0/icon_core_1_60.png",
+            "png_master_60": "assets/brand/icon/core/v1.0/icon_core_v1_60.png",
             "png_derived_120": "assets/brand/icon/core/v1.0/icon_core_v1_120.png",
             "png_derived_32": "assets/brand/icon/core/v1.0/icon_core_v1_32.png",
             "png_derived_24": "assets/brand/icon/core/v1.0/icon_core_v1_24.png",
@@ -191,7 +272,6 @@ def test_require_lock_values_rejects_placeholders(
     errors = _run_validator(
         monkeypatch,
         tmp_path,
-        strict=True,
         require_lock_values=True,
         include_masters=True,
         meta_payload=meta_with_placeholders,
@@ -199,15 +279,181 @@ def test_require_lock_values_rejects_placeholders(
     assert any("meta.json lock placeholders found" in err for err in errors)
 
 
-def test_default_and_strict_regression_without_tbd(
+def test_require_lock_values_rejects_noncanonical_placeholders(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Default and strict validator modes should both pass with filled lock values."""
+    """Lock mode must reject empty, TBD-like, and non-hash placeholder values."""
+
+    meta_with_noncanonical_placeholders = {
+        "contract_id": "EMBLEM_CORE_v1.0_LOCK",
+        "version": "v1.0",
+        "master_policy": "dual-master-svg-png",
+        "figma_source_type": "design",
+        "figma_design_url": "TBD",
+        "figma_file_key": "",
+        "figma_node_id": "unknown",
+        "assets": {
+            "svg_master": "assets/brand/icon/core/v1.0/icon_core_v1.svg",
+            "png_master_1024": "assets/brand/icon/core/v1.0/icon_core_v1_1024.png",
+            "png_master_60": "assets/brand/icon/core/v1.0/icon_core_v1_60.png",
+            "png_derived_120": "assets/brand/icon/core/v1.0/icon_core_v1_120.png",
+            "png_derived_32": "assets/brand/icon/core/v1.0/icon_core_v1_32.png",
+            "png_derived_24": "assets/brand/icon/core/v1.0/icon_core_v1_24.png",
+        },
+        "hashes": {
+            "master_svg_sha256": "",
+            "master_png_1024_sha256": "TBD",
+            "master_png_60_sha256": "sha256:png60",
+            "silhouette_mask_sha256_1024": "not-a-sha",
+            "silhouette_mask_sha256_60": "sha256:mask60",
+        },
+    }
+
+    errors = _run_validator(
+        monkeypatch,
+        tmp_path,
+        require_lock_values=True,
+        include_masters=True,
+        meta_payload=meta_with_noncanonical_placeholders,
+    )
+    assert any("meta.json lock placeholders found" in err for err in errors)
+
+
+def test_require_canonical_masters_requires_derived_files(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Master enforcement mode should require derived canonical files too."""
+
+    errors = _run_validator(
+        monkeypatch,
+        tmp_path,
+        require_canonical_masters=True,
+        include_masters=True,
+        include_derived=False,
+    )
+    assert any("icon_core_v1_120.png" in err for err in errors)
+    assert any("icon_core_v1_32.png" in err for err in errors)
+    assert any("icon_core_v1_24.png" in err for err in errors)
+
+
+def test_strict_mode_reports_missing_required_top_level_meta_fields(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Strict contract validation must list missing top-level meta fields."""
+
+    meta = {
+        "contract_id": "EMBLEM_CORE_v1.0_LOCK",
+        "version": "v1.0",
+        # Deliberately omit several REQUIRED_META_TOP_LEVEL_FIELDS.
+        "master_policy": "dual-master-svg-png",
+        "figma_source_type": "design",
+    }
+
+    errors = _run_validator(
+        monkeypatch,
+        tmp_path,
+        strict=True,
+        include_masters=True,
+        meta_payload=meta,
+    )
+    assert any("meta.json missing required top-level fields" in err for err in errors)
+    assert any("assets" in err for err in errors)
+    assert any("hashes" in err for err in errors)
+
+
+def test_strict_mode_reports_missing_asset_keys_without_duplicate_shape_errors(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing assets keys should not also emit a generic non-object error."""
+
+    meta = {
+        "contract_id": "EMBLEM_CORE_v1.0_LOCK",
+        "version": "v1.0",
+        "master_policy": "dual-master-svg-png",
+        "figma_source_type": "design",
+        "figma_design_url": "spec://design-url",
+        "figma_file_key": "design-file-key",
+        "figma_node_id": "1024:2048",
+        "assets": {
+            "svg_master": "assets/brand/icon/core/v1.0/icon_core_v1.svg",
+        },
+        "hashes": {
+            "master_svg_sha256": "sha256:svg",
+            "master_png_1024_sha256": "sha256:png1024",
+            "master_png_60_sha256": "sha256:png60",
+            "silhouette_mask_sha256_1024": "sha256:mask1024",
+            "silhouette_mask_sha256_60": "sha256:mask60",
+        },
+    }
+
+    errors = _run_validator(
+        monkeypatch, tmp_path, strict=True, include_masters=True, meta_payload=meta
+    )
+    assert any("meta.json assets missing required keys" in err for err in errors)
+    assert "meta.json must define assets as an object" not in errors
+
+
+def test_strict_mode_rejects_non_object_assets_and_hashes(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """assets/hashes must be JSON objects when present under strict validation."""
+
+    meta_assets_list = {
+        "contract_id": "EMBLEM_CORE_v1.0_LOCK",
+        "version": "v1.0",
+        "master_policy": "dual-master-svg-png",
+        "figma_source_type": "design",
+        "figma_design_url": "spec://design-url",
+        "figma_file_key": "design-file-key",
+        "figma_node_id": "1024:2048",
+        "assets": [],
+        "hashes": {
+            "master_svg_sha256": "sha256:svg",
+            "master_png_1024_sha256": "sha256:png1024",
+            "master_png_60_sha256": "sha256:png60",
+            "silhouette_mask_sha256_1024": "sha256:mask1024",
+            "silhouette_mask_sha256_60": "sha256:mask60",
+        },
+    }
+
+    errors_assets = _run_validator(
+        monkeypatch, tmp_path, strict=True, include_masters=True, meta_payload=meta_assets_list
+    )
+    assert "meta.json must define assets as an object" in errors_assets
+
+    meta_hashes_str = {
+        "contract_id": "EMBLEM_CORE_v1.0_LOCK",
+        "version": "v1.0",
+        "master_policy": "dual-master-svg-png",
+        "figma_source_type": "design",
+        "figma_design_url": "spec://design-url",
+        "figma_file_key": "design-file-key",
+        "figma_node_id": "1024:2048",
+        "assets": {
+            "svg_master": "assets/brand/icon/core/v1.0/icon_core_v1.svg",
+            "png_master_1024": "assets/brand/icon/core/v1.0/icon_core_v1_1024.png",
+            "png_master_60": "assets/brand/icon/core/v1.0/icon_core_v1_60.png",
+            "png_derived_120": "assets/brand/icon/core/v1.0/icon_core_v1_120.png",
+            "png_derived_32": "assets/brand/icon/core/v1.0/icon_core_v1_32.png",
+            "png_derived_24": "assets/brand/icon/core/v1.0/icon_core_v1_24.png",
+        },
+        "hashes": "not-a-dict",
+    }
+
+    errors_hashes = _run_validator(
+        monkeypatch, tmp_path, strict=True, include_masters=True, meta_payload=meta_hashes_str
+    )
+    assert "meta.json must define hashes as an object" in errors_hashes
+
+
+def test_default_and_compat_strict_cli_regression_without_tbd(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default and strict validation should pass with filled lock values."""
 
     errors_default = _run_validator(
         monkeypatch,
         tmp_path,
-        strict=False,
         require_lock_values=True,
         include_masters=True,
     )

--- a/tests/test_icon_core_validator.py
+++ b/tests/test_icon_core_validator.py
@@ -319,10 +319,10 @@ def test_require_lock_values_rejects_noncanonical_placeholders(
     assert any("meta.json lock placeholders found" in err for err in errors)
 
 
-def test_require_canonical_masters_requires_derived_files(
+def test_require_canonical_masters_does_not_require_derived_files(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Master enforcement mode should require derived canonical files too."""
+    """--require-canonical-masters checks masters only; derived PNGs remain optional on disk."""
 
     errors = _run_validator(
         monkeypatch,
@@ -331,9 +331,7 @@ def test_require_canonical_masters_requires_derived_files(
         include_masters=True,
         include_derived=False,
     )
-    assert any("icon_core_v1_120.png" in err for err in errors)
-    assert any("icon_core_v1_32.png" in err for err in errors)
-    assert any("icon_core_v1_24.png" in err for err in errors)
+    assert errors == []
 
 
 def test_strict_mode_reports_missing_required_top_level_meta_fields(

--- a/tests/test_icon_core_validator.py
+++ b/tests/test_icon_core_validator.py
@@ -149,6 +149,22 @@ def test_require_canonical_masters_catches_missing_masters(
     )
 
 
+def test_missing_meta_json_is_single_governance_error(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Absent meta.json should not produce duplicate governance-line errors."""
+
+    errors = _run_validator(
+        monkeypatch,
+        tmp_path,
+        include_masters=True,
+        include_meta=False,
+    )
+    meta_lines = [e for e in errors if "meta.json" in e]
+    assert len(meta_lines) == 1
+    assert meta_lines[0].startswith("missing required governance files:")
+
+
 def test_malformed_meta_json_is_detected(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_icon_core_validator.py
+++ b/tests/test_icon_core_validator.py
@@ -1,0 +1,222 @@
+"""Tests for icon core v1 validator behavior."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+from scripts import validate_icon_core_v1 as validator
+
+
+def _write_icon_core_fixture(
+    tmp_root: pathlib.Path,
+    *,
+    include_masters: bool,
+    include_meta: bool = True,
+    unexpected_files: list[str] | None = None,
+    meta_payload: dict | str | None = None,
+) -> pathlib.Path:
+    """Create a temporary icon-core fixture and return the core directory path."""
+
+    core_dir = tmp_root / "assets" / "brand" / "icon" / "core" / "v1.0"
+    core_dir.mkdir(parents=True, exist_ok=True)
+
+    (core_dir / "README.md").write_text("fixture\n", encoding="utf-8")
+
+    if include_masters:
+        for name in (
+            "icon_core_v1.svg",
+            "icon_core_v1_1024.png",
+            "icon_core_v1_60.png",
+        ):
+            (core_dir / name).write_text(f"{name}\n", encoding="utf-8")
+
+    if unexpected_files:
+        for filename in unexpected_files:
+            (core_dir / filename).write_text("unexpected\n", encoding="utf-8")
+
+    if include_meta:
+        if isinstance(meta_payload, str):
+            payload = meta_payload
+        elif meta_payload is None:
+            payload = json.dumps(
+                {
+                    "contract_id": "EMBLEM_CORE_v1.0_LOCK",
+                    "version": "v1.0",
+                    "master_policy": "dual-master-svg-png",
+                    "figma_source_type": "design",
+                    "figma_design_url": "spec://design-url",
+                    "figma_file_key": "design-file-key",
+                    "figma_node_id": "1024:2048",
+                    "assets": {
+                        "svg_master": "assets/brand/icon/core/v1.0/icon_core_v1.svg",
+                        "png_master_1024": "assets/brand/icon/core/v1.0/icon_core_1024.png",
+                        "png_master_60": "assets/brand/icon/core/v1.0/icon_core_60.png",
+                        "png_derived_120": "assets/brand/icon/core/v1.0/icon_core_120.png",
+                        "png_derived_32": "assets/brand/icon/core/v1.0/icon_core_32.png",
+                        "png_derived_24": "assets/brand/icon/core/v1.0/icon_core_24.png",
+                    },
+                    "hashes": {
+                        "master_svg_sha256": "sha256:svg",
+                        "master_png_1024_sha256": "sha256:png1024",
+                        "master_png_60_sha256": "sha256:png60",
+                        "silhouette_mask_sha256_1024": "sha256:mask1024",
+                        "silhouette_mask_sha256_60": "sha256:mask60",
+                    },
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        else:
+            payload = json.dumps(meta_payload, indent=2, ensure_ascii=False)
+
+        (core_dir / "meta.json").write_text(payload, encoding="utf-8")
+
+    return core_dir
+
+
+def _run_validator(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_root: pathlib.Path,
+    *,
+    strict: bool = False,
+    require_lock_values: bool = False,
+    include_masters: bool = True,
+    include_meta: bool = True,
+    unexpected_files: list[str] | None = None,
+    meta_payload: dict | str | None = None,
+) -> list[str]:
+    core_dir = _write_icon_core_fixture(
+        tmp_root,
+        include_masters=include_masters,
+        include_meta=include_meta,
+        unexpected_files=unexpected_files,
+        meta_payload=meta_payload,
+    )
+    monkeypatch.setattr(validator, "CORE_DIR", core_dir)
+    return validator.validate(strict=strict, require_lock_values=require_lock_values)
+
+
+def test_default_validator_passes_current_repo_fixture() -> None:
+    """Current repository fixture should pass in default mode."""
+
+    result = subprocess.run(
+        [sys.executable, "scripts/validate_icon_core_v1.py"],
+        cwd=pathlib.Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "OK: icon core v1.0 structure valid (default mode)" in result.stdout
+
+
+def test_strict_catches_missing_masters(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Strict mode should fail when canonical masters are missing."""
+
+    errors = _run_validator(
+        monkeypatch,
+        tmp_path,
+        strict=True,
+        include_masters=False,
+    )
+    assert any(err.startswith("missing canonical masters (strict mode)") for err in errors)
+
+
+def test_malformed_meta_json_is_detected(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Malformed meta JSON must be reported as validation error."""
+
+    errors = _run_validator(
+        monkeypatch,
+        tmp_path,
+        include_masters=True,
+        meta_payload='{"contract_id": "bad", "assets": ',
+    )
+    assert any("invalid meta.json" in err for err in errors)
+
+
+def test_unexpected_file_is_detected(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unexpected files in the icon core directory must fail validation."""
+
+    errors = _run_validator(
+        monkeypatch,
+        tmp_path,
+        include_masters=True,
+        unexpected_files=["tmp_backup.txt"],
+    )
+    assert any(err.startswith("unexpected files in") for err in errors)
+
+
+def test_require_lock_values_rejects_placeholders(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Lock mode must reject TBD placeholders and report exact fields."""
+
+    meta_with_placeholders = {
+        "contract_id": "EMBLEM_CORE_v1.0_LOCK",
+        "version": "v1.0",
+        "master_policy": "dual-master-svg-png",
+        "figma_source_type": "design",
+        "figma_design_url": "TBD_AFTER_WINNER_LOCK",
+        "figma_file_key": "TBD_AFTER_WINNER_LOCK",
+        "figma_node_id": "TBD_AFTER_WINNER_LOCK",
+        "assets": {
+            "svg_master": "assets/brand/icon/core/v1.0/icon_core_v1.svg",
+            "png_master_1024": "assets/brand/icon/core/v1.0/icon_core_v1_1024.png",
+            "png_master_60": "assets/brand/icon/core/v1.0/icon_core_1_60.png",
+            "png_derived_120": "assets/brand/icon/core/v1.0/icon_core_v1_120.png",
+            "png_derived_32": "assets/brand/icon/core/v1.0/icon_core_v1_32.png",
+            "png_derived_24": "assets/brand/icon/core/v1.0/icon_core_v1_24.png",
+        },
+        "hashes": {
+            "master_svg_sha256": "TBD_AFTER_WINNER_LOCK",
+            "master_png_1024_sha256": "TBD_AFTER_WINNER_LOCK",
+            "master_png_60_sha256": "TBD_AFTER_WINNER_LOCK",
+            "silhouette_mask_sha256_1024": "TBD_AFTER_WINNER_LOCK",
+            "silhouette_mask_sha256_60": "TBD_AFTER_WINNER_LOCK",
+        },
+    }
+
+    errors = _run_validator(
+        monkeypatch,
+        tmp_path,
+        strict=True,
+        require_lock_values=True,
+        include_masters=True,
+        meta_payload=meta_with_placeholders,
+    )
+    assert any("meta.json lock placeholders found" in err for err in errors)
+
+
+def test_default_and_strict_regression_without_tbd(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default and strict validator modes should both pass with filled lock values."""
+
+    errors_default = _run_validator(
+        monkeypatch,
+        tmp_path,
+        strict=False,
+        require_lock_values=True,
+        include_masters=True,
+    )
+    errors_strict = _run_validator(
+        monkeypatch,
+        tmp_path,
+        strict=True,
+        require_lock_values=True,
+        include_masters=True,
+    )
+    assert errors_default == []
+    assert errors_strict == []

--- a/tests/test_orchestration_preflight.py
+++ b/tests/test_orchestration_preflight.py
@@ -66,6 +66,41 @@ def test_execute_mode_fails_when_dirty_tree_outside_scope(monkeypatch: pytest.Mo
     )
 
 
+def test_execute_mode_preserves_leading_status_space_for_top_level_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Top-level files must not be truncated when porcelain status begins with a space."""
+
+    monkeypatch.setattr(preflight, "check_sot_files", lambda: True)
+    monkeypatch.setattr(preflight, "check_worktrees_untracked", lambda: True)
+    monkeypatch.setattr(preflight, "check_agent_consistency", lambda: True)
+    monkeypatch.setattr(preflight, "check_artifact_gitignore", lambda: True)
+    monkeypatch.setattr(preflight, "check_scoped_agents_exist", lambda _paths: True)
+    monkeypatch.setattr(
+        preflight,
+        "_run",
+        lambda cmd, cwd=None: (0, " M Makefile\n M docs/orchestration/workflow.md"),
+    )
+
+    assert (
+        preflight.main(
+            [
+                "--mode",
+                "execute",
+                "--path",
+                "Makefile",
+                "--path",
+                "docs/orchestration",
+                "--primary",
+                "agent-coordinator",
+                "--reviewer",
+                "architecture-specialist",
+            ]
+        )
+        == 0
+    )
+
+
 def test_merge_mode_requires_gate_evidence(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Merge mode must fail when gate evidence file is missing."""
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD033 -->

# Pull Request

## Summary

(Free-form description of changes, e.g., "Fix crash in BMI calculation when height is zero")

- [ ] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [ ] Select one change type:
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

(User-facing change? Data model/migration? Security- or Performance-sensitive?)

- [ ] User-facing change
- [ ] Data model/migration
- [ ] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

(Unit: small isolated functions; Integration: endpoints/DB; Manual: steps to verify)

- [ ] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [ ] Manual verification steps

## CI Gates

(PR tests must pass; Diff coverage means tests cover changed lines ≥ threshold)

- [ ] PR tests green (lint, type, unit)
- [ ] Diff coverage ≥ 97% on changed lines

## Split Justification

(Required only when the PR is > 800 changed LoC under Tier 1 governance.)

- Why this PR cannot be split safely:
- What invariant, contract, or rollout constraint requires one PR:
- What follow-up PRs remain after this large change:

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- `<review-comment-url>` -> `<commit-sha>`
- No actionable review comments

## Merge Readiness (Mandatory)

- [ ] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups

- [ ] Ledger item(s): <link to docs/roadmap/BACKLOG_LEDGER.md entry or "None">
- [ ] GitHub issue(s): <link> (if any)

## Notes

### For Simple Changes

Use this checklist to confirm the PR is truly simple:

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Example: Copy change in docs, minor log level tweak, small refactor of a pure function.

Rollback / Feature flag (brief):

- How to revert: describe the commit to revert or config to change
- Feature flag/toggle (if any): name and how to disable
- Owner for emergency contact: @username

### For Complex/High-Risk Changes

Please fill out the following sections if applicable:

#### Deployment Strategy

- [ ] Deployment order for multi-service changes (if services depend on each other)
- [ ] Feature flag configuration (enable/disable without redeploy)
- [ ] Blue-green / canary deployment plan (if applicable)

#### Database & Data Changes

- [ ] Database migrations required (Alembic version, backwards compatibility)
- [ ] Data migration/backfill steps (scripts, rollback procedures)
- [ ] Data cleanup steps (if removing deprecated data)
- [ ] Backwards compatibility guarantees (old clients still work)

#### Monitoring & Observability

- [ ] New monitoring/alerting rules to add (metrics, thresholds, SLOs)
- [ ] Dashboards to create/update (Grafana, DataDog, etc.)
- [ ] Logging changes (new log levels, structured logs, correlation IDs)
- [ ] Health check endpoints affected

#### Post-Deploy Verification

- [ ] Manual verification checklist (specific endpoints, user flows)
- [ ] Smoke tests to run (automated or manual)
- [ ] Performance benchmarks to verify (latency, throughput)
- [ ] Rollback triggers (what conditions require immediate rollback)

#### Additional Context

- [ ] Breaking changes (API contracts, response formats)
- [ ] Dependencies updated (requirements.txt, package versions)
- [ ] Configuration changes (env vars, secrets, feature toggles)
- [ ] Documentation updates needed (README, API docs, runbooks)

<!-- markdownlint-enable MD013 MD033 -->

## Summary by Sourcery

Ввести более строгую локальную для репозитория валидацию ассетов icon core v1, включая проверки режима блокировки (lock-mode), а также задокументировать поведение lane для защитного этапа (guard) ассетов App Store.

Enhancements:
- Расширить валидатор icon core v1 для принудительного контроля требуемой структуры `meta.json`, ключей `asset/hash`, а также опционального отклонения плейсхолдеров блокировки с помощью нового флага CLI.
- Уточнить документацию `APPSTORE_SCREENSHOT_ASSET_GATE` и `NEXT_DESIGN_AUTOMATION_MODULE_DECISION`, описав lane валидатора иконок, его ненетворковый (локальный) охват и роль только в применении (enforcement-only), без дополнительных побочных действий.

Documentation:
- Задокументировать скрипт валидатора icon core как часть App Store asset gate и явно ограничить его областью детерминированной, исключительно локальной проверки без загрузок или генерации ассетов.
- Обновить документацию по проектным решениям (design decision docs), зафиксировав, что этот PR реализует только локальный для репозитория валидатор иконок и часть процессов управления (governance slice), без изменений поведения во время исполнения или при загрузке.

Tests:
- Добавить комплексные тесты для валидатора icon core, покрывающие успешные сценарии, ошибки в строгом режиме, некорректный `meta.json`, неожиданные файлы и обнаружение плейсхолдеров режима блокировки (lock-mode).

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce stricter repo-local validation for icon core v1 assets, including lock-mode checks, and document the App Store asset guard lane behavior.

Enhancements:
- Extend icon core v1 validator to enforce required meta.json structure, asset/hash keys, and optional lock placeholder rejection via a new CLI flag.
- Clarify APPSTORE_SCREENSHOT_ASSET_GATE and NEXT_DESIGN_AUTOMATION_MODULE_DECISION docs to describe the icon asset validator lane, its non-networked scope, and enforcement-only role.

Documentation:
- Document the icon core validator script as part of the App Store asset gate and explicitly scope it to deterministic, local-only enforcement without uploads or asset generation.
- Update design decision docs to record that this PR implements only the repo-local icon asset validator and governance slice, with no runtime or upload behavior changes.

Tests:
- Add comprehensive tests for the icon core validator covering success paths, strict mode failures, malformed meta.json, unexpected files, and lock-mode placeholder detection.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds lock-mode and canonical-masters checks to the icon asset validator, enforces strict metadata/path rules, and runs strict checks in `make` and iOS verify. Hardens the validator with repo-root anchoring, a `meta.json` size cap, safer JSON error reporting, and updates docs/tests; refines the PR_1715 fixed-mapping artifact to pass the mapping validator and include the aggregated Cubic review.

- **New Features**
  - `scripts/validate_icon_core_v1.py`: adds `--require-canonical-masters` and `--require-lock-values`; strict validates required meta fields and canonical asset paths; allows canonical derived PNGs.
  - Makefile uses `$(DEV_PYTHON)` and runs default + `--strict`; `ios-appstore-verify` runs `--strict`.
  - Docs reinforce repo-local, enforcement-only scope and add validation commands; added/updated `docs/review/PR_1715_FIXED_MAPPING.md` to comply with mapping rules and record the Cubic review.

- **Bug Fixes**
  - Guard `assets`/`hashes` shape checks behind key presence; remove duplicate missing `meta.json` error; align canonical-masters to masters only; `check_preflight.py` preserves leading status spaces (tests added).
  - Security hardening: anchor validation to repo root and block symlink escapes; add `--repo-root`; cap `meta.json` at 256 KiB; limit JSON parse errors to line/column (tests added).

<sup>Written for commit 771783c6a5bd745d7affa630fffc7937d570cd6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded decision packet, release/runbook, README and review mapping to clarify validator scope, non-goals, gating/checklist, pre-lock guidance, and owner responsibilities.

* **New Features**
  * Validator now accepts canonical derived PNGs, adds stricter meta/schema checks and new options to require lock values and canonical masters; strict validation runs added to CI/preflight.

* **Tests**
  * New tests for validator modes, schema/metadata errors, lock-value enforcement, canonical-master rules, and edge cases.

* **Chores**
  * Preflight output handling adjusted to preserve leading whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

