### PR TITLE
fix(release): bind build-equivalence digests to governed sources

### DIFF
--- a/.github/workflows/build-equivalence-evidence.yml
+++ b/.github/workflows/build-equivalence-evidence.yml
@@ -16,8 +16,16 @@ on:
         description: "App Review build artifact digest in sha256:<64 lowercase hex> format"
         required: true
         type: string
+      review_artifact_digest_source:
+        description: "Single-line JSON with run_id, artifact_name, path=release-control-plane-build-sources for governed App Review artifact digest"
+        required: true
+        type: string
       production_candidate_artifact_digest:
         description: "Production-candidate build artifact digest in sha256:<64 lowercase hex> format"
+        required: true
+        type: string
+      production_candidate_artifact_digest_source:
+        description: "Single-line JSON with run_id, artifact_name, path=release-control-plane-build-sources for governed production-candidate artifact digest"
         required: true
         type: string
       evidence_artifact_name:
@@ -54,8 +62,10 @@ jobs:
           EXPECTED_GIT_SHA: ${{ inputs.git_sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRODUCTION_CANDIDATE_ARTIFACT_DIGEST: ${{ inputs.production_candidate_artifact_digest }}
+          PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE: ${{ inputs.production_candidate_artifact_digest_source }}
           RELEASE_MANIFEST_SOURCE: ${{ inputs.release_manifest_source }}
           REVIEW_ARTIFACT_DIGEST: ${{ inputs.review_artifact_digest }}
+          REVIEW_ARTIFACT_DIGEST_SOURCE: ${{ inputs.review_artifact_digest_source }}
         run: |
           set -euo pipefail
 
@@ -73,6 +83,34 @@ jobs:
           release_manifest_artifact_name="$RELEASE_MANIFEST_ARTIFACT_NAME"
           # shellcheck disable=SC2153
           release_manifest_source_path="$RELEASE_MANIFEST_PATH"
+          review_digest_source_env="${RUNNER_TEMP}/build-equivalence-review-digest-source.env"
+          python scripts/release/evidence_source.py source-env \
+            --label review_artifact_digest \
+            --prefix REVIEW_ARTIFACT_DIGEST_SOURCE \
+            --expected-path release-control-plane-build-sources \
+            --source-json "$REVIEW_ARTIFACT_DIGEST_SOURCE" > "$review_digest_source_env"
+          # shellcheck disable=SC1090
+          . "$review_digest_source_env"
+          # shellcheck disable=SC2153
+          review_digest_run_id="$REVIEW_ARTIFACT_DIGEST_SOURCE_RUN_ID"
+          # shellcheck disable=SC2153
+          review_digest_artifact_name="$REVIEW_ARTIFACT_DIGEST_SOURCE_ARTIFACT_NAME"
+          # shellcheck disable=SC2153
+          review_digest_source_path="$REVIEW_ARTIFACT_DIGEST_SOURCE_PATH"
+          production_digest_source_env="${RUNNER_TEMP}/build-equivalence-production-digest-source.env"
+          python scripts/release/evidence_source.py source-env \
+            --label production_candidate_artifact_digest \
+            --prefix PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE \
+            --expected-path release-control-plane-build-sources \
+            --source-json "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE" > "$production_digest_source_env"
+          # shellcheck disable=SC1090
+          . "$production_digest_source_env"
+          # shellcheck disable=SC2153
+          production_digest_run_id="$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE_RUN_ID"
+          # shellcheck disable=SC2153
+          production_digest_artifact_name="$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE_ARTIFACT_NAME"
+          # shellcheck disable=SC2153
+          production_digest_source_path="$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST_SOURCE_PATH"
 
           EVIDENCE_ARTIFACT_NAME="$(python scripts/release/evidence_source.py artifact-name "$EVIDENCE_ARTIFACT_NAME")"
           expected_git_sha_lc="$(python scripts/release/evidence_source.py git-sha "$EXPECTED_GIT_SHA")"
@@ -129,12 +167,59 @@ jobs:
 
           validate_source_run "release manifest" "$release_manifest_run_id" \
             "Release Manifest Evidence" ".github/workflows/release-manifest-evidence.yml"
+          validate_source_run "review artifact digest" "$review_digest_run_id" \
+            "Docker Build and Push" ".github/workflows/build.yml"
+          validate_source_run "production-candidate artifact digest" "$production_digest_run_id" \
+            "Docker Build and Push" ".github/workflows/build.yml"
+
+          fetch_text_source() {
+            label="$1"
+            source_path="$2"
+            download_dir="$3"
+            expected_value="$4"
+            mkdir -p "$download_dir"
+            source_file="${download_dir}/${source_path}/artifact_digest.txt"
+            if [ ! -f "$source_file" ]; then
+              echo "ERROR: Missing governed ${label} at ${source_path}/artifact_digest.txt"
+              exit 1
+            fi
+            resolved_download_dir="$(cd "$download_dir" && pwd -P)"
+            resolved_source_file="$(python - "$source_file" <<'PY'
+          from pathlib import Path
+          import sys
+
+          print(Path(sys.argv[1]).resolve())
+          PY
+            )"
+            case "$resolved_source_file" in
+              "$resolved_download_dir"/*) ;;
+              *) echo "ERROR: ${label} path escapes downloaded artifact"; exit 1 ;;
+            esac
+            actual_value="$(python - "$source_file" <<'PY'
+          from pathlib import Path
+          import sys
+
+          print(Path(sys.argv[1]).read_text(encoding="utf-8").strip())
+          PY
+            )"
+            actual_value="$(python scripts/release/evidence_source.py oci-digest --label "${label}_source" "$actual_value")"
+            if [ "$actual_value" != "$expected_value" ]; then
+              echo "ERROR: governed ${label} source does not match explicit input"
+              exit 1
+            fi
+          }
 
           download_dir="${RUNNER_TEMP}/build-equivalence-release-manifest-source"
+          review_digest_download_dir="${RUNNER_TEMP}/build-equivalence-review-digest-source"
+          production_digest_download_dir="${RUNNER_TEMP}/build-equivalence-production-digest-source"
           output_dir="${RUNNER_TEMP}/build-equivalence-evidence"
           identities_dir="${RUNNER_TEMP}/build-equivalence-identities"
-          mkdir -p "$download_dir" "$output_dir" "$identities_dir"
+          mkdir -p "$download_dir" "$review_digest_download_dir" "$production_digest_download_dir" "$output_dir" "$identities_dir"
           gh run download "$release_manifest_run_id" --name "$release_manifest_artifact_name" --dir "$download_dir"
+          gh run download "$review_digest_run_id" --name "$review_digest_artifact_name" --dir "$review_digest_download_dir"
+          gh run download "$production_digest_run_id" --name "$production_digest_artifact_name" --dir "$production_digest_download_dir"
+          fetch_text_source "review artifact digest" "$review_digest_source_path" "$review_digest_download_dir" "$REVIEW_ARTIFACT_DIGEST"
+          fetch_text_source "production-candidate artifact digest" "$production_digest_source_path" "$production_digest_download_dir" "$PRODUCTION_CANDIDATE_ARTIFACT_DIGEST"
           release_manifest_path="${download_dir}/${release_manifest_source_path}"
           if [ ! -f "$release_manifest_path" ]; then
             echo "ERROR: Missing governed release_manifest.json at ${release_manifest_source_path}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -499,6 +499,10 @@ jobs:
           attestation_payload = json.loads(attestation.read_text(encoding="utf-8"))
           if attestation_payload.get("passed") is not True:
               raise SystemExit("ERROR: Docker provenance/SBOM attestations are not verified")
+          (source_dir / "artifact_digest.txt").write_text(
+              "${{ steps.docker-build-push.outputs.digest }}\n",
+              encoding="utf-8",
+          )
           (source_dir / "sbom_digest.txt").write_text(
               f"sha256:{hashlib.sha256(sbom.read_bytes()).hexdigest()}\n",
               encoding="utf-8",
@@ -515,6 +519,7 @@ jobs:
         with:
           name: release-control-plane-build-sources
           path: |
+            release-control-plane-build-sources/artifact_digest.txt
             release-control-plane-build-sources/sbom_digest.txt
             release-control-plane-build-sources/provenance_digest.txt
             release-control-plane-build-sources/attestation_status.txt

--- a/docs/review/PR_1716_FIXED_MAPPING.md
+++ b/docs/review/PR_1716_FIXED_MAPPING.md
@@ -1,0 +1,52 @@
+<!-- markdownlint-disable MD013 MD034 -->
+# PR 1716 Fixed In Commit Mapping
+
+- PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1716>
+- Branch: `codex/fix-build-equivalence-evidence-vulnerability`
+- Title: `fix(release): bind build-equivalence digests to governed sources`
+- Initial reviewed head: `897294216ab1315e9fbe4797b6a7cb234fc5b92a`
+- Review-fix commit: `64b6c33d0b951a05fe3bf0b607096e20337d22c7`
+- Status: binds review/production digests to governed build-source artifacts (implementation); Phase2 mapping + tighter upload regression test tracked in bookkeeping commit atop this SHA.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Open review-bot actionables were dispositioned against the governance YAML change (`64b6c33`). This file plus the bookkeeping commit add merge-gate SoT coverage and assertions. PR body mirrors Phase2 checklist items only.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1716#discussion_r3212916333 -> 64b6c33d0b951a05fe3bf0b607096e20337d22c7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1716#discussion_r3212921878 -> 64b6c33d0b951a05fe3bf0b607096e20337d22c7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1716#pullrequestreview-4257513239 -> 64b6c33d0b951a05fe3bf0b607096e20337d22c7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1716#pullrequestreview-4257518721 -> 64b6c33d0b951a05fe3bf0b607096e20337d22c7
+
+Disposition: FIXED
+
+Commit: 64b6c33d0b951a05fe3bf0b607096e20337d22c7
+
+Evidence: `.github/workflows/build-equivalence-evidence.yml` validates `review_artifact_digest_source` / `production_candidate_artifact_digest_source` via governed `artifact_digest.txt` downloads and oci-digest checks before emitting equivalence evidence; upload uses `steps.generate-build-equivalence-evidence.outputs.artifact_name` (not `${{ inputs.evidence_artifact_name }}`).
+
+Evidence: `.github/workflows/build.yml` publishes `release-control-plane-build-sources/artifact_digest.txt` from the Docker build digest output.
+
+Evidence: `tests/test_build_equivalence_evidence_workflow.py` asserts upload-artifact binds the artifact `name` to the generation step output, step ordering versus the generate step, and rejects wiring the upload `with.name` straight to `${{ inputs.* }}`.
+
+Evidence: Aggregate review links disposition to the same governed-digest workflow commit noted above.
+
+## Local Validation Evidence
+
+- `.venv/bin/python3 -m pytest tests/test_build_equivalence_evidence_workflow.py` — PASS
+
+## Security Notes
+
+- Reduces trust in operator-supplied digest strings by requiring matching governed build-source artifacts and successful source-run metadata checks.
+
+## Risks / Rollback
+
+- Risk: callers must supply new JSON source inputs for equivalence runs. Mitigation: migration notes in PR description.
+- Rollback: revert `64b6c33d0b951a05fe3bf0b607096e20337d22c7` to drop governed digest enforcement; revert bookkeeping commits that added this artifact if merge policy must unwind.
+
+## Deferred / Follow-ups
+
+- None for this mapping cycle.

--- a/tests/test_build_equivalence_evidence_workflow.py
+++ b/tests/test_build_equivalence_evidence_workflow.py
@@ -109,15 +109,22 @@ def test_workflow_permissions_environment_and_inputs_are_bounded() -> None:
         "git_sha",
         "release_manifest_source",
         "review_artifact_digest",
+        "review_artifact_digest_source",
         "production_candidate_artifact_digest",
+        "production_candidate_artifact_digest_source",
         "evidence_artifact_name",
     }
 
     assert set(inputs) == expected_inputs
     assert all(inputs[name]["required"] is True for name in expected_inputs)
-    assert "run_id" in inputs["release_manifest_source"]["description"]
-    assert "artifact_name" in inputs["release_manifest_source"]["description"]
-    assert "path" in inputs["release_manifest_source"]["description"]
+    for source_input in (
+        "release_manifest_source",
+        "review_artifact_digest_source",
+        "production_candidate_artifact_digest_source",
+    ):
+        assert "run_id" in inputs[source_input]["description"]
+        assert "artifact_name" in inputs[source_input]["description"]
+        assert "path" in inputs[source_input]["description"]
     assert workflow["permissions"] == {"actions": "read", "contents": "read"}
     assert _job(workflow)["environment"]["name"] == "release-evidence"
     workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
@@ -142,17 +149,26 @@ def test_workflow_validates_release_manifest_source_run_and_git_sha() -> None:
     assert '[ "$run_conclusion" != "success" ]' in script
     assert '[ "$run_event" != "workflow_dispatch" ]' in script
     assert '"Release Manifest Evidence" ".github/workflows/release-manifest-evidence.yml"' in script
+    assert '"Docker Build and Push" ".github/workflows/build.yml"' in script
     assert "source run head SHA does not match git_sha" in script
     assert "Build Equivalence Evidence workflow ref must match git_sha" in script
 
 
-def test_workflow_keeps_review_and_production_candidate_digests_explicit() -> None:
+def test_workflow_binds_review_and_production_candidate_digests_to_sources() -> None:
     script = _run_script()
     workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
 
-    assert "review_artifact_digest_source" not in workflow_text
-    assert "production_candidate_artifact_digest_source" not in workflow_text
-    assert "fetch_digest_source" not in script
+    assert "review_artifact_digest_source" in workflow_text
+    assert "production_candidate_artifact_digest_source" in workflow_text
+    assert "--label review_artifact_digest" in script
+    assert "--label production_candidate_artifact_digest" in script
+    assert "--expected-path release-control-plane-build-sources" in script
+    assert "fetch_text_source" in script
+    assert "artifact_digest.txt" in script
+    assert 'gh run download "$review_digest_run_id"' in script
+    assert 'gh run download "$production_digest_run_id"' in script
+    assert "governed ${label} source does not match explicit input" in script
+    assert "path escapes downloaded artifact" in script
     assert "scripts/release/evidence_source.py oci-digest --label review_artifact_digest" in script
     assert (
         "scripts/release/evidence_source.py oci-digest --label production_candidate_artifact_digest"
@@ -266,8 +282,10 @@ def test_workflow_has_no_app_store_fastlane_or_runtime_surface() -> None:
     assert "ci/release-control-plane-source-producers" in LEDGER_PATH.read_text(encoding="utf-8")
 
 
-def test_docker_build_workflow_does_not_self_certify_review_or_production_digests() -> None:
+def test_docker_build_workflow_publishes_governed_artifact_digest_source() -> None:
     workflow_text = BUILD_WORKFLOW_PATH.read_text(encoding="utf-8")
 
+    assert "artifact_digest.txt" in workflow_text
+    assert "${{ steps.docker-build-push.outputs.digest }}" in workflow_text
     assert "review_artifact_digest.txt" not in workflow_text
     assert "production_candidate_artifact_digest.txt" not in workflow_text


### PR DESCRIPTION
### Motivation

- Prevent minting of falsified build-equivalence evidence by ensuring compared digests are backed by governed artifact sources rather than operator-supplied assertions.
- Tighten release-control-plane producer trust boundary so equivalence evidence is only produced when the digest strings are validated against published build-source artifacts.
- Keep existing behavior of generating deterministic build identity artifacts while adding an authoritative binding to the Docker build outputs.

### Description

- Added new workflow dispatch inputs `review_artifact_digest_source` and `production_candidate_artifact_digest_source` to `.github/workflows/build-equivalence-evidence.yml` and wire them into the evidence generation step so both digest strings must be accompanied by governed source objects. 
- Implemented validation steps in the build-equivalence workflow to `gh run download` the governed `release-control-plane-build-sources` artifacts and read `artifact_digest.txt`, then canonicalize/validate the digest formats and require the downloaded digest to match the explicit input before generating identities and publishing `EQUIVALENT` evidence.
- Updated `.github/workflows/build.yml` to publish `release-control-plane-build-sources/artifact_digest.txt` containing the actual Docker build digest so governed consumers can bind the digest to the produced artifact.
- Updated tests in `tests/test_build_equivalence_evidence_workflow.py` to assert the new source-bound inputs, the governed-download/validation behavior, and the Docker build digest publication.

### Testing

- Ran preflight and consistency checks: `python3 scripts/orchestration/check_preflight.py` (PASS) and `python3 scripts/orchestration/check_agent_consistency.py` (PASS).
- Ran focused workflow tests: `PYENV_VERSION=3.13.13 pytest -q tests/test_build_equivalence_evidence_workflow.py tests/test_release_manifest_evidence_workflow.py` (PASS) and parsed both modified workflows with `yaml.safe_load` (PASS); also ran `ruff`, `pre-commit --all-files`, `make validate-changed`, `make lint`, and `make typecheck` with all passing results on the touched surfaces.
- Two local gating commands could not complete or had unrelated failures: `make verify` was blocked by a missing `.venv` / `make venv` step (`❌ .venv missing. Run 'make venv' first.`) and `make venv` failed here due to missing private package proxy (`❌ Export PULSEPLATE_PYTHON_INDEX_URL to the approved private package proxy before continuing.`), and `PYENV_VERSION=3.13.13 make test-fast` hit unrelated existing VIP smoke failures in `tests/edges/test_vip_auth_edges.py` with assertion failures `tests/edges/test_vip_auth_edges.py:62` and `tests/edges/test_vip_auth_edges.py:77` showing `404 != 403` and `404 != 200` respectively; these VIP failures pre-existed in the local environment and are not caused by the release producer changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef90a1e188333ae098a1ef670c522)

## Summary by Sourcery

Связать генерацию доказательств эквивалентности сборок с управляемыми артефактами Docker build-source вместо переданных оператором строк дайджестов.

Исправления ошибок:
- Обеспечить генерацию доказательств эквивалентности сборок только в том случае, когда дайджесты review и production-candidate проверены по отношению к управляемым артефактам build-source.

Улучшения:
- Расширить входные данные рабочего процесса build-equivalence, включив в них управляемые метаданные исходников для дайджестов review и production-candidate и проверяя их исходные запуски.
- Загружать и проверять управляемые файлы `artifact_digest.txt` для обоих дайджестов, отклоняя несоответствия или попытки выхода за пределы путей до публикации идентификаторов эквивалентности.
- Публиковать дайджест Docker-образа как `artifact_digest.txt` из рабочего процесса сборки, чтобы он мог служить авторитетным источником для последующих проверок эквивалентности.

Тесты:
- Усилить тесты рабочих процессов, чтобы покрыть новые входные данные дайджестов, привязанные к исходникам, загрузку/валидацию управляемых артефактов и публикацию дайджеста Docker-сборки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bind build-equivalence evidence generation to governed Docker build-source artifacts instead of operator-supplied digest strings.

Bug Fixes:
- Ensure build-equivalence evidence is only generated when review and production-candidate digests are validated against governed build-source artifacts.

Enhancements:
- Extend the build-equivalence workflow inputs to include governed source metadata for review and production-candidate digests and validate their originating runs.
- Download and verify governed artifact_digest.txt files for both digests, rejecting mismatches or path-escape attempts before emitting equivalence identities.
- Publish the Docker image digest as artifact_digest.txt from the build workflow so it can serve as an authoritative source for downstream equivalence checks.

Tests:
- Strengthen workflow tests to cover the new source-bound digest inputs, governed artifact download/validation, and Docker build digest publication.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind build-equivalence digests to governed Docker build sources to prevent falsified evidence. Evidence is generated only when input digests match the digests published by the build workflow, and the upload name is bound to the generator output.

- **Bug Fixes**
  - Added required inputs `review_artifact_digest_source` and `production_candidate_artifact_digest_source`.
  - Download governed `release-control-plane-build-sources` and compare `artifact_digest.txt` to each explicit digest (canonicalized). Fail on mismatch or path escape.
  - Validate source runs are successful and from "Docker Build and Push" (`.github/workflows/build.yml`), and keep existing release-manifest and git SHA checks.
  - `build.yml` now publishes `release-control-plane-build-sources/artifact_digest.txt` with `${{ steps.docker-build-push.outputs.digest }}`.
  - Pin evidence upload artifact name to the generation step output; tests enforce this and the governed-digest checks.

- **Migration**
  - Pass both new source inputs as single-line JSON: `{run_id, artifact_name, path=release-control-plane-build-sources}` pointing to the Docker build run.
  - Ensure the referenced build uploaded `artifact_digest.txt` (re-run build if absent).

<sup>Written for commit a0f73684b7b072d00bce2352a4015fb553fde982. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added governed-source validation for release artifact digests to ensure published digests are provably sourced.
  * Build process now publishes a verified artifact digest file alongside releases.
* **Tests**
  * Expanded tests to assert artifact digest sourcing and validation behavior.
* **Documentation**
  * Updated docs describing the provenance checks, evidence generation, and rollback guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1716)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_1716_FIXED_MAPPING.md`
