### PR TITLE
fix(ci): emergency wheel for pre-commit 4.6.0 (proxy lag)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -466,51 +466,58 @@
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "7ab56d932ca71392d0d6f5c7584972c6d403a559",
+        "hashed_secret": "37f3319b650b84e9a7b3ed6aed6e3174d4b9aca3",
         "is_verified": false,
         "line_number": 89
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "77eba9fe3fffb9d2c5e751112eaf0361c00f4d86",
+        "hashed_secret": "7ab56d932ca71392d0d6f5c7584972c6d403a559",
         "is_verified": false,
-        "line_number": 97
+        "line_number": 96
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "68083e2bb8c89c57a4ea17b8b5c3894531e62f10",
+        "hashed_secret": "77eba9fe3fffb9d2c5e751112eaf0361c00f4d86",
         "is_verified": false,
         "line_number": 104
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "32b39bf851676b2992116bdc163f05656b2396e7",
+        "hashed_secret": "68083e2bb8c89c57a4ea17b8b5c3894531e62f10",
         "is_verified": false,
         "line_number": 111
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "9d99ddcde81d214a71fbade9b758ef72213c835d",
+        "hashed_secret": "32b39bf851676b2992116bdc163f05656b2396e7",
         "is_verified": false,
         "line_number": 118
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "d17b1dc21afd47e49ba9ece8f526d561059f8a7d",
+        "hashed_secret": "9d99ddcde81d214a71fbade9b758ef72213c835d",
         "is_verified": false,
         "line_number": 125
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "b777d4f08355af27079aa47b08fd59962aedf588",
+        "hashed_secret": "d17b1dc21afd47e49ba9ece8f526d561059f8a7d",
         "is_verified": false,
         "line_number": 132
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "scripts/ci/emergency_python_wheels.json",
+        "hashed_secret": "b777d4f08355af27079aa47b08fd59962aedf588",
+        "is_verified": false,
+        "line_number": 139
       }
     ],
     "scripts/ensure_database_versions.py": [

--- a/docs/review/PR_1723_FIXED_MAPPING.md
+++ b/docs/review/PR_1723_FIXED_MAPPING.md
@@ -1,0 +1,54 @@
+<!-- markdownlint-disable MD013 MD034 -->
+# PR 1723 Fixed In Commit Mapping
+
+- PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1723>
+- Branch: `fix/ci-emergency-wheel-pre-commit-460`
+- Title: `fix(ci): emergency wheel for pre-commit 4.6.0 (proxy lag)`
+- Implementing commit (pre-commit emergency wheel): `d58ea8eac16e71e9c305b1fc65b373b7632999a3`
+- Scope: `scripts/ci/emergency_python_wheels.json` (privileged CI surface), `.secrets.baseline` (detect-secrets refresh for manifest digest lines). No runtime application source changes.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+CI hotfix: registers the PyPI-hosted `pre-commit` 4.6.0 universal wheel for emergency install when the approved private proxy lags PyPI (same pattern as #1722 / hypothesis). CodeRabbit, Sourcery, and Cubic auto-summaries contained no actionable inline items requiring a disposition beyond this artifact.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Local Validation Evidence
+
+- Pre-flight: `python3 scripts/orchestration/check_preflight.py` — PASS.
+- Pre-flight: `python3 scripts/orchestration/check_agent_consistency.py` — PASS (runs as part of `check_preflight` bundle where configured).
+- `make validate-min` — PASS.
+- PyPI cross-check: URL `https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl` and `sha256=e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b` confirmed against `https://pypi.org/pypi/pre-commit/4.6.0/json` (matches exactly).
+- Targeted test: `pytest tests/test_install_locked_python_requirements.py::test_repo_emergency_manifest_tracks_current_active_fallback_set` — PASS.
+
+### Machine-heavy / operator-approved narrow gate
+
+- This PR scopes only `scripts/ci/**` (privileged surface) and `.secrets.baseline`. Per operator-approved narrow-gate policy and root `AGENTS.md` "Machine-heavy PR exception", full local `make verify` is deferred; PR-scoped gates above plus current-head GitHub CI are the merge truth signal.
+
+## Security Notes
+
+- Supply-chain: emergency wheel uses the canonical PyPI artifact (`files.pythonhosted.org`) with exact `sha256` digest matching PyPI metadata.
+- `.secrets.baseline` refresh follows repo detect-secrets policy for rotated hex fingerprints on `scripts/ci/emergency_python_wheels.json`, not a credential leak.
+
+## Risks / Rollback
+
+- Risk: manifest `expires_at` remains `2026-05-27`; remove the `pre-commit` entry once the private proxy serves `4.6.0` without miss.
+- Rollback: revert implementing commit `d58ea8eac16e71e9c305b1fc65b373b7632999a3` and regenerate `.secrets.baseline` for the prior manifest state.
+
+## Merge Readiness
+
+- [x] Pre-flight + agent consistency: PASS
+- [x] Canonical artifact: this file (`docs/review/PR_1723_FIXED_MAPPING.md`)
+- [x] PR body mirrors Discussion Thread Pass / Fixed in Commit Mapping / Merge Readiness sections
+- [x] Narrow gate: `make validate-min` (operator-approved, scope = `scripts/ci/**` + secrets baseline)
+- [x] CI parity (current-head): canonical Tier-1 `CI` workflow + merge governance gates once Phase2 body + artifact are on the branch tip
+- [x] Bot summaries reviewed (CodeRabbit / Sourcery / Cubic): no actionable code changes required
+
+## Deferred / Follow-ups
+
+- Remove emergency `pre-commit` wheel entry after proxy parity or manifest rotation policy.

--- a/scripts/ci/emergency_python_wheels.json
+++ b/scripts/ci/emergency_python_wheels.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "generated_at": "2026-05-10",
   "expires_at": "2026-05-27",
-  "reason": "Temporary exact-wheel fallback for cryptography, Pillow, python-multipart, pytest, faker, hypothesis, mypy (cp313 manylinux), sentence-transformers, ruff, types-pyyaml, and transformers while the approved private proxy lags the patched upstream releases used by active dependency PRs.",
+  "reason": "Temporary exact-wheel fallback for cryptography, Pillow, python-multipart, pytest, faker, hypothesis, pre-commit, mypy (cp313 manylinux), sentence-transformers, ruff, types-pyyaml, and transformers while the approved private proxy lags the patched upstream releases used by active dependency PRs.",
   "artifacts": [
     {
       "package": "cryptography",
@@ -80,6 +80,13 @@
       "filename": "hypothesis-6.152.4-py3-none-any.whl",
       "url": "https://files.pythonhosted.org/packages/19/89/0f50dd0d92e8a7dffc24f69ab910ff81db89b2f082ba42682bd57695e4d2/hypothesis-6.152.4-py3-none-any.whl",
       "sha256": "e730fd93c7578182efadc7f90b3c5437ee4d55edf738930eb5043c81ac1d97e8"
+    },
+    {
+      "package": "pre-commit",
+      "version": "4.6.0",
+      "filename": "pre_commit-4.6.0-py2.py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl",
+      "sha256": "e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b"
     },
     {
       "package": "mypy",


### PR DESCRIPTION
## Summary

Unblocks CI **Setup Python environment** when the approved private index cannot serve `pre-commit==4.6.0` (same pattern as hypothesis emergency wheel in #1722).

## Changes

- `scripts/ci/emergency_python_wheels.json`: add PyPI `pre_commit-4.6.0-py2.py3-none-any.whl` URL + sha256
- `.secrets.baseline`: refresh `emergency_python_wheels.json` fingerprint entries (line shift + new digest)
- `docs/review/PR_1723_FIXED_MAPPING.md`: canonical Fixed in Commit Mapping artifact (merge governance)

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

CI hotfix only. Canonical SoT for mapping and evidence: `docs/review/PR_1723_FIXED_MAPPING.md`.

### Fixed in Commit Mapping

- No actionable review comments

## Merge Readiness

- [x] Canonical artifact present and linked from PR description
- [x] Phase2 body checklist complete (this PR body)

## Validation

- `python3 scripts/orchestration/check_preflight.py`
- `make validate-min`
- `pytest tests/test_install_locked_python_requirements.py::test_repo_emergency_manifest_tracks_current_active_fallback_set`
- `pre-commit run detect-secrets --files scripts/ci/emergency_python_wheels.json .secrets.baseline`

## Deferred / Follow-ups

- Remove emergency `pre-commit` entry once the private proxy serves 4.6.0 without lag; see manifest `expires_at`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI configuration updated to include pre-commit 4.6.0 artifact and related wheel fallback details
  * Security baseline updated to reflect shifted secret-detection entries

* **Documentation**
  * Added a review document detailing the fix mapping, validation evidence, security notes, and rollback/checklist guidance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1723)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->