### PR TITLE
fix(guards): detect camelCase BMI category thresholds

### DIFF
--- a/tests/test_no_bmi_math_outside_core.py
+++ b/tests/test_no_bmi_math_outside_core.py
@@ -81,6 +81,8 @@ _BMI_THRESHOLD_CONTEXT = (
     r"(?:"
     r"(?<![A-Za-z0-9])bmi(?![A-Za-z0-9])|"
     r"(?<![A-Za-z0-9])(?:bmi|whr)(?-i:[A-Z])[A-Za-z0-9]*(?![A-Za-z0-9])|"
+    r"(?<![A-Za-z0-9])(?:category|threshold|underweight|normal|overweight|obesity|healthy)"
+    r"(?-i:[A-Z])[A-Za-z0-9]*(?![A-Za-z0-9])|"
     r"(?<![A-Za-z0-9])category(?![A-Za-z0-9])|"
     r"(?<![A-Za-z0-9])threshold(?![A-Za-z0-9])|"
     r"(?<![A-Za-z0-9])underweight(?![A-Za-z0-9])|"
@@ -506,6 +508,11 @@ def test_bmi_thresholds_re_matches_real_bmi_and_whr_contexts() -> None:
         "25.0 is the normal BMI threshold",
         "25.0 is the Normal BMI Threshold",
         "normal Bmi threshold 25.0",
+        "normalThreshold = 25.0",
+        "underweightThreshold = 18.5",
+        "overweightThreshold = 30.0",
+        "healthyRangeMax = 24.9",
+        "categoryNormalMax = 25.0",
     )
     for case in matching_cases:
         assert BMI_THRESHOLDS_RE.search(case) is not None, f"Should match: {case}"


### PR DESCRIPTION
### Motivation

- A recent token-aware regex change fixed a false-positive on `normalized_score` but introduced false negatives for camelCase category-style BMI identifiers (e.g. `normalThreshold`, `categoryNormalMax`), weakening the repo policy guard.

### Description

- Restores detection by extending `_BMI_THRESHOLD_CONTEXT` in `tests/test_no_bmi_math_outside_core.py` to allow camelCase context words for `category`, `threshold`, `underweight`, `normal`, `overweight`, `obesity`, and `healthy`.
- Adds regression coverage entries in the same test to assert that `normalThreshold`, `underweightThreshold`, `overweightThreshold`, `healthyRangeMax`, and `categoryNormalMax` are matched by `BMI_THRESHOLDS_RE`.
- Change is limited to the guard/test file `tests/test_no_bmi_math_outside_core.py` and preserves the earlier anti-false-positive behavior for scorecard `normalized_score` patterns.

### Testing

- Ran `PYENV_VERSION=3.13.13 pytest -q tests/test_no_bmi_math_outside_core.py` and the focused guard test file passed.
- Ran `PYENV_VERSION=3.13.13 pytest -q tests/test_repo_policy_guards.py` and the repository guard suite passed.
- Ran `PYENV_VERSION=3.13.13 pre-commit run --all-files` which completed successfully for the changed files and hooks.
- Attempts to run full `make verify` were blocked by local environment prerequisites: `verify-env` failed because `.venv` is missing and `make venv` is blocked by missing `PULSEPLATE_PYTHON_INDEX_URL`; `make test-fast` (as part of a chained run) exposed unrelated VIP route expectations failing in `tests/edges/test_vip_auth_edges.py` (two failing tests reporting `404` vs expected `403/200`), which are pre-existing and not caused by this guard fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fefd5a2afc8333af6dd0da10e0159f)

## Summary by Sourcery

Усиление защиты политики репозитория BMI за счёт восстановления обнаружения camelCase-идентификаторов порогов категорий BMI при сохранении существующих механизмов защиты от ложных срабатываний.

Исправления ошибок:
- Восстановлено покрытие защитного механизма для camelCase-идентификаторов в стиле категорий BMI, чтобы шаблоны порогов BMI, такие как `normalThreshold` и `categoryNormalMax`, корректно обнаруживались.

Тесты:
- Расширены тесты защитного механизма порогов BMI регрессионными случаями для camelCase-идентификаторов категорий BMI и пороговых значений.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen the BMI repository policy guard by restoring detection of camelCase BMI category threshold identifiers while preserving existing false-positive protections.

Bug Fixes:
- Restore guard coverage for camelCase BMI category-style identifiers so BMI threshold patterns like normalThreshold and categoryNormalMax are correctly detected.

Tests:
- Extend BMI threshold guard tests with regression cases for camelCase BMI category and threshold identifiers.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for body mass index and weight-height ratio threshold detection, including support for additional identifier format variations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1727)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1727#discussion_r3215462121 -> 8a6f79a31
  Disposition: FIXED
  Commit: 8a6f79a31
  Evidence: tests/test_no_bmi_math_outside_core.py:130-151
  Evidence: tests/test_no_bmi_math_outside_core.py:267-271
  Evidence: tests/test_no_bmi_math_outside_core.py:469-499
