### PR TITLE
ci: fail-closed for metadata-unavailable current-head checks

### DIFF
--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -320,15 +320,9 @@ def _required_snapshot(
 
 def _is_blocking_fallback_advisory(entry: CheckEntry) -> bool:
     """Return whether fallback merge gating must still block on this advisory entry."""
-    if entry.state not in {"pending", "failed"}:
-        return False
-    if entry.source_kind == "status_context":
-        return entry.name in CANONICAL_FALLBACK_STATUS_CONTEXT_NAMES
-    return (
-        entry.source_kind == "check_run"
-        and entry.workflow_name == "CI"
-        and entry.name in CANONICAL_FALLBACK_CI_CHECK_NAMES
-    )
+    # Fail closed when required-check metadata is unavailable: any pending/failed
+    # current-head entry remains merge-blocking until metadata can be resolved.
+    return entry.state in {"pending", "failed"}
 
 
 def _partition_fallback_advisory_entries(
@@ -466,8 +460,8 @@ def main(argv: list[str] | None = None) -> int:
         )
         print(
             "Required check metadata unavailable; merge gating falls back to GitHub "
-            "mergeStateStatus. Current-head checks stay advisory unless a canonical "
-            "ordinary-PR CI signal remains pending or failed."
+            "mergeStateStatus. Current-head checks fail closed: any pending/failed "
+            "current-head check remains blocking."
         )
         if advisory_blocking_entries:
             _print_entries("Current-head blocking fallback checks:", advisory_blocking_entries)
@@ -481,8 +475,6 @@ def main(argv: list[str] | None = None) -> int:
             print(_format_entry(entry))
 
     blocking_entries = [entry for entry in current_required if entry.state in {"pending", "failed"}]
-    # RU: В fallback-режиме без metadata блокирует только канонический workflow CI.
-    # EN: In metadata-unavailable fallback, only the canonical CI workflow remains blocking.
     merge_state_note_needed = not required_metadata_available and merge_state != "CLEAN"
     if blocking_entries or advisory_blocking_entries:
         print("ERROR: current-head check filter failed.")
@@ -491,7 +483,7 @@ def main(argv: list[str] | None = None) -> int:
         if blocking_entries:
             print("- Blocking current-head checks remain pending or failed.")
         if advisory_blocking_entries:
-            print("- Blocking canonical fallback current-head checks remain pending or failed.")
+            print("- Blocking fallback current-head checks remain pending or failed.")
         return 1
 
     if merge_state_note_needed:

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -107,7 +107,7 @@ def test_ci_workflow_matrix_display_name_stays_in_sync() -> None:
                 workflow_name="Docker Build and Push",
                 conclusion="",
             ),
-            False,
+            True,
         ),
         (
             current_head_checks.CheckEntry(
@@ -119,7 +119,7 @@ def test_ci_workflow_matrix_display_name_stays_in_sync() -> None:
                 workflow_name="Optional CI",
                 conclusion="FAILURE",
             ),
-            False,
+            True,
         ),
         (
             current_head_checks.CheckEntry(
@@ -135,13 +135,13 @@ def test_ci_workflow_matrix_display_name_stays_in_sync() -> None:
         ),
         (
             current_head_checks.CheckEntry(
-                name="iOS unit tests (xcodebuild)",
+                name="lint",
                 source_kind="check_run",
-                state="pending",
+                state="passed",
                 timestamp="2026-03-12T08:36:42Z",
-                details_url="https://example.invalid/ios-pending",
+                details_url="https://example.invalid/ci-passed",
                 workflow_name="CI",
-                conclusion="",
+                conclusion="SUCCESS",
             ),
             False,
         ),
@@ -433,7 +433,7 @@ def test_main_passes_when_merge_state_is_not_clean_but_advisory_snapshot_is_clea
     assert "NOTE: GitHub mergeStateStatus=UNSTABLE is stale/non-blocking" in captured.out
 
 
-def test_main_passes_when_merge_state_is_not_clean_and_specialized_advisory_check_is_pending(
+def test_main_fails_when_merge_state_is_not_clean_and_specialized_advisory_check_is_pending(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
@@ -467,15 +467,14 @@ def test_main_passes_when_merge_state_is_not_clean_and_specialized_advisory_chec
     )
 
     captured = capsys.readouterr()
-    assert exit_code == 0
+    assert exit_code == 1
     assert "Required check metadata unavailable" in captured.out
-    assert "Current-head advisory checks:" in captured.out
+    assert "Current-head blocking fallback checks:" in captured.out
     assert "- security-scan: pending [Docker Build and Push]" in captured.out
-    assert "Current-head blocking fallback checks:" not in captured.out
-    assert "NOTE: GitHub mergeStateStatus=UNSTABLE is stale/non-blocking" in captured.out
+    assert "Blocking fallback current-head checks remain pending or failed." in captured.out
 
 
-def test_main_passes_when_specialized_ci_job_is_pending_in_fallback_mode(
+def test_main_fails_when_specialized_ci_job_is_pending_in_fallback_mode(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
@@ -509,10 +508,10 @@ def test_main_passes_when_specialized_ci_job_is_pending_in_fallback_mode(
     )
 
     captured = capsys.readouterr()
-    assert exit_code == 0
+    assert exit_code == 1
     assert "- iOS unit tests (xcodebuild): pending [CI]" in captured.out
-    assert "Current-head blocking fallback checks:" not in captured.out
-    assert "current-head-checks: passed." in captured.out
+    assert "Current-head blocking fallback checks:" in captured.out
+    assert "Blocking fallback current-head checks remain pending or failed." in captured.out
 
 
 def test_main_fails_when_merge_state_is_not_clean_and_canonical_fallback_check_is_pending(
@@ -554,7 +553,7 @@ def test_main_fails_when_merge_state_is_not_clean_and_canonical_fallback_check_i
     assert "Current-head blocking fallback checks:" in captured.out
     assert "- Docs Phase1 gates: pending [CI]" in captured.out
     assert (
-        "Blocking canonical fallback current-head checks remain pending or failed." in captured.out
+        "Blocking fallback current-head checks remain pending or failed." in captured.out
     )
 
 
@@ -597,7 +596,7 @@ def test_main_fails_when_merge_state_is_clean_and_canonical_fallback_check_is_pe
     assert "Current-head blocking fallback checks:" in captured.out
     assert "- Docs Phase1 gates: pending [CI]" in captured.out
     assert (
-        "Blocking canonical fallback current-head checks remain pending or failed." in captured.out
+        "Blocking fallback current-head checks remain pending or failed." in captured.out
     )
 
 


### PR DESCRIPTION
### Motivation

- A fallback change allowed non-`CI` workflow failures to be treated as advisory when branch-protection required-check metadata was unavailable, weakening merge gating and creating a CI-integrity risk. 
- The intent of this change is to harden merge-gating in metadata-unavailable scenarios by failing closed so that any pending/failed current-head check blocks merges until metadata can be resolved.

### Description

- Hardened fallback logic in `scripts/ci/check_current_head_pr_checks.py` by changing `_is_blocking_fallback_advisory` to treat any `pending`/`failed` current-head entry as blocking when required-check metadata is unavailable. 
- Updated fallback messaging in `main()` to explicitly state the fail-closed behavior for metadata-unavailable mode. 
- Adjusted fallback-printing logic to surface blocking fallback checks consistently. 
- Updated `tests/test_current_head_pr_checks.py` expectations to reflect the stricter fallback semantics for both specialized non-`CI` check runs and `CI` check runs.

### Testing

- Ran `python3 -m py_compile scripts/ci/check_current_head_pr_checks.py tests/test_current_head_pr_checks.py` and the files compiled successfully after the fix. 
- Performed a small functional sanity check using a short Python invocation of `_is_blocking_fallback_advisory(...)` which returned the expected `True` for a failed non-`CI` check. 
- Attempted to run `pytest` and full `make verify`, but `pytest`/`.venv`/`pre-commit` are not available in this environment so full repo gates could not be executed (environment failures: `.venv missing` and `pre-commit: command not found`). 
- Test file `tests/test_current_head_pr_checks.py` was updated to assert the tightened behavior and was validated via `py_compile` (but not executed under `pytest` here due to the environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28904cd3c8333a7efdb70f1e68449)

## Summary by Sourcery

Усилено резервное поведение при недоступности метаданных, чтобы любой ожидающий или завершившийся с ошибкой current-head check рассматривался как блокирующий слияние, и соответствующим образом обновлены сообщения.

Улучшения:
- Изменить логику советов при резервном режиме (fallback advisory gating) на принцип «fail-closed», рассматривая все ожидающие или завершившиеся с ошибкой current-head checks как блокирующие, когда метаданные о требуемых проверках недоступны.
- Уточнить консольные сообщения в режиме fallback, чтобы описать поведение «fail-closed» и обобщённые блокирующие резервные проверки.

Тесты:
- Обновить тесты проверок текущей головы PR (current-head PR checks), чтобы ожидать ошибки и блокирующее поведение для ожидающих специализированных и CI‑задач в режиме fallback, а также использовать обобщённые сообщения о блокирующих резервных проверках.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen metadata-unavailable fallback behavior so that any pending or failed current-head check is treated as merge-blocking and update messaging accordingly.

Enhancements:
- Change fallback advisory gating logic to fail-closed by treating all pending or failed current-head checks as blocking when required-check metadata is unavailable.
- Clarify fallback-mode console messaging to describe fail-closed behavior and generic blocking fallback checks.

Tests:
- Update current-head PR checks tests to expect failures and blocking behavior for pending specialized and CI jobs in fallback mode, and to use generalized fallback-blocking messages.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-closed merge gating when required-check metadata is unavailable. Any pending or failed current-head check (CI or non-CI) now blocks merges to protect CI integrity.

- **Bug Fixes**
  - Updated `_is_blocking_fallback_advisory` to treat any `pending`/`failed` check as blocking in metadata-unavailable mode.
  - Clarified CLI messages in `main()` to state fail-closed behavior and use consistent “blocking fallback checks” wording.
  - Removed legacy logic/comment about only canonical CI being blocking; now all checks are considered.
  - Adjusted tests to match stricter behavior (updated expectations and messages for pending non-`CI` and specialized `CI` checks).

<sup>Written for commit ae6b2f9a4cd283083a83bcae859d40d20ba82b0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated merge-gating validation to enforce stricter blocking criteria for pending checks.

* **Tests**
  * Updated CI gate tests to reflect new validation behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1728)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

## Merge Readiness

- [ ] Current-head CI is green for PR branch head
- [ ] Required checks complete (no pending jobs)
- [ ] All review threads resolved on GitHub after disposition updates
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1728_FIXED_MAPPING.md`

