### PR TITLE
fix(security): verify Codex skill installs against repo sources

### DIFF
--- a/scripts/verify_codex_skills_install.py
+++ b/scripts/verify_codex_skills_install.py
@@ -10,6 +10,7 @@ No mutations, no network, no secrets, no shell profile access.
 from __future__ import annotations
 
 import argparse
+import filecmp
 import json
 import os
 import sys
@@ -22,18 +23,18 @@ CYBERSEC_SKILLS_ROOT = REPO_ROOT / "tools" / "cybersecurity_skills" / "skills"
 
 def _discover_expected_skills(
     include_cybersec: bool = False,
-) -> list[str]:
-    """Return sorted list of expected skill names from repo source of truth."""
-    skills: list[str] = []
+) -> dict[str, Path]:
+    """Return expected skill names mapped to repo source-of-truth paths."""
+    skills: dict[str, Path] = {}
     if PULSEPLATE_SKILLS_ROOT.is_dir():
         for entry in sorted(PULSEPLATE_SKILLS_ROOT.iterdir()):
             if entry.is_dir() and (entry / "SKILL.md").exists():
-                skills.append(entry.name)
+                skills[entry.name] = entry
     if include_cybersec and CYBERSEC_SKILLS_ROOT.is_dir():
         for entry in sorted(CYBERSEC_SKILLS_ROOT.iterdir()):
             if entry.is_dir() and (entry / "SKILL.md").exists():
-                skills.append(entry.name)
-    return sorted(skills)
+                skills[entry.name] = entry
+    return dict(sorted(skills.items()))
 
 
 def _resolve_destination(
@@ -55,34 +56,91 @@ def _resolve_destination(
     return Path.home() / ".agents" / "skills"
 
 
-def _inspect_installed_skill(dest_dir: Path, skill_name: str) -> dict[str, str]:
+COPY_MARKER_FILE = ".pulseplate_codex_skill_source"
+
+
+def _canonical_path(path: Path) -> str | None:
+    """Return the canonical path for an existing path, or None if unresolved."""
+    try:
+        return str(path.resolve(strict=True))
+    except (OSError, RuntimeError):
+        return None
+
+
+def _relative_entries(root: Path) -> set[Path]:
+    """Return all relative entries under a skill directory, excluding copy marker."""
+    return {
+        entry.relative_to(root)
+        for entry in root.rglob("*")
+        if entry.relative_to(root) != Path(COPY_MARKER_FILE)
+    }
+
+
+def _copied_skill_matches_source(skill_path: Path, source_skill: Path) -> bool:
+    """Return whether a copied skill directory matches its repo source."""
+    source_entries = _relative_entries(source_skill)
+    copied_entries = _relative_entries(skill_path)
+    if source_entries != copied_entries:
+        return False
+    for relative_entry in source_entries:
+        source_entry = source_skill / relative_entry
+        copied_entry = skill_path / relative_entry
+        if source_entry.is_dir() or copied_entry.is_dir():
+            if not (source_entry.is_dir() and copied_entry.is_dir()):
+                return False
+            continue
+        if not (source_entry.is_file() and copied_entry.is_file()):
+            return False
+        if not filecmp.cmp(source_entry, copied_entry, shallow=False):
+            return False
+    return True
+
+
+def _inspect_installed_skill(
+    dest_dir: Path,
+    skill_name: str,
+    source_skill: Path,
+) -> dict[str, str]:
     """Inspect a single skill entry at the destination."""
     skill_path = dest_dir / skill_name
+    expected_resolved = _canonical_path(source_skill)
     if skill_path.is_symlink():
         link_target = os.readlink(str(skill_path))
-        try:
-            resolved_target = str(skill_path.resolve())
-        except (OSError, RuntimeError):
-            resolved_target = link_target
+        resolved_target = _canonical_path(skill_path) or link_target
         has_skill_md = (skill_path / "SKILL.md").exists()
+        is_repo_managed = has_skill_md and resolved_target == expected_resolved
         return {
             "name": skill_name,
-            "status": "linked" if has_skill_md else "linked_invalid",
+            "status": "linked" if is_repo_managed else "linked_invalid",
             "type": "symlink",
             "target": link_target,
             "resolved": resolved_target,
+            "expected": expected_resolved or str(source_skill),
         }
     if skill_path.is_dir():
+        marker_path = skill_path / COPY_MARKER_FILE
+        marker_value = (
+            marker_path.read_text(encoding="utf-8").strip() if marker_path.exists() else ""
+        )
+        marker_resolved = _canonical_path(Path(marker_value)) if marker_value else None
         has_skill_md = (skill_path / "SKILL.md").exists()
+        is_repo_managed = (
+            has_skill_md
+            and marker_resolved == expected_resolved
+            and _copied_skill_matches_source(skill_path, source_skill)
+        )
         return {
             "name": skill_name,
-            "status": "copied" if has_skill_md else "copied_invalid",
+            "status": "copied" if is_repo_managed else "copied_invalid",
             "type": "directory",
+            "marker": marker_value,
+            "expected": expected_resolved or str(source_skill),
         }
     return {
         "name": skill_name,
         "status": "missing",
         "type": "absent",
+        "expected": expected_resolved or str(source_skill),
     }
 
 
@@ -94,7 +152,8 @@ def verify(
     output_json: bool,
 ) -> int:
     """Run verification and return exit code."""
-    expected = _discover_expected_skills(include_cybersec=include_cybersec)
+    expected_sources = _discover_expected_skills(include_cybersec=include_cybersec)
+    expected = list(expected_sources)
     dest_dir = _resolve_destination(target, dest)
 
     missing: list[str] = []
@@ -102,8 +161,8 @@ def verify(
     installed: list[str] = []
     details: list[dict[str, str]] = []
 
-    for skill_name in expected:
-        info = _inspect_installed_skill(dest_dir, skill_name)
+    for skill_name, source_skill in expected_sources.items():
+        info = _inspect_installed_skill(dest_dir, skill_name, source_skill)
         details.append(info)
         if info["status"] == "missing":
             missing.append(skill_name)
@@ -157,7 +216,10 @@ def verify(
         if missing:
             print("\nMissing skills:\n  " + "\n  ".join(missing))
         if invalid:
-            print("\nInvalid skills (no SKILL.md):\n  " + "\n  ".join(invalid))
+            print(
+                "\nInvalid skills (not repo-managed or content mismatch):\n  "
+                + "\n  ".join(invalid)
+            )
         if not missing and not invalid:
             print("\nAll expected skills are installed.")
 

--- a/tests/test_install_codex_skills.py
+++ b/tests/test_install_codex_skills.py
@@ -28,6 +28,8 @@ def _run_installer(
     }
     if set_codex_home:
         env["CODEX_HOME"] = str(home_root / ".codex")
+    else:
+        env.pop("CODEX_HOME", None)
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -377,6 +379,53 @@ def test_verify_codex_skills_install_passes_after_official_install(tmp_path: Pat
     result = _run_verifier(tmp_path, "--dest", str(agents_skills))
     assert result.returncode == 0
     assert "All expected skills are installed" in result.stdout
+
+
+def test_verify_codex_skills_install_passes_after_copy_install(tmp_path: Path) -> None:
+    """Verifier should trust copied skills only when they match repo sources."""
+
+    _run_installer(tmp_path, "--copy", "--no-cybersec")
+    agents_skills = tmp_path / ".agents" / "skills"
+
+    result = _run_verifier(tmp_path, "--dest", str(agents_skills), "--strict")
+    assert result.returncode == 0
+    assert "All expected skills are installed" in result.stdout
+
+
+def test_verify_codex_skills_install_rejects_external_same_name_symlink(
+    tmp_path: Path,
+) -> None:
+    """Strict verification must fail for same-name symlinks outside repo sources."""
+
+    _run_installer(tmp_path, "--no-cybersec")
+    agents_skills = tmp_path / ".agents" / "skills"
+    installed_skill = agents_skills / "pulseplate-workflow"
+    attacker_skill = tmp_path / "attacker-skills" / "pulseplate-workflow"
+    attacker_skill.mkdir(parents=True)
+    (attacker_skill / "SKILL.md").write_text("# attacker controlled\n", encoding="utf-8")
+    installed_skill.unlink()
+    installed_skill.symlink_to(attacker_skill)
+
+    result = _run_verifier(tmp_path, "--dest", str(agents_skills), "--strict")
+    assert result.returncode == 1
+    assert "Invalid: 1" in result.stdout
+    assert "pulseplate-workflow" in result.stdout
+
+
+def test_verify_codex_skills_install_rejects_modified_same_name_copy(
+    tmp_path: Path,
+) -> None:
+    """Strict verification must fail when a copied skill diverges from repo content."""
+
+    _run_installer(tmp_path, "--copy", "--no-cybersec")
+    agents_skills = tmp_path / ".agents" / "skills"
+    copied_skill = agents_skills / "pulseplate-workflow"
+    (copied_skill / "SKILL.md").write_text("# attacker controlled\n", encoding="utf-8")
+
+    result = _run_verifier(tmp_path, "--dest", str(agents_skills), "--strict")
+    assert result.returncode == 1
+    assert "Invalid: 1" in result.stdout
+    assert "pulseplate-workflow" in result.stdout
 
 
 def test_verify_codex_skills_install_fails_when_skill_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- The read-only verifier accepted same-name installs based only on the presence of `SKILL.md`, which allowed attacker-controlled same-name symlinks or copied directories to pass `--strict` verification and gave false integrity assurance.

### Description

- Change `_discover_expected_skills` to return a mapping of skill name → repo source Path so each expected entry is tied to its repository source-of-truth (`tools/codex_skills`).
- Harden `_inspect_installed_skill` to verify symlink installs resolve to the canonical repo source and to verify copied installs carry the `.pulseplate_codex_skill_source` marker and have matching content (byte-compare of files, ignoring the copy marker).
- Reclassify previously-accepted same-name-but-untrusted entries as `linked_invalid`/`copied_invalid` and surface them in the report as "not repo-managed or content mismatch".
- Add regression tests covering: trusted copied installs, rejection of external same-name symlinks, and rejection of modified copied installs; and fix the installer test helper to properly unset `CODEX_HOME` in the compat-fallback test.
- Files changed: `scripts/verify_codex_skills_install.py`, `tests/test_install_codex_skills.py` (added tests and small helper fix).

### Testing

- `python -m py_compile scripts/verify_codex_skills_install.py tests/test_install_codex_skills.py` — PASS.
- `PYENV_VERSION=3.13.8 python -m pytest -q tests/test_install_codex_skills.py` — PASS (new regression tests exercised and passed).
- `PYENV_VERSION=3.13.8 make lint` — PASS.
- `PYENV_VERSION=3.13.8 make typecheck` — PASS.
- `PYENV_VERSION=3.13.8 VIP_MODULE_ENABLED=true make test-fast` — PASS (smoke bundle with VIP enabled).
- `PYENV_VERSION=3.13.8 pre-commit run --all-files` — PASS.
- Environment-limited checks: `PYENV_VERSION=3.13.8 make verify` could not be completed in this environment because `verify-env` requires a local `.venv` and exited with: ".venv missing. Run 'make venv' first.".
- `PYENV_VERSION=3.13.8 make validate-changed` selected unrelated local tests and failed due to the shell startup environment when running a helper `sh -lc "pwd -P | cksum | cut -d' ' -f1"` producing `/bin/sh` startup errors (`[[: not found`, `export: Illegal option -a`) in this container; this is an unrelated environment artifact.

Commit: `cb043f9` — "fix(security): validate codex skill install sources" (includes verifier hardening and regression tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf8d3933483338111be582ea272bf)

## Summary by Sourcery

Усилена проверка установки навыков Codex, чтобы гарантировать, что установленные навыки берутся из репозитория – единого источника истины – и соответствуют ему.

Bug Fixes:
- Предотвращено принятие атакующих навыков-симлинков с тем же именем за валидные при строгой проверке.
- Предотвращено прохождение строгой проверки изменёнными или неуправляемыми репозиторием копированными навыками путём требования доверенной метки источника и совпадения содержимого.

Enhancements:
- Отслеживание ожидаемых навыков в виде отображения от имени к пути в репозитории и отображение ожидаемых путей источника в деталях проверки.
- Уточнены сообщения о недопустимых навыках, чтобы указывать, что навыки не управляются репозиторием или имеют несоответствие содержимого.

Tests:
- Добавлены регрессионные тесты для доверенных скопированных установок, отклонения внешних одноимённых симлинков и отклонения изменённых скопированных установок.
- Исправлен вспомогательный модуль тестов инсталлятора, чтобы он корректно сбрасывал переменную `CODEX_HOME`, когда это не требуется.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden Codex skill installation verification to ensure installed skills are sourced from and match the repository source of truth.

Bug Fixes:
- Prevent same-name attacker-controlled symlinked skills from being treated as valid in strict verification.
- Prevent modified or non–repo-managed copied skills from passing strict verification by requiring a trusted source marker and content match.

Enhancements:
- Track expected skills as a mapping from name to repository path and surface expected source paths in verification details.
- Clarify invalid-skill reporting to indicate skills are not repo-managed or have content mismatches.

Tests:
- Add regression tests for trusted copied installs, rejection of external same-name symlinks, and rejection of modified copied installs.
- Fix the installer test helper to correctly unset CODEX_HOME when not requested.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Codex skill verifier to ensure installs are validated against their repo sources, preventing false trust of same-name symlinks or modified copies. Only repo-managed symlinks or verified copies now pass in strict mode.

- **Bug Fixes**
  - Map expected skills to their source paths to bind installs to `tools/codex_skills`.
  - Require symlinks to resolve to the canonical source path; otherwise mark `linked_invalid`.
  - Require copied installs to include `.pulseplate_codex_skill_source` and byte-match the source (marker excluded); otherwise mark `copied_invalid`.
  - Update output to flag invalid skills as "not repo-managed or content mismatch".
  - Add regression tests for trusted copies, rejecting external same-name symlinks, and rejecting modified copies.
  - Fix test helper to unset `CODEX_HOME` in the compat-fallback test.

<sup>Written for commit d8998b08e89d4451d91f263eb3c3e5b6570167b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skill verification now validates that installed skills match their repository sources
  * Enhanced detection for modified or mismatched copied skills and symlinks
  * Improved error messaging for integrity validation failures

* **Tests**
  * Added test coverage for skill verification with copied installations and symlink validation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1730)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->