### PR TITLE
fix(ci): align RAG vector emergency transformers fallback

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -192,6 +192,24 @@
         "line_number": 321
       }
     ],
+    ".pytest_cache/CACHEDIR.TAG": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pytest_cache/CACHEDIR.TAG",
+        "hashed_secret": "e8f8c345877b2411a59897798e422b15b0c16d76",
+        "is_verified": false,
+        "line_number": 1
+      }
+    ],
+    ".ruff_cache/CACHEDIR.TAG": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".ruff_cache/CACHEDIR.TAG",
+        "hashed_secret": "e8f8c345877b2411a59897798e422b15b0c16d76",
+        "is_verified": false,
+        "line_number": 1
+      }
+    ],
     "conftest.py": [
       {
         "type": "Secret Keyword",
@@ -522,7 +540,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "b777d4f08355af27079aa47b08fd59962aedf588",
+        "hashed_secret": "5b9291e9516560d35add069c8f30e9e84e70fe30",
         "is_verified": false,
         "line_number": 147
       }
@@ -1676,5 +1694,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-10T17:59:36Z"
+  "generated_at": "2026-05-10T20:18:36Z"
 }

--- a/scripts/ci/emergency_python_wheels.json
+++ b/scripts/ci/emergency_python_wheels.json
@@ -141,10 +141,10 @@
     },
     {
       "package": "transformers",
-      "version": "5.5.4",
-      "filename": "transformers-5.5.4-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/29/fb/162a66789c65e5afa3b051309240c26bf37fbc8fea285b4546ae747995a2/transformers-5.5.4-py3-none-any.whl",
-      "sha256": "0bd6281b82966fe5a7a16f553ea517a9db1dee6284d7cb224dfd88fc0dd1c167"
+      "version": "5.8.0",
+      "filename": "transformers-5.8.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/97/7b/5621d08b34ac35deb9fa14b58d27d124d21ef125ee1c64bc724ca47dfb63/transformers-5.8.0-py3-none-any.whl",
+      "sha256": "e9d2cae6d195a7e1e05164c5ebf26142a7044e4dc4267274f4809204f92827e4"
     }
   ]
 }

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -121,6 +121,20 @@ def test_repo_mypy_emergency_fallback_matches_dev_requirement_surfaces() -> None
     assert ("mypy", expected_version) in _exact_requirement_pairs(requirements_dev_txt)
 
 
+def test_repo_transformers_emergency_fallback_matches_rag_vector_surfaces() -> None:
+    manifest = _repo_emergency_manifest()
+    expected_version = _manifest_artifact_version(manifest, "transformers")
+
+    for requirement_path in (
+        "requirements-rag-vector.in",
+        "requirements-rag-vector.txt",
+        "requirements-rag-vector-cpu.in",
+        "requirements-rag-vector-cpu.txt",
+    ):
+        requirement_text = (REPO_ROOT / requirement_path).read_text(encoding="utf-8")
+        assert ("transformers", expected_version) in _exact_requirement_pairs(requirement_text)
+
+
 def test_compatible_release_version_accepts_environment_markers() -> None:
     contents = 'ruff~=0.15.11 ; python_version >= "3.13"\n'
 


### PR DESCRIPTION
### Motivation
- Prevent a locked-install availability regression where optional RAG vector profiles request `transformers==5.8.0` but the emergency wheel manifest only provided `transformers==5.5.4`, leaving the retry fallback unable to stage the requested wheel.

### Description
- Rotated the emergency fallback artifact for `transformers` in `scripts/ci/emergency_python_wheels.json` from `5.5.4` to `5.8.0` and updated filename/URL/sha256 to match the PyPI wheel for `5.8.0`.
- Added `test_repo_transformers_emergency_fallback_matches_rag_vector_surfaces` to `tests/test_install_locked_python_requirements.py` to assert the manifest transformers version matches all RAG vector requirement surfaces (`requirements-rag-vector*.in/.txt`).
- Updated `.secrets.baseline` to record the new wheel hash false-positive so pre-commit/detect-secrets remains green.

### Testing
- Ran `python3 scripts/orchestration/check_preflight.py` which passed.
- Ran `uv run --no-project --python 3.13 --with-requirements requirements-ci-lite.txt pytest -q tests/test_install_locked_python_requirements.py -q` which passed (targeted regression tests).
- Ran `PYENV_VERSION=3.13.13 uv run --no-project --python 3.13 --with pre-commit pre-commit run --all-files` which passed after updating `.secrets.baseline` and committing hook fixes.
- Ran `PYENV_VERSION=3.13.13 make validate-changed` (diff-based validation) which passed.
- Attempted `PYENV_VERSION=3.13.13 make verify` but it stopped at environment parity check due to a missing repo `.venv`: `❌ .venv missing. Run 'make venv' first.` and therefore full `make verify` was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00e59398048333a24f61a00ffe896e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the emergency fallback wheel for `transformers` to 5.8.0 to match RAG vector requirement files, preventing locked-install failures when retries use the emergency cache.

- **Bug Fixes**
  - Updated `scripts/ci/emergency_python_wheels.json` to `transformers==5.8.0` with the correct filename, URL, and sha256.
  - Added a test to ensure the manifest’s `transformers` version matches all RAG vector requirement surfaces.
  - Refreshed `.secrets.baseline` to whitelist the new wheel hash.

<sup>Written for commit bfb4b13653a2b213fce0e7be1395eef6843eea04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated transformers wheel artifact from version 5.5.4 to 5.8.0
  * Added validation test to ensure emergency wheel manifest consistency with pinned requirements
  * Updated security baseline for cache file findings

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1731)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->