### PR TITLE
fix(design): require canonical sha256 icon locks

### DIFF
--- a/scripts/validate_icon_core_v1.py
+++ b/scripts/validate_icon_core_v1.py
@@ -19,10 +19,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from pathlib import Path
 
 ICON_CORE_SUBPATH = Path("assets") / "brand" / "icon" / "core" / "v1.0"
 META_JSON_MAX_BYTES = 256 * 1024
+SHA256_LOCK_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 def _default_repo_root() -> Path:
@@ -136,7 +138,7 @@ def _is_concrete_hash_value(value: object) -> bool:
     if not _is_concrete_lock_value(value):
         return False
     normalized = str(value).strip()
-    return normalized.startswith("sha256:") and len(normalized) > len("sha256:")
+    return SHA256_LOCK_RE.fullmatch(normalized) is not None
 
 
 def validate(

--- a/tests/test_icon_core_validator.py
+++ b/tests/test_icon_core_validator.py
@@ -70,11 +70,11 @@ def _write_icon_core_fixture(
                         "png_derived_24": "assets/brand/icon/core/v1.0/icon_core_v1_24.png",
                     },
                     "hashes": {
-                        "master_svg_sha256": "sha256:svg",
-                        "master_png_1024_sha256": "sha256:png1024",
-                        "master_png_60_sha256": "sha256:png60",
-                        "silhouette_mask_sha256_1024": "sha256:mask1024",
-                        "silhouette_mask_sha256_60": "sha256:mask60",
+                        "master_svg_sha256": "sha256:" + "a" * 64,
+                        "master_png_1024_sha256": "sha256:" + "b" * 64,
+                        "master_png_60_sha256": "sha256:" + "c" * 64,
+                        "silhouette_mask_sha256_1024": "sha256:" + "d" * 64,
+                        "silhouette_mask_sha256_60": "sha256:" + "e" * 64,
                     },
                 },
                 indent=2,
@@ -257,11 +257,11 @@ def test_asset_paths_must_match_canonical_names(
             "png_derived_24": "assets/brand/icon/core/v1.0/icon_core_v1_24.png",
         },
         "hashes": {
-            "master_svg_sha256": "sha256:svg",
-            "master_png_1024_sha256": "sha256:png1024",
-            "master_png_60_sha256": "sha256:png60",
-            "silhouette_mask_sha256_1024": "sha256:mask1024",
-            "silhouette_mask_sha256_60": "sha256:mask60",
+            "master_svg_sha256": "sha256:" + "a" * 64,
+            "master_png_1024_sha256": "sha256:" + "b" * 64,
+            "master_png_60_sha256": "sha256:" + "c" * 64,
+            "silhouette_mask_sha256_1024": "sha256:" + "d" * 64,
+            "silhouette_mask_sha256_60": "sha256:" + "e" * 64,
         },
     }
 
@@ -375,9 +375,9 @@ def test_require_lock_values_rejects_noncanonical_placeholders(
         "hashes": {
             "master_svg_sha256": "",
             "master_png_1024_sha256": "TBD",
-            "master_png_60_sha256": "sha256:png60",
+            "master_png_60_sha256": "sha256:" + "c" * 64,
             "silhouette_mask_sha256_1024": "not-a-sha",
-            "silhouette_mask_sha256_60": "sha256:mask60",
+            "silhouette_mask_sha256_60": "sha256:" + "e" * 64,
         },
     }
 
@@ -389,6 +389,50 @@ def test_require_lock_values_rejects_noncanonical_placeholders(
         meta_payload=meta_with_noncanonical_placeholders,
     )
     assert any("meta.json lock placeholders found" in err for err in errors)
+
+
+def test_require_lock_values_rejects_invalid_sha256_digest_shapes(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Lock mode must reject sha256-prefixed values without a real digest."""
+
+    invalid_hashes = {
+        "master_svg_sha256": "sha256:x",
+        "master_png_1024_sha256": "sha256:TBD_AFTER_WINNER_LOCK",
+        "master_png_60_sha256": "sha256:not-a-sha",
+        "silhouette_mask_sha256_1024": "sha256:ABCDEF",
+        "silhouette_mask_sha256_60": "sha256:123",
+    }
+    meta_with_invalid_hashes = {
+        "contract_id": "EMBLEM_CORE_v1.0_LOCK",
+        "version": "v1.0",
+        "master_policy": "dual-master-svg-png",
+        "figma_source_type": "design",
+        "figma_design_url": "spec://design-url",
+        "figma_file_key": "design-file-key",
+        "figma_node_id": "1024:2048",
+        "assets": {
+            "svg_master": "assets/brand/icon/core/v1.0/icon_core_v1.svg",
+            "png_master_1024": "assets/brand/icon/core/v1.0/icon_core_v1_1024.png",
+            "png_master_60": "assets/brand/icon/core/v1.0/icon_core_v1_60.png",
+            "png_derived_120": "assets/brand/icon/core/v1.0/icon_core_v1_120.png",
+            "png_derived_32": "assets/brand/icon/core/v1.0/icon_core_v1_32.png",
+            "png_derived_24": "assets/brand/icon/core/v1.0/icon_core_v1_24.png",
+        },
+        "hashes": invalid_hashes,
+    }
+
+    errors = _run_validator(
+        monkeypatch,
+        tmp_path,
+        require_lock_values=True,
+        include_masters=True,
+        meta_payload=meta_with_invalid_hashes,
+    )
+
+    assert any("meta.json lock placeholders found" in err for err in errors)
+    for key in invalid_hashes:
+        assert any(f"hashes.{key}=" in err for err in errors)
 
 
 def test_require_canonical_masters_does_not_require_derived_files(
@@ -448,11 +492,11 @@ def test_strict_mode_reports_missing_asset_keys_without_duplicate_shape_errors(
             "svg_master": "assets/brand/icon/core/v1.0/icon_core_v1.svg",
         },
         "hashes": {
-            "master_svg_sha256": "sha256:svg",
-            "master_png_1024_sha256": "sha256:png1024",
-            "master_png_60_sha256": "sha256:png60",
-            "silhouette_mask_sha256_1024": "sha256:mask1024",
-            "silhouette_mask_sha256_60": "sha256:mask60",
+            "master_svg_sha256": "sha256:" + "a" * 64,
+            "master_png_1024_sha256": "sha256:" + "b" * 64,
+            "master_png_60_sha256": "sha256:" + "c" * 64,
+            "silhouette_mask_sha256_1024": "sha256:" + "d" * 64,
+            "silhouette_mask_sha256_60": "sha256:" + "e" * 64,
         },
     }
 
@@ -478,16 +522,20 @@ def test_strict_mode_rejects_non_object_assets_and_hashes(
         "figma_node_id": "1024:2048",
         "assets": [],
         "hashes": {
-            "master_svg_sha256": "sha256:svg",
-            "master_png_1024_sha256": "sha256:png1024",
-            "master_png_60_sha256": "sha256:png60",
-            "silhouette_mask_sha256_1024": "sha256:mask1024",
-            "silhouette_mask_sha256_60": "sha256:mask60",
+            "master_svg_sha256": "sha256:" + "a" * 64,
+            "master_png_1024_sha256": "sha256:" + "b" * 64,
+            "master_png_60_sha256": "sha256:" + "c" * 64,
+            "silhouette_mask_sha256_1024": "sha256:" + "d" * 64,
+            "silhouette_mask_sha256_60": "sha256:" + "e" * 64,
         },
     }
 
     errors_assets = _run_validator(
-        monkeypatch, tmp_path, strict=True, include_masters=True, meta_payload=meta_assets_list
+        monkeypatch,
+        tmp_path,
+        strict=True,
+        include_masters=True,
+        meta_payload=meta_assets_list,
     )
     assert "meta.json must define assets as an object" in errors_assets
 
@@ -511,7 +559,11 @@ def test_strict_mode_rejects_non_object_assets_and_hashes(
     }
 
     errors_hashes = _run_validator(
-        monkeypatch, tmp_path, strict=True, include_masters=True, meta_payload=meta_hashes_str
+        monkeypatch,
+        tmp_path,
+        strict=True,
+        include_masters=True,
+        meta_payload=meta_hashes_str,
     )
     assert "meta.json must define hashes as an object" in errors_hashes
 


### PR DESCRIPTION
### Motivation
- Tighten the icon validator lock-mode so `sha256:` values must be real SHA-256 digests, preventing placeholders like `sha256:x` or `sha256:not-a-sha` from bypassing release-integrity checks.

### Description
- Replace the loose `sha256:` prefix check with a regex that requires exactly `sha256:` followed by 64 lowercase hex characters (`^sha256:[0-9a-f]{64}$`) in `scripts/validate_icon_core_v1.py`.
- Update test fixtures to use digest-shaped `sha256:` lock values so nominal tests remain valid under the stricter predicate in `tests/test_icon_core_validator.py`.
- Add a regression test `test_require_lock_values_rejects_invalid_sha256_digest_shapes` that asserts lock-mode rejects short, placeholder, non-hex, and otherwise malformed `sha256:` values.

### Testing
- `python3 -m compileall -q scripts/validate_icon_core_v1.py tests/test_icon_core_validator.py` succeeded (syntax OK).
- `python3 scripts/validate_icon_core_v1.py` ran in default mode and printed `OK: icon core v1.0 structure valid (default mode)`.
- Manual validator run with a fixture containing invalid `sha256:` values and `--require-lock-values` produced `meta.json lock placeholders found: ...`, demonstrating the new check rejects malformed digests.
- Unable to run the repo-wide automated gates in this environment: `pytest` is not installed so `python3 -m pytest` / `make validate-min` failed, `pre-commit` is not installed, `.venv` is missing so `make verify` failed, and `flake8` is not available so `make lint` could not run; these are environment limitations and not functional failures of the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00eb48802883339a54e55956933d5b)

## Summary by Sourcery

Ужесточена проверка блокировки icon-core, чтобы принимались только канонические дайджесты SHA-256, а также расширены тесты для покрытия корректных и некорректных значений блокировки.

Bug Fixes:
- Требовать, чтобы значения SHA-256 в режиме блокировки иконок соответствовали полному 64-значному шестнадцатеричному дайджесту в нижнем регистре, вместо допуска произвольных заполнителей с префиксом `sha256`.

Enhancements:
- Уточнить вспомогательный валидатор icon core для конкретных хэш-значений, используя скомпилированное регулярное выражение для сопоставления канонического дайджеста SHA-256.

Tests:
- Обновить фикстуры валидатора icon core для использования «похожих на дайджест» SHA-256 значений блокировки и добавить покрытие, гарантирующее, что некорректные значения с префиксом `sha256` отклоняются в режиме блокировки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten icon-core lock validation so only canonical SHA-256 digests are accepted and expand tests to cover valid and invalid lock values.

Bug Fixes:
- Require icon lock-mode SHA-256 values to match a full 64-character lowercase hex digest instead of allowing arbitrary sha256-prefixed placeholders.

Enhancements:
- Refine the icon core validator helper for concrete hash values to use a compiled regex for canonical SHA-256 digest matching.

Tests:
- Update icon core validator fixtures to use digest-shaped SHA-256 lock values and add coverage ensuring malformed sha256-prefixed values are rejected in lock mode.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces canonical SHA-256 lock values in icon metadata to block placeholders and tighten release integrity. Includes updated fixtures and a new regression test.

- **Bug Fixes**
  - Replace loose prefix check with regex `^sha256:[0-9a-f]{64}$` in `scripts/validate_icon_core_v1.py`.
  - Update test fixtures to use valid digest-shaped locks in `tests/test_icon_core_validator.py`.
  - Add regression test to reject short, non-hex, and placeholder `sha256:` values.

<sup>Written for commit a1fd16966d0d3fe224748c5640a996f67e6ddafd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

