### PR TITLE
fix(ci): make current-head fallback gating canonical-only

### DIFF
--- a/docs/review/PR_1733_FIXED_MAPPING.md
+++ b/docs/review/PR_1733_FIXED_MAPPING.md
@@ -1,0 +1,44 @@
+<!-- markdownlint-disable MD013 MD034 -->
+# PR 1733 Fixed In Commit Mapping
+
+- PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1733>
+- Branch: `fix-current-head-fallback`
+- Title: `fix(ci): make current-head fallback gating canonical-only`
+- Implementing commits:
+  - `1701d1fd14d57782131890aa038d1017436d8166` — make canonical CI fallback checks explicitly non-fragile and non-blocking for non-canonical workflows.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Per root `AGENTS.md` review governance, each actionable bot/human comment receives a disposition (`FIXED` / `NOT-A-BUG` / `DEFERRED`) with proof before thread resolution.
+
+### Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1733#pullrequestreview-4259985730 -> 1701d1fd14d57782131890aa038d1017436d8166
+
+Disposition: FIXED
+Commit: 1701d1fd14d57782131890aa038d1017436d8166
+Evidence: `scripts/ci/check_current_head_pr_checks.py:30-33` (canonical workflow identifiers moved to `CANONICAL_FALLBACK_WORKFLOW_NAMES`) and `_is_blocking_fallback_advisory` now checks membership in workflow set, not a literal.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1733#pullrequestreview-4259986894 -> 1701d1fd14d57782131890aa038d1017436d8166
+
+Disposition: FIXED
+Commit: 1701d1fd14d57782131890aa038d1017436d8166
+Evidence: `tests/test_current_head_pr_checks.py:149-159` adds explicit non-blocking test for canonical check-name in non-CI workflow (`lint` under `Docker Build and Push`), matching the review nitpick.
+
+## Merge Readiness
+
+- [ ] Pre-flight + agent consistency: PASS locally, re-run on final HEAD before final merge-call.
+- [ ] Canonical artifact: this file.
+- [ ] PR body Phase2 mirror synchronized (boxes + `Fixed in Commit Mapping`).
+- [ ] Required current-head CI jobs green (required check metadata unavailable case + required CI jobs).
+- [ ] Post-open reviewers completed (`qa-engineer-agent` → `bug-hunter`) and actionables dispositioned.
+- [ ] Mandatory wait-window after latest bot/review activity observed.
+
+## Local Validation Evidence
+
+- Pre-flight: `python3 scripts/orchestration/check_preflight.py` — PASS.
+- Agent consistency: `python3 scripts/orchestration/check_agent_consistency.py` — PASS.
+- Required test: `source .venv/bin/activate && python -m pytest tests/test_current_head_pr_checks.py -k "required_check_metadata_is_unavailable_and_optional_lane_fails"` — PASS.

--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -30,6 +30,7 @@ class CheckEntry:
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PENDING_STATUS_CONTEXT_STATES = {"EXPECTED", "PENDING"}
 CANONICAL_FALLBACK_STATUS_CONTEXT_NAMES = {"CI"}
+CANONICAL_FALLBACK_WORKFLOW_NAMES = {"CI"}
 # Keep this list aligned to the GitHub check-run display names emitted by the
 # canonical `.github/workflows/ci.yml` workflow, including matrix suffixes.
 CANONICAL_FALLBACK_CI_CHECK_NAMES = {
@@ -326,7 +327,7 @@ def _is_blocking_fallback_advisory(entry: CheckEntry) -> bool:
         return entry.name in CANONICAL_FALLBACK_STATUS_CONTEXT_NAMES
     return (
         entry.source_kind == "check_run"
-        and entry.workflow_name == "CI"
+        and entry.workflow_name in CANONICAL_FALLBACK_WORKFLOW_NAMES
         and entry.name in CANONICAL_FALLBACK_CI_CHECK_NAMES
     )
 

--- a/scripts/ci/check_current_head_pr_checks.py
+++ b/scripts/ci/check_current_head_pr_checks.py
@@ -320,9 +320,15 @@ def _required_snapshot(
 
 def _is_blocking_fallback_advisory(entry: CheckEntry) -> bool:
     """Return whether fallback merge gating must still block on this advisory entry."""
-    # Fail closed when required-check metadata is unavailable: any pending/failed
-    # current-head entry remains merge-blocking until metadata can be resolved.
-    return entry.state in {"pending", "failed"}
+    if entry.state not in {"pending", "failed"}:
+        return False
+    if entry.source_kind == "status_context":
+        return entry.name in CANONICAL_FALLBACK_STATUS_CONTEXT_NAMES
+    return (
+        entry.source_kind == "check_run"
+        and entry.workflow_name == "CI"
+        and entry.name in CANONICAL_FALLBACK_CI_CHECK_NAMES
+    )
 
 
 def _partition_fallback_advisory_entries(
@@ -460,8 +466,8 @@ def main(argv: list[str] | None = None) -> int:
         )
         print(
             "Required check metadata unavailable; merge gating falls back to GitHub "
-            "mergeStateStatus. Current-head checks fail closed: any pending/failed "
-            "current-head check remains blocking."
+            "mergeStateStatus. Current-head checks stay advisory unless a canonical "
+            "ordinary-PR CI signal remains pending or failed."
         )
         if advisory_blocking_entries:
             _print_entries("Current-head blocking fallback checks:", advisory_blocking_entries)
@@ -483,7 +489,7 @@ def main(argv: list[str] | None = None) -> int:
         if blocking_entries:
             print("- Blocking current-head checks remain pending or failed.")
         if advisory_blocking_entries:
-            print("- Blocking fallback current-head checks remain pending or failed.")
+            print("- Blocking canonical fallback current-head checks remain pending or failed.")
         return 1
 
     if merge_state_note_needed:

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -107,7 +107,7 @@ def test_ci_workflow_matrix_display_name_stays_in_sync() -> None:
                 workflow_name="Docker Build and Push",
                 conclusion="",
             ),
-            True,
+            False,
         ),
         (
             current_head_checks.CheckEntry(
@@ -119,7 +119,7 @@ def test_ci_workflow_matrix_display_name_stays_in_sync() -> None:
                 workflow_name="Optional CI",
                 conclusion="FAILURE",
             ),
-            True,
+            False,
         ),
         (
             current_head_checks.CheckEntry(
@@ -433,7 +433,7 @@ def test_main_passes_when_merge_state_is_not_clean_but_advisory_snapshot_is_clea
     assert "NOTE: GitHub mergeStateStatus=UNSTABLE is stale/non-blocking" in captured.out
 
 
-def test_main_fails_when_merge_state_is_not_clean_and_specialized_advisory_check_is_pending(
+def test_main_passes_when_merge_state_is_not_clean_and_specialized_advisory_check_is_pending(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
@@ -467,14 +467,17 @@ def test_main_fails_when_merge_state_is_not_clean_and_specialized_advisory_check
     )
 
     captured = capsys.readouterr()
-    assert exit_code == 1
+    assert exit_code == 0
     assert "Required check metadata unavailable" in captured.out
-    assert "Current-head blocking fallback checks:" in captured.out
+    assert "Current-head advisory checks:" in captured.out
     assert "- security-scan: pending [Docker Build and Push]" in captured.out
-    assert "Blocking fallback current-head checks remain pending or failed." in captured.out
+    assert (
+        "Blocking canonical fallback current-head checks remain pending or failed."
+        not in captured.out
+    )
 
 
-def test_main_fails_when_specialized_ci_job_is_pending_in_fallback_mode(
+def test_main_passes_when_specialized_ci_job_is_pending_in_fallback_mode(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(current_head_checks, "_github_token", lambda: "token")
@@ -508,10 +511,13 @@ def test_main_fails_when_specialized_ci_job_is_pending_in_fallback_mode(
     )
 
     captured = capsys.readouterr()
-    assert exit_code == 1
+    assert exit_code == 0
     assert "- iOS unit tests (xcodebuild): pending [CI]" in captured.out
-    assert "Current-head blocking fallback checks:" in captured.out
-    assert "Blocking fallback current-head checks remain pending or failed." in captured.out
+    assert "Current-head advisory checks:" in captured.out
+    assert (
+        "Blocking canonical fallback current-head checks remain pending or failed."
+        not in captured.out
+    )
 
 
 def test_main_fails_when_merge_state_is_not_clean_and_canonical_fallback_check_is_pending(
@@ -550,10 +556,9 @@ def test_main_fails_when_merge_state_is_not_clean_and_canonical_fallback_check_i
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "GitHub mergeStateStatus=UNSTABLE" in captured.out
-    assert "Current-head blocking fallback checks:" in captured.out
     assert "- Docs Phase1 gates: pending [CI]" in captured.out
     assert (
-        "Blocking fallback current-head checks remain pending or failed." in captured.out
+        "Blocking canonical fallback current-head checks remain pending or failed." in captured.out
     )
 
 
@@ -593,10 +598,9 @@ def test_main_fails_when_merge_state_is_clean_and_canonical_fallback_check_is_pe
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "GitHub mergeStateStatus=CLEAN" not in captured.out
-    assert "Current-head blocking fallback checks:" in captured.out
     assert "- Docs Phase1 gates: pending [CI]" in captured.out
     assert (
-        "Blocking fallback current-head checks remain pending or failed." in captured.out
+        "Blocking canonical fallback current-head checks remain pending or failed." in captured.out
     )
 
 

--- a/tests/test_current_head_pr_checks.py
+++ b/tests/test_current_head_pr_checks.py
@@ -145,6 +145,18 @@ def test_ci_workflow_matrix_display_name_stays_in_sync() -> None:
             ),
             False,
         ),
+        (
+            current_head_checks.CheckEntry(
+                name="lint",
+                source_kind="check_run",
+                state="pending",
+                timestamp="2026-03-12T08:36:42Z",
+                details_url="https://example.invalid/lint-other-workflow",
+                workflow_name="Docker Build and Push",
+                conclusion="",
+            ),
+            False,
+        ),
     ],
 )
 def test_is_blocking_fallback_advisory(


### PR DESCRIPTION
## Summary
- Fix current-head CI fallback logic to ignore specialized/non-canonical advisory signals (e.g. Docker Build and Push, Optional CI) when required-check metadata is unavailable.
- Keep blocking behavior for canonical CI checks only.

## Tests
- pre-commit run --files scripts/ci/check_current_head_pr_checks.py tests/test_current_head_pr_checks.py
- pre-push checks passed during push (hooks)

## Notes
- This addresses failing main CI behavior where Optional/auxiliary lanes incorrectly blocked merge.

## Summary by Sourcery

Настроить резервное ограничение CI для current-head так, чтобы в случае отсутствия метаданных о обязательных проверках только канонические CI-проверки считались блокирующими.

Bug Fixes:
- Предотвратить ситуацию, когда необязательные и специализированные рекомендательные CI-ленты некорректно блокируют слияния при отсутствии метаданных о обязательных проверках.

CI:
- Обновить резервную логику и сообщения current-head CI, чтобы в режиме fallback отличать рекомендательные проверки от канонических блокирующих проверок.

Tests:
- Обновить и расширить тесты current-head CI, чтобы покрыть поведение блокировки только каноническими проверками в режиме fallback и новое рекомендательное сообщение.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust current-head CI fallback gating to treat only canonical CI checks as blocking when required-check metadata is unavailable.

Bug Fixes:
- Prevent optional and specialized advisory CI lanes from incorrectly blocking merges when required-check metadata is missing.

CI:
- Update current-head CI fallback logic and messaging to distinguish advisory checks from canonical blocking checks in fallback mode.

Tests:
- Update and extend current-head CI tests to cover canonical-only fallback blocking behavior and new advisory messaging.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts fallback merge gating to canonical CI checks only when required-check metadata is missing. Optional and specialized lanes are advisory and no longer block merges.

- **Bug Fixes**
  - Updated `_is_blocking_fallback_advisory` to use canonical workflow and check-name sets: only `status_context` names in the canonical set, or `check_run` entries from workflows in the canonical set (e.g., `CI`) with canonical names, remain blocking.
  - Improved CLI copy and tests to reflect advisory behavior (exit code 0 for specialized lanes) and added a non-blocking case for canonical check names under non-canonical workflows; added review mapping doc at `docs/review/PR_1733_FIXED_MAPPING.md`.

<sup>Written for commit fcafba2b074793fac39c819536a1ba42ae000fe7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Merge-blocking logic narrowed to only canonical checks; non-canonical/specialized checks are now advisory-only, allowing merges when only those are pending/failed.
  * Status messaging clarified to identify which canonical fallback checks remain blocking versus advisory when metadata is missing.

* **Tests**
  * Updated tests to reflect advisory vs. blocking behavior and renamed scenarios to expect success where appropriate.

* **Documentation**
  * Added a review document recording a fixed PR-to-commit mapping and validation notes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1733)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1733#pullrequestreview-4259985730 -> 1701d1fd14d57782131890aa038d1017436d8166
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1733#pullrequestreview-4259986894 -> 1701d1fd14d57782131890aa038d1017436d8166

## Merge Readiness
- [ ] review-governance gate pass
- [ ] CI gate pass

