### PR TITLE
chore(deps): raise urllib3 floor to 2.7.0

### DIFF
--- a/requirements-ci-lite.txt
+++ b/requirements-ci-lite.txt
@@ -359,7 +359,7 @@ typing-inspection==0.4.2
     #   -c requirements.txt
     #   fastapi
     #   pydantic
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements.txt
     #   requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -237,7 +237,7 @@ typing-extensions==4.15.0
     # via
     #   -c requirements.txt
     #   mypy
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements.txt
     #   requests

--- a/requirements-docker-runtime.txt
+++ b/requirements-docker-runtime.txt
@@ -263,7 +263,7 @@ typing-inspection==0.4.2
     #   -c requirements.txt
     #   fastapi
     #   pydantic
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements.txt
     #   requests

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -199,7 +199,7 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests
 uvicorn==0.42.0
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -197,7 +197,7 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests
 uvicorn==0.42.0
     # via -r requirements.in


### PR DESCRIPTION
## Scope\n- Dependency-layer only bump of urllib3 floor to 2.7.0 across requirements manifests.\n\n## Files\n- requirements.txt\n- requirements-lock.txt\n- requirements-ci-lite.txt\n- requirements-docker-runtime.txt\n- requirements-dev.txt\n\n## Out of scope\n- No application or business logic changes.\n

## Summary by Sourcery

Build:
- Обновить закреплённую версию `urllib3` с 2.6.3 до 2.7.0 в основных файлах требований, файлах блокировок, лёгкой CI-сборке, dev-конфигурации и файлах требований для docker-окружения.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update urllib3 pin from 2.6.3 to 2.7.0 in primary, lock, CI-lite, dev, and docker runtime requirements files.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `urllib3` dependency to version 2.7.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1736)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->