### PR TITLE
fix(infra): restore requests floor via emergency proxy manifest

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -137,6 +137,12 @@
         "^dist/",
         "^build/"
       ]
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_secret",
+      "pattern": [
+        "3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b"
+      ]
     }
   ],
   "results": {
@@ -521,28 +527,28 @@
         "filename": "scripts/ci/emergency_python_wheels.json",
         "hashed_secret": "32b39bf851676b2992116bdc163f05656b2396e7",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 133
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
         "hashed_secret": "9d99ddcde81d214a71fbade9b758ef72213c835d",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 140
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
         "hashed_secret": "d17b1dc21afd47e49ba9ece8f526d561059f8a7d",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 147
       },
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
         "hashed_secret": "5b9291e9516560d35add069c8f30e9e84e70fe30",
         "is_verified": false,
-        "line_number": 147
+        "line_number": 154
       }
     ],
     "scripts/ensure_database_versions.py": [
@@ -1694,5 +1700,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-10T20:18:36Z"
+  "generated_at": "2026-05-11T20:00:17Z"
 }

--- a/scripts/ci/emergency_python_wheels.json
+++ b/scripts/ci/emergency_python_wheels.json
@@ -119,6 +119,13 @@
       "sha256": "6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645"
     },
     {
+      "package": "requests",
+      "version": "2.33.0",
+      "filename": "requests-2.33.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl",
+      "sha256": "3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b"
+    },
+    {
       "package": "sentence-transformers",
       "version": "5.4.1",
       "filename": "sentence_transformers-5.4.1-py3-none-any.whl",


### PR DESCRIPTION
## Scope
- Infrastructure-only dependency fix for PR 1734
- Add `requests==2.33.0` emergency floor artifact entry in `scripts/ci/emergency_python_wheels.json`

## Non-goals
- No business logic changes
- No replay-chain/app logic changes

## Validation
- Ran `python3 scripts/orchestration/check_preflight.py`
- Ran `python3 scripts/orchestration/task_bootstrap.py --goal "Restore requests floor via emergency proxy manifest" --task-class infra --path scripts/ci/emergency_python_wheels.json --requested-agent bug-hunter --pr-phase pre_open`
- Ran `pre-commit run --all-files`
- Ran `python3 scripts/ci/install_locked_python_requirements.py --preflight-only --requirements-profile ci-lite --emergency-wheel-manifest scripts/ci/emergency_python_wheels.json` (index-host check prevented public-host validation locally)

## Summary by Sourcery

Восстановить минимально поддерживаемую версию зависимости Python `requests`, используя аварийный манифест колёс для CI, и соответствующим образом обновить эталонные файлы секретов.

Исправления ошибок:
- Обеспечить надёжную установку в CI закреплённой версии `requests==2.33.0`, добавив её в аварийный манифест колёс.

Сборка:
- Расширить аварийный манифест Python-колёс, включив в него колесо `requests==2.33.0`, используемое в CI.

Рутинные задачи:
- Обновить эталонный файл секретов с учётом нового контрольного значения колеса, чтобы избежать ложных срабатываний при обнаружении секретов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore the Python requests dependency floor using the emergency wheel manifest for CI and update secrets baselines accordingly.

Bug Fixes:
- Ensure CI reliably installs the pinned requests==2.33.0 version by adding it to the emergency wheel manifest.

Build:
- Extend the emergency Python wheels manifest to include the requests==2.33.0 wheel used by CI.

Chores:
- Refresh the secrets baseline to account for the new wheel checksum and avoid false-positive secret detections.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Восстановить минимально поддерживаемую версию зависимости Python `requests`, используя аварийный манифест колёс для CI, и соответствующим образом обновить эталонные файлы секретов.

Исправления ошибок:
- Обеспечить надёжную установку в CI закреплённой версии `requests==2.33.0`, добавив её в аварийный манифест колёс.

Сборка:
- Расширить аварийный манифест Python-колёс, включив в него колесо `requests==2.33.0`, используемое в CI.

Рутинные задачи:
- Обновить эталонный файл секретов с учётом нового контрольного значения колеса, чтобы избежать ложных срабатываний при обнаружении секретов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore the Python requests dependency floor using the emergency wheel manifest for CI and update secrets baselines accordingly.

Bug Fixes:
- Ensure CI reliably installs the pinned requests==2.33.0 version by adding it to the emergency wheel manifest.

Build:
- Extend the emergency Python wheels manifest to include the requests==2.33.0 wheel used by CI.

Chores:
- Refresh the secrets baseline to account for the new wheel checksum and avoid false-positive secret detections.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the `requests` dependency floor by adding the 2.33.0 wheel to the emergency proxy manifest so CI can reliably install the pinned version.

- **Dependencies**
  - Added `requests==2.33.0` to `scripts/ci/emergency_python_wheels.json`.
  - Updated `.secrets.baseline` to ignore the wheel’s SHA256 to avoid false positives.

<sup>Written for commit dba8fb37740143d21e90d23e0677638830300317. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1737_FIXED_MAPPING.md`
