### PR TITLE
feat(orchestration): add experiment notification artifact sink

### DIFF
--- a/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
@@ -294,6 +294,22 @@ If a candidate wins, the coordinator promotes it into exactly one destination:
 - promotion decisions are emitted through `scripts/orchestration/experiment_promote.py`,
 - no duplicate canonical policy wording across multiple docs.
 
+### Artifact-only notification
+
+`scripts/orchestration/experiment_notify.py` may render a redacted markdown
+summary from validated experiment packet, result, and optional promotion
+decision artifacts.
+
+Rules:
+
+- notification output is evidence-only and does not change promotion,
+  merge-readiness, or review-thread disposition authority,
+- v1 notification must not send email, Slack messages, GitHub comments, or
+  other external delivery,
+- summaries must omit raw patch text, oracle stdout/stderr, cwd, secrets, and
+  local absolute paths,
+- optional `GITHUB_STEP_SUMMARY` writes require an explicit CLI flag.
+
 ---
 
 ## 9. Sequencing for the current program

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -9,6 +9,7 @@
   - `585607b04c0476fbb3f5f7cd8f35a42545c16858` - initial fixed-mapping artifact.
   - `e3f1232abc326ff805ae66737fddf5f34fd035d0` - post-open hardening and role-agent fixes.
   - `77bec5c2c3fef12c906be3c1f4625c44cb758fd8` - review-thread mapping update.
+  - `52c84f793caa6ec6be226169370a87e2f8429966` - stale-commit review-thread mapping.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -27,7 +28,7 @@ re-triggered through the normal ready-for-review cycle.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235757467 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761786 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761791 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761797 -> 77bec5c2c3fef12c906be3c1f4625c44cb758fd8
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761797 -> 52c84f793caa6ec6be226169370a87e2f8429966
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235799044 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235799048 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 
@@ -36,7 +37,7 @@ Commit: e3f1232abc326ff805ae66737fddf5f34fd035d0
 Evidence: `scripts/orchestration/experiment_notify.py` removes dynamic `sys.path.insert`, rejects symlinked artifact ancestors/components, redacts Windows/backslash local path shapes, and exposes explicit module-entrypoint failure for unsupported direct invocation contexts. `tests/test_experiment_notify.py` adds the regression coverage.
 
 Disposition: FIXED
-Commit: 77bec5c2c3fef12c906be3c1f4625c44cb758fd8
+Commit: 52c84f793caa6ec6be226169370a87e2f8429966
 Evidence: This artifact now lists all implementing commits instead of only the initial sink commit and maps the stale-commit review thread to the review-mapping update.
 
 ## Local Validation Evidence

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -15,6 +15,7 @@
   - `67dea3563288468c70d45895885c8d0b90712c15` - post-fix review-thread mapping.
   - `155b25f088f1f0fc5d36daf7d33243e7f11d1f50` - role review pass mapping.
   - `6b837c9207ccddb00f2663a8d73762f458b154d9` - result evidence validation fixes.
+  - `389e5c3d5d62ad6721842e8fc686db8a0b91107d` - valid ancestor proof mapping.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -42,6 +43,7 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235961729 -> b281fa42bf17d9a565f536e7b64acabc21e7202b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235961734 -> b281fa42bf17d9a565f536e7b64acabc21e7202b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236005091 -> b281fa42bf17d9a565f536e7b64acabc21e7202b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236168813 -> 389e5c3d5d62ad6721842e8fc686db8a0b91107d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236168816 -> 6b837c9207ccddb00f2663a8d73762f458b154d9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236168825 -> 6b837c9207ccddb00f2663a8d73762f458b154d9
 
@@ -60,6 +62,10 @@ Evidence: `scripts/orchestration/experiment_notify.py` now checks `is_symlink()`
 Disposition: FIXED
 Commit: 6b837c9207ccddb00f2663a8d73762f458b154d9
 Evidence: `scripts/orchestration/experiment_notify.py` now rejects promoted accepted results when `shared_tree_untouched` is false and cross-checks result `mutated_paths` / `oracle_results` against the validated packet before rendering notification evidence. `tests/test_experiment_notify.py` covers dirty shared-tree promotion, missing accepted oracle results, out-of-surface mutated paths, and extra oracle commands.
+
+Disposition: FIXED
+Commit: 389e5c3d5d62ad6721842e8fc686db8a0b91107d
+Evidence: This artifact now uses full valid commit SHAs reachable from the current branch head for every mapped FIXED proof.
 
 ## Local Validation Evidence
 

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -26,6 +26,7 @@
   - `98740bebd04302f0cd552558d09df60af8eeb48b` - fail-closed evidence drift validation.
   - `b5bf50f9f60204feb476ce2ca810fdb773d225df` - typed surface containment follow-up.
   - `261085d5e2fc8d760dcc743fc0adeffadcaa07c5` - runner-aligned notification evidence validation.
+  - `0b7790f853562deb0a58ddd934085636d990d7be` - sanitized validation diagnostics and accepted/rejected state checks.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -87,6 +88,11 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236869446 -> 261085d5e2fc8d760dcc743fc0adeffadcaa07c5
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236869450 -> 261085d5e2fc8d760dcc743fc0adeffadcaa07c5
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236869455 -> 261085d5e2fc8d760dcc743fc0adeffadcaa07c5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284762777 -> 0b7790f853562deb0a58ddd934085636d990d7be
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236937872 -> 0b7790f853562deb0a58ddd934085636d990d7be
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236937877 -> 0b7790f853562deb0a58ddd934085636d990d7be
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236937880 -> 0b7790f853562deb0a58ddd934085636d990d7be
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236937894 -> 0b7790f853562deb0a58ddd934085636d990d7be
 
 Disposition: FIXED
 Commit: e3f1232abc9a54743bc3485930c81f4de7c734ed
@@ -136,11 +142,15 @@ Disposition: FIXED
 Commit: 261085d5e2fc8d760dcc743fc0adeffadcaa07c5
 Evidence: `scripts/orchestration/experiment_notify.py` now aligns directory-surface matching with runner prefix behavior for new directories while still rejecting existing file surfaces, rejects rejected results whose terminal oracle passed, and redacts notification output write failures. `tests/test_experiment_notify.py` covers each regression.
 
+Disposition: FIXED
+Commit: 0b7790f853562deb0a58ddd934085636d990d7be
+Evidence: `scripts/orchestration/experiment_notify.py` now sanitizes shared-validator `ValueError` diagnostics, allows `infra_flake` rejected results after passing oracle prefixes, and rejects accepted results with dirty shared-tree evidence before notification rendering. `tests/test_experiment_notify.py` covers each regression.
+
 ## Local Validation Evidence
 
 - `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration --path tests` - PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
-- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 84 tests after post-open review fixes.
+- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 87 tests after post-open review fixes.
 - `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` - PASS.
 - `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` - PASS.
 - `pre-commit run --all-files` - PASS after black formatted `scripts/orchestration/experiment_notify.py`.

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -12,6 +12,7 @@
   - `52c84f793caa6ec6be226169370a87e2f8429966` - stale-commit review-thread mapping.
   - `f9fb7ef434b2177827eb06d56602079ed65c85df` - aggregate bot review mapping.
   - `b281fa42b32aec312a237e4cb49daf5297c00aa9` - redaction and symlink-containment follow-up fixes.
+  - `67dea3563288468c70d45895885c8d0b90712c15` - post-fix review-thread mapping.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -19,9 +20,9 @@
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-No review threads have been resolved. CodeRabbit initially skipped review while the PR
-was draft; the PR was marked ready for review on 2026-05-13 and bot review is being
-re-triggered through the normal ready-for-review cycle.
+Post-open bot review threads were classified, fixed, mapped, and resolved on 2026-05-13.
+The PR was marked ready for review after the draft-only CodeRabbit skip, and the latest
+current-head bot/CI cycle is being monitored before any merge-readiness claim.
 
 ## Fixed in Commit Mapping
 
@@ -75,9 +76,12 @@ Plain `make validate-changed` in this isolated worktree failed before test execu
 
 ## Premortem / Role Review Findings
 
+- Coordinator bootstrap: `artifacts/orchestration/task_packets/pr1749_post_open_review_2026-05-13.json` produced task packet `8384fad99c80`; declared executable order was `agent-coordinator -> architecture-specialist -> cursor-specialist-agent -> security-auditor -> qa-engineer-agent -> bug-hunter`.
 - Security-auditor / Codex Security finding: durable artifact paths could be misleading if promotion metadata named an unrelated repo path. Disposition: FIXED in `0d45edbe4df594cd22213107cd9aaf56c5bc87e6` by target-specific durable artifact path validation and negative tests.
 - QA / bug-hunter finding: false-green risk if tests only checked substring output. Disposition: FIXED in `0d45edbe4df594cd22213107cd9aaf56c5bc87e6` by deterministic full-body markdown checks, CLI JSON checks, and negative promotion/path tests.
 - Premortem finding: reviewers may confuse artifact notification with external delivery. Disposition: FIXED in `0d45edbe4df594cd22213107cd9aaf56c5bc87e6` by explicit docs and rendered delivery boundary.
+- Premortem finding: notification artifacts could leak local runner details through path edge cases. Disposition: FIXED in `e3f1232abc326ff805ae66737fddf5f34fd035d0` and `b281fa42b32aec312a237e4cb49daf5297c00aa9` by Windows/backslash, home-credential, control-character, symlinked-directory, symlinked-ancestor, symlinked-child, and broken-symlink output tests.
+- Premortem decision: proceed with changes; required changes have been applied, and readiness remains blocked only on current-head CI/bot review terminal state and the mandatory wait-window.
 
 ## Risks / Rollback
 

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -29,6 +29,7 @@
   - `0b7790f853562deb0a58ddd934085636d990d7be` - sanitized validation diagnostics and accepted/rejected state checks.
   - `367504ae685a97c0cd410b2acde0bfc115a13b5a` - forged evidence rejection hardening.
   - `a705625f9d39f652cee75463e07fd26d5a9ebab9` - rejected-result shape alignment.
+  - `1127bf9c4c5b979966191c28eaa05824483a3e2b` - rejected-shape review mapping update.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -100,6 +101,7 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236984659 -> 367504ae685a97c0cd410b2acde0bfc115a13b5a
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236984667 -> 367504ae685a97c0cd410b2acde0bfc115a13b5a
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236984673 -> 367504ae685a97c0cd410b2acde0bfc115a13b5a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237147907 -> 1127bf9c4c5b979966191c28eaa05824483a3e2b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237147911 -> a705625f9d39f652cee75463e07fd26d5a9ebab9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237147913 -> a705625f9d39f652cee75463e07fd26d5a9ebab9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237147920 -> a705625f9d39f652cee75463e07fd26d5a9ebab9
@@ -163,6 +165,10 @@ Evidence: `scripts/orchestration/experiment_notify.py` now rejects traversal com
 Disposition: FIXED
 Commit: a705625f9d39f652cee75463e07fd26d5a9ebab9
 Evidence: `scripts/orchestration/experiment_notify.py` now rejects pre-oracle rejected-result classes when oracle evidence is present, rejects `policy_violation` evidence with mutated paths, and scopes terminal-oracle failure requirements to oracle-derived failure classes so `metric_regression` can summarize passing oracle prefixes. `tests/test_experiment_notify.py` covers each regression.
+
+Disposition: FIXED
+Commit: 1127bf9c4c5b979966191c28eaa05824483a3e2b
+Evidence: This artifact maps the latest stale-proof review thread to a current-head ancestor commit made after the review comment.
 
 ## Local Validation Evidence
 

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -23,6 +23,7 @@
   - `9e42c202155683886b49ee381c3f1b15b67a0955` - promotion evidence and diagnostic validation.
   - `527ea55bce9345189a09403f13dc310c45d74a63` - promotion evidence mapping update.
   - `cc7a28debe49cc228abacb8196c8c33c63e27dbe` - command diagnostic and mutable-surface containment hardening.
+  - `98740bebd04302f0cd552558d09df60af8eeb48b` - fail-closed evidence drift validation.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -74,6 +75,12 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236650625 -> cc7a28debe49cc228abacb8196c8c33c63e27dbe
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284441229 -> cc7a28debe49cc228abacb8196c8c33c63e27dbe
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236651151 -> cc7a28debe49cc228abacb8196c8c33c63e27dbe
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284603279 -> 98740bebd04302f0cd552558d09df60af8eeb48b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236793354 -> 98740bebd04302f0cd552558d09df60af8eeb48b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284603849 -> 98740bebd04302f0cd552558d09df60af8eeb48b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236793887 -> 98740bebd04302f0cd552558d09df60af8eeb48b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236793892 -> 98740bebd04302f0cd552558d09df60af8eeb48b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236793897 -> 98740bebd04302f0cd552558d09df60af8eeb48b
 
 Disposition: FIXED
 Commit: e3f1232abc9a54743bc3485930c81f4de7c734ed
@@ -115,11 +122,15 @@ Disposition: FIXED
 Commit: cc7a28debe49cc228abacb8196c8c33c63e27dbe
 Evidence: `scripts/orchestration/experiment_notify.py` now redacts JSON load failures without echoing unsafe paths, skips multiline shell environment assignments before rendering oracle names, redacts credential-path command executables, and prevents file-like mutable surfaces from matching nested paths. `tests/test_experiment_notify.py` covers each regression.
 
+Disposition: FIXED
+Commit: 98740bebd04302f0cd552558d09df60af8eeb48b
+Evidence: `scripts/orchestration/experiment_notify.py` now allows nested mutable paths only for explicit or existing directory surfaces, rejects accepted results with non-null `failure_class`, requires rejected result oracle evidence to preserve packet prefix order, and redacts `GITHUB_STEP_SUMMARY` write failures. `tests/test_experiment_notify.py` covers each regression.
+
 ## Local Validation Evidence
 
 - `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration --path tests` - PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
-- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 77 tests after post-open review fixes.
+- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 81 tests after post-open review fixes.
 - `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` - PASS.
 - `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` - PASS.
 - `pre-commit run --all-files` - PASS after black formatted `scripts/orchestration/experiment_notify.py`.

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -22,6 +22,7 @@
   - `d2e15ebb1c51584d5d97da639bd04868185708d2` - stale proof mapping update.
   - `9e42c202155683886b49ee381c3f1b15b67a0955` - promotion evidence and diagnostic validation.
   - `527ea55bce9345189a09403f13dc310c45d74a63` - promotion evidence mapping update.
+  - `cc7a28debe49cc228abacb8196c8c33c63e27dbe` - command diagnostic and mutable-surface containment hardening.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -67,6 +68,12 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284232269 -> 9e42c202155683886b49ee381c3f1b15b67a0955
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236465759 -> 9e42c202155683886b49ee381c3f1b15b67a0955
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236465778 -> 9e42c202155683886b49ee381c3f1b15b67a0955
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236650609 -> cc7a28debe49cc228abacb8196c8c33c63e27dbe
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236650615 -> cc7a28debe49cc228abacb8196c8c33c63e27dbe
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236650623 -> cc7a28debe49cc228abacb8196c8c33c63e27dbe
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236650625 -> cc7a28debe49cc228abacb8196c8c33c63e27dbe
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284441229 -> cc7a28debe49cc228abacb8196c8c33c63e27dbe
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236651151 -> cc7a28debe49cc228abacb8196c8c33c63e27dbe
 
 Disposition: FIXED
 Commit: e3f1232abc9a54743bc3485930c81f4de7c734ed
@@ -104,11 +111,15 @@ Disposition: FIXED
 Commit: 9e42c202155683886b49ee381c3f1b15b67a0955
 Evidence: `scripts/orchestration/experiment_notify.py` now redacts outside-surface mutated-path diagnostics, accepts nested directory mutable surfaces without suffix heuristics, validates promotion evidence oracle commands/mutated paths/oracle count against packet/result metadata, and rejects accepted results with failed or timed-out oracles. `tests/test_experiment_notify.py` covers each regression.
 
+Disposition: FIXED
+Commit: cc7a28debe49cc228abacb8196c8c33c63e27dbe
+Evidence: `scripts/orchestration/experiment_notify.py` now redacts JSON load failures without echoing unsafe paths, skips multiline shell environment assignments before rendering oracle names, redacts credential-path command executables, and prevents file-like mutable surfaces from matching nested paths. `tests/test_experiment_notify.py` covers each regression.
+
 ## Local Validation Evidence
 
 - `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration --path tests` - PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
-- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 75 tests after post-open review fixes.
+- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 77 tests after post-open review fixes.
 - `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` - PASS.
 - `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` - PASS.
 - `pre-commit run --all-files` - PASS after black formatted `scripts/orchestration/experiment_notify.py`.

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -9,15 +9,16 @@
 
 ## Discussion Thread Pass
 
-- [x] Draft PR opened.
-- [x] Fixed in commit mapping artifact created.
-- [ ] Post-open review thread pass pending.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
-No review threads have been resolved.
+No review threads have been resolved. CodeRabbit initially skipped review while the PR
+was draft; the PR was marked ready for review on 2026-05-13 and bot review is being
+re-triggered through the normal ready-for-review cycle.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments as of draft PR open.
+- No actionable review comments
 
 ## Local Validation Evidence
 
@@ -54,14 +55,14 @@ Plain `make validate-changed` in this isolated worktree failed before test execu
 
 ## Merge Readiness
 
-- [x] Coordinator-first preflight/bootstrap completed.
-- [x] Canonical artifact exists.
-- [x] Local narrow gates completed.
-- [ ] Current-head CI pending.
+- [ ] Coordinator final synthesis completed.
+- [ ] Canonical artifact updated after bot/human review cycle.
+- [ ] Local narrow gates rerun after final review fixes.
+- [ ] Current-head CI pending after ready-for-review governance update.
 - [ ] Bot/human review pass pending.
 - [ ] Mandatory wait-window pending.
 
-Draft PR is not merge-ready.
+PR is not merge-ready.
 
 ## Deferred / Follow-ups
 

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -30,6 +30,7 @@
   - `367504ae685a97c0cd410b2acde0bfc115a13b5a` - forged evidence rejection hardening.
   - `a705625f9d39f652cee75463e07fd26d5a9ebab9` - rejected-result shape alignment.
   - `1127bf9c4c5b979966191c28eaa05824483a3e2b` - rejected-shape review mapping update.
+  - `5f9d2ec5479f734346e4fcc423848ff8bf2fd4da` - promotion notification evidence validation.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -105,6 +106,8 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237147911 -> a705625f9d39f652cee75463e07fd26d5a9ebab9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237147913 -> a705625f9d39f652cee75463e07fd26d5a9ebab9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237147920 -> a705625f9d39f652cee75463e07fd26d5a9ebab9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237325474 -> 5f9d2ec5479f734346e4fcc423848ff8bf2fd4da
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237325478 -> 5f9d2ec5479f734346e4fcc423848ff8bf2fd4da
 
 Disposition: FIXED
 Commit: e3f1232abc9a54743bc3485930c81f4de7c734ed
@@ -170,11 +173,15 @@ Disposition: FIXED
 Commit: 1127bf9c4c5b979966191c28eaa05824483a3e2b
 Evidence: This artifact maps the latest stale-proof review thread to a current-head ancestor commit made after the review comment.
 
+Disposition: FIXED
+Commit: 5f9d2ec5479f734346e4fcc423848ff8bf2fd4da
+Evidence: `scripts/orchestration/experiment_notify.py` now requires promotion decisions to point at an existing durable repo artifact, requires backlog promotions to include the experiment anchor/block, and requires `metric_regression` rejected results to include the full passing oracle list. `tests/test_experiment_notify.py` covers each regression.
+
 ## Local Validation Evidence
 
 - `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration --path tests` - PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
-- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 93 tests after post-open review fixes.
+- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, focused notify/runner/promote suite after post-open review fixes.
 - `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` - PASS.
 - `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` - PASS.
 - `pre-commit run --all-files` - PASS after black formatted `scripts/orchestration/experiment_notify.py`.

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -24,6 +24,7 @@
   - `527ea55bce9345189a09403f13dc310c45d74a63` - promotion evidence mapping update.
   - `cc7a28debe49cc228abacb8196c8c33c63e27dbe` - command diagnostic and mutable-surface containment hardening.
   - `98740bebd04302f0cd552558d09df60af8eeb48b` - fail-closed evidence drift validation.
+  - `b5bf50f9f60204feb476ce2ca810fdb773d225df` - typed surface containment follow-up.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -16,6 +16,8 @@
   - `155b25f088f1f0fc5d36daf7d33243e7f11d1f50` - role review pass mapping.
   - `6b837c9207ccddb00f2663a8d73762f458b154d9` - result evidence validation fixes.
   - `389e5c3d5d62ad6721842e8fc686db8a0b91107d` - valid ancestor proof mapping.
+  - `791caa567ff0f3f4bed2051e93141f16bf667554` - latest review-fix mapping.
+  - `c15f2ac344b92be833567d7c64745fd3c11d0013` - notification diagnostic hardening.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -43,9 +45,16 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235961729 -> b281fa42bf17d9a565f536e7b64acabc21e7202b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235961734 -> b281fa42bf17d9a565f536e7b64acabc21e7202b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236005091 -> b281fa42bf17d9a565f536e7b64acabc21e7202b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4283699021 -> b281fa42bf17d9a565f536e7b64acabc21e7202b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236168813 -> 389e5c3d5d62ad6721842e8fc686db8a0b91107d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236168816 -> 6b837c9207ccddb00f2663a8d73762f458b154d9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236168825 -> 6b837c9207ccddb00f2663a8d73762f458b154d9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284047218 -> c15f2ac344b92be833567d7c64745fd3c11d0013
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236302268 -> 791caa567ff0f3f4bed2051e93141f16bf667554
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236302273 -> c15f2ac344b92be833567d7c64745fd3c11d0013
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236302278 -> c15f2ac344b92be833567d7c64745fd3c11d0013
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284068594 -> c15f2ac344b92be833567d7c64745fd3c11d0013
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236321888 -> c15f2ac344b92be833567d7c64745fd3c11d0013
 
 Disposition: FIXED
 Commit: e3f1232abc9a54743bc3485930c81f4de7c734ed
@@ -67,11 +76,15 @@ Disposition: FIXED
 Commit: 389e5c3d5d62ad6721842e8fc686db8a0b91107d
 Evidence: This artifact now uses full valid commit SHAs reachable from the current branch head for every mapped FIXED proof.
 
+Disposition: FIXED
+Commit: c15f2ac344b92be833567d7c64745fd3c11d0013
+Evidence: `scripts/orchestration/experiment_notify.py` now treats directory mutable surfaces as containing nested result paths, skips leading shell `KEY=value` assignments before rendering oracle command names, and redacts unexpected-oracle diagnostics to command names. `tests/test_experiment_notify.py` covers directory surface containment, env-assignment command redaction, and secret-free fail-closed diagnostics.
+
 ## Local Validation Evidence
 
 - `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration --path tests` - PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
-- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 69 tests after post-open review fixes.
+- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 70 tests after post-open review fixes.
 - `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` - PASS.
 - `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` - PASS.
 - `pre-commit run --all-files` - PASS after black formatted `scripts/orchestration/experiment_notify.py`.

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -18,6 +18,7 @@
   - `389e5c3d5d62ad6721842e8fc686db8a0b91107d` - valid ancestor proof mapping.
   - `791caa567ff0f3f4bed2051e93141f16bf667554` - latest review-fix mapping.
   - `c15f2ac344b92be833567d7c64745fd3c11d0013` - notification diagnostic hardening.
+  - `a8d7432917674a63bd844e36d95748ab1e03d3e7` - diagnostic fix mapping update.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -50,7 +51,7 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236168816 -> 6b837c9207ccddb00f2663a8d73762f458b154d9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236168825 -> 6b837c9207ccddb00f2663a8d73762f458b154d9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284047218 -> c15f2ac344b92be833567d7c64745fd3c11d0013
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236302268 -> 791caa567ff0f3f4bed2051e93141f16bf667554
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236302268 -> a8d7432917674a63bd844e36d95748ab1e03d3e7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236302273 -> c15f2ac344b92be833567d7c64745fd3c11d0013
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236302278 -> c15f2ac344b92be833567d7c64745fd3c11d0013
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284068594 -> c15f2ac344b92be833567d7c64745fd3c11d0013
@@ -75,6 +76,10 @@ Evidence: `scripts/orchestration/experiment_notify.py` now rejects promoted acce
 Disposition: FIXED
 Commit: 389e5c3d5d62ad6721842e8fc686db8a0b91107d
 Evidence: This artifact now uses full valid commit SHAs reachable from the current branch head for every mapped FIXED proof.
+
+Disposition: FIXED
+Commit: a8d7432917674a63bd844e36d95748ab1e03d3e7
+Evidence: This artifact maps the latest stale-SHA review thread to a current-head ancestor commit made after the review comment.
 
 Disposition: FIXED
 Commit: c15f2ac344b92be833567d7c64745fd3c11d0013

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -25,6 +25,7 @@
   - `cc7a28debe49cc228abacb8196c8c33c63e27dbe` - command diagnostic and mutable-surface containment hardening.
   - `98740bebd04302f0cd552558d09df60af8eeb48b` - fail-closed evidence drift validation.
   - `b5bf50f9f60204feb476ce2ca810fdb773d225df` - typed surface containment follow-up.
+  - `261085d5e2fc8d760dcc743fc0adeffadcaa07c5` - runner-aligned notification evidence validation.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -82,6 +83,10 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236793887 -> 98740bebd04302f0cd552558d09df60af8eeb48b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236793892 -> 98740bebd04302f0cd552558d09df60af8eeb48b
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236793897 -> 98740bebd04302f0cd552558d09df60af8eeb48b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284687950 -> 261085d5e2fc8d760dcc743fc0adeffadcaa07c5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236869446 -> 261085d5e2fc8d760dcc743fc0adeffadcaa07c5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236869450 -> 261085d5e2fc8d760dcc743fc0adeffadcaa07c5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236869455 -> 261085d5e2fc8d760dcc743fc0adeffadcaa07c5
 
 Disposition: FIXED
 Commit: e3f1232abc9a54743bc3485930c81f4de7c734ed
@@ -127,11 +132,15 @@ Disposition: FIXED
 Commit: 98740bebd04302f0cd552558d09df60af8eeb48b
 Evidence: `scripts/orchestration/experiment_notify.py` now allows nested mutable paths only for explicit or existing directory surfaces, rejects accepted results with non-null `failure_class`, requires rejected result oracle evidence to preserve packet prefix order, and redacts `GITHUB_STEP_SUMMARY` write failures. `tests/test_experiment_notify.py` covers each regression.
 
+Disposition: FIXED
+Commit: 261085d5e2fc8d760dcc743fc0adeffadcaa07c5
+Evidence: `scripts/orchestration/experiment_notify.py` now aligns directory-surface matching with runner prefix behavior for new directories while still rejecting existing file surfaces, rejects rejected results whose terminal oracle passed, and redacts notification output write failures. `tests/test_experiment_notify.py` covers each regression.
+
 ## Local Validation Evidence
 
 - `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration --path tests` - PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
-- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 81 tests after post-open review fixes.
+- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 84 tests after post-open review fixes.
 - `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` - PASS.
 - `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` - PASS.
 - `pre-commit run --all-files` - PASS after black formatted `scripts/orchestration/experiment_notify.py`.

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -19,6 +19,8 @@
   - `791caa567ff0f3f4bed2051e93141f16bf667554` - latest review-fix mapping.
   - `c15f2ac344b92be833567d7c64745fd3c11d0013` - notification diagnostic hardening.
   - `a8d7432917674a63bd844e36d95748ab1e03d3e7` - diagnostic fix mapping update.
+  - `d2e15ebb1c51584d5d97da639bd04868185708d2` - stale proof mapping update.
+  - `9e42c202155683886b49ee381c3f1b15b67a0955` - promotion evidence and diagnostic validation.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -56,6 +58,13 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236302278 -> c15f2ac344b92be833567d7c64745fd3c11d0013
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284068594 -> c15f2ac344b92be833567d7c64745fd3c11d0013
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236321888 -> c15f2ac344b92be833567d7c64745fd3c11d0013
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284209741 -> 9e42c202155683886b49ee381c3f1b15b67a0955
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236445976 -> 9e42c202155683886b49ee381c3f1b15b67a0955
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236445980 -> 9e42c202155683886b49ee381c3f1b15b67a0955
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236445984 -> 9e42c202155683886b49ee381c3f1b15b67a0955
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284232269 -> 9e42c202155683886b49ee381c3f1b15b67a0955
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236465759 -> 9e42c202155683886b49ee381c3f1b15b67a0955
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236465778 -> 9e42c202155683886b49ee381c3f1b15b67a0955
 
 Disposition: FIXED
 Commit: e3f1232abc9a54743bc3485930c81f4de7c734ed
@@ -85,11 +94,15 @@ Disposition: FIXED
 Commit: c15f2ac344b92be833567d7c64745fd3c11d0013
 Evidence: `scripts/orchestration/experiment_notify.py` now treats directory mutable surfaces as containing nested result paths, skips leading shell `KEY=value` assignments before rendering oracle command names, and redacts unexpected-oracle diagnostics to command names. `tests/test_experiment_notify.py` covers directory surface containment, env-assignment command redaction, and secret-free fail-closed diagnostics.
 
+Disposition: FIXED
+Commit: 9e42c202155683886b49ee381c3f1b15b67a0955
+Evidence: `scripts/orchestration/experiment_notify.py` now redacts outside-surface mutated-path diagnostics, accepts nested directory mutable surfaces without suffix heuristics, validates promotion evidence oracle commands/mutated paths/oracle count against packet/result metadata, and rejects accepted results with failed or timed-out oracles. `tests/test_experiment_notify.py` covers each regression.
+
 ## Local Validation Evidence
 
 - `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration --path tests` - PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
-- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 70 tests after post-open review fixes.
+- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 75 tests after post-open review fixes.
 - `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` - PASS.
 - `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` - PASS.
 - `pre-commit run --all-files` - PASS after black formatted `scripts/orchestration/experiment_notify.py`.

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -1,0 +1,68 @@
+<!-- markdownlint-disable MD013 MD034 -->
+# PR 1749 Fixed In Commit Mapping
+
+- PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749>
+- Branch: `codex/experiment-runner-notification-sink`
+- Title: `feat(orchestration): add experiment notification artifact sink`
+- Implementing commit: `0d45edbe4df594cd22213107cd9aaf56c5bc87e6`
+- Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
+
+## Discussion Thread Pass
+
+- [x] Draft PR opened.
+- [x] Fixed in commit mapping artifact created.
+- [ ] Post-open review thread pass pending.
+
+No review threads have been resolved.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments as of draft PR open.
+
+## Local Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration --path tests` - PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
+- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 56 tests.
+- `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` - PASS.
+- `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` - PASS.
+- `pre-commit run --all-files` - PASS after black formatted `scripts/orchestration/experiment_notify.py`.
+- `make VENV_PYTHON=../../.venv/bin/python validate-changed` - PASS.
+- Push hook - PASS: changed-file mypy, pip-audit, backend pre-push tests, full-repo Bandit, Docker build test.
+
+Plain `make validate-changed` in this isolated worktree failed before test execution because the worktree has no local `.venv` and the target selected system `python3`, which lacked `fastapi`. The same target passed with explicit `VENV_PYTHON=../../.venv/bin/python`.
+
+## Security Notes
+
+- Artifact-only delivery: no email, Slack, GitHub PR comment, SMTP, or external network notification is introduced.
+- Rendered notification omits raw patch text, oracle stdout/stderr, cwd, local absolute paths, and sensitive path parts.
+- `GITHUB_STEP_SUMMARY` writes require explicit `--github-step-summary`.
+- Promotion decisions are checked against packet/result status and target-specific durable artifact paths.
+- `PulsePlate Experiment Runner <pulseplate@pm.me>` is public git metadata for this PR lane only; it is not a result delivery channel.
+
+## Premortem / Role Review Findings
+
+- Security-auditor / Codex Security finding: durable artifact paths could be misleading if promotion metadata named an unrelated repo path. Disposition: FIXED in `0d45edbe4df594cd22213107cd9aaf56c5bc87e6` by target-specific durable artifact path validation and negative tests.
+- QA / bug-hunter finding: false-green risk if tests only checked substring output. Disposition: FIXED in `0d45edbe4df594cd22213107cd9aaf56c5bc87e6` by deterministic full-body markdown checks, CLI JSON checks, and negative promotion/path tests.
+- Premortem finding: reviewers may confuse artifact notification with external delivery. Disposition: FIXED in `0d45edbe4df594cd22213107cd9aaf56c5bc87e6` by explicit docs and rendered delivery boundary.
+
+## Risks / Rollback
+
+- Risk: future callers may assume artifact notification sends email or Slack. Mitigation: script, docs, PR body, and artifact text state artifact-only delivery.
+- Risk: environment-specific worktree validation can false-red when `.venv` is root-local. Mitigation: recorded explicit `VENV_PYTHON` command and pre-push hook evidence.
+- Rollback: revert this PR; `experiment_runner.py` and `experiment_promote.py` behavior is unchanged.
+
+## Merge Readiness
+
+- [x] Coordinator-first preflight/bootstrap completed.
+- [x] Canonical artifact exists.
+- [x] Local narrow gates completed.
+- [ ] Current-head CI pending.
+- [ ] Bot/human review pass pending.
+- [ ] Mandatory wait-window pending.
+
+Draft PR is not merge-ready.
+
+## Deferred / Follow-ups
+
+- Real email, Slack, or GitHub-comment result delivery remains a later security-governed PR with explicit sink, auth, audit, opt-in behavior, and secret handling.

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -4,7 +4,10 @@
 - PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749>
 - Branch: `codex/experiment-runner-notification-sink`
 - Title: `feat(orchestration): add experiment notification artifact sink`
-- Implementing commit: `0d45edbe4df594cd22213107cd9aaf56c5bc87e6`
+- Implementing commits:
+  - `0d45edbe4df594cd22213107cd9aaf56c5bc87e6` - initial artifact-only sink.
+  - `585607b04c0476fbb3f5f7cd8f35a42545c16858` - initial fixed-mapping artifact.
+  - `e3f1232abc326ff805ae66737fddf5f34fd035d0` - post-open hardening and role-agent fixes.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -18,13 +21,23 @@ re-triggered through the normal ready-for-review cycle.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235757434 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235757454 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235757467 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761786 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761791 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235799044 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235799048 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
+
+Disposition: FIXED
+Commit: e3f1232abc326ff805ae66737fddf5f34fd035d0
+Evidence: `scripts/orchestration/experiment_notify.py` removes dynamic `sys.path.insert`, rejects symlinked artifact ancestors/components, redacts Windows/backslash local path shapes, and exposes explicit module-entrypoint failure for unsupported direct invocation contexts. `tests/test_experiment_notify.py` adds the regression coverage.
 
 ## Local Validation Evidence
 
 - `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration --path tests` - PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
-- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 56 tests.
+- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 63 tests after post-open review fixes.
 - `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` - PASS.
 - `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` - PASS.
 - `pre-commit run --all-files` - PASS after black formatted `scripts/orchestration/experiment_notify.py`.

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -8,6 +8,7 @@
   - `0d45edbe4df594cd22213107cd9aaf56c5bc87e6` - initial artifact-only sink.
   - `585607b04c0476fbb3f5f7cd8f35a42545c16858` - initial fixed-mapping artifact.
   - `e3f1232abc326ff805ae66737fddf5f34fd035d0` - post-open hardening and role-agent fixes.
+  - `77bec5c2c3fef12c906be3c1f4625c44cb758fd8` - review-thread mapping update.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -26,12 +27,17 @@ re-triggered through the normal ready-for-review cycle.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235757467 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761786 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761791 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761797 -> 77bec5c2c3fef12c906be3c1f4625c44cb758fd8
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235799044 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235799048 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 
 Disposition: FIXED
 Commit: e3f1232abc326ff805ae66737fddf5f34fd035d0
 Evidence: `scripts/orchestration/experiment_notify.py` removes dynamic `sys.path.insert`, rejects symlinked artifact ancestors/components, redacts Windows/backslash local path shapes, and exposes explicit module-entrypoint failure for unsupported direct invocation contexts. `tests/test_experiment_notify.py` adds the regression coverage.
+
+Disposition: FIXED
+Commit: 77bec5c2c3fef12c906be3c1f4625c44cb758fd8
+Evidence: This artifact now lists all implementing commits instead of only the initial sink commit and maps the stale-commit review thread to the review-mapping update.
 
 ## Local Validation Evidence
 

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -27,6 +27,7 @@
   - `b5bf50f9f60204feb476ce2ca810fdb773d225df` - typed surface containment follow-up.
   - `261085d5e2fc8d760dcc743fc0adeffadcaa07c5` - runner-aligned notification evidence validation.
   - `0b7790f853562deb0a58ddd934085636d990d7be` - sanitized validation diagnostics and accepted/rejected state checks.
+  - `367504ae685a97c0cd410b2acde0bfc115a13b5a` - forged evidence rejection hardening.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -93,6 +94,11 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236937877 -> 0b7790f853562deb0a58ddd934085636d990d7be
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236937880 -> 0b7790f853562deb0a58ddd934085636d990d7be
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236937894 -> 0b7790f853562deb0a58ddd934085636d990d7be
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284815927 -> 367504ae685a97c0cd410b2acde0bfc115a13b5a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236984651 -> 367504ae685a97c0cd410b2acde0bfc115a13b5a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236984659 -> 367504ae685a97c0cd410b2acde0bfc115a13b5a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236984667 -> 367504ae685a97c0cd410b2acde0bfc115a13b5a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236984673 -> 367504ae685a97c0cd410b2acde0bfc115a13b5a
 
 Disposition: FIXED
 Commit: e3f1232abc9a54743bc3485930c81f4de7c734ed
@@ -146,11 +152,15 @@ Disposition: FIXED
 Commit: 0b7790f853562deb0a58ddd934085636d990d7be
 Evidence: `scripts/orchestration/experiment_notify.py` now sanitizes shared-validator `ValueError` diagnostics, allows `infra_flake` rejected results after passing oracle prefixes, and rejects accepted results with dirty shared-tree evidence before notification rendering. `tests/test_experiment_notify.py` covers each regression.
 
+Disposition: FIXED
+Commit: 367504ae685a97c0cd410b2acde0bfc115a13b5a
+Evidence: `scripts/orchestration/experiment_notify.py` now rejects traversal components before mutable-surface matching, requires terminal oracle evidence for oracle-failure rejected statuses, and redacts sensitive bare oracle command names. `tests/test_experiment_notify.py` covers each regression.
+
 ## Local Validation Evidence
 
 - `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration --path tests` - PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
-- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 87 tests after post-open review fixes.
+- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 90 tests after post-open review fixes.
 - `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` - PASS.
 - `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` - PASS.
 - `pre-commit run --all-files` - PASS after black formatted `scripts/orchestration/experiment_notify.py`.

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -31,6 +31,7 @@
   - `a705625f9d39f652cee75463e07fd26d5a9ebab9` - rejected-result shape alignment.
   - `1127bf9c4c5b979966191c28eaa05824483a3e2b` - rejected-shape review mapping update.
   - `5f9d2ec5479f734346e4fcc423848ff8bf2fd4da` - promotion notification evidence validation.
+  - `ee5fab97b5b151d1760bf49b19a939d2cf7d8e8e` - promotion evidence review mapping update.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -106,6 +107,7 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237147911 -> a705625f9d39f652cee75463e07fd26d5a9ebab9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237147913 -> a705625f9d39f652cee75463e07fd26d5a9ebab9
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237147920 -> a705625f9d39f652cee75463e07fd26d5a9ebab9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237325467 -> ee5fab97b5b151d1760bf49b19a939d2cf7d8e8e
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237325474 -> 5f9d2ec5479f734346e4fcc423848ff8bf2fd4da
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237325478 -> 5f9d2ec5479f734346e4fcc423848ff8bf2fd4da
 
@@ -176,6 +178,10 @@ Evidence: This artifact maps the latest stale-proof review thread to a current-h
 Disposition: FIXED
 Commit: 5f9d2ec5479f734346e4fcc423848ff8bf2fd4da
 Evidence: `scripts/orchestration/experiment_notify.py` now requires promotion decisions to point at an existing durable repo artifact, requires backlog promotions to include the experiment anchor/block, and requires `metric_regression` rejected results to include the full passing oracle list. `tests/test_experiment_notify.py` covers each regression.
+
+Disposition: FIXED
+Commit: ee5fab97b5b151d1760bf49b19a939d2cf7d8e8e
+Evidence: This artifact maps the latest stale-proof review thread to a current-head ancestor commit made after the review comment.
 
 ## Local Validation Evidence
 

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -10,6 +10,8 @@
   - `e3f1232abc326ff805ae66737fddf5f34fd035d0` - post-open hardening and role-agent fixes.
   - `77bec5c2c3fef12c906be3c1f4625c44cb758fd8` - review-thread mapping update.
   - `52c84f793caa6ec6be226169370a87e2f8429966` - stale-commit review-thread mapping.
+  - `f9fb7ef434b2177827eb06d56602079ed65c85df` - aggregate bot review mapping.
+  - `b281fa42b32aec312a237e4cb49daf5297c00aa9` - redaction and symlink-containment follow-up fixes.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -33,6 +35,10 @@ re-triggered through the normal ready-for-review cycle.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235799044 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235799048 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4283452129 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235961723 -> b281fa42b32aec312a237e4cb49daf5297c00aa9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235961729 -> b281fa42b32aec312a237e4cb49daf5297c00aa9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235961734 -> b281fa42b32aec312a237e4cb49daf5297c00aa9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236005091 -> b281fa42b32aec312a237e4cb49daf5297c00aa9
 
 Disposition: FIXED
 Commit: e3f1232abc326ff805ae66737fddf5f34fd035d0
@@ -42,11 +48,15 @@ Disposition: FIXED
 Commit: 52c84f793caa6ec6be226169370a87e2f8429966
 Evidence: This artifact now lists all implementing commits instead of only the initial sink commit and maps the stale-commit review thread to the review-mapping update.
 
+Disposition: FIXED
+Commit: b281fa42b32aec312a237e4cb49daf5297c00aa9
+Evidence: `scripts/orchestration/experiment_notify.py` now checks `is_symlink()` without `exists()` gating, redacts home-relative credential paths and control-character paths, and `tests/test_experiment_notify.py` covers those regressions.
+
 ## Local Validation Evidence
 
 - `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration --path tests` - PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
-- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 63 tests after post-open review fixes.
+- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 65 tests after post-open review fixes.
 - `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` - PASS.
 - `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` - PASS.
 - `pre-commit run --all-files` - PASS after black formatted `scripts/orchestration/experiment_notify.py`.

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -28,6 +28,7 @@
   - `261085d5e2fc8d760dcc743fc0adeffadcaa07c5` - runner-aligned notification evidence validation.
   - `0b7790f853562deb0a58ddd934085636d990d7be` - sanitized validation diagnostics and accepted/rejected state checks.
   - `367504ae685a97c0cd410b2acde0bfc115a13b5a` - forged evidence rejection hardening.
+  - `a705625f9d39f652cee75463e07fd26d5a9ebab9` - rejected-result shape alignment.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -99,6 +100,9 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236984659 -> 367504ae685a97c0cd410b2acde0bfc115a13b5a
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236984667 -> 367504ae685a97c0cd410b2acde0bfc115a13b5a
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236984673 -> 367504ae685a97c0cd410b2acde0bfc115a13b5a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237147911 -> a705625f9d39f652cee75463e07fd26d5a9ebab9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237147913 -> a705625f9d39f652cee75463e07fd26d5a9ebab9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3237147920 -> a705625f9d39f652cee75463e07fd26d5a9ebab9
 
 Disposition: FIXED
 Commit: e3f1232abc9a54743bc3485930c81f4de7c734ed
@@ -156,11 +160,15 @@ Disposition: FIXED
 Commit: 367504ae685a97c0cd410b2acde0bfc115a13b5a
 Evidence: `scripts/orchestration/experiment_notify.py` now rejects traversal components before mutable-surface matching, requires terminal oracle evidence for oracle-failure rejected statuses, and redacts sensitive bare oracle command names. `tests/test_experiment_notify.py` covers each regression.
 
+Disposition: FIXED
+Commit: a705625f9d39f652cee75463e07fd26d5a9ebab9
+Evidence: `scripts/orchestration/experiment_notify.py` now rejects pre-oracle rejected-result classes when oracle evidence is present, rejects `policy_violation` evidence with mutated paths, and scopes terminal-oracle failure requirements to oracle-derived failure classes so `metric_regression` can summarize passing oracle prefixes. `tests/test_experiment_notify.py` covers each regression.
+
 ## Local Validation Evidence
 
 - `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration --path tests` - PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
-- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 90 tests after post-open review fixes.
+- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 93 tests after post-open review fixes.
 - `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` - PASS.
 - `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` - PASS.
 - `pre-commit run --all-files` - PASS after black formatted `scripts/orchestration/experiment_notify.py`.

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -26,11 +26,13 @@ re-triggered through the normal ready-for-review cycle.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235757434 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235757454 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235757467 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4283401283 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761786 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761791 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761797 -> 52c84f793caa6ec6be226169370a87e2f8429966
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235799044 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235799048 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4283452129 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
 
 Disposition: FIXED
 Commit: e3f1232abc326ff805ae66737fddf5f34fd035d0

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -21,6 +21,7 @@
   - `a8d7432917674a63bd844e36d95748ab1e03d3e7` - diagnostic fix mapping update.
   - `d2e15ebb1c51584d5d97da639bd04868185708d2` - stale proof mapping update.
   - `9e42c202155683886b49ee381c3f1b15b67a0955` - promotion evidence and diagnostic validation.
+  - `527ea55bce9345189a09403f13dc310c45d74a63` - promotion evidence mapping update.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -58,6 +59,7 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236302278 -> c15f2ac344b92be833567d7c64745fd3c11d0013
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284068594 -> c15f2ac344b92be833567d7c64745fd3c11d0013
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236321888 -> c15f2ac344b92be833567d7c64745fd3c11d0013
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236445973 -> 527ea55bce9345189a09403f13dc310c45d74a63
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4284209741 -> 9e42c202155683886b49ee381c3f1b15b67a0955
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236445976 -> 9e42c202155683886b49ee381c3f1b15b67a0955
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236445980 -> 9e42c202155683886b49ee381c3f1b15b67a0955
@@ -89,6 +91,10 @@ Evidence: This artifact now uses full valid commit SHAs reachable from the curre
 Disposition: FIXED
 Commit: a8d7432917674a63bd844e36d95748ab1e03d3e7
 Evidence: This artifact maps the latest stale-SHA review thread to a current-head ancestor commit made after the review comment.
+
+Disposition: FIXED
+Commit: 527ea55bce9345189a09403f13dc310c45d74a63
+Evidence: This artifact maps the latest current-head stale-proof review thread to a current-head ancestor commit made after the review comment.
 
 Disposition: FIXED
 Commit: c15f2ac344b92be833567d7c64745fd3c11d0013

--- a/docs/review/PR_1749_FIXED_MAPPING.md
+++ b/docs/review/PR_1749_FIXED_MAPPING.md
@@ -7,12 +7,14 @@
 - Implementing commits:
   - `0d45edbe4df594cd22213107cd9aaf56c5bc87e6` - initial artifact-only sink.
   - `585607b04c0476fbb3f5f7cd8f35a42545c16858` - initial fixed-mapping artifact.
-  - `e3f1232abc326ff805ae66737fddf5f34fd035d0` - post-open hardening and role-agent fixes.
-  - `77bec5c2c3fef12c906be3c1f4625c44cb758fd8` - review-thread mapping update.
-  - `52c84f793caa6ec6be226169370a87e2f8429966` - stale-commit review-thread mapping.
-  - `f9fb7ef434b2177827eb06d56602079ed65c85df` - aggregate bot review mapping.
-  - `b281fa42b32aec312a237e4cb49daf5297c00aa9` - redaction and symlink-containment follow-up fixes.
+  - `e3f1232abc9a54743bc3485930c81f4de7c734ed` - post-open hardening and role-agent fixes.
+  - `77bec5c2ca36167cee1077a3dcb0639487eb10d2` - review-thread mapping update.
+  - `52c84f793b5338b14fc5953d9bab0672257acb9d` - stale-commit review-thread mapping.
+  - `f9fb7ef437644b1782ca9906ad8131aa6a50ea50` - aggregate bot review mapping.
+  - `b281fa42bf17d9a565f536e7b64acabc21e7202b` - redaction and symlink-containment follow-up fixes.
   - `67dea3563288468c70d45895885c8d0b90712c15` - post-fix review-thread mapping.
+  - `155b25f088f1f0fc5d36daf7d33243e7f11d1f50` - role review pass mapping.
+  - `6b837c9207ccddb00f2663a8d73762f458b154d9` - result evidence validation fixes.
 - Scope: artifact-only experiment result notification sink, governance docs, and focused tests.
 
 ## Discussion Thread Pass
@@ -26,38 +28,44 @@ current-head bot/CI cycle is being monitored before any merge-readiness claim.
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235757434 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235757454 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235757467 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4283401283 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761786 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761791 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761797 -> 52c84f793caa6ec6be226169370a87e2f8429966
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235799044 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235799048 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4283452129 -> e3f1232abc326ff805ae66737fddf5f34fd035d0
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235961723 -> b281fa42b32aec312a237e4cb49daf5297c00aa9
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235961729 -> b281fa42b32aec312a237e4cb49daf5297c00aa9
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235961734 -> b281fa42b32aec312a237e4cb49daf5297c00aa9
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236005091 -> b281fa42b32aec312a237e4cb49daf5297c00aa9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235757434 -> e3f1232abc9a54743bc3485930c81f4de7c734ed
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235757454 -> e3f1232abc9a54743bc3485930c81f4de7c734ed
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235757467 -> e3f1232abc9a54743bc3485930c81f4de7c734ed
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4283401283 -> e3f1232abc9a54743bc3485930c81f4de7c734ed
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761786 -> e3f1232abc9a54743bc3485930c81f4de7c734ed
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761791 -> e3f1232abc9a54743bc3485930c81f4de7c734ed
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235761797 -> 52c84f793b5338b14fc5953d9bab0672257acb9d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235799044 -> e3f1232abc9a54743bc3485930c81f4de7c734ed
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235799048 -> e3f1232abc9a54743bc3485930c81f4de7c734ed
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#pullrequestreview-4283452129 -> e3f1232abc9a54743bc3485930c81f4de7c734ed
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235961723 -> b281fa42bf17d9a565f536e7b64acabc21e7202b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235961729 -> b281fa42bf17d9a565f536e7b64acabc21e7202b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3235961734 -> b281fa42bf17d9a565f536e7b64acabc21e7202b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236005091 -> b281fa42bf17d9a565f536e7b64acabc21e7202b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236168816 -> 6b837c9207ccddb00f2663a8d73762f458b154d9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1749#discussion_r3236168825 -> 6b837c9207ccddb00f2663a8d73762f458b154d9
 
 Disposition: FIXED
-Commit: e3f1232abc326ff805ae66737fddf5f34fd035d0
+Commit: e3f1232abc9a54743bc3485930c81f4de7c734ed
 Evidence: `scripts/orchestration/experiment_notify.py` removes dynamic `sys.path.insert`, rejects symlinked artifact ancestors/components, redacts Windows/backslash local path shapes, and exposes explicit module-entrypoint failure for unsupported direct invocation contexts. `tests/test_experiment_notify.py` adds the regression coverage.
 
 Disposition: FIXED
-Commit: 52c84f793caa6ec6be226169370a87e2f8429966
+Commit: 52c84f793b5338b14fc5953d9bab0672257acb9d
 Evidence: This artifact now lists all implementing commits instead of only the initial sink commit and maps the stale-commit review thread to the review-mapping update.
 
 Disposition: FIXED
-Commit: b281fa42b32aec312a237e4cb49daf5297c00aa9
+Commit: b281fa42bf17d9a565f536e7b64acabc21e7202b
 Evidence: `scripts/orchestration/experiment_notify.py` now checks `is_symlink()` without `exists()` gating, redacts home-relative credential paths and control-character paths, and `tests/test_experiment_notify.py` covers those regressions.
+
+Disposition: FIXED
+Commit: 6b837c9207ccddb00f2663a8d73762f458b154d9
+Evidence: `scripts/orchestration/experiment_notify.py` now rejects promoted accepted results when `shared_tree_untouched` is false and cross-checks result `mutated_paths` / `oracle_results` against the validated packet before rendering notification evidence. `tests/test_experiment_notify.py` covers dirty shared-tree promotion, missing accepted oracle results, out-of-surface mutated paths, and extra oracle commands.
 
 ## Local Validation Evidence
 
 - `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration --path tests` - PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
-- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 65 tests after post-open review fixes.
+- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` - PASS, 69 tests after post-open review fixes.
 - `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` - PASS.
 - `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` - PASS.
 - `pre-commit run --all-files` - PASS after black formatted `scripts/orchestration/experiment_notify.py`.
@@ -80,7 +88,8 @@ Plain `make validate-changed` in this isolated worktree failed before test execu
 - Security-auditor / Codex Security finding: durable artifact paths could be misleading if promotion metadata named an unrelated repo path. Disposition: FIXED in `0d45edbe4df594cd22213107cd9aaf56c5bc87e6` by target-specific durable artifact path validation and negative tests.
 - QA / bug-hunter finding: false-green risk if tests only checked substring output. Disposition: FIXED in `0d45edbe4df594cd22213107cd9aaf56c5bc87e6` by deterministic full-body markdown checks, CLI JSON checks, and negative promotion/path tests.
 - Premortem finding: reviewers may confuse artifact notification with external delivery. Disposition: FIXED in `0d45edbe4df594cd22213107cd9aaf56c5bc87e6` by explicit docs and rendered delivery boundary.
-- Premortem finding: notification artifacts could leak local runner details through path edge cases. Disposition: FIXED in `e3f1232abc326ff805ae66737fddf5f34fd035d0` and `b281fa42b32aec312a237e4cb49daf5297c00aa9` by Windows/backslash, home-credential, control-character, symlinked-directory, symlinked-ancestor, symlinked-child, and broken-symlink output tests.
+- Premortem finding: notification artifacts could leak local runner details through path edge cases. Disposition: FIXED in `e3f1232abc9a54743bc3485930c81f4de7c734ed` and `b281fa42bf17d9a565f536e7b64acabc21e7202b` by Windows/backslash, home-credential, control-character, symlinked-directory, symlinked-ancestor, symlinked-child, and broken-symlink output tests.
+- Premortem finding: stale or hand-edited result/promotion evidence could be summarized as accepted/promoted. Disposition: FIXED in `6b837c9207ccddb00f2663a8d73762f458b154d9` by packet/result evidence cross-checking and dirty shared-tree promotion rejection.
 - Premortem decision: proceed with changes; required changes have been applied, and readiness remains blocked only on current-head CI/bot review terminal state and the mandatory wait-window.
 
 ## Risks / Rollback

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -19,11 +19,9 @@
 - The runner must apply patches only inside an isolated temporary checkout and must leave the shared working tree untouched.
 - Mutable surfaces, immutable oracles, budgets, and promotion boundaries are defined by `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`; do not duplicate or relax them here.
 - Result artifacts stay local under `artifacts/orchestration/experiments/results/` and are evidence only, not merge-ready or promotion-ready output.
-- `experiment_notify.py` may render local/GitHub-step-summary markdown from validated
-  packet/result/promotion artifacts, but it must not send email, Slack messages,
-  GitHub comments, or any other external notification in v1.
-- Notification summaries must omit raw patch text, oracle stdout/stderr, cwd,
-  secrets, and local absolute paths.
+- `experiment_notify.py` follows the artifact-only notification contract in
+  `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`; do not duplicate or
+  relax that canonical boundary here.
 
 ## Pre-push backend tests (smart diff runner)
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -19,6 +19,11 @@
 - The runner must apply patches only inside an isolated temporary checkout and must leave the shared working tree untouched.
 - Mutable surfaces, immutable oracles, budgets, and promotion boundaries are defined by `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`; do not duplicate or relax them here.
 - Result artifacts stay local under `artifacts/orchestration/experiments/results/` and are evidence only, not merge-ready or promotion-ready output.
+- `experiment_notify.py` may render local/GitHub-step-summary markdown from validated
+  packet/result/promotion artifacts, but it must not send email, Slack messages,
+  GitHub comments, or any other external notification in v1.
+- Notification summaries must omit raw patch text, oracle stdout/stderr, cwd,
+  secrets, and local absolute paths.
 
 ## Pre-push backend tests (smart diff runner)
 

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 import re
 import shlex
 import sys
@@ -25,18 +25,14 @@ try:
         validate_experiment_packet,
         validate_experiment_result,
     )
-except ImportError:  # pragma: no cover - CLI fallback for direct script execution.
-    experiment_notify_repo_root = Path(__file__).resolve().parents[2]
-    if str(experiment_notify_repo_root) not in sys.path:
-        sys.path.insert(0, str(experiment_notify_repo_root))
-    from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
-    from scripts.orchestration.experiment_contract import (
-        PROMOTION_TARGETS,
-        SCHEMA_VERSION,
-        validate_experiment_id,
-        validate_experiment_packet,
-        validate_experiment_result,
+except ModuleNotFoundError as exc:  # pragma: no cover - direct script invocation guard.
+    if exc.name != "scripts":
+        raise
+    print(
+        "FAIL: run as `python -m scripts.orchestration.experiment_notify` from repo root.",
+        file=sys.stderr,
     )
+    raise SystemExit(2) from exc
 
 
 NOTIFICATION_ARTIFACT_DIR = (
@@ -44,6 +40,7 @@ NOTIFICATION_ARTIFACT_DIR = (
 )
 PROMOTION_DISPOSITIONS: tuple[str, ...] = ("promoted", "deferred")
 SENSITIVE_PATH_PART_RE = re.compile(r"(secret|token|password|private|credential|key)", re.I)
+WINDOWS_ABSOLUTE_PATH_RE = re.compile(r'^(?:"?[A-Za-z]:|"?\\\\|"?//)')
 
 
 class ExperimentNotificationError(RuntimeError):
@@ -61,20 +58,49 @@ def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
 
 
 def _resolve_output_path(raw_output: str | None, experiment_id: str) -> Path:
+    """Resolve a notification output path inside the local artifacts directory."""
+
+    artifact_dir = NOTIFICATION_ARTIFACT_DIR.absolute()
     if raw_output:
         candidate = Path(raw_output)
+        if any(part == ".." for part in candidate.parts):
+            raise ValueError(
+                "--output must stay within artifacts/orchestration/experiments/notifications"
+            )
         if not candidate.is_absolute():
-            candidate = NOTIFICATION_ARTIFACT_DIR / candidate
+            candidate = artifact_dir / candidate
     else:
-        candidate = NOTIFICATION_ARTIFACT_DIR / f"{experiment_id}.md"
-    candidate = candidate.resolve()
+        candidate = artifact_dir / f"{experiment_id}.md"
+    candidate = candidate.absolute()
     try:
-        candidate.relative_to(NOTIFICATION_ARTIFACT_DIR.resolve())
+        candidate.relative_to(artifact_dir)
     except ValueError as exc:
         raise ValueError(
             "--output must stay within artifacts/orchestration/experiments/notifications"
         ) from exc
+    _reject_symlinked_output_components(candidate, artifact_dir=artifact_dir)
     return candidate
+
+
+def _reject_symlinked_output_components(candidate: Path, *, artifact_dir: Path) -> None:
+    """Reject writes through existing symlinks in the notification artifact path."""
+
+    repo_artifact_root = REPO_ROOT.absolute() / "artifacts"
+    artifact_dir.relative_to(repo_artifact_root)
+    current = repo_artifact_root
+    if current.exists() and current.is_symlink():
+        raise ValueError("notification artifact ancestors must not be symlinks.")
+    for part in artifact_dir.relative_to(repo_artifact_root).parts:
+        current = current / part
+        if current.exists() and current.is_symlink():
+            raise ValueError("notification artifact ancestors must not be symlinks.")
+    if artifact_dir.exists() and artifact_dir.is_symlink():
+        raise ValueError("notification artifact directory must not be a symlink.")
+    current = artifact_dir
+    for part in candidate.relative_to(artifact_dir).parts:
+        current = current / part
+        if current.exists() and current.is_symlink():
+            raise ValueError("notification output path must not traverse a symlink.")
 
 
 def _require_matching_experiment(
@@ -82,6 +108,8 @@ def _require_matching_experiment(
     result: dict[str, Any],
     promotion: dict[str, Any] | None,
 ) -> None:
+    """Require packet, result, and optional promotion metadata to describe one run."""
+
     if packet["experiment_id"] != result["experiment_id"]:
         raise ExperimentNotificationError(
             "Experiment packet and result must reference the same experiment_id."
@@ -124,6 +152,8 @@ def _require_matching_experiment(
 
 
 def _validate_promotion_decision(payload: dict[str, Any]) -> dict[str, Any]:
+    """Validate the subset of promotion decision metadata safe to summarize."""
+
     schema_version = str(payload.get("schema_version", "")).strip()
     if schema_version != SCHEMA_VERSION:
         raise ValueError(
@@ -178,6 +208,8 @@ def _validate_durable_artifact_path_for_target(
     promotion_target: str,
     durable_artifact_path: str,
 ) -> None:
+    """Require durable artifact paths to match the declared promotion target."""
+
     upper_id = experiment_id.upper().replace("-", "_")
     expected_paths = {
         "pr_packet": f"docs/orchestration/experiment_pr_packets/{experiment_id}.md",
@@ -192,6 +224,8 @@ def _validate_durable_artifact_path_for_target(
 
 
 def _safe_inline(value: Any) -> str:
+    """Render a scalar markdown inline value without backtick injection."""
+
     text = str(value).strip()
     if not text:
         return "none"
@@ -199,9 +233,13 @@ def _safe_inline(value: Any) -> str:
 
 
 def _safe_repo_path(value: Any) -> str:
+    """Render a repo-relative path or redact unsafe path-shaped values."""
+
     text = str(value).strip()
     if not text:
         return "none"
+    if WINDOWS_ABSOLUTE_PATH_RE.match(text) or "\\" in text:
+        return "[redacted-path]"
     path = PurePosixPath(text)
     if (
         path.is_absolute()
@@ -213,19 +251,30 @@ def _safe_repo_path(value: Any) -> str:
 
 
 def _oracle_command_name(command: Any) -> str:
+    """Return only the executable name from an oracle command."""
+
+    raw_command = str(command).strip()
+    if WINDOWS_ABSOLUTE_PATH_RE.match(raw_command) or "\\" in raw_command:
+        return "[redacted-command]"
     try:
-        argv = shlex.split(str(command))
+        argv = shlex.split(raw_command)
     except ValueError:
         return "[unparseable-command]"
     if not argv:
         return "[empty-command]"
     binary = argv[0]
-    if "/" in binary or "\\" in binary:
+    if WINDOWS_ABSOLUTE_PATH_RE.match(binary) or "\\" in binary:
+        return "[redacted-command]"
+    if "\\" in binary:
+        return _safe_inline(PureWindowsPath(binary).name)
+    if "/" in binary:
         return _safe_inline(Path(binary).name)
     return _safe_inline(binary)
 
 
 def _oracle_lines(result: dict[str, Any]) -> list[str]:
+    """Render safe oracle result summary lines."""
+
     lines: list[str] = []
     for oracle_result in result["oracle_results"]:
         lines.append(
@@ -286,6 +335,8 @@ def render_notification_markdown(
 
 
 def _append_github_step_summary(markdown: str) -> None:
+    """Append markdown to GitHub step summary only when explicitly requested."""
+
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "").strip()
     if not summary_path:
         raise ExperimentNotificationError(
@@ -301,6 +352,8 @@ def _append_github_step_summary(markdown: str) -> None:
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI flags for artifact-only notification rendering."""
+
     parser = argparse.ArgumentParser(
         prog="experiment_notify",
         description="Render artifact-only notifications for governed experiment results.",
@@ -326,6 +379,8 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the notification renderer CLI."""
+
     args = _parse_args(argv)
     packet_path = Path(args.packet).expanduser().resolve()
     result_path = Path(args.result).expanduser().resolve()

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -217,13 +217,17 @@ def _require_result_evidence_matches_packet(
         )
     if result["status"] == "rejected":
         _require_rejected_oracles_are_prefix(expected_oracles, result_oracles)
-        if result["oracle_results"]:
+        if result["failure_class"] != "infra_flake" and result["oracle_results"]:
             terminal_oracle = result["oracle_results"][-1]
             if terminal_oracle["returncode"] == 0 and not terminal_oracle["timed_out"]:
                 raise ExperimentNotificationError(
                     "Rejected experiment result terminal oracle must fail or time out."
                 )
     if result["status"] == "accepted":
+        if not result["shared_tree_untouched"]:
+            raise ExperimentNotificationError(
+                "Accepted experiment result shared_tree_untouched must be true."
+            )
         if result["failure_class"] is not None:
             raise ExperimentNotificationError(
                 "Accepted experiment result failure_class must be null."
@@ -575,7 +579,10 @@ def main(argv: list[str] | None = None) -> int:
             )
         output_path = _resolve_output_path(args.output, packet["experiment_id"])
         markdown = render_notification_markdown(packet, result, promotion)
-    except (ValueError, ExperimentNotificationError) as exc:
+    except ValueError:
+        print("FAIL: invalid experiment notification input.")
+        return 1
+    except ExperimentNotificationError as exc:
         print(f"FAIL: {exc}")
         return 1
 

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -252,7 +252,7 @@ def _surface_allows_nested_paths(surface: str) -> bool:
         return True
     if PurePosixPath(surface).suffix.lower() in FILE_LIKE_SURFACE_SUFFIXES:
         return False
-    return (REPO_ROOT / surface).is_dir()
+    return Path(REPO_ROOT, surface).is_dir()
 
 
 def _require_rejected_oracles_are_prefix(

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -118,6 +118,7 @@ def _require_matching_experiment(
         raise ExperimentNotificationError(
             "Experiment packet and result must reference the same experiment_id."
         )
+    _require_result_evidence_matches_packet(packet, result)
     if promotion is not None and packet["experiment_id"] != promotion.get("experiment_id"):
         raise ExperimentNotificationError(
             "Experiment packet and promotion must reference the same experiment_id."
@@ -140,6 +141,14 @@ def _require_matching_experiment(
         raise ExperimentNotificationError(
             "Promotion decision shared_tree_untouched must match experiment result."
         )
+    if (
+        result["status"] == "accepted"
+        and promotion["disposition"] == "promoted"
+        and not result["shared_tree_untouched"]
+    ):
+        raise ExperimentNotificationError(
+            "Accepted result is not promotable when shared_tree_untouched is false."
+        )
     if result["status"] == "accepted" and promotion["disposition"] != "promoted":
         raise ExperimentNotificationError(
             "Accepted experiment results must have promotion disposition promoted."
@@ -153,6 +162,37 @@ def _require_matching_experiment(
             raise ExperimentNotificationError(
                 "Rejected experiment results must have promotion disposition deferred."
             )
+
+
+def _require_result_evidence_matches_packet(
+    packet: dict[str, Any],
+    result: dict[str, Any],
+) -> None:
+    """Fail closed when result evidence is stale or outside the packet contract."""
+
+    mutable_surface = set(packet["mutable_candidate_surface"])
+    outside_surface = sorted(
+        path for path in result["mutated_paths"] if path not in mutable_surface
+    )
+    if outside_surface:
+        joined = ", ".join(outside_surface)
+        raise ExperimentNotificationError(
+            "Experiment result mutated_paths must stay within packet "
+            f"mutable_candidate_surface: {joined}"
+        )
+
+    expected_oracles = [oracle["command"] for oracle in packet["immutable_oracles"]]
+    result_oracles = [oracle_result["command"] for oracle_result in result["oracle_results"]]
+    unexpected_oracles = sorted(set(result_oracles) - set(expected_oracles))
+    if unexpected_oracles:
+        joined = ", ".join(unexpected_oracles)
+        raise ExperimentNotificationError(
+            f"Experiment result oracle_results include commands outside packet: {joined}"
+        )
+    if result["status"] == "accepted" and result_oracles != expected_oracles:
+        raise ExperimentNotificationError(
+            "Accepted experiment result oracle_results must match packet immutable_oracles."
+        )
 
 
 def _validate_promotion_decision(payload: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -49,7 +49,21 @@ SENSITIVE_PATH_PART_RE = re.compile(
     re.I,
 )
 WINDOWS_ABSOLUTE_PATH_RE = re.compile(r'^(?:"?[A-Za-z]:|"?\\\\|"?//)')
-SHELL_ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
+SHELL_ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+FILE_LIKE_SURFACE_SUFFIXES = {
+    ".cfg",
+    ".conf",
+    ".ini",
+    ".json",
+    ".lock",
+    ".md",
+    ".py",
+    ".sh",
+    ".toml",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
 
 
 class ExperimentNotificationError(RuntimeError):
@@ -60,7 +74,7 @@ def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise ValueError(f"Unable to load {label} JSON: {exc}") from exc
+        raise ValueError(f"Unable to load {label} JSON.") from exc
     if not isinstance(payload, dict):
         raise ValueError(f"{label} must be a JSON object.")
     return payload
@@ -220,9 +234,18 @@ def _mutable_surface_contains_path(mutable_surface: set[str], path: str) -> bool
     for surface in mutable_surface:
         if path == surface:
             return True
-        if path.startswith(f"{surface.rstrip('/')}/"):
+        if _surface_allows_nested_paths(surface) and path.startswith(f"{surface.rstrip('/')}/"):
             return True
     return False
+
+
+def _surface_allows_nested_paths(surface: str) -> bool:
+    """Return whether a mutable surface entry should match nested result paths."""
+
+    if surface.endswith("/"):
+        return True
+    suffix = PurePosixPath(surface).suffix.lower()
+    return suffix not in FILE_LIKE_SURFACE_SUFFIXES
 
 
 def _require_promotion_evidence_matches_result(
@@ -392,6 +415,8 @@ def _oracle_command_name(command: Any) -> str:
     if "\\" in binary:
         return _safe_inline(PureWindowsPath(binary).name)
     if "/" in binary:
+        if any(SENSITIVE_PATH_PART_RE.search(part) for part in PurePosixPath(binary).parts):
+            return "[redacted-command]"
         return _safe_inline(Path(binary).name)
     return _safe_inline(binary)
 

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -217,6 +217,12 @@ def _require_result_evidence_matches_packet(
         )
     if result["status"] == "rejected":
         _require_rejected_oracles_are_prefix(expected_oracles, result_oracles)
+        if result["oracle_results"]:
+            terminal_oracle = result["oracle_results"][-1]
+            if terminal_oracle["returncode"] == 0 and not terminal_oracle["timed_out"]:
+                raise ExperimentNotificationError(
+                    "Rejected experiment result terminal oracle must fail or time out."
+                )
     if result["status"] == "accepted":
         if result["failure_class"] is not None:
             raise ExperimentNotificationError(
@@ -250,9 +256,11 @@ def _surface_allows_nested_paths(surface: str) -> bool:
 
     if surface.endswith("/"):
         return True
+    if Path(REPO_ROOT, surface).is_file():
+        return False
     if PurePosixPath(surface).suffix.lower() in FILE_LIKE_SURFACE_SUFFIXES:
         return False
-    return Path(REPO_ROOT, surface).is_dir()
+    return True
 
 
 def _require_rejected_oracles_are_prefix(
@@ -576,7 +584,10 @@ def main(argv: list[str] | None = None) -> int:
         output_path.write_text(markdown, encoding="utf-8")
         if args.github_step_summary:
             _append_github_step_summary(markdown)
-    except (OSError, ExperimentNotificationError) as exc:
+    except OSError:
+        print("FAIL: unable to write experiment notification.")
+        return 1
+    except ExperimentNotificationError as exc:
         print(f"FAIL: unable to write experiment notification: {exc}")
         return 1
 

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -17,7 +17,11 @@ import sys
 from typing import Any
 
 try:
-    from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
+    from scripts.orchestration.context_pack import (
+        REPO_ROOT,
+        normalize_repo_path,
+        repo_relative_paths,
+    )
     from scripts.orchestration.experiment_contract import (
         PROMOTION_TARGETS,
         SCHEMA_VERSION,
@@ -142,6 +146,7 @@ def _require_matching_experiment(
         raise ExperimentNotificationError(
             "Promotion decision shared_tree_untouched must match experiment result."
         )
+    _require_promotion_evidence_matches_result(packet, result, promotion)
     if (
         result["status"] == "accepted"
         and promotion["disposition"] == "promoted"
@@ -173,7 +178,7 @@ def _require_result_evidence_matches_packet(
 
     mutable_surface = set(packet["mutable_candidate_surface"])
     outside_surface = sorted(
-        path
+        _safe_repo_path(path)
         for path in result["mutated_paths"]
         if not _mutable_surface_contains_path(mutable_surface, path)
     )
@@ -196,18 +201,51 @@ def _require_result_evidence_matches_packet(
         raise ExperimentNotificationError(
             "Accepted experiment result oracle_results must match packet immutable_oracles."
         )
+    if result["status"] == "accepted":
+        failed_oracles = [
+            _oracle_command_name(oracle_result["command"])
+            for oracle_result in result["oracle_results"]
+            if oracle_result["returncode"] != 0 or oracle_result["timed_out"]
+        ]
+        if failed_oracles:
+            joined = ", ".join(failed_oracles)
+            raise ExperimentNotificationError(
+                f"Accepted experiment result oracle_results must pass: {joined}"
+            )
 
 
 def _mutable_surface_contains_path(mutable_surface: set[str], path: str) -> bool:
     """Return whether a result path belongs to the packet mutable surface."""
 
     for surface in mutable_surface:
-        surface_path = PurePosixPath(surface)
         if path == surface:
             return True
-        if not surface_path.suffix and path.startswith(f"{surface.rstrip('/')}/"):
+        if path.startswith(f"{surface.rstrip('/')}/"):
             return True
     return False
+
+
+def _require_promotion_evidence_matches_result(
+    packet: dict[str, Any],
+    result: dict[str, Any],
+    promotion: dict[str, Any],
+) -> None:
+    """Require promotion evidence to describe the same packet/result pair."""
+
+    evidence = promotion["evidence"]
+    expected_oracles = [oracle["command"] for oracle in packet["immutable_oracles"]]
+    if evidence["oracle_commands"] != expected_oracles:
+        raise ExperimentNotificationError(
+            "Promotion decision evidence.oracle_commands must match packet immutable_oracles."
+        )
+    if evidence["mutated_paths"] != result["mutated_paths"]:
+        raise ExperimentNotificationError(
+            "Promotion decision evidence.mutated_paths must match experiment result."
+        )
+    if evidence["oracle_count"] != len(result["oracle_results"]):
+        raise ExperimentNotificationError(
+            "Promotion decision evidence.oracle_count must match experiment result."
+        )
 
 
 def _validate_promotion_decision(payload: dict[str, Any]) -> dict[str, Any]:
@@ -232,6 +270,7 @@ def _validate_promotion_decision(payload: dict[str, Any]) -> dict[str, Any]:
     normalized["result_status"] = str(payload.get("result_status", "")).strip()
     normalized["failure_class"] = payload.get("failure_class")
     shared_tree_untouched = payload.get("shared_tree_untouched")
+    evidence = payload.get("evidence")
     if normalized["promotion_target"] not in PROMOTION_TARGETS:
         allowed = ", ".join(PROMOTION_TARGETS)
         raise ValueError(f"Promotion decision promotion_target must be one of: {allowed}")
@@ -245,6 +284,26 @@ def _validate_promotion_decision(payload: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(shared_tree_untouched, bool):
         raise ValueError("Promotion decision shared_tree_untouched must be a boolean.")
     normalized["shared_tree_untouched"] = shared_tree_untouched
+    if not isinstance(evidence, dict):
+        raise ValueError("Promotion decision evidence must be an object.")
+    oracle_commands = evidence.get("oracle_commands")
+    mutated_paths = evidence.get("mutated_paths")
+    oracle_count = evidence.get("oracle_count")
+    if not isinstance(oracle_commands, list) or not all(
+        isinstance(command, str) for command in oracle_commands
+    ):
+        raise ValueError("Promotion decision evidence.oracle_commands must be a string list.")
+    if not isinstance(mutated_paths, list) or not all(
+        isinstance(path, str) for path in mutated_paths
+    ):
+        raise ValueError("Promotion decision evidence.mutated_paths must be a string list.")
+    if not isinstance(oracle_count, int):
+        raise ValueError("Promotion decision evidence.oracle_count must be an integer.")
+    normalized["evidence"] = {
+        "oracle_commands": list(oracle_commands),
+        "mutated_paths": repo_relative_paths(mutated_paths),
+        "oracle_count": oracle_count,
+    }
     durable_artifact_path = normalized["durable_artifact_path"]
     durable_path = PurePosixPath(durable_artifact_path)
     if (

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -39,7 +39,11 @@ NOTIFICATION_ARTIFACT_DIR = (
     REPO_ROOT / "artifacts" / "orchestration" / "experiments" / "notifications"
 )
 PROMOTION_DISPOSITIONS: tuple[str, ...] = ("promoted", "deferred")
-SENSITIVE_PATH_PART_RE = re.compile(r"(secret|token|password|private|credential|key)", re.I)
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+SENSITIVE_PATH_PART_RE = re.compile(
+    r"(secret|token|password|private|credential|key|\.ssh|id_rsa|id_dsa|id_ecdsa|id_ed25519|\.aws|\.gnupg|\.kube)",
+    re.I,
+)
 WINDOWS_ABSOLUTE_PATH_RE = re.compile(r'^(?:"?[A-Za-z]:|"?\\\\|"?//)')
 
 
@@ -88,18 +92,18 @@ def _reject_symlinked_output_components(candidate: Path, *, artifact_dir: Path) 
     repo_artifact_root = REPO_ROOT.absolute() / "artifacts"
     artifact_dir.relative_to(repo_artifact_root)
     current = repo_artifact_root
-    if current.exists() and current.is_symlink():
+    if current.is_symlink():
         raise ValueError("notification artifact ancestors must not be symlinks.")
     for part in artifact_dir.relative_to(repo_artifact_root).parts:
         current = current / part
-        if current.exists() and current.is_symlink():
+        if current.is_symlink():
             raise ValueError("notification artifact ancestors must not be symlinks.")
-    if artifact_dir.exists() and artifact_dir.is_symlink():
+    if artifact_dir.is_symlink():
         raise ValueError("notification artifact directory must not be a symlink.")
     current = artifact_dir
     for part in candidate.relative_to(artifact_dir).parts:
         current = current / part
-        if current.exists() and current.is_symlink():
+        if current.is_symlink():
             raise ValueError("notification output path must not traverse a symlink.")
 
 
@@ -226,7 +230,7 @@ def _validate_durable_artifact_path_for_target(
 def _safe_inline(value: Any) -> str:
     """Render a scalar markdown inline value without backtick injection."""
 
-    text = str(value).strip()
+    text = CONTROL_CHAR_RE.sub(" ", str(value)).strip()
     if not text:
         return "none"
     return text.replace("`", "'")
@@ -238,6 +242,8 @@ def _safe_repo_path(value: Any) -> str:
     text = str(value).strip()
     if not text:
         return "none"
+    if CONTROL_CHAR_RE.search(text) or text.startswith("~"):
+        return "[redacted-path]"
     if WINDOWS_ABSOLUTE_PATH_RE.match(text) or "\\" in text:
         return "[redacted-path]"
     path = PurePosixPath(text)

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -184,6 +184,7 @@ def _require_matching_experiment(
             raise ExperimentNotificationError(
                 "Rejected experiment results must have promotion disposition deferred."
             )
+    _require_promotion_durable_artifact_exists(promotion)
 
 
 def _require_result_evidence_matches_packet(
@@ -227,6 +228,21 @@ def _require_result_evidence_matches_packet(
             raise ExperimentNotificationError(
                 "Rejected policy_violation result mutated_paths must be empty."
             )
+        if result["failure_class"] == "metric_regression":
+            if result_oracles != expected_oracles:
+                raise ExperimentNotificationError(
+                    "Rejected metric_regression result oracle_results must match packet immutable_oracles."
+                )
+            failed_oracles = [
+                _oracle_command_name(oracle_result["command"])
+                for oracle_result in result["oracle_results"]
+                if oracle_result["returncode"] != 0 or oracle_result["timed_out"]
+            ]
+            if failed_oracles:
+                joined = ", ".join(failed_oracles)
+                raise ExperimentNotificationError(
+                    f"Rejected metric_regression oracle_results must pass: {joined}"
+                )
         if result["failure_class"] in ORACLE_FAILURE_CLASSES:
             if not result["oracle_results"]:
                 raise ExperimentNotificationError(
@@ -315,6 +331,30 @@ def _require_promotion_evidence_matches_result(
     if evidence["oracle_count"] != len(result["oracle_results"]):
         raise ExperimentNotificationError(
             "Promotion decision evidence.oracle_count must match experiment result."
+        )
+
+
+def _require_promotion_durable_artifact_exists(promotion: dict[str, Any]) -> None:
+    """Require promotion evidence to point at a durable repo artifact."""
+
+    durable_path = REPO_ROOT / promotion["durable_artifact_path"]
+    if not durable_path.is_file():
+        raise ExperimentNotificationError("Promotion decision durable_artifact_path must exist.")
+    if promotion["promotion_target"] != "backlog_entry":
+        return
+
+    try:
+        content = durable_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ExperimentNotificationError(
+            "Promotion decision backlog durable_artifact_path must be readable."
+        ) from exc
+    experiment_slug = promotion["experiment_id"].replace("_", "-")
+    expected_anchor = f'<a id="ledger-{experiment_slug}"></a>'
+    expected_title = f"Experiment follow-up for {promotion['experiment_id']}"
+    if expected_anchor not in content or expected_title not in content:
+        raise ExperimentNotificationError(
+            "Promotion decision backlog durable_artifact_path must include experiment anchor."
         )
 
 

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -45,6 +45,7 @@ SENSITIVE_PATH_PART_RE = re.compile(
     re.I,
 )
 WINDOWS_ABSOLUTE_PATH_RE = re.compile(r'^(?:"?[A-Za-z]:|"?\\\\|"?//)')
+SHELL_ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
 
 
 class ExperimentNotificationError(RuntimeError):
@@ -172,7 +173,9 @@ def _require_result_evidence_matches_packet(
 
     mutable_surface = set(packet["mutable_candidate_surface"])
     outside_surface = sorted(
-        path for path in result["mutated_paths"] if path not in mutable_surface
+        path
+        for path in result["mutated_paths"]
+        if not _mutable_surface_contains_path(mutable_surface, path)
     )
     if outside_surface:
         joined = ", ".join(outside_surface)
@@ -185,7 +188,7 @@ def _require_result_evidence_matches_packet(
     result_oracles = [oracle_result["command"] for oracle_result in result["oracle_results"]]
     unexpected_oracles = sorted(set(result_oracles) - set(expected_oracles))
     if unexpected_oracles:
-        joined = ", ".join(unexpected_oracles)
+        joined = ", ".join(_oracle_command_name(command) for command in unexpected_oracles)
         raise ExperimentNotificationError(
             f"Experiment result oracle_results include commands outside packet: {joined}"
         )
@@ -193,6 +196,18 @@ def _require_result_evidence_matches_packet(
         raise ExperimentNotificationError(
             "Accepted experiment result oracle_results must match packet immutable_oracles."
         )
+
+
+def _mutable_surface_contains_path(mutable_surface: set[str], path: str) -> bool:
+    """Return whether a result path belongs to the packet mutable surface."""
+
+    for surface in mutable_surface:
+        surface_path = PurePosixPath(surface)
+        if path == surface:
+            return True
+        if not surface_path.suffix and path.startswith(f"{surface.rstrip('/')}/"):
+            return True
+    return False
 
 
 def _validate_promotion_decision(payload: dict[str, Any]) -> dict[str, Any]:
@@ -308,6 +323,10 @@ def _oracle_command_name(command: Any) -> str:
         return "[unparseable-command]"
     if not argv:
         return "[empty-command]"
+    while argv and SHELL_ENV_ASSIGNMENT_RE.match(argv[0]):
+        argv.pop(0)
+    if not argv:
+        return "[redacted-command]"
     binary = argv[0]
     if WINDOWS_ABSOLUTE_PATH_RE.match(binary) or "\\" in binary:
         return "[redacted-command]"

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -215,7 +215,13 @@ def _require_result_evidence_matches_packet(
         raise ExperimentNotificationError(
             "Accepted experiment result oracle_results must match packet immutable_oracles."
         )
+    if result["status"] == "rejected":
+        _require_rejected_oracles_are_prefix(expected_oracles, result_oracles)
     if result["status"] == "accepted":
+        if result["failure_class"] is not None:
+            raise ExperimentNotificationError(
+                "Accepted experiment result failure_class must be null."
+            )
         failed_oracles = [
             _oracle_command_name(oracle_result["command"])
             for oracle_result in result["oracle_results"]
@@ -244,8 +250,21 @@ def _surface_allows_nested_paths(surface: str) -> bool:
 
     if surface.endswith("/"):
         return True
-    suffix = PurePosixPath(surface).suffix.lower()
-    return suffix not in FILE_LIKE_SURFACE_SUFFIXES
+    if PurePosixPath(surface).suffix.lower() in FILE_LIKE_SURFACE_SUFFIXES:
+        return False
+    return (REPO_ROOT / surface).is_dir()
+
+
+def _require_rejected_oracles_are_prefix(
+    expected_oracles: list[str],
+    result_oracles: list[str],
+) -> None:
+    """Require rejected results to describe a prefix of the immutable oracle list."""
+
+    if result_oracles != expected_oracles[: len(result_oracles)]:
+        raise ExperimentNotificationError(
+            "Rejected experiment result oracle_results must be a packet immutable_oracles prefix."
+        )
 
 
 def _require_promotion_evidence_matches_result(
@@ -497,7 +516,7 @@ def _append_github_step_summary(markdown: str) -> None:
             if not markdown.endswith("\n"):
                 summary_file.write("\n")
     except OSError as exc:
-        raise ExperimentNotificationError(f"Unable to write GITHUB_STEP_SUMMARY: {exc}") from exc
+        raise ExperimentNotificationError("Unable to write GITHUB_STEP_SUMMARY.") from exc
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -44,6 +44,7 @@ NOTIFICATION_ARTIFACT_DIR = (
 )
 PROMOTION_DISPOSITIONS: tuple[str, ...] = ("promoted", "deferred")
 ORACLE_FAILURE_CLASSES: frozenset[str] = frozenset({"guard_failure", "timeout", "oom"})
+PRE_ORACLE_FAILURE_CLASSES: frozenset[str] = frozenset({"policy_violation", "unchanged_result"})
 CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 SENSITIVE_PATH_PART_RE = re.compile(
     r"(secret|token|password|private|credential|key|\.ssh|id_rsa|id_dsa|id_ecdsa|id_ed25519|\.aws|\.gnupg|\.kube)",
@@ -218,11 +219,19 @@ def _require_result_evidence_matches_packet(
         )
     if result["status"] == "rejected":
         _require_rejected_oracles_are_prefix(expected_oracles, result_oracles)
-        if result["failure_class"] in ORACLE_FAILURE_CLASSES and not result["oracle_results"]:
+        if result["failure_class"] in PRE_ORACLE_FAILURE_CLASSES and result["oracle_results"]:
             raise ExperimentNotificationError(
-                "Rejected oracle failure result must include terminal oracle evidence."
+                "Rejected pre-oracle result must not include oracle evidence."
             )
-        if result["failure_class"] != "infra_flake" and result["oracle_results"]:
+        if result["failure_class"] == "policy_violation" and result["mutated_paths"]:
+            raise ExperimentNotificationError(
+                "Rejected policy_violation result mutated_paths must be empty."
+            )
+        if result["failure_class"] in ORACLE_FAILURE_CLASSES:
+            if not result["oracle_results"]:
+                raise ExperimentNotificationError(
+                    "Rejected oracle failure result must include terminal oracle evidence."
+                )
             terminal_oracle = result["oracle_results"][-1]
             if terminal_oracle["returncode"] == 0 and not terminal_oracle["timed_out"]:
                 raise ExperimentNotificationError(

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -43,6 +43,7 @@ NOTIFICATION_ARTIFACT_DIR = (
     REPO_ROOT / "artifacts" / "orchestration" / "experiments" / "notifications"
 )
 PROMOTION_DISPOSITIONS: tuple[str, ...] = ("promoted", "deferred")
+ORACLE_FAILURE_CLASSES: frozenset[str] = frozenset({"guard_failure", "timeout", "oom"})
 CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 SENSITIVE_PATH_PART_RE = re.compile(
     r"(secret|token|password|private|credential|key|\.ssh|id_rsa|id_dsa|id_ecdsa|id_ed25519|\.aws|\.gnupg|\.kube)",
@@ -217,6 +218,10 @@ def _require_result_evidence_matches_packet(
         )
     if result["status"] == "rejected":
         _require_rejected_oracles_are_prefix(expected_oracles, result_oracles)
+        if result["failure_class"] in ORACLE_FAILURE_CLASSES and not result["oracle_results"]:
+            raise ExperimentNotificationError(
+                "Rejected oracle failure result must include terminal oracle evidence."
+            )
         if result["failure_class"] != "infra_flake" and result["oracle_results"]:
             terminal_oracle = result["oracle_results"][-1]
             if terminal_oracle["returncode"] == 0 and not terminal_oracle["timed_out"]:
@@ -247,6 +252,8 @@ def _require_result_evidence_matches_packet(
 def _mutable_surface_contains_path(mutable_surface: set[str], path: str) -> bool:
     """Return whether a result path belongs to the packet mutable surface."""
 
+    if any(part == ".." for part in PurePosixPath(path).parts):
+        return False
     for surface in mutable_surface:
         if path == surface:
             return True
@@ -449,6 +456,8 @@ def _oracle_command_name(command: Any) -> str:
         if any(SENSITIVE_PATH_PART_RE.search(part) for part in PurePosixPath(binary).parts):
             return "[redacted-command]"
         return _safe_inline(Path(binary).name)
+    if SENSITIVE_PATH_PART_RE.search(binary):
+        return "[redacted-command]"
     return _safe_inline(binary)
 
 

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Render safe, artifact-only notifications for governed experiment results.
+
+RU: Пишет локальный markdown summary для experiment result без внешней доставки.
+EN: Writes a local markdown summary for experiment results without external delivery.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import shlex
+import sys
+from typing import Any
+
+try:
+    from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
+    from scripts.orchestration.experiment_contract import (
+        PROMOTION_TARGETS,
+        SCHEMA_VERSION,
+        validate_experiment_id,
+        validate_experiment_packet,
+        validate_experiment_result,
+    )
+except ImportError:  # pragma: no cover - CLI fallback for direct script execution.
+    experiment_notify_repo_root = Path(__file__).resolve().parents[2]
+    if str(experiment_notify_repo_root) not in sys.path:
+        sys.path.insert(0, str(experiment_notify_repo_root))
+    from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
+    from scripts.orchestration.experiment_contract import (
+        PROMOTION_TARGETS,
+        SCHEMA_VERSION,
+        validate_experiment_id,
+        validate_experiment_packet,
+        validate_experiment_result,
+    )
+
+
+NOTIFICATION_ARTIFACT_DIR = (
+    REPO_ROOT / "artifacts" / "orchestration" / "experiments" / "notifications"
+)
+PROMOTION_DISPOSITIONS: tuple[str, ...] = ("promoted", "deferred")
+SENSITIVE_PATH_PART_RE = re.compile(r"(secret|token|password|private|credential|key)", re.I)
+
+
+class ExperimentNotificationError(RuntimeError):
+    """Base error for notification rendering contract violations."""
+
+
+def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Unable to load {label} JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be a JSON object.")
+    return payload
+
+
+def _resolve_output_path(raw_output: str | None, experiment_id: str) -> Path:
+    if raw_output:
+        candidate = Path(raw_output)
+        if not candidate.is_absolute():
+            candidate = NOTIFICATION_ARTIFACT_DIR / candidate
+    else:
+        candidate = NOTIFICATION_ARTIFACT_DIR / f"{experiment_id}.md"
+    candidate = candidate.resolve()
+    try:
+        candidate.relative_to(NOTIFICATION_ARTIFACT_DIR.resolve())
+    except ValueError as exc:
+        raise ValueError(
+            "--output must stay within artifacts/orchestration/experiments/notifications"
+        ) from exc
+    return candidate
+
+
+def _require_matching_experiment(
+    packet: dict[str, Any],
+    result: dict[str, Any],
+    promotion: dict[str, Any] | None,
+) -> None:
+    if packet["experiment_id"] != result["experiment_id"]:
+        raise ExperimentNotificationError(
+            "Experiment packet and result must reference the same experiment_id."
+        )
+    if promotion is not None and packet["experiment_id"] != promotion.get("experiment_id"):
+        raise ExperimentNotificationError(
+            "Experiment packet and promotion must reference the same experiment_id."
+        )
+    if promotion is None:
+        return
+    if promotion["promotion_target"] != packet["promotion_target"]:
+        raise ExperimentNotificationError(
+            "Promotion decision target must match experiment packet promotion_target."
+        )
+    if promotion["result_status"] != result["status"]:
+        raise ExperimentNotificationError(
+            "Promotion decision result_status must match experiment result status."
+        )
+    if promotion["failure_class"] != result["failure_class"]:
+        raise ExperimentNotificationError(
+            "Promotion decision failure_class must match experiment result failure_class."
+        )
+    if promotion["shared_tree_untouched"] != result["shared_tree_untouched"]:
+        raise ExperimentNotificationError(
+            "Promotion decision shared_tree_untouched must match experiment result."
+        )
+    if result["status"] == "accepted" and promotion["disposition"] != "promoted":
+        raise ExperimentNotificationError(
+            "Accepted experiment results must have promotion disposition promoted."
+        )
+    if result["status"] == "rejected":
+        if packet["promotion_target"] != "backlog_entry":
+            raise ExperimentNotificationError(
+                "Rejected experiment results may notify only backlog_entry promotions."
+            )
+        if promotion["disposition"] != "deferred":
+            raise ExperimentNotificationError(
+                "Rejected experiment results must have promotion disposition deferred."
+            )
+
+
+def _validate_promotion_decision(payload: dict[str, Any]) -> dict[str, Any]:
+    schema_version = str(payload.get("schema_version", "")).strip()
+    if schema_version != SCHEMA_VERSION:
+        raise ValueError(
+            f"Promotion decision schema_version must equal {SCHEMA_VERSION!r}, "
+            f"got {schema_version!r}."
+        )
+    experiment_id = validate_experiment_id(
+        payload.get("experiment_id", ""),
+        label="Promotion decision",
+    )
+    normalized = dict(payload)
+    normalized["schema_version"] = schema_version
+    normalized["experiment_id"] = experiment_id
+    normalized["promotion_target"] = str(payload.get("promotion_target", "")).strip()
+    normalized["disposition"] = str(payload.get("disposition", "")).strip()
+    normalized["durable_artifact_path"] = str(payload.get("durable_artifact_path", "")).strip()
+    normalized["result_status"] = str(payload.get("result_status", "")).strip()
+    normalized["failure_class"] = payload.get("failure_class")
+    shared_tree_untouched = payload.get("shared_tree_untouched")
+    if normalized["promotion_target"] not in PROMOTION_TARGETS:
+        allowed = ", ".join(PROMOTION_TARGETS)
+        raise ValueError(f"Promotion decision promotion_target must be one of: {allowed}")
+    if normalized["disposition"] not in PROMOTION_DISPOSITIONS:
+        allowed = ", ".join(PROMOTION_DISPOSITIONS)
+        raise ValueError(f"Promotion decision disposition must be one of: {allowed}")
+    if normalized["result_status"] not in {"accepted", "rejected"}:
+        raise ValueError("Promotion decision result_status must be accepted or rejected.")
+    if normalized["failure_class"] is not None:
+        normalized["failure_class"] = str(normalized["failure_class"]).strip()
+    if not isinstance(shared_tree_untouched, bool):
+        raise ValueError("Promotion decision shared_tree_untouched must be a boolean.")
+    normalized["shared_tree_untouched"] = shared_tree_untouched
+    durable_artifact_path = normalized["durable_artifact_path"]
+    durable_path = PurePosixPath(durable_artifact_path)
+    if (
+        not durable_artifact_path
+        or durable_path.is_absolute()
+        or any(part == ".." for part in durable_path.parts)
+    ):
+        raise ValueError("Promotion decision durable_artifact_path must be repo-relative.")
+    _validate_durable_artifact_path_for_target(
+        experiment_id=experiment_id,
+        promotion_target=normalized["promotion_target"],
+        durable_artifact_path=durable_artifact_path,
+    )
+    return normalized
+
+
+def _validate_durable_artifact_path_for_target(
+    *,
+    experiment_id: str,
+    promotion_target: str,
+    durable_artifact_path: str,
+) -> None:
+    upper_id = experiment_id.upper().replace("-", "_")
+    expected_paths = {
+        "pr_packet": f"docs/orchestration/experiment_pr_packets/{experiment_id}.md",
+        "audit_artifact": f"docs/audit/EXPERIMENT_{upper_id}.md",
+        "guard_test_proposal": f"docs/orchestration/experiment_guard_proposals/{experiment_id}.md",
+        "backlog_entry": "docs/roadmap/BACKLOG_LEDGER.md",
+        "memory_capsule": f"docs/memory/{experiment_id}_capsule.md",
+    }
+    expected = expected_paths.get(promotion_target)
+    if expected is None or durable_artifact_path != expected:
+        raise ValueError("Promotion decision durable_artifact_path must match promotion_target.")
+
+
+def _safe_inline(value: Any) -> str:
+    text = str(value).strip()
+    if not text:
+        return "none"
+    return text.replace("`", "'")
+
+
+def _safe_repo_path(value: Any) -> str:
+    text = str(value).strip()
+    if not text:
+        return "none"
+    path = PurePosixPath(text)
+    if (
+        path.is_absolute()
+        or any(part == ".." for part in path.parts)
+        or any(SENSITIVE_PATH_PART_RE.search(part) for part in path.parts)
+    ):
+        return "[redacted-path]"
+    return _safe_inline(path.as_posix())
+
+
+def _oracle_command_name(command: Any) -> str:
+    try:
+        argv = shlex.split(str(command))
+    except ValueError:
+        return "[unparseable-command]"
+    if not argv:
+        return "[empty-command]"
+    binary = argv[0]
+    if "/" in binary or "\\" in binary:
+        return _safe_inline(Path(binary).name)
+    return _safe_inline(binary)
+
+
+def _oracle_lines(result: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    for oracle_result in result["oracle_results"]:
+        lines.append(
+            "- `"
+            + _oracle_command_name(oracle_result["command"])
+            + "` -> rc="
+            + str(oracle_result["returncode"])
+            + ", timed_out="
+            + str(oracle_result["timed_out"]).lower()
+            + ", truncated="
+            + str(oracle_result["truncated"]).lower()
+        )
+    if not lines:
+        lines.append("- No oracle commands executed.")
+    return lines
+
+
+def render_notification_markdown(
+    packet: dict[str, Any],
+    result: dict[str, Any],
+    promotion: dict[str, Any] | None = None,
+) -> str:
+    """Render the stable, redacted markdown notification body."""
+
+    _require_matching_experiment(packet, result, promotion)
+    failure_class = result["failure_class"] if result["failure_class"] is not None else "none"
+    mutated_paths = (
+        "\n".join(f"- `{_safe_repo_path(path)}`" for path in result["mutated_paths"])
+        if result["mutated_paths"]
+        else "- No mutated paths recorded."
+    )
+    promotion_lines = [
+        f"- Promotion target: `{_safe_inline(packet['promotion_target'])}`",
+        "- Promotion disposition: `not-run`",
+        "- Durable artifact: `none`",
+    ]
+    if promotion is not None:
+        promotion_lines = [
+            f"- Promotion target: `{_safe_inline(promotion['promotion_target'])}`",
+            f"- Promotion disposition: `{_safe_inline(promotion['disposition'])}`",
+            f"- Durable artifact: `{_safe_repo_path(promotion['durable_artifact_path'])}`",
+        ]
+
+    return (
+        f"# Experiment Result Notification: {packet['experiment_id']}\n\n"
+        f"- Result status: `{_safe_inline(result['status'])}`\n"
+        f"- Failure class: `{_safe_inline(failure_class)}`\n"
+        f"- Shared tree untouched: `{str(result['shared_tree_untouched']).lower()}`\n"
+        f"{chr(10).join(promotion_lines)}\n\n"
+        "## Mutated Paths\n\n"
+        f"{mutated_paths}\n\n"
+        "## Oracle Summary\n\n"
+        f"{chr(10).join(_oracle_lines(result))}\n\n"
+        "## Delivery Boundary\n\n"
+        "- Artifact-only summary; no email, Slack, PR comment, or external delivery was sent.\n"
+        "- Raw patch text, oracle stdout/stderr, cwd, and local absolute paths are intentionally omitted.\n"
+    )
+
+
+def _append_github_step_summary(markdown: str) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "").strip()
+    if not summary_path:
+        raise ExperimentNotificationError(
+            "--github-step-summary requires GITHUB_STEP_SUMMARY to be set."
+        )
+    try:
+        with Path(summary_path).open("a", encoding="utf-8") as summary_file:
+            summary_file.write(markdown)
+            if not markdown.endswith("\n"):
+                summary_file.write("\n")
+    except OSError as exc:
+        raise ExperimentNotificationError(f"Unable to write GITHUB_STEP_SUMMARY: {exc}") from exc
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="experiment_notify",
+        description="Render artifact-only notifications for governed experiment results.",
+    )
+    parser.add_argument("--packet", required=True, help="Experiment packet JSON path.")
+    parser.add_argument("--result", required=True, help="Experiment result JSON path.")
+    parser.add_argument("--promotion", default=None, help="Optional promotion decision JSON path.")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help=(
+            "Optional notification markdown path under "
+            "artifacts/orchestration/experiments/notifications/. "
+            "Defaults to artifacts/orchestration/experiments/notifications/<id>.md"
+        ),
+    )
+    parser.add_argument(
+        "--github-step-summary",
+        action="store_true",
+        help="Also append the rendered markdown to GITHUB_STEP_SUMMARY when explicitly requested.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    packet_path = Path(args.packet).expanduser().resolve()
+    result_path = Path(args.result).expanduser().resolve()
+
+    try:
+        packet = validate_experiment_packet(
+            _read_json_object(packet_path, label="experiment packet")
+        )
+        result = validate_experiment_result(
+            _read_json_object(result_path, label="experiment result")
+        )
+        promotion = None
+        if args.promotion:
+            promotion = _validate_promotion_decision(
+                _read_json_object(Path(args.promotion).expanduser().resolve(), label="promotion")
+            )
+        output_path = _resolve_output_path(args.output, packet["experiment_id"])
+        markdown = render_notification_markdown(packet, result, promotion)
+    except (ValueError, ExperimentNotificationError) as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(markdown, encoding="utf-8")
+        if args.github_step_summary:
+            _append_github_step_summary(markdown)
+    except (OSError, ExperimentNotificationError) as exc:
+        print(f"FAIL: unable to write experiment notification: {exc}")
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "experiment_id": packet["experiment_id"],
+                "output": normalize_repo_path(output_path),
+                "github_step_summary": bool(args.github_step_summary),
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -128,6 +128,26 @@ def _write_json(path: Path, payload: dict[str, object]) -> Path:
     return path
 
 
+def _write_audit_artifact(repo: Path, experiment_id: str = "exp-notify") -> Path:
+    upper_id = experiment_id.upper().replace("-", "_")
+    path = repo / "docs" / "audit" / f"EXPERIMENT_{upper_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"# Experiment Audit Artifact: {experiment_id}\n", encoding="utf-8")
+    return path
+
+
+def _write_backlog_entry(repo: Path, experiment_id: str = "exp-notify") -> Path:
+    experiment_slug = experiment_id.replace("_", "-")
+    path = repo / "docs" / "roadmap" / "BACKLOG_LEDGER.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f'<a id="ledger-{experiment_slug}"></a>\n'
+        f"- [ ] P1: Experiment follow-up for {experiment_id}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
 def _subprocess_env_without_repo_pythonpath() -> dict[str, str]:
     env = dict(os.environ)
     env.pop("PYTHONPATH", None)
@@ -198,6 +218,7 @@ def test_notification_includes_promotion_decision(
 ) -> None:
     repo = _init_repo(tmp_path)
     _configure_repo(monkeypatch, repo)
+    _write_audit_artifact(repo)
     packet_path = _write_json(tmp_path / "packet.json", _packet())
     result_path = _write_json(tmp_path / "result.json", _result())
     promotion_path = _write_json(tmp_path / "promotion.json", _promotion())
@@ -574,16 +595,56 @@ def test_rejected_infra_flake_allows_passing_oracle_prefix() -> None:
 
 
 def test_rejected_metric_regression_allows_passing_oracle_prefix() -> None:
-    packet = experiment_contract.validate_experiment_packet(_packet())
+    packet = experiment_contract.validate_experiment_packet(
+        _packet()
+        | {
+            "immutable_oracles": [
+                {"command": "python3 -m pytest tests/test_a.py", "expected_signal": "must pass"},
+                {"command": "python3 -m pytest tests/test_b.py", "expected_signal": "must pass"},
+            ]
+        }
+    )
     result = experiment_contract.validate_experiment_result(
         _result(status="rejected", failure_class="metric_regression")
     )
-    result["oracle_results"][0]["returncode"] = 0
+    result["oracle_results"] = [
+        {
+            "command": "python3 -m pytest tests/test_a.py",
+            "returncode": 0,
+            "timed_out": False,
+            "truncated": False,
+            "stdout": "",
+            "stderr": "",
+            "cwd": "",
+        },
+        {
+            "command": "python3 -m pytest tests/test_b.py",
+            "returncode": 0,
+            "timed_out": False,
+            "truncated": False,
+            "stdout": "",
+            "stderr": "",
+            "cwd": "",
+        },
+    ]
 
     content = experiment_notify.render_notification_markdown(packet, result)
 
     assert "- Result status: `rejected`" in content
     assert "- Failure class: `metric_regression`" in content
+
+
+def test_rejected_metric_regression_requires_full_passing_oracle_evidence() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(
+        _result(status="rejected", failure_class="metric_regression")
+    )
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="oracle_results must pass",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
 
 
 def test_rejected_result_terminal_oracle_must_fail() -> None:
@@ -680,6 +741,86 @@ def test_promotion_evidence_must_match_packet_and_result() -> None:
         experiment_notify.render_notification_markdown(packet, result, promotion)
 
 
+def test_promoted_durable_artifact_must_exist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(_result())
+    promotion = experiment_notify._validate_promotion_decision(_promotion())
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="durable_artifact_path must exist",
+    ):
+        experiment_notify.render_notification_markdown(packet, result, promotion)
+
+
+def test_backlog_promotion_requires_experiment_anchor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    backlog_path = repo / "docs" / "roadmap" / "BACKLOG_LEDGER.md"
+    backlog_path.parent.mkdir(parents=True, exist_ok=True)
+    backlog_path.write_text("# Backlog\n", encoding="utf-8")
+    packet = experiment_contract.validate_experiment_packet(
+        _packet(promotion_target="backlog_entry")
+    )
+    result = experiment_contract.validate_experiment_result(
+        _result(status="rejected", failure_class="guard_failure")
+    )
+    promotion = experiment_notify._validate_promotion_decision(
+        {
+            **_promotion(),
+            "result_status": "rejected",
+            "failure_class": "guard_failure",
+            "promotion_target": "backlog_entry",
+            "disposition": "deferred",
+            "durable_artifact_path": "docs/roadmap/BACKLOG_LEDGER.md",
+        }
+    )
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="experiment anchor",
+    ):
+        experiment_notify.render_notification_markdown(packet, result, promotion)
+
+
+def test_backlog_promotion_accepts_existing_experiment_anchor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _write_backlog_entry(repo)
+    packet = experiment_contract.validate_experiment_packet(
+        _packet(promotion_target="backlog_entry")
+    )
+    result = experiment_contract.validate_experiment_result(
+        _result(status="rejected", failure_class="guard_failure")
+    )
+    promotion = experiment_notify._validate_promotion_decision(
+        {
+            **_promotion(),
+            "result_status": "rejected",
+            "failure_class": "guard_failure",
+            "promotion_target": "backlog_entry",
+            "disposition": "deferred",
+            "durable_artifact_path": "docs/roadmap/BACKLOG_LEDGER.md",
+        }
+    )
+
+    content = experiment_notify.render_notification_markdown(packet, result, promotion)
+
+    assert "- Promotion target: `backlog_entry`" in content
+    assert "- Promotion disposition: `deferred`" in content
+
+
 def test_promotion_evidence_oracle_count_must_match_result() -> None:
     packet = experiment_contract.validate_experiment_packet(_packet())
     result = experiment_contract.validate_experiment_result(_result())
@@ -738,6 +879,7 @@ def test_notification_redacts_raw_outputs_patch_and_local_paths(
 ) -> None:
     repo = _init_repo(tmp_path)
     _configure_repo(monkeypatch, repo)
+    _write_audit_artifact(repo)
     packet = experiment_contract.validate_experiment_packet(_packet())
     result = experiment_contract.validate_experiment_result(_result())
     promotion = experiment_notify._validate_promotion_decision(

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -1,0 +1,427 @@
+"""Deterministic tests for governed experiment notification rendering."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import scripts.orchestration.context_pack as context_pack
+import scripts.orchestration.experiment_contract as experiment_contract
+import scripts.orchestration.experiment_notify as experiment_notify
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "core" / "rag").mkdir(parents=True)
+    (repo / "core" / "rag" / "allowed.py").write_text(
+        "def candidate_value() -> int:\n    return 2\n",
+        encoding="utf-8",
+    )
+    return repo
+
+
+def _configure_repo(monkeypatch: pytest.MonkeyPatch, repo: Path) -> Path:
+    notification_dir = repo / "artifacts" / "orchestration" / "experiments" / "notifications"
+    monkeypatch.setattr(context_pack, "REPO_ROOT", repo)
+    monkeypatch.setattr(experiment_contract, "REPO_ROOT", repo)
+    monkeypatch.setattr(experiment_notify, "REPO_ROOT", repo)
+    monkeypatch.setattr(experiment_notify, "NOTIFICATION_ARTIFACT_DIR", notification_dir)
+    return notification_dir
+
+
+def _packet(
+    *,
+    experiment_id: str = "exp-notify",
+    promotion_target: str = "audit_artifact",
+) -> dict[str, object]:
+    return {
+        "schema_version": "1.0",
+        "experiment_id": experiment_id,
+        "decision_question": "Notify about governed experiment result",
+        "task_class": "Experimentation",
+        "domain": "ml",
+        "mutable_candidate_surface": ["core/rag/allowed.py"],
+        "immutable_oracles": [
+            {
+                "command": 'python3 -c "import sys; sys.exit(0)"',
+                "expected_signal": "must pass",
+            }
+        ],
+        "budgets": {
+            "wall_clock_seconds": 300,
+            "retry_budget": 1,
+            "max_changed_files": 1,
+            "network_budget": 0,
+            "benchmark_budget": 1,
+            "test_budget": 1,
+            "stop_condition": "stop",
+        },
+        "metrics": {
+            "primary": "reliability_score",
+            "secondary": [],
+            "baseline_reference": "current-main",
+            "acceptance_threshold": "strict_improvement",
+        },
+        "negative_controls": ["oracle file unchanged", "no hidden memory"],
+        "promotion_target": promotion_target,
+    }
+
+
+def _result(
+    *,
+    experiment_id: str = "exp-notify",
+    status: str = "accepted",
+    failure_class: str | None = None,
+    command: str = 'python3 -c "import sys; sys.exit(0)"',
+) -> dict[str, object]:
+    return {
+        "schema_version": "1.0",
+        "experiment_id": experiment_id,
+        "candidate_patch": "candidate.patch",
+        "status": status,
+        "failure_class": failure_class,
+        "mutated_paths": ["core/rag/allowed.py"],
+        "oracle_results": [
+            {
+                "command": command,
+                "returncode": 0 if status == "accepted" else 1,
+                "timed_out": False,
+                "truncated": False,
+                "stdout": "secret stdout should never render",
+                "stderr": "secret stderr should never render",
+                "cwd": "/Users/example/local/repo",
+            }
+        ],
+        "budget_observations": {"attempts": 1},
+        "shared_tree_untouched": True,
+        "promotion_ready": False,
+    }
+
+
+def _promotion(*, experiment_id: str = "exp-notify") -> dict[str, object]:
+    return {
+        "schema_version": "1.0",
+        "experiment_id": experiment_id,
+        "result_status": "accepted",
+        "failure_class": None,
+        "promotion_target": "audit_artifact",
+        "disposition": "promoted",
+        "durable_artifact_path": "docs/audit/EXPERIMENT_EXP_NOTIFY.md",
+        "shared_tree_untouched": True,
+        "domain": "ml",
+        "evidence": {
+            "oracle_commands": ['python3 -c "import sys; sys.exit(0)"'],
+            "mutated_paths": ["core/rag/allowed.py"],
+            "oracle_count": 1,
+        },
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+EXPECTED_NOTIFICATION = """# Experiment Result Notification: exp-notify
+
+- Result status: `accepted`
+- Failure class: `none`
+- Shared tree untouched: `true`
+- Promotion target: `audit_artifact`
+- Promotion disposition: `not-run`
+- Durable artifact: `none`
+
+## Mutated Paths
+
+- `core/rag/allowed.py`
+
+## Oracle Summary
+
+- `python3` -> rc=0, timed_out=false, truncated=false
+
+## Delivery Boundary
+
+- Artifact-only summary; no email, Slack, PR comment, or external delivery was sent.
+- Raw patch text, oracle stdout/stderr, cwd, and local absolute paths are intentionally omitted.
+"""
+
+
+def test_main_writes_deterministic_notification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+
+    exit_code = experiment_notify.main(["--packet", str(packet_path), "--result", str(result_path)])
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 0
+    output = (
+        repo / "artifacts" / "orchestration" / "experiments" / "notifications" / "exp-notify.md"
+    )
+    content = output.read_text(encoding="utf-8")
+    assert content == EXPECTED_NOTIFICATION
+    assert json.loads(stdout) == {
+        "experiment_id": "exp-notify",
+        "github_step_summary": False,
+        "output": "artifacts/orchestration/experiments/notifications/exp-notify.md",
+    }
+
+    second_exit_code = experiment_notify.main(
+        ["--packet", str(packet_path), "--result", str(result_path)]
+    )
+    capsys.readouterr()
+
+    assert second_exit_code == 0
+    assert output.read_text(encoding="utf-8") == EXPECTED_NOTIFICATION
+
+
+def test_notification_includes_promotion_decision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+    promotion_path = _write_json(tmp_path / "promotion.json", _promotion())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--promotion",
+            str(promotion_path),
+        ]
+    )
+
+    assert exit_code == 0
+    content = (
+        repo / "artifacts" / "orchestration" / "experiments" / "notifications" / "exp-notify.md"
+    ).read_text(encoding="utf-8")
+    assert "- Promotion target: `audit_artifact`" in content
+    assert "- Promotion disposition: `promoted`" in content
+    assert "- Durable artifact: `docs/audit/EXPERIMENT_EXP_NOTIFY.md`" in content
+
+
+@pytest.mark.parametrize(
+    ("override", "match"),
+    [
+        (
+            {
+                "promotion_target": "memory_capsule",
+                "durable_artifact_path": "docs/memory/exp-notify_capsule.md",
+            },
+            "target must match",
+        ),
+        ({"disposition": "claimed"}, "disposition must be one of"),
+        ({"disposition": "deferred"}, "must have promotion disposition promoted"),
+        ({"result_status": "rejected"}, "result_status must match"),
+        ({"failure_class": "guard_failure"}, "failure_class must match"),
+        ({"shared_tree_untouched": False}, "shared_tree_untouched must match"),
+        ({"durable_artifact_path": "../outside.md"}, "repo-relative"),
+        ({"durable_artifact_path": ""}, "repo-relative"),
+        (
+            {"durable_artifact_path": "docs/review/PR_999_FIXED_MAPPING.md"},
+            "must match promotion_target",
+        ),
+    ],
+)
+def test_invalid_promotion_decision_is_rejected(
+    override: dict[str, object],
+    match: str,
+) -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(_result())
+
+    with pytest.raises((ValueError, experiment_notify.ExperimentNotificationError), match=match):
+        promotion = experiment_notify._validate_promotion_decision({**_promotion(), **override})
+        experiment_notify.render_notification_markdown(packet, result, promotion)
+
+
+def test_wrong_rejected_promotion_policy_is_rejected() -> None:
+    packet = experiment_contract.validate_experiment_packet(
+        _packet(promotion_target="backlog_entry")
+    )
+    result = experiment_contract.validate_experiment_result(
+        _result(status="rejected", failure_class="guard_failure")
+    )
+    promotion = experiment_notify._validate_promotion_decision(
+        {
+            **_promotion(),
+            "result_status": "rejected",
+            "failure_class": "guard_failure",
+            "promotion_target": "backlog_entry",
+            "disposition": "promoted",
+            "durable_artifact_path": "docs/roadmap/BACKLOG_LEDGER.md",
+        }
+    )
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="must have promotion disposition deferred",
+    ):
+        experiment_notify.render_notification_markdown(packet, result, promotion)
+
+
+def test_promotion_experiment_id_mismatch_is_rejected() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(_result())
+    promotion = experiment_notify._validate_promotion_decision(
+        {
+            **_promotion(experiment_id="other-exp"),
+            "durable_artifact_path": "docs/audit/EXPERIMENT_OTHER_EXP.md",
+        }
+    )
+
+    with pytest.raises(experiment_notify.ExperimentNotificationError, match="same experiment_id"):
+        experiment_notify.render_notification_markdown(packet, result, promotion)
+
+
+def test_rejected_result_includes_failure_class(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(
+        _result(status="rejected", failure_class="guard_failure")
+    )
+
+    content = experiment_notify.render_notification_markdown(packet, result)
+
+    assert "- Result status: `rejected`" in content
+    assert "- Failure class: `guard_failure`" in content
+
+
+def test_notification_redacts_raw_outputs_patch_and_local_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(
+        _result(command="/Users/example/.venv/bin/python3 --token super-secret")
+    )
+    result["mutated_paths"] = ["/Users/example/private-token/path.py", "../outside.py"]
+    promotion = experiment_notify._validate_promotion_decision(
+        {
+            **_promotion(),
+            "durable_artifact_path": "docs/audit/EXPERIMENT_EXP_NOTIFY.md",
+        }
+    )
+
+    content = experiment_notify.render_notification_markdown(packet, result, promotion)
+
+    assert "secret stdout" not in content
+    assert "secret stderr" not in content
+    assert "candidate.patch" not in content
+    assert "Notify about governed experiment result" not in content
+    assert "/Users/example" not in content
+    assert "--token" not in content
+    assert "super-secret" not in content
+    assert "- `python3` -> rc=0, timed_out=false, truncated=false" in content
+    assert content.count("[redacted-path]") == 2
+
+
+def test_resolve_output_path_rejects_escape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+
+    with pytest.raises(ValueError, match="notifications"):
+        experiment_notify._resolve_output_path("../outside.md", "exp-notify")
+
+
+def test_cli_rejects_absolute_output_escape_without_writing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+    outside_path = tmp_path / "outside.md"
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--output",
+            str(outside_path),
+        ]
+    )
+
+    assert exit_code == 1
+    assert not outside_path.exists()
+
+
+def test_github_step_summary_requires_explicit_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    summary_path = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+
+    exit_without_flag = experiment_notify.main(
+        ["--packet", str(packet_path), "--result", str(result_path)]
+    )
+    assert exit_without_flag == 0
+    assert not summary_path.exists()
+
+    exit_with_flag = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--github-step-summary",
+        ]
+    )
+
+    assert exit_with_flag == 0
+    assert "# Experiment Result Notification: exp-notify" in summary_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_github_step_summary_flag_fails_without_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--github-step-summary",
+        ]
+    )
+
+    assert exit_code == 1

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -282,6 +282,84 @@ def test_wrong_rejected_promotion_policy_is_rejected() -> None:
         experiment_notify.render_notification_markdown(packet, result, promotion)
 
 
+def test_promoted_accepted_result_with_dirty_shared_tree_is_rejected() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(
+        _result(status="accepted", failure_class=None) | {"shared_tree_untouched": False}
+    )
+    promotion = experiment_notify._validate_promotion_decision(
+        {
+            **_promotion(),
+            "shared_tree_untouched": False,
+        }
+    )
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="shared_tree_untouched is false",
+    ):
+        experiment_notify.render_notification_markdown(packet, result, promotion)
+
+
+def test_accepted_result_must_include_packet_oracle_results() -> None:
+    packet = experiment_contract.validate_experiment_packet(
+        _packet()
+        | {
+            "immutable_oracles": [
+                {"command": "python3 -m pytest tests/test_a.py", "expected_signal": "must pass"},
+                {"command": "python3 -m pytest tests/test_b.py", "expected_signal": "must pass"},
+            ]
+        }
+    )
+    result = experiment_contract.validate_experiment_result(
+        _result(command="python3 -m pytest tests/test_a.py")
+    )
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="oracle_results must match",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
+
+
+def test_result_evidence_must_stay_within_packet_mutable_surface() -> None:
+    packet = experiment_contract.validate_experiment_packet(
+        _packet() | {"mutable_candidate_surface": ["core/rag/allowed.py"]}
+    )
+    result = experiment_contract.validate_experiment_result(_result())
+    result["mutated_paths"] = ["core/rag/other.py"]
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="mutable_candidate_surface",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
+
+
+def test_result_oracle_commands_must_come_from_packet() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(
+        _result(status="rejected", failure_class="guard_failure")
+    )
+    result["oracle_results"] = [
+        {
+            "command": "python3 -m pytest tests/unknown.py",
+            "returncode": 1,
+            "timed_out": False,
+            "truncated": False,
+            "stdout": "",
+            "stderr": "",
+            "cwd": "",
+        }
+    ]
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="commands outside packet",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
+
+
 def test_promotion_experiment_id_mismatch_is_rejected() -> None:
     packet = experiment_contract.validate_experiment_packet(_packet())
     result = experiment_contract.validate_experiment_result(_result())
@@ -320,10 +398,7 @@ def test_notification_redacts_raw_outputs_patch_and_local_paths(
     repo = _init_repo(tmp_path)
     _configure_repo(monkeypatch, repo)
     packet = experiment_contract.validate_experiment_packet(_packet())
-    result = experiment_contract.validate_experiment_result(
-        _result(command="/Users/example/.venv/bin/python3 --token super-secret")
-    )
-    result["mutated_paths"] = ["/Users/example/private-token/path.py", "../outside.py"]
+    result = experiment_contract.validate_experiment_result(_result())
     promotion = experiment_notify._validate_promotion_decision(
         {
             **_promotion(),
@@ -341,7 +416,16 @@ def test_notification_redacts_raw_outputs_patch_and_local_paths(
     assert "--token" not in content
     assert "super-secret" not in content
     assert "- `python3` -> rc=0, timed_out=false, truncated=false" in content
-    assert content.count("[redacted-path]") == 2
+    assert (
+        experiment_notify._oracle_command_name(
+            "/Users/example/.venv/bin/python3 --token super-secret"
+        )
+        == "python3"
+    )
+    assert experiment_notify._safe_repo_path("/Users/example/private-token/path.py") == (
+        "[redacted-path]"
+    )
+    assert experiment_notify._safe_repo_path("../outside.py") == "[redacted-path]"
 
 
 def test_notification_redacts_windows_local_paths(
@@ -351,10 +435,8 @@ def test_notification_redacts_windows_local_paths(
     repo = _init_repo(tmp_path)
     _configure_repo(monkeypatch, repo)
     packet = experiment_contract.validate_experiment_packet(_packet())
-    result = experiment_contract.validate_experiment_result(
-        _result(command=r"C:\Users\alice\repo\.venv\Scripts\python.exe -m pytest")
-    )
-    result["mutated_paths"] = [
+    result = experiment_contract.validate_experiment_result(_result())
+    unsafe_paths = [
         r"C:\Users\alice\repo\core\rag.py",
         r"C:Users\alice\repo\core\rag.py",
         r"Users\alice\repo\core\rag.py",
@@ -367,8 +449,14 @@ def test_notification_redacts_windows_local_paths(
     assert "Users" not in content
     assert "server" not in content
     assert "share" not in content
-    assert "- `[redacted-command]` -> rc=0, timed_out=false, truncated=false" in content
-    assert content.count("[redacted-path]") == 4
+    assert (
+        experiment_notify._oracle_command_name(
+            r"C:\Users\alice\repo\.venv\Scripts\python.exe -m pytest"
+        )
+        == "[redacted-command]"
+    )
+    for unsafe_path in unsafe_paths:
+        assert experiment_notify._safe_repo_path(unsafe_path) == "[redacted-path]"
 
 
 def test_notification_redacts_home_credential_and_control_character_paths(
@@ -378,21 +466,23 @@ def test_notification_redacts_home_credential_and_control_character_paths(
     repo = _init_repo(tmp_path)
     _configure_repo(monkeypatch, repo)
     packet = experiment_contract.validate_experiment_packet(_packet())
-    result = experiment_contract.validate_experiment_result(_result())
-    result["mutated_paths"] = [
+    unsafe_paths = [
         "~/.ssh/id_rsa",
         ".aws/credentials",
         "core/rag/allowed.py\n- Result status: `accepted`",
     ]
 
-    content = experiment_notify.render_notification_markdown(packet, result)
+    content = experiment_notify.render_notification_markdown(
+        packet,
+        experiment_contract.validate_experiment_result(_result()),
+    )
 
     assert ".ssh" not in content
     assert "id_rsa" not in content
     assert ".aws" not in content
     assert "credentials" not in content
-    assert "core/rag/allowed.py" not in content
-    assert content.count("[redacted-path]") == 3
+    for unsafe_path in unsafe_paths:
+        assert experiment_notify._safe_repo_path(unsafe_path) == "[redacted-path]"
 
 
 def test_resolve_output_path_rejects_escape(

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -336,7 +336,13 @@ def test_result_evidence_must_stay_within_packet_mutable_surface() -> None:
         experiment_notify.render_notification_markdown(packet, result)
 
 
-def test_result_evidence_allows_directory_mutable_surface() -> None:
+def test_result_evidence_allows_directory_mutable_surface(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    (repo / "docs" / "prompts" / "reliability").mkdir(parents=True)
     packet = experiment_contract.validate_experiment_packet(
         _packet()
         | {
@@ -356,7 +362,13 @@ def test_result_evidence_allows_directory_mutable_surface() -> None:
     assert "- `docs/prompts/reliability/program.md`" in content
 
 
-def test_result_evidence_allows_directory_surface_with_dots() -> None:
+def test_result_evidence_allows_directory_surface_with_dots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    (repo / "docs" / "prompts" / "v1.2").mkdir(parents=True)
     packet = experiment_contract.validate_experiment_packet(
         _packet()
         | {
@@ -382,6 +394,26 @@ def test_result_evidence_rejects_nested_paths_under_file_surface() -> None:
     )
     result = experiment_contract.validate_experiment_result(_result())
     result["mutated_paths"] = ["core/rag/allowed.py/child.py"]
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="mutable_candidate_surface",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
+
+
+def test_result_evidence_rejects_nested_paths_under_extensionless_file_surface(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    (repo / "core" / "rag" / "runner").write_text("#!/bin/sh\n", encoding="utf-8")
+    packet = experiment_contract.validate_experiment_packet(
+        _packet() | {"mutable_candidate_surface": ["core/rag/runner"]}
+    )
+    result = experiment_contract.validate_experiment_result(_result())
+    result["mutated_paths"] = ["core/rag/runner/child.py"]
 
     with pytest.raises(
         experiment_notify.ExperimentNotificationError,
@@ -442,6 +474,50 @@ def test_accepted_result_with_failed_oracle_is_rejected() -> None:
     with pytest.raises(
         experiment_notify.ExperimentNotificationError,
         match="oracle_results must pass",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
+
+
+def test_accepted_result_with_failure_class_is_rejected() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(_result())
+    result["failure_class"] = "guard_failure"
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="failure_class must be null",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
+
+
+def test_rejected_result_oracles_must_preserve_packet_prefix() -> None:
+    packet = experiment_contract.validate_experiment_packet(
+        _packet()
+        | {
+            "immutable_oracles": [
+                {"command": "python3 -m pytest tests/test_a.py", "expected_signal": "must pass"},
+                {"command": "python3 -m pytest tests/test_b.py", "expected_signal": "must pass"},
+            ]
+        }
+    )
+    result = experiment_contract.validate_experiment_result(
+        _result(status="rejected", failure_class="guard_failure")
+    )
+    result["oracle_results"] = [
+        {
+            "command": "python3 -m pytest tests/test_b.py",
+            "returncode": 1,
+            "timed_out": False,
+            "truncated": False,
+            "stdout": "",
+            "stderr": "",
+            "cwd": "",
+        }
+    ]
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="immutable_oracles prefix",
     ):
         experiment_notify.render_notification_markdown(packet, result)
 
@@ -844,3 +920,33 @@ def test_github_step_summary_flag_fails_without_env(
     )
 
     assert exit_code == 1
+
+
+def test_github_step_summary_write_failure_redacts_unsafe_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    unsafe_summary_path = tmp_path / ".ssh" / "id_rsa"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(unsafe_summary_path))
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--github-step-summary",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Unable to write GITHUB_STEP_SUMMARY." in captured.out
+    assert ".ssh" not in captured.out
+    assert "id_rsa" not in captured.out
+    assert str(tmp_path) not in captured.out

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 import pytest
 
@@ -123,6 +126,12 @@ def _write_json(path: Path, payload: dict[str, object]) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return path
+
+
+def _subprocess_env_without_repo_pythonpath() -> dict[str, str]:
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+    return env
 
 
 EXPECTED_NOTIFICATION = """# Experiment Result Notification: exp-notify
@@ -335,6 +344,33 @@ def test_notification_redacts_raw_outputs_patch_and_local_paths(
     assert content.count("[redacted-path]") == 2
 
 
+def test_notification_redacts_windows_local_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(
+        _result(command=r"C:\Users\alice\repo\.venv\Scripts\python.exe -m pytest")
+    )
+    result["mutated_paths"] = [
+        r"C:\Users\alice\repo\core\rag.py",
+        r"C:Users\alice\repo\core\rag.py",
+        r"Users\alice\repo\core\rag.py",
+        r"\\server\share\pulseplate\core\rag.py",
+    ]
+
+    content = experiment_notify.render_notification_markdown(packet, result)
+
+    assert "C:" not in content
+    assert "Users" not in content
+    assert "server" not in content
+    assert "share" not in content
+    assert "- `[redacted-command]` -> rc=0, timed_out=false, truncated=false" in content
+    assert content.count("[redacted-path]") == 4
+
+
 def test_resolve_output_path_rejects_escape(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -344,6 +380,101 @@ def test_resolve_output_path_rejects_escape(
 
     with pytest.raises(ValueError, match="notifications"):
         experiment_notify._resolve_output_path("../outside.md", "exp-notify")
+
+
+def test_resolve_output_path_rejects_symlinked_notification_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    notification_dir = _configure_repo(monkeypatch, repo)
+    outside = tmp_path / "outside"
+    notification_dir.parent.mkdir(parents=True, exist_ok=True)
+    outside.mkdir()
+    notification_dir.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink"):
+        experiment_notify._resolve_output_path("exp-notify.md", "exp-notify")
+
+
+def test_resolve_output_path_rejects_symlinked_child_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    notification_dir = _configure_repo(monkeypatch, repo)
+    outside = tmp_path / "outside"
+    symlinked_child = notification_dir / "child"
+    notification_dir.mkdir(parents=True, exist_ok=True)
+    outside.mkdir()
+    symlinked_child.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink"):
+        experiment_notify._resolve_output_path("child/exp-notify.md", "exp-notify")
+
+
+def test_resolve_output_path_rejects_symlinked_artifact_ancestor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    outside = tmp_path / "outside"
+    experiments = repo / "artifacts" / "orchestration" / "experiments"
+    experiments.parent.mkdir(parents=True, exist_ok=True)
+    outside.mkdir()
+    experiments.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink"):
+        experiment_notify._resolve_output_path("exp-notify.md", "exp-notify")
+
+
+def test_module_cli_shows_help() -> None:
+    completed = subprocess.run(
+        [sys.executable, "-m", "scripts.orchestration.experiment_notify", "--help"],
+        check=False,
+        capture_output=True,
+        env=_subprocess_env_without_repo_pythonpath(),
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "Render artifact-only notifications" in completed.stdout
+
+
+def test_direct_script_invocation_fails_without_repo_pythonpath() -> None:
+    script_path = Path("scripts/orchestration/experiment_notify.py")
+
+    completed = subprocess.run(
+        [sys.executable, str(script_path), "--help"],
+        check=False,
+        capture_output=True,
+        env=_subprocess_env_without_repo_pythonpath(),
+        text=True,
+    )
+
+    assert completed.returncode == 2
+    assert "python -m scripts.orchestration.experiment_notify" in completed.stderr
+    assert "ModuleNotFoundError" not in completed.stderr
+
+
+def test_direct_script_invocation_outside_repo_fails_without_sys_path_mutation(
+    tmp_path: Path,
+) -> None:
+    script_path = Path("scripts/orchestration/experiment_notify.py").resolve()
+
+    completed = subprocess.run(
+        [sys.executable, str(script_path), "--help"],
+        check=False,
+        capture_output=True,
+        cwd=tmp_path,
+        env=_subprocess_env_without_repo_pythonpath(),
+        text=True,
+    )
+
+    assert completed.returncode == 2
+    assert "python -m scripts.orchestration.experiment_notify" in completed.stderr
+    assert "ModuleNotFoundError" not in completed.stderr
 
 
 def test_cli_rejects_absolute_output_escape_without_writing(

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -573,6 +573,19 @@ def test_rejected_infra_flake_allows_passing_oracle_prefix() -> None:
     assert "- Failure class: `infra_flake`" in content
 
 
+def test_rejected_metric_regression_allows_passing_oracle_prefix() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(
+        _result(status="rejected", failure_class="metric_regression")
+    )
+    result["oracle_results"][0]["returncode"] = 0
+
+    content = experiment_notify.render_notification_markdown(packet, result)
+
+    assert "- Result status: `rejected`" in content
+    assert "- Failure class: `metric_regression`" in content
+
+
 def test_rejected_result_terminal_oracle_must_fail() -> None:
     packet = experiment_contract.validate_experiment_packet(
         _packet()
@@ -615,6 +628,33 @@ def test_rejected_oracle_failure_requires_terminal_oracle_evidence() -> None:
     with pytest.raises(
         experiment_notify.ExperimentNotificationError,
         match="terminal oracle evidence",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
+
+
+def test_rejected_pre_oracle_class_must_not_include_oracle_evidence() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(
+        _result(status="rejected", failure_class="unchanged_result")
+    )
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="must not include oracle evidence",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
+
+
+def test_rejected_policy_violation_must_not_include_mutated_paths() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(
+        _result(status="rejected", failure_class="policy_violation")
+    )
+    result["oracle_results"] = []
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="mutated_paths must be empty",
     ):
         experiment_notify.render_notification_markdown(packet, result)
 

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -371,6 +371,30 @@ def test_notification_redacts_windows_local_paths(
     assert content.count("[redacted-path]") == 4
 
 
+def test_notification_redacts_home_credential_and_control_character_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(_result())
+    result["mutated_paths"] = [
+        "~/.ssh/id_rsa",
+        ".aws/credentials",
+        "core/rag/allowed.py\n- Result status: `accepted`",
+    ]
+
+    content = experiment_notify.render_notification_markdown(packet, result)
+
+    assert ".ssh" not in content
+    assert "id_rsa" not in content
+    assert ".aws" not in content
+    assert "credentials" not in content
+    assert "core/rag/allowed.py" not in content
+    assert content.count("[redacted-path]") == 3
+
+
 def test_resolve_output_path_rejects_escape(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -411,6 +435,21 @@ def test_resolve_output_path_rejects_symlinked_child_directory(
 
     with pytest.raises(ValueError, match="symlink"):
         experiment_notify._resolve_output_path("child/exp-notify.md", "exp-notify")
+
+
+def test_resolve_output_path_rejects_broken_symlinked_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    notification_dir = _configure_repo(monkeypatch, repo)
+    outside = tmp_path / "outside.md"
+    output_path = notification_dir / "exp-notify.md"
+    notification_dir.mkdir(parents=True, exist_ok=True)
+    output_path.symlink_to(outside)
+
+    with pytest.raises(ValueError, match="symlink"):
+        experiment_notify._resolve_output_path("exp-notify.md", "exp-notify")
 
 
 def test_resolve_output_path_rejects_symlinked_artifact_ancestor(

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -296,7 +296,7 @@ def test_promoted_accepted_result_with_dirty_shared_tree_is_rejected() -> None:
 
     with pytest.raises(
         experiment_notify.ExperimentNotificationError,
-        match="shared_tree_untouched is false",
+        match="shared_tree_untouched must be true",
     ):
         experiment_notify.render_notification_markdown(packet, result, promotion)
 
@@ -502,6 +502,18 @@ def test_accepted_result_with_failure_class_is_rejected() -> None:
         experiment_notify.render_notification_markdown(packet, result)
 
 
+def test_accepted_result_with_dirty_shared_tree_is_rejected() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(_result())
+    result["shared_tree_untouched"] = False
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="shared_tree_untouched must be true",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
+
+
 def test_rejected_result_oracles_must_preserve_packet_prefix() -> None:
     packet = experiment_contract.validate_experiment_packet(
         _packet()
@@ -532,6 +544,19 @@ def test_rejected_result_oracles_must_preserve_packet_prefix() -> None:
         match="immutable_oracles prefix",
     ):
         experiment_notify.render_notification_markdown(packet, result)
+
+
+def test_rejected_infra_flake_allows_passing_oracle_prefix() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(
+        _result(status="rejected", failure_class="infra_flake")
+    )
+    result["oracle_results"][0]["returncode"] = 0
+
+    content = experiment_notify.render_notification_markdown(packet, result)
+
+    assert "- Result status: `rejected`" in content
+    assert "- Failure class: `infra_flake`" in content
 
 
 def test_rejected_result_terminal_oracle_must_fail() -> None:
@@ -938,6 +963,27 @@ def test_cli_write_failure_redacts_output_path(
     assert "unable to write experiment notification" in captured.out
     assert "artifacts/orchestration" not in captured.out
     assert str(repo) not in captured.out
+
+
+def test_cli_validation_failure_redacts_validator_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result = _result()
+    result["oracle_results"][0]["returncode"] = "API_TOKEN=super-secret"
+    result_path = _write_json(tmp_path / "result.json", result)
+
+    exit_code = experiment_notify.main(["--packet", str(packet_path), "--result", str(result_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "invalid experiment notification input" in captured.out
+    assert "API_TOKEN" not in captured.out
+    assert "super-secret" not in captured.out
 
 
 def test_github_step_summary_requires_explicit_flag(

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -422,6 +422,18 @@ def test_result_evidence_rejects_nested_paths_under_extensionless_file_surface(
         experiment_notify.render_notification_markdown(packet, result)
 
 
+def test_result_evidence_allows_new_extensionless_directory_surface() -> None:
+    packet = experiment_contract.validate_experiment_packet(
+        _packet() | {"mutable_candidate_surface": ["core/rag/new_feature"]}
+    )
+    result = experiment_contract.validate_experiment_result(_result())
+    result["mutated_paths"] = ["core/rag/new_feature/impl.py"]
+
+    content = experiment_notify.render_notification_markdown(packet, result)
+
+    assert "- `core/rag/new_feature/impl.py`" in content
+
+
 def test_result_oracle_commands_must_come_from_packet() -> None:
     packet = experiment_contract.validate_experiment_packet(_packet())
     result = experiment_contract.validate_experiment_result(
@@ -518,6 +530,38 @@ def test_rejected_result_oracles_must_preserve_packet_prefix() -> None:
     with pytest.raises(
         experiment_notify.ExperimentNotificationError,
         match="immutable_oracles prefix",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
+
+
+def test_rejected_result_terminal_oracle_must_fail() -> None:
+    packet = experiment_contract.validate_experiment_packet(
+        _packet()
+        | {
+            "immutable_oracles": [
+                {"command": "python3 -m pytest tests/test_a.py", "expected_signal": "must pass"},
+                {"command": "python3 -m pytest tests/test_b.py", "expected_signal": "must pass"},
+            ]
+        }
+    )
+    result = experiment_contract.validate_experiment_result(
+        _result(status="rejected", failure_class="guard_failure")
+    )
+    result["oracle_results"] = [
+        {
+            "command": "python3 -m pytest tests/test_a.py",
+            "returncode": 0,
+            "timed_out": False,
+            "truncated": False,
+            "stdout": "",
+            "stderr": "",
+            "cwd": "",
+        }
+    ]
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="terminal oracle must fail",
     ):
         experiment_notify.render_notification_markdown(packet, result)
 
@@ -864,6 +908,36 @@ def test_cli_rejects_absolute_output_escape_without_writing(
 
     assert exit_code == 1
     assert not outside_path.exists()
+
+
+def test_cli_write_failure_redacts_output_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+    output_dir = repo / "artifacts" / "orchestration" / "experiments" / "notifications" / "exp.md"
+    output_dir.mkdir(parents=True)
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--output",
+            str(output_dir),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "unable to write experiment notification" in captured.out
+    assert "artifacts/orchestration" not in captured.out
+    assert str(repo) not in captured.out
 
 
 def test_github_step_summary_requires_explicit_flag(

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -336,6 +336,26 @@ def test_result_evidence_must_stay_within_packet_mutable_surface() -> None:
         experiment_notify.render_notification_markdown(packet, result)
 
 
+def test_result_evidence_allows_directory_mutable_surface() -> None:
+    packet = experiment_contract.validate_experiment_packet(
+        _packet()
+        | {
+            "mutable_candidate_surface": ["docs/prompts/reliability"],
+            "immutable_oracles": [
+                {"command": "python3 -m pytest tests/test_a.py", "expected_signal": "must pass"}
+            ],
+        }
+    )
+    result = experiment_contract.validate_experiment_result(
+        _result(command="python3 -m pytest tests/test_a.py")
+    )
+    result["mutated_paths"] = ["docs/prompts/reliability/program.md"]
+
+    content = experiment_notify.render_notification_markdown(packet, result)
+
+    assert "- `docs/prompts/reliability/program.md`" in content
+
+
 def test_result_oracle_commands_must_come_from_packet() -> None:
     packet = experiment_contract.validate_experiment_packet(_packet())
     result = experiment_contract.validate_experiment_result(
@@ -343,7 +363,7 @@ def test_result_oracle_commands_must_come_from_packet() -> None:
     )
     result["oracle_results"] = [
         {
-            "command": "python3 -m pytest tests/unknown.py",
+            "command": "API_TOKEN=super-secret python3 -m pytest tests/unknown.py",
             "returncode": 1,
             "timed_out": False,
             "truncated": False,
@@ -356,8 +376,12 @@ def test_result_oracle_commands_must_come_from_packet() -> None:
     with pytest.raises(
         experiment_notify.ExperimentNotificationError,
         match="commands outside packet",
-    ):
+    ) as exc_info:
         experiment_notify.render_notification_markdown(packet, result)
+    message = str(exc_info.value)
+    assert "python3" in message
+    assert "API_TOKEN" not in message
+    assert "super-secret" not in message
 
 
 def test_promotion_experiment_id_mismatch_is_rejected() -> None:
@@ -421,6 +445,13 @@ def test_notification_redacts_raw_outputs_patch_and_local_paths(
             "/Users/example/.venv/bin/python3 --token super-secret"
         )
         == "python3"
+    )
+    assert (
+        experiment_notify._oracle_command_name("API_TOKEN=super-secret python3 -m pytest")
+        == "python3"
+    )
+    assert "super-secret" not in experiment_notify._oracle_command_name(
+        "API_TOKEN=super-secret python3 -m pytest"
     )
     assert experiment_notify._safe_repo_path("/Users/example/private-token/path.py") == (
         "[redacted-path]"

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -434,6 +434,20 @@ def test_result_evidence_allows_new_extensionless_directory_surface() -> None:
     assert "- `core/rag/new_feature/impl.py`" in content
 
 
+def test_result_evidence_rejects_traversal_under_directory_surface() -> None:
+    packet = experiment_contract.validate_experiment_packet(
+        _packet() | {"mutable_candidate_surface": ["core/rag/new_feature"]}
+    )
+    result = experiment_contract.validate_experiment_result(_result())
+    result["mutated_paths"] = ["core/rag/new_feature/../../docs/orchestration/workflow.md"]
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="mutable_candidate_surface",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
+
+
 def test_result_oracle_commands_must_come_from_packet() -> None:
     packet = experiment_contract.validate_experiment_packet(_packet())
     result = experiment_contract.validate_experiment_result(
@@ -591,6 +605,20 @@ def test_rejected_result_terminal_oracle_must_fail() -> None:
         experiment_notify.render_notification_markdown(packet, result)
 
 
+def test_rejected_oracle_failure_requires_terminal_oracle_evidence() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(
+        _result(status="rejected", failure_class="guard_failure")
+    )
+    result["oracle_results"] = []
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="terminal oracle evidence",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
+
+
 def test_promotion_evidence_must_match_packet_and_result() -> None:
     packet = experiment_contract.validate_experiment_packet(_packet())
     result = experiment_contract.validate_experiment_result(_result())
@@ -714,6 +742,7 @@ def test_notification_redacts_raw_outputs_patch_and_local_paths(
         == "[redacted-command]"
     )
     assert "id_rsa" not in experiment_notify._oracle_command_name("/Users/alice/.ssh/id_rsa --help")
+    assert experiment_notify._oracle_command_name("id_rsa --help") == "[redacted-command]"
     assert experiment_notify._safe_repo_path("/Users/example/private-token/path.py") == (
         "[redacted-path]"
     )

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -356,6 +356,26 @@ def test_result_evidence_allows_directory_mutable_surface() -> None:
     assert "- `docs/prompts/reliability/program.md`" in content
 
 
+def test_result_evidence_allows_directory_surface_with_dots() -> None:
+    packet = experiment_contract.validate_experiment_packet(
+        _packet()
+        | {
+            "mutable_candidate_surface": ["docs/prompts/v1.2"],
+            "immutable_oracles": [
+                {"command": "python3 -m pytest tests/test_a.py", "expected_signal": "must pass"}
+            ],
+        }
+    )
+    result = experiment_contract.validate_experiment_result(
+        _result(command="python3 -m pytest tests/test_a.py")
+    )
+    result["mutated_paths"] = ["docs/prompts/v1.2/program.md"]
+
+    content = experiment_notify.render_notification_markdown(packet, result)
+
+    assert "- `docs/prompts/v1.2/program.md`" in content
+
+
 def test_result_oracle_commands_must_come_from_packet() -> None:
     packet = experiment_contract.validate_experiment_packet(_packet())
     result = experiment_contract.validate_experiment_result(
@@ -382,6 +402,76 @@ def test_result_oracle_commands_must_come_from_packet() -> None:
     assert "python3" in message
     assert "API_TOKEN" not in message
     assert "super-secret" not in message
+
+
+def test_outside_surface_diagnostic_redacts_mutated_paths() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(_result())
+    result["mutated_paths"] = ["/Users/alice/.ssh/id_rsa"]
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="mutable_candidate_surface",
+    ) as exc_info:
+        experiment_notify.render_notification_markdown(packet, result)
+    message = str(exc_info.value)
+    assert "[redacted-path]" in message
+    assert "/Users/alice" not in message
+    assert "id_rsa" not in message
+
+
+def test_accepted_result_with_failed_oracle_is_rejected() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(_result())
+    result["oracle_results"][0]["returncode"] = 1
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="oracle_results must pass",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
+
+
+def test_promotion_evidence_must_match_packet_and_result() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(_result())
+    promotion = experiment_notify._validate_promotion_decision(
+        {
+            **_promotion(),
+            "evidence": {
+                "oracle_commands": ["python3 -m pytest tests/stale.py"],
+                "mutated_paths": ["core/rag/allowed.py"],
+                "oracle_count": 1,
+            },
+        }
+    )
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="evidence.oracle_commands",
+    ):
+        experiment_notify.render_notification_markdown(packet, result, promotion)
+
+
+def test_promotion_evidence_oracle_count_must_match_result() -> None:
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(_result())
+    promotion = experiment_notify._validate_promotion_decision(
+        {
+            **_promotion(),
+            "evidence": {
+                "oracle_commands": ['python3 -c "import sys; sys.exit(0)"'],
+                "mutated_paths": ["core/rag/allowed.py"],
+                "oracle_count": 2,
+            },
+        }
+    )
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="evidence.oracle_count",
+    ):
+        experiment_notify.render_notification_markdown(packet, result, promotion)
 
 
 def test_promotion_experiment_id_mismatch_is_rejected() -> None:

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -376,6 +376,20 @@ def test_result_evidence_allows_directory_surface_with_dots() -> None:
     assert "- `docs/prompts/v1.2/program.md`" in content
 
 
+def test_result_evidence_rejects_nested_paths_under_file_surface() -> None:
+    packet = experiment_contract.validate_experiment_packet(
+        _packet() | {"mutable_candidate_surface": ["core/rag/allowed.py"]}
+    )
+    result = experiment_contract.validate_experiment_result(_result())
+    result["mutated_paths"] = ["core/rag/allowed.py/child.py"]
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="mutable_candidate_surface",
+    ):
+        experiment_notify.render_notification_markdown(packet, result)
+
+
 def test_result_oracle_commands_must_come_from_packet() -> None:
     packet = experiment_contract.validate_experiment_packet(_packet())
     result = experiment_contract.validate_experiment_result(
@@ -543,6 +557,18 @@ def test_notification_redacts_raw_outputs_patch_and_local_paths(
     assert "super-secret" not in experiment_notify._oracle_command_name(
         "API_TOKEN=super-secret python3 -m pytest"
     )
+    assert (
+        experiment_notify._oracle_command_name("API_TOKEN='super\nsecret' python3 -m pytest")
+        == "python3"
+    )
+    assert "super" not in experiment_notify._oracle_command_name(
+        "API_TOKEN='super\nsecret' python3 -m pytest"
+    )
+    assert (
+        experiment_notify._oracle_command_name("/Users/alice/.ssh/id_rsa --help")
+        == "[redacted-command]"
+    )
+    assert "id_rsa" not in experiment_notify._oracle_command_name("/Users/alice/.ssh/id_rsa --help")
     assert experiment_notify._safe_repo_path("/Users/example/private-token/path.py") == (
         "[redacted-path]"
     )
@@ -604,6 +630,18 @@ def test_notification_redacts_home_credential_and_control_character_paths(
     assert "credentials" not in content
     for unsafe_path in unsafe_paths:
         assert experiment_notify._safe_repo_path(unsafe_path) == "[redacted-path]"
+
+
+def test_read_json_load_failures_do_not_echo_unsafe_paths(tmp_path: Path) -> None:
+    unsafe_path = tmp_path / ".ssh" / "id_rsa"
+
+    with pytest.raises(ValueError, match="Unable to load packet JSON") as exc_info:
+        experiment_notify._read_json_object(unsafe_path, label="packet")
+
+    message = str(exc_info.value)
+    assert ".ssh" not in message
+    assert "id_rsa" not in message
+    assert str(tmp_path) not in message
 
 
 def test_resolve_output_path_rejects_escape(


### PR DESCRIPTION
## Goal
Add a governed, artifact-only experiment result notification sink and keep the experiment runner identity explicit for this PR lane.

## Business Reason
Experiment results need a durable local evidence artifact without introducing external delivery, secrets, or notification side effects in the runner MVP.

## Scope
- Add `scripts/orchestration/experiment_notify.py` for safe markdown notification artifacts.
- Default output is `artifacts/orchestration/experiments/notifications/<experiment_id>.md`.
- Support optional promotion decision metadata and explicit-only `GITHUB_STEP_SUMMARY` append.
- Document the artifact-only boundary in orchestration governance docs.
- Add focused tests for deterministic output, promotion validation, path containment, rejected results, redaction, and explicit step-summary writes.

## Out of Scope
- No Slack delivery.
- No SMTP/email sending.
- No GitHub PR comments.
- No external secrets.
- No behavior changes to `experiment_runner.py` or `experiment_promote.py`.

## Split Justification
This PR exceeds the size-governance split threshold because the sink, its negative/security tests, the experiment protocol boundary, script-scoped agent guidance, and canonical PR mapping artifact must land together to keep the artifact-only notification contract auditable. The implementation intentionally avoids runtime/OpenAPI/backend/web/iOS changes and keeps external delivery out of scope.

## Files Changed
- `scripts/orchestration/experiment_notify.py`
- `tests/test_experiment_notify.py`
- `scripts/AGENTS.md`
- `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`
- `docs/review/PR_1749_FIXED_MAPPING.md`

## Key Decisions
- The notification sink renders only safe metadata: experiment id, status, failure class, promotion target/disposition, durable artifact path, mutated paths, and oracle command name plus return code/timeout/truncation.
- Raw patch text, oracle stdout/stderr, cwd, local absolute paths, and sensitive path parts are omitted or redacted.
- Promotion decisions are validated against packet/result status and target-specific durable artifact paths.
- `GITHUB_STEP_SUMMARY` writes require the explicit CLI flag `--github-step-summary`.

## Tests / Validation
- `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration --path docs/orchestration --path tests`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py`
- `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py`
- `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null`
- `pre-commit run --all-files`
- `make VENV_PYTHON=../../.venv/bin/python validate-changed`
- Push hook: mypy changed files, pip-audit, backend tests, full-repo bandit, docker build test

Note: plain `make validate-changed` in this worktree used system `python3` because `.venv` lives in the root checkout, so it failed before importing `fastapi`. The equivalent target passed with explicit `VENV_PYTHON=../../.venv/bin/python`.

## Security Notes
- Artifact-only delivery; no email, Slack, PR comments, or network delivery.
- Codex Security diff pass focused on leakage, path containment, and promotion artifact forgery.
- Coordinator bootstrap produced task packet `8384fad99c80`; declared role order was `agent-coordinator -> architecture-specialist -> cursor-specialist-agent -> security-auditor -> qa-engineer-agent -> bug-hunter`.
- Security-auditor/Codex Security findings fixed: durable promotion artifact path is constrained by promotion target, notification output cannot escape through symlink/path redaction edge cases, and notification evidence now fails closed on dirty shared-tree promotion, stale packet/result oracle/path metadata, env-assignment oracle command leakage, or raw unexpected-oracle diagnostics.
- `pulseplate@pm.me` is intentionally public git commit metadata for this lane only; it does not create a result-delivery channel.

## Risks / Rollback
- Risk: consumers may confuse artifact notification with external delivery. Mitigation: docs and rendered artifact state the delivery boundary explicitly.
- Risk: malformed promotion metadata could mislead a reviewer. Mitigation: strict promotion decision validation and negative tests.
- Rollback: revert this PR; runner/promote behavior is unchanged.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Post-open bot review threads were classified, fixed, mapped, and resolved on 2026-05-13. The latest current-head bot/CI cycle is being monitored before any merge-readiness claim.

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1749_FIXED_MAPPING.md`

## Merge Readiness
Not merge-ready until current-head CI, bot review, fixed mapping updates for any review threads, and required review-cycle gates complete.

## Deferred / Follow-ups
Real Slack/email/GitHub-comment delivery remains a later security-governed PR with explicit notification sink, identity, auth, audit, and opt-in behavior.

## Next Best Step
Wait for latest current-head CI and bot review to reach terminal state, then run final merge-readiness synthesis/wait-window checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool to validate experiment inputs and emit deterministic, redacted Markdown notifications (optional append to GitHub step summary with explicit flag).

* **Security / Safety**
  * Notifications redact sensitive outputs, patches, tokens, and local paths; enforce output path safety to prevent traversal or symlink escapes.

* **Documentation**
  * Added an artifact-only notification protocol and a PR fixed-in-commit mapping with validation evidence and guidance.

* **Tests**
  * Added comprehensive end-to-end tests for validation, rendering, redaction, path-safety, and CLI/GitHub-summary behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1749)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


