### PR TITLE
feat(orchestration): add experiment email notification sink

### DIFF
--- a/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
@@ -325,6 +325,8 @@ Rules:
 - local markdown artifacts are the default delivery sink,
 - SMTP email delivery requires an explicit CLI flag, an explicit allowlisted
   recipient, and runtime SMTP secret configuration,
+- SMTP port `465` uses implicit TLS (`SMTP_SSL`); other allowed ports use
+  explicit STARTTLS,
 - v1 SMTP delivery is limited to `pulseplate@pm.me` when that address is present
   in `EXPERIMENT_NOTIFICATION_EMAIL_ALLOWLIST`,
 - Slack messages, GitHub comments, and other external delivery sinks remain out

--- a/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
@@ -199,6 +199,24 @@ The experiment is accepted for promotion only if:
 - Winning candidates are promoted through KPP into exactly one durable destination.
 - Rejected candidates are discarded, with failure reason recorded in the result packet.
 
+### Step 6: Notify
+
+Experiment notification is evidence delivery only; it does not promote a
+candidate or change merge readiness.
+
+- Local markdown notification artifacts are the default and must be written
+  under `artifacts/orchestration/experiments/notifications/`.
+- Email delivery is explicit opt-in only. A notifier must require an explicit
+  email flag and an allowlisted recipient before sending.
+- The v1 governed email recipient is `pulseplate@pm.me`; it is configured as a
+  delivery recipient, separate from any public git attribution metadata.
+- SMTP credentials and sender config must come from runtime secrets or env and
+  must never be committed.
+- Email bodies may contain only the redacted notification markdown: no raw patch
+  text, oracle stdout/stderr, secrets, absolute local paths, or user data.
+- Git attribution email, including `PulsePlate Experiment Runner
+  <pulseplate@pm.me>`, is not a result delivery channel.
+
 ---
 
 ## 5. Hard budgets
@@ -294,7 +312,7 @@ If a candidate wins, the coordinator promotes it into exactly one destination:
 - promotion decisions are emitted through `scripts/orchestration/experiment_promote.py`,
 - no duplicate canonical policy wording across multiple docs.
 
-### Artifact-only notification
+### Notification delivery
 
 `scripts/orchestration/experiment_notify.py` may render a redacted markdown
 summary from validated experiment packet, result, and optional promotion
@@ -304,8 +322,13 @@ Rules:
 
 - notification output is evidence-only and does not change promotion,
   merge-readiness, or review-thread disposition authority,
-- v1 notification must not send email, Slack messages, GitHub comments, or
-  other external delivery,
+- local markdown artifacts are the default delivery sink,
+- SMTP email delivery requires an explicit CLI flag, an explicit allowlisted
+  recipient, and runtime SMTP secret configuration,
+- v1 SMTP delivery is limited to `pulseplate@pm.me` when that address is present
+  in `EXPERIMENT_NOTIFICATION_EMAIL_ALLOWLIST`,
+- Slack messages, GitHub comments, and other external delivery sinks remain out
+  of scope,
 - summaries must omit raw patch text, oracle stdout/stderr, cwd, secrets, and
   local absolute paths,
 - optional `GITHUB_STEP_SUMMARY` writes require an explicit CLI flag.

--- a/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
@@ -156,6 +156,7 @@ charter
  -> candidate run
  -> oracle evaluation
  -> promote or discard
+ -> notify
 ```
 
 ### Step 1: Charter

--- a/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
@@ -368,6 +368,8 @@ An experimentation cycle is complete only when all are true:
 - budgets are explicit,
 - result packet records metric outcome and failure class,
 - promotion decision is explicit,
+- notification evidence is explicit (local artifact by default; optional email
+  audit only when email delivery was requested),
 - if deferred, the ledger entry exists,
 - if promoted, the destination artifact is unique and evidence-backed.
 

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -21,6 +21,7 @@
 - `098975392a15f195ebd92bde7d6ddcfa7a67f878` - `docs(orchestration): add experiment notification completion gate`
 - `5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85` - `fix(orchestration): block ambiguous email audit retries`
 - `f791e99393864bf65e8fb9b1fd95a14d67defcec` - `docs(review): map PR 1751 coderabbit retry review`
+- `86f3871fc5b9a193917960765cafe7b31fcae0cf` - `fix(orchestration): bind email audit source hashes`
 
 ## Coordinator / Agent Passes
 
@@ -191,6 +192,16 @@ Evidence: Invalid UTF-8 email audit files now raise sanitized `ExperimentEmailDe
 Disposition: FIXED
 Commit: 5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85
 Evidence: CodeRabbit review-level retry/audit finding is addressed by fail-closed existing-audit handling and invalid-audit sanitization; automatic reclaim remains intentionally unsupported for v1 to avoid ambiguous duplicate delivery.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3241276490 -> 86f3871fc5b9a193917960765cafe7b31fcae0cf
+Disposition: FIXED
+Commit: 86f3871fc5b9a193917960765cafe7b31fcae0cf
+Evidence: Email audit source hashes are computed once before delivery and reused for claim/failure/sent records; `tests/test_experiment_notify.py::test_email_audit_source_hashes_match_rendered_sources` covers it.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3241276501 -> 86f3871fc5b9a193917960765cafe7b31fcae0cf
+Disposition: FIXED
+Commit: 86f3871fc5b9a193917960765cafe7b31fcae0cf
+Evidence: Unknown existing email audit statuses now fail closed as invalid; `tests/test_experiment_notify.py::test_unknown_email_audit_status_fails_closed` covers it.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -13,6 +13,7 @@
 - `da8b2db70bbd11afe765b30da551b5aa629a43fa` - `fix(orchestration): harden experiment email notification sink`
 - `fcef53e4ec82b14c6be9f3bd31ecb2d22a1d0fcd` - `docs(review): map PR 1751 review fixes`
 - `716e94e0932f1e708fd1e7333fe3f2ba03116d26` - `fix(orchestration): type email audit path resolution`
+- `51f034410348aa55fa15d3b8e15ffb18b70fc61e` - `fix(orchestration): stabilize email audit path typing`
 
 ## Coordinator / Agent Passes
 

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -22,6 +22,7 @@
 - `5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85` - `fix(orchestration): block ambiguous email audit retries`
 - `f791e99393864bf65e8fb9b1fd95a14d67defcec` - `docs(review): map PR 1751 coderabbit retry review`
 - `86f3871fc5b9a193917960765cafe7b31fcae0cf` - `fix(orchestration): bind email audit source hashes`
+- `614e9389ae96098f2f0aaf38530a906a331caa90` - `fix(orchestration): precheck email audit before artifact writes`
 
 ## Coordinator / Agent Passes
 
@@ -202,6 +203,16 @@ Evidence: Email audit source hashes are computed once before delivery and reused
 Disposition: FIXED
 Commit: 86f3871fc5b9a193917960765cafe7b31fcae0cf
 Evidence: Unknown existing email audit statuses now fail closed as invalid; `tests/test_experiment_notify.py::test_unknown_email_audit_status_fails_closed` covers it.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3241441065 -> 614e9389ae96098f2f0aaf38530a906a331caa90
+Disposition: FIXED
+Commit: 614e9389ae96098f2f0aaf38530a906a331caa90
+Evidence: JSON source hashes are now computed from the same bytes loaded for validation/rendering before markdown render and reused for email audit records.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3241441071 -> 614e9389ae96098f2f0aaf38530a906a331caa90
+Disposition: FIXED
+Commit: 614e9389ae96098f2f0aaf38530a906a331caa90
+Evidence: Email runs now check blocking existing audit artifacts before rewriting the markdown notification artifact; `tests/test_experiment_notify.py::test_email_delivery_is_idempotent_for_experiment_id_when_markdown_changes` covers artifact preservation.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -10,10 +10,11 @@
 - `584b5d00f93ebc5f799c4631509b4800f869c10a` - `feat(orchestration): add experiment email notification sink`
 - `f4c2601df6cb55f409e62b332773b5512354b7bf` - `docs(review): add PR 1751 fixed mapping`
 - `7ef7d0904c0d32337e84fd4400267d0eb0db7ce7` - `docs(review): fix PR 1751 phase2 mapping contract`
-- `da8b2db70bbd11afe765b30da551b5aa629a43fa` - `fix(orchestration): harden experiment email notification sink`
-- `fcef53e4ec82b14c6be9f3bd31ecb2d22a1d0fcd` - `docs(review): map PR 1751 review fixes`
-- `716e94e0932f1e708fd1e7333fe3f2ba03116d26` - `fix(orchestration): type email audit path resolution`
-- `51f034410348aa55fa15d3b8e15ffb18b70fc61e` - `fix(orchestration): stabilize email audit path typing`
+- `da8b2db703c4a9e8840524f7d5987e1da4d79463` - `fix(orchestration): harden experiment email notification sink`
+- `fcef53e4e53eac11ff165084a8efb08c72b0cf73` - `docs(review): map PR 1751 review fixes`
+- `716e94e09e5386ffeb4abb90ece0b8c1456456f9` - `fix(orchestration): type email audit path resolution`
+- `51f0344106f92846e168685ce62f61145358037a` - `fix(orchestration): stabilize email audit path typing`
+- `ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4` - `fix(orchestration): harden smtp email delivery claims`
 
 ## Coordinator / Agent Passes
 
@@ -33,7 +34,7 @@
   - duplicate send risk -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
   - SMTP send before durable audit evidence -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
   - malformed SMTP sender bypassing sanitized failure path -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
-  - promotion overclaim risk -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`; real `experiment_promote` result compatibility fixed in `da8b2db70bbd11afe765b30da551b5aa629a43fa`
+  - promotion overclaim risk -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`; real `experiment_promote` result compatibility fixed in `da8b2db703c4a9e8840524f7d5987e1da4d79463`
   - email audit not bound to exact evidence body/source artifacts -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
   - missing SMTP validation negative tests -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
 - Codex Security scan:
@@ -60,35 +61,50 @@ Operator explicitly held main on control and approved opening this PR lane. This
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237898304 -> da8b2db70bbd11afe765b30da551b5aa629a43fa
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237898304 -> da8b2db703c4a9e8840524f7d5987e1da4d79463
 Disposition: FIXED
-Commit: da8b2db70bbd11afe765b30da551b5aa629a43fa
+Commit: da8b2db703c4a9e8840524f7d5987e1da4d79463
 Evidence: `scripts/AGENTS.md` now says `local artifact output is the default`; `VENV_PYTHON=../../.venv/bin/python pre-commit run --all-files` PASS.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237901619 -> fcef53e4ec82b14c6be9f3bd31ecb2d22a1d0fcd
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237901619 -> fcef53e4e53eac11ff165084a8efb08c72b0cf73
 Disposition: FIXED
-Commit: fcef53e4ec82b14c6be9f3bd31ecb2d22a1d0fcd
+Commit: fcef53e4e53eac11ff165084a8efb08c72b0cf73
 Evidence: Merge-readiness checklist boxes in this artifact are unchecked until the final merge cycle.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905243 -> da8b2db70bbd11afe765b30da551b5aa629a43fa
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905243 -> da8b2db703c4a9e8840524f7d5987e1da4d79463
 Disposition: FIXED
-Commit: da8b2db70bbd11afe765b30da551b5aa629a43fa
-Evidence: Implementing commit list now includes current branch fix commits through `da8b2db70bbd11afe765b30da551b5aa629a43fa`.
+Commit: da8b2db703c4a9e8840524f7d5987e1da4d79463
+Evidence: Implementing commit list now uses reachable commits from this branch.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905249 -> da8b2db70bbd11afe765b30da551b5aa629a43fa
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905249 -> da8b2db703c4a9e8840524f7d5987e1da4d79463
 Disposition: FIXED
-Commit: da8b2db70bbd11afe765b30da551b5aa629a43fa
+Commit: da8b2db703c4a9e8840524f7d5987e1da4d79463
 Evidence: `scripts/orchestration/experiment_notify.py` accepts promoted results from the real runner/promote flow without requiring runner-only `promotion_ready=true`; `tests/test_experiment_notify.py::test_notification_includes_promotion_decision_from_promote_output` covers it.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905251 -> da8b2db70bbd11afe765b30da551b5aa629a43fa
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905251 -> ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
 Disposition: FIXED
-Commit: da8b2db70bbd11afe765b30da551b5aa629a43fa
-Evidence: Email audit writes `send_in_progress` before SMTP send and duplicate retry blocks on matching `send_in_progress`; `tests/test_experiment_notify.py::test_email_delivery_blocks_retry_when_sent_audit_write_fails` covers it.
+Commit: ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
+Evidence: Email audit is claimed before SMTP send and retry blocks on matching non-stale `send_in_progress`; `tests/test_experiment_notify.py::test_email_delivery_blocks_retry_when_sent_audit_write_fails` covers it.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905252 -> da8b2db70bbd11afe765b30da551b5aa629a43fa
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905252 -> da8b2db703c4a9e8840524f7d5987e1da4d79463
 Disposition: FIXED
-Commit: da8b2db70bbd11afe765b30da551b5aa629a43fa
+Commit: da8b2db703c4a9e8840524f7d5987e1da4d79463
 Evidence: Email audit path is canonical by experiment id, not caller-controlled `--output`; `tests/test_experiment_notify.py::test_email_delivery_is_idempotent_across_output_paths` covers it.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239524561 -> ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
+Disposition: FIXED
+Commit: ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
+Evidence: Email send claim now uses exclusive create, duplicate-blocking `send_in_progress`, and stale-claim reclaim; `tests/test_experiment_notify.py::test_stale_email_send_claim_can_be_reclaimed` covers reclaim.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239524565 -> ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
+Disposition: FIXED
+Commit: ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
+Evidence: SMTP port `465` uses `SMTP_SSL`; `tests/test_experiment_notify.py::test_smtp_implicit_tls_uses_smtp_ssl` covers it.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239534963 -> ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
+Disposition: FIXED
+Commit: ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
+Evidence: SMTP `quit()` failures after accepted `send_message()` are ignored so the final `sent` audit remains durable; `tests/test_experiment_notify.py::test_smtp_quit_failure_after_send_keeps_delivery_successful` covers it.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -8,6 +8,9 @@
 ## Implementing Commits
 
 - `584b5d00f93ebc5f799c4631509b4800f869c10a` - `feat(orchestration): add experiment email notification sink`
+- `f4c2601df6cb55f409e62b332773b5512354b7bf` - `docs(review): add PR 1751 fixed mapping`
+- `7ef7d0904c0d32337e84fd4400267d0eb0db7ce7` - `docs(review): fix PR 1751 phase2 mapping contract`
+- `da8b2db70bbd11afe765b30da551b5aa629a43fa` - `fix(orchestration): harden experiment email notification sink`
 
 ## Coordinator / Agent Passes
 
@@ -27,7 +30,7 @@
   - duplicate send risk -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
   - SMTP send before durable audit evidence -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
   - malformed SMTP sender bypassing sanitized failure path -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
-  - promotion overclaim when `promotion_ready=false` -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
+  - promotion overclaim risk -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`; real `experiment_promote` result compatibility fixed in `da8b2db70bbd11afe765b30da551b5aa629a43fa`
   - email audit not bound to exact evidence body/source artifacts -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
   - missing SMTP validation negative tests -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
 - Codex Security scan:
@@ -38,12 +41,12 @@
 
 - `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration/experiment_notify.py --path tests/test_experiment_notify.py --path docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md --path scripts/AGENTS.md` -> PASS
 - `python3 scripts/orchestration/check_agent_consistency.py` -> PASS
-- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` -> PASS
-- `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` -> PASS
-- `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` -> PASS
-- `. ../../.venv/bin/activate && bandit -q scripts/orchestration/experiment_notify.py` -> PASS
-- `make VENV_PYTHON=../../.venv/bin/python validate-changed` -> PASS
-- `VENV_PYTHON=../../.venv/bin/python pre-commit run --all-files` -> PASS
+- `source .venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` -> PASS
+- `source .venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` -> PASS
+- `source .venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` -> PASS
+- `source .venv/bin/activate && bandit -q scripts/orchestration/experiment_notify.py` -> PASS
+- `make VENV_PYTHON=.venv/bin/python validate-changed` -> PASS
+- `VENV_PYTHON=.venv/bin/python pre-commit run --all-files` -> PASS
 - `git push -u origin codex/experiment-email-notification-sink` pre-push hooks -> PASS
 
 ## Main CI Note
@@ -54,13 +57,36 @@ Operator explicitly held main on control and approved opening this PR lane. This
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237898304 -> da8b2db70bbd11afe765b30da551b5aa629a43fa
+Disposition: FIXED
+Commit: da8b2db70bbd11afe765b30da551b5aa629a43fa
+Evidence: `scripts/AGENTS.md` now says `local artifact output is the default`; `VENV_PYTHON=../../.venv/bin/python pre-commit run --all-files` PASS.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905243 -> da8b2db70bbd11afe765b30da551b5aa629a43fa
+Disposition: FIXED
+Commit: da8b2db70bbd11afe765b30da551b5aa629a43fa
+Evidence: Implementing commit list now includes current branch fix commits through `da8b2db70bbd11afe765b30da551b5aa629a43fa`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905249 -> da8b2db70bbd11afe765b30da551b5aa629a43fa
+Disposition: FIXED
+Commit: da8b2db70bbd11afe765b30da551b5aa629a43fa
+Evidence: `scripts/orchestration/experiment_notify.py` accepts promoted results from the real runner/promote flow without requiring runner-only `promotion_ready=true`; `tests/test_experiment_notify.py::test_notification_includes_promotion_decision_from_promote_output` covers it.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905251 -> da8b2db70bbd11afe765b30da551b5aa629a43fa
+Disposition: FIXED
+Commit: da8b2db70bbd11afe765b30da551b5aa629a43fa
+Evidence: Email audit writes `send_in_progress` before SMTP send and duplicate retry blocks on matching `send_in_progress`; `tests/test_experiment_notify.py::test_email_delivery_blocks_retry_when_sent_audit_write_fails` covers it.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905252 -> da8b2db70bbd11afe765b30da551b5aa629a43fa
+Disposition: FIXED
+Commit: da8b2db70bbd11afe765b30da551b5aa629a43fa
+Evidence: Email audit path is canonical by experiment id, not caller-controlled `--output`; `tests/test_experiment_notify.py::test_email_delivery_is_idempotent_across_output_paths` covers it.
 
 ## Merge Readiness
 
-- [x] Coordinator-first preflight/bootstrap completed.
-- [x] Canonical artifact exists.
-- [x] Local narrow gates completed.
+- [ ] Coordinator-first preflight/bootstrap completed.
+- [ ] Canonical artifact exists.
+- [ ] Local narrow gates completed.
 - [ ] Current-head CI pending.
 - [ ] Bot/human review pass pending.
 - [ ] Mandatory wait-window pending.

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -20,6 +20,7 @@
 - `6acfee69f276900e47c844fceb8ceb048eade324` - `fix(orchestration): fail closed on duplicate experiment email sends`
 - `098975392a15f195ebd92bde7d6ddcfa7a67f878` - `docs(orchestration): add experiment notification completion gate`
 - `5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85` - `fix(orchestration): block ambiguous email audit retries`
+- `f791e99393864bf65e8fb9b1fd95a14d67defcec` - `docs(review): map PR 1751 coderabbit retry review`
 
 ## Coordinator / Agent Passes
 

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -186,6 +186,11 @@ Disposition: FIXED
 Commit: 5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85
 Evidence: Invalid UTF-8 email audit files now raise sanitized `ExperimentEmailDeliveryError`; `tests/test_experiment_notify.py::test_invalid_utf8_email_audit_fails_closed` covers it.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#pullrequestreview-4287993553 -> 5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85
+Disposition: FIXED
+Commit: 5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85
+Evidence: CodeRabbit review-level retry/audit finding is addressed by fail-closed existing-audit handling and invalid-audit sanitization; automatic reclaim remains intentionally unsupported for v1 to avoid ambiguous duplicate delivery.
+
 ## Merge Readiness
 
 - [ ] Coordinator-first preflight/bootstrap completed.

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -16,6 +16,7 @@
 - `51f0344106f92846e168685ce62f61145358037a` - `fix(orchestration): stabilize email audit path typing`
 - `ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4` - `fix(orchestration): harden smtp email delivery claims`
 - `f0d39d65e5554fa8b2798dc2d4494c04cbab0b4d` - `docs(review): map PR 1751 smtp claim fixes`
+- `d5998b4899df9b07a6c295841f52dab27b08df51` - `docs(orchestration): align experiment notify lifecycle`
 
 ## Coordinator / Agent Passes
 
@@ -67,10 +68,20 @@ Disposition: FIXED
 Commit: da8b2db703c4a9e8840524f7d5987e1da4d79463
 Evidence: `scripts/AGENTS.md` now says `local artifact output is the default`; `VENV_PYTHON=../../.venv/bin/python pre-commit run --all-files` PASS.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#pullrequestreview-4285886523 -> da8b2db703c4a9e8840524f7d5987e1da4d79463
+Disposition: FIXED
+Commit: da8b2db703c4a9e8840524f7d5987e1da4d79463
+Evidence: Sourcery review-level actionable typo is fixed by the same `scripts/AGENTS.md` wording change as `discussion_r3237898304`.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237901619 -> fcef53e4e53eac11ff165084a8efb08c72b0cf73
 Disposition: FIXED
 Commit: fcef53e4e53eac11ff165084a8efb08c72b0cf73
 Evidence: Merge-readiness checklist boxes in this artifact are unchecked until the final merge cycle.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#pullrequestreview-4285890872 -> fcef53e4e53eac11ff165084a8efb08c72b0cf73
+Disposition: FIXED
+Commit: fcef53e4e53eac11ff165084a8efb08c72b0cf73
+Evidence: CodeRabbit review-level actionables are mapped through their inline findings; the checklist/mapping artifact correction is fixed in this commit, and CLI help/command replay concerns are covered by the associated inline mappings.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905243 -> da8b2db703c4a9e8840524f7d5987e1da4d79463
 Disposition: FIXED
@@ -97,10 +108,25 @@ Disposition: FIXED
 Commit: ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
 Evidence: Email send claim now uses exclusive create, duplicate-blocking `send_in_progress`, and stale-claim reclaim; `tests/test_experiment_notify.py::test_stale_email_send_claim_can_be_reclaimed` covers reclaim.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#pullrequestreview-4287802089 -> ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
+Disposition: FIXED
+Commit: ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
+Evidence: CodeRabbit review-level actionables are fixed by the atomic send claim and implicit TLS changes mapped below.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239524565 -> ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
 Disposition: FIXED
 Commit: ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
 Evidence: SMTP port `465` uses `SMTP_SSL`; `tests/test_experiment_notify.py::test_smtp_implicit_tls_uses_smtp_ssl` covers it.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#pullrequestreview-4287893382 -> d5998b4899df9b07a6c295841f52dab27b08df51
+Disposition: FIXED
+Commit: d5998b4899df9b07a6c295841f52dab27b08df51
+Evidence: Experiment lifecycle flow now appends `-> notify` after `-> promote or discard`, matching `Step 6: Notify`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239603946 -> d5998b4899df9b07a6c295841f52dab27b08df51
+Disposition: FIXED
+Commit: d5998b4899df9b07a6c295841f52dab27b08df51
+Evidence: `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md` lifecycle flow now includes the notify stage.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239534960 -> f0d39d65e5554fa8b2798dc2d4494c04cbab0b4d
 Disposition: FIXED

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -2,8 +2,8 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed.
-- [ ] Fixed in commit mapping completed.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Implementing Commits
 
@@ -52,9 +52,9 @@ At lane start, local `main` was synced with `origin/main` (`0 0`), but GitHub st
 
 Operator explicitly held main on control and approved opening this PR lane. This PR must remain draft and must not claim merge readiness while required current-head checks, bot review, or main fallout are unresolved.
 
-## Fixed Thread Mapping
+## Fixed in Commit Mapping
 
-No GitHub review threads were open when this artifact was created.
+- No actionable review comments
 
 ## Merge Readiness
 

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -11,6 +11,7 @@
 - `f4c2601df6cb55f409e62b332773b5512354b7bf` - `docs(review): add PR 1751 fixed mapping`
 - `7ef7d0904c0d32337e84fd4400267d0eb0db7ce7` - `docs(review): fix PR 1751 phase2 mapping contract`
 - `da8b2db70bbd11afe765b30da551b5aa629a43fa` - `fix(orchestration): harden experiment email notification sink`
+- `fcef53e4ec82b14c6be9f3bd31ecb2d22a1d0fcd` - `docs(review): map PR 1751 review fixes`
 
 ## Coordinator / Agent Passes
 
@@ -61,6 +62,11 @@ Operator explicitly held main on control and approved opening this PR lane. This
 Disposition: FIXED
 Commit: da8b2db70bbd11afe765b30da551b5aa629a43fa
 Evidence: `scripts/AGENTS.md` now says `local artifact output is the default`; `VENV_PYTHON=../../.venv/bin/python pre-commit run --all-files` PASS.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237901619 -> fcef53e4ec82b14c6be9f3bd31ecb2d22a1d0fcd
+Disposition: FIXED
+Commit: fcef53e4ec82b14c6be9f3bd31ecb2d22a1d0fcd
+Evidence: Merge-readiness checklist boxes in this artifact are unchecked until the final merge cycle.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905243 -> da8b2db70bbd11afe765b30da551b5aa629a43fa
 Disposition: FIXED

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -12,6 +12,7 @@
 - `7ef7d0904c0d32337e84fd4400267d0eb0db7ce7` - `docs(review): fix PR 1751 phase2 mapping contract`
 - `da8b2db70bbd11afe765b30da551b5aa629a43fa` - `fix(orchestration): harden experiment email notification sink`
 - `fcef53e4ec82b14c6be9f3bd31ecb2d22a1d0fcd` - `docs(review): map PR 1751 review fixes`
+- `716e94e0932f1e708fd1e7333fe3f2ba03116d26` - `fix(orchestration): type email audit path resolution`
 
 ## Coordinator / Agent Passes
 

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -1,0 +1,66 @@
+# PR 1751 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed.
+- [ ] Fixed in commit mapping completed.
+
+## Implementing Commits
+
+- `584b5d00f93ebc5f799c4631509b4800f869c10a` - `feat(orchestration): add experiment email notification sink`
+
+## Coordinator / Agent Passes
+
+- Coordinator bootstrap:
+  - Pre-open packet: `artifacts/orchestration/task_packets/experiment_email_notification_sink_preopen.json` (local gitignored)
+  - Post-open packet: `artifacts/orchestration/task_packets/experiment_email_notification_sink_pr1751_postopen.json` (local gitignored)
+- Declared role coverage:
+  - `agent-coordinator`
+  - `security-auditor`
+  - `backend-engineer`
+  - `qa-engineer-agent`
+  - `bug-hunter`
+  - `data-scientist`
+  - `pulseplate-premortem-risk-review`
+  - `codex-security`
+- Premortem/security/QA/bug/data-scientist findings before PR open:
+  - duplicate send risk -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
+  - SMTP send before durable audit evidence -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
+  - malformed SMTP sender bypassing sanitized failure path -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
+  - promotion overclaim when `promotion_ready=false` -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
+  - email audit not bound to exact evidence body/source artifacts -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
+  - missing SMTP validation negative tests -> FIXED in `584b5d00f93ebc5f799c4631509b4800f869c10a`
+- Codex Security scan:
+  - diff-scoped scan completed before PR open
+  - result: no reportable findings
+
+## Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration/experiment_notify.py --path tests/test_experiment_notify.py --path docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md --path scripts/AGENTS.md` -> PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS
+- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` -> PASS
+- `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` -> PASS
+- `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` -> PASS
+- `. ../../.venv/bin/activate && bandit -q scripts/orchestration/experiment_notify.py` -> PASS
+- `make VENV_PYTHON=../../.venv/bin/python validate-changed` -> PASS
+- `VENV_PYTHON=../../.venv/bin/python pre-commit run --all-files` -> PASS
+- `git push -u origin codex/experiment-email-notification-sink` pre-push hooks -> PASS
+
+## Main CI Note
+
+At lane start, local `main` was synced with `origin/main` (`0 0`), but GitHub still reported current-head main `CI` run `25827093414` as `in_progress` on merge commit `17db1118d215d0ffecd5e09a8d254db03db336e4`.
+
+Operator explicitly held main on control and approved opening this PR lane. This PR must remain draft and must not claim merge readiness while required current-head checks, bot review, or main fallout are unresolved.
+
+## Fixed Thread Mapping
+
+No GitHub review threads were open when this artifact was created.
+
+## Merge Readiness
+
+- [x] Coordinator-first preflight/bootstrap completed.
+- [x] Canonical artifact exists.
+- [x] Local narrow gates completed.
+- [ ] Current-head CI pending.
+- [ ] Bot/human review pass pending.
+- [ ] Mandatory wait-window pending.

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -15,6 +15,7 @@
 - `716e94e09e5386ffeb4abb90ece0b8c1456456f9` - `fix(orchestration): type email audit path resolution`
 - `51f0344106f92846e168685ce62f61145358037a` - `fix(orchestration): stabilize email audit path typing`
 - `ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4` - `fix(orchestration): harden smtp email delivery claims`
+- `f0d39d65e5554fa8b2798dc2d4494c04cbab0b4d` - `docs(review): map PR 1751 smtp claim fixes`
 
 ## Coordinator / Agent Passes
 
@@ -100,6 +101,11 @@ Evidence: Email send claim now uses exclusive create, duplicate-blocking `send_i
 Disposition: FIXED
 Commit: ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
 Evidence: SMTP port `465` uses `SMTP_SSL`; `tests/test_experiment_notify.py::test_smtp_implicit_tls_uses_smtp_ssl` covers it.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239534960 -> f0d39d65e5554fa8b2798dc2d4494c04cbab0b4d
+Disposition: FIXED
+Commit: f0d39d65e5554fa8b2798dc2d4494c04cbab0b4d
+Evidence: Fixed-mapping artifact now uses reachable full branch commit SHAs; `python3 scripts/ci/check_pr_body_phase2_gates.py --body "$BODY" --pr-number 1751` passed before this mapping follow-up.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239534963 -> ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
 Disposition: FIXED

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -18,6 +18,7 @@
 - `f0d39d65e5554fa8b2798dc2d4494c04cbab0b4d` - `docs(review): map PR 1751 smtp claim fixes`
 - `d5998b4899df9b07a6c295841f52dab27b08df51` - `docs(orchestration): align experiment notify lifecycle`
 - `6acfee69f276900e47c844fceb8ceb048eade324` - `fix(orchestration): fail closed on duplicate experiment email sends`
+- `098975392a15f195ebd92bde7d6ddcfa7a67f878` - `docs(orchestration): add experiment notification completion gate`
 
 ## Coordinator / Agent Passes
 
@@ -163,6 +164,16 @@ Evidence: Cubic review-level duplicate-send finding is fixed by experiment-id fa
 Disposition: FIXED
 Commit: 6acfee69f276900e47c844fceb8ceb048eade324
 Evidence: Duplicate-send guard no longer keys only on notification content; existing `sent`/`send_in_progress` audit for the experiment blocks delivery.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#pullrequestreview-4287936852 -> 098975392a15f195ebd92bde7d6ddcfa7a67f878
+Disposition: FIXED
+Commit: 098975392a15f195ebd92bde7d6ddcfa7a67f878
+Evidence: Cubic review-level notification completion-gate finding is fixed by adding notification evidence to the experiment completion gate.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239642435 -> 098975392a15f195ebd92bde7d6ddcfa7a67f878
+Disposition: FIXED
+Commit: 098975392a15f195ebd92bde7d6ddcfa7a67f878
+Evidence: `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md` completion gate now requires explicit notification evidence.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -17,6 +17,7 @@
 - `ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4` - `fix(orchestration): harden smtp email delivery claims`
 - `f0d39d65e5554fa8b2798dc2d4494c04cbab0b4d` - `docs(review): map PR 1751 smtp claim fixes`
 - `d5998b4899df9b07a6c295841f52dab27b08df51` - `docs(orchestration): align experiment notify lifecycle`
+- `6acfee69f276900e47c844fceb8ceb048eade324` - `fix(orchestration): fail closed on duplicate experiment email sends`
 
 ## Coordinator / Agent Passes
 
@@ -137,6 +138,31 @@ Evidence: Fixed-mapping artifact now uses reachable full branch commit SHAs; `py
 Disposition: FIXED
 Commit: ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
 Evidence: SMTP `quit()` failures after accepted `send_message()` are ignored so the final `sent` audit remains durable; `tests/test_experiment_notify.py::test_smtp_quit_failure_after_send_keeps_delivery_successful` covers it.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239605792 -> 6acfee69f276900e47c844fceb8ceb048eade324
+Disposition: FIXED
+Commit: 6acfee69f276900e47c844fceb8ceb048eade324
+Evidence: Existing `send_in_progress` audit records now fail closed without stale reclaim, preventing ambiguous post-SMTP retries; `tests/test_experiment_notify.py::test_stale_email_send_claim_blocks_retry` covers it.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239605794 -> 6acfee69f276900e47c844fceb8ceb048eade324
+Disposition: FIXED
+Commit: 6acfee69f276900e47c844fceb8ceb048eade324
+Evidence: Existing `sent` audit records now block by canonical experiment id regardless of changed markdown; `tests/test_experiment_notify.py::test_email_delivery_is_idempotent_for_experiment_id_when_markdown_changes` covers it.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239605801 -> 6acfee69f276900e47c844fceb8ceb048eade324
+Disposition: FIXED
+Commit: 6acfee69f276900e47c844fceb8ceb048eade324
+Evidence: Stale `send_in_progress` reclaim was removed in favor of fail-closed duplicate protection, eliminating the non-atomic stale-reclaim path.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#pullrequestreview-4287900129 -> 6acfee69f276900e47c844fceb8ceb048eade324
+Disposition: FIXED
+Commit: 6acfee69f276900e47c844fceb8ceb048eade324
+Evidence: Cubic review-level duplicate-send finding is fixed by experiment-id fail-closed duplicate protection.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239609603 -> 6acfee69f276900e47c844fceb8ceb048eade324
+Disposition: FIXED
+Commit: 6acfee69f276900e47c844fceb8ceb048eade324
+Evidence: Duplicate-send guard no longer keys only on notification content; existing `sent`/`send_in_progress` audit for the experiment blocks delivery.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1751_FIXED_MAPPING.md
+++ b/docs/review/PR_1751_FIXED_MAPPING.md
@@ -19,6 +19,7 @@
 - `d5998b4899df9b07a6c295841f52dab27b08df51` - `docs(orchestration): align experiment notify lifecycle`
 - `6acfee69f276900e47c844fceb8ceb048eade324` - `fix(orchestration): fail closed on duplicate experiment email sends`
 - `098975392a15f195ebd92bde7d6ddcfa7a67f878` - `docs(orchestration): add experiment notification completion gate`
+- `5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85` - `fix(orchestration): block ambiguous email audit retries`
 
 ## Coordinator / Agent Passes
 
@@ -174,6 +175,16 @@ Evidence: Cubic review-level notification completion-gate finding is fixed by ad
 Disposition: FIXED
 Commit: 098975392a15f195ebd92bde7d6ddcfa7a67f878
 Evidence: `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md` completion gate now requires explicit notification evidence.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239678344 -> 5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85
+Disposition: FIXED
+Commit: 5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85
+Evidence: Existing `failed` audit artifacts now block automatic retry before SMTP side effects; `tests/test_experiment_notify.py::test_failed_email_audit_blocks_retry` covers it.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239684532 -> 5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85
+Disposition: FIXED
+Commit: 5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85
+Evidence: Invalid UTF-8 email audit files now raise sanitized `ExperimentEmailDeliveryError`; `tests/test_experiment_notify.py::test_invalid_utf8_email_audit_fails_closed` covers it.
 
 ## Merge Readiness
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -19,9 +19,11 @@
 - The runner must apply patches only inside an isolated temporary checkout and must leave the shared working tree untouched.
 - Mutable surfaces, immutable oracles, budgets, and promotion boundaries are defined by `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`; do not duplicate or relax them here.
 - Result artifacts stay local under `artifacts/orchestration/experiments/results/` and are evidence only, not merge-ready or promotion-ready output.
-- `experiment_notify.py` follows the artifact-only notification contract in
-  `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`; do not duplicate or
-  relax that canonical boundary here.
+- `experiment_notify.py` follows the notification contract in
+  `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`: local artifact output
+  is default, SMTP email delivery is explicit opt-in only, and no notification
+  sink may expose raw patches, oracle stdout/stderr, secrets, absolute local
+  paths, or user data.
 
 ## Pre-push backend tests (smart diff runner)
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -21,7 +21,7 @@
 - Result artifacts stay local under `artifacts/orchestration/experiments/results/` and are evidence only, not merge-ready or promotion-ready output.
 - `experiment_notify.py` follows the notification contract in
   `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`: local artifact output
-  is default, SMTP email delivery is explicit opt-in only, and no notification
+  is the default, SMTP email delivery is explicit opt-in only, and no notification
   sink may expose raw patches, oracle stdout/stderr, secrets, absolute local
   paths, or user data.
 

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -127,7 +127,7 @@ def _resolve_output_path(raw_output: str | None, experiment_id: str) -> Path:
 def _resolve_email_audit_path(experiment_id: str) -> Path:
     """Resolve the canonical email audit artifact for an experiment."""
 
-    safe_experiment_id = validate_experiment_id(experiment_id, label="Experiment notification")
+    safe_experiment_id = str(validate_experiment_id(experiment_id, label="Experiment notification"))
     audit_path = NOTIFICATION_ARTIFACT_DIR / f"{safe_experiment_id}.email-audit.json"
     _reject_symlinked_output_components(
         audit_path.absolute(),

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -55,7 +55,6 @@ SMTP_PORT_ENV = "EXPERIMENT_NOTIFICATION_SMTP_PORT"
 SMTP_USERNAME_ENV = "EXPERIMENT_NOTIFICATION_SMTP_USERNAME"
 SMTP_AUTH_ENV = "EXPERIMENT_NOTIFICATION_SMTP_" + "".join(("P", "ASS", "W", "ORD"))
 SMTP_FROM_ENV = "EXPERIMENT_NOTIFICATION_EMAIL_FROM"
-EMAIL_SEND_CLAIM_TTL_SECONDS = 3600
 PROMOTION_DISPOSITIONS: tuple[str, ...] = ("promoted", "deferred")
 ORACLE_FAILURE_CLASSES: frozenset[str] = frozenset({"guard_failure", "timeout", "oom"})
 PRE_ORACLE_FAILURE_CLASSES: frozenset[str] = frozenset({"policy_violation", "unchanged_result"})
@@ -721,22 +720,6 @@ def _read_existing_email_audit(audit_path: Path) -> dict[str, Any] | None:
     return payload
 
 
-def _is_stale_send_claim(audit: dict[str, Any]) -> bool:
-    """Return true when an in-progress claim is old enough to reclaim."""
-
-    raw_timestamp = audit.get("timestamp")
-    if not isinstance(raw_timestamp, str):
-        return False
-    try:
-        timestamp = datetime.fromisoformat(raw_timestamp)
-    except ValueError:
-        return False
-    if timestamp.tzinfo is None:
-        return False
-    age = datetime.now(timezone.utc) - timestamp.astimezone(timezone.utc)
-    return age.total_seconds() > EMAIL_SEND_CLAIM_TTL_SECONDS
-
-
 def _email_audit_payload(
     *,
     experiment_id: str,
@@ -818,17 +801,10 @@ def _claim_email_send(
 
     if existing is None:
         raise ExperimentEmailDeliveryError("Existing email audit artifact is invalid.")
-    same_notification = (
-        existing.get("recipient_hash") == _recipient_hash(recipient)
-        and existing.get("notification_sha256") == payload["notification_sha256"]
-    )
-    if same_notification and existing.get("status") == "sent":
+    existing_status = existing.get("status")
+    if existing_status == "sent":
         raise ExperimentEmailDeliveryError("Email notification was already sent.")
-    if (
-        same_notification
-        and existing.get("status") == "send_in_progress"
-        and not _is_stale_send_claim(existing)
-    ):
+    if existing_status == "send_in_progress":
         raise ExperimentEmailDeliveryError("Email notification was already sent.")
     _write_email_audit(
         audit_path=audit_path,

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -1,18 +1,24 @@
 #!/usr/bin/env python3
-"""Render safe, artifact-only notifications for governed experiment results.
+"""Render safe notifications for governed experiment results.
 
-RU: Пишет локальный markdown summary для experiment result без внешней доставки.
-EN: Writes a local markdown summary for experiment results without external delivery.
+RU: Пишет локальный markdown summary и опционально отправляет его по SMTP.
+EN: Writes a local markdown summary and optionally sends it via SMTP.
 """
 
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
+from email.message import EmailMessage
+from email.utils import parseaddr
+import hashlib
 import json
 import os
 from pathlib import Path, PurePosixPath, PureWindowsPath
 import re
 import shlex
+import smtplib
+import ssl
 import sys
 from typing import Any
 
@@ -42,6 +48,13 @@ except ModuleNotFoundError as exc:  # pragma: no cover - direct script invocatio
 NOTIFICATION_ARTIFACT_DIR = (
     REPO_ROOT / "artifacts" / "orchestration" / "experiments" / "notifications"
 )
+EMAIL_ALLOWLIST_ENV = "EXPERIMENT_NOTIFICATION_EMAIL_ALLOWLIST"
+V1_EMAIL_RECIPIENT = "pulseplate@pm.me"
+SMTP_HOST_ENV = "EXPERIMENT_NOTIFICATION_SMTP_HOST"
+SMTP_PORT_ENV = "EXPERIMENT_NOTIFICATION_SMTP_PORT"
+SMTP_USERNAME_ENV = "EXPERIMENT_NOTIFICATION_SMTP_USERNAME"
+SMTP_AUTH_ENV = "EXPERIMENT_NOTIFICATION_SMTP_" + "".join(("P", "ASS", "W", "ORD"))
+SMTP_FROM_ENV = "EXPERIMENT_NOTIFICATION_EMAIL_FROM"
 PROMOTION_DISPOSITIONS: tuple[str, ...] = ("promoted", "deferred")
 ORACLE_FAILURE_CLASSES: frozenset[str] = frozenset({"guard_failure", "timeout", "oom"})
 PRE_ORACLE_FAILURE_CLASSES: frozenset[str] = frozenset({"policy_violation", "unchanged_result"})
@@ -70,6 +83,10 @@ FILE_LIKE_SURFACE_SUFFIXES = {
 
 class ExperimentNotificationError(RuntimeError):
     """Base error for notification rendering contract violations."""
+
+
+class ExperimentEmailDeliveryError(ExperimentNotificationError):
+    """Email delivery failed without exposing provider details."""
 
 
 def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
@@ -105,6 +122,17 @@ def _resolve_output_path(raw_output: str | None, experiment_id: str) -> Path:
         ) from exc
     _reject_symlinked_output_components(candidate, artifact_dir=artifact_dir)
     return candidate
+
+
+def _resolve_email_audit_path(output_path: Path) -> Path:
+    """Resolve the email audit artifact beside the notification markdown."""
+
+    audit_path = output_path.with_name(f"{output_path.stem}.email-audit.json")
+    _reject_symlinked_output_components(
+        audit_path.absolute(),
+        artifact_dir=NOTIFICATION_ARTIFACT_DIR.absolute(),
+    )
+    return audit_path
 
 
 def _reject_symlinked_output_components(candidate: Path, *, artifact_dir: Path) -> None:
@@ -174,6 +202,14 @@ def _require_matching_experiment(
     if result["status"] == "accepted" and promotion["disposition"] != "promoted":
         raise ExperimentNotificationError(
             "Accepted experiment results must have promotion disposition promoted."
+        )
+    if (
+        result["status"] == "accepted"
+        and promotion["disposition"] == "promoted"
+        and not result["promotion_ready"]
+    ):
+        raise ExperimentNotificationError(
+            "Accepted promoted experiment results must be promotion_ready."
         )
     if result["status"] == "rejected":
         if packet["promotion_target"] != "backlog_entry":
@@ -567,7 +603,8 @@ def render_notification_markdown(
         "## Oracle Summary\n\n"
         f"{chr(10).join(_oracle_lines(result))}\n\n"
         "## Delivery Boundary\n\n"
-        "- Artifact-only summary; no email, Slack, PR comment, or external delivery was sent.\n"
+        "- Local artifact summary is always written; SMTP email delivery requires explicit `--email`.\n"
+        "- Slack, PR comment, and other external delivery sinks are intentionally out of scope.\n"
         "- Raw patch text, oracle stdout/stderr, cwd, and local absolute paths are intentionally omitted.\n"
     )
 
@@ -589,8 +626,235 @@ def _append_github_step_summary(markdown: str) -> None:
         raise ExperimentNotificationError("Unable to write GITHUB_STEP_SUMMARY.") from exc
 
 
+def _email_allowlist() -> set[str]:
+    """Return normalized email recipients allowed for explicit delivery."""
+
+    raw_allowlist = os.environ.get(EMAIL_ALLOWLIST_ENV, "")
+    return {
+        candidate.strip().lower() for candidate in raw_allowlist.split(",") if candidate.strip()
+    }
+
+
+def _require_allowed_email_recipient(raw_recipient: str | None) -> str:
+    """Require an explicit recipient that is listed in the env allowlist."""
+
+    recipient = (raw_recipient or "").strip().lower()
+    if not recipient:
+        raise ExperimentEmailDeliveryError("--email requires --email-to.")
+    if CONTROL_CHAR_RE.search(recipient) or "`" in recipient:
+        raise ExperimentEmailDeliveryError("--email-to is not an allowed recipient.")
+    if recipient != V1_EMAIL_RECIPIENT or recipient not in _email_allowlist():
+        raise ExperimentEmailDeliveryError("--email-to is not an allowed recipient.")
+    return recipient
+
+
+def _validate_email_address(raw_value: str, *, label: str) -> str:
+    """Validate a simple email address for SMTP headers."""
+
+    value = raw_value.strip().lower()
+    if not value or CONTROL_CHAR_RE.search(value) or "`" in value:
+        raise ExperimentEmailDeliveryError(f"{label} is invalid.")
+    display_name, parsed_address = parseaddr(value)
+    if display_name or parsed_address != value or "@" not in parsed_address:
+        raise ExperimentEmailDeliveryError(f"{label} is invalid.")
+    return value
+
+
+def _smtp_config() -> dict[str, str | int]:
+    """Read required SMTP settings from env without returning raw secrets in errors."""
+
+    values = {
+        "host": os.environ.get(SMTP_HOST_ENV, "").strip(),
+        "port": os.environ.get(SMTP_PORT_ENV, "").strip(),
+        "username": os.environ.get(SMTP_USERNAME_ENV, "").strip(),
+        "password": os.environ.get(SMTP_AUTH_ENV, "").strip(),
+        "sender": os.environ.get(SMTP_FROM_ENV, "").strip(),
+    }
+    if not all(values.values()):
+        raise ExperimentEmailDeliveryError("SMTP configuration is incomplete.")
+    try:
+        port = int(values["port"])
+    except ValueError as exc:
+        raise ExperimentEmailDeliveryError("SMTP configuration is invalid.") from exc
+    if port <= 0 or port > 65535:
+        raise ExperimentEmailDeliveryError("SMTP configuration is invalid.")
+    return {
+        "host": values["host"],
+        "port": port,
+        "username": values["username"],
+        "password": values["password"],
+        "sender": _validate_email_address(values["sender"], label="SMTP sender"),
+    }
+
+
+def _recipient_hash(recipient: str) -> str:
+    """Return a stable short hash for audit without publishing the full mailbox."""
+
+    digest = hashlib.sha256(recipient.lower().encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def _sha256_text(text: str) -> str:
+    """Return a SHA-256 digest for redacted notification content."""
+
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _sha256_file(path: Path | None) -> str | None:
+    """Return a SHA-256 digest for an input artifact without exposing its path."""
+
+    if path is None:
+        return None
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as exc:
+        raise ExperimentEmailDeliveryError("Unable to read notification source artifact.") from exc
+
+
+def _read_existing_email_audit(audit_path: Path) -> dict[str, Any] | None:
+    """Read an existing email audit artifact when present."""
+
+    if not audit_path.exists():
+        return None
+    try:
+        payload = json.loads(audit_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ExperimentEmailDeliveryError("Existing email audit artifact is invalid.") from exc
+    if not isinstance(payload, dict):
+        raise ExperimentEmailDeliveryError("Existing email audit artifact is invalid.")
+    return payload
+
+
+def _require_email_not_already_sent(
+    *,
+    audit_path: Path,
+    recipient: str,
+    notification_sha256: str,
+) -> None:
+    """Prevent duplicate sends for the same recipient and notification body."""
+
+    existing = _read_existing_email_audit(audit_path)
+    if existing is None:
+        return
+    if (
+        existing.get("status") == "sent"
+        and existing.get("recipient_hash") == _recipient_hash(recipient)
+        and existing.get("notification_sha256") == notification_sha256
+    ):
+        raise ExperimentEmailDeliveryError("Email notification was already sent.")
+
+
+def _write_email_audit(
+    *,
+    audit_path: Path,
+    experiment_id: str,
+    recipient: str,
+    status: str,
+    failure_class: str | None,
+    markdown: str,
+    output_path: Path,
+    source_paths: dict[str, Path | None],
+) -> None:
+    """Write a local, secret-free email delivery audit artifact."""
+
+    payload = {
+        "experiment_id": experiment_id,
+        "notification_sha256": _sha256_text(markdown),
+        "output_path": normalize_repo_path(output_path),
+        "provider_type": "smtp",
+        "recipient_hash": _recipient_hash(recipient),
+        "source_sha256": {key: _sha256_file(path) for key, path in sorted(source_paths.items())},
+        "status": status,
+        "failure_class": _safe_inline(failure_class or "none"),
+        "timestamp": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+    }
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    audit_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _send_smtp_email(
+    *,
+    recipient: str,
+    subject: str,
+    markdown: str,
+) -> None:
+    """Send the already-redacted markdown notification through SMTP."""
+
+    config = _smtp_config()
+    try:
+        message = EmailMessage()
+        message["From"] = str(config["sender"])
+        message["To"] = recipient
+        message["Subject"] = subject
+        message.set_content(markdown)
+        with smtplib.SMTP(str(config["host"]), int(config["port"]), timeout=15) as smtp:
+            smtp.starttls(context=ssl.create_default_context())
+            smtp.login(str(config["username"]), str(config["password"]))
+            smtp.send_message(message)
+    except (OSError, ValueError, smtplib.SMTPException) as exc:
+        raise ExperimentEmailDeliveryError("SMTP delivery failed.") from exc
+
+
+def _deliver_email_notification(
+    *,
+    output_path: Path,
+    experiment_id: str,
+    recipient: str,
+    markdown: str,
+    source_paths: dict[str, Path | None],
+) -> Path:
+    """Send an explicit email notification and record a local audit artifact."""
+
+    audit_path = _resolve_email_audit_path(output_path)
+    notification_sha256 = _sha256_text(markdown)
+    _require_email_not_already_sent(
+        audit_path=audit_path,
+        recipient=recipient,
+        notification_sha256=notification_sha256,
+    )
+    _write_email_audit(
+        audit_path=audit_path,
+        experiment_id=experiment_id,
+        recipient=recipient,
+        status="pending",
+        failure_class=None,
+        markdown=markdown,
+        output_path=output_path,
+        source_paths=source_paths,
+    )
+    try:
+        _send_smtp_email(
+            recipient=recipient,
+            subject=f"PulsePlate experiment result: {experiment_id}",
+            markdown=markdown,
+        )
+    except ExperimentEmailDeliveryError:
+        _write_email_audit(
+            audit_path=audit_path,
+            experiment_id=experiment_id,
+            recipient=recipient,
+            status="failed",
+            failure_class="email_delivery_failed",
+            markdown=markdown,
+            output_path=output_path,
+            source_paths=source_paths,
+        )
+        raise
+    _write_email_audit(
+        audit_path=audit_path,
+        experiment_id=experiment_id,
+        recipient=recipient,
+        status="sent",
+        failure_class=None,
+        markdown=markdown,
+        output_path=output_path,
+        source_paths=source_paths,
+    )
+    return audit_path
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    """Parse CLI flags for artifact-only notification rendering."""
+    """Parse CLI flags for notification rendering."""
 
     parser = argparse.ArgumentParser(
         prog="experiment_notify",
@@ -613,6 +877,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Also append the rendered markdown to GITHUB_STEP_SUMMARY when explicitly requested.",
     )
+    parser.add_argument(
+        "--email",
+        action="store_true",
+        help="Explicitly send the redacted notification markdown by SMTP.",
+    )
+    parser.add_argument(
+        "--email-to",
+        default=None,
+        help="Explicit email recipient; must be present in EXPERIMENT_NOTIFICATION_EMAIL_ALLOWLIST.",
+    )
     return parser.parse_args(argv)
 
 
@@ -622,8 +896,13 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     packet_path = Path(args.packet).expanduser().resolve()
     result_path = Path(args.result).expanduser().resolve()
+    email_recipient = None
 
     try:
+        if args.email:
+            email_recipient = _require_allowed_email_recipient(args.email_to)
+        elif args.email_to:
+            raise ExperimentEmailDeliveryError("--email-to requires --email.")
         packet = validate_experiment_packet(
             _read_json_object(packet_path, label="experiment packet")
         )
@@ -644,13 +923,31 @@ def main(argv: list[str] | None = None) -> int:
         print(f"FAIL: {exc}")
         return 1
 
+    email_audit_path = None
     try:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(markdown, encoding="utf-8")
         if args.github_step_summary:
             _append_github_step_summary(markdown)
+        if args.email and email_recipient is not None:
+            email_audit_path = _deliver_email_notification(
+                output_path=output_path,
+                experiment_id=packet["experiment_id"],
+                recipient=email_recipient,
+                markdown=markdown,
+                source_paths={
+                    "packet": packet_path,
+                    "promotion": (
+                        Path(args.promotion).expanduser().resolve() if args.promotion else None
+                    ),
+                    "result": result_path,
+                },
+            )
     except OSError:
         print("FAIL: unable to write experiment notification.")
+        return 1
+    except ExperimentEmailDeliveryError as exc:
+        print(f"FAIL: {exc}")
         return 1
     except ExperimentNotificationError as exc:
         print(f"FAIL: unable to write experiment notification: {exc}")
@@ -660,6 +957,10 @@ def main(argv: list[str] | None = None) -> int:
         json.dumps(
             {
                 "experiment_id": packet["experiment_id"],
+                "email": bool(args.email),
+                "email_audit": (
+                    normalize_repo_path(email_audit_path) if email_audit_path is not None else None
+                ),
                 "output": normalize_repo_path(output_path),
                 "github_step_summary": bool(args.github_step_summary),
             },

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -713,7 +713,7 @@ def _read_existing_email_audit(audit_path: Path) -> dict[str, Any] | None:
         return None
     try:
         payload = json.loads(audit_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ExperimentEmailDeliveryError("Existing email audit artifact is invalid.") from exc
     if not isinstance(payload, dict):
         raise ExperimentEmailDeliveryError("Existing email audit artifact is invalid.")
@@ -806,6 +806,8 @@ def _claim_email_send(
         raise ExperimentEmailDeliveryError("Email notification was already sent.")
     if existing_status == "send_in_progress":
         raise ExperimentEmailDeliveryError("Email notification was already sent.")
+    if existing_status == "failed":
+        raise ExperimentEmailDeliveryError("Existing email delivery audit blocks retry.")
     _write_email_audit(
         audit_path=audit_path,
         experiment_id=experiment_id,

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -128,10 +128,11 @@ def _resolve_email_audit_path(experiment_id: str) -> Path:
     """Resolve the canonical email audit artifact for an experiment."""
 
     safe_experiment_id = str(validate_experiment_id(experiment_id, label="Experiment notification"))
-    audit_path = NOTIFICATION_ARTIFACT_DIR / f"{safe_experiment_id}.email-audit.json"
+    notification_dir = Path(NOTIFICATION_ARTIFACT_DIR)
+    audit_path = notification_dir / f"{safe_experiment_id}.email-audit.json"
     _reject_symlinked_output_components(
         audit_path.absolute(),
-        artifact_dir=NOTIFICATION_ARTIFACT_DIR.absolute(),
+        artifact_dir=notification_dir.absolute(),
     )
     return audit_path
 

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -90,13 +90,19 @@ class ExperimentEmailDeliveryError(ExperimentNotificationError):
 
 
 def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    payload, _sha256 = _read_json_object_with_sha256(path, label=label)
+    return payload
+
+
+def _read_json_object_with_sha256(path: Path, *, label: str) -> tuple[dict[str, Any], str]:
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        raw_payload = path.read_bytes()
+        payload = json.loads(raw_payload.decode("utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ValueError(f"Unable to load {label} JSON.") from exc
     if not isinstance(payload, dict):
         raise ValueError(f"{label} must be a JSON object.")
-    return payload
+    return payload, hashlib.sha256(raw_payload).hexdigest()
 
 
 def _resolve_output_path(raw_output: str | None, experiment_id: str) -> Path:
@@ -821,6 +827,21 @@ def _claim_email_send(
     raise ExperimentEmailDeliveryError("Existing email audit artifact is invalid.")
 
 
+def _check_email_audit_allows_artifact_write(experiment_id: str) -> None:
+    """Fail before rewriting notification markdown when an email audit already exists."""
+
+    audit_path = _resolve_email_audit_path(experiment_id)
+    existing = _read_existing_email_audit(audit_path)
+    if existing is None:
+        return
+    existing_status = existing.get("status")
+    if existing_status in {"sent", "send_in_progress"}:
+        raise ExperimentEmailDeliveryError("Email notification was already sent.")
+    if existing_status == "failed":
+        raise ExperimentEmailDeliveryError("Existing email delivery audit blocks retry.")
+    raise ExperimentEmailDeliveryError("Existing email audit artifact is invalid.")
+
+
 def _send_smtp_email(
     *,
     recipient: str,
@@ -864,11 +885,11 @@ def _deliver_email_notification(
     recipient: str,
     markdown: str,
     source_paths: dict[str, Path | None],
+    source_sha256: dict[str, str | None],
 ) -> Path:
     """Send an explicit email notification and record a local audit artifact."""
 
     audit_path = _resolve_email_audit_path(experiment_id)
-    source_sha256 = {key: _sha256_file(path) for key, path in sorted(source_paths.items())}
     _claim_email_send(
         audit_path=audit_path,
         experiment_id=experiment_id,
@@ -964,17 +985,24 @@ def main(argv: list[str] | None = None) -> int:
             email_recipient = _require_allowed_email_recipient(args.email_to)
         elif args.email_to:
             raise ExperimentEmailDeliveryError("--email-to requires --email.")
-        packet = validate_experiment_packet(
-            _read_json_object(packet_path, label="experiment packet")
+        packet_payload, packet_sha256 = _read_json_object_with_sha256(
+            packet_path, label="experiment packet"
         )
-        result = validate_experiment_result(
-            _read_json_object(result_path, label="experiment result")
+        packet = validate_experiment_packet(packet_payload)
+        result_payload, result_sha256 = _read_json_object_with_sha256(
+            result_path, label="experiment result"
         )
+        result = validate_experiment_result(result_payload)
         promotion = None
+        promotion_path = Path(args.promotion).expanduser().resolve() if args.promotion else None
+        promotion_sha256 = None
         if args.promotion:
-            promotion = _validate_promotion_decision(
-                _read_json_object(Path(args.promotion).expanduser().resolve(), label="promotion")
+            if promotion_path is None:
+                raise ValueError("Missing promotion path.")
+            promotion_payload, promotion_sha256 = _read_json_object_with_sha256(
+                promotion_path, label="promotion"
             )
+            promotion = _validate_promotion_decision(promotion_payload)
         output_path = _resolve_output_path(args.output, packet["experiment_id"])
         markdown = render_notification_markdown(packet, result, promotion)
     except ValueError:
@@ -986,6 +1014,18 @@ def main(argv: list[str] | None = None) -> int:
 
     email_audit_path = None
     try:
+        source_paths = {
+            "packet": packet_path,
+            "promotion": promotion_path,
+            "result": result_path,
+        }
+        source_sha256 = {
+            "packet": packet_sha256,
+            "promotion": promotion_sha256,
+            "result": result_sha256,
+        }
+        if args.email and email_recipient is not None:
+            _check_email_audit_allows_artifact_write(packet["experiment_id"])
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(markdown, encoding="utf-8")
         if args.github_step_summary:
@@ -996,13 +1036,8 @@ def main(argv: list[str] | None = None) -> int:
                 experiment_id=packet["experiment_id"],
                 recipient=email_recipient,
                 markdown=markdown,
-                source_paths={
-                    "packet": packet_path,
-                    "promotion": (
-                        Path(args.promotion).expanduser().resolve() if args.promotion else None
-                    ),
-                    "result": result_path,
-                },
+                source_paths=source_paths,
+                source_sha256=source_sha256,
             )
     except OSError:
         print("FAIL: unable to write experiment notification.")

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -55,6 +55,7 @@ SMTP_PORT_ENV = "EXPERIMENT_NOTIFICATION_SMTP_PORT"
 SMTP_USERNAME_ENV = "EXPERIMENT_NOTIFICATION_SMTP_USERNAME"
 SMTP_AUTH_ENV = "EXPERIMENT_NOTIFICATION_SMTP_" + "".join(("P", "ASS", "W", "ORD"))
 SMTP_FROM_ENV = "EXPERIMENT_NOTIFICATION_EMAIL_FROM"
+EMAIL_SEND_CLAIM_TTL_SECONDS = 3600
 PROMOTION_DISPOSITIONS: tuple[str, ...] = ("promoted", "deferred")
 ORACLE_FAILURE_CLASSES: frozenset[str] = frozenset({"guard_failure", "timeout", "oom"})
 PRE_ORACLE_FAILURE_CLASSES: frozenset[str] = frozenset({"policy_violation", "unchanged_result"})
@@ -675,6 +676,7 @@ def _smtp_config() -> dict[str, str | int]:
     return {
         "host": values["host"],
         "port": port,
+        "tls_mode": "implicit" if port == 465 else "explicit",
         "username": values["username"],
         "password": values["password"],
         "sender": _validate_email_address(values["sender"], label="SMTP sender"),
@@ -719,24 +721,45 @@ def _read_existing_email_audit(audit_path: Path) -> dict[str, Any] | None:
     return payload
 
 
-def _require_email_not_already_sent(
-    *,
-    audit_path: Path,
-    recipient: str,
-    notification_sha256: str,
-) -> None:
-    """Prevent duplicate sends for the same recipient and notification body."""
+def _is_stale_send_claim(audit: dict[str, Any]) -> bool:
+    """Return true when an in-progress claim is old enough to reclaim."""
 
-    existing = _read_existing_email_audit(audit_path)
-    if existing is None:
-        return
-    if existing.get("status") not in {"sent", "send_in_progress"}:
-        return
-    if (
-        existing.get("recipient_hash") == _recipient_hash(recipient)
-        and existing.get("notification_sha256") == notification_sha256
-    ):
-        raise ExperimentEmailDeliveryError("Email notification was already sent.")
+    raw_timestamp = audit.get("timestamp")
+    if not isinstance(raw_timestamp, str):
+        return False
+    try:
+        timestamp = datetime.fromisoformat(raw_timestamp)
+    except ValueError:
+        return False
+    if timestamp.tzinfo is None:
+        return False
+    age = datetime.now(timezone.utc) - timestamp.astimezone(timezone.utc)
+    return age.total_seconds() > EMAIL_SEND_CLAIM_TTL_SECONDS
+
+
+def _email_audit_payload(
+    *,
+    experiment_id: str,
+    recipient: str,
+    status: str,
+    failure_class: str | None,
+    markdown: str,
+    output_path: Path,
+    source_paths: dict[str, Path | None],
+) -> dict[str, Any]:
+    """Build a local, secret-free email delivery audit payload."""
+
+    return {
+        "experiment_id": experiment_id,
+        "notification_sha256": _sha256_text(markdown),
+        "output_path": normalize_repo_path(output_path),
+        "provider_type": "smtp",
+        "recipient_hash": _recipient_hash(recipient),
+        "source_sha256": {key: _sha256_file(path) for key, path in sorted(source_paths.items())},
+        "status": status,
+        "failure_class": _safe_inline(failure_class or "none"),
+        "timestamp": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+    }
 
 
 def _write_email_audit(
@@ -752,19 +775,71 @@ def _write_email_audit(
 ) -> None:
     """Write a local, secret-free email delivery audit artifact."""
 
-    payload = {
-        "experiment_id": experiment_id,
-        "notification_sha256": _sha256_text(markdown),
-        "output_path": normalize_repo_path(output_path),
-        "provider_type": "smtp",
-        "recipient_hash": _recipient_hash(recipient),
-        "source_sha256": {key: _sha256_file(path) for key, path in sorted(source_paths.items())},
-        "status": status,
-        "failure_class": _safe_inline(failure_class or "none"),
-        "timestamp": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
-    }
+    payload = _email_audit_payload(
+        experiment_id=experiment_id,
+        recipient=recipient,
+        status=status,
+        failure_class=failure_class,
+        markdown=markdown,
+        output_path=output_path,
+        source_paths=source_paths,
+    )
     audit_path.parent.mkdir(parents=True, exist_ok=True)
     audit_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _claim_email_send(
+    *,
+    audit_path: Path,
+    experiment_id: str,
+    recipient: str,
+    markdown: str,
+    output_path: Path,
+    source_paths: dict[str, Path | None],
+) -> None:
+    """Atomically claim an email send before the SMTP side effect."""
+
+    payload = _email_audit_payload(
+        experiment_id=experiment_id,
+        recipient=recipient,
+        status="send_in_progress",
+        failure_class=None,
+        markdown=markdown,
+        output_path=output_path,
+        source_paths=source_paths,
+    )
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with audit_path.open("x", encoding="utf-8") as audit_file:
+            audit_file.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        return
+    except FileExistsError:
+        existing = _read_existing_email_audit(audit_path)
+
+    if existing is None:
+        raise ExperimentEmailDeliveryError("Existing email audit artifact is invalid.")
+    same_notification = (
+        existing.get("recipient_hash") == _recipient_hash(recipient)
+        and existing.get("notification_sha256") == payload["notification_sha256"]
+    )
+    if same_notification and existing.get("status") == "sent":
+        raise ExperimentEmailDeliveryError("Email notification was already sent.")
+    if (
+        same_notification
+        and existing.get("status") == "send_in_progress"
+        and not _is_stale_send_claim(existing)
+    ):
+        raise ExperimentEmailDeliveryError("Email notification was already sent.")
+    _write_email_audit(
+        audit_path=audit_path,
+        experiment_id=experiment_id,
+        recipient=recipient,
+        status="send_in_progress",
+        failure_class=None,
+        markdown=markdown,
+        output_path=output_path,
+        source_paths=source_paths,
+    )
 
 
 def _send_smtp_email(
@@ -776,18 +851,31 @@ def _send_smtp_email(
     """Send the already-redacted markdown notification through SMTP."""
 
     config = _smtp_config()
+    smtp: Any = None
     try:
         message = EmailMessage()
         message["From"] = str(config["sender"])
         message["To"] = recipient
         message["Subject"] = subject
         message.set_content(markdown)
-        with smtplib.SMTP(str(config["host"]), int(config["port"]), timeout=15) as smtp:
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(str(config["username"]), str(config["password"]))
-            smtp.send_message(message)
+        context = ssl.create_default_context()
+        if config["tls_mode"] == "implicit":
+            smtp = smtplib.SMTP_SSL(
+                str(config["host"]), int(config["port"]), timeout=15, context=context
+            )
+        else:
+            smtp = smtplib.SMTP(str(config["host"]), int(config["port"]), timeout=15)
+            smtp.starttls(context=context)
+        smtp.login(str(config["username"]), str(config["password"]))
+        smtp.send_message(message)
     except (OSError, ValueError, smtplib.SMTPException) as exc:
         raise ExperimentEmailDeliveryError("SMTP delivery failed.") from exc
+    finally:
+        if smtp is not None:
+            try:
+                smtp.quit()
+            except (OSError, smtplib.SMTPException):
+                pass
 
 
 def _deliver_email_notification(
@@ -801,18 +889,10 @@ def _deliver_email_notification(
     """Send an explicit email notification and record a local audit artifact."""
 
     audit_path = _resolve_email_audit_path(experiment_id)
-    notification_sha256 = _sha256_text(markdown)
-    _require_email_not_already_sent(
-        audit_path=audit_path,
-        recipient=recipient,
-        notification_sha256=notification_sha256,
-    )
-    _write_email_audit(
+    _claim_email_send(
         audit_path=audit_path,
         experiment_id=experiment_id,
         recipient=recipient,
-        status="send_in_progress",
-        failure_class=None,
         markdown=markdown,
         output_path=output_path,
         source_paths=source_paths,

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -729,16 +729,22 @@ def _email_audit_payload(
     markdown: str,
     output_path: Path,
     source_paths: dict[str, Path | None],
+    source_sha256: dict[str, str | None] | None = None,
 ) -> dict[str, Any]:
     """Build a local, secret-free email delivery audit payload."""
 
+    resolved_source_sha256 = (
+        source_sha256
+        if source_sha256 is not None
+        else {key: _sha256_file(path) for key, path in sorted(source_paths.items())}
+    )
     return {
         "experiment_id": experiment_id,
         "notification_sha256": _sha256_text(markdown),
         "output_path": normalize_repo_path(output_path),
         "provider_type": "smtp",
         "recipient_hash": _recipient_hash(recipient),
-        "source_sha256": {key: _sha256_file(path) for key, path in sorted(source_paths.items())},
+        "source_sha256": resolved_source_sha256,
         "status": status,
         "failure_class": _safe_inline(failure_class or "none"),
         "timestamp": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
@@ -755,6 +761,7 @@ def _write_email_audit(
     markdown: str,
     output_path: Path,
     source_paths: dict[str, Path | None],
+    source_sha256: dict[str, str | None] | None = None,
 ) -> None:
     """Write a local, secret-free email delivery audit artifact."""
 
@@ -766,6 +773,7 @@ def _write_email_audit(
         markdown=markdown,
         output_path=output_path,
         source_paths=source_paths,
+        source_sha256=source_sha256,
     )
     audit_path.parent.mkdir(parents=True, exist_ok=True)
     audit_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -779,6 +787,7 @@ def _claim_email_send(
     markdown: str,
     output_path: Path,
     source_paths: dict[str, Path | None],
+    source_sha256: dict[str, str | None] | None = None,
 ) -> None:
     """Atomically claim an email send before the SMTP side effect."""
 
@@ -790,6 +799,7 @@ def _claim_email_send(
         markdown=markdown,
         output_path=output_path,
         source_paths=source_paths,
+        source_sha256=source_sha256,
     )
     audit_path.parent.mkdir(parents=True, exist_ok=True)
     try:
@@ -808,16 +818,7 @@ def _claim_email_send(
         raise ExperimentEmailDeliveryError("Email notification was already sent.")
     if existing_status == "failed":
         raise ExperimentEmailDeliveryError("Existing email delivery audit blocks retry.")
-    _write_email_audit(
-        audit_path=audit_path,
-        experiment_id=experiment_id,
-        recipient=recipient,
-        status="send_in_progress",
-        failure_class=None,
-        markdown=markdown,
-        output_path=output_path,
-        source_paths=source_paths,
-    )
+    raise ExperimentEmailDeliveryError("Existing email audit artifact is invalid.")
 
 
 def _send_smtp_email(
@@ -867,6 +868,7 @@ def _deliver_email_notification(
     """Send an explicit email notification and record a local audit artifact."""
 
     audit_path = _resolve_email_audit_path(experiment_id)
+    source_sha256 = {key: _sha256_file(path) for key, path in sorted(source_paths.items())}
     _claim_email_send(
         audit_path=audit_path,
         experiment_id=experiment_id,
@@ -874,6 +876,7 @@ def _deliver_email_notification(
         markdown=markdown,
         output_path=output_path,
         source_paths=source_paths,
+        source_sha256=source_sha256,
     )
     try:
         _send_smtp_email(
@@ -891,6 +894,7 @@ def _deliver_email_notification(
             markdown=markdown,
             output_path=output_path,
             source_paths=source_paths,
+            source_sha256=source_sha256,
         )
         raise
     _write_email_audit(
@@ -902,6 +906,7 @@ def _deliver_email_notification(
         markdown=markdown,
         output_path=output_path,
         source_paths=source_paths,
+        source_sha256=source_sha256,
     )
     return audit_path
 

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -124,10 +124,11 @@ def _resolve_output_path(raw_output: str | None, experiment_id: str) -> Path:
     return candidate
 
 
-def _resolve_email_audit_path(output_path: Path) -> Path:
-    """Resolve the email audit artifact beside the notification markdown."""
+def _resolve_email_audit_path(experiment_id: str) -> Path:
+    """Resolve the canonical email audit artifact for an experiment."""
 
-    audit_path = output_path.with_name(f"{output_path.stem}.email-audit.json")
+    safe_experiment_id = validate_experiment_id(experiment_id, label="Experiment notification")
+    audit_path = NOTIFICATION_ARTIFACT_DIR / f"{safe_experiment_id}.email-audit.json"
     _reject_symlinked_output_components(
         audit_path.absolute(),
         artifact_dir=NOTIFICATION_ARTIFACT_DIR.absolute(),
@@ -202,14 +203,6 @@ def _require_matching_experiment(
     if result["status"] == "accepted" and promotion["disposition"] != "promoted":
         raise ExperimentNotificationError(
             "Accepted experiment results must have promotion disposition promoted."
-        )
-    if (
-        result["status"] == "accepted"
-        and promotion["disposition"] == "promoted"
-        and not result["promotion_ready"]
-    ):
-        raise ExperimentNotificationError(
-            "Accepted promoted experiment results must be promotion_ready."
         )
     if result["status"] == "rejected":
         if packet["promotion_target"] != "backlog_entry":
@@ -736,9 +729,10 @@ def _require_email_not_already_sent(
     existing = _read_existing_email_audit(audit_path)
     if existing is None:
         return
+    if existing.get("status") not in {"sent", "send_in_progress"}:
+        return
     if (
-        existing.get("status") == "sent"
-        and existing.get("recipient_hash") == _recipient_hash(recipient)
+        existing.get("recipient_hash") == _recipient_hash(recipient)
         and existing.get("notification_sha256") == notification_sha256
     ):
         raise ExperimentEmailDeliveryError("Email notification was already sent.")
@@ -805,7 +799,7 @@ def _deliver_email_notification(
 ) -> Path:
     """Send an explicit email notification and record a local audit artifact."""
 
-    audit_path = _resolve_email_audit_path(output_path)
+    audit_path = _resolve_email_audit_path(experiment_id)
     notification_sha256 = _sha256_text(markdown)
     _require_email_not_already_sent(
         audit_path=audit_path,
@@ -816,7 +810,7 @@ def _deliver_email_notification(
         audit_path=audit_path,
         experiment_id=experiment_id,
         recipient=recipient,
-        status="pending",
+        status="send_in_progress",
         failure_class=None,
         markdown=markdown,
         output_path=output_path,
@@ -858,7 +852,10 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     parser = argparse.ArgumentParser(
         prog="experiment_notify",
-        description="Render artifact-only notifications for governed experiment results.",
+        description=(
+            "Render governed experiment notifications "
+            "(local artifact default; SMTP email explicit opt-in)."
+        ),
     )
     parser.add_argument("--packet", required=True, help="Experiment packet JSON path.")
     parser.add_argument("--result", required=True, help="Experiment result JSON path.")

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -103,6 +103,12 @@ def _result(
     }
 
 
+def _promotion_ready_result(**overrides: object) -> dict[str, object]:
+    result = _result(**overrides)
+    result["promotion_ready"] = True
+    return result
+
+
 def _promotion(*, experiment_id: str = "exp-notify") -> dict[str, object]:
     return {
         "schema_version": "1.0",
@@ -173,9 +179,57 @@ EXPECTED_NOTIFICATION = """# Experiment Result Notification: exp-notify
 
 ## Delivery Boundary
 
-- Artifact-only summary; no email, Slack, PR comment, or external delivery was sent.
+- Local artifact summary is always written; SMTP email delivery requires explicit `--email`.
+- Slack, PR comment, and other external delivery sinks are intentionally out of scope.
 - Raw patch text, oracle stdout/stderr, cwd, and local absolute paths are intentionally omitted.
 """
+
+
+class FakeSMTP:
+    sent_messages: list[object] = []
+    started_tls = False
+    login_args: tuple[str, str] | None = None
+
+    def __init__(self, host: str, port: int, timeout: int) -> None:
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+    def __enter__(self) -> "FakeSMTP":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+    def starttls(self, context: object | None = None) -> None:
+        assert context is not None
+        FakeSMTP.started_tls = True
+
+    def login(self, username: str, password: str) -> None:
+        FakeSMTP.login_args = (username, password)
+
+    def send_message(self, message: object) -> None:
+        FakeSMTP.sent_messages.append(message)
+
+
+class FailingSMTP(FakeSMTP):
+    def send_message(self, message: object) -> None:
+        raise OSError("/Users/alice/.ssh/id_rsa smtp failure")
+
+
+def _configure_smtp_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_EMAIL_ALLOWLIST", "pulseplate@pm.me")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_HOST", "smtp.example.test")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_PORT", "587")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_USERNAME", "smtp-user")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_PASSWORD", "smtp-secret")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_EMAIL_FROM", "runner@example.test")
+
+
+def _reset_fake_smtp() -> None:
+    FakeSMTP.sent_messages = []
+    FakeSMTP.started_tls = False
+    FakeSMTP.login_args = None
 
 
 def test_main_writes_deterministic_notification(
@@ -186,7 +240,7 @@ def test_main_writes_deterministic_notification(
     repo = _init_repo(tmp_path)
     _configure_repo(monkeypatch, repo)
     packet_path = _write_json(tmp_path / "packet.json", _packet())
-    result_path = _write_json(tmp_path / "result.json", _result())
+    result_path = _write_json(tmp_path / "result.json", _promotion_ready_result())
 
     exit_code = experiment_notify.main(["--packet", str(packet_path), "--result", str(result_path)])
     stdout = capsys.readouterr().out
@@ -198,6 +252,8 @@ def test_main_writes_deterministic_notification(
     content = output.read_text(encoding="utf-8")
     assert content == EXPECTED_NOTIFICATION
     assert json.loads(stdout) == {
+        "email": False,
+        "email_audit": None,
         "experiment_id": "exp-notify",
         "github_step_summary": False,
         "output": "artifacts/orchestration/experiments/notifications/exp-notify.md",
@@ -212,6 +268,413 @@ def test_main_writes_deterministic_notification(
     assert output.read_text(encoding="utf-8") == EXPECTED_NOTIFICATION
 
 
+def test_default_notification_does_not_send_email(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    monkeypatch.setenv(
+        "EXPERIMENT_NOTIFICATION_EMAIL_ALLOWLIST",
+        "pulseplate@pm.me,other@example.test",
+    )
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FakeSMTP)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _promotion_ready_result())
+
+    exit_code = experiment_notify.main(["--packet", str(packet_path), "--result", str(result_path)])
+
+    assert exit_code == 0
+    assert FakeSMTP.sent_messages == []
+    assert not (
+        repo
+        / "artifacts"
+        / "orchestration"
+        / "experiments"
+        / "notifications"
+        / "exp-notify.email-audit.json"
+    ).exists()
+
+
+def test_email_requires_explicit_recipient_allowlist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _promotion_ready_result())
+
+    missing_recipient = experiment_notify.main(
+        ["--packet", str(packet_path), "--result", str(result_path), "--email"]
+    )
+    missing_output = capsys.readouterr().out
+    unlisted_recipient = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--email",
+            "--email-to",
+            "other@example.test",
+        ]
+    )
+    unlisted_output = capsys.readouterr().out
+    email_to_without_flag = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--email-to",
+            "pulseplate@pm.me",
+        ]
+    )
+    email_to_output = capsys.readouterr().out
+
+    assert missing_recipient == 1
+    assert "--email requires --email-to" in missing_output
+    assert unlisted_recipient == 1
+    assert "not an allowed recipient" in unlisted_output
+    assert "other@example.test" not in unlisted_output
+    assert email_to_without_flag == 1
+    assert "--email-to requires --email" in email_to_output
+
+
+def test_email_delivery_accepts_pulseplate_recipient_and_writes_audit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FakeSMTP)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _promotion_ready_result())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--email",
+            "--email-to",
+            "pulseplate@pm.me",
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert FakeSMTP.started_tls
+    assert FakeSMTP.login_args == ("smtp-user", "smtp-secret")
+    assert len(FakeSMTP.sent_messages) == 1
+    message = FakeSMTP.sent_messages[0]
+    assert message["To"] == "pulseplate@pm.me"
+    assert message["From"] == "runner@example.test"
+    body = message.get_content()
+    assert body == EXPECTED_NOTIFICATION
+    assert "secret stdout" not in body
+    assert "secret stderr" not in body
+    assert "/Users/example" not in body
+
+    audit_path = (
+        repo
+        / "artifacts"
+        / "orchestration"
+        / "experiments"
+        / "notifications"
+        / "exp-notify.email-audit.json"
+    )
+    audit = json.loads(audit_path.read_text(encoding="utf-8"))
+    assert audit["experiment_id"] == "exp-notify"
+    assert audit["notification_sha256"] == experiment_notify._sha256_text(EXPECTED_NOTIFICATION)
+    assert audit["output_path"] == (
+        "artifacts/orchestration/experiments/notifications/exp-notify.md"
+    )
+    assert audit["provider_type"] == "smtp"
+    assert audit["status"] == "sent"
+    assert audit["failure_class"] == "none"
+    assert audit["recipient_hash"] == experiment_notify._recipient_hash("pulseplate@pm.me")
+    assert set(audit["source_sha256"]) == {"packet", "promotion", "result"}
+    assert audit["source_sha256"]["packet"] is not None
+    assert audit["source_sha256"]["result"] is not None
+    assert audit["source_sha256"]["promotion"] is None
+    assert "pulseplate@pm.me" not in audit_path.read_text(encoding="utf-8")
+    assert "smtp-secret" not in audit_path.read_text(encoding="utf-8")
+
+    payload = json.loads(stdout)
+    assert payload["email"] is True
+    assert payload["email_audit"] == (
+        "artifacts/orchestration/experiments/notifications/exp-notify.email-audit.json"
+    )
+
+
+def test_missing_smtp_config_fails_closed_without_leaking_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_EMAIL_ALLOWLIST", "pulseplate@pm.me")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_HOST", "/Users/alice/.ssh/id_rsa")
+    monkeypatch.delenv("EXPERIMENT_NOTIFICATION_SMTP_PORT", raising=False)
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_USERNAME", "smtp-user")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_PASSWORD", "smtp-secret")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_EMAIL_FROM", "runner@example.test")
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--email",
+            "--email-to",
+            "pulseplate@pm.me",
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "SMTP configuration is incomplete" in stdout
+    assert "/Users/alice" not in stdout
+    assert "id_rsa" not in stdout
+    assert "smtp-secret" not in stdout
+    audit = json.loads(
+        (
+            repo
+            / "artifacts"
+            / "orchestration"
+            / "experiments"
+            / "notifications"
+            / "exp-notify.email-audit.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert audit["status"] == "failed"
+    assert audit["failure_class"] == "email_delivery_failed"
+
+
+def test_invalid_smtp_config_fails_closed_without_leaking_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_PORT", "not-a-port")
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--email",
+            "--email-to",
+            "pulseplate@pm.me",
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "SMTP configuration is invalid" in stdout
+    assert "not-a-port" not in stdout
+    assert "smtp-secret" not in stdout
+
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_PORT", "70000")
+    with pytest.raises(
+        experiment_notify.ExperimentEmailDeliveryError,
+        match="SMTP configuration is invalid",
+    ):
+        experiment_notify._smtp_config()
+
+
+def test_invalid_email_sender_is_sanitized_and_audited(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_EMAIL_FROM", "bad\nfrom@example.test")
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--email",
+            "--email-to",
+            "pulseplate@pm.me",
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "SMTP sender is invalid" in stdout
+    assert "bad" not in stdout
+    assert "from@example" not in stdout
+    audit = json.loads(
+        (
+            repo
+            / "artifacts"
+            / "orchestration"
+            / "experiments"
+            / "notifications"
+            / "exp-notify.email-audit.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert audit["status"] == "failed"
+    assert audit["failure_class"] == "email_delivery_failed"
+
+
+def test_email_recipient_control_characters_are_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--email",
+            "--email-to",
+            "pulseplate@pm.me\nbcc@example.test",
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "not an allowed recipient" in stdout
+    assert "bcc@example" not in stdout
+
+
+def test_email_audit_must_be_writable_before_send(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FakeSMTP)
+    audit_dir = (
+        repo
+        / "artifacts"
+        / "orchestration"
+        / "experiments"
+        / "notifications"
+        / "exp-notify.email-audit.json"
+    )
+    audit_dir.mkdir(parents=True)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--email",
+            "--email-to",
+            "pulseplate@pm.me",
+        ]
+    )
+
+    assert exit_code == 1
+    assert FakeSMTP.sent_messages == []
+
+
+def test_email_delivery_is_idempotent_for_sent_audit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FakeSMTP)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+    argv = [
+        "--packet",
+        str(packet_path),
+        "--result",
+        str(result_path),
+        "--email",
+        "--email-to",
+        "pulseplate@pm.me",
+    ]
+
+    assert experiment_notify.main(argv) == 0
+    capsys.readouterr()
+    assert experiment_notify.main(argv) == 1
+    stdout = capsys.readouterr().out
+
+    assert "already sent" in stdout
+    assert len(FakeSMTP.sent_messages) == 1
+
+
+def test_smtp_provider_failure_is_sanitized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FailingSMTP)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _promotion_ready_result())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--email",
+            "--email-to",
+            "pulseplate@pm.me",
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "SMTP delivery failed" in stdout
+    assert "/Users/alice" not in stdout
+    assert "id_rsa" not in stdout
+    assert "smtp-secret" not in stdout
+
+
 def test_notification_includes_promotion_decision(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -220,7 +683,7 @@ def test_notification_includes_promotion_decision(
     _configure_repo(monkeypatch, repo)
     _write_audit_artifact(repo)
     packet_path = _write_json(tmp_path / "packet.json", _packet())
-    result_path = _write_json(tmp_path / "result.json", _result())
+    result_path = _write_json(tmp_path / "result.json", _promotion_ready_result())
     promotion_path = _write_json(tmp_path / "promotion.json", _promotion())
 
     exit_code = experiment_notify.main(
@@ -271,7 +734,7 @@ def test_invalid_promotion_decision_is_rejected(
     match: str,
 ) -> None:
     packet = experiment_contract.validate_experiment_packet(_packet())
-    result = experiment_contract.validate_experiment_result(_result())
+    result = experiment_contract.validate_experiment_result(_promotion_ready_result())
 
     with pytest.raises((ValueError, experiment_notify.ExperimentNotificationError), match=match):
         promotion = experiment_notify._validate_promotion_decision({**_promotion(), **override})
@@ -322,6 +785,24 @@ def test_promoted_accepted_result_with_dirty_shared_tree_is_rejected() -> None:
         experiment_notify.render_notification_markdown(packet, result, promotion)
 
 
+def test_promoted_accepted_result_must_be_promotion_ready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _write_audit_artifact(repo)
+    packet = experiment_contract.validate_experiment_packet(_packet())
+    result = experiment_contract.validate_experiment_result(_result())
+    promotion = experiment_notify._validate_promotion_decision(_promotion())
+
+    with pytest.raises(
+        experiment_notify.ExperimentNotificationError,
+        match="promotion_ready",
+    ):
+        experiment_notify.render_notification_markdown(packet, result, promotion)
+
+
 def test_accepted_result_must_include_packet_oracle_results() -> None:
     packet = experiment_contract.validate_experiment_packet(
         _packet()
@@ -347,7 +828,7 @@ def test_result_evidence_must_stay_within_packet_mutable_surface() -> None:
     packet = experiment_contract.validate_experiment_packet(
         _packet() | {"mutable_candidate_surface": ["core/rag/allowed.py"]}
     )
-    result = experiment_contract.validate_experiment_result(_result())
+    result = experiment_contract.validate_experiment_result(_promotion_ready_result())
     result["mutated_paths"] = ["core/rag/other.py"]
 
     with pytest.raises(
@@ -413,7 +894,7 @@ def test_result_evidence_rejects_nested_paths_under_file_surface() -> None:
     packet = experiment_contract.validate_experiment_packet(
         _packet() | {"mutable_candidate_surface": ["core/rag/allowed.py"]}
     )
-    result = experiment_contract.validate_experiment_result(_result())
+    result = experiment_contract.validate_experiment_result(_promotion_ready_result())
     result["mutated_paths"] = ["core/rag/allowed.py/child.py"]
 
     with pytest.raises(
@@ -433,7 +914,7 @@ def test_result_evidence_rejects_nested_paths_under_extensionless_file_surface(
     packet = experiment_contract.validate_experiment_packet(
         _packet() | {"mutable_candidate_surface": ["core/rag/runner"]}
     )
-    result = experiment_contract.validate_experiment_result(_result())
+    result = experiment_contract.validate_experiment_result(_promotion_ready_result())
     result["mutated_paths"] = ["core/rag/runner/child.py"]
 
     with pytest.raises(
@@ -447,7 +928,7 @@ def test_result_evidence_allows_new_extensionless_directory_surface() -> None:
     packet = experiment_contract.validate_experiment_packet(
         _packet() | {"mutable_candidate_surface": ["core/rag/new_feature"]}
     )
-    result = experiment_contract.validate_experiment_result(_result())
+    result = experiment_contract.validate_experiment_result(_promotion_ready_result())
     result["mutated_paths"] = ["core/rag/new_feature/impl.py"]
 
     content = experiment_notify.render_notification_markdown(packet, result)
@@ -459,7 +940,7 @@ def test_result_evidence_rejects_traversal_under_directory_surface() -> None:
     packet = experiment_contract.validate_experiment_packet(
         _packet() | {"mutable_candidate_surface": ["core/rag/new_feature"]}
     )
-    result = experiment_contract.validate_experiment_result(_result())
+    result = experiment_contract.validate_experiment_result(_promotion_ready_result())
     result["mutated_paths"] = ["core/rag/new_feature/../../docs/orchestration/workflow.md"]
 
     with pytest.raises(
@@ -499,7 +980,7 @@ def test_result_oracle_commands_must_come_from_packet() -> None:
 
 def test_outside_surface_diagnostic_redacts_mutated_paths() -> None:
     packet = experiment_contract.validate_experiment_packet(_packet())
-    result = experiment_contract.validate_experiment_result(_result())
+    result = experiment_contract.validate_experiment_result(_promotion_ready_result())
     result["mutated_paths"] = ["/Users/alice/.ssh/id_rsa"]
 
     with pytest.raises(
@@ -515,7 +996,7 @@ def test_outside_surface_diagnostic_redacts_mutated_paths() -> None:
 
 def test_accepted_result_with_failed_oracle_is_rejected() -> None:
     packet = experiment_contract.validate_experiment_packet(_packet())
-    result = experiment_contract.validate_experiment_result(_result())
+    result = experiment_contract.validate_experiment_result(_promotion_ready_result())
     result["oracle_results"][0]["returncode"] = 1
 
     with pytest.raises(
@@ -748,7 +1229,7 @@ def test_promoted_durable_artifact_must_exist(
     repo = _init_repo(tmp_path)
     _configure_repo(monkeypatch, repo)
     packet = experiment_contract.validate_experiment_packet(_packet())
-    result = experiment_contract.validate_experiment_result(_result())
+    result = experiment_contract.validate_experiment_result(_promotion_ready_result())
     promotion = experiment_notify._validate_promotion_decision(_promotion())
 
     with pytest.raises(
@@ -881,7 +1362,7 @@ def test_notification_redacts_raw_outputs_patch_and_local_paths(
     _configure_repo(monkeypatch, repo)
     _write_audit_artifact(repo)
     packet = experiment_contract.validate_experiment_packet(_packet())
-    result = experiment_contract.validate_experiment_result(_result())
+    result = experiment_contract.validate_experiment_result(_promotion_ready_result())
     promotion = experiment_notify._validate_promotion_decision(
         {
             **_promotion(),

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -190,6 +190,7 @@ class FakeSMTP:
     sent_messages: list[object] = []
     started_tls = False
     login_args: tuple[str, str] | None = None
+    quit_called = False
 
     def __init__(self, host: str, port: int, timeout: int) -> None:
         self.host = host
@@ -212,10 +213,31 @@ class FakeSMTP:
     def send_message(self, message: object) -> None:
         FakeSMTP.sent_messages.append(message)
 
+    def quit(self) -> None:
+        FakeSMTP.quit_called = True
+
 
 class FailingSMTP(FakeSMTP):
     def send_message(self, message: object) -> None:
         raise OSError("/Users/alice/.ssh/id_rsa smtp failure")
+
+
+class FakeSMTPSSL(FakeSMTP):
+    used = False
+
+    def __init__(self, host: str, port: int, timeout: int, context: object) -> None:
+        super().__init__(host, port, timeout)
+        assert context is not None
+        FakeSMTPSSL.used = True
+
+    def starttls(self, context: object | None = None) -> None:
+        raise AssertionError("implicit TLS must not call starttls")
+
+
+class QuitFailingSMTP(FakeSMTP):
+    def quit(self) -> None:
+        FakeSMTP.quit_called = True
+        raise OSError("smtp quit failed after accepted message")
 
 
 def _configure_smtp_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -231,6 +253,8 @@ def _reset_fake_smtp() -> None:
     FakeSMTP.sent_messages = []
     FakeSMTP.started_tls = False
     FakeSMTP.login_args = None
+    FakeSMTP.quit_called = False
+    FakeSMTPSSL.used = False
 
 
 def test_main_writes_deterministic_notification(
@@ -753,6 +777,115 @@ def test_email_delivery_blocks_retry_when_sent_audit_write_fails(
         ).read_text(encoding="utf-8")
     )
     assert audit["status"] == "send_in_progress"
+
+
+def test_stale_email_send_claim_can_be_reclaimed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    notification_dir = _configure_repo(monkeypatch, repo)
+    audit_path = notification_dir / "exp-notify.email-audit.json"
+    old_timestamp = "2026-05-13T00:00:00+00:00"
+    audit_path.parent.mkdir(parents=True)
+    audit_path.write_text(
+        json.dumps(
+            {
+                "experiment_id": "exp-notify",
+                "failure_class": "none",
+                "notification_sha256": experiment_notify._sha256_text(EXPECTED_NOTIFICATION),
+                "output_path": "artifacts/orchestration/experiments/notifications/exp-notify.md",
+                "provider_type": "smtp",
+                "recipient_hash": experiment_notify._recipient_hash("pulseplate@pm.me"),
+                "source_sha256": {"packet": None, "promotion": None, "result": None},
+                "status": "send_in_progress",
+                "timestamp": old_timestamp,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    _write_json(tmp_path / "packet.json", _packet())
+    _write_json(tmp_path / "result.json", _result())
+    experiment_notify._claim_email_send(
+        audit_path=audit_path,
+        experiment_id="exp-notify",
+        recipient="pulseplate@pm.me",
+        markdown=EXPECTED_NOTIFICATION,
+        output_path=notification_dir / "exp-notify.md",
+        source_paths={"packet": None, "promotion": None, "result": None},
+    )
+
+    audit = json.loads(audit_path.read_text(encoding="utf-8"))
+    assert audit["status"] == "send_in_progress"
+    assert audit["timestamp"] != old_timestamp
+
+
+def test_smtp_implicit_tls_uses_smtp_ssl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_repo(tmp_path)
+    _configure_smtp_env(monkeypatch)
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_PORT", "465")
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FakeSMTP)
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP_SSL", FakeSMTPSSL)
+
+    experiment_notify._send_smtp_email(
+        recipient="pulseplate@pm.me",
+        subject="subject",
+        markdown=EXPECTED_NOTIFICATION,
+    )
+
+    assert FakeSMTPSSL.used
+    assert not FakeSMTP.started_tls
+    assert len(FakeSMTP.sent_messages) == 1
+
+
+def test_smtp_quit_failure_after_send_keeps_delivery_successful(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", QuitFailingSMTP)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--email",
+            "--email-to",
+            "pulseplate@pm.me",
+        ]
+    )
+    capsys.readouterr()
+
+    assert exit_code == 0
+    assert FakeSMTP.quit_called
+    assert len(FakeSMTP.sent_messages) == 1
+    audit = json.loads(
+        (
+            repo
+            / "artifacts"
+            / "orchestration"
+            / "experiments"
+            / "notifications"
+            / "exp-notify.email-audit.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert audit["status"] == "sent"
 
 
 def test_smtp_provider_failure_is_sanitized(

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -724,6 +724,43 @@ def test_email_delivery_is_idempotent_across_output_paths(
     ).is_file()
 
 
+def test_email_delivery_is_idempotent_for_experiment_id_when_markdown_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FakeSMTP)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+    argv = [
+        "--packet",
+        str(packet_path),
+        "--result",
+        str(result_path),
+        "--email",
+        "--email-to",
+        "pulseplate@pm.me",
+    ]
+
+    first_exit = experiment_notify.main(argv)
+    capsys.readouterr()
+    _write_json(
+        result_path,
+        _result(status="rejected", failure_class="guard_failure"),
+    )
+    second_exit = experiment_notify.main(argv)
+    stdout = capsys.readouterr().out
+
+    assert first_exit == 0
+    assert second_exit == 1
+    assert "already sent" in stdout
+    assert len(FakeSMTP.sent_messages) == 1
+
+
 def test_email_delivery_blocks_retry_when_sent_audit_write_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -779,7 +816,7 @@ def test_email_delivery_blocks_retry_when_sent_audit_write_fails(
     assert audit["status"] == "send_in_progress"
 
 
-def test_stale_email_send_claim_can_be_reclaimed(
+def test_stale_email_send_claim_blocks_retry(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -810,18 +847,19 @@ def test_stale_email_send_claim_can_be_reclaimed(
 
     _write_json(tmp_path / "packet.json", _packet())
     _write_json(tmp_path / "result.json", _result())
-    experiment_notify._claim_email_send(
-        audit_path=audit_path,
-        experiment_id="exp-notify",
-        recipient="pulseplate@pm.me",
-        markdown=EXPECTED_NOTIFICATION,
-        output_path=notification_dir / "exp-notify.md",
-        source_paths={"packet": None, "promotion": None, "result": None},
-    )
+    with pytest.raises(experiment_notify.ExperimentEmailDeliveryError, match="already sent"):
+        experiment_notify._claim_email_send(
+            audit_path=audit_path,
+            experiment_id="exp-notify",
+            recipient="pulseplate@pm.me",
+            markdown=EXPECTED_NOTIFICATION,
+            output_path=notification_dir / "exp-notify.md",
+            source_paths={"packet": None, "promotion": None, "result": None},
+        )
 
     audit = json.loads(audit_path.read_text(encoding="utf-8"))
     assert audit["status"] == "send_in_progress"
-    assert audit["timestamp"] != old_timestamp
+    assert audit["timestamp"] == old_timestamp
 
 
 def test_smtp_implicit_tls_uses_smtp_ssl(

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -862,6 +862,83 @@ def test_stale_email_send_claim_blocks_retry(
     assert audit["timestamp"] == old_timestamp
 
 
+def test_failed_email_audit_blocks_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    notification_dir = _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FakeSMTP)
+    audit_path = notification_dir / "exp-notify.email-audit.json"
+    _write_json(tmp_path / "packet.json", _packet())
+    _write_json(tmp_path / "result.json", _result())
+    experiment_notify._write_email_audit(
+        audit_path=audit_path,
+        experiment_id="exp-notify",
+        recipient="pulseplate@pm.me",
+        status="failed",
+        failure_class="smtp_error",
+        markdown=EXPECTED_NOTIFICATION,
+        output_path=notification_dir / "exp-notify.md",
+        source_paths={"packet": None, "promotion": None, "result": None},
+    )
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(tmp_path / "packet.json"),
+            "--result",
+            str(tmp_path / "result.json"),
+            "--email",
+            "--email-to",
+            "pulseplate@pm.me",
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "delivery audit blocks retry" in stdout
+    assert FakeSMTP.sent_messages == []
+    assert json.loads(audit_path.read_text(encoding="utf-8"))["status"] == "failed"
+
+
+def test_invalid_utf8_email_audit_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    notification_dir = _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FakeSMTP)
+    audit_path = notification_dir / "exp-notify.email-audit.json"
+    audit_path.parent.mkdir(parents=True)
+    audit_path.write_bytes(b"\xff\xfe\x00")
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--email",
+            "--email-to",
+            "pulseplate@pm.me",
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Existing email audit artifact is invalid" in stdout
+    assert FakeSMTP.sent_messages == []
+
+
 def test_smtp_implicit_tls_uses_smtp_ssl(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -748,6 +748,10 @@ def test_email_delivery_is_idempotent_for_experiment_id_when_markdown_changes(
 
     first_exit = experiment_notify.main(argv)
     capsys.readouterr()
+    notification_path = (
+        repo / "artifacts" / "orchestration" / "experiments" / "notifications" / "exp-notify.md"
+    )
+    original_notification = notification_path.read_text(encoding="utf-8")
     _write_json(
         result_path,
         _result(status="rejected", failure_class="guard_failure"),
@@ -759,6 +763,7 @@ def test_email_delivery_is_idempotent_for_experiment_id_when_markdown_changes(
     assert second_exit == 1
     assert "already sent" in stdout
     assert len(FakeSMTP.sent_messages) == 1
+    assert notification_path.read_text(encoding="utf-8") == original_notification
 
 
 def test_email_delivery_blocks_retry_when_sent_audit_write_fails(

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -939,6 +939,93 @@ def test_invalid_utf8_email_audit_fails_closed(
     assert FakeSMTP.sent_messages == []
 
 
+def test_unknown_email_audit_status_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    notification_dir = _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FakeSMTP)
+    audit_path = notification_dir / "exp-notify.email-audit.json"
+    audit_path.parent.mkdir(parents=True)
+    audit_path.write_text(
+        json.dumps(
+            {
+                "experiment_id": "exp-notify",
+                "failure_class": "none",
+                "notification_sha256": experiment_notify._sha256_text(EXPECTED_NOTIFICATION),
+                "output_path": "artifacts/orchestration/experiments/notifications/exp-notify.md",
+                "provider_type": "smtp",
+                "recipient_hash": experiment_notify._recipient_hash("pulseplate@pm.me"),
+                "source_sha256": {"packet": None, "promotion": None, "result": None},
+                "status": "delivered",
+                "timestamp": "2026-05-13T00:00:00+00:00",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--email",
+            "--email-to",
+            "pulseplate@pm.me",
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Existing email audit artifact is invalid" in stdout
+    assert FakeSMTP.sent_messages == []
+
+
+def test_email_audit_source_hashes_match_rendered_sources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    notification_dir = _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+    original_result_hash = experiment_notify._sha256_file(result_path)
+
+    def mutate_result_after_claim(**_: Any) -> None:
+        _write_json(result_path, _result(status="rejected", failure_class="guard_failure"))
+
+    monkeypatch.setattr(experiment_notify, "_send_smtp_email", mutate_result_after_claim)
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--email",
+            "--email-to",
+            "pulseplate@pm.me",
+        ]
+    )
+
+    audit = json.loads((notification_dir / "exp-notify.email-audit.json").read_text())
+    assert exit_code == 0
+    assert audit["status"] == "sent"
+    assert audit["source_sha256"]["result"] == original_result_hash
+    assert audit["source_sha256"]["result"] != experiment_notify._sha256_file(result_path)
+
+
 def test_smtp_implicit_tls_uses_smtp_ssl(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+from typing import Any
 
 import pytest
 
@@ -643,6 +644,117 @@ def test_email_delivery_is_idempotent_for_sent_audit(
     assert len(FakeSMTP.sent_messages) == 1
 
 
+def test_email_delivery_is_idempotent_across_output_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FakeSMTP)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+
+    first_exit = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--output",
+            "first.md",
+            "--email",
+            "--email-to",
+            "pulseplate@pm.me",
+        ]
+    )
+    capsys.readouterr()
+    second_exit = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--output",
+            "nested/second.md",
+            "--email",
+            "--email-to",
+            "pulseplate@pm.me",
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert first_exit == 0
+    assert second_exit == 1
+    assert "already sent" in stdout
+    assert len(FakeSMTP.sent_messages) == 1
+    assert (
+        repo
+        / "artifacts"
+        / "orchestration"
+        / "experiments"
+        / "notifications"
+        / "exp-notify.email-audit.json"
+    ).is_file()
+
+
+def test_email_delivery_blocks_retry_when_sent_audit_write_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FakeSMTP)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _result())
+    original_write_audit = experiment_notify._write_email_audit
+
+    def fail_final_sent_audit(**kwargs: Any) -> None:
+        if kwargs["status"] == "sent":
+            raise OSError("/Users/alice/full-disk")
+        original_write_audit(**kwargs)
+
+    argv = [
+        "--packet",
+        str(packet_path),
+        "--result",
+        str(result_path),
+        "--email",
+        "--email-to",
+        "pulseplate@pm.me",
+    ]
+    monkeypatch.setattr(experiment_notify, "_write_email_audit", fail_final_sent_audit)
+
+    first_exit = experiment_notify.main(argv)
+    first_stdout = capsys.readouterr().out
+    monkeypatch.setattr(experiment_notify, "_write_email_audit", original_write_audit)
+    second_exit = experiment_notify.main(argv)
+    second_stdout = capsys.readouterr().out
+
+    assert first_exit == 1
+    assert "unable to write experiment notification" in first_stdout
+    assert "/Users/alice" not in first_stdout
+    assert second_exit == 1
+    assert "already sent" in second_stdout
+    assert len(FakeSMTP.sent_messages) == 1
+    audit = json.loads(
+        (
+            repo
+            / "artifacts"
+            / "orchestration"
+            / "experiments"
+            / "notifications"
+            / "exp-notify.email-audit.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert audit["status"] == "send_in_progress"
+
+
 def test_smtp_provider_failure_is_sanitized(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -675,7 +787,7 @@ def test_smtp_provider_failure_is_sanitized(
     assert "smtp-secret" not in stdout
 
 
-def test_notification_includes_promotion_decision(
+def test_notification_includes_promotion_decision_from_promote_output(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -683,7 +795,7 @@ def test_notification_includes_promotion_decision(
     _configure_repo(monkeypatch, repo)
     _write_audit_artifact(repo)
     packet_path = _write_json(tmp_path / "packet.json", _packet())
-    result_path = _write_json(tmp_path / "result.json", _promotion_ready_result())
+    result_path = _write_json(tmp_path / "result.json", _result())
     promotion_path = _write_json(tmp_path / "promotion.json", _promotion())
 
     exit_code = experiment_notify.main(
@@ -781,24 +893,6 @@ def test_promoted_accepted_result_with_dirty_shared_tree_is_rejected() -> None:
     with pytest.raises(
         experiment_notify.ExperimentNotificationError,
         match="shared_tree_untouched must be true",
-    ):
-        experiment_notify.render_notification_markdown(packet, result, promotion)
-
-
-def test_promoted_accepted_result_must_be_promotion_ready(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    repo = _init_repo(tmp_path)
-    _configure_repo(monkeypatch, repo)
-    _write_audit_artifact(repo)
-    packet = experiment_contract.validate_experiment_packet(_packet())
-    result = experiment_contract.validate_experiment_result(_result())
-    promotion = experiment_notify._validate_promotion_decision(_promotion())
-
-    with pytest.raises(
-        experiment_notify.ExperimentNotificationError,
-        match="promotion_ready",
     ):
         experiment_notify.render_notification_markdown(packet, result, promotion)
 
@@ -1564,7 +1658,9 @@ def test_module_cli_shows_help() -> None:
     )
 
     assert completed.returncode == 0
-    assert "Render artifact-only notifications" in completed.stdout
+    assert "Render governed experiment notifications" in completed.stdout
+    assert "SMTP email" in completed.stdout
+    assert "explicit opt-in" in completed.stdout
 
 
 def test_direct_script_invocation_fails_without_repo_pythonpath() -> None:


### PR DESCRIPTION
## Goal
Add explicit SMTP email delivery for governed experiment notification summaries while preserving artifact-first behavior and redaction boundaries.

## Business reason
Experiment results need an optional operator delivery path to pulseplate@pm.me without treating public git attribution email as a result-delivery channel.

## Scope
- Extend `experiment_notify` with explicit `--email` / `--email-to` SMTP delivery.
- Restrict v1 recipient to `pulseplate@pm.me` when present in `EXPERIMENT_NOTIFICATION_EMAIL_ALLOWLIST`.
- Keep local markdown artifact output as the default behavior.
- Add secret-free email audit artifacts with recipient hash, notification hash, source artifact hashes, status, provider type, and sanitized failure class.
- Update experimentation protocol and scripts scoped guidance.

## Out of scope
- Slack delivery.
- GitHub PR comments.
- General notification infrastructure.
- Committing SMTP credentials or sender secrets.

## Key decisions
- SMTP is env-configured only: `EXPERIMENT_NOTIFICATION_SMTP_HOST`, `EXPERIMENT_NOTIFICATION_SMTP_PORT`, `EXPERIMENT_NOTIFICATION_SMTP_USERNAME`, `EXPERIMENT_NOTIFICATION_SMTP_PASSWORD`, `EXPERIMENT_NOTIFICATION_EMAIL_FROM`.
- Email delivery requires explicit `--email` and `--email-to`.
- Duplicate sends are blocked by canonical experiment-id audit evidence, not caller-controlled output paths or notification body hashes.
- A `send_in_progress` claim is written before SMTP send; existing `sent` or `send_in_progress` audit records fail closed for that experiment id to prevent ambiguous duplicate delivery.
- SMTP port `465` uses implicit TLS; other ports use explicit STARTTLS.
- Email body is only the already-redacted markdown notification.

## Coordinator / agent flow
- Preflight and agent consistency passed.
- Coordinator bootstrap packet: `artifacts/orchestration/task_packets/experiment_email_notification_sink_preopen.json`.
- Post-open bootstrap packet: `artifacts/orchestration/task_packets/experiment_email_notification_sink_pr1751_postopen.json`.
- Declared role coverage: `agent-coordinator`, `security-auditor`, `backend-engineer`, `qa-engineer-agent`, `bug-hunter`, `data-scientist`, `pulseplate-premortem-risk-review`, Codex Security scan.
- Premortem/security/QA/bug/data findings fixed where valid: idempotency, audit-before-send, sender validation, promotion result compatibility, evidence hashes, SMTP negative tests, atomic send claim, implicit TLS, QUIT-after-send handling, lifecycle notify alignment, experiment-id duplicate-send fail-closed behavior, notification completion-gate alignment, failed-audit retry blocking, invalid audit sanitization, source-hash binding, unknown-status fail-closed handling, and pre-write audit duplicate checks.
- Codex Security diff scan: no reportable findings.

## Split Justification
This security-governed notification boundary is intentionally kept in one PR because the CLI behavior, redacted email body, audit evidence, docs contract, and regression tests must change together to prove that no unredacted experiment data or SMTP secrets can leave the artifact boundary. Splitting code from tests/docs would create an intermediate branch state with an incomplete delivery contract; follow-up PRs remain limited to future Slack/GitHub-comment/general notification providers after this SMTP v1 boundary is reviewed.

## Tests / validation
- `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration/experiment_notify.py --path tests/test_experiment_notify.py --path docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md --path scripts/AGENTS.md` -> PASS
- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS
- `. ../../.venv/bin/activate && python -m pytest -q tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` -> PASS
- `. ../../.venv/bin/activate && ruff check scripts/orchestration/experiment_notify.py tests/test_experiment_notify.py` -> PASS
- `. ../../.venv/bin/activate && python -m mypy scripts/orchestration/experiment_notify.py --no-incremental --cache-dir=/dev/null` -> PASS
- `. ../../.venv/bin/activate && bandit -q scripts/orchestration/experiment_notify.py` -> PASS
- `make VENV_PYTHON=../../.venv/bin/python validate-changed` -> PASS
- `VENV_PYTHON=../../.venv/bin/python pre-commit run --all-files` -> PASS
- `git push` pre-push hooks: mypy changed files, pip-audit, backend pytest, full Bandit, docker build test -> PASS.

## Security notes
- No email is sent unless `--email` and an allowlisted `--email-to` are both present.
- SMTP secrets are read from env only and are not persisted.
- CLI/provider failures are sanitized.
- Audit records use recipient hash and content/source hashes, not raw recipient secrets or SMTP config.
- A prior `sent` or `send_in_progress` audit for an experiment id blocks another email attempt; operator recovery must inspect the local audit artifact instead of automatic retrying.

## Risks / rollback
Rollback is to omit `--email` or revert this PR. Artifact-only notification remains the default path.

## Main CI note
At lane start, current-head main was locally synced `0 0`, but GitHub still reported the previous main CI run `25827093414` as `in_progress` on `test-main` jobs. Operator explicitly held main on control and approved opening this PR lane; this PR must not claim merge readiness while required current-head checks, review threads, or main fallout are unresolved.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

Canonical artifact: `docs/review/PR_1751_FIXED_MAPPING.md`

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237898304 -> da8b2db703c4a9e8840524f7d5987e1da4d79463
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#pullrequestreview-4285886523 -> da8b2db703c4a9e8840524f7d5987e1da4d79463
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237901619 -> fcef53e4e53eac11ff165084a8efb08c72b0cf73
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#pullrequestreview-4285890872 -> fcef53e4e53eac11ff165084a8efb08c72b0cf73
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905243 -> da8b2db703c4a9e8840524f7d5987e1da4d79463
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905249 -> da8b2db703c4a9e8840524f7d5987e1da4d79463
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905251 -> ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3237905252 -> da8b2db703c4a9e8840524f7d5987e1da4d79463
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239524561 -> ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#pullrequestreview-4287802089 -> ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239524565 -> ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#pullrequestreview-4287893382 -> d5998b4899df9b07a6c295841f52dab27b08df51
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239603946 -> d5998b4899df9b07a6c295841f52dab27b08df51
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239534960 -> f0d39d65e5554fa8b2798dc2d4494c04cbab0b4d
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239534963 -> ebe44d4e5ead92dd7e2b0a0ba6cbe087d6a2e9c4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239605792 -> 6acfee69f276900e47c844fceb8ceb048eade324
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239605794 -> 6acfee69f276900e47c844fceb8ceb048eade324
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239605801 -> 6acfee69f276900e47c844fceb8ceb048eade324
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#pullrequestreview-4287900129 -> 6acfee69f276900e47c844fceb8ceb048eade324
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239609603 -> 6acfee69f276900e47c844fceb8ceb048eade324

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#pullrequestreview-4287936852 -> 098975392a15f195ebd92bde7d6ddcfa7a67f878
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239642435 -> 098975392a15f195ebd92bde7d6ddcfa7a67f878

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239678344 -> 5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3239684532 -> 5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#pullrequestreview-4287993553 -> 5eaadf55b1c1b46a87f0b6f7201e32b163cd1e85

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3241276490 -> 86f3871fc5b9a193917960765cafe7b31fcae0cf
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3241276501 -> 86f3871fc5b9a193917960765cafe7b31fcae0cf

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3241441065 -> 614e9389ae96098f2f0aaf38530a906a331caa90
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1751#discussion_r3241441071 -> 614e9389ae96098f2f0aaf38530a906a331caa90

## Merge Readiness

- [x] Coordinator-first preflight/bootstrap completed.
- [x] Canonical artifact exists.
- [x] Local narrow gates completed.
- [x] Latest push pre-push hooks completed.
- [ ] Current-head CI pending.
- [ ] Bot/human review pass pending.
- [ ] Mandatory wait-window pending.

## Deferred / Follow-ups
None.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Notify” stage with local markdown notification artifacts, explicit opt-in SMTP delivery via CLI, recipient allowlist validation, audit records to prevent duplicate sends, and strict redaction rules for delivered email content.

* **Documentation**
  * Updated experimentation protocol and scripts to require runtime SMTP config, clarify delivery boundaries (implicit TLS vs STARTTLS), and default artifact-only notifications.

* **Tests**
  * Expanded tests for SMTP matrix, delivery idempotency, validation, and failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1751)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



