### PR TITLE
fix(ci): migrate artifact script actions to Node 24 pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1188,7 +1188,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download coverage artifact (Python ${{ env.COVERAGE_PY }})
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.6.2
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 / Node 24
         with:
           name: coverage-xml-${{ env.COVERAGE_PY }}
           path: ./coverage-artifacts
@@ -1226,7 +1226,7 @@ jobs:
           install-mode: direct-proxy
 
       - name: Download coverage artifact (Python ${{ env.COVERAGE_PY }})
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.6.2
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 / Node 24
         with:
           name: coverage-xml-${{ env.COVERAGE_PY }}
           path: ./coverage-artifacts
@@ -1276,7 +1276,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download coverage artifact (Python ${{ env.COVERAGE_PY }})
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.6.2
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 / Node 24
         with:
           name: coverage-xml-${{ env.COVERAGE_PY }}
           path: ./coverage-artifacts
@@ -1306,21 +1306,21 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download coverage artifact (Python 3.11)
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.6.2
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 / Node 24
         with:
           name: coverage-main-xml-3.11
           path: ./coverage-artifacts/3.11
         continue-on-error: true
 
       - name: Download coverage artifact (Python 3.12)
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.6.2
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 / Node 24
         with:
           name: coverage-main-xml-3.12
           path: ./coverage-artifacts/3.12
         continue-on-error: true
 
       - name: Download coverage artifact (Python 3.13)
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.6.2
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 / Node 24
         with:
           name: coverage-main-xml-3.13
           path: ./coverage-artifacts/3.13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1196,7 +1196,7 @@ jobs:
 
       - name: Upload to Codecov
         if: ${{ hashFiles('./coverage-artifacts/coverage.xml') != '' }}
-        uses: codecov/codecov-action@af09b5e394c93991b95a5e7646aeb90c1917f78f # v5.5.1
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0 / Node 24 transitive github-script
         with:
           files: ./coverage-artifacts/coverage.xml
           fail_ci_if_error: false
@@ -1284,7 +1284,7 @@ jobs:
 
       - name: Upload to Codecov
         if: ${{ hashFiles('./coverage-artifacts/coverage.xml') != '' }}
-        uses: codecov/codecov-action@af09b5e394c93991b95a5e7646aeb90c1917f78f # v5.5.1
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0 / Node 24 transitive github-script
         with:
           files: ./coverage-artifacts/coverage.xml
           fail_ci_if_error: false
@@ -1328,7 +1328,7 @@ jobs:
 
       - name: Upload to Codecov
         if: ${{ hashFiles('./coverage-artifacts/**/coverage.xml') != '' }}
-        uses: codecov/codecov-action@af09b5e394c93991b95a5e7646aeb90c1917f78f # v5.5.1
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0 / Node 24 transitive github-script
         with:
           files: ./coverage-artifacts/**/coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/codecov-upload.yml
+++ b/.github/workflows/codecov-upload.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Download coverage artifact
         if: ${{ inputs['coverage-artifact'] != '' }}
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.6.2
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 / Node 24
         with:
           name: ${{ inputs['coverage-artifact'] }}
           path: ./coverage-artifact

--- a/.github/workflows/codecov-upload.yml
+++ b/.github/workflows/codecov-upload.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload to Codecov
         if: ${{ !inputs['skip-upload'] }}
-        uses: codecov/codecov-action@af09b5e394c93991b95a5e7646aeb90c1917f78f # v5.5.1
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0 / Node 24 transitive github-script
         with:
           files: ${{ inputs['coverage-file'] }}
           flags: ${{ inputs.flags }}

--- a/.github/workflows/ios-appstore-assets.yml
+++ b/.github/workflows/ios-appstore-assets.yml
@@ -169,7 +169,7 @@ jobs:
         run: bundle install
 
       - name: Download screenshot artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 / Node 24
         with:
           name: ios-appstore-screenshots
           path: ios/fastlane/screenshots

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -380,7 +380,7 @@ jobs:
           install-mode: direct-proxy
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.6.2
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 / Node 24
         with:
           pattern: coverage-reports-shard-*
           merge-multiple: true

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Get PR details
         id: get-pr
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 / Node 24
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/docs/review/PR_1754_FIXED_MAPPING.md
+++ b/docs/review/PR_1754_FIXED_MAPPING.md
@@ -4,7 +4,8 @@
 
 - PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1754
 - Branch: `codex/fix-gha-node24-artifact-script-cleanup`
-- Head commit: `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
+- Implementation commit: `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
+- Governance artifact commits: `f1e652604`, `0cf7965e6`, `e7ae5b552`
 - Backlog anchor: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-gha-node24-cache-warning-cleanup`
 
 ## Goal

--- a/docs/review/PR_1754_FIXED_MAPPING.md
+++ b/docs/review/PR_1754_FIXED_MAPPING.md
@@ -1,0 +1,147 @@
+# PR #1754 Fixed Mapping
+
+## PR
+
+- PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1754
+- Branch: `codex/fix-gha-node24-artifact-script-cleanup`
+- Head commit: `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
+- Backlog anchor: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-gha-node24-cache-warning-cleanup`
+
+## Goal
+
+Remove the remaining GitHub Actions Node 20 deprecation warnings for
+`actions/download-artifact` and `actions/github-script` while preserving
+existing artifact, permission, and workflow topology contracts.
+
+## Business Reason
+
+Keep CI annotations actionable and avoid future GitHub runner runtime churn
+without widening this narrow tooling PR into cache cleanup, SQLite/SQLAlchemy
+warning cleanup, runtime code, or CI topology rewrites.
+
+## Scope
+
+- Update `actions/download-artifact` to `v8.0.1` full commit SHA
+  `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`.
+- Update `actions/github-script` to `v9.0.0` peeled commit SHA
+  `3a2844b7e9c422d3c10d287c895573f7108da1b3`.
+- Add workflow contract tests for Node 24-compatible pins, comments, preserved
+  artifact names/paths/merge behavior, preserved PR automation permissions, and
+  preserved `dorny/paths-filter` pin.
+
+## Out of Scope
+
+- No GitHub Actions cache topology rewrite.
+- No SQLite/SQLAlchemy warning fix.
+- No runtime/backend/frontend/iOS behavior changes.
+- No package proxy, OpenAPI, deployment, or release-control-plane changes.
+
+## Tests
+
+- `.venv/bin/python -m pytest -q tests/test_ci_workflow_pr_size_governance_contract.py tests/test_tooling_surface_guards.py`
+  - Result: `30 passed`.
+- `.venv/bin/python scripts/orchestration/check_preflight.py`
+  - Result: PASS.
+- `.venv/bin/python scripts/orchestration/check_agent_consistency.py`
+  - Result: PASS.
+- `.venv/bin/python scripts/ci/guard_actions_pin.py --root .`
+  - Result: PASS.
+- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed`
+  - Result: PASS, changed workflow contract test `14 passed`.
+- `PATH=.venv/bin:$PATH pre-commit run --all-files`
+  - Result: PASS after `black` formatted
+    `tests/test_ci_workflow_pr_size_governance_contract.py`.
+- Push hooks
+  - Result: PASS, including backend tests, `pip-audit`, and full-repo `bandit`.
+
+## Security Notes
+
+- Full SHA pins are preserved.
+- `actions/github-script` uses the peeled commit SHA for `v9.0.0`, not the
+  annotated tag object SHA.
+- `pr-automation.yml` remains limited to `pull-requests: read` and keeps
+  `github-token: ${{ secrets.GITHUB_TOKEN }}`.
+- Artifact names, paths, `merge-multiple`, and `continue-on-error` behavior are
+  regression-guarded unchanged.
+- Codex Security diff-scoped scan completed with no surviving reportable
+  findings. Local scan bundle:
+  `/tmp/codex-security-scans/PulsePlate/ba103c3f_20260515T114752Z`.
+
+## Risks / Rollback
+
+- Risk: action runtime bump changes behavior despite stable workflow inputs.
+- Mitigation: regression tests assert exact pins, comments, artifact contracts,
+  and PR automation permissions; current-head PR CI remains required.
+- Rollback: restore previous action SHAs/comments for `download-artifact` and
+  `github-script`.
+
+## Premortem
+
+Frame: 48 hours from now this CI/tooling PR made merge confidence worse.
+
+| Finding | Disposition | Evidence |
+| --- | --- | --- |
+| Wrong runtime SHA | FIXED | `actions/github-script` plan SHA `d746ffe35508b1917358783b479e04febd2b8f71` was an annotated tag object. Commit `459038d99bb4a0ed4a3a9d255859e8ea215d367e` pins the peeled commit `3a2844b7e9c422d3c10d287c895573f7108da1b3` and rejects the tag-object SHA in tests. |
+| Artifact names/paths drift | FIXED | Commit `459038d99bb4a0ed4a3a9d255859e8ea215d367e` adds exact artifact contract assertions for `name`, `pattern`, `path`, `merge-multiple`, and `continue-on-error`. |
+| `github-script` permissions drift | FIXED | Commit `459038d99bb4a0ed4a3a9d255859e8ea215d367e` asserts `pull-requests: read`, `github-token`, and the PR read script contract. |
+| Node 20 annotation remains | FIXED pending current-head runtime proof | Code replaces all scoped `download-artifact` and `github-script` old pins; current-head PR CI must still confirm no Node 20 annotation before readiness. |
+| Scope expands into cache topology | NOT-A-BUG | Diff has no cache topology changes; cache cleanup remains tracked by `ledger-p2-gha-node24-cache-warning-cleanup`. |
+| Readiness before current-head proof | FIXED by governance | PR opened as draft and this mapping keeps merge readiness blocked until current-head CI, review disposition, and strict merge wrapper pass. |
+
+## Codex Security
+
+- Threat model: completed.
+- Finding discovery: completed; candidates were wrong SHA type, artifact drift,
+  and permission drift.
+- Validation: completed; wrong SHA type fixed, artifact/permission drift guarded.
+- Attack-path analysis: completed; no surviving reportable finding.
+- Final report: no surviving reportable findings.
+
+## Bug-Hunter
+
+Pre-open `bug-hunter` pass found no blocking logical/regression issues. It
+confirmed:
+
+- all 9 `actions/download-artifact` occurrences use
+  `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`;
+- `actions/github-script` uses the peeled commit
+  `3a2844b7e9c422d3c10d287c895573f7108da1b3`;
+- no stale old SHA or annotated tag-object SHA remains in scoped repo surfaces.
+
+Post-open `qa-engineer-agent -> bug-hunter` pass is required before readiness.
+
+## Discussion Thread Pass
+
+Draft PR opened with no review threads at mapping creation time. Any future
+CodeRabbit, Sourcery, Cubic, Codex, or human comments are blocking when
+actionable and must be dispositioned here before resolution.
+
+## Fixed In Commit Mapping
+
+- Premortem/security finding: wrong `actions/github-script` tag-object SHA ->
+  `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
+- Premortem finding: artifact contract drift risk ->
+  `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
+- Premortem finding: PR automation permission drift risk ->
+  `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
+- Workflow runtime cleanup: `actions/download-artifact` Node 24 pin ->
+  `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
+- Workflow runtime cleanup: `actions/github-script` Node 24 pin ->
+  `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
+
+## Merge Readiness
+
+Not ready at mapping creation time.
+
+Required before readiness:
+
+- Current-head PR CI terminal green, especially `CI`, workflow-change attached
+  jobs, `lint`, `security`, `test-main`, iOS workflow-coupled jobs, and
+  `diff-coverage`.
+- Current-head run confirms no Node 20 annotations for `download-artifact`,
+  `github-script`, or `dorny/paths-filter`.
+- Post-open `qa-engineer-agent -> bug-hunter` pass complete.
+- CodeRabbit, Sourcery, Cubic, Codex, and human comments checked and
+  dispositioned.
+- Strict wrapper passes:
+  `GH_TOKEN=$(gh auth token) GITHUB_TOKEN=$(gh auth token) .venv/bin/python scripts/orchestration/check_merge_ready.py --pr-number 1754 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`.

--- a/docs/review/PR_1754_FIXED_MAPPING.md
+++ b/docs/review/PR_1754_FIXED_MAPPING.md
@@ -116,7 +116,7 @@ Draft PR opened with no review threads at mapping creation time. Any future
 CodeRabbit, Sourcery, Cubic, Codex, or human comments are blocking when
 actionable and must be dispositioned here before resolution.
 
-## Fixed In Commit Mapping
+## Fixed in Commit Mapping
 
 - Premortem/security finding: wrong `actions/github-script` tag-object SHA ->
   `459038d99bb4a0ed4a3a9d255859e8ea215d367e`

--- a/docs/review/PR_1754_FIXED_MAPPING.md
+++ b/docs/review/PR_1754_FIXED_MAPPING.md
@@ -112,21 +112,28 @@ Post-open `qa-engineer-agent -> bug-hunter` pass is required before readiness.
 
 ## Discussion Thread Pass
 
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
 Draft PR opened with no review threads at mapping creation time. Any future
 CodeRabbit, Sourcery, Cubic, Codex, or human comments are blocking when
 actionable and must be dispositioned here before resolution.
 
 ## Fixed in Commit Mapping
 
-- Premortem/security finding: wrong `actions/github-script` tag-object SHA ->
+- No actionable review comments
+
+## Premortem Fixed Evidence Mapping
+
+- Wrong `actions/github-script` tag-object SHA:
   `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
-- Premortem finding: artifact contract drift risk ->
+- Artifact contract drift risk:
   `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
-- Premortem finding: PR automation permission drift risk ->
+- PR automation permission drift risk:
   `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
-- Workflow runtime cleanup: `actions/download-artifact` Node 24 pin ->
+- `actions/download-artifact` Node 24 pin:
   `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
-- Workflow runtime cleanup: `actions/github-script` Node 24 pin ->
+- `actions/github-script` Node 24 pin:
   `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
 
 ## Merge Readiness

--- a/docs/review/PR_1754_FIXED_MAPPING.md
+++ b/docs/review/PR_1754_FIXED_MAPPING.md
@@ -4,7 +4,8 @@
 
 - PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1754
 - Branch: `codex/fix-gha-node24-artifact-script-cleanup`
-- Implementation commit: `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
+- Implementation commits: `459038d99bb4a0ed4a3a9d255859e8ea215d367e`,
+  `3b79f7669c857f42cd53853121f966409ed0bc1e`
 - Governance artifact commits: `f1e652604`, `0cf7965e6`, `e7ae5b552`
 - Backlog anchor: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-gha-node24-cache-warning-cleanup`
 
@@ -26,9 +27,13 @@ warning cleanup, runtime code, or CI topology rewrites.
   `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`.
 - Update `actions/github-script` to `v9.0.0` peeled commit SHA
   `3a2844b7e9c422d3c10d287c895573f7108da1b3`.
+- Update `codecov/codecov-action` to `v6.0.0` full commit SHA
+  `57e3a136b779b570ffcdbf80b3bdc90e7fab3de2` because `v5.5.1`
+  transitively pulled old `actions/github-script@60a0...` and kept the
+  Node 20 annotation alive.
 - Add workflow contract tests for Node 24-compatible pins, comments, preserved
   artifact names/paths/merge behavior, preserved PR automation permissions, and
-  preserved `dorny/paths-filter` pin.
+  preserved `dorny/paths-filter` and Codecov upload pins.
 
 ## Out of Scope
 
@@ -40,7 +45,7 @@ warning cleanup, runtime code, or CI topology rewrites.
 ## Tests
 
 - `.venv/bin/python -m pytest -q tests/test_ci_workflow_pr_size_governance_contract.py tests/test_tooling_surface_guards.py`
-  - Result: `30 passed`.
+  - Result after Codecov v6 follow-up: `31 passed`.
 - `.venv/bin/python scripts/orchestration/check_preflight.py`
   - Result: PASS.
 - `.venv/bin/python scripts/orchestration/check_agent_consistency.py`
@@ -48,10 +53,10 @@ warning cleanup, runtime code, or CI topology rewrites.
 - `.venv/bin/python scripts/ci/guard_actions_pin.py --root .`
   - Result: PASS.
 - `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed`
-  - Result: PASS, changed workflow contract test `14 passed`.
+  - Result after Codecov v6 follow-up: PASS, changed workflow contract test
+    `15 passed`.
 - `PATH=.venv/bin:$PATH pre-commit run --all-files`
-  - Result: PASS after `black` formatted
-    `tests/test_ci_workflow_pr_size_governance_contract.py`.
+  - Result after Codecov v6 follow-up: PASS.
 - Push hooks
   - Result: PASS, including backend tests, `pip-audit`, and full-repo `bandit`.
 
@@ -60,6 +65,10 @@ warning cleanup, runtime code, or CI topology rewrites.
 - Full SHA pins are preserved.
 - `actions/github-script` uses the peeled commit SHA for `v9.0.0`, not the
   annotated tag object SHA.
+- `codecov/codecov-action` now uses `v6.0.0` full commit SHA
+  `57e3a136b779b570ffcdbf80b3bdc90e7fab3de2`, whose composite action uses
+  `actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd`
+  (`v8.0.0`, `runs.using: node24`) for OIDC token retrieval.
 - `pr-automation.yml` remains limited to `pull-requests: read` and keeps
   `github-token: ${{ secrets.GITHUB_TOKEN }}`.
 - Artifact names, paths, `merge-multiple`, and `continue-on-error` behavior are
@@ -73,8 +82,8 @@ warning cleanup, runtime code, or CI topology rewrites.
 - Risk: action runtime bump changes behavior despite stable workflow inputs.
 - Mitigation: regression tests assert exact pins, comments, artifact contracts,
   and PR automation permissions; current-head PR CI remains required.
-- Rollback: restore previous action SHAs/comments for `download-artifact` and
-  `github-script`.
+- Rollback: restore previous action SHAs/comments for `download-artifact`,
+  direct `github-script`, and `codecov/codecov-action`.
 
 ## Premortem
 
@@ -85,7 +94,7 @@ Frame: 48 hours from now this CI/tooling PR made merge confidence worse.
 | Wrong runtime SHA | FIXED | `actions/github-script` plan SHA `d746ffe35508b1917358783b479e04febd2b8f71` was an annotated tag object. Commit `459038d99bb4a0ed4a3a9d255859e8ea215d367e` pins the peeled commit `3a2844b7e9c422d3c10d287c895573f7108da1b3` and rejects the tag-object SHA in tests. |
 | Artifact names/paths drift | FIXED | Commit `459038d99bb4a0ed4a3a9d255859e8ea215d367e` adds exact artifact contract assertions for `name`, `pattern`, `path`, `merge-multiple`, and `continue-on-error`. |
 | `github-script` permissions drift | FIXED | Commit `459038d99bb4a0ed4a3a9d255859e8ea215d367e` asserts `pull-requests: read`, `github-token`, and the PR read script contract. |
-| Node 20 annotation remains | FIXED pending current-head runtime proof | Code replaces all scoped `download-artifact` and `github-script` old pins; current-head PR CI must still confirm no Node 20 annotation before readiness. |
+| Node 20 annotation remains | FIXED pending current-head runtime proof | Current-head run `25917162392` showed the warning survived through `codecov/codecov-action@v5.5.1`, which transitively downloaded `actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea`. Commit `3b79f7669c857f42cd53853121f966409ed0bc1e` updates Codecov uploads to `v6.0.0` SHA `57e3a136b779b570ffcdbf80b3bdc90e7fab3de2`, whose transitive `actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd` uses Node 24. Current-head PR CI must still confirm no Node 20 annotation before readiness. |
 | Scope expands into cache topology | NOT-A-BUG | Diff has no cache topology changes; cache cleanup remains tracked by `ledger-p2-gha-node24-cache-warning-cleanup`. |
 | Readiness before current-head proof | FIXED by governance | PR opened as draft and this mapping keeps merge readiness blocked until current-head CI, review disposition, and strict merge wrapper pass. |
 
@@ -108,6 +117,11 @@ confirmed:
 - `actions/github-script` uses the peeled commit
   `3a2844b7e9c422d3c10d287c895573f7108da1b3`;
 - no stale old SHA or annotated tag-object SHA remains in scoped repo surfaces.
+
+Follow-up investigation found the remaining Node 20 annotation came from
+`codecov/codecov-action@v5.5.1` pulling `actions/github-script@60a0...`;
+commit `3b79f7669c857f42cd53853121f966409ed0bc1e` moves those upload steps to
+Codecov `v6.0.0`.
 
 Post-open `qa-engineer-agent -> bug-hunter` pass is required before readiness.
 
@@ -136,6 +150,8 @@ actionable and must be dispositioned here before resolution.
   `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
 - `actions/github-script` Node 24 pin:
   `459038d99bb4a0ed4a3a9d255859e8ea215d367e`
+- `codecov/codecov-action` Node 24 transitive `github-script` pin:
+  `3b79f7669c857f42cd53853121f966409ed0bc1e`
 
 ## Merge Readiness
 

--- a/docs/review/PR_1754_FIXED_MAPPING.md
+++ b/docs/review/PR_1754_FIXED_MAPPING.md
@@ -6,7 +6,8 @@
 - Branch: `codex/fix-gha-node24-artifact-script-cleanup`
 - Implementation commits: `459038d99bb4a0ed4a3a9d255859e8ea215d367e`,
   `3b79f7669c857f42cd53853121f966409ed0bc1e`
-- Governance artifact commits: `f1e652604`, `0cf7965e6`, `e7ae5b552`
+- Governance artifact commits include: `f1e652604`, `0cf7965e6`,
+  `e7ae5b552`, `c5fff3903`
 - Backlog anchor: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-gha-node24-cache-warning-cleanup`
 
 ## Goal

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -61,6 +61,20 @@ GITHUB_SCRIPT_NODE24_SHA = "".join(
         "a1b3",
     )
 )
+CODECOV_ACTION_NODE24_SHA = "".join(
+    (
+        "57e3",
+        "a136",
+        "b779",
+        "b570",
+        "ffcd",
+        "bf80",
+        "b3bd",
+        "c90e",
+        "7fab",
+        "3de2",
+    )
+)
 OLD_DOWNLOAD_ARTIFACT_SHA = "".join(
     (
         "fa0a",
@@ -87,6 +101,20 @@ OLD_GITHUB_SCRIPT_SHA = "".join(
         "cb62",
         "90c5",
         "673b",
+    )
+)
+OLD_CODECOV_ACTION_SHA = "".join(
+    (
+        "af09",
+        "b5e3",
+        "94c9",
+        "3991",
+        "b95a",
+        "5e76",
+        "46ae",
+        "b90c",
+        "1917",
+        "f78f",
     )
 )
 GITHUB_SCRIPT_V9_TAG_OBJECT_SHA = "".join(
@@ -268,6 +296,33 @@ def test_node24_artifact_and_script_action_pins_use_verified_commit_shas() -> No
     )
     assert f"actions/github-script@{OLD_GITHUB_SCRIPT_SHA}" not in pr_automation_text
     assert GITHUB_SCRIPT_V9_TAG_OBJECT_SHA not in pr_automation_text
+
+
+def test_codecov_action_pin_uses_node24_transitive_github_script() -> None:
+    """Guard Codecov uploads against reintroducing the old Node 20 github-script dependency."""
+
+    expected_codecov_line = (
+        f"codecov/codecov-action@{CODECOV_ACTION_NODE24_SHA} "
+        "# v6.0.0 / Node 24 transitive github-script"
+    )
+    workflow_counts = {
+        CI_WORKFLOW_PATH: 3,
+        CODECOV_UPLOAD_WORKFLOW_PATH: 1,
+    }
+
+    observed_codecov_steps = []
+    for workflow_path, expected_count in workflow_counts.items():
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        assert workflow_text.count(expected_codecov_line) == expected_count
+        assert f"codecov/codecov-action@{OLD_CODECOV_ACTION_SHA}" not in workflow_text
+
+        for job_id, step in _iter_job_steps(workflow_path):
+            uses = step.get("uses")
+            if isinstance(uses, str) and uses.startswith("codecov/codecov-action@"):
+                observed_codecov_steps.append((workflow_path, job_id, step))
+                assert uses == f"codecov/codecov-action@{CODECOV_ACTION_NODE24_SHA}"
+
+    assert len(observed_codecov_steps) == sum(workflow_counts.values())
 
 
 def test_node24_artifact_migration_preserves_download_contracts() -> None:

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 import re
 
@@ -9,6 +10,10 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+CODECOV_UPLOAD_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "codecov-upload.yml"
+IOS_APPSTORE_ASSETS_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ios-appstore-assets.yml"
+NIGHTLY_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "nightly.yml"
+PR_AUTOMATION_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "pr-automation.yml"
 AGENTS_PATH = REPO_ROOT / "AGENTS.md"
 RUNBOOK_PATH = REPO_ROOT / "RUNBOOK_AGENT.md"
 ORCHESTRATION_CONTRACT_PATH = (
@@ -26,6 +31,76 @@ PATHS_FILTER_NODE24_SHA = "".join(
         "3fc2",
         "5e6d",
         "187d",
+    )
+)
+DOWNLOAD_ARTIFACT_NODE24_SHA = "".join(
+    (
+        "3e5f",
+        "45b2",
+        "cfb9",
+        "1720",
+        "54b4",
+        "087a",
+        "40e8",
+        "e0b5",
+        "a546",
+        "1e7c",
+    )
+)
+GITHUB_SCRIPT_NODE24_SHA = "".join(
+    (
+        "3a28",
+        "44b7",
+        "e9c4",
+        "22d3",
+        "c10d",
+        "287c",
+        "8955",
+        "73f7",
+        "108d",
+        "a1b3",
+    )
+)
+OLD_DOWNLOAD_ARTIFACT_SHA = "".join(
+    (
+        "fa0a",
+        "91b8",
+        "5d4f",
+        "404e",
+        "444e",
+        "00e0",
+        "0597",
+        "1372",
+        "dc80",
+        "1d16",
+    )
+)
+OLD_GITHUB_SCRIPT_SHA = "".join(
+    (
+        "f28e",
+        "40c7",
+        "f34b",
+        "de8b",
+        "3046",
+        "d885",
+        "e986",
+        "cb62",
+        "90c5",
+        "673b",
+    )
+)
+GITHUB_SCRIPT_V9_TAG_OBJECT_SHA = "".join(
+    (
+        "d746",
+        "ffe3",
+        "5508",
+        "b191",
+        "7358",
+        "783b",
+        "479e",
+        "04fe",
+        "bd2b",
+        "8f71",
     )
 )
 
@@ -55,9 +130,27 @@ def _extract_job_section(workflow_text: str, job_anchor: str) -> str:
 
 
 def _load_ci_workflow() -> dict[str, object]:
-    workflow = yaml.safe_load(CI_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    return _load_workflow(CI_WORKFLOW_PATH)
+
+
+def _load_workflow(path: Path) -> dict[str, object]:
+    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
     assert isinstance(workflow, dict)
     return workflow
+
+
+def _iter_job_steps(path: Path) -> Iterator[tuple[str, dict[str, object]]]:
+    workflow = _load_workflow(path)
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    for job_id, job in jobs.items():
+        assert isinstance(job_id, str)
+        assert isinstance(job, dict)
+        steps = job.get("steps", [])
+        assert isinstance(steps, list)
+        for step in steps:
+            assert isinstance(step, dict)
+            yield job_id, step
 
 
 def _assert_contains_all_tokens(expression: str, expected_tokens: tuple[str, ...]) -> None:
@@ -140,6 +233,164 @@ def test_changes_job_uses_node24_paths_filter_pin_and_keeps_ios_filters() -> Non
     assert "- 'ios/**'" in filters
     assert "- '.github/workflows/**'" in filters
     assert "- '.github/actions/**'" in filters
+
+
+def test_node24_artifact_and_script_action_pins_use_verified_commit_shas() -> None:
+    """Guard remaining Node 20 action migrations against tag-object drift."""
+
+    download_workflows = {
+        CI_WORKFLOW_PATH: 6,
+        CODECOV_UPLOAD_WORKFLOW_PATH: 1,
+        IOS_APPSTORE_ASSETS_WORKFLOW_PATH: 1,
+        NIGHTLY_WORKFLOW_PATH: 1,
+    }
+    expected_download_line = (
+        f"actions/download-artifact@{DOWNLOAD_ARTIFACT_NODE24_SHA} # v8.0.1 / Node 24"
+    )
+
+    observed_download_steps = 0
+    for workflow_path, expected_count in download_workflows.items():
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        assert workflow_text.count(expected_download_line) == expected_count
+        assert f"actions/download-artifact@{OLD_DOWNLOAD_ARTIFACT_SHA}" not in workflow_text
+
+        for _job_id, step in _iter_job_steps(workflow_path):
+            uses = step.get("uses")
+            if isinstance(uses, str) and uses.startswith("actions/download-artifact@"):
+                observed_download_steps += 1
+                assert uses == f"actions/download-artifact@{DOWNLOAD_ARTIFACT_NODE24_SHA}"
+
+    assert observed_download_steps == sum(download_workflows.values())
+
+    pr_automation_text = PR_AUTOMATION_WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert (
+        f"actions/github-script@{GITHUB_SCRIPT_NODE24_SHA} # v9.0.0 / Node 24" in pr_automation_text
+    )
+    assert f"actions/github-script@{OLD_GITHUB_SCRIPT_SHA}" not in pr_automation_text
+    assert GITHUB_SCRIPT_V9_TAG_OBJECT_SHA not in pr_automation_text
+
+
+def test_node24_artifact_migration_preserves_download_contracts() -> None:
+    """Guard artifact names, paths, and merge behavior during action runtime bumps."""
+
+    expected_download_contracts = [
+        (
+            ".github/workflows/ci.yml",
+            "coverage-pr",
+            "Download coverage artifact (Python ${{ env.COVERAGE_PY }})",
+            {"name": "coverage-xml-${{ env.COVERAGE_PY }}", "path": "./coverage-artifacts"},
+            True,
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "diff-coverage",
+            "Download coverage artifact (Python ${{ env.COVERAGE_PY }})",
+            {"name": "coverage-xml-${{ env.COVERAGE_PY }}", "path": "./coverage-artifacts"},
+            None,
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "coverage-feature",
+            "Download coverage artifact (Python ${{ env.COVERAGE_PY }})",
+            {"name": "coverage-xml-${{ env.COVERAGE_PY }}", "path": "./coverage-artifacts"},
+            True,
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "coverage-main",
+            "Download coverage artifact (Python 3.11)",
+            {"name": "coverage-main-xml-3.11", "path": "./coverage-artifacts/3.11"},
+            True,
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "coverage-main",
+            "Download coverage artifact (Python 3.12)",
+            {"name": "coverage-main-xml-3.12", "path": "./coverage-artifacts/3.12"},
+            True,
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "coverage-main",
+            "Download coverage artifact (Python 3.13)",
+            {"name": "coverage-main-xml-3.13", "path": "./coverage-artifacts/3.13"},
+            True,
+        ),
+        (
+            ".github/workflows/codecov-upload.yml",
+            "upload",
+            "Download coverage artifact",
+            {"name": "${{ inputs['coverage-artifact'] }}", "path": "./coverage-artifact"},
+            None,
+        ),
+        (
+            ".github/workflows/nightly.yml",
+            "coverage-merge",
+            "Download coverage artifacts",
+            {
+                "pattern": "coverage-reports-shard-*",
+                "merge-multiple": True,
+                "path": "coverage-artifacts",
+            },
+            None,
+        ),
+        (
+            ".github/workflows/ios-appstore-assets.yml",
+            "upload-assets",
+            "Download screenshot artifacts",
+            {"name": "ios-appstore-screenshots", "path": "ios/fastlane/screenshots"},
+            None,
+        ),
+    ]
+
+    observed_download_contracts = []
+    for workflow_path in (
+        CI_WORKFLOW_PATH,
+        CODECOV_UPLOAD_WORKFLOW_PATH,
+        NIGHTLY_WORKFLOW_PATH,
+        IOS_APPSTORE_ASSETS_WORKFLOW_PATH,
+    ):
+        for job_id, step in _iter_job_steps(workflow_path):
+            uses = step.get("uses")
+            if isinstance(uses, str) and uses.startswith("actions/download-artifact@"):
+                observed_download_contracts.append(
+                    (
+                        str(workflow_path.relative_to(REPO_ROOT)),
+                        job_id,
+                        step.get("name"),
+                        step.get("with"),
+                        step.get("continue-on-error"),
+                    )
+                )
+
+    assert observed_download_contracts == expected_download_contracts
+
+
+def test_node24_github_script_migration_preserves_pr_read_permissions() -> None:
+    """Guard the PR automation script runtime bump against permission drift."""
+
+    workflow = _load_workflow(PR_AUTOMATION_WORKFLOW_PATH)
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    validate_pr_job = jobs["validate-pr"]
+    assert isinstance(validate_pr_job, dict)
+
+    assert validate_pr_job["permissions"] == {"pull-requests": "read"}
+
+    github_script_steps = []
+    for _job_id, step in _iter_job_steps(PR_AUTOMATION_WORKFLOW_PATH):
+        uses = step.get("uses")
+        if isinstance(uses, str) and uses.startswith("actions/github-script@"):
+            github_script_steps.append(step)
+
+    assert len(github_script_steps) == 1
+    script_step = github_script_steps[0]
+    assert script_step["uses"] == f"actions/github-script@{GITHUB_SCRIPT_NODE24_SHA}"
+    with_section = script_step["with"]
+    assert isinstance(with_section, dict)
+    assert sorted(with_section) == ["github-token", "script"]
+    assert with_section["github-token"] == "${{ secrets.GITHUB_TOKEN }}"
+    assert "github.rest.pulls.get" in str(with_section["script"])
 
 
 def test_feature_push_risk_profile_uses_origin_main_merge_base() -> None:


### PR DESCRIPTION
## Goal
Remove the remaining GitHub Actions Node 20 deprecation annotations for `actions/download-artifact`, direct `actions/github-script`, and the scoped Codecov upload path that transitively invokes `actions/github-script`, while preserving existing workflow behavior.

## Business reason
Keep CI warnings actionable and reduce future runner-runtime churn without widening into cache topology, SQLite/SQLAlchemy diagnostics, or unrelated test-suite work.

## Scope
- Update `actions/download-artifact` to `v8.0.1` full commit SHA `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`.
- Update direct `actions/github-script` to the `v9.0.0` peeled commit SHA `3a2844b7e9c422d3c10d287c895573f7108da1b3`.
- Update `codecov/codecov-action` to `v6.0.0` full commit SHA `57e3a136b779b570ffcdbf80b3bdc90e7fab3de2` because `v5.5.1` transitively downloaded old `actions/github-script@60a0...` and kept the Node 20 annotation alive.
- Add workflow contract tests for Node 24-compatible pins, version comments, preserved artifact names/paths/merge behavior, preserved PR automation permissions, preserved `dorny/paths-filter` pin, and the Codecov upload pin.
- Add canonical review mapping at `docs/review/PR_1754_FIXED_MAPPING.md`.

## Out of scope
- No cache topology rewrite.
- No SQLite/SQLAlchemy warning fix.
- No runtime/backend/frontend/iOS behavior changes.
- No package proxy or OpenAPI changes.

## Tests
- `.venv/bin/python -m pytest -q tests/test_ci_workflow_pr_size_governance_contract.py tests/test_tooling_surface_guards.py` -> `31 passed` after Codecov v6 follow-up.
- `.venv/bin/python scripts/orchestration/check_preflight.py` -> PASS.
- `.venv/bin/python scripts/orchestration/check_agent_consistency.py` -> PASS.
- `.venv/bin/python scripts/ci/guard_actions_pin.py --root .` -> PASS.
- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed` -> PASS, changed contract test `15 passed` after Codecov v6 follow-up.
- `PATH=.venv/bin:$PATH pre-commit run --all-files` -> PASS.
- Commit/push hooks -> PASS, including backend tests, pip-audit, and full-repo bandit.

## Security notes
- Full SHA pins are preserved.
- Premortem/security loop caught that the initially planned `actions/github-script` SHA `d746ffe35508b1917358783b479e04febd2b8f71` is an annotated tag object, not the executable commit. This PR pins the peeled commit `3a2844b7e9c422d3c10d287c895573f7108da1b3` instead.
- Current-head runtime proof caught that Codecov `v5.5.1` still pulled `actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea`; commit `3b79f7669c857f42cd53853121f966409ed0bc1e` updates Codecov upload steps to `v6.0.0`, whose transitive `actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd` uses Node 24.
- `pr-automation.yml` remains `pull-requests: read` and keeps `github-token: ${{ secrets.GITHUB_TOKEN }}`.
- Artifact names, paths, `merge-multiple`, and `continue-on-error` behavior are guarded unchanged.
- Codex Security diff-scoped phases completed with no surviving reportable findings. Local scan bundle: `/tmp/codex-security-scans/PulsePlate/ba103c3f_20260515T114752Z`.

## Risks / Rollback
- Risk: action runtime bump changes behavior despite stable inputs.
- Mitigation: contract tests pin exact inputs/paths and PR current-head CI must validate the representative jobs.
- Rollback: restore the previous action SHAs/comments for `download-artifact`, direct `github-script`, and `codecov/codecov-action`.

## Premortem
Frame: 48 hours from now this CI/tooling PR made merge confidence worse.

- Wrong runtime SHA: FIXED in `459038d99bb4a0ed4a3a9d255859e8ea215d367e` by using verified Node 24 commit SHAs and rejecting the `github-script` tag-object SHA in tests.
- Artifact names/paths drift: FIXED in `459038d99bb4a0ed4a3a9d255859e8ea215d367e` with exact artifact contract regression tests.
- `github-script` permissions drift: FIXED in `459038d99bb4a0ed4a3a9d255859e8ea215d367e` with a PR automation permission/token guard.
- Node 20 annotation remains: FIXED in `3b79f7669c857f42cd53853121f966409ed0bc1e` after current-head runtime proof found Codecov `v5.5.1` transitively pulled `actions/github-script@60a0...`; current-head PR run will be used as final runtime evidence before readiness.
- Scope expands into cache topology: NOT-A-BUG for this diff; cache cleanup remains out of scope under `ledger-p2-gha-node24-cache-warning-cleanup`.
- Readiness before proof: FIXED by keeping this PR draft until mapping/current-head CI/review governance gates are complete.

## Codex Security
- Threat model: completed.
- Finding discovery: completed; candidates were wrong SHA type, artifact drift, permission drift, and surviving transitive Node 20 runtime.
- Validation: completed; wrong SHA type fixed, artifact/permission drift guarded, and Codecov v6 transitive `github-script` runtime verified as Node 24.
- Attack-path analysis: completed; no surviving reportable finding.
- Final report: no surviving reportable findings.

## Bug-hunter
Pre-open `bug-hunter` pass found no blocking logical/regression issues. It confirmed all 9 `download-artifact` occurrences use the Node 24 pin, direct `github-script` uses the peeled commit, and no stale old SHA or annotated tag-object SHA remains in scoped repo surfaces.

Follow-up runtime proof found the remaining annotation through Codecov `v5.5.1`; that is fixed in `3b79f7669c857f42cd53853121f966409ed0bc1e`. Post-open `qa-engineer-agent -> bug-hunter` pass remains required before readiness.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- No review threads existed at mapping creation time.
- Bot/human thread disposition remains required if new actionable comments appear.

### Fixed in Commit Mapping
- [x] Fixed in commit mapping completed
- Canonical artifact: `docs/review/PR_1754_FIXED_MAPPING.md`.
- No actionable review comments at mapping creation time.
- Premortem/code evidence is recorded in `docs/review/PR_1754_FIXED_MAPPING.md` under `Premortem` and `Premortem Fixed Evidence Mapping`.

## Merge Readiness
Not ready. Required before readiness:
- Current-head PR CI terminal green, especially `CI`, workflow-change attached jobs, `lint`, `security`, `test-main`, iOS workflow-coupled jobs, and `diff-coverage`.
- Confirm current-head run no longer emits Node 20 annotations for `download-artifact`, `github-script`, Codecov's transitive `github-script`, or `dorny/paths-filter`.
- Post-open `qa-engineer-agent -> bug-hunter` pass.
- CodeRabbit/Sourcery/Cubic/human comments triaged with disposition evidence.
- Strict wrapper: `GH_TOKEN=$(gh auth token) GITHUB_TOKEN=$(gh auth token) .venv/bin/python scripts/orchestration/check_merge_ready.py --pr-number 1754 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use latest stable versions across CI/CD pipelines for improved compatibility and stability
  * Updated code coverage reporting configurations

* **Tests**
  * Added comprehensive workflow validation tests to verify configuration consistency and artifact handling across multiple jobs

* **Documentation**
  * Added detailed PR evidence mapping documentation for quality assurance and audit trail

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1754)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->