### PR TITLE
Walk3: Ollama-Codex operator workflow

### DIFF
--- a/docs/dev/CODEX_SKILLS.md
+++ b/docs/dev/CODEX_SKILLS.md
@@ -95,6 +95,42 @@ For a **minimal copy-paste starter only**, see
 [`docs/templates/codex.config.example.toml`](../templates/codex.config.example.toml).
 Customize on your machine; do not treat that template as a production or team contract.
 
+### Optional Codex + Ollama operator workflow
+
+This section is host-only operator guidance. It does not change PulsePlate
+runtime LLM provider selection, MCP behavior, or repo source-of-truth rules.
+
+Use the repo doctor before debugging Codex/Ollama wiring:
+
+```bash
+python3 scripts/orchestration/check_codex_ollama_operator.py
+```
+
+The doctor is read-only: it checks local `ollama`, local `codex`, and the
+localhost Ollama server, then prints next steps. It never writes
+`~/.codex/config.toml`, shell profiles, Cursor config, MCP config, or repo
+runtime files.
+
+Current operator paths:
+
+- `ollama launch codex` for Ollama-managed setup and launch.
+- `ollama launch codex --config` for Ollama-managed configuration without
+  launching immediately.
+- `codex --oss` for manual local mode.
+- `codex --profile ollama-launch` after copying/adapting the host-only profile
+  from [`docs/templates/codex.config.example.toml`](../templates/codex.config.example.toml).
+
+`ollama launch codex-app` is not the expected integration command for this
+workflow. If it fails, first check your Ollama version: `ollama launch` requires
+Ollama v0.15+.
+
+Do not confuse this with PulsePlate backend runtime configuration. Product
+runtime Ollama validation uses environment such as `LLM_PROVIDER=ollama` and
+`OLLAMA_ENDPOINT=http://localhost:11434`; see
+[`docs/runbooks/LOCAL_OLLAMA_NEMOTRON_RUNTIME.md`](../runbooks/LOCAL_OLLAMA_NEMOTRON_RUNTIME.md).
+V1 of this operator workflow intentionally does not modify `llm.py`,
+`providers/ollama.py`, or `mcp_pulseplate_server.py`.
+
 ## Repo compatibility bridge
 
 Use the repo bridge documents together:

--- a/docs/dev/CODEX_SKILLS.md
+++ b/docs/dev/CODEX_SKILLS.md
@@ -113,16 +113,19 @@ runtime files.
 
 Current operator paths:
 
+- `ollama launch codex-app` for the desktop Codex App. This requires Ollama
+  v0.24+.
 - `ollama launch codex` for Ollama-managed setup and launch.
 - `ollama launch codex --config` for Ollama-managed configuration without
-  launching immediately.
+  launching immediately. These Codex CLI launch paths require Ollama v0.15+.
 - `codex --oss` for manual local mode.
 - `codex --profile ollama-launch` after copying/adapting the host-only profile
   from [`docs/templates/codex.config.example.toml`](../templates/codex.config.example.toml).
 
-`ollama launch codex-app` is not the expected integration command for this
-workflow. If it fails, first check your Ollama version: `ollama launch` requires
-Ollama v0.15+.
+If `ollama launch codex-app` fails on this machine, first check the Ollama
+version. Older Ollama builds may support the Codex CLI integration while still
+not supporting the desktop Codex App integration. The repo doctor reports these
+two version gates separately.
 
 Do not confuse this with PulsePlate backend runtime configuration. Product
 runtime Ollama validation uses environment such as `LLM_PROVIDER=ollama` and

--- a/docs/dev/CODEX_SKILLS.md
+++ b/docs/dev/CODEX_SKILLS.md
@@ -110,6 +110,8 @@ The doctor is read-only: it checks local `ollama`, local `codex`, and the
 localhost Ollama server, then prints next steps. It never writes
 `~/.codex/config.toml`, shell profiles, Cursor config, MCP config, or repo
 runtime files.
+For profile-based Codex use, the running Ollama server also needs OpenAI
+Responses API support; the doctor gates that at Ollama server v0.13.3+.
 
 Current operator paths:
 

--- a/docs/review/PR_1755_FIXED_MAPPING.md
+++ b/docs/review/PR_1755_FIXED_MAPPING.md
@@ -1,0 +1,82 @@
+# PR #1755 Fixed in Commit Mapping
+
+## PR
+
+- PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755
+- Branch: `codex/walk3-ollama-codex-operator-workflow`
+- Base: `main`
+- Evidence head at mapping creation: `064cb8f0fca606178e58868d424d5213ea2b653d`
+- Note: later mapping-only or review-fix commits may advance the branch head; use GitHub PR current-head checks for live merge-readiness truth.
+
+## Scope
+
+Walk3: add operator-only Ollama-Codex workflow support through repo docs, a host-only Codex config template, and a read-only doctor script. This PR does not change PulsePlate backend runtime, MCP behavior, product LLM contracts, OpenAPI, or provider code.
+
+## Discussion Thread Pass
+
+- [x] Initial discussion-thread pass completed at PR open.
+- [x] Fixed in commit mapping created after PR open.
+- [x] No human, CodeRabbit, Sourcery, or Cubic actionable comments were present when this mapping was created.
+- [ ] Re-run discussion-thread pass after each new review cycle before merge readiness.
+
+## Coordinator / Premortem / Agent Findings
+
+- Coordinator scope lock: FIXED by `064cb8f0fca606178e58868d424d5213ea2b653d`
+  - Evidence: `docs/templates/codex.config.example.toml`, `docs/dev/CODEX_SKILLS.md`, `scripts/orchestration/check_codex_ollama_operator.py`, and `tests/test_codex_ollama_operator_doctor.py` are the implementation surface.
+  - Evidence: no changes were made to `llm.py`, `providers/ollama.py`, `mcp_pulseplate_server.py`, OpenAPI, backend routes, or product runtime contracts.
+- Premortem finding 1: FIXED by `064cb8f0fca606178e58868d424d5213ea2b653d`
+  - Finding: operator tooling could accidentally write host config such as `~/.codex/config.toml`.
+  - Evidence: `scripts/orchestration/check_codex_ollama_operator.py` is diagnostic-only and reports `host_config_write_guard` without reading or writing host config.
+  - Evidence: `tests/test_codex_ollama_operator_doctor.py` asserts JSON output includes the host-write guard.
+- Premortem finding 2: FIXED by `064cb8f0fca606178e58868d424d5213ea2b653d`
+  - Finding: stale guidance for `ollama launch codex-app` could keep failing.
+  - Evidence: `docs/dev/CODEX_SKILLS.md` explains that `codex-app` is not the launched CLI target and points to `ollama launch codex`, `codex --oss`, and `codex --profile ollama-launch`.
+  - Evidence: the doctor enforces Ollama `0.15.0+` for `ollama launch` guidance.
+- Premortem finding 3: FIXED by `064cb8f0fca606178e58868d424d5213ea2b653d`
+  - Finding: host Codex/Ollama workflow could be confused with PulsePlate runtime `LLM_PROVIDER=ollama`.
+  - Evidence: `docs/dev/CODEX_SKILLS.md` separates host operator setup from runtime `LLM_PROVIDER=ollama` / `OLLAMA_ENDPOINT=http://localhost:11434`.
+  - Evidence: `docs/review/WALK3_OLLAMA_CODEX_OPERATOR_PREMORTEM.md` records MCP/backend integration as out of V1.
+- Premortem finding 4: FIXED by `064cb8f0fca606178e58868d424d5213ea2b653d`
+  - Finding: doctor tests could depend on local tools or real network state.
+  - Evidence: `tests/test_codex_ollama_operator_doctor.py` uses fakes/mocks for binaries and HTTP probes.
+- Premortem finding 5: NOT-A-BUG
+  - Evidence: V1 has no MCP/backend provider runtime changes; the changed files are docs, template, doctor script, tests, and review artifact only.
+  - Reason: MCP/Ollama server integration is explicitly out of scope for this PR and requires a separate contract-bearing lane.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755 -> 064cb8f0fca606178e58868d424d5213ea2b653d
+Disposition: FIXED
+Commit: 064cb8f0fca606178e58868d424d5213ea2b653d
+Evidence: initial implementation commit added the host-only Ollama-Codex template/profile guidance, read-only doctor script, deterministic tests, and premortem closure artifact.
+
+## Local Validation
+
+- `python3 scripts/orchestration/check_preflight.py --path docs/dev/CODEX_SKILLS.md --path docs/templates/codex.config.example.toml --path scripts/orchestration/check_codex_ollama_operator.py --path tests/test_codex_ollama_operator_doctor.py` PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` OK.
+- `../../.venv/bin/python -m pytest -q tests/test_codex_ollama_operator_doctor.py` PASS, 8 tests.
+- `../../.venv/bin/python -m py_compile scripts/orchestration/check_codex_ollama_operator.py` PASS.
+- `git diff --check` PASS.
+- `../../.venv/bin/python -m pytest -q tests/test_repo_policy_guards.py` PASS.
+- `../../.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py tests/test_codex_ollama_operator_doctor.py` PASS.
+- `../../.venv/bin/python -m flake8 scripts/orchestration/check_codex_ollama_operator.py tests/test_codex_ollama_operator_doctor.py` PASS.
+- `../../.venv/bin/python -m ruff check scripts/orchestration/check_codex_ollama_operator.py tests/test_codex_ollama_operator_doctor.py` PASS.
+- `../../.venv/bin/python -m black --check scripts/orchestration/check_codex_ollama_operator.py tests/test_codex_ollama_operator_doctor.py` PASS.
+- `../../.venv/bin/python -m bandit -q -r scripts/orchestration/check_codex_ollama_operator.py` PASS.
+- `VENV_PYTHON=../../.venv/bin/python pre-commit run --all-files` PASS.
+- `VENV_PYTHON=../../.venv/bin/python make validate-changed` PASS.
+- `VENV_PYTHON=../../.venv/bin/python git push -u origin codex/walk3-ollama-codex-operator-workflow` pre-push hooks PASS.
+
+## Deferred Heavy Gate
+
+- Full local `make verify` is deferred by operator choice for this machine-heavy lane.
+- This deferral is not a merge-readiness claim.
+- Before merge readiness, current-head CI must provide heavy parity and all review threads/bot comments must be dispositioned.
+
+## Post-Open Review Lane
+
+- [ ] `security-auditor`
+- [ ] `qa-engineer-agent`
+- [ ] `bug-hunter`
+- [ ] `pulseplate-pr-review`
+- [ ] Codex Security plugin/local security scan

--- a/docs/review/PR_1755_FIXED_MAPPING.md
+++ b/docs/review/PR_1755_FIXED_MAPPING.md
@@ -5,7 +5,7 @@
 - PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755
 - Branch: `codex/walk3-ollama-codex-operator-workflow`
 - Base: `main`
-- Evidence head at mapping creation: `064cb8f0fca606178e58868d424d5213ea2b653d`
+- Evidence head at latest mapping update: `b22efdab36355f5f068e63a8598d7a37f76d5673`
 - Note: later mapping-only or review-fix commits may advance the branch head; use GitHub PR current-head checks for live merge-readiness truth.
 
 ## Scope
@@ -15,6 +15,8 @@ Walk3: add operator-only Ollama-Codex workflow support through repo docs, a host
 ## Discussion Thread Pass
 
 - [x] Initial discussion-thread pass completed at PR open.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 - [x] Fixed in commit mapping created after PR open.
 - [x] No human, CodeRabbit, Sourcery, or Cubic actionable comments were present when this mapping was created.
 - [ ] Re-run discussion-thread pass after each new review cycle before merge readiness.
@@ -30,8 +32,8 @@ Walk3: add operator-only Ollama-Codex workflow support through repo docs, a host
   - Evidence: `tests/test_codex_ollama_operator_doctor.py` asserts JSON output includes the host-write guard.
 - Premortem finding 2: FIXED by `064cb8f0fca606178e58868d424d5213ea2b653d`
   - Finding: stale guidance for `ollama launch codex-app` could keep failing.
-  - Evidence: `docs/dev/CODEX_SKILLS.md` explains that `codex-app` is not the launched CLI target and points to `ollama launch codex`, `codex --oss`, and `codex --profile ollama-launch`.
-  - Evidence: the doctor enforces Ollama `0.15.0+` for `ollama launch` guidance.
+  - Evidence: `b22efdab36355f5f068e63a8598d7a37f76d5673` corrects this to split Codex App and Codex CLI paths: `ollama launch codex-app` requires Ollama v0.24+, while `ollama launch codex` / `codex --oss` / profile setup remain CLI paths.
+  - Evidence: the doctor now reports the Codex CLI and Codex App version gates separately.
 - Premortem finding 3: FIXED by `064cb8f0fca606178e58868d424d5213ea2b653d`
   - Finding: host Codex/Ollama workflow could be confused with PulsePlate runtime `LLM_PROVIDER=ollama`.
   - Evidence: `docs/dev/CODEX_SKILLS.md` separates host operator setup from runtime `LLM_PROVIDER=ollama` / `OLLAMA_ENDPOINT=http://localhost:11434`.
@@ -50,21 +52,57 @@ Disposition: FIXED
 Commit: 064cb8f0fca606178e58868d424d5213ea2b653d
 Evidence: initial implementation commit added the host-only Ollama-Codex template/profile guidance, read-only doctor script, deterministic tests, and premortem closure artifact.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755#discussion_r3248128051 -> 5c296d7562676b5494c512c25b943886b9d5488d
+Disposition: FIXED
+Commit: 5c296d7562676b5494c512c25b943886b9d5488d
+Evidence: `_run_version(...)` now catches `subprocess.TimeoutExpired` and returns exit code `124` with a diagnostic message; `tests/test_codex_ollama_operator_doctor.py` covers the timeout path.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755#discussion_r3248130605 -> 5c296d7562676b5494c512c25b943886b9d5488d
+Disposition: FIXED
+Commit: 5c296d7562676b5494c512c25b943886b9d5488d
+Evidence: `_run_version(...)` now returns a structured timeout failure instead of raising a traceback; focused doctor tests pass.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755#discussion_r3248128038 -> 5c296d7562676b5494c512c25b943886b9d5488d
+Disposition: FIXED
+Commit: 5c296d7562676b5494c512c25b943886b9d5488d
+Evidence: `--timeout` now uses `_positive_timeout(...)`, which rejects non-positive values during argument parsing; `tests/test_codex_ollama_operator_doctor.py` covers this parser failure.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755#discussion_r3248131779 -> 5c296d7562676b5494c512c25b943886b9d5488d
+Disposition: FIXED
+Commit: 5c296d7562676b5494c512c25b943886b9d5488d
+Evidence: `--timeout` validation fails fast before the network probe and focused tests pass.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755#discussion_r3248130616 -> b22efdab36355f5f068e63a8598d7a37f76d5673
+Disposition: FIXED
+Commit: b22efdab36355f5f068e63a8598d7a37f76d5673
+Evidence: `/v1` provider URLs are normalized back to the Ollama root before probing `/api/version`; `tests/test_codex_ollama_operator_doctor.py` asserts `http://127.0.0.1:11434/v1` probes `http://127.0.0.1:11434/api/version`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755#discussion_r3248130620 -> b22efdab36355f5f068e63a8598d7a37f76d5673
+Disposition: FIXED
+Commit: b22efdab36355f5f068e63a8598d7a37f76d5673
+Evidence: `_parse_ollama_binary_version(...)` now prefers explicit client-version output before server-version output; `tests/test_codex_ollama_operator_doctor.py` covers mixed server/client output.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755#discussion_r3248131771 -> b22efdab36355f5f068e63a8598d7a37f76d5673
+Disposition: FIXED
+Commit: b22efdab36355f5f068e63a8598d7a37f76d5673
+Evidence: the localhost probe now uses a no-redirect opener and reports redirect HTTP responses as blocked; `tests/test_codex_ollama_operator_doctor.py` covers redirect blocking.
+
 ## Local Validation
 
-- `python3 scripts/orchestration/check_preflight.py --path docs/dev/CODEX_SKILLS.md --path docs/templates/codex.config.example.toml --path scripts/orchestration/check_codex_ollama_operator.py --path tests/test_codex_ollama_operator_doctor.py` PASS.
+- `python3 scripts/orchestration/check_preflight.py --path docs/dev/CODEX_SKILLS.md --path docs/templates/codex.config.example.toml --path scripts/orchestration/check_codex_ollama_operator.py --path tests/test_codex_ollama_operator_doctor.py --path docs/review/PR_1755_FIXED_MAPPING.md` PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` OK.
-- `../../.venv/bin/python -m pytest -q tests/test_codex_ollama_operator_doctor.py` PASS, 8 tests.
+- `../../.venv/bin/python -m pytest -q tests/test_codex_ollama_operator_doctor.py` PASS, 16 tests.
 - `../../.venv/bin/python -m py_compile scripts/orchestration/check_codex_ollama_operator.py` PASS.
 - `git diff --check` PASS.
 - `../../.venv/bin/python -m pytest -q tests/test_repo_policy_guards.py` PASS.
-- `../../.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py tests/test_codex_ollama_operator_doctor.py` PASS.
+- `../../.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py tests/test_codex_ollama_operator_doctor.py` PASS, 21 tests.
 - `../../.venv/bin/python -m flake8 scripts/orchestration/check_codex_ollama_operator.py tests/test_codex_ollama_operator_doctor.py` PASS.
 - `../../.venv/bin/python -m ruff check scripts/orchestration/check_codex_ollama_operator.py tests/test_codex_ollama_operator_doctor.py` PASS.
 - `../../.venv/bin/python -m black --check scripts/orchestration/check_codex_ollama_operator.py tests/test_codex_ollama_operator_doctor.py` PASS.
 - `../../.venv/bin/python -m bandit -q -r scripts/orchestration/check_codex_ollama_operator.py` PASS.
+- `VENV_PYTHON=../../.venv/bin/python make validate-changed` PASS after post-open fixes.
+- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1755` PASS after parser-safe mapping update.
 - `VENV_PYTHON=../../.venv/bin/python pre-commit run --all-files` PASS.
-- `VENV_PYTHON=../../.venv/bin/python make validate-changed` PASS.
 - `VENV_PYTHON=../../.venv/bin/python git push -u origin codex/walk3-ollama-codex-operator-workflow` pre-push hooks PASS.
 
 ## Deferred Heavy Gate
@@ -75,8 +113,18 @@ Evidence: initial implementation commit added the host-only Ollama-Codex templat
 
 ## Post-Open Review Lane
 
-- [ ] `security-auditor`
-- [ ] `qa-engineer-agent`
-- [ ] `bug-hunter`
-- [ ] `pulseplate-pr-review`
-- [ ] Codex Security plugin/local security scan
+- [x] `security-auditor`
+  - Finding: version-command timeout crashed the doctor instead of returning a diagnostic failure.
+  - Disposition: FIXED by `5c296d7562676b5494c512c25b943886b9d5488d`.
+- [x] `qa-engineer-agent`
+  - Finding: aggregate CLI/text path and template contract were undercovered.
+  - Disposition: FIXED by `b22efdab36355f5f068e63a8598d7a37f76d5673`.
+- [x] `bug-hunter`
+  - Findings: Codex App guidance/version gate was stale and localhost HTTP errors were misclassified.
+  - Disposition: FIXED by `b22efdab36355f5f068e63a8598d7a37f76d5673`.
+- [x] `pulseplate-pr-review`
+  - Findings: parser-safe Phase2 labels were missing, post-open thread disposition was incomplete, redirects could escape localhost validation, `/v1` provider URLs false-failed, and mixed Ollama client/server versions could be parsed incorrectly.
+  - Disposition: FIXED through the mapping labels in this artifact and code/docs/tests commits `5c296d7562676b5494c512c25b943886b9d5488d` and `b22efdab36355f5f068e63a8598d7a37f76d5673`.
+- [x] Codex Security plugin/local security scan
+  - Finding: version-command timeout robustness.
+  - Disposition: FIXED by `5c296d7562676b5494c512c25b943886b9d5488d`; no secrets, host config writes, backend/MCP/runtime drift, OpenAPI drift, or non-local probing remained after the redirect fix.

--- a/docs/review/PR_1755_FIXED_MAPPING.md
+++ b/docs/review/PR_1755_FIXED_MAPPING.md
@@ -5,7 +5,7 @@
 - PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755
 - Branch: `codex/walk3-ollama-codex-operator-workflow`
 - Base: `main`
-- Evidence head at latest mapping update: `8a4d1af0f75425b6647201b9907b5dbfd7b59d15`
+- Evidence head at latest mapping update: `706cea66f8c4ac96fb03a737f8aa4a1b18a54c8f`
 - Note: later mapping-only or review-fix commits may advance the branch head; use GitHub PR current-head checks for live merge-readiness truth.
 
 ## Scope
@@ -72,6 +72,16 @@ Disposition: FIXED
 Commit: 5c296d7562676b5494c512c25b943886b9d5488d
 Evidence: `--timeout` validation fails fast before the network probe and focused tests pass.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755#pullrequestreview-4298048488 -> 5c296d7562676b5494c512c25b943886b9d5488d
+Disposition: FIXED
+Commit: 5c296d7562676b5494c512c25b943886b9d5488d
+Evidence: cubic review-level finding listed the timeout and positive-timeout issues; both inline threads are mapped above and fixed by the same commit.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755#pullrequestreview-4298052588 -> b22efdab36355f5f068e63a8598d7a37f76d5673
+Disposition: FIXED
+Commit: b22efdab36355f5f068e63a8598d7a37f76d5673
+Evidence: CodeRabbit review-level finding listed positive-timeout and redirect issues; positive timeout is fixed by `5c296d7562676b5494c512c25b943886b9d5488d`, and redirect blocking is fixed by this commit.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755#discussion_r3248130616 -> b22efdab36355f5f068e63a8598d7a37f76d5673
 Disposition: FIXED
 Commit: b22efdab36355f5f068e63a8598d7a37f76d5673
@@ -87,15 +97,35 @@ Disposition: FIXED
 Commit: b22efdab36355f5f068e63a8598d7a37f76d5673
 Evidence: the localhost probe now uses a no-redirect opener and reports redirect HTTP responses as blocked; `tests/test_codex_ollama_operator_doctor.py` covers redirect blocking.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755#discussion_r3248229932 -> 706cea66f8c4ac96fb03a737f8aa4a1b18a54c8f
+Disposition: FIXED
+Commit: 706cea66f8c4ac96fb03a737f8aa4a1b18a54c8f
+Evidence: `_check_ollama_server(...)` now parses `/api/version` JSON and fails closed when the running server is below v0.13.3, the minimum documented here for Codex profile Responses API support; focused tests cover stale and unparseable server versions.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755#discussion_r3248229934 -> 706cea66f8c4ac96fb03a737f8aa4a1b18a54c8f
+Disposition: FIXED
+Commit: 706cea66f8c4ac96fb03a737f8aa4a1b18a54c8f
+Evidence: `_normalize_ollama_root_url(...)` catches malformed URL parse errors and returns a structured `ollama-local-server` failure; focused tests cover malformed bracketed IPv6 input.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755#discussion_r3248229941 -> 706cea66f8c4ac96fb03a737f8aa4a1b18a54c8f
+Disposition: FIXED
+Commit: 706cea66f8c4ac96fb03a737f8aa4a1b18a54c8f
+Evidence: `_check_ollama_version(...)` now treats any non-zero `ollama --version` exit as a failed check even when the output includes a parseable version; focused tests cover this path.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755#pullrequestreview-4298161871 -> 706cea66f8c4ac96fb03a737f8aa4a1b18a54c8f
+Disposition: FIXED
+Commit: 706cea66f8c4ac96fb03a737f8aa4a1b18a54c8f
+Evidence: the second Codex review-level finding surfaced malformed URL handling, non-zero version exits, and stale server version gating; all three inline threads are mapped above and fixed by this commit.
+
 ## Local Validation
 
 - `python3 scripts/orchestration/check_preflight.py --path docs/dev/CODEX_SKILLS.md --path docs/templates/codex.config.example.toml --path scripts/orchestration/check_codex_ollama_operator.py --path tests/test_codex_ollama_operator_doctor.py --path docs/review/PR_1755_FIXED_MAPPING.md` PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` OK.
-- `../../.venv/bin/python -m pytest -q tests/test_codex_ollama_operator_doctor.py` PASS, 16 tests.
+- `../../.venv/bin/python -m pytest -q tests/test_codex_ollama_operator_doctor.py` PASS, 20 tests.
 - `../../.venv/bin/python -m py_compile scripts/orchestration/check_codex_ollama_operator.py` PASS.
 - `git diff --check` PASS.
 - `../../.venv/bin/python -m pytest -q tests/test_repo_policy_guards.py` PASS.
-- `../../.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py tests/test_codex_ollama_operator_doctor.py` PASS, 21 tests.
+- `../../.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py tests/test_codex_ollama_operator_doctor.py` PASS, 25 tests.
 - `../../.venv/bin/python -m flake8 scripts/orchestration/check_codex_ollama_operator.py tests/test_codex_ollama_operator_doctor.py` PASS.
 - `../../.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/check_codex_ollama_operator.py` PASS after typing the no-redirect opener.
 - `../../.venv/bin/python -m ruff check scripts/orchestration/check_codex_ollama_operator.py tests/test_codex_ollama_operator_doctor.py` PASS.

--- a/docs/review/PR_1755_FIXED_MAPPING.md
+++ b/docs/review/PR_1755_FIXED_MAPPING.md
@@ -5,7 +5,7 @@
 - PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1755
 - Branch: `codex/walk3-ollama-codex-operator-workflow`
 - Base: `main`
-- Evidence head at latest mapping update: `b22efdab36355f5f068e63a8598d7a37f76d5673`
+- Evidence head at latest mapping update: `8a4d1af0f75425b6647201b9907b5dbfd7b59d15`
 - Note: later mapping-only or review-fix commits may advance the branch head; use GitHub PR current-head checks for live merge-readiness truth.
 
 ## Scope
@@ -97,6 +97,7 @@ Evidence: the localhost probe now uses a no-redirect opener and reports redirect
 - `../../.venv/bin/python -m pytest -q tests/test_repo_policy_guards.py` PASS.
 - `../../.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py tests/test_codex_ollama_operator_doctor.py` PASS, 21 tests.
 - `../../.venv/bin/python -m flake8 scripts/orchestration/check_codex_ollama_operator.py tests/test_codex_ollama_operator_doctor.py` PASS.
+- `../../.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/check_codex_ollama_operator.py` PASS after typing the no-redirect opener.
 - `../../.venv/bin/python -m ruff check scripts/orchestration/check_codex_ollama_operator.py tests/test_codex_ollama_operator_doctor.py` PASS.
 - `../../.venv/bin/python -m black --check scripts/orchestration/check_codex_ollama_operator.py tests/test_codex_ollama_operator_doctor.py` PASS.
 - `../../.venv/bin/python -m bandit -q -r scripts/orchestration/check_codex_ollama_operator.py` PASS.

--- a/docs/review/WALK3_OLLAMA_CODEX_OPERATOR_PREMORTEM.md
+++ b/docs/review/WALK3_OLLAMA_CODEX_OPERATOR_PREMORTEM.md
@@ -1,0 +1,27 @@
+# Walk3 Ollama-Codex Operator Workflow Premortem
+
+Status: pre-open closure artifact for `codex/walk3-ollama-codex-operator-workflow`.
+
+Failure frame: it is 6 months from now and the operator workflow failed because
+host-only Codex/Ollama guidance was mistaken for product runtime truth or
+because the diagnostic script created new local security/tooling risk.
+
+## Findings And Closure
+
+| Finding | Disposition | Closure |
+| --- | --- | --- |
+| Doctor mutates host config or shell state. | FIXED | `scripts/orchestration/check_codex_ollama_operator.py` is read-only, uses `shutil.which()` for local binaries, and has no file write path. |
+| Stale Ollama versions produce confusing `ollama launch codex-app` failures. | FIXED | The doctor checks for Ollama v0.15+ and docs name `ollama launch codex`, `codex --oss`, and profile-based setup. |
+| Operator docs blur host Codex setup with PulsePlate backend LLM runtime. | FIXED | `docs/dev/CODEX_SKILLS.md` separates host-only Codex/Ollama workflow from `LLM_PROVIDER=ollama` runtime validation. |
+| Doctor tests accidentally depend on real network or installed tools. | FIXED | `tests/test_codex_ollama_operator_doctor.py` monkeypatches binary/version/server behavior and covers missing/stale/unavailable paths. |
+| MCP or backend provider integration expands V1 scope. | NOT-A-BUG | This PR explicitly leaves `llm.py`, `providers/ollama.py`, and `mcp_pulseplate_server.py` out of scope; MCP/provider work needs a separate coordinator packet. |
+
+## Pre-Open Checklist
+
+- Run focused doctor/template tests.
+- Run repo policy guards.
+- Run `make validate-changed`.
+- Run `pre-commit run --all-files` before push.
+- Open non-draft PR only after local narrow gates pass.
+- After PR open, run `security-auditor`, `qa-engineer-agent`, `bug-hunter`,
+  `pulseplate-pr-review`, and Codex Security plugin review where available.

--- a/docs/review/WALK3_OLLAMA_CODEX_OPERATOR_PREMORTEM.md
+++ b/docs/review/WALK3_OLLAMA_CODEX_OPERATOR_PREMORTEM.md
@@ -11,7 +11,7 @@ because the diagnostic script created new local security/tooling risk.
 | Finding | Disposition | Closure |
 | --- | --- | --- |
 | Doctor mutates host config or shell state. | FIXED | `scripts/orchestration/check_codex_ollama_operator.py` is read-only, uses `shutil.which()` for local binaries, and has no file write path. |
-| Stale Ollama versions produce confusing `ollama launch codex-app` failures. | FIXED | The doctor checks for Ollama v0.15+ and docs name `ollama launch codex`, `codex --oss`, and profile-based setup. |
+| Stale Ollama versions produce confusing `ollama launch codex-app` failures. | FIXED | The doctor now separates Codex CLI (`ollama launch codex`, v0.15+) from desktop Codex App (`ollama launch codex-app`, v0.24+) and docs name both paths. |
 | Operator docs blur host Codex setup with PulsePlate backend LLM runtime. | FIXED | `docs/dev/CODEX_SKILLS.md` separates host-only Codex/Ollama workflow from `LLM_PROVIDER=ollama` runtime validation. |
 | Doctor tests accidentally depend on real network or installed tools. | FIXED | `tests/test_codex_ollama_operator_doctor.py` monkeypatches binary/version/server behavior and covers missing/stale/unavailable paths. |
 | MCP or backend provider integration expands V1 scope. | NOT-A-BUG | This PR explicitly leaves `llm.py`, `providers/ollama.py`, and `mcp_pulseplate_server.py` out of scope; MCP/provider work needs a separate coordinator packet. |

--- a/docs/templates/codex.config.example.toml
+++ b/docs/templates/codex.config.example.toml
@@ -12,6 +12,27 @@ model = "gpt-5-codex"
 # personality = "pragmatic"
 # model_reasoning_effort = "medium"
 
+# Optional Ollama-backed Codex profiles.
+# Host-only setup choices:
+# - quick one-shot: `ollama launch codex`
+# - manual local mode: `codex --oss`
+# - persistent profile: copy/adapt the provider/profile blocks below
+#
+# Requires Ollama v0.15+ for `ollama launch`.
+# This template does not make Ollama the repo or team source of truth.
+#
+# [model_providers.ollama-launch]
+# name = "Ollama"
+# base_url = "http://localhost:11434/v1"
+#
+# [profiles.ollama-launch]
+# model = "gpt-oss:120b"
+# model_provider = "ollama-launch"
+#
+# [profiles.ollama-cloud]
+# model = "gpt-oss:120b-cloud"
+# model_provider = "ollama-launch"
+
 # Optional per-clone trust (use your real absolute path after copy)
 # [projects."/absolute/path/to/PulsePlate"]
 # trust_level = "trusted"

--- a/docs/templates/codex.config.example.toml
+++ b/docs/templates/codex.config.example.toml
@@ -14,11 +14,11 @@ model = "gpt-5-codex"
 
 # Optional Ollama-backed Codex profiles.
 # Host-only setup choices:
-# - quick one-shot: `ollama launch codex`
+# - desktop app: `ollama launch codex-app` (requires Ollama v0.24+)
+# - CLI one-shot: `ollama launch codex` (requires Ollama v0.15+)
 # - manual local mode: `codex --oss`
 # - persistent profile: copy/adapt the provider/profile blocks below
 #
-# Requires Ollama v0.15+ for `ollama launch`.
 # This template does not make Ollama the repo or team source of truth.
 #
 # [model_providers.ollama-launch]

--- a/scripts/orchestration/check_codex_ollama_operator.py
+++ b/scripts/orchestration/check_codex_ollama_operator.py
@@ -16,14 +16,23 @@ import subprocess  # nosec B404: required for bounded local CLI version checks (
 import sys
 from dataclasses import asdict, dataclass
 from typing import Sequence
-from urllib.error import URLError
-from urllib.parse import urlparse
-from urllib.request import urlopen
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse, urlunparse
+from urllib.request import HTTPRedirectHandler, build_opener
 
-MIN_OLLAMA_LAUNCH_VERSION = (0, 15, 0)
+MIN_OLLAMA_CODEX_CLI_VERSION = (0, 15, 0)
+MIN_OLLAMA_CODEX_APP_VERSION = (0, 24, 0)
 DEFAULT_OLLAMA_URL = "http://localhost:11434"
 LOCAL_OLLAMA_HOSTS = {"localhost", "127.0.0.1", "::1"}
 VERSION_RE = re.compile(r"(\d+)\.(\d+)(?:\.(\d+))?")
+CLIENT_VERSION_RE = re.compile(
+    r"\bclient\s+version(?:\s+is)?\s+(\d+\.\d+(?:\.\d+)?)",
+    flags=re.IGNORECASE,
+)
+OLLAMA_VERSION_RE = re.compile(
+    r"\bollama\s+version\s+is\s+(\d+\.\d+(?:\.\d+)?)",
+    flags=re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -40,6 +49,14 @@ def _parse_version(text: str) -> tuple[int, int, int] | None:
         return None
     major, minor, patch = match.groups()
     return (int(major), int(minor), int(patch or "0"))
+
+
+def _parse_ollama_binary_version(text: str) -> tuple[int, int, int] | None:
+    for pattern in (CLIENT_VERSION_RE, OLLAMA_VERSION_RE):
+        match = pattern.search(text)
+        if match is not None:
+            return _parse_version(match.group(1))
+    return _parse_version(text)
 
 
 def _format_version(version: tuple[int, int, int]) -> str:
@@ -87,55 +104,121 @@ def _check_ollama_binary() -> tuple[CheckResult, str | None, str]:
     )
 
 
-def _check_ollama_version(binary: str | None) -> CheckResult:
+def _check_ollama_version(binary: str | None) -> tuple[CheckResult, CheckResult]:
     if binary is None:
-        return CheckResult(
-            name="ollama-launch-version",
+        missing = CheckResult(
+            name="ollama-codex-cli-version",
             ok=False,
             detail="skipped because ollama executable is missing.",
-            fix="Install Ollama v0.15+ before using `ollama launch codex`.",
+            fix="Install Ollama v0.15+ before using `ollama launch codex` for Codex CLI.",
+        )
+        return (
+            missing,
+            CheckResult(
+                name="ollama-codex-app-version",
+                ok=False,
+                detail="skipped because ollama executable is missing.",
+                fix="Install Ollama v0.24+ before using `ollama launch codex-app` for Codex App.",
+            ),
         )
     returncode, output = _run_version(binary, ["--version"])
-    version = _parse_version(output)
+    version = _parse_ollama_binary_version(output)
     if returncode != 0 and version is None:
-        return CheckResult(
-            name="ollama-launch-version",
+        failed = CheckResult(
+            name="ollama-codex-cli-version",
             ok=False,
             detail=f"`ollama --version` failed: {output or 'no output'}",
             fix="Update Ollama and confirm `ollama --version` works.",
         )
+        return (
+            failed,
+            CheckResult(
+                name="ollama-codex-app-version",
+                ok=False,
+                detail=failed.detail,
+                fix=failed.fix,
+            ),
+        )
     if version is None:
-        return CheckResult(
-            name="ollama-launch-version",
+        failed = CheckResult(
+            name="ollama-codex-cli-version",
             ok=False,
             detail=f"could not parse Ollama version from: {output or 'no output'}",
-            fix="Update Ollama to v0.15+ and rerun this doctor.",
+            fix="Update Ollama to v0.24+ and rerun this doctor.",
         )
-    if version < MIN_OLLAMA_LAUNCH_VERSION:
-        return CheckResult(
-            name="ollama-launch-version",
+        return (
+            failed,
+            CheckResult(
+                name="ollama-codex-app-version",
+                ok=False,
+                detail=failed.detail,
+                fix=failed.fix,
+            ),
+        )
+    if version < MIN_OLLAMA_CODEX_CLI_VERSION:
+        cli_check = CheckResult(
+            name="ollama-codex-cli-version",
             ok=False,
             detail=(
-                f"found Ollama {_format_version(version)}; `ollama launch` "
-                f"requires {_format_version(MIN_OLLAMA_LAUNCH_VERSION)}+."
+                f"found Ollama {_format_version(version)}; `ollama launch codex` "
+                f"requires {_format_version(MIN_OLLAMA_CODEX_CLI_VERSION)}+."
             ),
-            fix="Upgrade Ollama, then use `ollama launch codex`, not `ollama launch codex-app`.",
+            fix="Upgrade Ollama, then use `ollama launch codex` for Codex CLI.",
         )
-    return CheckResult(
-        name="ollama-launch-version",
-        ok=True,
-        detail=f"found Ollama {_format_version(version)} with launch support.",
-        fix="",
-    )
+    else:
+        cli_check = CheckResult(
+            name="ollama-codex-cli-version",
+            ok=True,
+            detail=(f"found Ollama {_format_version(version)} with Codex CLI launch support."),
+            fix="",
+        )
+    if version < MIN_OLLAMA_CODEX_APP_VERSION:
+        app_check = CheckResult(
+            name="ollama-codex-app-version",
+            ok=False,
+            detail=(
+                f"found Ollama {_format_version(version)}; `ollama launch codex-app` "
+                f"requires {_format_version(MIN_OLLAMA_CODEX_APP_VERSION)}+."
+            ),
+            fix="Upgrade Ollama, then use `ollama launch codex-app` for Codex App.",
+        )
+    else:
+        app_check = CheckResult(
+            name="ollama-codex-app-version",
+            ok=True,
+            detail=(f"found Ollama {_format_version(version)} with Codex App launch support."),
+            fix="",
+        )
+    return cli_check, app_check
 
 
-def _validate_local_url(raw_url: str) -> tuple[bool, str]:
+def _normalize_ollama_root_url(raw_url: str) -> tuple[bool, str, str]:
     parsed = urlparse(raw_url)
     if parsed.scheme not in {"http", "https"}:
-        return False, "Ollama URL must use http or https."
+        return False, "", "Ollama URL must use http or https."
     if parsed.hostname not in LOCAL_OLLAMA_HOSTS:
-        return False, "Ollama URL must be localhost, 127.0.0.1, or ::1 for this doctor."
-    return True, ""
+        return False, "", "Ollama URL must be localhost, 127.0.0.1, or ::1 for this doctor."
+    if parsed.query or parsed.fragment:
+        return False, "", "Ollama URL must not include query strings or fragments."
+    normalized_path = parsed.path.rstrip("/")
+    if normalized_path not in {"", "/v1"}:
+        return (
+            False,
+            "",
+            "Ollama URL must be the server root or OpenAI-compatible /v1 path.",
+        )
+    root_url = urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
+    return True, root_url, ""
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    def redirect_request(self, *args: object, **kwargs: object) -> None:
+        return None
+
+
+def _open_no_redirect(url: str, timeout_s: float) -> object:
+    opener = build_opener(_NoRedirectHandler)
+    return opener.open(url, timeout=timeout_s)
 
 
 def _positive_timeout(raw_value: str) -> float:
@@ -149,7 +232,7 @@ def _positive_timeout(raw_value: str) -> float:
 
 
 def _check_ollama_server(base_url: str, timeout_s: float) -> CheckResult:
-    valid, reason = _validate_local_url(base_url)
+    valid, root_url, reason = _normalize_ollama_root_url(base_url)
     if not valid:
         return CheckResult(
             name="ollama-local-server",
@@ -157,12 +240,26 @@ def _check_ollama_server(base_url: str, timeout_s: float) -> CheckResult:
             detail=reason,
             fix="Use the default local URL or pass a localhost Ollama URL.",
         )
-    version_url = base_url.rstrip("/") + "/api/version"
+    version_url = root_url.rstrip("/") + "/api/version"
     try:
-        with urlopen(
-            version_url, timeout=timeout_s
+        with _open_no_redirect(
+            version_url, timeout_s
         ) as response:  # nosec B310: URL is validated as localhost http(s) immediately before use (remove-by: 2026-08-15, ref: PR-WALK3-OLLAMA-CODEX)
             status = getattr(response, "status", 200)
+    except HTTPError as exc:
+        if 300 <= exc.code < 400:
+            return CheckResult(
+                name="ollama-local-server",
+                ok=False,
+                detail=f"{version_url} returned redirect HTTP {exc.code}; redirects are blocked.",
+                fix="Use the direct localhost Ollama server URL without redirects.",
+            )
+        return CheckResult(
+            name="ollama-local-server",
+            ok=False,
+            detail=f"{version_url} returned HTTP {exc.code}.",
+            fix="Confirm a healthy Ollama server is listening on the configured localhost URL.",
+        )
     except (OSError, URLError) as exc:
         return CheckResult(
             name="ollama-local-server",
@@ -213,9 +310,11 @@ def _check_codex_binary() -> CheckResult:
 
 def run_checks(ollama_url: str, timeout_s: float) -> list[CheckResult]:
     ollama_binary_check, ollama_binary, _ = _check_ollama_binary()
+    cli_version_check, app_version_check = _check_ollama_version(ollama_binary)
     return [
         ollama_binary_check,
-        _check_ollama_version(ollama_binary),
+        cli_version_check,
+        app_version_check,
         _check_ollama_server(ollama_url, timeout_s),
         _check_codex_binary(),
         CheckResult(
@@ -238,7 +337,11 @@ def _print_text(results: list[CheckResult]) -> None:
             print(f"  fix: {result.fix}")
     print()
     if all(result.ok for result in results):
-        print("Next: run `ollama launch codex` or `codex --profile ollama-launch`.")
+        print(
+            "Next: run `ollama launch codex-app` for Codex App, "
+            "`ollama launch codex` for Codex CLI, or "
+            "`codex --profile ollama-launch` for the host profile."
+        )
     else:
         print("Next: fix failed checks, then rerun this doctor.")
 

--- a/scripts/orchestration/check_codex_ollama_operator.py
+++ b/scripts/orchestration/check_codex_ollama_operator.py
@@ -22,6 +22,7 @@ from urllib.request import HTTPRedirectHandler, build_opener
 
 MIN_OLLAMA_CODEX_CLI_VERSION = (0, 15, 0)
 MIN_OLLAMA_CODEX_APP_VERSION = (0, 24, 0)
+MIN_OLLAMA_OPENAI_RESPONSES_VERSION = (0, 13, 3)
 DEFAULT_OLLAMA_URL = "http://localhost:11434"
 LOCAL_OLLAMA_HOSTS = {"localhost", "127.0.0.1", "::1"}
 VERSION_RE = re.compile(r"(\d+)\.(\d+)(?:\.(\d+))?")
@@ -123,11 +124,12 @@ def _check_ollama_version(binary: str | None) -> tuple[CheckResult, CheckResult]
         )
     returncode, output = _run_version(binary, ["--version"])
     version = _parse_ollama_binary_version(output)
-    if returncode != 0 and version is None:
+    if returncode != 0:
+        version_detail = f" Parsed version: {_format_version(version)}." if version else ""
         failed = CheckResult(
             name="ollama-codex-cli-version",
             ok=False,
-            detail=f"`ollama --version` failed: {output or 'no output'}",
+            detail=f"`ollama --version` failed: {output or 'no output'}.{version_detail}",
             fix="Update Ollama and confirm `ollama --version` works.",
         )
         return (
@@ -193,10 +195,14 @@ def _check_ollama_version(binary: str | None) -> tuple[CheckResult, CheckResult]
 
 
 def _normalize_ollama_root_url(raw_url: str) -> tuple[bool, str, str]:
-    parsed = urlparse(raw_url)
+    try:
+        parsed = urlparse(raw_url)
+        hostname = parsed.hostname
+    except ValueError as exc:
+        return False, "", f"Malformed Ollama URL: {exc}"
     if parsed.scheme not in {"http", "https"}:
         return False, "", "Ollama URL must use http or https."
-    if parsed.hostname not in LOCAL_OLLAMA_HOSTS:
+    if hostname not in LOCAL_OLLAMA_HOSTS:
         return False, "", "Ollama URL must be localhost, 127.0.0.1, or ::1 for this doctor."
     if parsed.query or parsed.fragment:
         return False, "", "Ollama URL must not include query strings or fragments."
@@ -219,6 +225,22 @@ class _NoRedirectHandler(HTTPRedirectHandler):
 def _open_no_redirect(url: str, timeout_s: float) -> ContextManager[Any]:
     opener = build_opener(_NoRedirectHandler)
     return cast(ContextManager[Any], opener.open(url, timeout=timeout_s))
+
+
+def _read_ollama_server_version(response: Any) -> tuple[int, int, int] | None:
+    raw_body = response.read()
+    if isinstance(raw_body, bytes):
+        raw_text = raw_body.decode("utf-8", errors="replace")
+    else:
+        raw_text = str(raw_body)
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError:
+        return None
+    version = payload.get("version")
+    if not isinstance(version, str):
+        return None
+    return _parse_version(version)
 
 
 def _positive_timeout(raw_value: str) -> float:
@@ -246,6 +268,7 @@ def _check_ollama_server(base_url: str, timeout_s: float) -> CheckResult:
             version_url, timeout_s
         ) as response:  # nosec B310: URL is validated as localhost http(s) immediately before use (remove-by: 2026-08-15, ref: PR-WALK3-OLLAMA-CODEX)
             status = getattr(response, "status", 200)
+            server_version = _read_ollama_server_version(response)
     except HTTPError as exc:
         if 300 <= exc.code < 400:
             return CheckResult(
@@ -274,10 +297,28 @@ def _check_ollama_server(base_url: str, timeout_s: float) -> CheckResult:
             detail=f"{version_url} returned HTTP {status}.",
             fix="Confirm Ollama is healthy on localhost:11434.",
         )
+    if server_version is None:
+        return CheckResult(
+            name="ollama-local-server",
+            ok=False,
+            detail=f"{version_url} returned HTTP 200 but no parseable server version.",
+            fix="Confirm this is an Ollama server and rerun the doctor.",
+        )
+    if server_version < MIN_OLLAMA_OPENAI_RESPONSES_VERSION:
+        return CheckResult(
+            name="ollama-local-server",
+            ok=False,
+            detail=(
+                f"{version_url} returned Ollama server {_format_version(server_version)}; "
+                "Codex profiles need OpenAI Responses API support "
+                f"({_format_version(MIN_OLLAMA_OPENAI_RESPONSES_VERSION)}+)."
+            ),
+            fix="Upgrade or restart Ollama so the running server is v0.13.3+ before using Codex profiles.",
+        )
     return CheckResult(
         name="ollama-local-server",
         ok=True,
-        detail=f"{version_url} returned HTTP 200.",
+        detail=f"{version_url} returned Ollama server {_format_version(server_version)}.",
         fix="",
     )
 

--- a/scripts/orchestration/check_codex_ollama_operator.py
+++ b/scripts/orchestration/check_codex_ollama_operator.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Diagnose host-only Codex + Ollama operator setup.
+
+This script is intentionally read-only. It checks local tool availability and
+prints actionable guidance, but it never writes host config such as
+``~/.codex/config.toml``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess  # nosec B404: required for bounded local CLI version checks (remove-by: 2026-08-15, ref: PR-WALK3-OLLAMA-CODEX)
+import sys
+from dataclasses import asdict, dataclass
+from typing import Sequence
+from urllib.error import URLError
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+MIN_OLLAMA_LAUNCH_VERSION = (0, 15, 0)
+DEFAULT_OLLAMA_URL = "http://localhost:11434"
+LOCAL_OLLAMA_HOSTS = {"localhost", "127.0.0.1", "::1"}
+VERSION_RE = re.compile(r"(\d+)\.(\d+)(?:\.(\d+))?")
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+    fix: str
+
+
+def _parse_version(text: str) -> tuple[int, int, int] | None:
+    match = VERSION_RE.search(text)
+    if match is None:
+        return None
+    major, minor, patch = match.groups()
+    return (int(major), int(minor), int(patch or "0"))
+
+
+def _format_version(version: tuple[int, int, int]) -> str:
+    return ".".join(str(part) for part in version)
+
+
+def _run_version(binary: str, args: Sequence[str]) -> tuple[int, str]:
+    completed = subprocess.run(  # nosec B603: argv uses shutil.which-resolved absolute binaries (remove-by: 2026-08-15, ref: PR-WALK3-OLLAMA-CODEX)
+        [binary, *args],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+    output = "\n".join(part for part in (completed.stdout, completed.stderr) if part)
+    return completed.returncode, output.strip()
+
+
+def _check_ollama_binary() -> tuple[CheckResult, str | None, str]:
+    binary = shutil.which("ollama")
+    if binary is None:
+        return (
+            CheckResult(
+                name="ollama-binary",
+                ok=False,
+                detail="ollama executable was not found on PATH.",
+                fix="Install or update Ollama, then rerun this doctor.",
+            ),
+            None,
+            "",
+        )
+    return (
+        CheckResult(
+            name="ollama-binary",
+            ok=True,
+            detail=f"found {binary}",
+            fix="",
+        ),
+        binary,
+        "",
+    )
+
+
+def _check_ollama_version(binary: str | None) -> CheckResult:
+    if binary is None:
+        return CheckResult(
+            name="ollama-launch-version",
+            ok=False,
+            detail="skipped because ollama executable is missing.",
+            fix="Install Ollama v0.15+ before using `ollama launch codex`.",
+        )
+    returncode, output = _run_version(binary, ["--version"])
+    version = _parse_version(output)
+    if returncode != 0 and version is None:
+        return CheckResult(
+            name="ollama-launch-version",
+            ok=False,
+            detail=f"`ollama --version` failed: {output or 'no output'}",
+            fix="Update Ollama and confirm `ollama --version` works.",
+        )
+    if version is None:
+        return CheckResult(
+            name="ollama-launch-version",
+            ok=False,
+            detail=f"could not parse Ollama version from: {output or 'no output'}",
+            fix="Update Ollama to v0.15+ and rerun this doctor.",
+        )
+    if version < MIN_OLLAMA_LAUNCH_VERSION:
+        return CheckResult(
+            name="ollama-launch-version",
+            ok=False,
+            detail=(
+                f"found Ollama {_format_version(version)}; `ollama launch` "
+                f"requires {_format_version(MIN_OLLAMA_LAUNCH_VERSION)}+."
+            ),
+            fix="Upgrade Ollama, then use `ollama launch codex`, not `ollama launch codex-app`.",
+        )
+    return CheckResult(
+        name="ollama-launch-version",
+        ok=True,
+        detail=f"found Ollama {_format_version(version)} with launch support.",
+        fix="",
+    )
+
+
+def _validate_local_url(raw_url: str) -> tuple[bool, str]:
+    parsed = urlparse(raw_url)
+    if parsed.scheme not in {"http", "https"}:
+        return False, "Ollama URL must use http or https."
+    if parsed.hostname not in LOCAL_OLLAMA_HOSTS:
+        return False, "Ollama URL must be localhost, 127.0.0.1, or ::1 for this doctor."
+    return True, ""
+
+
+def _check_ollama_server(base_url: str, timeout_s: float) -> CheckResult:
+    valid, reason = _validate_local_url(base_url)
+    if not valid:
+        return CheckResult(
+            name="ollama-local-server",
+            ok=False,
+            detail=reason,
+            fix="Use the default local URL or pass a localhost Ollama URL.",
+        )
+    version_url = base_url.rstrip("/") + "/api/version"
+    try:
+        with urlopen(
+            version_url, timeout=timeout_s
+        ) as response:  # nosec B310: URL is validated as localhost http(s) immediately before use (remove-by: 2026-08-15, ref: PR-WALK3-OLLAMA-CODEX)
+            status = getattr(response, "status", 200)
+    except (OSError, URLError) as exc:
+        return CheckResult(
+            name="ollama-local-server",
+            ok=False,
+            detail=f"could not reach {version_url}: {exc}",
+            fix="Start Ollama with `ollama serve` or the desktop app, then rerun this doctor.",
+        )
+    if status != 200:
+        return CheckResult(
+            name="ollama-local-server",
+            ok=False,
+            detail=f"{version_url} returned HTTP {status}.",
+            fix="Confirm Ollama is healthy on localhost:11434.",
+        )
+    return CheckResult(
+        name="ollama-local-server",
+        ok=True,
+        detail=f"{version_url} returned HTTP 200.",
+        fix="",
+    )
+
+
+def _check_codex_binary() -> CheckResult:
+    binary = shutil.which("codex")
+    if binary is None:
+        return CheckResult(
+            name="codex-binary",
+            ok=False,
+            detail="codex executable was not found on PATH.",
+            fix="Install Codex CLI, then rerun this doctor.",
+        )
+    returncode, output = _run_version(binary, ["--version"])
+    if returncode != 0:
+        return CheckResult(
+            name="codex-binary",
+            ok=False,
+            detail=f"found {binary}, but `codex --version` failed: {output or 'no output'}",
+            fix="Repair or reinstall Codex CLI.",
+        )
+    first_line = output.splitlines()[0] if output else "version output empty"
+    return CheckResult(
+        name="codex-binary",
+        ok=True,
+        detail=f"found {binary}; {first_line}",
+        fix="",
+    )
+
+
+def run_checks(ollama_url: str, timeout_s: float) -> list[CheckResult]:
+    ollama_binary_check, ollama_binary, _ = _check_ollama_binary()
+    return [
+        ollama_binary_check,
+        _check_ollama_version(ollama_binary),
+        _check_ollama_server(ollama_url, timeout_s),
+        _check_codex_binary(),
+        CheckResult(
+            name="host-config-write-guard",
+            ok=True,
+            detail="read-only diagnostic; no host config files are inspected or written.",
+            fix="",
+        ),
+    ]
+
+
+def _print_text(results: list[CheckResult]) -> None:
+    print("PulsePlate Codex/Ollama operator doctor")
+    print("Scope: host-only diagnostics; no PulsePlate runtime or MCP changes.")
+    print()
+    for result in results:
+        status = "PASS" if result.ok else "FAIL"
+        print(f"{status}: {result.name}: {result.detail}")
+        if result.fix:
+            print(f"  fix: {result.fix}")
+    print()
+    if all(result.ok for result in results):
+        print("Next: run `ollama launch codex` or `codex --profile ollama-launch`.")
+    else:
+        print("Next: fix failed checks, then rerun this doctor.")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check local Codex + Ollama operator setup without writing host config."
+    )
+    parser.add_argument("--ollama-url", default=DEFAULT_OLLAMA_URL)
+    parser.add_argument("--timeout", type=float, default=1.0)
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    args = parser.parse_args(argv)
+
+    results = run_checks(ollama_url=args.ollama_url, timeout_s=args.timeout)
+    if args.json:
+        print(json.dumps([asdict(result) for result in results], indent=2, sort_keys=True))
+    else:
+        _print_text(results)
+    return 0 if all(result.ok for result in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/orchestration/check_codex_ollama_operator.py
+++ b/scripts/orchestration/check_codex_ollama_operator.py
@@ -47,13 +47,17 @@ def _format_version(version: tuple[int, int, int]) -> str:
 
 
 def _run_version(binary: str, args: Sequence[str]) -> tuple[int, str]:
-    completed = subprocess.run(  # nosec B603: argv uses shutil.which-resolved absolute binaries (remove-by: 2026-08-15, ref: PR-WALK3-OLLAMA-CODEX)
-        [binary, *args],
-        text=True,
-        capture_output=True,
-        check=False,
-        timeout=10,
-    )
+    try:
+        completed = subprocess.run(  # nosec B603: argv uses shutil.which-resolved absolute binaries (remove-by: 2026-08-15, ref: PR-WALK3-OLLAMA-CODEX)
+            [binary, *args],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired as exc:
+        command = " ".join(str(part) for part in exc.cmd)
+        return 124, f"`{command}` timed out after {exc.timeout} seconds"
     output = "\n".join(part for part in (completed.stdout, completed.stderr) if part)
     return completed.returncode, output.strip()
 
@@ -132,6 +136,16 @@ def _validate_local_url(raw_url: str) -> tuple[bool, str]:
     if parsed.hostname not in LOCAL_OLLAMA_HOSTS:
         return False, "Ollama URL must be localhost, 127.0.0.1, or ::1 for this doctor."
     return True, ""
+
+
+def _positive_timeout(raw_value: str) -> float:
+    try:
+        timeout_s = float(raw_value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("timeout must be a number of seconds") from exc
+    if timeout_s <= 0:
+        raise argparse.ArgumentTypeError("timeout must be greater than 0 seconds")
+    return timeout_s
 
 
 def _check_ollama_server(base_url: str, timeout_s: float) -> CheckResult:
@@ -234,7 +248,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         description="Check local Codex + Ollama operator setup without writing host config."
     )
     parser.add_argument("--ollama-url", default=DEFAULT_OLLAMA_URL)
-    parser.add_argument("--timeout", type=float, default=1.0)
+    parser.add_argument("--timeout", type=_positive_timeout, default=1.0)
     parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     args = parser.parse_args(argv)
 

--- a/scripts/orchestration/check_codex_ollama_operator.py
+++ b/scripts/orchestration/check_codex_ollama_operator.py
@@ -15,7 +15,7 @@ import shutil
 import subprocess  # nosec B404: required for bounded local CLI version checks (remove-by: 2026-08-15, ref: PR-WALK3-OLLAMA-CODEX)
 import sys
 from dataclasses import asdict, dataclass
-from typing import Sequence
+from typing import Any, ContextManager, Sequence, cast
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse, urlunparse
 from urllib.request import HTTPRedirectHandler, build_opener
@@ -216,9 +216,9 @@ class _NoRedirectHandler(HTTPRedirectHandler):
         return None
 
 
-def _open_no_redirect(url: str, timeout_s: float) -> object:
+def _open_no_redirect(url: str, timeout_s: float) -> ContextManager[Any]:
     opener = build_opener(_NoRedirectHandler)
-    return opener.open(url, timeout=timeout_s)
+    return cast(ContextManager[Any], opener.open(url, timeout=timeout_s))
 
 
 def _positive_timeout(raw_value: str) -> float:

--- a/tests/test_codex_ollama_operator_doctor.py
+++ b/tests/test_codex_ollama_operator_doctor.py
@@ -1,0 +1,127 @@
+"""Tests for the host-only Codex/Ollama operator doctor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from scripts.orchestration import check_codex_ollama_operator as doctor
+
+
+def test_parse_version_accepts_major_minor_patch() -> None:
+    assert doctor._parse_version("ollama version is 0.15.1") == (0, 15, 1)
+    assert doctor._parse_version("client version is 0.12.0") == (0, 12, 0)
+    assert doctor._parse_version("version 1.2") == (1, 2, 0)
+
+
+def test_stale_ollama_version_reports_launch_fix(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        doctor,
+        "_run_version",
+        lambda binary, args: (0, "Warning: client version is 0.12.0"),
+    )
+
+    result = doctor._check_ollama_version("/usr/bin/ollama")
+
+    assert result.ok is False
+    assert "requires 0.15.0+" in result.detail
+    assert "ollama launch codex" in result.fix
+    assert "codex-app" in result.fix
+
+
+def test_missing_binaries_are_actionable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: None)
+
+    ollama_check, binary, _ = doctor._check_ollama_binary()
+    codex_check = doctor._check_codex_binary()
+
+    assert binary is None
+    assert ollama_check.ok is False
+    assert "not found" in ollama_check.detail
+    assert "Install" in ollama_check.fix
+    assert codex_check.ok is False
+    assert "Codex CLI" in codex_check.fix
+
+
+def test_rejects_non_local_ollama_url() -> None:
+    result = doctor._check_ollama_server("https://example.com", timeout_s=0.01)
+
+    assert result.ok is False
+    assert "localhost" in result.detail
+    assert "local" in result.fix
+
+
+def test_unavailable_local_ollama_server_reports_serve_fix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(*args: Any, **kwargs: Any) -> Any:
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(doctor, "urlopen", _raise)
+
+    result = doctor._check_ollama_server("http://localhost:11434", timeout_s=0.01)
+
+    assert result.ok is False
+    assert "could not reach" in result.detail
+    assert "ollama serve" in result.fix
+
+
+def test_successful_server_check_uses_local_version_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, Any] = {}
+
+    class _Response:
+        status = 200
+
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def _fake_urlopen(url: str, *, timeout: float) -> _Response:
+        observed["url"] = url
+        observed["timeout"] = timeout
+        return _Response()
+
+    monkeypatch.setattr(doctor, "urlopen", _fake_urlopen)
+
+    result = doctor._check_ollama_server("http://127.0.0.1:11434", timeout_s=0.5)
+
+    assert result.ok is True
+    assert observed == {"url": "http://127.0.0.1:11434/api/version", "timeout": 0.5}
+
+
+def test_main_json_reports_host_write_guard(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
+    monkeypatch.setattr(
+        doctor,
+        "run_checks",
+        lambda ollama_url, timeout_s: [
+            doctor.CheckResult(
+                name="host-config-write-guard",
+                ok=True,
+                detail="read-only diagnostic; no host config files are inspected or written.",
+                fix="",
+            )
+        ],
+    )
+
+    exit_code = doctor.main(["--json"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "host-config-write-guard" in out
+    assert "read-only diagnostic" in out
+
+
+def test_template_does_not_contain_secrets_or_personal_paths() -> None:
+    template = Path("docs/templates/codex.config.example.toml").read_text(encoding="utf-8")
+
+    assert "sk-" not in template
+    assert "/Users/" not in template
+    assert "api_key" not in template.lower()

--- a/tests/test_codex_ollama_operator_doctor.py
+++ b/tests/test_codex_ollama_operator_doctor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from types import SimpleNamespace
+from subprocess import TimeoutExpired
 from typing import Any
 
 import pytest
@@ -15,6 +15,19 @@ def test_parse_version_accepts_major_minor_patch() -> None:
     assert doctor._parse_version("ollama version is 0.15.1") == (0, 15, 1)
     assert doctor._parse_version("client version is 0.12.0") == (0, 12, 0)
     assert doctor._parse_version("version 1.2") == (1, 2, 0)
+
+
+def test_run_version_reports_cli_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _timeout(*args: Any, **kwargs: Any) -> Any:
+        raise TimeoutExpired(cmd=["/usr/bin/ollama", "--version"], timeout=10)
+
+    monkeypatch.setattr(doctor.subprocess, "run", _timeout)
+
+    returncode, output = doctor._run_version("/usr/bin/ollama", ["--version"])
+
+    assert returncode == 124
+    assert "timed out" in output
+    assert "/usr/bin/ollama --version" in output
 
 
 def test_stale_ollama_version_reports_launch_fix(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -95,6 +108,13 @@ def test_successful_server_check_uses_local_version_endpoint(
 
     assert result.ok is True
     assert observed == {"url": "http://127.0.0.1:11434/api/version", "timeout": 0.5}
+
+
+def test_timeout_must_be_positive() -> None:
+    assert doctor._positive_timeout("0.5") == 0.5
+
+    with pytest.raises(SystemExit):
+        doctor.main(["--timeout", "0"])
 
 
 def test_main_json_reports_host_write_guard(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:

--- a/tests/test_codex_ollama_operator_doctor.py
+++ b/tests/test_codex_ollama_operator_doctor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from subprocess import TimeoutExpired
 from typing import Any
+from urllib.error import HTTPError
 
 import pytest
 
@@ -15,6 +16,17 @@ def test_parse_version_accepts_major_minor_patch() -> None:
     assert doctor._parse_version("ollama version is 0.15.1") == (0, 15, 1)
     assert doctor._parse_version("client version is 0.12.0") == (0, 12, 0)
     assert doctor._parse_version("version 1.2") == (1, 2, 0)
+
+
+def test_ollama_version_prefers_client_version_from_mixed_output() -> None:
+    output = "\n".join(
+        [
+            "ollama version is 0.24.0",
+            "Warning: client version is 0.12.0",
+        ]
+    )
+
+    assert doctor._parse_ollama_binary_version(output) == (0, 12, 0)
 
 
 def test_run_version_reports_cli_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -38,12 +50,31 @@ def test_stale_ollama_version_reports_launch_fix(monkeypatch: pytest.MonkeyPatch
         lambda binary, args: (0, "Warning: client version is 0.12.0"),
     )
 
-    result = doctor._check_ollama_version("/usr/bin/ollama")
+    cli_result, app_result = doctor._check_ollama_version("/usr/bin/ollama")
 
-    assert result.ok is False
-    assert "requires 0.15.0+" in result.detail
-    assert "ollama launch codex" in result.fix
-    assert "codex-app" in result.fix
+    assert cli_result.ok is False
+    assert "requires 0.15.0+" in cli_result.detail
+    assert "ollama launch codex" in cli_result.fix
+    assert app_result.ok is False
+    assert "requires 0.24.0+" in app_result.detail
+    assert "ollama launch codex-app" in app_result.fix
+
+
+def test_cli_ready_version_can_still_require_codex_app_upgrade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(doctor.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        doctor,
+        "_run_version",
+        lambda binary, args: (0, "ollama version is 0.15.0"),
+    )
+
+    cli_result, app_result = doctor._check_ollama_version("/usr/bin/ollama")
+
+    assert cli_result.ok is True
+    assert app_result.ok is False
+    assert "0.24.0+" in app_result.detail
 
 
 def test_missing_binaries_are_actionable(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -68,13 +99,20 @@ def test_rejects_non_local_ollama_url() -> None:
     assert "local" in result.fix
 
 
+def test_rejects_unexpected_ollama_url_path() -> None:
+    result = doctor._check_ollama_server("http://localhost:11434/admin", timeout_s=0.01)
+
+    assert result.ok is False
+    assert "server root" in result.detail
+
+
 def test_unavailable_local_ollama_server_reports_serve_fix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def _raise(*args: Any, **kwargs: Any) -> Any:
         raise OSError("connection refused")
 
-    monkeypatch.setattr(doctor, "urlopen", _raise)
+    monkeypatch.setattr(doctor, "_open_no_redirect", _raise)
 
     result = doctor._check_ollama_server("http://localhost:11434", timeout_s=0.01)
 
@@ -97,17 +135,57 @@ def test_successful_server_check_uses_local_version_endpoint(
         def __exit__(self, *args: object) -> None:
             return None
 
-    def _fake_urlopen(url: str, *, timeout: float) -> _Response:
+    def _fake_open(url: str, timeout_s: float) -> _Response:
         observed["url"] = url
-        observed["timeout"] = timeout
+        observed["timeout"] = timeout_s
         return _Response()
 
-    monkeypatch.setattr(doctor, "urlopen", _fake_urlopen)
+    monkeypatch.setattr(doctor, "_open_no_redirect", _fake_open)
 
-    result = doctor._check_ollama_server("http://127.0.0.1:11434", timeout_s=0.5)
+    result = doctor._check_ollama_server("http://127.0.0.1:11434/v1", timeout_s=0.5)
 
     assert result.ok is True
     assert observed == {"url": "http://127.0.0.1:11434/api/version", "timeout": 0.5}
+
+
+def test_http_error_reports_status_instead_of_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_http_error(*args: Any, **kwargs: Any) -> Any:
+        raise HTTPError(
+            url="http://localhost:11434/api/version",
+            code=500,
+            msg="Server Error",
+            hdrs={},
+            fp=None,
+        )
+
+    monkeypatch.setattr(doctor, "_open_no_redirect", _raise_http_error)
+
+    result = doctor._check_ollama_server("http://localhost:11434", timeout_s=0.5)
+
+    assert result.ok is False
+    assert "HTTP 500" in result.detail
+    assert "could not reach" not in result.detail
+
+
+def test_redirects_are_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_redirect(*args: Any, **kwargs: Any) -> Any:
+        raise HTTPError(
+            url="http://localhost:11434/api/version",
+            code=302,
+            msg="Found",
+            hdrs={"Location": "https://example.com"},
+            fp=None,
+        )
+
+    monkeypatch.setattr(doctor, "_open_no_redirect", _raise_redirect)
+
+    result = doctor._check_ollama_server("http://localhost:11434", timeout_s=0.5)
+
+    assert result.ok is False
+    assert "redirect" in result.detail
+    assert "blocked" in result.detail
 
 
 def test_timeout_must_be_positive() -> None:
@@ -139,9 +217,58 @@ def test_main_json_reports_host_write_guard(monkeypatch: pytest.MonkeyPatch, cap
     assert "read-only diagnostic" in out
 
 
-def test_template_does_not_contain_secrets_or_personal_paths() -> None:
+def test_main_text_output_exercises_real_aggregate_path(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: Any,
+) -> None:
+    monkeypatch.setattr(
+        doctor,
+        "_check_ollama_binary",
+        lambda: (
+            doctor.CheckResult("ollama-binary", True, "found /usr/bin/ollama", ""),
+            "/usr/bin/ollama",
+            "",
+        ),
+    )
+    monkeypatch.setattr(
+        doctor,
+        "_check_ollama_version",
+        lambda binary: (
+            doctor.CheckResult("ollama-codex-cli-version", True, "CLI ready", ""),
+            doctor.CheckResult("ollama-codex-app-version", True, "App ready", ""),
+        ),
+    )
+    monkeypatch.setattr(
+        doctor,
+        "_check_ollama_server",
+        lambda ollama_url, timeout_s: doctor.CheckResult(
+            "ollama-local-server", True, "server ready", ""
+        ),
+    )
+    monkeypatch.setattr(
+        doctor,
+        "_check_codex_binary",
+        lambda: doctor.CheckResult("codex-binary", True, "Codex ready", ""),
+    )
+
+    exit_code = doctor.main([])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "ollama launch codex-app" in out
+    assert "ollama launch codex" in out
+    assert "host-config-write-guard" in out
+
+
+def test_template_contains_expected_ollama_profile_contract() -> None:
     template = Path("docs/templates/codex.config.example.toml").read_text(encoding="utf-8")
 
     assert "sk-" not in template
     assert "/Users/" not in template
     assert "api_key" not in template.lower()
+    assert "[model_providers.ollama-launch]" in template
+    assert 'base_url = "http://localhost:11434/v1"' in template
+    assert "[profiles.ollama-launch]" in template
+    assert 'model = "gpt-oss:120b"' in template
+    assert "[profiles.ollama-cloud]" in template
+    assert 'model = "gpt-oss:120b-cloud"' in template

--- a/tests/test_codex_ollama_operator_doctor.py
+++ b/tests/test_codex_ollama_operator_doctor.py
@@ -77,6 +77,23 @@ def test_cli_ready_version_can_still_require_codex_app_upgrade(
     assert "0.24.0+" in app_result.detail
 
 
+def test_nonzero_ollama_version_fails_even_with_parseable_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        doctor,
+        "_run_version",
+        lambda binary, args: (1, "ollama version is 0.24.0"),
+    )
+
+    cli_result, app_result = doctor._check_ollama_version("/usr/bin/ollama")
+
+    assert cli_result.ok is False
+    assert app_result.ok is False
+    assert "`ollama --version` failed" in cli_result.detail
+    assert "Parsed version: 0.24.0" in cli_result.detail
+
+
 def test_missing_binaries_are_actionable(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(doctor.shutil, "which", lambda name: None)
 
@@ -106,6 +123,13 @@ def test_rejects_unexpected_ollama_url_path() -> None:
     assert "server root" in result.detail
 
 
+def test_malformed_ollama_url_returns_check_failure() -> None:
+    result = doctor._check_ollama_server("http://[::1", timeout_s=0.01)
+
+    assert result.ok is False
+    assert "Malformed Ollama URL" in result.detail
+
+
 def test_unavailable_local_ollama_server_reports_serve_fix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -129,6 +153,9 @@ def test_successful_server_check_uses_local_version_endpoint(
     class _Response:
         status = 200
 
+        def read(self) -> bytes:
+            return b'{"version":"0.13.3"}'
+
         def __enter__(self) -> "_Response":
             return self
 
@@ -146,6 +173,54 @@ def test_successful_server_check_uses_local_version_endpoint(
 
     assert result.ok is True
     assert observed == {"url": "http://127.0.0.1:11434/api/version", "timeout": 0.5}
+    assert "0.13.3" in result.detail
+
+
+def test_stale_running_ollama_server_fails_profile_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Response:
+        status = 200
+
+        def read(self) -> bytes:
+            return b'{"version":"0.12.0"}'
+
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(doctor, "_open_no_redirect", lambda url, timeout_s: _Response())
+
+    result = doctor._check_ollama_server("http://localhost:11434", timeout_s=0.5)
+
+    assert result.ok is False
+    assert "0.12.0" in result.detail
+    assert "0.13.3+" in result.detail
+
+
+def test_unparseable_ollama_server_version_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Response:
+        status = 200
+
+        def read(self) -> bytes:
+            return b"not json"
+
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(doctor, "_open_no_redirect", lambda url, timeout_s: _Response())
+
+    result = doctor._check_ollama_server("http://localhost:11434", timeout_s=0.5)
+
+    assert result.ok is False
+    assert "no parseable server version" in result.detail
 
 
 def test_http_error_reports_status_instead_of_unreachable(


### PR DESCRIPTION
## Goal
Ship Walk3: Ollama-Codex Operator Workflow V1 as repo-guided operator support for local/cloud Ollama-backed Codex usage.

## Business reason
Reduce operator friction when using Codex with local Ollama while keeping PulsePlate product runtime, MCP behavior, and backend LLM contracts unchanged.

## Scope
- Add a host-only Codex config template section for Ollama-backed Codex profiles.
- Add a read-only operator doctor for Ollama/Codex launch readiness.
- Document why `ollama launch codex-app` can fail on stale Ollama builds and how it differs from Codex CLI launch.
- Document the separation between host Codex/Ollama setup and PulsePlate runtime `LLM_PROVIDER=ollama`.
- Add deterministic tests for the doctor and template safety.
- Add premortem closure and PR-numbered fixed mapping artifacts.

## Split Justification
This PR exceeds the default size threshold because post-open security, QA, bug-hunter, and PR-review passes found real operator-doctor issues that had to be fixed in the same lane before disposition: timeout handling, Codex App version guidance, `/v1` URL normalization, redirect blocking, mixed client/server version parsing, and parser-safe fixed mapping. Splitting those fixes would leave PR #1755 with known actionable review findings and failed governance gates. Scope remains narrow: docs/template, one read-only operator doctor, deterministic tests, and review artifacts only; no backend runtime, MCP, OpenAPI, provider, product LLM, web, or iOS behavior changes are included.

## Out of scope
- No backend runtime changes.
- No changes to `llm.py`, `providers/ollama.py`, or `mcp_pulseplate_server.py`.
- No MCP/Ollama server integration changes in V1.
- No writes to `~/.codex/config.toml` or other host config files.

## Files changed / likely touched
- `docs/templates/codex.config.example.toml`
- `docs/dev/CODEX_SKILLS.md`
- `scripts/orchestration/check_codex_ollama_operator.py`
- `tests/test_codex_ollama_operator_doctor.py`
- `docs/review/WALK3_OLLAMA_CODEX_OPERATOR_PREMORTEM.md`
- `docs/review/PR_1755_FIXED_MAPPING.md`

## Key decisions
- Keep Ollama-Codex support operator-only and host-only in V1.
- Make the doctor diagnostic/read-only; it never edits host config.
- Split Ollama launch guidance by surface: `ollama launch codex-app` for desktop Codex App requires Ollama v0.24+, while Codex CLI launch/profile paths require lower CLI support and are checked separately.
- Normalize provider-style `/v1` URLs back to the Ollama root before probing `/api/version`.
- Block redirects during localhost probes so the local-only guarantee is not bypassed.

## Tests / validation
Local narrow gates run:
- `python3 scripts/orchestration/check_preflight.py --path docs/dev/CODEX_SKILLS.md --path docs/templates/codex.config.example.toml --path scripts/orchestration/check_codex_ollama_operator.py --path tests/test_codex_ollama_operator_doctor.py --path docs/review/PR_1755_FIXED_MAPPING.md` PASS.
- `python3 scripts/orchestration/check_agent_consistency.py` OK.
- `../../.venv/bin/python -m pytest -q tests/test_codex_ollama_operator_doctor.py` PASS, 20 tests.
- `../../.venv/bin/python -m pytest -q tests/test_repo_policy_guards.py` PASS.
- `../../.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py tests/test_codex_ollama_operator_doctor.py` PASS, 25 tests.
- `../../.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/check_codex_ollama_operator.py` PASS.
- `../../.venv/bin/python -m flake8 scripts/orchestration/check_codex_ollama_operator.py tests/test_codex_ollama_operator_doctor.py` PASS.
- `../../.venv/bin/python -m ruff check scripts/orchestration/check_codex_ollama_operator.py tests/test_codex_ollama_operator_doctor.py` PASS.
- `../../.venv/bin/python -m black --check scripts/orchestration/check_codex_ollama_operator.py tests/test_codex_ollama_operator_doctor.py` PASS.
- `../../.venv/bin/python -m bandit -q -r scripts/orchestration/check_codex_ollama_operator.py` PASS.
- `VENV_PYTHON=../../.venv/bin/python make validate-changed` PASS.
- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1755` PASS locally after parser-safe mapping update.
- `VENV_PYTHON=../../.venv/bin/python pre-commit run --all-files` PASS.
- `VENV_PYTHON=../../.venv/bin/python git push` pre-push hooks PASS, including changed-file mypy, pip-audit, backend tests, full-repo bandit, and docker build test.

Host diagnostic evidence:
- `python3 scripts/orchestration/check_codex_ollama_operator.py --json` correctly returned non-zero on this host because Ollama is `0.12.0` and the local server is not running, while Codex CLI was found. This is expected diagnostic behavior, not a project gate failure.

Full `make verify`:
- Deferred by operator choice for this machine-heavy lane. This PR relies on narrow local gates plus current-head CI parity for heavy validation. No merge-ready claim is made from this deferral.

## Security notes
- The doctor only checks local binaries and localhost Ollama availability.
- It rejects non-local Ollama URLs, rejects unexpected URL paths, normalizes `/v1`, and blocks redirects.
- It uses absolute binary paths resolved by `shutil.which()` and no shell execution.
- It catches version-command timeouts and malformed URLs, blocks redirects, gates running server version for Codex profile support, and reports diagnostic failures instead of traceback crashes.
- It does not read or write `~/.codex/config.toml`, shell profiles, Cursor config, MCP config, runtime config, or secrets.
- Policy-compliant Bandit suppressions include explicit rule, rationale, remove-by date, and PR reference.

## Risks / rollback
- Risk: operators could confuse host Codex/Ollama setup with PulsePlate backend `LLM_PROVIDER=ollama`. Mitigation: docs explicitly separate these surfaces.
- Risk: stale Ollama versions make `ollama launch codex-app` fail. Mitigation: doctor detects Codex CLI and Codex App version gates separately.
- Risk: MCP/backend integration scope creep. Mitigation: V1 explicitly excludes MCP and backend runtime changes.
- Rollback: revert the docs/template/doctor/test/review commits. No runtime migration or persistent host config write is required.

## Deferred / follow-ups
- MCP/Ollama server integration is intentionally out of V1 and should be handled only by a dedicated future PR with backend/MCP contracts, guards, and tests.
- Full local `make verify` remains deferred by operator choice for this machine-heavy lane; current-head CI must provide heavy parity before merge readiness.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Post-open `security-auditor`, `qa-engineer-agent`, `bug-hunter`, `pulseplate-pr-review`, and Codex Security/local security scan findings are dispositioned in `docs/review/PR_1755_FIXED_MAPPING.md`.
- [ ] Re-run discussion-thread pass after any new review cycle before merge readiness.

### Fixed in Commit Mapping
- Canonical artifact: `docs/review/PR_1755_FIXED_MAPPING.md`.
- Initial implementation: `064cb8f0fca606178e58868d424d5213ea2b653d`.
- Timeout/positive-timeout fix: `5c296d7562676b5494c512c25b943886b9d5488d`.
- Codex App guidance, redirect, `/v1`, mixed-version parsing, and test coverage fix: `b22efdab36355f5f068e63a8598d7a37f76d5673`.
- Server diagnostics hardening: `706cea66f8c4ac96fb03a737f8aa4a1b18a54c8f`.
- Mapping/current evidence update: `8dec7ebc3`.

## Merge Readiness
- Not merge-ready yet.
- Required before merge-readiness claim:
  - Current-head CI checked after latest push.
  - Required checks terminal/pass.
  - Any new human/bot review comments dispositioned.
  - No unresolved actionable review threads.

