### PR TITLE
feat(orchestration): add experiment runner email pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,6 +367,13 @@ If adding rate-limit to endpoints, use thin **route wrappers**; do not change ca
 - Semantic cache is forbidden until evidence asset lineage, replay-safe promotion, and metadata admission gates exist and the dedicated semantic-cache gate (`docs/roadmap/PulsePlate_Semantic_Cache_Gate_and_Plan.md`) explicitly opens.
 - Any new evidence-bearing artifact must define asset type, upstream assets, fingerprint, policy version, idempotency key, and replay/admission behavior.
 
+**Experiment Runner attribution invariant (hard rule):**
+
+- When the Experiment Runner materially contributes to a commit, use exactly this co-author trailer:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+- Do not use placeholder attribution such as `runner@example.com` for new Experiment Runner work.
+- This trailer is public Git attribution text only; it is not an email delivery channel, a cryptographic signature, review-thread authority, or merge-readiness authority.
+
 ---
 
 ## REQUIRED READING (before any change)

--- a/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
@@ -85,6 +85,13 @@ identity defined in `docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.md`:
 PulsePlate Experiment Runner <pulseplate@pm.me>
 ```
 
+When the Experiment Runner materially contributes to a commit, use the
+canonical trailer:
+
+```text
+Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>
+```
+
 This identity is attribution-only unless an operator-managed external signing
 boundary exists. Git author fields and `Co-authored-by` trailers are text and
 must not be treated as proof of machine authorship by themselves.
@@ -348,11 +355,19 @@ If a candidate wins, the coordinator promotes it into exactly one destination:
 summary from validated experiment packet, result, and optional promotion
 decision artifacts.
 
+`scripts/orchestration/experiment_pipeline.py` is the governed completion
+wrapper for agents that should not manually run each stage. It sequences
+runner -> promotion -> notification and may request email delivery only with
+the explicit `--email-reports` flag.
+
 Rules:
 
 - notification output is evidence-only and does not change promotion,
   merge-readiness, or review-thread disposition authority,
 - local markdown artifacts are the default delivery sink,
+- automatic email reports are available only through
+  `experiment_pipeline.py --email-reports`; git attribution email is never a
+  delivery trigger,
 - SMTP email delivery requires an explicit CLI flag, an explicit allowlisted
   recipient, and runtime SMTP secret configuration,
 - SMTP port `465` uses implicit TLS (`SMTP_SSL`); other allowed ports use

--- a/docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.json
+++ b/docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.json
@@ -5,6 +5,7 @@
   "git_attribution": {
     "name": "PulsePlate Experiment Runner",
     "email": "pulseplate@pm.me",
+    "co_author_trailer": "Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>",
     "purpose": "public_attribution_only",
     "forbidden_placeholder_emails": [
       "runner@example.com"

--- a/docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.md
+++ b/docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.md
@@ -14,6 +14,13 @@ The governed Experiment Runner identity is:
 PulsePlate Experiment Runner <pulseplate@pm.me>
 ```
 
+When the Experiment Runner materially contributes to a commit, the canonical
+co-author trailer is:
+
+```text
+Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>
+```
+
 The email address is public Git attribution metadata only. It is not an experiment result delivery channel, an SMTP recipient by implication, or proof that a commit was produced by a trusted machine.
 
 The placeholder `runner@example.com` is forbidden for new Experiment Runner attribution. Historical references may remain only when they describe prior behavior or review evidence.
@@ -42,9 +49,14 @@ The Experiment Runner may be a co-author or local PR-lane author only when a hum
 
 ## Notification Boundary
 
-Experiment result delivery is governed by `scripts/orchestration/experiment_notify.py` and `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`.
+Experiment result delivery is governed by `scripts/orchestration/experiment_notify.py`, `scripts/orchestration/experiment_pipeline.py`, and `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`.
 
 Default delivery is a local artifact. Email delivery is explicit opt-in and requires an allowlisted recipient plus runtime SMTP secrets. The Git attribution email does not cause email delivery.
+
+Automatic email reports are available only through the governed completion
+wrapper when `experiment_pipeline.py --email-reports` is explicitly used. The
+recipient remains the v1 governed recipient `pulseplate@pm.me`, and SMTP
+configuration remains runtime-secret backed.
 
 ## Slack Boundary
 

--- a/docs/review/PR_1765_FIXED_MAPPING.md
+++ b/docs/review/PR_1765_FIXED_MAPPING.md
@@ -19,20 +19,17 @@
 Disposition: FIXED
 Commit: cd05b9a2d
 Evidence: Cubic found that pre-resolving `--promotion-output` broke relative output paths. `scripts/orchestration/experiment_pipeline.py` now preserves the raw relative output argument for `experiment_promote.py` while resolving the expected artifact path for notification/summary use, and `tests/test_experiment_pipeline.py` covers `--promotion-output nested/decision.json`.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#pullrequestreview-4306228421 -> cd05b9a2d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#discussion_r3255402933 -> cd05b9a2d
 
 Disposition: FIXED
 Commit: cd05b9a2d
 Evidence: CodeRabbit found that placeholder co-author guidance with whitespace inside angle brackets could bypass the regex. `scripts/orchestration/check_experiment_runner_identity.py` now rejects `< runner@example.com >`, and `tests/test_experiment_runner_identity_policy.py` covers that variant.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#discussion_r3255410259 -> cd05b9a2d
 
 Disposition: FIXED
 Commit: cd05b9a2d
 Evidence: CodeRabbit found that child stage stderr and unexpected exceptions could leak outside the pipeline's sanitized failure path. `scripts/orchestration/experiment_pipeline.py` now redirects both stdout and stderr and normalizes unexpected stage exceptions to the generic stage failure message; `tests/test_experiment_pipeline.py` covers stderr and exception redaction.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#discussion_r3255410262 -> cd05b9a2d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#pullrequestreview-4306234841 -> cd05b9a2d
 

--- a/docs/review/PR_1765_FIXED_MAPPING.md
+++ b/docs/review/PR_1765_FIXED_MAPPING.md
@@ -43,6 +43,20 @@ Disposition: NOT-A-BUG
 Evidence: Codex Security diff-focused scan found no surviving reportable finding: the wrapper uses no shell/subprocess execution, delegates SMTP/redaction/audit to `experiment_notify.py`, suppresses child stdout leakage, does not accept arbitrary recipients, and returns sanitized stage failures.
 Reason: The remaining sensitive behaviors are handled by existing tested notification and experiment modules.
 
+## Bot Review Notes
+
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit CLI agent review completed on committed diff with `findings: 0`.
+Reason: No actionable CodeRabbit code issues were reported.
+
+Disposition: NOT-A-BUG
+Evidence: `chatgpt-codex-connector` PR comment reported Codex code-review usage limits only and did not identify code changes or review-thread actionables.
+Reason: Usage-limit notification is operational, not a code finding.
+
+Disposition: NOT-A-BUG
+Evidence: Sourcery review comment reported weekly diff-character rate-limit exhaustion only and did not identify code changes or review-thread actionables.
+Reason: Rate-limit notification is operational, not a code finding.
+
 ## Local Validation
 
 - `python3 scripts/orchestration/check_preflight.py --path ...` PASS.

--- a/docs/review/PR_1765_FIXED_MAPPING.md
+++ b/docs/review/PR_1765_FIXED_MAPPING.md
@@ -37,6 +37,7 @@ Evidence: CodeRabbit found that child stage stderr and unexpected exceptions cou
 Disposition: FIXED
 Commit: fcb539efa
 Evidence: CodeRabbit found that `experiment_pipeline.py --promotion-output` could widen the wrapper write boundary with absolute paths or `..` escapes. `scripts/orchestration/experiment_pipeline.py` now resolves the candidate output and fails closed unless it remains under `artifacts/orchestration/experiments/promotions/`; `tests/test_experiment_pipeline.py` covers parent-directory and absolute-path escapes.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#pullrequestreview-4306290275 -> fcb539efa
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#discussion_r3255475576 -> fcb539efa
 
 ## Role-Agent Findings

--- a/docs/review/PR_1765_FIXED_MAPPING.md
+++ b/docs/review/PR_1765_FIXED_MAPPING.md
@@ -1,0 +1,65 @@
+<!-- markdownlint-disable MD013 MD034 -->
+# PR 1765 Fixed In Commit Mapping
+
+- PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765>
+- Branch: `codex/experiment-runner-attribution-auto-email-reports`
+- Title: `feat(orchestration): add experiment runner email pipeline`
+- Implementing commit:
+  - `d0daee249` - added canonical Experiment Runner co-author guidance, governed pipeline wrapper, identity guidance guard coverage, email-report regression tests, and mypy-compatible promotion typing cleanup.
+- Scope: Experiment Runner attribution instructions and governed automatic email report wrapper only. No Slack delivery, no git-attribution delivery trigger, no signing key storage, no merge authority change, and no review-thread authority change.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Role-Agent Findings
+
+Disposition: FIXED
+Commit: d0daee249
+Evidence: `bug-hunter` found that exact-string placeholder rejection would miss `Co-authored-by: PulsePlate Experiment Runner <runner@example.com>`. `scripts/orchestration/check_experiment_runner_identity.py` now rejects any `Co-authored-by: ... <runner@example.com>` guidance, and `tests/test_experiment_runner_identity_policy.py` covers the governed-name placeholder variant.
+
+Disposition: NOT-A-BUG
+Evidence: `security-auditor` required automatic email to remain explicit and fixed-recipient. `scripts/orchestration/experiment_pipeline.py` exposes only `--email-reports`, passes `--email --email-to pulseplate@pm.me` to `experiment_notify.py`, and exposes no arbitrary recipient flag.
+Reason: This preserves the existing allowlist, SMTP secret, redaction, and audit boundaries owned by `experiment_notify.py`.
+
+Disposition: NOT-A-BUG
+Evidence: `architecture-specialist` required the wrapper not to become a second policy engine. `scripts/orchestration/experiment_pipeline.py` sequences `experiment_runner.main`, `experiment_promote.main`, and `experiment_notify.main` without reimplementing runner sandboxing, promotion policy, notification redaction, or identity policy.
+Reason: The wrapper is orchestration-only and delegates stage-specific authority to existing governed modules.
+
+Disposition: NOT-A-BUG
+Evidence: `backend-engineer` and `qa-engineer-agent` found no blocking backend/test gaps after focused coverage for default no-email behavior, explicit email report behavior, sanitized SMTP failure, audit artifact hygiene, and identity guidance validation.
+Reason: The changed behavior is covered by deterministic unit tests and does not add runtime app endpoints.
+
+Disposition: FIXED
+Commit: d0daee249
+Evidence: `pulseplate-premortem-risk-review` identified placeholder guidance drift and hidden automatic email behavior as the two main failure modes. Placeholder drift is guarded by `check_experiment_runner_identity.py`; hidden email behavior is blocked by requiring explicit `experiment_pipeline.py --email-reports` and documenting that git attribution email is never a delivery trigger.
+
+Disposition: NOT-A-BUG
+Evidence: Codex Security diff-focused scan found no surviving reportable finding: the wrapper uses no shell/subprocess execution, delegates SMTP/redaction/audit to `experiment_notify.py`, suppresses child stdout leakage, does not accept arbitrary recipients, and returns sanitized stage failures.
+Reason: The remaining sensitive behaviors are handled by existing tested notification and experiment modules.
+
+## Local Validation
+
+- `python3 scripts/orchestration/check_preflight.py --path ...` PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS.
+- `python3 scripts/orchestration/check_experiment_runner_identity.py --json` PASS.
+- `pytest -q tests/test_experiment_pipeline.py tests/test_experiment_runner_identity_policy.py tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py` PASS.
+- `pre-commit run --all-files` PASS.
+- `make validate-changed` PASS.
+- Pre-push hook PASS: mypy changed files, pip-audit, backend tests, full-repo bandit, and docker build test.
+
+## Merge Readiness
+
+- [ ] Current-head CI terminal and required checks passing after latest push.
+- [ ] CodeRabbit no actionables after latest push.
+- [ ] Cubic no actionables after latest push.
+- [ ] Sourcery no actionables or rate-limit-only disposition recorded.
+- [ ] Discussion-thread pass repeated after latest review activity.
+- [ ] Fixed mapping artifact/body mirror updated after latest review activity.
+- [ ] Strict merge-readiness wrapper passes.
+- [ ] Required wait-window complete.

--- a/docs/review/PR_1765_FIXED_MAPPING.md
+++ b/docs/review/PR_1765_FIXED_MAPPING.md
@@ -7,6 +7,7 @@
 - Implementing commits:
   - `d0daee249` - added canonical Experiment Runner co-author guidance, governed pipeline wrapper, identity guidance guard coverage, email-report regression tests, and mypy-compatible promotion typing cleanup.
   - `cd05b9a2d` - fixed Cubic and CodeRabbit review findings for relative promotion output handling, placeholder-email whitespace variants, and sanitized stage stderr/exception handling.
+  - `fcb539efa` - fixed CodeRabbit promotion-output containment finding by rejecting wrapper output paths that escape the governed promotions artifact root.
 - Scope: Experiment Runner attribution instructions and governed automatic email report wrapper only. No Slack delivery, no git-attribution delivery trigger, no signing key storage, no merge authority change, and no review-thread authority change.
 
 ## Discussion Thread Pass
@@ -32,6 +33,11 @@ Commit: cd05b9a2d
 Evidence: CodeRabbit found that child stage stderr and unexpected exceptions could leak outside the pipeline's sanitized failure path. `scripts/orchestration/experiment_pipeline.py` now redirects both stdout and stderr and normalizes unexpected stage exceptions to the generic stage failure message; `tests/test_experiment_pipeline.py` covers stderr and exception redaction.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#discussion_r3255410262 -> cd05b9a2d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#pullrequestreview-4306234841 -> cd05b9a2d
+
+Disposition: FIXED
+Commit: fcb539efa
+Evidence: CodeRabbit found that `experiment_pipeline.py --promotion-output` could widen the wrapper write boundary with absolute paths or `..` escapes. `scripts/orchestration/experiment_pipeline.py` now resolves the candidate output and fails closed unless it remains under `artifacts/orchestration/experiments/promotions/`; `tests/test_experiment_pipeline.py` covers parent-directory and absolute-path escapes.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#discussion_r3255475576 -> fcb539efa
 
 ## Role-Agent Findings
 

--- a/docs/review/PR_1765_FIXED_MAPPING.md
+++ b/docs/review/PR_1765_FIXED_MAPPING.md
@@ -4,8 +4,9 @@
 - PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765>
 - Branch: `codex/experiment-runner-attribution-auto-email-reports`
 - Title: `feat(orchestration): add experiment runner email pipeline`
-- Implementing commit:
+- Implementing commits:
   - `d0daee249` - added canonical Experiment Runner co-author guidance, governed pipeline wrapper, identity guidance guard coverage, email-report regression tests, and mypy-compatible promotion typing cleanup.
+  - `cd05b9a2d` - fixed Cubic and CodeRabbit review findings for relative promotion output handling, placeholder-email whitespace variants, and sanitized stage stderr/exception handling.
 - Scope: Experiment Runner attribution instructions and governed automatic email report wrapper only. No Slack delivery, no git-attribution delivery trigger, no signing key storage, no merge authority change, and no review-thread authority change.
 
 ## Discussion Thread Pass
@@ -15,7 +16,25 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: cd05b9a2d
+Evidence: Cubic found that pre-resolving `--promotion-output` broke relative output paths. `scripts/orchestration/experiment_pipeline.py` now preserves the raw relative output argument for `experiment_promote.py` while resolving the expected artifact path for notification/summary use, and `tests/test_experiment_pipeline.py` covers `--promotion-output nested/decision.json`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#pullrequestreview-4306228421 -> cd05b9a2d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#discussion_r3255402933 -> cd05b9a2d
+
+Disposition: FIXED
+Commit: cd05b9a2d
+Evidence: CodeRabbit found that placeholder co-author guidance with whitespace inside angle brackets could bypass the regex. `scripts/orchestration/check_experiment_runner_identity.py` now rejects `< runner@example.com >`, and `tests/test_experiment_runner_identity_policy.py` covers that variant.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#discussion_r3255410259 -> cd05b9a2d
+
+Disposition: FIXED
+Commit: cd05b9a2d
+Evidence: CodeRabbit found that child stage stderr and unexpected exceptions could leak outside the pipeline's sanitized failure path. `scripts/orchestration/experiment_pipeline.py` now redirects both stdout and stderr and normalizes unexpected stage exceptions to the generic stage failure message; `tests/test_experiment_pipeline.py` covers stderr and exception redaction.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#discussion_r3255410262 -> cd05b9a2d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1765#pullrequestreview-4306234841 -> cd05b9a2d
 
 ## Role-Agent Findings
 
@@ -46,8 +65,8 @@ Reason: The remaining sensitive behaviors are handled by existing tested notific
 ## Bot Review Notes
 
 Disposition: NOT-A-BUG
-Evidence: CodeRabbit CLI agent review completed on committed diff with `findings: 0`.
-Reason: No actionable CodeRabbit code issues were reported.
+Evidence: CodeRabbit CLI agent review completed on the initial committed diff with `findings: 0`; GitHub CodeRabbit later reported two actionable comments, both fixed in `cd05b9a2d` and mapped above.
+Reason: The CLI result is historical evidence only; GitHub CodeRabbit actionables are treated as fixed.
 
 Disposition: NOT-A-BUG
 Evidence: `chatgpt-codex-connector` PR comment reported Codex code-review usage limits only and did not identify code changes or review-thread actionables.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -24,9 +24,16 @@
   is the default, SMTP email delivery is explicit opt-in only, and no notification
   sink may expose raw patches, oracle stdout/stderr, secrets, absolute local
   paths, or user data.
+- `experiment_pipeline.py` is the governed completion wrapper for
+  runner -> promotion -> notification sequencing. Email reports are automatic
+  only inside that wrapper when `--email-reports` is explicitly present; the
+  wrapper must use the fixed governed v1 recipient and must delegate SMTP,
+  redaction, idempotency, and audit behavior to `experiment_notify.py`.
 - Experiment Runner Git attribution must follow
   `docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.md`; placeholder
   identities such as `runner@example.com` are not allowed for new attribution.
+  When Experiment Runner materially contributes to a commit, use exactly:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
 - `scripts/orchestration/check_experiment_runner_identity.py` validates the
   machine-readable identity policy. It must remain offline, deterministic, and
   must not generate, read, or persist signing key material.

--- a/scripts/orchestration/check_experiment_runner_identity.py
+++ b/scripts/orchestration/check_experiment_runner_identity.py
@@ -19,7 +19,19 @@ EXPECTED_SCHEMA_VERSION = "1.0"
 EXPECTED_IDENTITY_SLUG = "experiment-runner"
 EXPECTED_DISPLAY_NAME = "PulsePlate Experiment Runner"
 EXPECTED_EMAIL = "pulseplate@pm.me"
+EXPECTED_CO_AUTHOR_TRAILER = "Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>"
+FORBIDDEN_CO_AUTHOR_TRAILER = "Co-authored-by: Experiment Runner <runner@example.com>"
 FORBIDDEN_EMAILS = frozenset({"runner@example.com"})
+FORBIDDEN_CO_AUTHOR_EMAIL_RE = re.compile(
+    r"Co-authored-by:\s*[^\n<]*<runner@example\.com>",
+    re.IGNORECASE,
+)
+GUIDANCE_PATHS = (
+    REPO_ROOT / "AGENTS.md",
+    REPO_ROOT / "scripts" / "AGENTS.md",
+    REPO_ROOT / "docs" / "orchestration" / "AGENT_EXPERIMENTATION_PROTOCOL.md",
+    REPO_ROOT / "docs" / "orchestration" / "GOVERNED_NON_HUMAN_IDENTITY_POLICY.md",
+)
 ALLOWED_SIGNING_METHODS = frozenset({"ssh", "gpg", "github_app_verified_signature"})
 SENSITIVE_FIELD_RE = re.compile(
     r"(access[\s_-]*key|api[\s_-]*key|private[\s_-]*key|pass[\s_-]*phrase|password|secret|token|credential|signing[\s_-]*key)",
@@ -282,6 +294,11 @@ def validate_identity_policy(payload: dict[str, Any]) -> dict[str, Any]:
         raise IdentityPolicyError("git_attribution.name must match display_name.")
     if _normalized_email(git_attribution.get("email")) != EXPECTED_EMAIL:
         raise IdentityPolicyError("git_attribution.email must be pulseplate@pm.me.")
+    if git_attribution.get("co_author_trailer") != EXPECTED_CO_AUTHOR_TRAILER:
+        raise IdentityPolicyError(
+            "git_attribution.co_author_trailer must use the governed PulsePlate "
+            "Experiment Runner identity."
+        )
     if git_attribution.get("purpose") != "public_attribution_only":
         raise IdentityPolicyError("git_attribution.purpose must be public_attribution_only.")
     forbidden = git_attribution.get("forbidden_placeholder_emails")
@@ -357,6 +374,24 @@ def validate_identity_policy(payload: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
+def validate_co_author_guidance(paths: tuple[Path, ...] = GUIDANCE_PATHS) -> None:
+    """Validate agent-facing co-author guidance stays on the governed identity."""
+
+    for path in paths:
+        try:
+            label = str(path.relative_to(REPO_ROOT))
+        except ValueError:
+            label = path.name
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise IdentityPolicyError("Unable to read Experiment Runner guidance.") from exc
+        if EXPECTED_CO_AUTHOR_TRAILER not in content:
+            raise IdentityPolicyError(f"{label} must include the governed co-author trailer.")
+        if FORBIDDEN_CO_AUTHOR_TRAILER in content or FORBIDDEN_CO_AUTHOR_EMAIL_RE.search(content):
+            raise IdentityPolicyError(f"{label} must not include placeholder co-author guidance.")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--policy", default=str(DEFAULT_POLICY_PATH), help="Policy JSON path.")
@@ -365,6 +400,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         policy = validate_identity_policy(_read_policy(Path(args.policy)))
+        validate_co_author_guidance()
     except IdentityPolicyError as exc:
         if args.json:
             print(json.dumps({"status": "fail", "error": str(exc)}, sort_keys=True))
@@ -375,6 +411,7 @@ def main(argv: list[str] | None = None) -> int:
     result = {
         "status": "pass",
         "identity_slug": policy["identity_slug"],
+        "co_author_trailer": policy["git_attribution"]["co_author_trailer"],
         "git_email": policy["git_attribution"]["email"],
         "slack_identity": policy["slack_identity"]["status"],
     }

--- a/scripts/orchestration/check_experiment_runner_identity.py
+++ b/scripts/orchestration/check_experiment_runner_identity.py
@@ -23,7 +23,7 @@ EXPECTED_CO_AUTHOR_TRAILER = "Co-authored-by: PulsePlate Experiment Runner <puls
 FORBIDDEN_CO_AUTHOR_TRAILER = "Co-authored-by: Experiment Runner <runner@example.com>"
 FORBIDDEN_EMAILS = frozenset({"runner@example.com"})
 FORBIDDEN_CO_AUTHOR_EMAIL_RE = re.compile(
-    r"Co-authored-by:\s*[^\n<]*<runner@example\.com>",
+    r"Co-authored-by:\s*[^\n<]*<\s*runner@example\.com\s*>",
     re.IGNORECASE,
 )
 GUIDANCE_PATHS = (

--- a/scripts/orchestration/experiment_pipeline.py
+++ b/scripts/orchestration/experiment_pipeline.py
@@ -75,11 +75,18 @@ def _default_promotion_path(experiment_id: str) -> Path:
 def _promotion_output_path(raw_output: str | None, experiment_id: str) -> Path:
     """Mirror promotion output path selection without widening write permissions."""
 
+    artifact_dir: Path = experiment_promote.PROMOTION_ARTIFACT_DIR.resolve()
     if raw_output:
         candidate = Path(raw_output).expanduser()
         if not candidate.is_absolute():
-            artifact_dir: Path = experiment_promote.PROMOTION_ARTIFACT_DIR
             candidate = artifact_dir / candidate
+        candidate = candidate.resolve()
+        try:
+            candidate.relative_to(artifact_dir)
+        except ValueError as exc:
+            raise ExperimentPipelineError(
+                "Experiment promotion output must stay within governed artifact directory."
+            ) from exc
         return candidate
     return _default_promotion_path(experiment_id)
 

--- a/scripts/orchestration/experiment_pipeline.py
+++ b/scripts/orchestration/experiment_pipeline.py
@@ -10,7 +10,7 @@ authority boundaries.
 from __future__ import annotations
 
 import argparse
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 import io
 import json
 from pathlib import Path
@@ -72,6 +72,18 @@ def _default_promotion_path(experiment_id: str) -> Path:
     return artifact_dir / f"{experiment_id}.json"
 
 
+def _promotion_output_path(raw_output: str | None, experiment_id: str) -> Path:
+    """Mirror promotion output path selection without widening write permissions."""
+
+    if raw_output:
+        candidate = Path(raw_output).expanduser()
+        if not candidate.is_absolute():
+            artifact_dir: Path = experiment_promote.PROMOTION_ARTIFACT_DIR
+            candidate = artifact_dir / candidate
+        return candidate
+    return _default_promotion_path(experiment_id)
+
+
 def _run_stage(
     stage: str,
     stage_main: Callable[[list[str]], int],
@@ -80,8 +92,12 @@ def _run_stage(
     """Run a child stage while preventing child stdout leakage."""
 
     stdout = io.StringIO()
-    with redirect_stdout(stdout):
-        exit_code = stage_main(argv)
+    stderr = io.StringIO()
+    try:
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            exit_code = stage_main(argv)
+    except Exception as exc:
+        raise ExperimentPipelineError(f"Experiment pipeline {stage} stage failed.") from exc
     if exit_code != 0:
         raise ExperimentPipelineError(f"Experiment pipeline {stage} stage failed.")
     raw_output = stdout.getvalue().strip()
@@ -134,10 +150,11 @@ def main(argv: list[str] | None = None) -> int:
         packet = _read_packet(packet_path)
         experiment_id = packet["experiment_id"]
         result_path = _default_result_path(experiment_id)
-        promotion_path = (
-            Path(args.promotion_output).expanduser().resolve()
+        promotion_path = _promotion_output_path(args.promotion_output, experiment_id)
+        promotion_output_arg = (
+            str(Path(args.promotion_output).expanduser())
             if args.promotion_output
-            else _default_promotion_path(experiment_id)
+            else str(promotion_path)
         )
 
         _run_stage(
@@ -161,7 +178,7 @@ def main(argv: list[str] | None = None) -> int:
                 "--result",
                 str(result_path),
                 "--output",
-                str(promotion_path),
+                promotion_output_arg,
             ],
         )
         notify_args = [

--- a/scripts/orchestration/experiment_pipeline.py
+++ b/scripts/orchestration/experiment_pipeline.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Run the governed experiment completion flow.
+
+RU: Последовательно запускает runner, promotion и notification, не расширяя их
+полномочия.
+EN: Sequences runner, promotion, and notification without widening their
+authority boundaries.
+"""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import redirect_stdout
+import io
+import json
+from pathlib import Path
+import sys
+from typing import Any, Callable
+
+try:
+    from scripts.orchestration.context_pack import normalize_repo_path
+    from scripts.orchestration.experiment_contract import validate_experiment_packet
+    from scripts.orchestration import experiment_notify
+    from scripts.orchestration import experiment_promote
+    from scripts.orchestration import experiment_runner
+except ModuleNotFoundError as exc:  # pragma: no cover - direct script invocation guard.
+    if exc.name != "scripts":
+        raise
+    print(
+        "FAIL: run as `python -m scripts.orchestration.experiment_pipeline` from repo root.",
+        file=sys.stderr,
+    )
+    raise SystemExit(2) from exc
+
+
+EMAIL_REPORT_RECIPIENT = experiment_notify.V1_EMAIL_RECIPIENT
+
+
+class ExperimentPipelineError(RuntimeError):
+    """Pipeline orchestration failed without exposing child process details."""
+
+
+def _read_packet(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ExperimentPipelineError("Experiment pipeline packet is invalid.") from exc
+    if not isinstance(payload, dict):
+        raise ExperimentPipelineError("Experiment pipeline packet is invalid.")
+    try:
+        validated_packet: dict[str, Any] = validate_experiment_packet(payload)
+        return validated_packet
+    except ValueError as exc:
+        raise ExperimentPipelineError("Experiment pipeline packet is invalid.") from exc
+
+
+def _repo_ref(path: Path) -> str:
+    try:
+        repo_ref: str = normalize_repo_path(path)
+        return repo_ref
+    except ValueError:
+        return "[artifact-path]"
+
+
+def _default_result_path(experiment_id: str) -> Path:
+    artifact_dir: Path = experiment_runner.RESULT_ARTIFACT_DIR
+    return artifact_dir / f"{experiment_id}.json"
+
+
+def _default_promotion_path(experiment_id: str) -> Path:
+    artifact_dir: Path = experiment_promote.PROMOTION_ARTIFACT_DIR
+    return artifact_dir / f"{experiment_id}.json"
+
+
+def _run_stage(
+    stage: str,
+    stage_main: Callable[[list[str]], int],
+    argv: list[str],
+) -> dict[str, Any]:
+    """Run a child stage while preventing child stdout leakage."""
+
+    stdout = io.StringIO()
+    with redirect_stdout(stdout):
+        exit_code = stage_main(argv)
+    if exit_code != 0:
+        raise ExperimentPipelineError(f"Experiment pipeline {stage} stage failed.")
+    raw_output = stdout.getvalue().strip()
+    if not raw_output:
+        return {}
+    try:
+        payload = json.loads(raw_output)
+    except json.JSONDecodeError as exc:
+        raise ExperimentPipelineError(
+            f"Experiment pipeline {stage} stage output is invalid."
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ExperimentPipelineError(f"Experiment pipeline {stage} stage output is invalid.")
+    return payload
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="experiment_pipeline",
+        description=(
+            "Run governed experiment runner, promotion, and notification stages. "
+            "Email reports are explicit opt-in and fixed to the governed v1 recipient."
+        ),
+    )
+    parser.add_argument("--packet", required=True, help="Experiment packet JSON path.")
+    parser.add_argument("--candidate-patch", required=True, help="Unified diff patch path.")
+    parser.add_argument(
+        "--promotion-output",
+        default=None,
+        help=(
+            "Optional promotion decision JSON path under "
+            "artifacts/orchestration/experiments/promotions/. "
+            "Defaults to artifacts/orchestration/experiments/promotions/<id>.json"
+        ),
+    )
+    parser.add_argument(
+        "--email-reports",
+        action="store_true",
+        help="After local notification rendering, send the redacted report to the governed v1 recipient.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    try:
+        packet_path = Path(args.packet).expanduser().resolve()
+        candidate_patch_path = Path(args.candidate_patch).expanduser().resolve()
+        packet = _read_packet(packet_path)
+        experiment_id = packet["experiment_id"]
+        result_path = _default_result_path(experiment_id)
+        promotion_path = (
+            Path(args.promotion_output).expanduser().resolve()
+            if args.promotion_output
+            else _default_promotion_path(experiment_id)
+        )
+
+        _run_stage(
+            "runner",
+            experiment_runner.main,
+            [
+                "--packet",
+                str(packet_path),
+                "--candidate-patch",
+                str(candidate_patch_path),
+                "--output",
+                str(result_path),
+            ],
+        )
+        _run_stage(
+            "promotion",
+            experiment_promote.main,
+            [
+                "--packet",
+                str(packet_path),
+                "--result",
+                str(result_path),
+                "--output",
+                str(promotion_path),
+            ],
+        )
+        notify_args = [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--promotion",
+            str(promotion_path),
+        ]
+        if args.email_reports:
+            notify_args.extend(["--email", "--email-to", EMAIL_REPORT_RECIPIENT])
+        notify_payload = _run_stage("notification", experiment_notify.main, notify_args)
+    except ExperimentPipelineError as exc:
+        print(f"FAIL: {exc}")
+        return 1
+    except OSError:
+        print("FAIL: experiment pipeline artifact path is invalid.")
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "email_reports": bool(args.email_reports),
+                "email_recipient": "governed-v1-recipient" if args.email_reports else None,
+                "experiment_id": experiment_id,
+                "notification": notify_payload.get("output"),
+                "email_audit": notify_payload.get("email_audit"),
+                "promotion": _repo_ref(promotion_path),
+                "result": _repo_ref(result_path),
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/experiment_promote.py
+++ b/scripts/orchestration/experiment_promote.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 try:
     from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
@@ -264,28 +264,33 @@ def _write_durable_artifacts(
     if target == "pr_packet":
         durable_path = artifact_paths[0]
         _stable_write(durable_path, _render_pr_packet(packet, result, disposition))
-        return cast(str, normalize_repo_path(durable_path))
+        repo_ref: str = normalize_repo_path(durable_path)
+        return repo_ref
     if target == "audit_artifact":
         durable_path = artifact_paths[0]
         _stable_write(durable_path, _render_audit_artifact(packet, result, disposition))
-        return cast(str, normalize_repo_path(durable_path))
+        repo_ref = normalize_repo_path(durable_path)
+        return repo_ref
     if target == "guard_test_proposal":
         durable_path = artifact_paths[0]
         _stable_write(durable_path, _render_guard_proposal(packet, result, disposition))
-        return cast(str, normalize_repo_path(durable_path))
+        repo_ref = normalize_repo_path(durable_path)
+        return repo_ref
     if target == "backlog_entry":
         durable_path = artifact_paths[0]
         _insert_once(
             durable_path, BACKLOG_MARKER, _render_backlog_entry(packet, result, disposition)
         )
-        return cast(str, normalize_repo_path(durable_path))
+        repo_ref = normalize_repo_path(durable_path)
+        return repo_ref
     if target == "memory_capsule":
         capsule_path, index_path = artifact_paths
         _stable_write(capsule_path, _render_memory_capsule(packet, result, disposition))
         _insert_once(
             index_path, MEMORY_INDEX_MARKER, _render_memory_index_line(packet["experiment_id"])
         )
-        return cast(str, normalize_repo_path(capsule_path))
+        repo_ref = normalize_repo_path(capsule_path)
+        return repo_ref
     raise ExperimentPromotionError(f"Unsupported promotion target: {target}")
 
 

--- a/tests/test_experiment_pipeline.py
+++ b/tests/test_experiment_pipeline.py
@@ -1,0 +1,335 @@
+"""Tests for the governed experiment completion pipeline."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import scripts.orchestration.context_pack as context_pack
+import scripts.orchestration.experiment_contract as experiment_contract
+import scripts.orchestration.experiment_notify as experiment_notify
+import scripts.orchestration.experiment_pipeline as experiment_pipeline
+import scripts.orchestration.experiment_promote as experiment_promote
+import scripts.orchestration.experiment_runner as experiment_runner
+
+ORACLE_COMMAND = 'python3 -c "import sys; sys.exit(0)"'
+
+
+class FakeSMTP:
+    sent_messages: list[Any] = []
+    started_tls = False
+    login_args: tuple[str, str] | None = None
+
+    def __init__(self, host: str, port: int, timeout: int) -> None:
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+    def __enter__(self) -> "FakeSMTP":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+    def starttls(self, context: object | None = None) -> None:
+        assert context is not None
+        FakeSMTP.started_tls = True
+
+    def login(self, username: str, password: str) -> None:
+        FakeSMTP.login_args = (username, password)
+
+    def send_message(self, message: object) -> None:
+        FakeSMTP.sent_messages.append(message)
+
+    def quit(self) -> None:
+        return None
+
+
+def _reset_fake_smtp() -> None:
+    FakeSMTP.sent_messages = []
+    FakeSMTP.started_tls = False
+    FakeSMTP.login_args = None
+
+
+def _configure_repo(monkeypatch: pytest.MonkeyPatch, repo: Path) -> None:
+    monkeypatch.setattr(context_pack, "REPO_ROOT", repo)
+    monkeypatch.setattr(experiment_contract, "REPO_ROOT", repo)
+    monkeypatch.setattr(experiment_notify, "REPO_ROOT", repo)
+    monkeypatch.setattr(
+        experiment_runner,
+        "RESULT_ARTIFACT_DIR",
+        repo / "artifacts/orchestration/experiments/results",
+    )
+    monkeypatch.setattr(
+        experiment_promote,
+        "PROMOTION_ARTIFACT_DIR",
+        repo / "artifacts/orchestration/experiments/promotions",
+    )
+    monkeypatch.setattr(
+        experiment_notify,
+        "NOTIFICATION_ARTIFACT_DIR",
+        repo / "artifacts/orchestration/experiments/notifications",
+    )
+    (repo / "core/rag").mkdir(parents=True)
+    (repo / "core/rag/allowed.py").write_text("value = 1\n", encoding="utf-8")
+
+
+def _configure_smtp_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_EMAIL_ALLOWLIST", "pulseplate@pm.me")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_HOST", "smtp.example.test")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_PORT", "587")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_USERNAME", "smtp-user")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_PASSWORD", "smtp-secret")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_EMAIL_FROM", "runner@example.test")
+
+
+def _packet() -> dict[str, object]:
+    return {
+        "schema_version": "1.0",
+        "experiment_id": "exp-pipeline",
+        "decision_question": "Run governed completion pipeline",
+        "task_class": "Experimentation",
+        "domain": "ml",
+        "mutable_candidate_surface": ["core/rag/allowed.py"],
+        "immutable_oracles": [
+            {
+                "command": ORACLE_COMMAND,
+                "expected_signal": "must pass",
+            }
+        ],
+        "budgets": {
+            "wall_clock_seconds": 300,
+            "retry_budget": 1,
+            "max_changed_files": 1,
+            "network_budget": 0,
+            "benchmark_budget": 1,
+            "test_budget": 1,
+            "stop_condition": "stop",
+        },
+        "metrics": {
+            "primary": "reliability_score",
+            "secondary": [],
+            "baseline_reference": "current-main",
+            "acceptance_threshold": "strict_improvement",
+        },
+        "negative_controls": ["oracle file unchanged", "no hidden memory"],
+        "promotion_target": "audit_artifact",
+    }
+
+
+def _result() -> dict[str, object]:
+    return {
+        "schema_version": "1.0",
+        "experiment_id": "exp-pipeline",
+        "candidate_patch": "candidate.patch",
+        "status": "accepted",
+        "failure_class": None,
+        "mutated_paths": ["core/rag/allowed.py"],
+        "oracle_results": [
+            {
+                "command": ORACLE_COMMAND,
+                "returncode": 0,
+                "timed_out": False,
+                "truncated": False,
+                "stdout": "secret stdout should not be emailed",
+                "stderr": "secret stderr should not be emailed",
+                "cwd": "/Users/example/local/repo",
+            }
+        ],
+        "budget_observations": {"attempts": 1},
+        "shared_tree_untouched": True,
+        "promotion_ready": True,
+    }
+
+
+def _promotion() -> dict[str, object]:
+    return {
+        "schema_version": "1.0",
+        "experiment_id": "exp-pipeline",
+        "result_status": "accepted",
+        "failure_class": None,
+        "promotion_target": "audit_artifact",
+        "disposition": "promoted",
+        "durable_artifact_path": "docs/audit/EXPERIMENT_EXP_PIPELINE.md",
+        "shared_tree_untouched": True,
+        "domain": "ml",
+        "evidence": {
+            "oracle_commands": [ORACLE_COMMAND],
+            "mutated_paths": ["core/rag/allowed.py"],
+            "oracle_count": 1,
+        },
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _install_fake_runner_and_promote(monkeypatch: pytest.MonkeyPatch, repo: Path) -> None:
+    def fake_runner_main(argv: list[str]) -> int:
+        output_path = Path(argv[argv.index("--output") + 1])
+        _write_json(output_path, _result())
+        print(
+            json.dumps(
+                {
+                    "experiment_id": "exp-pipeline",
+                    "failure_class": None,
+                    "output": str(output_path),
+                    "status": "accepted",
+                }
+            )
+        )
+        return 0
+
+    def fake_promote_main(argv: list[str]) -> int:
+        output_path = Path(argv[argv.index("--output") + 1])
+        audit_path = repo / "docs/audit/EXPERIMENT_EXP_PIPELINE.md"
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        audit_path.write_text("# Experiment Audit Artifact: exp-pipeline\n", encoding="utf-8")
+        _write_json(output_path, _promotion())
+        print(
+            json.dumps(
+                {
+                    "disposition": "promoted",
+                    "experiment_id": "exp-pipeline",
+                    "output": str(output_path),
+                    "promotion_target": "audit_artifact",
+                }
+            )
+        )
+        return 0
+
+    monkeypatch.setattr(experiment_pipeline.experiment_runner, "main", fake_runner_main)
+    monkeypatch.setattr(experiment_pipeline.experiment_promote, "main", fake_promote_main)
+
+
+def test_pipeline_does_not_email_without_explicit_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FakeSMTP)
+    _install_fake_runner_and_promote(monkeypatch, repo)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    patch_path = tmp_path / "candidate.patch"
+    patch_path.write_text("patch text must not render\n", encoding="utf-8")
+
+    exit_code = experiment_pipeline.main(
+        ["--packet", str(packet_path), "--candidate-patch", str(patch_path)]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 0
+    payload = json.loads(stdout)
+    assert payload["email_reports"] is False
+    assert payload["email_recipient"] is None
+    assert FakeSMTP.sent_messages == []
+    assert (repo / "artifacts/orchestration/experiments/notifications/exp-pipeline.md").is_file()
+
+
+def test_pipeline_email_reports_use_governed_recipient_and_redacted_body(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    _configure_repo(monkeypatch, repo)
+    _configure_smtp_env(monkeypatch)
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FakeSMTP)
+    _install_fake_runner_and_promote(monkeypatch, repo)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    patch_path = tmp_path / "candidate.patch"
+    patch_path.write_text("raw patch secret should not render\n", encoding="utf-8")
+
+    exit_code = experiment_pipeline.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--candidate-patch",
+            str(patch_path),
+            "--email-reports",
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 0
+    payload = json.loads(stdout)
+    assert payload["email_reports"] is True
+    assert payload["email_recipient"] == "governed-v1-recipient"
+    assert len(FakeSMTP.sent_messages) == 1
+    message = FakeSMTP.sent_messages[0]
+    assert message["To"] == "pulseplate@pm.me"
+    body = message.get_content()
+    assert "secret stdout" not in body
+    assert "secret stderr" not in body
+    assert "raw patch secret" not in body
+    assert "/Users/example" not in body
+
+    audit_path = (
+        repo / "artifacts/orchestration/experiments/notifications/exp-pipeline.email-audit.json"
+    )
+    audit_text = audit_path.read_text(encoding="utf-8")
+    assert "pulseplate@pm.me" not in audit_text
+    assert "smtp-secret" not in audit_text
+    assert payload["email_audit"] == (
+        "artifacts/orchestration/experiments/notifications/exp-pipeline.email-audit.json"
+    )
+
+
+def test_pipeline_missing_smtp_config_fails_closed_without_secret_leak(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    _configure_repo(monkeypatch, repo)
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_EMAIL_ALLOWLIST", "pulseplate@pm.me")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_HOST", "/Users/alice/.ssh/id_rsa")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_USERNAME", "smtp-user")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_SMTP_PASSWORD", "smtp-secret")
+    monkeypatch.setenv("EXPERIMENT_NOTIFICATION_EMAIL_FROM", "runner@example.test")
+    _reset_fake_smtp()
+    monkeypatch.setattr(experiment_notify.smtplib, "SMTP", FakeSMTP)
+    _install_fake_runner_and_promote(monkeypatch, repo)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    patch_path = tmp_path / "candidate.patch"
+    patch_path.write_text("patch text\n", encoding="utf-8")
+
+    exit_code = experiment_pipeline.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--candidate-patch",
+            str(patch_path),
+            "--email-reports",
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "notification stage failed" in stdout
+    assert "/Users/alice" not in stdout
+    assert "id_rsa" not in stdout
+    assert "smtp-secret" not in stdout
+    assert FakeSMTP.sent_messages == []
+
+
+def test_pipeline_help_documents_explicit_email_reports(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        experiment_pipeline.main(["--help"])
+    stdout = capsys.readouterr().out
+
+    assert exc_info.value.code == 0
+    assert "--email-reports" in stdout
+    assert "--email-to" not in stdout
+    assert "fixed to the governed v1 recipient" in stdout

--- a/tests/test_experiment_pipeline.py
+++ b/tests/test_experiment_pipeline.py
@@ -263,6 +263,83 @@ def test_pipeline_preserves_relative_promotion_output(
     )
 
 
+@pytest.mark.parametrize(
+    "raw_output",
+    [
+        "../outside.json",
+        "../../outside.json",
+    ],
+)
+def test_pipeline_rejects_parent_promotion_output_escape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    raw_output: str,
+) -> None:
+    repo = tmp_path / "repo"
+    _configure_repo(monkeypatch, repo)
+
+    def forbidden_runner_main(argv: list[str]) -> int:
+        raise AssertionError(f"runner should not run for invalid output: {argv}")
+
+    monkeypatch.setattr(experiment_pipeline.experiment_runner, "main", forbidden_runner_main)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    patch_path = tmp_path / "candidate.patch"
+    patch_path.write_text("patch text\n", encoding="utf-8")
+
+    exit_code = experiment_pipeline.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--candidate-patch",
+            str(patch_path),
+            "--promotion-output",
+            raw_output,
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "promotion output must stay within governed artifact directory" in captured.out
+    assert raw_output not in captured.out
+    assert str(tmp_path) not in captured.out
+
+
+def test_pipeline_rejects_absolute_promotion_output_escape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    _configure_repo(monkeypatch, repo)
+
+    def forbidden_runner_main(argv: list[str]) -> int:
+        raise AssertionError(f"runner should not run for invalid output: {argv}")
+
+    monkeypatch.setattr(experiment_pipeline.experiment_runner, "main", forbidden_runner_main)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    patch_path = tmp_path / "candidate.patch"
+    patch_path.write_text("patch text\n", encoding="utf-8")
+    absolute_output = tmp_path / "outside.json"
+
+    exit_code = experiment_pipeline.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--candidate-patch",
+            str(patch_path),
+            "--promotion-output",
+            str(absolute_output),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "promotion output must stay within governed artifact directory" in captured.out
+    assert str(absolute_output) not in captured.out
+    assert str(tmp_path) not in captured.out
+
+
 def test_pipeline_stage_failure_captures_stderr_without_leak(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_experiment_pipeline.py
+++ b/tests/test_experiment_pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import sys
 from typing import Any
 
 import pytest
@@ -206,6 +207,119 @@ def _install_fake_runner_and_promote(monkeypatch: pytest.MonkeyPatch, repo: Path
 
     monkeypatch.setattr(experiment_pipeline.experiment_runner, "main", fake_runner_main)
     monkeypatch.setattr(experiment_pipeline.experiment_promote, "main", fake_promote_main)
+
+
+def test_pipeline_preserves_relative_promotion_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    _configure_repo(monkeypatch, repo)
+    _reset_fake_smtp()
+    captured_promote_args: list[str] = []
+
+    def fake_runner_main(argv: list[str]) -> int:
+        output_path = Path(argv[argv.index("--output") + 1])
+        _write_json(output_path, _result())
+        print(json.dumps({"output": str(output_path), "status": "accepted"}))
+        return 0
+
+    def fake_promote_main(argv: list[str]) -> int:
+        captured_promote_args.extend(argv)
+        raw_output = argv[argv.index("--output") + 1]
+        assert raw_output == "nested/decision.json"
+        output_path = experiment_promote.PROMOTION_ARTIFACT_DIR / raw_output
+        audit_path = repo / "docs/audit/EXPERIMENT_EXP_PIPELINE.md"
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        audit_path.write_text("# Experiment Audit Artifact: exp-pipeline\n", encoding="utf-8")
+        _write_json(output_path, _promotion())
+        print(json.dumps({"output": str(output_path), "disposition": "promoted"}))
+        return 0
+
+    monkeypatch.setattr(experiment_pipeline.experiment_runner, "main", fake_runner_main)
+    monkeypatch.setattr(experiment_pipeline.experiment_promote, "main", fake_promote_main)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    patch_path = tmp_path / "candidate.patch"
+    patch_path.write_text("patch text\n", encoding="utf-8")
+
+    exit_code = experiment_pipeline.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--candidate-patch",
+            str(patch_path),
+            "--promotion-output",
+            "nested/decision.json",
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert captured_promote_args
+    payload = json.loads(stdout)
+    assert payload["promotion"] == (
+        "artifacts/orchestration/experiments/promotions/nested/decision.json"
+    )
+
+
+def test_pipeline_stage_failure_captures_stderr_without_leak(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    _configure_repo(monkeypatch, repo)
+
+    def leaking_runner_main(argv: list[str]) -> int:
+        del argv
+        print("secret stdout")
+        print("secret stderr", file=sys.stderr)
+        return 1
+
+    monkeypatch.setattr(experiment_pipeline.experiment_runner, "main", leaking_runner_main)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    patch_path = tmp_path / "candidate.patch"
+    patch_path.write_text("patch text\n", encoding="utf-8")
+
+    exit_code = experiment_pipeline.main(
+        ["--packet", str(packet_path), "--candidate-patch", str(patch_path)]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "runner stage failed" in captured.out
+    assert "secret stdout" not in captured.out
+    assert "secret stderr" not in captured.out
+    assert "secret stderr" not in captured.err
+
+
+def test_pipeline_stage_exception_is_sanitized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    _configure_repo(monkeypatch, repo)
+
+    def exploding_runner_main(argv: list[str]) -> int:
+        del argv
+        raise RuntimeError("secret exception detail")
+
+    monkeypatch.setattr(experiment_pipeline.experiment_runner, "main", exploding_runner_main)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    patch_path = tmp_path / "candidate.patch"
+    patch_path.write_text("patch text\n", encoding="utf-8")
+
+    exit_code = experiment_pipeline.main(
+        ["--packet", str(packet_path), "--candidate-patch", str(patch_path)]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "runner stage failed" in captured.out
+    assert "secret exception detail" not in captured.out
+    assert "secret exception detail" not in captured.err
 
 
 def test_pipeline_does_not_email_without_explicit_flag(

--- a/tests/test_experiment_runner_identity_policy.py
+++ b/tests/test_experiment_runner_identity_policy.py
@@ -64,6 +64,18 @@ def test_rejects_placeholder_co_author_email_with_governed_name(tmp_path: Path) 
         identity_check.validate_co_author_guidance((guidance_path,))
 
 
+def test_rejects_placeholder_co_author_email_with_angle_whitespace(tmp_path: Path) -> None:
+    guidance_path = tmp_path / "AGENTS.md"
+    guidance_path.write_text(
+        "Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>\n"
+        "Co-authored-by: PulsePlate Experiment Runner < runner@example.com >\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(identity_check.IdentityPolicyError, match="placeholder"):
+        identity_check.validate_co_author_guidance((guidance_path,))
+
+
 def test_rejects_placeholder_runner_email() -> None:
     policy = _valid_policy()
     policy["git_attribution"]["email"] = "runner@example.com"

--- a/tests/test_experiment_runner_identity_policy.py
+++ b/tests/test_experiment_runner_identity_policy.py
@@ -21,7 +21,47 @@ def test_default_policy_validates() -> None:
 
     assert policy["identity_slug"] == "experiment-runner"
     assert policy["git_attribution"]["email"] == "pulseplate@pm.me"
+    assert (
+        policy["git_attribution"]["co_author_trailer"]
+        == "Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>"
+    )
     assert policy["slack_identity"]["status"] == "deferred"
+
+
+def test_default_co_author_guidance_validates() -> None:
+    identity_check.validate_co_author_guidance()
+
+
+def test_rejects_missing_co_author_trailer() -> None:
+    policy = _valid_policy()
+    policy["git_attribution"].pop("co_author_trailer")
+
+    with pytest.raises(identity_check.IdentityPolicyError, match="co_author_trailer"):
+        identity_check.validate_identity_policy(policy)
+
+
+def test_rejects_placeholder_co_author_guidance(tmp_path: Path) -> None:
+    guidance_path = tmp_path / "AGENTS.md"
+    guidance_path.write_text(
+        "Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>\n"
+        "Co-authored-by: Experiment Runner <runner@example.com>\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(identity_check.IdentityPolicyError, match="placeholder"):
+        identity_check.validate_co_author_guidance((guidance_path,))
+
+
+def test_rejects_placeholder_co_author_email_with_governed_name(tmp_path: Path) -> None:
+    guidance_path = tmp_path / "AGENTS.md"
+    guidance_path.write_text(
+        "Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>\n"
+        "Co-authored-by: PulsePlate Experiment Runner <runner@example.com>\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(identity_check.IdentityPolicyError, match="placeholder"):
+        identity_check.validate_co_author_guidance((guidance_path,))
 
 
 def test_rejects_placeholder_runner_email() -> None:
@@ -425,6 +465,7 @@ def test_cli_json_success(capsys: pytest.CaptureFixture[str]) -> None:
 
     assert exit_code == 0
     assert json.loads(capsys.readouterr().out) == {
+        "co_author_trailer": "Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>",
         "git_email": "pulseplate@pm.me",
         "identity_slug": "experiment-runner",
         "slack_identity": "deferred",


### PR DESCRIPTION
## Summary

- Add canonical Experiment Runner co-author guidance across root/scoped agent docs and experimentation docs:
  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
- Add `scripts/orchestration/experiment_pipeline.py`, a governed completion wrapper that sequences runner -> promotion -> notification without changing those stage boundaries.
- Keep email delivery explicit: reports are sent only when `--email-reports` is passed, to the fixed governed v1 recipient via existing `experiment_notify.py` allowlist/SMTP/audit controls.
- Tighten identity validation so agent-facing guidance must include the governed trailer and must reject any `Co-authored-by: ... <runner@example.com>` placeholder variant.

## Scope

In scope:
- Experiment Runner attribution instructions.
- Automatic email report orchestration inside the governed experiment pipeline wrapper.
- Regression tests for no-email default, explicit email path, redaction, audit artifact hygiene, sanitized failure output, and identity guidance guards.

Out of scope:
- GitHub account/email verification for `pulseplate@pm.me`.
- Slack identity or Slack notification delivery.
- Making git attribution email a delivery channel.
- Merge/readiness authority changes for Experiment Runner.

## Coordinator / Agents

Coordinator-first lane:
- Worktree: `worktrees/experiment-runner-attribution-auto-email-reports`
- Branch: `codex/experiment-runner-attribution-auto-email-reports`
- Bootstrap packet: `artifacts/orchestration/task_packets/1e81354e95c0.json`
- Premortem packet: `artifacts/orchestration/task_packets/1cfd0dfc5620.json`

Role order used:
- `agent-coordinator`
- `security-auditor`
- `architecture-specialist`
- `backend-engineer`
- `qa-engineer-agent`
- `bug-hunter`
- `pulseplate-premortem-risk-review`
- Codex Security diff-focused scan

## Premortem Findings

- FIXED: placeholder co-author variants could survive if only the exact old trailer was rejected. Added regex guard for any `Co-authored-by: ... <runner@example.com>` and regression coverage.
- NOT-A-BUG: automatic email remains explicit pipeline behavior, not hidden env-triggered behavior; `--email-reports` is required and the wrapper exposes no arbitrary recipient flag.
- NOT-A-BUG: Slack remains deferred because it is notification/display identity only, not cryptographic authorship.

## Codex Security

Diff-focused scan covered:
- `scripts/orchestration/experiment_pipeline.py`
- `scripts/orchestration/experiment_promote.py`
- `scripts/orchestration/check_experiment_runner_identity.py`
- Experimentation/identity docs and tests

Result: no surviving security findings. The wrapper does not introduce shell execution, does not accept arbitrary recipients, delegates SMTP/redaction/audit to `experiment_notify.py`, suppresses child stdout leakage, and returns sanitized stage failures.

## Tests / Validation

Local gates run:

```bash
python3 scripts/orchestration/check_preflight.py --path AGENTS.md --path scripts/AGENTS.md --path docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md --path docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.md --path docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.json --path scripts/orchestration/experiment_pipeline.py --path scripts/orchestration/experiment_promote.py --path scripts/orchestration/check_experiment_runner_identity.py --path tests/test_experiment_pipeline.py --path tests/test_experiment_runner_identity_policy.py
python3 scripts/orchestration/check_agent_consistency.py
python3 scripts/orchestration/check_experiment_runner_identity.py --json
pytest -q tests/test_experiment_pipeline.py tests/test_experiment_runner_identity_policy.py tests/test_experiment_notify.py tests/test_experiment_runner.py tests/test_experiment_promote.py
pre-commit run --all-files
make validate-changed
```

Pre-push hook also passed:
- mypy changed files
- pip-audit
- backend tests
- bandit full repo
- docker build test

## Security Notes

- SMTP secrets remain runtime/env only and are not committed.
- Email body remains the existing redacted markdown notification output.
- Pipeline output redacts recipient as `governed-v1-recipient`.
- Audit artifact remains handled by `experiment_notify.py` and omits plaintext recipient/secrets.
- `runner@example.com` remains forbidden for new Experiment Runner attribution.

## Deferred / Follow-ups

- Operator-owned: GitHub account verification/linking for `pulseplate@pm.me` if contributor/avatar linking is desired.
- Separate security-governed PR if Slack display identity or Slack notification delivery is desired.

## Merge Readiness

Not merge-ready at PR open. Pending current-head PR CI, bot review comments, fixed mapping artifact, review-thread disposition, strict merge-readiness wrapper, and final wait-window.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a governed experiment completion pipeline (runner → promotion → notification) with explicit opt‑in email reports, and enforces the Experiment Runner co‑author attribution policy. Tightens promotion output paths and sanitizes stage failures.

- New Features
  - Added `scripts/orchestration/experiment_pipeline.py` to orchestrate stages with sanitized JSON output and stable artifact paths.
  - Email reports are opt-in via `--email-reports`; recipient is fixed to the governed v1 address and SMTP/redaction/audit are delegated to `experiment_notify.py`.
  - Identity policy: added `co_author_trailer` to the policy JSON and a validator that requires the governed trailer in agent/docs and rejects any `runner@example.com` placeholder; added tests.
  - Added `docs/review/PR_1765_FIXED_MAPPING.md` to record fixed-in-commit mapping for review findings.

- Bug Fixes
  - Contained `--promotion-output` to `artifacts/orchestration/experiments/promotions/`; reject absolute and parent-directory escapes; added tests.
  - Preserved relative `--promotion-output` when invoking `experiment_promote.py`, resolving paths only for summary/notification.
  - Sanitized stage failures by capturing stdout/stderr and normalizing exceptions to generic messages.

<sup>Written for commit eb539cb0b3ba95ce39ce96111f7854969db5dd58. Summary will update on new commits. <a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1765?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1765_FIXED_MAPPING.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified governed Experiment Runner identity: mandated the exact Co-authored-by trailer, forbade placeholder attribution emails, and documented notification boundaries and opt-in email behavior requiring explicit flag and governed recipient.

* **New Features**
  * Added a governed experiment orchestration CLI that sequences runner → promotion → notification and supports opt-in, redacted email reports to the governed recipient.

* **Tests**
  * Expanded end-to-end pipeline and identity tests for email/no-email, redaction, path safety, failure sanitization, and trailer validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Split Justification

This PR intentionally keeps Experiment Runner co-author guidance, the governed pipeline wrapper, and the regression guards/tests together. Splitting the docs first would leave agents with attribution instructions before the automatic report path is testable; splitting the wrapper first would add a delivery path before the canonical identity guidance and placeholder guards are enforced. The changed surface is still one orchestration boundary and has focused local gates plus current-head CI coverage.
