### PR TITLE
fix(security): scope jwt CVE suppression

### DIFF
--- a/docs/review/PR_1766_FIXED_MAPPING.md
+++ b/docs/review/PR_1766_FIXED_MAPPING.md
@@ -11,6 +11,8 @@
     tracker references and Dependabot alert #142 evidence.
   - `8751b4958c0f3f432bd75f9860abbd37770f8533` - aligned the Rego predicate
     with Trivy 0.69.3 Bundler policy input fields.
+  - `5053d698bc8b69655e471abb2918497bf2b81063` - clarified single file-level
+    expiry handling and normalized `PkgID` wording.
 - Scope: Trivy suppression governance for Ruby `jwt` CVE-2026-45363 in
   `ios/Gemfile.lock` release tooling only. No `.trivyignore`, lockfile,
   workflow, runtime backend, frontend, OpenAPI, iOS app binary, auth, billing,
@@ -31,6 +33,16 @@ Disposition: FIXED
 Commit: dd24159e3a6f099b6f7334098baae275e65459c7
 Evidence: CodeRabbit found that the new Trivy suppression block referenced Fastlane and jwt version pages but lacked a direct CVE tracker URL. The suppression block now includes `https://avd.aquasec.com/nvd/cve-2026-45363` and `https://github.com/advisories/GHSA-c32j-vqhx-rx3x`; the security note and ledger also link GitHub Dependabot alert #142 for the same `jwt` / `ios/Gemfile.lock` advisory.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1766#discussion_r3261793183 -> dd24159e3a6f099b6f7334098baae275e65459c7
+
+Disposition: FIXED
+Commit: 5053d698bc8b69655e471abb2918497bf2b81063
+Evidence: Sourcery found inconsistent `package id` wording in the security note. `docs/security/CVE-2026-45363-jwt-fastlane.md` now uses explicit `PkgID` wording for the Trivy field.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1766#discussion_r3261847247 -> 5053d698bc8b69655e471abb2918497bf2b81063
+
+Disposition: NOT-A-BUG
+Evidence: `trivy/ignore-policy.rego:10` documents that CI enforces a single file-level expiry marker; `trivy/ignore-policy.rego:12` has the required `Suppression expires: 2026-05-27` marker; `scripts/ci/check_trivy_ignore_policy_expiry.py:21` rejects multiple markers with `expected exactly one expiry per policy file`; `trivy/ignore-policy.rego:435` now notes that expiry is governed by the single file-level marker.
+Reason: CodeRabbit requested a second block-level `Suppression expires:` marker for the JWT rule, but adding it would break the canonical expiry checker. The current file-level expiry is the repo-approved policy format.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1766#discussion_r3261895753
 
 ## Role-Agent Findings
 
@@ -77,9 +89,13 @@ release tooling no longer depends on Fastlane's `jwt` 2.x graph.
 ## Bot Review Notes
 
 - CodeRabbit: one actionable thread fixed in
-  `dd24159e3a6f099b6f7334098baae275e65459c7`; pending current-head terminal
+  `dd24159e3a6f099b6f7334098baae275e65459c7`; one expiry-format thread
+  dispositioned as NOT-A-BUG because the requested second expiry marker would
+  violate the repo's exactly-one-expiry checker; pending current-head terminal
   review after latest push.
-- Sourcery: pending current-head terminal review.
+- Sourcery: wording nit fixed in `5053d698bc8b69655e471abb2918497bf2b81063`;
+  stale PkgPath helper comment was superseded by
+  `8751b4958c0f3f432bd75f9860abbd37770f8533`.
 - Cubic: pending current-head terminal review.
 
 ## Local Validation

--- a/docs/review/PR_1766_FIXED_MAPPING.md
+++ b/docs/review/PR_1766_FIXED_MAPPING.md
@@ -9,7 +9,7 @@
     temporary Trivy suppression, security note, and backlog removal item.
   - `dd24159e3a6f099b6f7334098baae275e65459c7` - added direct CVE/GHSA
     tracker references and Dependabot alert #142 evidence.
-  - `8751b4958c0f3f432bd75f9860abbd37770f8533` - aligned the Rego predicate
+  - `8751b49584c375bedd4fd640f0247221560fa98a` - aligned the Rego predicate
     with Trivy 0.69.3 Bundler policy input fields.
   - `5053d698bc8b69655e471abb2918497bf2b81063` - clarified single file-level
     expiry handling and normalized `PkgID` wording.
@@ -32,16 +32,19 @@ merge-blocking until their current-head statuses are terminal and reviewed.
 Disposition: FIXED
 Commit: dd24159e3a6f099b6f7334098baae275e65459c7
 Evidence: CodeRabbit found that the new Trivy suppression block referenced Fastlane and jwt version pages but lacked a direct CVE tracker URL. The suppression block now includes `https://avd.aquasec.com/nvd/cve-2026-45363` and `https://github.com/advisories/GHSA-c32j-vqhx-rx3x`; the security note and ledger also link GitHub Dependabot alert #142 for the same `jwt` / `ios/Gemfile.lock` advisory.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1766#pullrequestreview-4313494312 -> dd24159e3a6f099b6f7334098baae275e65459c7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1766#discussion_r3261793183 -> dd24159e3a6f099b6f7334098baae275e65459c7
 
 Disposition: FIXED
 Commit: 5053d698bc8b69655e471abb2918497bf2b81063
 Evidence: Sourcery found inconsistent `package id` wording in the security note. `docs/security/CVE-2026-45363-jwt-fastlane.md` now uses explicit `PkgID` wording for the Trivy field.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1766#pullrequestreview-4313559314 -> 5053d698bc8b69655e471abb2918497bf2b81063
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1766#discussion_r3261847247 -> 5053d698bc8b69655e471abb2918497bf2b81063
 
 Disposition: NOT-A-BUG
 Evidence: `trivy/ignore-policy.rego:10` documents that CI enforces a single file-level expiry marker; `trivy/ignore-policy.rego:12` has the required `Suppression expires: 2026-05-27` marker; `scripts/ci/check_trivy_ignore_policy_expiry.py:21` rejects multiple markers with `expected exactly one expiry per policy file`; `trivy/ignore-policy.rego:435` now notes that expiry is governed by the single file-level marker.
 Reason: CodeRabbit requested a second block-level `Suppression expires:` marker for the JWT rule, but adding it would break the canonical expiry checker. The current file-level expiry is the repo-approved policy format.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1766#pullrequestreview-4313617562
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1766#discussion_r3261895753
 
 ## Role-Agent Findings
@@ -91,12 +94,11 @@ release tooling no longer depends on Fastlane's `jwt` 2.x graph.
 - CodeRabbit: one actionable thread fixed in
   `dd24159e3a6f099b6f7334098baae275e65459c7`; one expiry-format thread
   dispositioned as NOT-A-BUG because the requested second expiry marker would
-  violate the repo's exactly-one-expiry checker; pending current-head terminal
-  review after latest push.
+  violate the repo's exactly-one-expiry checker.
 - Sourcery: wording nit fixed in `5053d698bc8b69655e471abb2918497bf2b81063`;
   stale PkgPath helper comment was superseded by
-  `8751b4958c0f3f432bd75f9860abbd37770f8533`.
-- Cubic: pending current-head terminal review.
+  `8751b49584c375bedd4fd640f0247221560fa98a`.
+- Cubic: no issues found in the current review pass.
 
 ## Local Validation
 
@@ -133,17 +135,21 @@ release tooling no longer depends on Fastlane's `jwt` 2.x graph.
   security-scan rather than silently over-suppress.
 - Rollback: revert implementing commits `9df304969f34712868223eadd75151206ecf07fb`,
   `dd24159e3a6f099b6f7334098baae275e65459c7`, and
-  `8751b4958c0f3f432bd75f9860abbd37770f8533`; no runtime behavior changed.
+  `8751b49584c375bedd4fd640f0247221560fa98a`; no runtime behavior changed.
 
 ## Merge Readiness
 
 - [x] Pre-flight + agent consistency: PASS.
 - [x] Canonical artifact: this file (`docs/review/PR_1766_FIXED_MAPPING.md`).
 - [x] PR body mirror: PASS.
-- [ ] Current-head CI: pending terminal current-head checks.
-- [ ] Bot summaries reviewed (CodeRabbit / Sourcery / Cubic): pending terminal statuses.
-- [ ] Strict review-thread disposition: pending `check_review_threads_disposition.py --require-auth`.
-- [ ] Strict merge readiness: pending `check_merge_ready.py --require-auth`.
+- [ ] Current-head CI: pending terminal current-head checks after the latest
+  governance commit.
+- [x] Bot summaries reviewed (CodeRabbit / Sourcery / Cubic): no open
+  actionables after disposition.
+- [x] Strict review-thread disposition: PASS
+  (`check_review_threads_disposition.py --require-auth`).
+- [x] Strict merge-readiness review governance: PASS
+  (`check_pr_merge_readiness.py --pr-number 1766 --repo Katsiarynakavaleuskaya/PulsePlate`).
 
 ## Deferred / Follow-ups
 

--- a/docs/review/PR_1766_FIXED_MAPPING.md
+++ b/docs/review/PR_1766_FIXED_MAPPING.md
@@ -15,13 +15,16 @@
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-Initial post-open governance pass found no actionable human review threads.
-External CodeRabbit, Sourcery, and Cubic reviews remain merge-blocking until
-their current-head statuses are terminal and reviewed.
+Initial post-open governance pass found one actionable CodeRabbit review thread,
+fixed and mapped below. External CodeRabbit, Sourcery, and Cubic reviews remain
+merge-blocking until their current-head statuses are terminal and reviewed.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: dd24159e3a6f099b6f7334098baae275e65459c7
+Evidence: CodeRabbit found that the new Trivy suppression block referenced Fastlane and jwt version pages but lacked a direct CVE tracker URL. The suppression block now includes `https://avd.aquasec.com/nvd/cve-2026-45363` and `https://github.com/advisories/GHSA-c32j-vqhx-rx3x`; the security note and ledger also link GitHub Dependabot alert #142 for the same `jwt` / `ios/Gemfile.lock` advisory.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1766#discussion_r3261793183 -> dd24159e3a6f099b6f7334098baae275e65459c7
 
 ## Role-Agent Findings
 
@@ -65,7 +68,9 @@ release tooling no longer depends on Fastlane's `jwt` 2.x graph.
 
 ## Bot Review Notes
 
-- CodeRabbit: pending current-head terminal review.
+- CodeRabbit: one actionable thread fixed in
+  `dd24159e3a6f099b6f7334098baae275e65459c7`; pending current-head terminal
+  review after latest push.
 - Sourcery: pending current-head terminal review.
 - Cubic: pending current-head terminal review.
 

--- a/docs/review/PR_1766_FIXED_MAPPING.md
+++ b/docs/review/PR_1766_FIXED_MAPPING.md
@@ -33,8 +33,9 @@ Commit: 9df304969f34712868223eadd75151206ecf07fb
 Evidence: `bug-hunter` found that a CVE-only `.trivyignore` entry would be too
 broad. The PR does not modify `.trivyignore`; `trivy/ignore-policy.rego` now
 scopes the suppression to CVE-2026-45363, package `jwt`, installed version
-`2.10.2`, fixed version `3.2.0`, `PkgID` prefix `jwt@2.10.2`, and `PkgPath`
-matching `ios/Gemfile.lock`.
+`2.10.2`, fixed version `3.2.0`, `PkgID` `jwt@2.10.2`, PURL
+`pkg:gem/jwt@2.10.2`, and primary advisory URL
+`https://avd.aquasec.com/nvd/cve-2026-45363`.
 
 Disposition: FIXED
 Commit: 9df304969f34712868223eadd75151206ecf07fb
@@ -103,9 +104,9 @@ release tooling no longer depends on Fastlane's `jwt` 2.x graph.
 
 ## Risks / Rollback
 
-- Risk: Trivy policy input does not populate `PkgPath` for Bundler findings,
-  leaving alert #594 open. This should fail current-head security-scan rather
-  than silently over-suppress.
+- Risk: Trivy's Bundler policy input shape changes again and the exact
+  package/advisory predicate no longer matches. This should fail current-head
+  security-scan rather than silently over-suppress.
 - Rollback: revert implementing commit `9df304969f34712868223eadd75151206ecf07fb`
   and this mapping artifact commit; no runtime behavior changed.
 

--- a/docs/review/PR_1766_FIXED_MAPPING.md
+++ b/docs/review/PR_1766_FIXED_MAPPING.md
@@ -1,0 +1,119 @@
+<!-- markdownlint-disable MD013 MD034 -->
+# PR 1766 Fixed In Commit Mapping
+
+- PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1766>
+- Branch: `codex/security-jwt-cve-2026-45363`
+- Title: `fix(security): scope jwt CVE suppression`
+- Implementing commit: `9df304969f34712868223eadd75151206ecf07fb`
+- Scope: Trivy suppression governance for Ruby `jwt` CVE-2026-45363 in
+  `ios/Gemfile.lock` release tooling only. No `.trivyignore`, lockfile,
+  workflow, runtime backend, frontend, OpenAPI, iOS app binary, auth, billing,
+  quota, or deployment behavior changed.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+Initial post-open governance pass found no actionable human review threads.
+External CodeRabbit, Sourcery, and Cubic reviews remain merge-blocking until
+their current-head statuses are terminal and reviewed.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Role-Agent Findings
+
+Disposition: FIXED
+Commit: 9df304969f34712868223eadd75151206ecf07fb
+Evidence: `bug-hunter` found that a CVE-only `.trivyignore` entry would be too
+broad. The PR does not modify `.trivyignore`; `trivy/ignore-policy.rego` now
+scopes the suppression to CVE-2026-45363, package `jwt`, installed version
+`2.10.2`, fixed version `3.2.0`, `PkgID` prefix `jwt@2.10.2`, and `PkgPath`
+matching `ios/Gemfile.lock`.
+
+Disposition: FIXED
+Commit: 9df304969f34712868223eadd75151206ecf07fb
+Evidence: `security-auditor` required temporary risk acceptance to remain
+documented and removable. `docs/security/CVE-2026-45363-jwt-fastlane.md`
+records the resolver blocker, release-tooling risk, monitor links, review
+target, and removal condition; `docs/roadmap/BACKLOG_LEDGER.md` tracks the
+follow-up removal DoD.
+
+Disposition: NOT-A-BUG
+Evidence: `app-store-release-agent` confirmed that this dependency is release
+tooling, not iOS app binary runtime, and that local validation should not claim
+protected App Store upload success.
+Reason: The PR body and security note explicitly limit local Fastlane evidence
+to no-auth metadata validation.
+
+Disposition: NOT-A-BUG
+Evidence: Codex Security diff-focused scan found no new reportable finding in
+the diff. Artifact:
+`/tmp/codex-security-scans/BMI-App_2025_clean/jwt_cve_2026_45363_20260518T200205Z/report.md`.
+Reason: The patch adds no executable runtime code, no secrets, no auth/network
+path, and no global suppression.
+
+Disposition: FIXED
+Commit: 9df304969f34712868223eadd75151206ecf07fb
+Evidence: `pulseplate-premortem-risk-review` identified broad suppression and
+stale risk acceptance as the likely failure modes. The Rego rule is path and
+version scoped, the policy file keeps the shared 2026-05-27 expiry, and the
+ledger entry requires removal once Fastlane permits `jwt >= 3.2.0` or the
+release tooling no longer depends on Fastlane's `jwt` 2.x graph.
+
+## Bot Review Notes
+
+- CodeRabbit: pending current-head terminal review.
+- Sourcery: pending current-head terminal review.
+- Cubic: pending current-head terminal review.
+
+## Local Validation
+
+- `.venv/bin/python scripts/orchestration/check_preflight.py` - PASS.
+- `.venv/bin/python scripts/orchestration/check_agent_consistency.py` - PASS.
+- `.venv/bin/python scripts/ci/check_trivy_ignore_policy_expiry.py` - PASS.
+- `.venv/bin/python scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-45363-jwt-fastlane.md docs/roadmap/BACKLOG_LEDGER.md` - PASS.
+- `cd ios && bundle check` - PASS.
+- `cd ios && bundle exec fastlane validate_metadata_package` - PASS.
+- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed` - PASS; no Python files changed.
+- `pre-commit run --all-files` - PASS.
+- Pre-push hook PASS: pip-audit, backend pre-push tests, and full-repo Bandit.
+
+### Machine-heavy / operator-approved narrow gate
+
+- Full local `make verify` is deferred per the operator-approved machine-safe
+  policy and root `AGENTS.md` machine-heavy PR exception. This PR uses focused
+  local gates plus current-head GitHub CI as the heavy matrix/security signal.
+
+## Security Notes
+
+- This is temporary release-tooling risk acceptance, not a full vulnerability
+  remediation.
+- The suppression must be removed once Fastlane permits `jwt >= 3.2.0` or iOS
+  release tooling no longer depends on the Fastlane `jwt` 2.x graph.
+- Current-head Trivy/GitHub Code Scanning evidence is required before any
+  merge-ready claim.
+
+## Risks / Rollback
+
+- Risk: Trivy policy input does not populate `PkgPath` for Bundler findings,
+  leaving alert #594 open. This should fail current-head security-scan rather
+  than silently over-suppress.
+- Rollback: revert implementing commit `9df304969f34712868223eadd75151206ecf07fb`
+  and this mapping artifact commit; no runtime behavior changed.
+
+## Merge Readiness
+
+- [x] Pre-flight + agent consistency: PASS.
+- [x] Canonical artifact: this file (`docs/review/PR_1766_FIXED_MAPPING.md`).
+- [ ] PR body mirror: pending update after this artifact lands.
+- [ ] Current-head CI: pending terminal current-head checks.
+- [ ] Bot summaries reviewed (CodeRabbit / Sourcery / Cubic): pending terminal statuses.
+- [ ] Strict review-thread disposition: pending `check_review_threads_disposition.py --require-auth`.
+- [ ] Strict merge readiness: pending `check_merge_ready.py --require-auth`.
+
+## Deferred / Follow-ups
+
+- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363`

--- a/docs/review/PR_1766_FIXED_MAPPING.md
+++ b/docs/review/PR_1766_FIXED_MAPPING.md
@@ -4,7 +4,13 @@
 - PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1766>
 - Branch: `codex/security-jwt-cve-2026-45363`
 - Title: `fix(security): scope jwt CVE suppression`
-- Implementing commit: `9df304969f34712868223eadd75151206ecf07fb`
+- Implementing commits:
+  - `9df304969f34712868223eadd75151206ecf07fb` - added the initial
+    temporary Trivy suppression, security note, and backlog removal item.
+  - `dd24159e3a6f099b6f7334098baae275e65459c7` - added direct CVE/GHSA
+    tracker references and Dependabot alert #142 evidence.
+  - `8751b4958c0f3f432bd75f9860abbd37770f8533` - aligned the Rego predicate
+    with Trivy 0.69.3 Bundler policy input fields.
 - Scope: Trivy suppression governance for Ruby `jwt` CVE-2026-45363 in
   `ios/Gemfile.lock` release tooling only. No `.trivyignore`, lockfile,
   workflow, runtime backend, frontend, OpenAPI, iOS app binary, auth, billing,
@@ -62,9 +68,10 @@ path, and no global suppression.
 Disposition: FIXED
 Commit: 9df304969f34712868223eadd75151206ecf07fb
 Evidence: `pulseplate-premortem-risk-review` identified broad suppression and
-stale risk acceptance as the likely failure modes. The Rego rule is path and
-version scoped, the policy file keeps the shared 2026-05-27 expiry, and the
-ledger entry requires removal once Fastlane permits `jwt >= 3.2.0` or the
+stale risk acceptance as the likely failure modes. The Rego rule is scoped to
+exact CVE, package, installed version, fixed version, PURL, and primary
+advisory URL fields; the policy file keeps the shared 2026-05-27 expiry, and
+the ledger entry requires removal once Fastlane permits `jwt >= 3.2.0` or the
 release tooling no longer depends on Fastlane's `jwt` 2.x graph.
 
 ## Bot Review Notes
@@ -81,6 +88,7 @@ release tooling no longer depends on Fastlane's `jwt` 2.x graph.
 - `.venv/bin/python scripts/orchestration/check_agent_consistency.py` - PASS.
 - `.venv/bin/python scripts/ci/check_trivy_ignore_policy_expiry.py` - PASS.
 - `.venv/bin/python scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-45363-jwt-fastlane.md docs/roadmap/BACKLOG_LEDGER.md` - PASS.
+- `trivy 0.69.3 fs --scanners vuln --severity HIGH,CRITICAL --ignore-policy trivy/ignore-policy.rego --format json ios` - PASS; no `jwt` / `CVE-2026-45363` findings remained after the exact-field policy update.
 - `cd ios && bundle check` - PASS.
 - `cd ios && bundle exec fastlane validate_metadata_package` - PASS.
 - `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed` - PASS; no Python files changed.
@@ -107,14 +115,15 @@ release tooling no longer depends on Fastlane's `jwt` 2.x graph.
 - Risk: Trivy's Bundler policy input shape changes again and the exact
   package/advisory predicate no longer matches. This should fail current-head
   security-scan rather than silently over-suppress.
-- Rollback: revert implementing commit `9df304969f34712868223eadd75151206ecf07fb`
-  and this mapping artifact commit; no runtime behavior changed.
+- Rollback: revert implementing commits `9df304969f34712868223eadd75151206ecf07fb`,
+  `dd24159e3a6f099b6f7334098baae275e65459c7`, and
+  `8751b4958c0f3f432bd75f9860abbd37770f8533`; no runtime behavior changed.
 
 ## Merge Readiness
 
 - [x] Pre-flight + agent consistency: PASS.
 - [x] Canonical artifact: this file (`docs/review/PR_1766_FIXED_MAPPING.md`).
-- [ ] PR body mirror: pending update after this artifact lands.
+- [x] PR body mirror: PASS.
 - [ ] Current-head CI: pending terminal current-head checks.
 - [ ] Bot summaries reviewed (CodeRabbit / Sourcery / Cubic): pending terminal statuses.
 - [ ] Strict review-thread disposition: pending `check_review_threads_disposition.py --require-auth`.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4518,6 +4518,28 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Mark `docs/security/CVE-2026-33846-gnutls.md` resolved or update with remediation evidence
     - Trivy Code Scanning alert #590 remains closed on `main`
 
+<a id="ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363"></a>
+- [ ] Remove Trivy suppression for Ruby jwt CVE-2026-45363
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: TBD (follow-up after Fastlane permits jwt 3.x)
+  - Status: Open
+  - Area: security / iOS release tooling / code-scanning
+  - Finding Type: release-tooling dependency vulnerability
+  - Reason: GitHub Code Scanning alert #594 reports Ruby gem `jwt` `CVE-2026-45363` at `2.10.2` from `ios/Gemfile.lock`, with fixed version `3.2.0`. Bundler resolver evidence on 2026-05-18 shows latest Fastlane `2.234.0` still requires `jwt >= 2.1.0, < 3`, so the fixed `jwt` 3.x line is not reachable through a safe lockfile update. This is covered by a narrow temporary suppression in `trivy/ignore-policy.rego` scoped to `ios/Gemfile.lock` while monitoring Fastlane support.
+  - Links:
+    - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/594
+    - docs/security/CVE-2026-45363-jwt-fastlane.md
+    - trivy/ignore-policy.rego
+    - https://rubygems.org/gems/fastlane/versions/2.234.0
+    - https://rubygems.org/gems/jwt/versions/3.2.0
+  - DoD:
+    - Fastlane publishes a compatible release that permits `jwt >= 3.2.0`, or iOS release tooling no longer depends on Fastlane's `jwt` 2.x graph
+    - Update `ios/Gemfile.lock` to remove the vulnerable `jwt` resolution
+    - Remove suppression rule from `trivy/ignore-policy.rego`
+    - Mark `docs/security/CVE-2026-45363-jwt-fastlane.md` resolved or update with remediation evidence
+    - Trivy Code Scanning alert #594 remains closed on `main`
+
 <a id="ledger-p1-reconcile-open-dependabot-alerts"></a>
 - [ ] P1: Reconcile open Dependabot alerts on `main` after manifest fixes
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4526,7 +4526,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Status: Open
   - Area: security / iOS release tooling / code-scanning
   - Finding Type: release-tooling dependency vulnerability
-  - Reason: GitHub Code Scanning alert #594 reports Ruby gem `jwt` `CVE-2026-45363` at `2.10.2` from `ios/Gemfile.lock`, with fixed version `3.2.0`. Bundler resolver evidence on 2026-05-18 shows latest Fastlane `2.234.0` still requires `jwt >= 2.1.0, < 3`, so the fixed `jwt` 3.x line is not reachable through a safe lockfile update. This is covered by a narrow temporary suppression in `trivy/ignore-policy.rego` scoped to `ios/Gemfile.lock` while monitoring Fastlane support.
+  - Reason: GitHub Code Scanning alert #594 and Dependabot alert #142 report Ruby gem `jwt` `CVE-2026-45363` at `2.10.2` from `ios/Gemfile.lock`, with fixed version `3.2.0`. Bundler resolver evidence on 2026-05-18 shows latest Fastlane `2.234.0` still requires `jwt >= 2.1.0, < 3`, so the fixed `jwt` 3.x line is not reachable through a safe lockfile update. This is covered by a narrow temporary suppression in `trivy/ignore-policy.rego` scoped by exact CVE, package, installed version, fixed version, PURL, and primary advisory URL while monitoring Fastlane support.
   - Links:
     - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/142
     - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/594

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -4528,9 +4528,11 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Finding Type: release-tooling dependency vulnerability
   - Reason: GitHub Code Scanning alert #594 reports Ruby gem `jwt` `CVE-2026-45363` at `2.10.2` from `ios/Gemfile.lock`, with fixed version `3.2.0`. Bundler resolver evidence on 2026-05-18 shows latest Fastlane `2.234.0` still requires `jwt >= 2.1.0, < 3`, so the fixed `jwt` 3.x line is not reachable through a safe lockfile update. This is covered by a narrow temporary suppression in `trivy/ignore-policy.rego` scoped to `ios/Gemfile.lock` while monitoring Fastlane support.
   - Links:
+    - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/142
     - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/code-scanning/594
     - docs/security/CVE-2026-45363-jwt-fastlane.md
     - trivy/ignore-policy.rego
+    - https://github.com/advisories/GHSA-c32j-vqhx-rx3x
     - https://rubygems.org/gems/fastlane/versions/2.234.0
     - https://rubygems.org/gems/jwt/versions/3.2.0
   - DoD:

--- a/docs/security/CVE-2026-45363-jwt-fastlane.md
+++ b/docs/security/CVE-2026-45363-jwt-fastlane.md
@@ -49,8 +49,14 @@ exactly:
 - `PkgName == jwt`
 - `InstalledVersion == 2.10.2`
 - `FixedVersion == 3.2.0`
-- `PkgID` prefix `jwt@2.10.2`
-- `PkgPath` matching `ios/Gemfile.lock`
+- `PkgID == jwt@2.10.2`
+- `PkgIdentifier.PURL == pkg:gem/jwt@2.10.2`
+- `PrimaryURL == https://avd.aquasec.com/nvd/cve-2026-45363`
+
+GitHub alert and repository evidence identify the affected carrier as
+`ios/Gemfile.lock`. Trivy 0.69.3's Rego input for Bundler vulnerabilities does
+not expose that target path to the policy predicate, so the rule intentionally
+uses exact package/advisory fields instead of a broad CVE-only suppression.
 
 ## Attack-surface assessment
 
@@ -96,8 +102,8 @@ confirm Trivy/GitHub Code Scanning alert #594 remains closed on `main`.
 - `ios/Gemfile.lock:103` - Fastlane requires `jwt >= 2.1.0, < 3`.
 - `ios/Gemfile.lock:169` - current Bundler resolution is `jwt 2.10.2`.
 - `trivy/ignore-policy.rego:419` - narrow suppression anchor.
-- `trivy/ignore-policy.rego:444` - suppression rule matches CVE, package,
-  installed version, fixed version, path, and package id.
+- `trivy/ignore-policy.rego:440` - suppression rule matches CVE, package,
+  installed version, fixed version, package id, PURL, and primary advisory URL.
 - `security/dependabot/142` - GitHub reports the same RubyGems `jwt`
   CVE-2026-45363 alert for `ios/Gemfile.lock`, fixed in `3.2.0`.
 

--- a/docs/security/CVE-2026-45363-jwt-fastlane.md
+++ b/docs/security/CVE-2026-45363-jwt-fastlane.md
@@ -7,6 +7,7 @@ Temporary narrow suppression with upstream Fastlane dependency monitoring.
 ## Alert
 
 - GitHub Code Scanning alert: #594
+- GitHub Dependabot alert: #142
 - Tool: Trivy
 - Package: `jwt`
 - Installed version: `2.10.2`
@@ -80,6 +81,8 @@ confirm Trivy/GitHub Code Scanning alert #594 remains closed on `main`.
 - <https://rubygems.org/gems/fastlane/versions/2.234.0>
 - <https://rubygems.org/gems/jwt/versions/3.2.0>
 - <https://avd.aquasec.com/nvd/cve-2026-45363>
+- <https://github.com/advisories/GHSA-c32j-vqhx-rx3x>
+- <https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/142>
 
 ## Suppression implementation
 
@@ -95,6 +98,8 @@ confirm Trivy/GitHub Code Scanning alert #594 remains closed on `main`.
 - `trivy/ignore-policy.rego:419` - narrow suppression anchor.
 - `trivy/ignore-policy.rego:444` - suppression rule matches CVE, package,
   installed version, fixed version, path, and package id.
+- `security/dependabot/142` - GitHub reports the same RubyGems `jwt`
+  CVE-2026-45363 alert for `ios/Gemfile.lock`, fixed in `3.2.0`.
 
 ## Review / expiry
 

--- a/docs/security/CVE-2026-45363-jwt-fastlane.md
+++ b/docs/security/CVE-2026-45363-jwt-fastlane.md
@@ -1,0 +1,111 @@
+# CVE-2026-45363 - Ruby jwt / Fastlane release tooling
+
+## Status
+
+Temporary narrow suppression with upstream Fastlane dependency monitoring.
+
+## Alert
+
+- GitHub Code Scanning alert: #594
+- Tool: Trivy
+- Package: `jwt`
+- Installed version: `2.10.2`
+- Fixed version reported by GitHub/Trivy: `3.2.0`
+- Vulnerability: `CVE-2026-45363`
+- Severity: HIGH
+- Affected repo path: `ios/Gemfile.lock`
+
+## Summary
+
+Trivy reports a HIGH-severity vulnerability for the Ruby `jwt` gem resolved by
+the iOS Fastlane/Bundler dependency graph. This is release tooling, not an iOS
+application runtime dependency shipped in the app binary.
+
+## Current decision
+
+The repository cannot safely update to `jwt >= 3.2.0` through the current
+Fastlane dependency graph. Resolver evidence from 2026-05-18 shows:
+
+```text
+cd ios && bundle lock --update fastlane jwt googleauth signet --print
+fastlane (2.234.0)
+  jwt (>= 2.1.0, < 3)
+googleauth (1.11.2)
+  jwt (>= 1.4, < 3.0)
+jwt (2.10.2)
+signet (0.21.0)
+  jwt (>= 1.5, < 4.0)
+```
+
+Fastlane remains the hard blocker because its latest available release still
+requires `jwt < 3`. Forcing `jwt 3.2.0` in `ios/Gemfile` would violate the
+upstream Fastlane contract and risk breaking App Store Connect upload tooling.
+
+The repository therefore uses a narrow, time-boxed Trivy suppression for
+exactly:
+
+- `VulnerabilityID == CVE-2026-45363`
+- `PkgName == jwt`
+- `InstalledVersion == 2.10.2`
+- `FixedVersion == 3.2.0`
+- `PkgID` prefix `jwt@2.10.2`
+- `PkgPath` matching `ios/Gemfile.lock`
+
+## Attack-surface assessment
+
+This dependency is used by Fastlane release tooling, including protected App
+Store Connect API-key/JWT paths. Treat it as privileged CI/release-tooling risk,
+not as a harmless dev-only dependency. It is also not part of the iOS app binary
+runtime dependency surface.
+
+Protected upload success must not be claimed from local no-auth validation.
+Local validation may use no-auth metadata checks such as:
+
+```bash
+cd ios && bundle exec fastlane validate_metadata_package
+```
+
+## Removal condition
+
+Remove the suppression when either condition is true:
+
+1. Fastlane publishes a compatible release that permits `jwt >= 3.2.0`.
+2. The iOS release tooling no longer depends on Fastlane's `jwt 2.x` graph.
+
+After either condition, update the Bundler lockfile, remove the Rego rule, and
+confirm Trivy/GitHub Code Scanning alert #594 remains closed on `main`.
+
+## Monitor
+
+- <https://rubygems.org/gems/fastlane/versions/2.234.0>
+- <https://rubygems.org/gems/jwt/versions/3.2.0>
+- <https://avd.aquasec.com/nvd/cve-2026-45363>
+
+## Suppression implementation
+
+- Policy file: `trivy/ignore-policy.rego`
+- Policy anchor: `cve-2026-45363-jwt-fastlane-suppression`
+- Ledger anchor:
+  `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363`
+
+## Evidence anchors
+
+- `ios/Gemfile.lock:103` - Fastlane requires `jwt >= 2.1.0, < 3`.
+- `ios/Gemfile.lock:169` - current Bundler resolution is `jwt 2.10.2`.
+- `trivy/ignore-policy.rego:419` - narrow suppression anchor.
+- `trivy/ignore-policy.rego:444` - suppression rule matches CVE, package,
+  installed version, fixed version, path, and package id.
+
+## Review / expiry
+
+- **Next review target**: 2026-05-27 (aligned with existing Trivy suppression window)
+
+## Validation
+
+```bash
+python3 scripts/orchestration/check_preflight.py
+python3 scripts/orchestration/check_agent_consistency.py
+python3 scripts/ci/check_trivy_ignore_policy_expiry.py
+cd ios && bundle exec fastlane validate_metadata_package
+pre-commit run --all-files
+```

--- a/docs/security/CVE-2026-45363-jwt-fastlane.md
+++ b/docs/security/CVE-2026-45363-jwt-fastlane.md
@@ -103,7 +103,7 @@ confirm Trivy/GitHub Code Scanning alert #594 remains closed on `main`.
 - `ios/Gemfile.lock:169` - current Bundler resolution is `jwt 2.10.2`.
 - `trivy/ignore-policy.rego:419` - narrow suppression anchor.
 - `trivy/ignore-policy.rego:440` - suppression rule matches CVE, package,
-  installed version, fixed version, package id, PURL, and primary advisory URL.
+  installed version, fixed version, `PkgID`, PURL, and primary advisory URL.
 - `security/dependabot/142` - GitHub reports the same RubyGems `jwt`
   CVE-2026-45363 alert for `ios/Gemfile.lock`, fixed in `3.2.0`.
 

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -11,7 +11,7 @@ default ignore := false
 #
 # Suppression expires: 2026-05-27 (manual removal)
 # Last reviewed: 2026-04-02
-# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2026-4046-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-14831-gnutls.md, docs/security/CVE-2026-33845-gnutls.md, docs/security/CVE-2026-33846-gnutls.md, docs/security/CVE-2025-69720-ncurses.md, docs/security/CVE-2026-29111-systemd.md, docs/security/CVE-2026-4878-libcap2.md
+# Documented in: docs/security/CVE-2026-0915-glibc.md, docs/security/CVE-2026-4046-glibc.md, docs/security/CVE-2025-15281-glibc.md, docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-14831-gnutls.md, docs/security/CVE-2026-33845-gnutls.md, docs/security/CVE-2026-33846-gnutls.md, docs/security/CVE-2025-69720-ncurses.md, docs/security/CVE-2026-29111-systemd.md, docs/security/CVE-2026-4878-libcap2.md, docs/security/CVE-2026-45363-jwt-fastlane.md
 
 ignore if {
 	input.VulnerabilityID == "CVE-2026-0915"
@@ -414,4 +414,38 @@ ignore if {
 	cve_2026_4878_image_reference_match
 	cve_2026_4878_distro_match
 	startswith(input.PkgID, sprintf("libcap2@%s", [cve_2026_4878_libcap2_version]))
+}
+
+# anchor:cve-2026-45363-jwt-fastlane-suppression
+# CVE-2026-45363 (Ruby jwt) - fixed version blocked by Fastlane dependency constraint
+# Review-by: 2026-05-27 (manual removal)
+# Rationale: GitHub Code Scanning alert #594 reports Ruby gem `jwt` 2.10.2
+#   from ios/Gemfile.lock with fixed version 3.2.0. Bundler resolves latest
+#   Fastlane 2.234.0 with `jwt >= 2.1.0, < 3`, so the fixed jwt 3.x line is
+#   not reachable through a safe lockfile update. This is release tooling only,
+#   not an iOS app binary runtime dependency.
+# Monitor: https://rubygems.org/gems/fastlane/versions/2.234.0
+# Monitor: https://rubygems.org/gems/jwt/versions/3.2.0
+# Documented in: docs/security/CVE-2026-45363-jwt-fastlane.md
+# Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363
+# Removal condition: Remove when Fastlane permits jwt >= 3.2.0 or the iOS
+#   release tooling no longer depends on Fastlane's jwt 2.x graph
+
+cve_2026_45363_jwt_version := "2.10.2"
+
+cve_2026_45363_jwt_pkgpath_match if {
+	input.PkgPath == "ios/Gemfile.lock"
+}
+
+cve_2026_45363_jwt_pkgpath_match if {
+	endswith(input.PkgPath, "/ios/Gemfile.lock")
+}
+
+ignore if {
+	input.VulnerabilityID == "CVE-2026-45363"
+	input.PkgName == "jwt"
+	input.InstalledVersion == cve_2026_45363_jwt_version
+	input.FixedVersion == "3.2.0"
+	cve_2026_45363_jwt_pkgpath_match
+	startswith(input.PkgID, sprintf("jwt@%s", [cve_2026_45363_jwt_version]))
 }

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -422,8 +422,11 @@ ignore if {
 # Rationale: GitHub Code Scanning alert #594 reports Ruby gem `jwt` 2.10.2
 #   from ios/Gemfile.lock with fixed version 3.2.0. Bundler resolves latest
 #   Fastlane 2.234.0 with `jwt >= 2.1.0, < 3`, so the fixed jwt 3.x line is
-#   not reachable through a safe lockfile update. This is release tooling only,
-#   not an iOS app binary runtime dependency.
+#   not reachable through a safe lockfile update. Trivy's Rego input for
+#   Bundler findings does not expose the target path, so this rule uses exact
+#   package, version, PURL, and advisory URL fields instead of a global CVE-only
+#   suppression. This is release tooling only, not an iOS app binary runtime
+#   dependency.
 # Monitor: https://rubygems.org/gems/fastlane/versions/2.234.0
 # Monitor: https://rubygems.org/gems/jwt/versions/3.2.0
 # Monitor: https://avd.aquasec.com/nvd/cve-2026-45363
@@ -435,19 +438,12 @@ ignore if {
 
 cve_2026_45363_jwt_version := "2.10.2"
 
-cve_2026_45363_jwt_pkgpath_match if {
-	input.PkgPath == "ios/Gemfile.lock"
-}
-
-cve_2026_45363_jwt_pkgpath_match if {
-	endswith(input.PkgPath, "/ios/Gemfile.lock")
-}
-
 ignore if {
 	input.VulnerabilityID == "CVE-2026-45363"
 	input.PkgName == "jwt"
 	input.InstalledVersion == cve_2026_45363_jwt_version
 	input.FixedVersion == "3.2.0"
-	cve_2026_45363_jwt_pkgpath_match
-	startswith(input.PkgID, sprintf("jwt@%s", [cve_2026_45363_jwt_version]))
+	input.PkgID == sprintf("jwt@%s", [cve_2026_45363_jwt_version])
+	input.PkgIdentifier.PURL == sprintf("pkg:gem/jwt@%s", [cve_2026_45363_jwt_version])
+	input.PrimaryURL == "https://avd.aquasec.com/nvd/cve-2026-45363"
 }

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -426,6 +426,8 @@ ignore if {
 #   not an iOS app binary runtime dependency.
 # Monitor: https://rubygems.org/gems/fastlane/versions/2.234.0
 # Monitor: https://rubygems.org/gems/jwt/versions/3.2.0
+# Monitor: https://avd.aquasec.com/nvd/cve-2026-45363
+# Monitor: https://github.com/advisories/GHSA-c32j-vqhx-rx3x
 # Documented in: docs/security/CVE-2026-45363-jwt-fastlane.md
 # Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363
 # Removal condition: Remove when Fastlane permits jwt >= 3.2.0 or the iOS

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -433,6 +433,7 @@ ignore if {
 # Monitor: https://github.com/advisories/GHSA-c32j-vqhx-rx3x
 # Documented in: docs/security/CVE-2026-45363-jwt-fastlane.md
 # Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363
+# Expiry is governed by the single file-level marker at the top of this policy.
 # Removal condition: Remove when Fastlane permits jwt >= 3.2.0 or the iOS
 #   release tooling no longer depends on Fastlane's jwt 2.x graph
 


### PR DESCRIPTION
## Summary
- Adds a narrow Trivy Rego suppression for CVE-2026-45363 limited to Ruby jwt 2.10.2 from ios/Gemfile.lock with fixed version 3.2.0.
- Documents why a direct remediation is currently blocked: latest Fastlane resolver path still requires jwt >= 2.1.0, < 3.
- Adds backlog removal tracking for the temporary suppression.

## Coordinator / Agents
- Task packet: artifacts/orchestration/task_packets/faa3e7d8ff13.json (local, not committed).
- Role order used: agent-coordinator -> security-auditor -> app-store-release-agent -> qa-engineer-agent -> bug-hunter -> agent-coordinator.
- Codex Security diff scan artifact: /tmp/codex-security-scans/BMI-App_2025_clean/jwt_cve_2026_45363_20260518T200205Z/report.md.
- Premortem risk: broad suppression / false-green risk mitigated by Rego scoping, no .trivyignore change, expiry, and backlog removal DoD.

## Resolver Evidence
```text
cd ios && bundle lock --update fastlane jwt googleauth signet --print
fastlane (2.234.0)
  jwt (>= 2.1.0, < 3)
googleauth (1.11.2)
  jwt (>= 1.4, < 3.0)
jwt (2.10.2)
signet (0.21.0)
  jwt (>= 1.5, < 4.0)
```

## Validation
- .venv/bin/python scripts/orchestration/check_preflight.py
- .venv/bin/python scripts/orchestration/check_agent_consistency.py
- .venv/bin/python scripts/ci/check_trivy_ignore_policy_expiry.py
- .venv/bin/python scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-45363-jwt-fastlane.md docs/roadmap/BACKLOG_LEDGER.md
- cd ios && bundle check
- cd ios && bundle exec fastlane validate_metadata_package
- DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed
- pre-commit run --all-files
- pre-push hooks: pip-audit, backend pytest, full Bandit passed; docker build skipped because no relevant files changed
- Full local `make verify` was not run; deferred under the operator-approved machine-heavy exception. The PR uses focused local gates plus current-head GitHub CI as the heavy matrix/security signal.

## Security Notes
This is temporary release-tooling risk acceptance, not a full vulnerability fix. The suppression must be removed once Fastlane permits jwt >= 3.2.0 or iOS release tooling no longer depends on the Fastlane jwt 2.x graph. Full closure requires current-head Trivy/GitHub Code Scanning evidence after this PR runs.

## Merge Readiness
Not merge-ready yet. Waiting for current-head CI, security-scan/code-scanning evidence, bot review disposition, and strict merge-readiness gates.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1766_FIXED_MAPPING.md`

## Summary by Sourcery

Ограничить временное подавление Trivy для уязвимости Ruby jwt CVE-2026-45363 зависимостью в `Gemfile.lock`, связанной с iOS Fastlane, и задокументировать принятие риска и условия удаления этого подавления.

Bug Fixes:
- Добавить узко сфокусированное правило `ignore-policy` для CVE-2026-45363, затрагивающей Ruby `jwt` 2.10.2 в `ios/Gemfile.lock`, пока Fastlane блокирует обновление до исправленного релиза 3.2.0.

Enhancements:
- Расширить список ссылок в документации по политике `ignore-policy` Trivy, включив в него новую запись о подавлении уязвимости jwt CVE-2026-45363.
- Добавить запись в бэклог для отслеживания удаления временного подавления jwt CVE-2026-45363, как только Fastlane позволит обновиться до исправленной версии.

Documentation:
- Добавить документацию по безопасности с подробным описанием зависимости Fastlane от jwt, связанной с CVE-2026-45363, обоснования подавления, плана мониторинга и шагов по валидации.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Scope a temporary Trivy suppression for Ruby jwt CVE-2026-45363 to the Fastlane-related iOS Gemfile.lock dependency and document its risk acceptance and removal conditions.

Bug Fixes:
- Add a narrowly scoped ignore-policy rule for CVE-2026-45363 affecting Ruby jwt 2.10.2 in ios/Gemfile.lock while Fastlane blocks upgrading to the fixed 3.2.0 release.

Enhancements:
- Extend the Trivy ignore-policy documentation reference list to include the new jwt CVE suppression record.
- Add a backlog ledger entry to track removal of the temporary jwt CVE-2026-45363 suppression once Fastlane allows upgrading to a fixed version.

Documentation:
- Add security documentation detailing the jwt CVE-2026-45363 Fastlane dependency, suppression rationale, monitoring plan, and validation steps.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes a temporary Trivy suppression for `CVE-2026-45363` in Ruby `jwt` to the iOS Fastlane toolchain only. Aligns with Trivy 0.69.3 policy fields, uses a single file-level expiry, and adds review-mapping docs; remove once Fastlane permits `jwt >= 3.2.0`.

- **Dependencies**
  - Narrow rule in `trivy/ignore-policy.rego` for `jwt` `2.10.2` (fixed in `3.2.0`) matching `VulnerabilityID`, `PkgName`, `InstalledVersion`, `FixedVersion`, `PkgID`, `PkgIdentifier.PURL`, and `PrimaryURL`; no `PkgPath` check (not provided by Bundler input); file-level expiry remains 2026-05-27; anchored with monitor links; no `.trivyignore` changes.

- **Documentation**
  - Added `docs/security/CVE-2026-45363-jwt-fastlane.md` (scope, monitoring, removal conditions).
  - Updated `docs/roadmap/BACKLOG_LEDGER.md` with a P1 removal task.
  - Added `docs/review/PR_1766_FIXED_MAPPING.md` mapping and resolving bot review comments.

<sup>Written for commit c90ea417be0a7ef04b2f6eb50d35d20ffd4a99ce. Summary will update on new commits. <a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1766?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added security guidance for CVE-2026-45363 (Ruby jwt) describing a temporary, narrowly scoped suppression for iOS release tooling, risk assessment, validation commands, monitoring links, expiry/review targets, and required removal conditions.
  * Added backlog/trace and review artifacts documenting the suppression, evidence, validation results, merge-readiness notes, and removal checklist.

* **Chores**
  * Added a targeted Trivy suppression for the affected jwt version with explicit matching criteria and documented removal/validation steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1766?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


