### PR TITLE
fix(deps): raise idna security floor

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1246,14 +1246,14 @@
         "filename": "tests/test_install_locked_python_requirements.py",
         "hashed_secret": "663515f876d16ed69744bc68a1f9f5d5eae8c304",
         "is_verified": false,
-        "line_number": 420
+        "line_number": 446
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_install_locked_python_requirements.py",
         "hashed_secret": "932a464a2ff1cbe189ac1ccecc8e48829399bae4",
         "is_verified": false,
-        "line_number": 426
+        "line_number": 452
       }
     ],
     "tests/test_integrated_bayesian_analyzer.py": [
@@ -1750,5 +1750,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-19T13:11:37Z"
+  "generated_at": "2026-05-19T18:48:56Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1246,14 +1246,14 @@
         "filename": "tests/test_install_locked_python_requirements.py",
         "hashed_secret": "663515f876d16ed69744bc68a1f9f5d5eae8c304",
         "is_verified": false,
-        "line_number": 446
+        "line_number": 448
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/test_install_locked_python_requirements.py",
         "hashed_secret": "932a464a2ff1cbe189ac1ccecc8e48829399bae4",
         "is_verified": false,
-        "line_number": 452
+        "line_number": 454
       }
     ],
     "tests/test_integrated_bayesian_analyzer.py": [
@@ -1750,5 +1750,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-19T18:48:56Z"
+  "generated_at": "2026-05-19T19:03:41Z"
 }

--- a/docs/review/PR_1770_FIXED_MAPPING.md
+++ b/docs/review/PR_1770_FIXED_MAPPING.md
@@ -6,37 +6,27 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [x] Fixed in commit mapping initialized
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 - [ ] Post-open `qa-engineer-agent -> bug-hunter` pass completed
 - [ ] CodeRabbit, Sourcery, Cubic, and review-thread no-actionable status verified
 
-## Premortem Finding Dispositions
+## Fixed in Commit Mapping
 
 Disposition: FIXED
 Commit: b1a74e849593e3c7289fc029ac69ae807bf37833
-Evidence: `tests/test_install_locked_python_requirements.py:339` verifies all
-seven alert surfaces pin `idna==3.15`, no repo-managed requirement profile
-returns to `idna==3.11`, and no active emergency fallback exists for `idna`.
+Evidence: `tests/test_install_locked_python_requirements.py:339` verifies all seven alert surfaces pin `idna==3.15`, no repo-managed requirement profile returns to `idna==3.11`, and no active emergency fallback exists for `idna`.
 
 Disposition: DEFERRED
 Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363`
-Evidence: `docs/security/CVE-2026-45363-jwt-fastlane.md:28` records the
-2026-05-19 resolver recheck. `ios/Gemfile.lock:103` keeps Fastlane on
-`jwt >= 2.1.0, < 3`, so Dependabot alert #142 is not force-fixed in this PR.
+Evidence: `docs/security/CVE-2026-45363-jwt-fastlane.md:28` records the 2026-05-19 resolver recheck. `ios/Gemfile.lock:103` keeps Fastlane on `jwt >= 2.1.0, < 3`, so Dependabot alert #142 is not force-fixed in this PR.
 
 Disposition: NOT-A-BUG
-Evidence: `pip index versions idna --index-url "$PULSEPLATE_PYTHON_INDEX_URL"`
-confirmed `idna (3.15)` is exposed by the approved private index. The
-Dependabot updater failure was a broad resolver failure, not proof that the
-exact patched `idna` wheel is unavailable.
-
-## Dependabot Alert Mapping
+Evidence: `pip index versions idna --index-url "$PULSEPLATE_PYTHON_INDEX_URL"` confirmed `idna (3.15)` is exposed by the approved private index. The Dependabot updater failure was a broad resolver failure, not proof that the exact patched `idna` wheel is unavailable.
 
 Disposition: FIXED
 Commit: b1a74e849593e3c7289fc029ac69ae807bf37833
-Evidence: exact `idna==3.15` pins plus regression coverage in
-`tests/test_install_locked_python_requirements.py:339`.
+Evidence: exact `idna==3.15` pins plus regression coverage in `tests/test_install_locked_python_requirements.py:339`.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/145 -> b1a74e849593e3c7289fc029ac69ae807bf37833
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/146 -> b1a74e849593e3c7289fc029ac69ae807bf37833
@@ -48,10 +38,16 @@ Evidence: exact `idna==3.15` pins plus regression coverage in
 
 Disposition: DEFERRED
 Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363`
-Evidence: `docs/security/CVE-2026-45363-jwt-fastlane.md:28` and
-`ios/Gemfile.lock:103` record the Fastlane `jwt < 3` blocker.
+Evidence: `docs/security/CVE-2026-45363-jwt-fastlane.md:28` and `ios/Gemfile.lock:103` record the Fastlane `jwt < 3` blocker.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/142
+
+Disposition: FIXED
+Commit: fc4ca0ed4
+Evidence: `docs/review/PR_1770_PREMORTEM.md:62` now uses the clearer wording suggested by Sourcery. `tests/test_install_locked_python_requirements.py:17` defines shared idna floor constants and the test uses one repo requirements scan instead of rereading the same files through separate loops.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1770#pullrequestreview-4322175139 -> fc4ca0ed4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1770#discussion_r3268835017 -> fc4ca0ed4
 
 ## Validation
 
@@ -59,9 +55,9 @@ Evidence: `docs/security/CVE-2026-45363-jwt-fastlane.md:28` and
 - PASS: `python3 scripts/orchestration/check_agent_consistency.py`
 - PASS: `python3 scripts/orchestration/task_bootstrap.py --task-class security --pr-phase pre_open`
 - PASS: `python3 scripts/orchestration/task_bootstrap.py --task-class security --pr-phase post_open_review`
-- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_install_locked_python_requirements.py tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py`
-- PASS: `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
-- PASS: `PRE_COMMIT_HOME=/tmp/pulseplate-precommit-cache VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python pre-commit run --all-files`
+- PASS: `python -m pytest -q tests/test_install_locked_python_requirements.py tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py`
+- PASS: `make validate-changed`
+- PASS: `pre-commit run --all-files`
 - PASS: pre-push hooks including backend tests, full-repo Bandit, and Docker build test
 - PASS: `pip index versions idna --index-url "$PULSEPLATE_PYTHON_INDEX_URL"` confirmed `idna (3.15)`
 - PASS: `cd ios && bundle lock --update fastlane jwt googleauth signet --print` confirmed Fastlane still resolves `jwt (2.10.2)` and requires `jwt >= 2.1.0, < 3`

--- a/docs/review/PR_1770_FIXED_MAPPING.md
+++ b/docs/review/PR_1770_FIXED_MAPPING.md
@@ -1,0 +1,78 @@
+<!-- markdownlint-disable MD013 MD034 -->
+# PR #1770 - Fixed in Commit Mapping
+
+**PR:** fix(deps): raise idna security floor
+**Branch:** `codex/security-idna-3-15-dependabot-alerts`
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [x] Fixed in commit mapping initialized
+- [ ] Post-open `qa-engineer-agent -> bug-hunter` pass completed
+- [ ] CodeRabbit, Sourcery, Cubic, and review-thread no-actionable status verified
+
+## Premortem Finding Dispositions
+
+Disposition: FIXED
+Commit: b1a74e849593e3c7289fc029ac69ae807bf37833
+Evidence: `tests/test_install_locked_python_requirements.py:339` verifies all
+seven alert surfaces pin `idna==3.15`, no repo-managed requirement profile
+returns to `idna==3.11`, and no active emergency fallback exists for `idna`.
+
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363`
+Evidence: `docs/security/CVE-2026-45363-jwt-fastlane.md:28` records the
+2026-05-19 resolver recheck. `ios/Gemfile.lock:103` keeps Fastlane on
+`jwt >= 2.1.0, < 3`, so Dependabot alert #142 is not force-fixed in this PR.
+
+Disposition: NOT-A-BUG
+Evidence: `pip index versions idna --index-url "$PULSEPLATE_PYTHON_INDEX_URL"`
+confirmed `idna (3.15)` is exposed by the approved private index. The
+Dependabot updater failure was a broad resolver failure, not proof that the
+exact patched `idna` wheel is unavailable.
+
+## Dependabot Alert Mapping
+
+Disposition: FIXED
+Commit: b1a74e849593e3c7289fc029ac69ae807bf37833
+Evidence: exact `idna==3.15` pins plus regression coverage in
+`tests/test_install_locked_python_requirements.py:339`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/145 -> b1a74e849593e3c7289fc029ac69ae807bf37833
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/146 -> b1a74e849593e3c7289fc029ac69ae807bf37833
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/147 -> b1a74e849593e3c7289fc029ac69ae807bf37833
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/148 -> b1a74e849593e3c7289fc029ac69ae807bf37833
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/149 -> b1a74e849593e3c7289fc029ac69ae807bf37833
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/150 -> b1a74e849593e3c7289fc029ac69ae807bf37833
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/151 -> b1a74e849593e3c7289fc029ac69ae807bf37833
+
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363`
+Evidence: `docs/security/CVE-2026-45363-jwt-fastlane.md:28` and
+`ios/Gemfile.lock:103` record the Fastlane `jwt < 3` blocker.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/142
+
+## Validation
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `python3 scripts/orchestration/task_bootstrap.py --task-class security --pr-phase pre_open`
+- PASS: `python3 scripts/orchestration/task_bootstrap.py --task-class security --pr-phase post_open_review`
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_install_locked_python_requirements.py tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py`
+- PASS: `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
+- PASS: `PRE_COMMIT_HOME=/tmp/pulseplate-precommit-cache VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python pre-commit run --all-files`
+- PASS: pre-push hooks including backend tests, full-repo Bandit, and Docker build test
+- PASS: `pip index versions idna --index-url "$PULSEPLATE_PYTHON_INDEX_URL"` confirmed `idna (3.15)`
+- PASS: `cd ios && bundle lock --update fastlane jwt googleauth signet --print` confirmed Fastlane still resolves `jwt (2.10.2)` and requires `jwt >= 2.1.0, < 3`
+
+## Validation Caveats
+
+Full local `make verify` is deferred under the operator-approved machine-heavy
+exception. Per-profile dry-run resolution confirmed `idna-3.15` for
+`requirements.txt`, `requirements-dev.txt`, `requirements-ci-lite.txt`,
+`requirements-docker-runtime.txt`, and `requirements-lock.txt`. Local macOS
+dry-runs for `requirements-rag-vector.txt` and `requirements-rag-vector-cpu.txt`
+are blocked by existing non-idna profile constraints (`cuda-bindings==13.2.0`
+and `torch==2.11.0+cpu` distribution exposure respectively), so current-head CI
+parity remains the heavy signal for those profiles.

--- a/docs/review/PR_1770_FIXED_MAPPING.md
+++ b/docs/review/PR_1770_FIXED_MAPPING.md
@@ -15,7 +15,7 @@
 
 Disposition: FIXED
 Commit: b1a74e849593e3c7289fc029ac69ae807bf37833
-Evidence: `tests/test_install_locked_python_requirements.py:339` verifies all seven alert surfaces pin `idna==3.15`, no repo-managed requirement profile returns to `idna==3.11`, and no active emergency fallback exists for `idna`.
+Evidence: `tests/test_install_locked_python_requirements.py:350` verifies all seven alert surfaces pin `idna==3.15`, no repo-managed requirement profile returns to `idna==3.11`, and no active emergency fallback exists for `idna`.
 
 Disposition: DEFERRED
 Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363`
@@ -26,8 +26,6 @@ Evidence: `pip index versions idna --index-url "$PULSEPLATE_PYTHON_INDEX_URL"` c
 
 Disposition: FIXED
 Commit: b1a74e849593e3c7289fc029ac69ae807bf37833
-Evidence: exact `idna==3.15` pins plus regression coverage in `tests/test_install_locked_python_requirements.py:339`.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/145 -> b1a74e849593e3c7289fc029ac69ae807bf37833
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/146 -> b1a74e849593e3c7289fc029ac69ae807bf37833
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/147 -> b1a74e849593e3c7289fc029ac69ae807bf37833
@@ -39,13 +37,11 @@ Evidence: exact `idna==3.15` pins plus regression coverage in `tests/test_instal
 Disposition: DEFERRED
 Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363`
 Evidence: `docs/security/CVE-2026-45363-jwt-fastlane.md:28` and `ios/Gemfile.lock:103` record the Fastlane `jwt < 3` blocker.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/142
 
 Disposition: FIXED
 Commit: fc4ca0ed4
-Evidence: `docs/review/PR_1770_PREMORTEM.md:62` now uses the clearer wording suggested by Sourcery. `tests/test_install_locked_python_requirements.py:17` defines shared idna floor constants and the test uses one repo requirements scan instead of rereading the same files through separate loops.
-
+Evidence: `docs/review/PR_1770_PREMORTEM.md:62` now uses the clearer wording suggested by Sourcery. `tests/test_install_locked_python_requirements.py:18` defines shared idna floor constants and the test uses one repo requirements scan instead of rereading the same files through separate loops.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1770#pullrequestreview-4322175139 -> fc4ca0ed4
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1770#discussion_r3268835017 -> fc4ca0ed4
 

--- a/docs/review/PR_1770_FIXED_MAPPING.md
+++ b/docs/review/PR_1770_FIXED_MAPPING.md
@@ -8,7 +8,7 @@
 
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
-- [ ] Post-open `qa-engineer-agent -> bug-hunter` pass completed
+- [x] Post-open `qa-engineer-agent -> bug-hunter` pass completed
 - [ ] CodeRabbit, Sourcery, Cubic, and review-thread no-actionable status verified
 
 ## Fixed in Commit Mapping

--- a/docs/review/PR_1770_PREMORTEM.md
+++ b/docs/review/PR_1770_PREMORTEM.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD013 MD034 -->
-# PR TBD Premortem - idna 3.15 Dependabot security alerts
+# PR #1770 Premortem - idna 3.15 Dependabot security alerts
 
 ## Summary
 
@@ -55,10 +55,10 @@ broad `pip-compile` regeneration.
 
 ## Pre-merge Checklist
 
-- [ ] All seven Python alert surfaces pin `idna==3.15`.
-- [ ] No repo-managed Python requirement profile pins `idna==3.11`.
-- [ ] No `idna` emergency wheel entry was added.
-- [ ] Bundler resolver evidence still records Fastlane's `jwt < 3` blocker.
+- [x] All seven Python alert surfaces pin `idna==3.15`.
+- [x] No repo-managed Python requirement profile pins `idna==3.11`.
+- [x] No `idna` emergency wheel entry was added.
+- [x] Bundler resolver evidence still records Fastlane's `jwt < 3` blocker.
 - [ ] Fixed mapping and PR body mirror classify #145-#151 as FIXED and #142 as
       DEFERRED.
 - [ ] CodeRabbit, Sourcery, Cubic, review threads, and strict governance gates

--- a/docs/review/PR_1770_PREMORTEM.md
+++ b/docs/review/PR_1770_PREMORTEM.md
@@ -59,7 +59,7 @@ broad `pip-compile` regeneration.
 - [x] No repo-managed Python requirement profile pins `idna==3.11`.
 - [x] No `idna` emergency wheel entry was added.
 - [x] Bundler resolver evidence still records Fastlane's `jwt < 3` blocker.
-- [ ] Fixed mapping and PR body mirror classify #145-#151 as FIXED and #142 as
+- [x] Fixed mapping and PR body both classify #145-#151 as FIXED and #142 as
       DEFERRED.
 - [ ] CodeRabbit, Sourcery, Cubic, review threads, and strict governance gates
       have no unresolved actionables before merge-readiness.

--- a/docs/review/PR_TBD_PREMORTEM.md
+++ b/docs/review/PR_TBD_PREMORTEM.md
@@ -1,0 +1,69 @@
+<!-- markdownlint-disable MD013 MD034 -->
+# PR TBD Premortem - idna 3.15 Dependabot security alerts
+
+## Summary
+
+Plan: fix Dependabot alerts #145-#151 by raising the exact `idna` pins from
+`3.11` to `3.15` across the seven repo-managed Python requirement profiles, and
+record Ruby `jwt` alert #142 as blocked/deferred because Fastlane still
+constrains `jwt < 3`.
+
+Failure frame: it is 48 hours from now; this hotfix made the dependency/security
+state worse, and we are looking backward to understand why.
+
+## Most likely failure
+
+The most likely failure is a partial alert fix: one requirements profile stays
+on `idna==3.11`, so Dependabot keeps reopening one of the Python alerts even
+though the PR body claims the alert set is fixed.
+
+Disposition: FIXED by adding a regression test that checks all seven alert
+surfaces pin `idna==3.15` and do not pin `idna==3.11`.
+
+## Most dangerous failure
+
+The most dangerous failure is falsely claiming Ruby `jwt` alert #142 as fixed.
+Forcing `jwt >= 3.2.0` would violate the current Fastlane dependency graph and
+could break privileged App Store release tooling.
+
+Disposition: DEFERRED. Existing backlog:
+`docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363`.
+Resolver evidence was rechecked on 2026-05-19 and still shows Fastlane
+`2.234.0` requiring `jwt >= 2.1.0, < 3`.
+
+## Hidden assumption
+
+The hidden assumption is that Dependabot's failed update means `idna 3.15` is
+not installable. Local evidence shows the approved private Python index exposes
+`idna 3.15`; the Dependabot updater failed while attempting broad resolver work,
+not because the exact patched wheel is unavailable.
+
+Disposition: NOT-A-BUG. This PR intentionally uses exact line edits rather than
+broad `pip-compile` regeneration.
+
+## Revised Plan
+
+- Keep the diff to exact `idna==3.15` pins in the seven alert surfaces.
+- Do not edit `requirements*.in`, `constraints.txt`, or `requirements-all.txt`
+  because `idna` is not a direct declared requirement there.
+- Do not add an emergency `idna` wheel; the approved private index already
+  serves the patched version.
+- Keep Ruby `jwt` #142 as DEFERRED with the existing backlog and Trivy policy
+  evidence.
+- Use current-head CI as the heavy signal under the machine-heavy exception
+  after local narrow gates pass.
+
+## Pre-merge Checklist
+
+- [ ] All seven Python alert surfaces pin `idna==3.15`.
+- [ ] No repo-managed Python requirement profile pins `idna==3.11`.
+- [ ] No `idna` emergency wheel entry was added.
+- [ ] Bundler resolver evidence still records Fastlane's `jwt < 3` blocker.
+- [ ] Fixed mapping and PR body mirror classify #145-#151 as FIXED and #142 as
+      DEFERRED.
+- [ ] CodeRabbit, Sourcery, Cubic, review threads, and strict governance gates
+      have no unresolved actionables before merge-readiness.
+
+## Decision
+
+Proceed with changes.

--- a/docs/security/CVE-2026-45363-jwt-fastlane.md
+++ b/docs/security/CVE-2026-45363-jwt-fastlane.md
@@ -25,7 +25,7 @@ application runtime dependency shipped in the app binary.
 ## Current decision
 
 The repository cannot safely update to `jwt >= 3.2.0` through the current
-Fastlane dependency graph. Resolver evidence from 2026-05-18 shows:
+Fastlane dependency graph. Resolver evidence rechecked on 2026-05-19 shows:
 
 ```text
 cd ios && bundle lock --update fastlane jwt googleauth signet --print

--- a/requirements-ci-lite.txt
+++ b/requirements-ci-lite.txt
@@ -120,7 +120,7 @@ httpx==0.28.1
     #   openai
 identify==2.6.18
     # via pre-commit
-idna==3.11
+idna==3.15
     # via
     #   -c requirements.txt
     #   anyio

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -71,7 +71,7 @@ hypothesis==6.152.7
     # via -r requirements-dev.in
 identify==2.6.15
     # via pre-commit
-idna==3.11
+idna==3.15
     # via
     #   -c requirements.txt
     #   requests

--- a/requirements-docker-runtime.txt
+++ b/requirements-docker-runtime.txt
@@ -91,7 +91,7 @@ httpx==0.28.1
     #   -c requirements.txt
     #   -r requirements-docker-runtime.in
     #   openai
-idna==3.11
+idna==3.15
     # via
     #   -c requirements.txt
     #   anyio

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -64,7 +64,7 @@ httpx==0.28.1
     # via
     #   -r requirements.in
     #   openai
-idna==3.11
+idna==3.15
     # via
     #   anyio
     #   email-validator

--- a/requirements-rag-vector-cpu.txt
+++ b/requirements-rag-vector-cpu.txt
@@ -48,7 +48,7 @@ huggingface-hub==1.13.0
     #   sentence-transformers
     #   tokenizers
     #   transformers
-idna==3.11
+idna==3.15
     # via
     #   -c requirements.txt
     #   anyio

--- a/requirements-rag-vector.txt
+++ b/requirements-rag-vector.txt
@@ -54,7 +54,7 @@ huggingface-hub==1.11.0
     #   sentence-transformers
     #   tokenizers
     #   transformers
-idna==3.11
+idna==3.15
     # via
     #   -c requirements.txt
     #   anyio

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ httpx==0.28.1
     # via
     #   -r requirements.in
     #   openai
-idna==3.11
+idna==3.15
     # via
     #   anyio
     #   email-validator

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -336,6 +336,32 @@ def test_repo_emergency_manifest_tracks_current_active_fallback_set() -> None:
     assert ("python-multipart", "0.0.27") in requirements_ci_lite_pins
 
 
+def test_repo_idna_security_floor_matches_dependabot_alert_surfaces() -> None:
+    requirement_files = (
+        "requirements.txt",
+        "requirements-dev.txt",
+        "requirements-ci-lite.txt",
+        "requirements-lock.txt",
+        "requirements-docker-runtime.txt",
+        "requirements-rag-vector.txt",
+        "requirements-rag-vector-cpu.txt",
+    )
+
+    for requirement_file in requirement_files:
+        contents = (REPO_ROOT / requirement_file).read_text(encoding="utf-8")
+        assert ("idna", "3.15") in _exact_requirement_pairs(contents)
+        assert ("idna", "3.11") not in _exact_requirement_pairs(contents)
+
+    repo_requirement_files = sorted(REPO_ROOT.glob("requirements*.txt"))
+    assert repo_requirement_files
+    for requirement_file in repo_requirement_files:
+        contents = requirement_file.read_text(encoding="utf-8")
+        assert ("idna", "3.11") not in _exact_requirement_pairs(contents)
+
+    artifact_packages = {item["package"] for item in _repo_active_emergency_artifacts()}
+    assert "idna" not in artifact_packages
+
+
 def test_repo_ruff_emergency_fallback_matches_dev_requirement_surfaces() -> None:
     expected_version = _active_manifest_artifact_version("ruff")
 

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -15,6 +15,17 @@ import scripts.ci.install_locked_python_requirements as installer
 
 APPROVED_PROXY_URL = "https://packages.example.internal/simple"
 REPO_ROOT = Path(__file__).resolve().parents[1]
+IDNA_SECURITY_FLOOR = "3.15"
+IDNA_PREVIOUS_VULNERABLE_PIN = "3.11"
+IDNA_DEPENDABOT_ALERT_REQUIREMENT_FILES = (
+    "requirements.txt",
+    "requirements-dev.txt",
+    "requirements-ci-lite.txt",
+    "requirements-lock.txt",
+    "requirements-docker-runtime.txt",
+    "requirements-rag-vector.txt",
+    "requirements-rag-vector-cpu.txt",
+)
 
 
 def _repo_emergency_manifest_path() -> Path:
@@ -337,26 +348,17 @@ def test_repo_emergency_manifest_tracks_current_active_fallback_set() -> None:
 
 
 def test_repo_idna_security_floor_matches_dependabot_alert_surfaces() -> None:
-    requirement_files = (
-        "requirements.txt",
-        "requirements-dev.txt",
-        "requirements-ci-lite.txt",
-        "requirements-lock.txt",
-        "requirements-docker-runtime.txt",
-        "requirements-rag-vector.txt",
-        "requirements-rag-vector-cpu.txt",
-    )
+    requirement_files = set(IDNA_DEPENDABOT_ALERT_REQUIREMENT_FILES)
 
-    for requirement_file in requirement_files:
-        contents = (REPO_ROOT / requirement_file).read_text(encoding="utf-8")
-        assert ("idna", "3.15") in _exact_requirement_pairs(contents)
-        assert ("idna", "3.11") not in _exact_requirement_pairs(contents)
-
-    repo_requirement_files = sorted(REPO_ROOT.glob("requirements*.txt"))
+    repo_requirement_files = {path.name: path for path in REPO_ROOT.glob("requirements*.txt")}
     assert repo_requirement_files
-    for requirement_file in repo_requirement_files:
-        contents = requirement_file.read_text(encoding="utf-8")
-        assert ("idna", "3.11") not in _exact_requirement_pairs(contents)
+    assert requirement_files <= set(repo_requirement_files)
+
+    for requirement_file, path in repo_requirement_files.items():
+        pairs = _exact_requirement_pairs(path.read_text(encoding="utf-8"))
+        assert ("idna", IDNA_PREVIOUS_VULNERABLE_PIN) not in pairs
+        if requirement_file in requirement_files:
+            assert ("idna", IDNA_SECURITY_FLOOR) in pairs
 
     artifact_packages = {item["package"] for item in _repo_active_emergency_artifacts()}
     assert "idna" not in artifact_packages


### PR DESCRIPTION
## Goal
Fix seven active Python Dependabot alerts by raising the pinned `idna` security floor from `3.11` to `3.15` across the repo-managed Python requirement profiles.

## Scope
- Updated only exact `idna==3.11` pins to `idna==3.15` in `requirements.txt`, `requirements-dev.txt`, `requirements-ci-lite.txt`, `requirements-lock.txt`, `requirements-docker-runtime.txt`, `requirements-rag-vector.txt`, and `requirements-rag-vector-cpu.txt`.
- Added regression coverage that all seven alert surfaces stay on `idna==3.15`, no repo-managed requirements profile returns to `idna==3.11`, and no active emergency wheel fallback is added for `idna`.
- Revalidated Ruby `jwt` alert evidence without forcing an unsafe Fastlane override.

## Out of Scope
- No broad `pip-compile` regeneration.
- No runtime API, OpenAPI, frontend, backend behavior, iOS app behavior, or Fastlane graph override.
- No emergency wheel entry for `idna`.

## Security Notes
Dependabot alerts `#145`-`#151` are mapped as `FIXED` by commit `b1a74e849593e3c7289fc029ac69ae807bf37833`. Alert `#142` remains `DEFERRED`: Fastlane `2.234.0` still requires `jwt >= 2.1.0, < 3`, while the advisory requires `jwt >= 3.2.0`.

## Deferred / Follow-ups
- `jwt` / `ios/Gemfile.lock` alert `#142`: deferred to `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363` until Fastlane permits `jwt >= 3.2.0` or the release tooling graph is replaced.

## Validation
- `python3 scripts/orchestration/check_preflight.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `python3 scripts/orchestration/task_bootstrap.py --task-class security --pr-phase pre_open` PASS
- `python3 scripts/orchestration/task_bootstrap.py --task-class security --pr-phase post_open_review` PASS
- `python -m pytest -q tests/guards/test_security_devtooling_regression_guards.py::test_changed_docs_do_not_add_local_users_absolute_paths` PASS
- `python -m pytest -q tests/test_install_locked_python_requirements.py tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py` PASS
- `make validate-changed` PASS
- `pre-commit run --all-files` PASS
- `GH_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_review_threads_disposition.py --pr-number 1770 --require-auth` PASS
- Pre-push hooks PASS: backend tests, pip-audit, full-repo Bandit, Docker build test where applicable
- `pip index versions idna --index-url "$PULSEPLATE_PYTHON_INDEX_URL"` confirmed `idna (3.15)`
- Per-profile dry-run resolution confirmed `idna-3.15` for `requirements.txt`, `requirements-dev.txt`, `requirements-ci-lite.txt`, `requirements-docker-runtime.txt`, and `requirements-lock.txt`
- RAG dry-run caveat: `requirements-rag-vector.txt` is blocked on existing unavailable `cuda-bindings==13.2.0` for this local macOS/private-index shape; `requirements-rag-vector-cpu.txt` is blocked on existing `torch==2.11.0+cpu` distribution exposure. Neither failure is an `idna` resolver conflict.
- `cd ios && bundle lock --update fastlane jwt googleauth signet --print` confirms `fastlane (2.234.0)` still constrains `jwt (>= 2.1.0, < 3)` and resolves `jwt (2.10.2)`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Post-open `qa-engineer-agent` and `bug-hunter` found governance blockers; fixes landed in `fc4ca0ed4`, `688d8b109`, `2865f7bdc`, and `725d888c6`.

### Fixed in Commit Mapping
Canonical artifact: `docs/review/PR_1770_FIXED_MAPPING.md`.
Premortem artifact: `docs/review/PR_1770_PREMORTEM.md`.

Disposition: FIXED
Commit: `b1a74e849593e3c7289fc029ac69ae807bf37833`
Evidence: exact `idna==3.15` pins and `tests/test_install_locked_python_requirements.py::test_repo_idna_security_floor_matches_dependabot_alert_surfaces`.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/145 -> b1a74e849593e3c7289fc029ac69ae807bf37833
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/146 -> b1a74e849593e3c7289fc029ac69ae807bf37833
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/147 -> b1a74e849593e3c7289fc029ac69ae807bf37833
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/148 -> b1a74e849593e3c7289fc029ac69ae807bf37833
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/149 -> b1a74e849593e3c7289fc029ac69ae807bf37833
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/150 -> b1a74e849593e3c7289fc029ac69ae807bf37833
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/151 -> b1a74e849593e3c7289fc029ac69ae807bf37833

Disposition: DEFERRED
Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-remove-trivy-suppression-jwt-cve-2026-45363`
Evidence: `docs/security/CVE-2026-45363-jwt-fastlane.md` and `ios/Gemfile.lock:103`.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/security/dependabot/142

Disposition: FIXED
Commit: `fc4ca0ed4`
Evidence: Sourcery wording and idna guard simplification addressed; `2865f7bdc` fixed the contiguous disposition block for strict governance parsing; `725d888c6` records post-open role completion.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1770#pullrequestreview-4322175139 -> fc4ca0ed4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1770#discussion_r3268835017 -> fc4ca0ed4

## Merge Readiness
Current-head CI parity passed on run `26119632658` for head `725d888c668ddfe1ce23043cf38018708debfcfc`. Strict PR body, review-thread disposition, and merge-readiness governance gates passed with auth. CodeRabbit, Sourcery, and Cubic have no actionable blockers. Mandatory wait-window was observed after the latest bot activity before merge.

## Local Full Verify
Full local `make verify` is deferred under the operator-approved machine-heavy exception. This PR uses focused local gates plus current-head CI parity as the heavy signal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped IDNA from 3.11 to 3.15 across requirements and lock files.
  * Updated secret-scan baseline metadata (timestamp and scan entries).

* **Tests**
  * Added a repository-level test enforcing the IDNA security floor across requirement profiles.

* **Documentation**
  * Added premortem and validation/mapping records for the IDNA update.
  * Updated a CVE-related note with a new recheck date.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
