### PR TITLE
Add oracle-only Experiment Runner PR participation

### DIFF
--- a/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
@@ -64,6 +64,8 @@ Current governed sub-lane:
 
 - Dev-only agent experimentation loops for bounded optimization or evaluation tasks.
 - Fixed-budget candidate runs against immutable evaluation oracles.
+- Oracle-only governance reviewer runs that evaluate validators and write local
+  result artifacts without applying candidate patches.
 - Experiment charters, result packets, and KPP-compliant promotion decisions.
 - First-wave experimentation for `LLM/RAG reliability`, then later `CV` evaluation and other approved research lanes.
 - CV-specific packet fields, privacy posture, and degrade semantics live in
@@ -106,6 +108,10 @@ Rules:
   before they can be treated as cryptographically attributable.
 - The Experiment Runner has no merge rights, review-thread resolution authority,
   or merge-readiness authority.
+- For non-trivial PR lanes, Experiment Runner participation is expected as
+  advisory evidence: either a local oracle-only result artifact or a documented
+  `not applicable` reason in the PR lane notes. This is not a merge-readiness
+  gate until a later hardening PR explicitly promotes it.
 - Slack identity is not a cryptographic Git identity. A Slack bot/display
   identity remains a separate security-governed follow-up, not part of this
   experimentation protocol.
@@ -125,6 +131,8 @@ Examples:
 - fixture datasets, manifests, checksums, and golden outputs
 - policy and governance docs used as gates
 - review / merge-readiness artifacts
+- governance validators such as preflight, agent-consistency, PR-body,
+  review-thread, semantic-cache, or merge-readiness checks
 
 ### Mutable candidate surfaces
 
@@ -147,6 +155,8 @@ The candidate loop must never mutate:
 - `AGENTS.md`, scoped `AGENTS.md`, `RUNBOOK_AGENT.md`
 - `docs/orchestration/*` policy and governance SoT files
 - `docs/review/PR_*_FIXED_MAPPING.md`
+- `scripts/ci/*`, merge-readiness scripts, review-thread disposition scripts,
+  PR-body gate scripts, or other governance validators
 - `docs/contracts/*` unless a human opens an explicit follow-up PR for contract changes
 - `docs/security/*`, `docs/compliance/*`, `docs/legal/*`
 - benchmark harnesses, tests, fixtures, manifests, or expected outputs used as evaluation oracles
@@ -157,6 +167,29 @@ Interpretation:
 
 - The candidate may optimize implementation under test.
 - The candidate may not rewrite the exam.
+
+### Oracle-only governance reviewer mode
+
+`runner_mode: oracle_only_governance_reviewer` is the safe PR participation
+mode for tooling/governance lanes. In this mode the runner:
+
+- runs immutable oracle commands against an isolated temporary checkout;
+- writes a local result artifact under
+  `artifacts/orchestration/experiments/results/`;
+- records `mutated_paths: []` and `promotion_ready: false`;
+- does not accept or apply `--candidate-patch`;
+- does not resolve review threads, update fixed mappings, claim merge readiness,
+  or change canonical policy.
+
+Oracle-only packets still include `mutable_candidate_surface` for schema
+compatibility and to bind the advisory evidence to the PR's owned context
+surface, including tooling/governance files. In this mode those paths are
+context, not mutation permission.
+
+Validator-script mutation access, including any runner mutation of
+`scripts/ci/**`, requires a separate threat-model PR with an explicit allowlist,
+forbidden-surface regression tests, identity/trailer checks, rollback notes, and
+coordinator approval.
 
 ---
 

--- a/docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.md
+++ b/docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.md
@@ -47,6 +47,11 @@ Forbidden in this repository:
 
 The Experiment Runner may be a co-author or local PR-lane author only when a human/coordinator-owned process keeps normal PR governance in force.
 
+For oracle-only PR participation, attribution is evidence-based. Add the
+canonical co-author trailer only when the local Experiment Runner result
+artifact materially shaped the human-reviewed commit. Do not add the trailer to
+unrelated human-only commits merely because the PR lane ran the advisory oracle.
+
 ## Notification Boundary
 
 Experiment result delivery is governed by `scripts/orchestration/experiment_notify.py`, `scripts/orchestration/experiment_pipeline.py`, and `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`.

--- a/docs/review/PR_1773_FIXED_MAPPING.md
+++ b/docs/review/PR_1773_FIXED_MAPPING.md
@@ -9,7 +9,7 @@
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 - [x] Post-open `qa-engineer-agent -> bug-hunter` pass completed
-- [ ] CodeRabbit, Sourcery, Cubic, and review-thread no-actionable status verified
+- [x] CodeRabbit, Sourcery, Cubic, and review-thread no-actionable status verified
 
 ## Fixed in Commit Mapping
 
@@ -58,6 +58,8 @@ Evidence: `scripts/orchestration/experiment_contract.py:245` defaults only missi
 - PASS: `make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python`
 - PASS: `pre-commit run --all-files`
 - PASS: pre-push hooks including changed-file mypy, pip-audit, backend tests, full-repo Bandit, and Docker build test
+- PASS: `GH_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_review_threads_disposition.py --pr-number 1773 --require-auth`
+- PASS: `GH_TOKEN="$(gh auth token)" GITHUB_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_merge_ready.py --pr-number 1773 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`
 
 ## Validation Caveats
 
@@ -67,4 +69,6 @@ interpreter override above is the successful equivalent for this worktree.
 
 CodeRabbit CLI review timed out locally with review ID
 `db6a3353-c90e-4c98-91ea-bb0e42e736ac`. GitHub PR status reported CodeRabbit
-`SUCCESS`, Sourcery `SKIPPED`, and Cubic `SUCCESS` before this artifact update.
+`SUCCESS`, Sourcery `SKIPPED` after weekly diff-character quota exhaustion with
+no new actionable finding, and Cubic `SUCCESS`; strict review-thread disposition
+confirmed zero unresolved threads and all actionable bot comments mapped.

--- a/docs/review/PR_1773_FIXED_MAPPING.md
+++ b/docs/review/PR_1773_FIXED_MAPPING.md
@@ -25,6 +25,20 @@ Commit: 8806dd1f2c71ce725fab4b8834c18b2cdd00610f
 Evidence: `scripts/orchestration/experiment_runner.py:268` normalizes invalid packet `runner_mode` values for rejection artifacts, `scripts/orchestration/experiment_runner.py:594` uses the stable oracle-only `candidate_patch` marker for oracle-only candidate-API rejection, and `tests/test_experiment_runner.py:427` plus `tests/test_experiment_runner.py:457` validate both rejection artifacts with `validate_experiment_result`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#discussion_r3271443753 -> 8806dd1f2c71ce725fab4b8834c18b2cdd00610f
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#discussion_r3271443760 -> 8806dd1f2c71ce725fab4b8834c18b2cdd00610f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#discussion_r3271463092 -> 8806dd1f2c71ce725fab4b8834c18b2cdd00610f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#discussion_r3271463098 -> 8806dd1f2c71ce725fab4b8834c18b2cdd00610f
+
+Disposition: FIXED
+Commit: fe943dc8e4469d349c65b493a7f2bc3451e2aacc
+Evidence: `scripts/orchestration/experiment_runner.py:264` now handles non-dict packets before `.get()`, and `tests/test_experiment_runner.py:524` validates the non-dict invalid-packet rejection artifact with `validate_experiment_result`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#discussion_r3271463082 -> fe943dc8e4469d349c65b493a7f2bc3451e2aacc
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#pullrequestreview-4325482196 -> fe943dc8e4469d349c65b493a7f2bc3451e2aacc
+
+Disposition: FIXED
+Commit: 2de4809281ebb35a6ec49b75775eaa13f685854e
+Evidence: `scripts/orchestration/experiment_contract.py:245` defaults only missing/`None` runner modes and rejects explicit non-string or unknown values, `scripts/orchestration/experiment_runner.py:264` normalizes invalid experiment IDs to a schema-valid sentinel, and `tests/test_experiment_runner.py:254` plus `tests/test_experiment_runner.py:494` cover both cases.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#discussion_r3271489521 -> 2de4809281ebb35a6ec49b75775eaa13f685854e
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#discussion_r3271489523 -> 2de4809281ebb35a6ec49b75775eaa13f685854e
 
 ## Validation
 
@@ -38,6 +52,9 @@ Evidence: `scripts/orchestration/experiment_runner.py:268` normalizes invalid pa
 - PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_experiment_runner.py tests/test_experiment_bootstrap.py tests/test_experiment_promote.py tests/test_experiment_notify.py tests/test_experiment_pipeline.py tests/test_experiment_runner_identity_policy.py` after fixing Codex rejection-artifact findings
 - PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m flake8 scripts/orchestration/experiment_runner.py tests/test_experiment_runner.py`
 - PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py`
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_experiment_runner.py tests/test_experiment_bootstrap.py tests/test_experiment_promote.py tests/test_experiment_notify.py tests/test_experiment_pipeline.py tests/test_experiment_runner_identity_policy.py` after fixing Cubic non-dict packet and Codex sentinel findings
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m flake8 scripts/orchestration/experiment_contract.py scripts/orchestration/experiment_runner.py tests/test_experiment_runner.py`
+- PASS: `pre-commit run mypy --hook-stage pre-push --files scripts/orchestration/experiment_contract.py scripts/orchestration/experiment_runner.py`
 - PASS: `make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python`
 - PASS: `pre-commit run --all-files`
 - PASS: pre-push hooks including changed-file mypy, pip-audit, backend tests, full-repo Bandit, and Docker build test

--- a/docs/review/PR_1773_FIXED_MAPPING.md
+++ b/docs/review/PR_1773_FIXED_MAPPING.md
@@ -9,11 +9,15 @@
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 - [x] Post-open `qa-engineer-agent -> bug-hunter` pass completed
-- [x] CodeRabbit, Sourcery, Cubic, and review-thread no-actionable status verified
+- [ ] CodeRabbit, Sourcery, Cubic, and review-thread no-actionable status verified
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 783ee256eecb7d8c65852fecbb2f4b8e4f214715
+Evidence: `scripts/orchestration/experiment_contract.py:226` now calls `git --literal-pathspecs ls-files --error-unmatch -- <paths>`, and `tests/test_experiment_runner.py:273` covers `:(glob)` pathspec magic rejection.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#discussion_r3270121817 -> 783ee256eecb7d8c65852fecbb2f4b8e4f214715
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#discussion_r3270168271 -> 783ee256eecb7d8c65852fecbb2f4b8e4f214715
 
 ## Validation
 
@@ -22,6 +26,8 @@
 - PASS: `python3 scripts/orchestration/check_experiment_runner_identity.py`
 - PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_experiment_runner.py tests/test_experiment_bootstrap.py tests/test_experiment_promote.py tests/test_experiment_notify.py tests/test_experiment_pipeline.py tests/test_experiment_runner_identity_policy.py`
 - PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py tests/test_experiment_runner_identity_policy.py`
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_experiment_runner.py tests/test_experiment_bootstrap.py tests/test_experiment_promote.py tests/test_experiment_notify.py tests/test_experiment_pipeline.py tests/test_experiment_runner_identity_policy.py` after fixing CodeRabbit/Cubic pathspec findings
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py` after fixing CodeRabbit/Cubic pathspec findings
 - PASS: `make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python`
 - PASS: `pre-commit run --all-files`
 - PASS: pre-push hooks including changed-file mypy, pip-audit, backend tests, full-repo Bandit, and Docker build test

--- a/docs/review/PR_1773_FIXED_MAPPING.md
+++ b/docs/review/PR_1773_FIXED_MAPPING.md
@@ -18,6 +18,13 @@ Commit: 783ee256eecb7d8c65852fecbb2f4b8e4f214715
 Evidence: `scripts/orchestration/experiment_contract.py:226` now calls `git --literal-pathspecs ls-files --error-unmatch -- <paths>`, and `tests/test_experiment_runner.py:273` covers `:(glob)` pathspec magic rejection.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#discussion_r3270121817 -> 783ee256eecb7d8c65852fecbb2f4b8e4f214715
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#discussion_r3270168271 -> 783ee256eecb7d8c65852fecbb2f4b8e4f214715
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#pullrequestreview-4323820483 -> 783ee256eecb7d8c65852fecbb2f4b8e4f214715
+
+Disposition: FIXED
+Commit: 8806dd1f2c71ce725fab4b8834c18b2cdd00610f
+Evidence: `scripts/orchestration/experiment_runner.py:268` normalizes invalid packet `runner_mode` values for rejection artifacts, `scripts/orchestration/experiment_runner.py:594` uses the stable oracle-only `candidate_patch` marker for oracle-only candidate-API rejection, and `tests/test_experiment_runner.py:427` plus `tests/test_experiment_runner.py:457` validate both rejection artifacts with `validate_experiment_result`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#discussion_r3271443753 -> 8806dd1f2c71ce725fab4b8834c18b2cdd00610f
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1773#discussion_r3271443760 -> 8806dd1f2c71ce725fab4b8834c18b2cdd00610f
 
 ## Validation
 
@@ -28,6 +35,9 @@ Evidence: `scripts/orchestration/experiment_contract.py:226` now calls `git --li
 - PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py tests/test_experiment_runner_identity_policy.py`
 - PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_experiment_runner.py tests/test_experiment_bootstrap.py tests/test_experiment_promote.py tests/test_experiment_notify.py tests/test_experiment_pipeline.py tests/test_experiment_runner_identity_policy.py` after fixing CodeRabbit/Cubic pathspec findings
 - PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py` after fixing CodeRabbit/Cubic pathspec findings
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_experiment_runner.py tests/test_experiment_bootstrap.py tests/test_experiment_promote.py tests/test_experiment_notify.py tests/test_experiment_pipeline.py tests/test_experiment_runner_identity_policy.py` after fixing Codex rejection-artifact findings
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m flake8 scripts/orchestration/experiment_runner.py tests/test_experiment_runner.py`
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py`
 - PASS: `make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python`
 - PASS: `pre-commit run --all-files`
 - PASS: pre-push hooks including changed-file mypy, pip-audit, backend tests, full-repo Bandit, and Docker build test

--- a/docs/review/PR_1773_FIXED_MAPPING.md
+++ b/docs/review/PR_1773_FIXED_MAPPING.md
@@ -1,0 +1,37 @@
+<!-- markdownlint-disable MD013 MD034 -->
+# PR #1773 - Fixed in Commit Mapping
+
+**PR:** Add oracle-only Experiment Runner PR participation
+**Branch:** `codex/experiment-runner-oracle-only-pr-participation`
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] Post-open `qa-engineer-agent -> bug-hunter` pass completed
+- [x] CodeRabbit, Sourcery, Cubic, and review-thread no-actionable status verified
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Validation
+
+- PASS: `python3 scripts/orchestration/check_preflight.py --path docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md --path docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.md --path scripts/AGENTS.md --path scripts/orchestration/experiment_runner.py --path tests/test_experiment_runner.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `python3 scripts/orchestration/check_experiment_runner_identity.py`
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_experiment_runner.py tests/test_experiment_bootstrap.py tests/test_experiment_promote.py tests/test_experiment_notify.py tests/test_experiment_pipeline.py tests/test_experiment_runner_identity_policy.py`
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py tests/test_experiment_runner_identity_policy.py`
+- PASS: `make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python`
+- PASS: `pre-commit run --all-files`
+- PASS: pre-push hooks including changed-file mypy, pip-audit, backend tests, full-repo Bandit, and Docker build test
+
+## Validation Caveats
+
+Bare `make validate-changed` in this secondary worktree forced
+`VENV_PYTHON="python3"` and failed on missing `fastapi`; the repo-vendored
+interpreter override above is the successful equivalent for this worktree.
+
+CodeRabbit CLI review timed out locally with review ID
+`db6a3353-c90e-4c98-91ea-bb0e42e736ac`. GitHub PR status reported CodeRabbit
+`SUCCESS`, Sourcery `SKIPPED`, and Cubic `SUCCESS` before this artifact update.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -15,9 +15,22 @@
 
 - Canonical entrypoints for the experimentation lane are `scripts/orchestration/experiment_bootstrap.py` and `scripts/orchestration/experiment_runner.py`.
 - Run both scripts from repo root so path validation and artifact resolution stay deterministic.
-- `experiment_runner.py` accepts only a validated packet plus a prebuilt unified diff via `--packet <packet.json> --candidate-patch <candidate.patch> [--output ...]`.
+- `experiment_runner.py` accepts a validated packet plus a prebuilt unified diff
+  via `--packet <packet.json> --candidate-patch <candidate.patch> [--output ...]`
+  for default `candidate_patch` mode.
+- In `oracle_only_governance_reviewer` mode, `experiment_runner.py` accepts
+  `--packet <packet.json> [--output ...]` without `--candidate-patch`, runs only
+  immutable oracle commands in an isolated checkout, applies the current tracked
+  worktree diff to that checkout for evidence freshness, and writes a local
+  evidence artifact. This mode is advisory PR participation only and must not
+  promote, resolve review threads, claim merge readiness, or mutate governance
+  surfaces.
 - The runner must apply patches only inside an isolated temporary checkout and must leave the shared working tree untouched.
 - Mutable surfaces, immutable oracles, budgets, and promotion boundaries are defined by `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`; do not duplicate or relax them here.
+- Runner mutation of `scripts/ci/**`, `docs/review/**`, `AGENTS.md`, merge
+  gates, review-thread scripts, tests, fixtures, or policy docs is forbidden
+  unless a separate threat-model PR explicitly opens a narrow allowlist with
+  tests and rollback notes.
 - Result artifacts stay local under `artifacts/orchestration/experiments/results/` and are evidence only, not merge-ready or promotion-ready output.
 - `experiment_notify.py` follows the notification contract in
   `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`: local artifact output

--- a/scripts/orchestration/experiment_bootstrap.py
+++ b/scripts/orchestration/experiment_bootstrap.py
@@ -13,7 +13,7 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 EXPERIMENT_BOOTSTRAP_REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(EXPERIMENT_BOOTSTRAP_REPO_ROOT) not in sys.path:
@@ -30,18 +30,24 @@ from scripts.orchestration.experiment_contract import (
     DEFAULT_BUDGETS,
     DEFAULT_METRIC_ACCEPTANCE_THRESHOLD,
     DEFAULT_METRIC_BASELINE_REF,
+    DEFAULT_RUNNER_MODE,
     DEFAULT_STOP_CONDITION,
+    ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
     PRIMARY_AGENT,
     REVIEWER,
+    RUNNER_MODES,
     SCHEMA_VERSION,
     is_cv_experiment,
     validate_budget_payload,
     validate_cv_context,
+    validate_experiment_packet,
     validate_immutable_oracles,
     validate_metrics,
     validate_mutable_candidate_surface,
     validate_negative_controls,
+    validate_oracle_context_surface,
     validate_promotion_target,
+    validate_runner_mode,
 )
 from scripts.orchestration.route_with_telemetry import TELEMETRY_PATH, route
 from scripts.orchestration.routing_graph_loader import load_routing_graph
@@ -186,6 +192,7 @@ def compute_experiment_id(
     promotion_target: str,
     budgets: dict[str, int],
     stop_condition: str,
+    runner_mode: str = DEFAULT_RUNNER_MODE,
     cv_context: dict[str, Any] | None = None,
 ) -> str:
     """Return deterministic short experiment id."""
@@ -201,6 +208,8 @@ def compute_experiment_id(
         "budgets": budgets,
         "stop_condition": stop_condition.strip() or DEFAULT_STOP_CONDITION,
     }
+    if runner_mode != DEFAULT_RUNNER_MODE:
+        payload_data["runner_mode"] = runner_mode
     if cv_context is not None:
         payload_data["cv_context"] = cv_context
 
@@ -226,11 +235,16 @@ def build_experiment_packet(
     stop_condition: str = DEFAULT_STOP_CONDITION,
     metric_baseline_reference: str = DEFAULT_METRIC_BASELINE_REF,
     metric_acceptance_threshold: str = DEFAULT_METRIC_ACCEPTANCE_THRESHOLD,
+    runner_mode: str = DEFAULT_RUNNER_MODE,
     cv_context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a deterministic experiment packet for PR2 bootstrap tooling."""
 
-    validated_paths = validate_mutable_candidate_surface(mutable_paths)
+    validated_runner_mode = validate_runner_mode(runner_mode)
+    if validated_runner_mode == ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE:
+        validated_paths = validate_oracle_context_surface(mutable_paths)
+    else:
+        validated_paths = validate_mutable_candidate_surface(mutable_paths)
     immutable_oracles = validate_immutable_oracles(oracle_commands)
     metric_payload = validate_metrics(
         metrics,
@@ -276,6 +290,7 @@ def build_experiment_packet(
         promotion_target=validated_promotion_target,
         budgets=budget_payload,
         stop_condition=stop_condition,
+        runner_mode=validated_runner_mode,
         cv_context=validated_cv_context,
     )
 
@@ -295,6 +310,7 @@ def build_experiment_packet(
     packet = {
         "schema_version": SCHEMA_VERSION,
         "experiment_id": experiment_id,
+        "runner_mode": validated_runner_mode,
         "decision_question": decision_question.strip(),
         "task_class": task_class.strip(),
         "domain": domain,
@@ -323,7 +339,7 @@ def build_experiment_packet(
     }
     if validated_cv_context is not None:
         packet["cv_context"] = validated_cv_context
-    return packet
+    return cast(dict[str, Any], validate_experiment_packet(packet))
 
 
 def _resolve_output_path(raw_output: str | None, experiment_id: str) -> Path:
@@ -352,6 +368,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--decision-question", required=True)
     parser.add_argument("--task-class", default="Experimentation")
+    parser.add_argument(
+        "--runner-mode",
+        choices=RUNNER_MODES,
+        default=DEFAULT_RUNNER_MODE,
+        help="Runner behavior mode for this experiment packet.",
+    )
     parser.add_argument("--mutable-path", action="append", default=[])
     parser.add_argument("--oracle-command", action="append", default=[])
     parser.add_argument("--metric", action="append", default=[])
@@ -434,6 +456,7 @@ def main(argv: list[str] | None = None) -> int:
             stop_condition=args.stop_condition,
             metric_baseline_reference=args.metric_baseline_ref,
             metric_acceptance_threshold=args.metric_acceptance_threshold,
+            runner_mode=args.runner_mode,
             cv_context=_build_cv_context_from_args(args),
         )
         out_path = _resolve_output_path(args.output, packet["experiment_id"])
@@ -458,6 +481,7 @@ def main(argv: list[str] | None = None) -> int:
         json.dumps(
             {
                 "experiment_id": packet["experiment_id"],
+                "runner_mode": packet["runner_mode"],
                 "domain": packet["domain"],
                 "primary_agent": packet["primary_agent"],
                 "reviewer": packet["reviewer"],

--- a/scripts/orchestration/experiment_contract.py
+++ b/scripts/orchestration/experiment_contract.py
@@ -223,7 +223,7 @@ def validate_oracle_context_surface(paths: list[str] | tuple[str, ...]) -> list[
     if not git_binary:
         raise ValueError("git binary is required to validate oracle-only context paths.")
     tracked_process = subprocess.run(  # nosec B603: absolute git binary checks tracked context paths without shell (remove-by: 2026-07-31, ref: ledger-p1-experiment-runner-oracle-only-governance-reviewer)
-        [git_binary, "ls-files", "--error-unmatch", *normalized_paths],
+        [git_binary, "--literal-pathspecs", "ls-files", "--error-unmatch", "--", *normalized_paths],
         cwd=str(REPO_ROOT),
         env=_git_env_without_parent_state(),
         capture_output=True,

--- a/scripts/orchestration/experiment_contract.py
+++ b/scripts/orchestration/experiment_contract.py
@@ -242,7 +242,13 @@ def validate_oracle_context_surface(paths: list[str] | tuple[str, ...]) -> list[
 def validate_runner_mode(value: Any) -> str:
     """Normalize the runner mode while preserving backward compatibility."""
 
-    normalized = str(value or DEFAULT_RUNNER_MODE).strip().lower()
+    if value is None:
+        normalized = DEFAULT_RUNNER_MODE
+    elif not isinstance(value, str):
+        allowed = ", ".join(RUNNER_MODES)
+        raise ValueError(f"Experiment packet runner_mode must be one of: {allowed}")
+    else:
+        normalized = value.strip().lower()
     if normalized not in RUNNER_MODES:
         allowed = ", ".join(RUNNER_MODES)
         raise ValueError(f"Experiment packet runner_mode must be one of: {allowed}")

--- a/scripts/orchestration/experiment_contract.py
+++ b/scripts/orchestration/experiment_contract.py
@@ -6,9 +6,12 @@ EN: Shared constants and fail-closed validation helpers for experiment packets.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import re
 import shlex
+import shutil
+import subprocess  # nosec B404: bounded git ls-files validation only (remove-by: 2026-07-31, ref: ledger-p1-experiment-runner-oracle-only-governance-reviewer)
 from typing import Any
 
 from scripts.orchestration.context_pack import REPO_ROOT, normalize_text, repo_relative_paths
@@ -26,6 +29,12 @@ PROMOTION_TARGETS: tuple[str, ...] = (
     "memory_capsule",
 )
 RESULT_STATUSES: tuple[str, ...] = ("accepted", "rejected")
+DEFAULT_RUNNER_MODE = "candidate_patch"
+ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE = "oracle_only_governance_reviewer"
+RUNNER_MODES: tuple[str, ...] = (
+    DEFAULT_RUNNER_MODE,
+    ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
+)
 FAILURE_CLASSES: tuple[str, ...] = (
     "timeout",
     "oom",
@@ -76,6 +85,22 @@ ORACLE_BINARY_ALLOWLIST: tuple[str, ...] = (
     "python3",
     "ruff",
 )
+FORBIDDEN_AUTONOMOUS_MUTATION_PREFIXES: tuple[str, ...] = (
+    ".github/workflows/",
+    "docs/orchestration/",
+    "docs/review/",
+    "scripts/ci/",
+    "tests/",
+)
+FORBIDDEN_AUTONOMOUS_MUTATION_EXACT_PATHS: frozenset[str] = frozenset(
+    {
+        "AGENTS.md",
+        "RUNBOOK_AGENT.md",
+        "scripts/orchestration/check_merge_ready.py",
+        "scripts/orchestration/check_review_threads_disposition.py",
+    }
+)
+FORBIDDEN_AUTONOMOUS_MUTATION_FILENAMES: frozenset[str] = frozenset({"AGENTS.md"})
 EXPERIMENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
 CV_EXPERIMENT_HINTS: tuple[str, ...] = (
     "cv",
@@ -126,6 +151,18 @@ def _normalize_mutable_surface_path(raw_path: str) -> str:
         return resolved.as_posix()
 
 
+def _is_forbidden_autonomous_mutation_surface(path: str) -> bool:
+    return (
+        path in FORBIDDEN_AUTONOMOUS_MUTATION_EXACT_PATHS
+        or Path(path).name in FORBIDDEN_AUTONOMOUS_MUTATION_FILENAMES
+        or any(path.startswith(prefix) for prefix in FORBIDDEN_AUTONOMOUS_MUTATION_PREFIXES)
+    )
+
+
+def _git_env_without_parent_state() -> dict[str, str]:
+    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+
 def validate_mutable_candidate_surface(paths: list[str] | tuple[str, ...]) -> list[str]:
     """Validate mutable surfaces against the PR1 experimentation allowlist."""
 
@@ -153,6 +190,63 @@ def validate_mutable_candidate_surface(paths: list[str] | tuple[str, ...]) -> li
             f"or approved prompt/program docs. Invalid paths: {joined}"
         )
     return normalized_paths
+
+
+def validate_oracle_context_surface(paths: list[str] | tuple[str, ...]) -> list[str]:
+    """Validate PR-owned context paths for oracle-only reviewer evidence."""
+
+    normalized_paths = sorted(
+        {_normalize_mutable_surface_path(path) for path in repo_relative_paths(paths)}
+    )
+    if not normalized_paths:
+        raise ValueError("At least one oracle-only context path is required.")
+
+    invalid_paths = [
+        path
+        for path in normalized_paths
+        if Path(path).is_absolute()
+        or path == "artifacts"
+        or path.startswith("artifacts/")
+        or path == "worktrees"
+        or path.startswith("worktrees/")
+        or path == ".venv"
+        or path.startswith(".venv/")
+    ]
+    if invalid_paths:
+        joined = ", ".join(invalid_paths)
+        raise ValueError(
+            "Oracle-only context paths must be repo-relative tracked surfaces. "
+            f"Invalid paths: {joined}"
+        )
+
+    git_binary = shutil.which("git")
+    if not git_binary:
+        raise ValueError("git binary is required to validate oracle-only context paths.")
+    tracked_process = subprocess.run(  # nosec B603: absolute git binary checks tracked context paths without shell (remove-by: 2026-07-31, ref: ledger-p1-experiment-runner-oracle-only-governance-reviewer)
+        [git_binary, "ls-files", "--error-unmatch", *normalized_paths],
+        cwd=str(REPO_ROOT),
+        env=_git_env_without_parent_state(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if tracked_process.returncode != 0:
+        diagnostic = tracked_process.stderr.strip() or tracked_process.stdout.strip()
+        raise ValueError(
+            "Oracle-only context paths must already be tracked by git: "
+            f"{diagnostic or ', '.join(normalized_paths)}"
+        )
+    return normalized_paths
+
+
+def validate_runner_mode(value: Any) -> str:
+    """Normalize the runner mode while preserving backward compatibility."""
+
+    normalized = str(value or DEFAULT_RUNNER_MODE).strip().lower()
+    if normalized not in RUNNER_MODES:
+        allowed = ", ".join(RUNNER_MODES)
+        raise ValueError(f"Experiment packet runner_mode must be one of: {allowed}")
+    return normalized
 
 
 def validate_immutable_oracles(commands: list[str] | tuple[str, ...]) -> list[dict[str, str]]:
@@ -435,12 +529,25 @@ def validate_experiment_packet(packet: dict[str, Any]) -> dict[str, Any]:
     if not task_class:
         raise ValueError("Experiment packet must include a non-empty task_class.")
 
+    runner_mode = validate_runner_mode(packet.get("runner_mode", DEFAULT_RUNNER_MODE))
+
     mutable_surface_raw = packet.get("mutable_candidate_surface")
     if not isinstance(mutable_surface_raw, list):
         raise ValueError("Experiment packet mutable_candidate_surface must be a list.")
-    mutable_surface = validate_mutable_candidate_surface(
-        [str(path) for path in mutable_surface_raw]
-    )
+    if runner_mode == ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE:
+        mutable_surface = validate_oracle_context_surface(
+            [str(path) for path in mutable_surface_raw]
+        )
+    else:
+        mutable_surface = validate_mutable_candidate_surface(
+            [str(path) for path in mutable_surface_raw]
+        )
+        if any(_is_forbidden_autonomous_mutation_surface(path) for path in mutable_surface):
+            raise ValueError(
+                "Experiment packet mutable_candidate_surface must not include governance, "
+                "review, CI validator, merge-gate, test, fixture, or AGENTS surfaces. "
+                "Use immutable_oracles for governance reviewer evidence instead."
+            )
 
     immutable_oracles_raw = packet.get("immutable_oracles")
     if not isinstance(immutable_oracles_raw, list):
@@ -505,6 +612,7 @@ def validate_experiment_packet(packet: dict[str, Any]) -> dict[str, Any]:
     normalized["experiment_id"] = experiment_id
     normalized["decision_question"] = decision_question
     normalized["task_class"] = task_class
+    normalized["runner_mode"] = runner_mode
     normalized["mutable_candidate_surface"] = mutable_surface
     normalized["immutable_oracles"] = immutable_oracles
     normalized["budgets"] = {
@@ -536,6 +644,8 @@ def validate_experiment_result(result: dict[str, Any]) -> dict[str, Any]:
         result.get("experiment_id", ""),
         label="Experiment result",
     )
+
+    runner_mode = validate_runner_mode(result.get("runner_mode", DEFAULT_RUNNER_MODE))
 
     status = str(result.get("status", "")).strip()
     if status not in RESULT_STATUSES:
@@ -601,10 +711,23 @@ def validate_experiment_result(result: dict[str, Any]) -> dict[str, Any]:
     candidate_patch = str(result.get("candidate_patch", "")).strip()
     if not candidate_patch:
         raise ValueError("Experiment result must include a non-empty candidate_patch.")
+    if runner_mode == ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE:
+        if mutated_paths:
+            raise ValueError(
+                "Oracle-only governance reviewer results must not record mutated_paths."
+            )
+        if promotion_ready:
+            raise ValueError("Oracle-only governance reviewer results must not be promotion_ready.")
+        if candidate_patch != ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE:
+            raise ValueError(
+                "Oracle-only governance reviewer results must use the stable "
+                "candidate_patch marker."
+            )
 
     normalized = dict(result)
     normalized["schema_version"] = schema_version
     normalized["experiment_id"] = experiment_id
+    normalized["runner_mode"] = runner_mode
     normalized["status"] = status
     normalized["failure_class"] = failure_class
     normalized["mutated_paths"] = mutated_paths

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -189,6 +189,10 @@ def _require_matching_experiment(
         raise ExperimentNotificationError(
             "Experiment packet and result must reference the same experiment_id."
         )
+    if packet.get("runner_mode") != result.get("runner_mode"):
+        raise ExperimentNotificationError(
+            "Experiment packet and result must reference the same runner_mode."
+        )
     _require_result_evidence_matches_packet(packet, result)
     if promotion is not None and packet["experiment_id"] != promotion.get("experiment_id"):
         raise ExperimentNotificationError(

--- a/scripts/orchestration/experiment_pipeline.py
+++ b/scripts/orchestration/experiment_pipeline.py
@@ -19,7 +19,10 @@ from typing import Any, Callable
 
 try:
     from scripts.orchestration.context_pack import normalize_repo_path
-    from scripts.orchestration.experiment_contract import validate_experiment_packet
+    from scripts.orchestration.experiment_contract import (
+        ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
+        validate_experiment_packet,
+    )
     from scripts.orchestration import experiment_notify
     from scripts.orchestration import experiment_promote
     from scripts.orchestration import experiment_runner
@@ -155,6 +158,11 @@ def main(argv: list[str] | None = None) -> int:
         packet_path = Path(args.packet).expanduser().resolve()
         candidate_patch_path = Path(args.candidate_patch).expanduser().resolve()
         packet = _read_packet(packet_path)
+        if packet.get("runner_mode") == ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE:
+            raise ExperimentPipelineError(
+                "Oracle-only governance reviewer packets are runner-only advisory evidence "
+                "and must not enter promotion pipeline."
+            )
         experiment_id = packet["experiment_id"]
         result_path = _default_result_path(experiment_id)
         promotion_path = _promotion_output_path(args.promotion_output, experiment_id)

--- a/scripts/orchestration/experiment_promote.py
+++ b/scripts/orchestration/experiment_promote.py
@@ -17,6 +17,7 @@ from typing import Any
 try:
     from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
     from scripts.orchestration.experiment_contract import (
+        ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
         SCHEMA_VERSION,
         validate_experiment_id,
         validate_experiment_packet,
@@ -30,6 +31,7 @@ except ImportError:  # pragma: no cover - CLI fallback for direct script executi
         sys.path.insert(0, str(experiment_promote_repo_root))
     from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
     from scripts.orchestration.experiment_contract import (
+        ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
         SCHEMA_VERSION,
         validate_experiment_id,
         validate_experiment_packet,
@@ -88,11 +90,23 @@ def _require_matching_experiment(packet: dict[str, Any], result: dict[str, Any])
         raise ExperimentPromotionError(
             "Experiment packet and result must reference the same experiment_id."
         )
+    if packet.get("runner_mode") != result.get("runner_mode"):
+        raise ExperimentPromotionError(
+            "Experiment packet and result must reference the same runner_mode."
+        )
 
 
 def _result_policy(packet: dict[str, Any], result: dict[str, Any]) -> str:
     target = packet["promotion_target"]
     status = result["status"]
+    if (
+        packet.get("runner_mode") == ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE
+        or result.get("runner_mode") == ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE
+    ):
+        raise ExperimentPromotionError(
+            "Oracle-only governance reviewer results are advisory local evidence "
+            "and must not be promoted."
+        )
     if status == "accepted":
         if not result["shared_tree_untouched"]:
             raise ExperimentPromotionError(

--- a/scripts/orchestration/experiment_runner.py
+++ b/scripts/orchestration/experiment_runner.py
@@ -38,6 +38,7 @@ from scripts.orchestration.experiment_contract import (
     ORACLE_BINARY_ALLOWLIST,
     ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
     SCHEMA_VERSION,
+    validate_experiment_id,
     validate_runner_mode,
     validate_experiment_packet,
 )
@@ -264,7 +265,12 @@ def _safe_result_experiment_id(packet: Any) -> str:
     if not isinstance(packet, dict):
         return "invalid-experiment"
     raw_experiment_id = str(packet.get("experiment_id", "")).strip()
-    return raw_experiment_id or "invalid-experiment"
+    if not raw_experiment_id:
+        return "invalid-experiment"
+    try:
+        return str(validate_experiment_id(raw_experiment_id, label="Experiment result"))
+    except ValueError:
+        return "invalid-experiment"
 
 
 def _safe_result_runner_mode(packet: Any) -> str:

--- a/scripts/orchestration/experiment_runner.py
+++ b/scripts/orchestration/experiment_runner.py
@@ -267,14 +267,14 @@ def _safe_result_experiment_id(packet: dict[str, Any]) -> str:
 
 def _safe_result_runner_mode(packet: dict[str, Any]) -> str:
     try:
-        return validate_runner_mode(packet.get("runner_mode", DEFAULT_RUNNER_MODE))
+        return str(validate_runner_mode(packet.get("runner_mode", DEFAULT_RUNNER_MODE)))
     except ValueError:
-        return DEFAULT_RUNNER_MODE
+        return str(DEFAULT_RUNNER_MODE)
 
 
 def _candidate_patch_ref_for_runner_mode(runner_mode: str, candidate_patch_ref: str) -> str:
     if runner_mode == ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE:
-        return ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE
+        return str(ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE)
     return candidate_patch_ref
 
 

--- a/scripts/orchestration/experiment_runner.py
+++ b/scripts/orchestration/experiment_runner.py
@@ -34,7 +34,9 @@ from app.security.execution_sandbox import SandboxRequest
 from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
 from scripts.orchestration.experiment_contract import (
     DEFAULT_STOP_CONDITION,
+    DEFAULT_RUNNER_MODE,
     ORACLE_BINARY_ALLOWLIST,
+    ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
     SCHEMA_VERSION,
     validate_experiment_packet,
 )
@@ -63,6 +65,7 @@ class InfraFlakeError(ExperimentRunnerError):
 def _result_payload(
     *,
     experiment_id: str,
+    runner_mode: str = DEFAULT_RUNNER_MODE,
     candidate_patch: str,
     status: str,
     failure_class: str | None,
@@ -76,6 +79,7 @@ def _result_payload(
     return {
         "schema_version": RESULT_SCHEMA_VERSION,
         "experiment_id": experiment_id,
+        "runner_mode": runner_mode,
         "candidate_patch": candidate_patch,
         "status": status,
         "failure_class": failure_class,
@@ -247,6 +251,37 @@ def _shared_tree_status(root: Path) -> str:
     """Capture tracked/untracked status to prove the shared tree stayed untouched."""
 
     return _run_git(["status", "--short"], cwd=root).stdout
+
+
+def _working_tree_diff_against_head(root: Path) -> str:
+    """Capture tracked working-tree changes for oracle-only reviewer evidence."""
+
+    return _run_git(["diff", "--binary", "HEAD"], cwd=root).stdout
+
+
+def _safe_result_experiment_id(packet: dict[str, Any]) -> str:
+    raw_experiment_id = str(packet.get("experiment_id", "")).strip()
+    return raw_experiment_id or "invalid-experiment"
+
+
+def _invalid_packet_result(
+    *,
+    packet: dict[str, Any],
+    candidate_patch_ref: str,
+    runner_mode: str,
+    error: str,
+) -> dict[str, Any]:
+    return _result_payload(
+        experiment_id=_safe_result_experiment_id(packet),
+        runner_mode=runner_mode,
+        candidate_patch=candidate_patch_ref,
+        status="rejected",
+        failure_class="policy_violation",
+        mutated_paths=[],
+        oracle_results=[],
+        budget_observations={"runner_error": error},
+        shared_tree_untouched=False,
+    )
 
 
 @contextmanager
@@ -435,6 +470,7 @@ def _evaluate_attempt(
         if not _has_effective_diff(checkout_root):
             return _result_payload(
                 experiment_id=packet["experiment_id"],
+                runner_mode=packet.get("runner_mode", DEFAULT_RUNNER_MODE),
                 candidate_patch=candidate_patch_ref,
                 status="rejected",
                 failure_class="unchanged_result",
@@ -449,6 +485,7 @@ def _evaluate_attempt(
         status = "accepted" if failure_class is None else "rejected"
         return _result_payload(
             experiment_id=packet["experiment_id"],
+            runner_mode=packet.get("runner_mode", DEFAULT_RUNNER_MODE),
             candidate_patch=candidate_patch_ref,
             status=status,
             failure_class=failure_class,
@@ -468,6 +505,15 @@ def evaluate_candidate(packet: dict[str, Any], candidate_patch_path: Path) -> di
     """Evaluate a candidate patch against a validated experiment packet."""
 
     candidate_patch_ref = str(candidate_patch_path)
+    try:
+        packet = validate_experiment_packet(packet)
+    except ValueError as exc:
+        return _invalid_packet_result(
+            packet=packet,
+            candidate_patch_ref=candidate_patch_ref,
+            runner_mode=str(packet.get("runner_mode", DEFAULT_RUNNER_MODE)),
+            error=str(exc),
+        )
     budget_observations = {
         "configured_budgets": dict(packet["budgets"]),
         "stop_condition": packet["budgets"].get("stop_condition", DEFAULT_STOP_CONDITION),
@@ -482,12 +528,17 @@ def evaluate_candidate(packet: dict[str, Any], candidate_patch_path: Path) -> di
     try:
         candidate_patch_ref = normalize_repo_path(candidate_patch_path)
         shared_status_before = _shared_tree_status(REPO_ROOT)
+        if packet.get("runner_mode") == ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE:
+            raise PolicyViolationError(
+                "oracle_only_governance_reviewer mode must not evaluate candidate patches"
+            )
         patch_text = _read_patch_text(candidate_patch_path)
         mutated_paths = _extract_mutated_paths(patch_text)
         budget_observations["candidate_changed_files"] = len(mutated_paths)
         if not mutated_paths:
             result = _result_payload(
                 experiment_id=packet["experiment_id"],
+                runner_mode=packet.get("runner_mode", DEFAULT_RUNNER_MODE),
                 candidate_patch=candidate_patch_ref,
                 status="rejected",
                 failure_class="unchanged_result",
@@ -526,6 +577,7 @@ def evaluate_candidate(packet: dict[str, Any], candidate_patch_path: Path) -> di
         budget_observations["runner_error"] = str(exc)
         result = _result_payload(
             experiment_id=packet["experiment_id"],
+            runner_mode=packet.get("runner_mode", DEFAULT_RUNNER_MODE),
             candidate_patch=candidate_patch_ref,
             status="rejected",
             failure_class="policy_violation",
@@ -538,7 +590,132 @@ def evaluate_candidate(packet: dict[str, Any], candidate_patch_path: Path) -> di
         budget_observations["runner_error"] = str(exc)
         result = _result_payload(
             experiment_id=packet["experiment_id"],
+            runner_mode=packet.get("runner_mode", DEFAULT_RUNNER_MODE),
             candidate_patch=candidate_patch_ref,
+            status="rejected",
+            failure_class="infra_flake",
+            mutated_paths=[],
+            oracle_results=[],
+            budget_observations=budget_observations,
+            shared_tree_untouched=shared_status_before is not None,
+        )
+
+    if shared_status_before is None:
+        result["shared_tree_untouched"] = False
+        result["status"] = "rejected"
+        result["failure_class"] = "infra_flake"
+        result["budget_observations"].setdefault(
+            "runner_error",
+            "Unable to capture shared working tree status before run.",
+        )
+        return result
+
+    try:
+        shared_status_after = _shared_tree_status(REPO_ROOT)
+    except InfraFlakeError as exc:
+        result["shared_tree_untouched"] = False
+        result["status"] = "rejected"
+        result["failure_class"] = "infra_flake"
+        result["budget_observations"]["runner_error"] = str(exc)
+        return result
+    if shared_status_before != shared_status_after:
+        result["shared_tree_untouched"] = False
+        result["status"] = "rejected"
+        result["failure_class"] = "infra_flake"
+        result["budget_observations"]["runner_error"] = "Shared working tree changed during run."
+    return result
+
+
+def evaluate_oracle_only_governance_reviewer(packet: dict[str, Any]) -> dict[str, Any]:
+    """Run immutable governance oracles without applying any candidate patch."""
+
+    try:
+        packet = validate_experiment_packet(packet)
+    except ValueError as exc:
+        return _invalid_packet_result(
+            packet=packet,
+            candidate_patch_ref=ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
+            runner_mode=ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
+            error=str(exc),
+        )
+    if packet.get("runner_mode") != ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE:
+        raise PolicyViolationError(
+            "evaluate_oracle_only_governance_reviewer requires oracle-only runner_mode"
+        )
+
+    budget_observations = {
+        "configured_budgets": dict(packet["budgets"]),
+        "stop_condition": packet["budgets"].get("stop_condition", DEFAULT_STOP_CONDITION),
+        "oracle_commands_configured": len(packet["immutable_oracles"]),
+        "oracle_commands_executed": 0,
+        "candidate_changed_files": 0,
+        "attempts": 1,
+        "retries_consumed": 0,
+        "runner_mode": ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
+        "source_diff_applied": False,
+        "source_diff_paths": [],
+    }
+    shared_status_before: str | None = None
+
+    try:
+        shared_status_before = _shared_tree_status(REPO_ROOT)
+        source_diff = _working_tree_diff_against_head(REPO_ROOT)
+        source_diff_paths = _extract_mutated_paths(source_diff) if source_diff else []
+        budget_observations["source_diff_paths"] = source_diff_paths
+        context_surface = packet["mutable_candidate_surface"]
+        outside_context = [
+            path
+            for path in source_diff_paths
+            if not any(_path_matches_surface(path, surface) for surface in context_surface)
+        ]
+        if outside_context:
+            joined = ", ".join(outside_context)
+            raise PolicyViolationError(
+                "Oracle-only source diff must stay within packet context surface: " f"{joined}"
+            )
+        temp_dir, checkout_root = _create_temp_checkout(REPO_ROOT)
+        try:
+            if source_diff:
+                _apply_candidate_patch(checkout_root, source_diff)
+                budget_observations["source_diff_applied"] = True
+            oracle_results, failure_class = _run_oracles(packet, checkout_root)
+            budget_observations["oracle_commands_executed"] = len(oracle_results)
+            status = "accepted" if failure_class is None else "rejected"
+            result = _result_payload(
+                experiment_id=packet["experiment_id"],
+                runner_mode=ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
+                candidate_patch=ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
+                status=status,
+                failure_class=failure_class,
+                mutated_paths=[],
+                oracle_results=oracle_results,
+                budget_observations=budget_observations,
+                shared_tree_untouched=True,
+            )
+        finally:
+            try:
+                temp_dir.cleanup()
+            except Exception as exc:
+                raise InfraFlakeError(f"Unable to clean temp checkout: {exc}") from exc
+    except PolicyViolationError as exc:
+        budget_observations["runner_error"] = str(exc)
+        result = _result_payload(
+            experiment_id=packet["experiment_id"],
+            runner_mode=ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
+            candidate_patch=ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
+            status="rejected",
+            failure_class="policy_violation",
+            mutated_paths=[],
+            oracle_results=[],
+            budget_observations=budget_observations,
+            shared_tree_untouched=shared_status_before is not None,
+        )
+    except InfraFlakeError as exc:
+        budget_observations["runner_error"] = str(exc)
+        result = _result_payload(
+            experiment_id=packet["experiment_id"],
+            runner_mode=ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
+            candidate_patch=ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
             status="rejected",
             failure_class="infra_flake",
             mutated_paths=[],
@@ -576,10 +753,10 @@ def evaluate_candidate(packet: dict[str, Any], candidate_patch_path: Path) -> di
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="experiment_runner",
-        description="Evaluate a candidate patch inside the governed experimentation lane.",
+        description="Evaluate a governed candidate patch or oracle-only reviewer packet.",
     )
     parser.add_argument("--packet", required=True, help="Experiment packet JSON path.")
-    parser.add_argument("--candidate-patch", required=True, help="Unified diff patch path.")
+    parser.add_argument("--candidate-patch", default=None, help="Unified diff patch path.")
     parser.add_argument(
         "--output",
         default=None,
@@ -594,7 +771,6 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     packet_path = Path(args.packet).expanduser().resolve()
-    candidate_patch_path = Path(args.candidate_patch).expanduser().resolve()
 
     try:
         packet = validate_experiment_packet(_read_json_object(packet_path))
@@ -603,7 +779,18 @@ def main(argv: list[str] | None = None) -> int:
         print(f"FAIL: {exc}")
         return 1
 
-    result = evaluate_candidate(packet, candidate_patch_path)
+    runner_mode = packet.get("runner_mode", DEFAULT_RUNNER_MODE)
+    if runner_mode == ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE:
+        if args.candidate_patch:
+            print("FAIL: oracle-only governance reviewer mode does not accept --candidate-patch")
+            return 1
+        result = evaluate_oracle_only_governance_reviewer(packet)
+    else:
+        if not args.candidate_patch:
+            print("FAIL: --candidate-patch is required for candidate_patch runner mode")
+            return 1
+        candidate_patch_path = Path(args.candidate_patch).expanduser().resolve()
+        result = evaluate_candidate(packet, candidate_patch_path)
     try:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(

--- a/scripts/orchestration/experiment_runner.py
+++ b/scripts/orchestration/experiment_runner.py
@@ -260,12 +260,16 @@ def _working_tree_diff_against_head(root: Path) -> str:
     return _run_git(["diff", "--binary", "HEAD"], cwd=root).stdout
 
 
-def _safe_result_experiment_id(packet: dict[str, Any]) -> str:
+def _safe_result_experiment_id(packet: Any) -> str:
+    if not isinstance(packet, dict):
+        return "invalid-experiment"
     raw_experiment_id = str(packet.get("experiment_id", "")).strip()
     return raw_experiment_id or "invalid-experiment"
 
 
-def _safe_result_runner_mode(packet: dict[str, Any]) -> str:
+def _safe_result_runner_mode(packet: Any) -> str:
+    if not isinstance(packet, dict):
+        return str(DEFAULT_RUNNER_MODE)
     try:
         return str(validate_runner_mode(packet.get("runner_mode", DEFAULT_RUNNER_MODE)))
     except ValueError:
@@ -280,7 +284,7 @@ def _candidate_patch_ref_for_runner_mode(runner_mode: str, candidate_patch_ref: 
 
 def _invalid_packet_result(
     *,
-    packet: dict[str, Any],
+    packet: Any,
     candidate_patch_ref: str,
     error: str,
 ) -> dict[str, Any]:

--- a/scripts/orchestration/experiment_runner.py
+++ b/scripts/orchestration/experiment_runner.py
@@ -38,6 +38,7 @@ from scripts.orchestration.experiment_contract import (
     ORACLE_BINARY_ALLOWLIST,
     ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
     SCHEMA_VERSION,
+    validate_runner_mode,
     validate_experiment_packet,
 )
 
@@ -264,17 +265,30 @@ def _safe_result_experiment_id(packet: dict[str, Any]) -> str:
     return raw_experiment_id or "invalid-experiment"
 
 
+def _safe_result_runner_mode(packet: dict[str, Any]) -> str:
+    try:
+        return validate_runner_mode(packet.get("runner_mode", DEFAULT_RUNNER_MODE))
+    except ValueError:
+        return DEFAULT_RUNNER_MODE
+
+
+def _candidate_patch_ref_for_runner_mode(runner_mode: str, candidate_patch_ref: str) -> str:
+    if runner_mode == ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE:
+        return ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE
+    return candidate_patch_ref
+
+
 def _invalid_packet_result(
     *,
     packet: dict[str, Any],
     candidate_patch_ref: str,
-    runner_mode: str,
     error: str,
 ) -> dict[str, Any]:
+    runner_mode = _safe_result_runner_mode(packet)
     return _result_payload(
         experiment_id=_safe_result_experiment_id(packet),
         runner_mode=runner_mode,
-        candidate_patch=candidate_patch_ref,
+        candidate_patch=_candidate_patch_ref_for_runner_mode(runner_mode, candidate_patch_ref),
         status="rejected",
         failure_class="policy_violation",
         mutated_paths=[],
@@ -511,7 +525,6 @@ def evaluate_candidate(packet: dict[str, Any], candidate_patch_path: Path) -> di
         return _invalid_packet_result(
             packet=packet,
             candidate_patch_ref=candidate_patch_ref,
-            runner_mode=str(packet.get("runner_mode", DEFAULT_RUNNER_MODE)),
             error=str(exc),
         )
     budget_observations = {
@@ -578,7 +591,10 @@ def evaluate_candidate(packet: dict[str, Any], candidate_patch_path: Path) -> di
         result = _result_payload(
             experiment_id=packet["experiment_id"],
             runner_mode=packet.get("runner_mode", DEFAULT_RUNNER_MODE),
-            candidate_patch=candidate_patch_ref,
+            candidate_patch=_candidate_patch_ref_for_runner_mode(
+                packet.get("runner_mode", DEFAULT_RUNNER_MODE),
+                candidate_patch_ref,
+            ),
             status="rejected",
             failure_class="policy_violation",
             mutated_paths=[],
@@ -635,7 +651,6 @@ def evaluate_oracle_only_governance_reviewer(packet: dict[str, Any]) -> dict[str
         return _invalid_packet_result(
             packet=packet,
             candidate_patch_ref=ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
-            runner_mode=ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE,
             error=str(exc),
         )
     if packet.get("runner_mode") != ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE:

--- a/tests/test_experiment_bootstrap.py
+++ b/tests/test_experiment_bootstrap.py
@@ -184,6 +184,63 @@ def test_build_experiment_packet_keeps_non_cv_packets_backward_compatible() -> N
     )
 
     assert "cv_context" not in packet
+    assert packet["runner_mode"] == "candidate_patch"
+
+
+def test_build_experiment_packet_emits_oracle_only_runner_mode() -> None:
+    """Bootstrap must expose oracle-only mode through the canonical packet surface."""
+
+    packet = build_experiment_packet(
+        decision_question="Run governance validators for PR evidence",
+        task_class="Experimentation",
+        runner_mode="oracle_only_governance_reviewer",
+        mutable_paths=[
+            "scripts/orchestration/experiment_runner.py",
+            "docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md",
+        ],
+        oracle_commands=["python3 scripts/orchestration/check_agent_consistency.py"],
+        metrics=["governance_validator_pass"],
+        negative_controls=["no candidate patch", "no governance mutation"],
+        promotion_target="audit_artifact",
+    )
+
+    assert packet["runner_mode"] == "oracle_only_governance_reviewer"
+    assert packet["mutable_candidate_surface"] == [
+        "docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md",
+        "scripts/orchestration/experiment_runner.py",
+    ]
+    assert validate_experiment_packet(packet)["runner_mode"] == "oracle_only_governance_reviewer"
+
+
+def test_build_experiment_packet_rejects_governance_surface_in_candidate_mode() -> None:
+    """Bootstrap must not mint candidate packets that rewrite governance oracles."""
+
+    with pytest.raises(ValueError, match="must not include governance"):
+        build_experiment_packet(
+            decision_question="Run governance validators for PR evidence",
+            task_class="Experimentation",
+            mutable_paths=["docs/orchestration/prompts/governance.program.md"],
+            oracle_commands=["python3 scripts/orchestration/check_agent_consistency.py"],
+            metrics=["governance_validator_pass"],
+            negative_controls=["no candidate patch", "no governance mutation"],
+            promotion_target="audit_artifact",
+        )
+
+
+def test_build_experiment_packet_rejects_local_artifact_context_in_oracle_only_mode() -> None:
+    """Oracle-only context must point at repo surfaces, not local artifact paths."""
+
+    with pytest.raises(ValueError, match="repo-relative tracked surfaces"):
+        build_experiment_packet(
+            decision_question="Run governance validators for PR evidence",
+            task_class="Experimentation",
+            runner_mode="oracle_only_governance_reviewer",
+            mutable_paths=["artifacts/orchestration/experiments/results/latest.json"],
+            oracle_commands=["python3 scripts/orchestration/check_agent_consistency.py"],
+            metrics=["governance_validator_pass"],
+            negative_controls=["no candidate patch", "no governance mutation"],
+            promotion_target="audit_artifact",
+        )
 
 
 def test_build_experiment_packet_is_deterministic_for_cv_lane() -> None:
@@ -313,6 +370,45 @@ def test_main_writes_cv_context_when_metadata_is_complete(
     assert packet["cv_context"]["privacy_packet"]["consent_policy"] == "explicit_opt_in"
 
 
+def test_main_writes_oracle_only_runner_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path.resolve()
+    experiment_dir = (repo_root / "artifacts" / "orchestration" / "experiments").resolve()
+    monkeypatch.setattr(experiment_bootstrap, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(experiment_bootstrap, "EXPERIMENT_PACKET_DIR", experiment_dir)
+
+    exit_code = main(
+        [
+            "--decision-question",
+            "Run governance validators for PR evidence",
+            "--runner-mode",
+            "oracle_only_governance_reviewer",
+            "--mutable-path",
+            "core/rag/vector_rag.py",
+            "--oracle-command",
+            "python3 scripts/orchestration/check_agent_consistency.py",
+            "--metric",
+            "governance_validator_pass",
+            "--negative-control",
+            "no candidate patch",
+            "--negative-control",
+            "no governance mutation",
+            "--promotion-target",
+            "audit_artifact",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    output = json.loads(captured.out)
+    packet = json.loads((repo_root / output["output"]).read_text(encoding="utf-8"))
+    assert output["runner_mode"] == "oracle_only_governance_reviewer"
+    assert packet["runner_mode"] == "oracle_only_governance_reviewer"
+
+
 def test_validate_experiment_packet_requires_cv_context_for_cv_lane() -> None:
     """Validation should reject CV packets that arrive without cv_context."""
 
@@ -430,6 +526,7 @@ def test_main_writes_relative_output_inside_repo(
     packet = {
         "schema_version": "1.0",
         "experiment_id": "exp-testpacket",
+        "runner_mode": "candidate_patch",
         "decision_question": "Test experiment bootstrap write",
         "task_class": "Experimentation",
         "domain": "ml",
@@ -731,6 +828,47 @@ def test_compute_experiment_id_keeps_legacy_non_cv_shape() -> None:
     legacy_id = f"exp-{hashlib.sha256(legacy_payload.encode('utf-8')).hexdigest()[:12]}"
 
     assert compute_experiment_id(cv_context=None, **base_kwargs) == legacy_id
+
+
+def test_compute_experiment_id_changes_with_oracle_only_runner_mode() -> None:
+    """Non-default runner behavior must participate in deterministic ids."""
+
+    base_kwargs = {
+        "decision_question": "Run governance validators for PR evidence",
+        "task_class": "Experimentation",
+        "mutable_paths": ["core/rag/vector_rag.py"],
+        "immutable_oracles": [
+            {
+                "command": "python3 scripts/orchestration/check_agent_consistency.py",
+                "expected_signal": "must pass",
+            }
+        ],
+        "metrics": {
+            "primary": "governance_validator_pass",
+            "secondary": [],
+            "baseline_reference": "current-main",
+            "acceptance_threshold": "strict_improvement",
+        },
+        "negative_controls": ["no candidate patch", "no governance mutation"],
+        "promotion_target": "audit_artifact",
+        "budgets": {
+            "wall_clock_seconds": 300,
+            "retry_budget": 1,
+            "max_changed_files": 3,
+            "network_budget": 0,
+            "benchmark_budget": 1,
+            "test_budget": 2,
+        },
+        "stop_condition": "Stop on timeout.",
+    }
+
+    candidate_id = compute_experiment_id(**base_kwargs)
+    oracle_only_id = compute_experiment_id(
+        runner_mode="oracle_only_governance_reviewer",
+        **base_kwargs,
+    )
+
+    assert candidate_id != oracle_only_id
 
 
 def test_validate_cv_context_rejects_missing_dataset() -> None:

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -39,10 +39,12 @@ def _packet(
     *,
     experiment_id: str = "exp-notify",
     promotion_target: str = "audit_artifact",
+    runner_mode: str = "candidate_patch",
 ) -> dict[str, object]:
     return {
         "schema_version": "1.0",
         "experiment_id": experiment_id,
+        "runner_mode": runner_mode,
         "decision_question": "Notify about governed experiment result",
         "task_class": "Experimentation",
         "domain": "ml",
@@ -79,10 +81,12 @@ def _result(
     status: str = "accepted",
     failure_class: str | None = None,
     command: str = 'python3 -c "import sys; sys.exit(0)"',
+    runner_mode: str = "candidate_patch",
 ) -> dict[str, object]:
     return {
         "schema_version": "1.0",
         "experiment_id": experiment_id,
+        "runner_mode": runner_mode,
         "candidate_patch": "candidate.patch",
         "status": status,
         "failure_class": failure_class,
@@ -283,7 +287,6 @@ def test_main_writes_deterministic_notification(
         "github_step_summary": False,
         "output": "artifacts/orchestration/experiments/notifications/exp-notify.md",
     }
-
     second_exit_code = experiment_notify.main(
         ["--packet", str(packet_path), "--result", str(result_path)]
     )
@@ -291,6 +294,17 @@ def test_main_writes_deterministic_notification(
 
     assert second_exit_code == 0
     assert output.read_text(encoding="utf-8") == EXPECTED_NOTIFICATION
+
+
+def test_render_rejects_packet_result_runner_mode_mismatch() -> None:
+    packet = {
+        **_packet(runner_mode="oracle_only_governance_reviewer"),
+        "mutable_candidate_surface": ["scripts/orchestration/experiment_runner.py"],
+    }
+    result = _promotion_ready_result()
+
+    with pytest.raises(experiment_notify.ExperimentNotificationError, match="runner_mode"):
+        experiment_notify.render_notification_markdown(packet, result, None)
 
 
 def test_default_notification_does_not_send_email(

--- a/tests/test_experiment_pipeline.py
+++ b/tests/test_experiment_pipeline.py
@@ -340,6 +340,39 @@ def test_pipeline_rejects_absolute_promotion_output_escape(
     assert str(tmp_path) not in captured.out
 
 
+def test_pipeline_rejects_oracle_only_packet_before_runner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    _configure_repo(monkeypatch, repo)
+
+    def oracle_only_packet(payload: dict[str, object]) -> dict[str, object]:
+        del payload
+        packet = _packet()
+        packet["runner_mode"] = experiment_contract.ORACLE_ONLY_GOVERNANCE_REVIEWER_MODE
+        return packet
+
+    def forbidden_runner_main(argv: list[str]) -> int:
+        raise AssertionError(f"oracle-only packet must not enter runner pipeline: {argv}")
+
+    monkeypatch.setattr(experiment_pipeline, "validate_experiment_packet", oracle_only_packet)
+    monkeypatch.setattr(experiment_pipeline.experiment_runner, "main", forbidden_runner_main)
+    packet_path = _write_json(tmp_path / "packet.json", {"stub": True})
+    patch_path = tmp_path / "candidate.patch"
+    patch_path.write_text("patch text\n", encoding="utf-8")
+
+    exit_code = experiment_pipeline.main(
+        ["--packet", str(packet_path), "--candidate-patch", str(patch_path)]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "runner-only advisory evidence" in captured.out
+    assert str(tmp_path) not in captured.out
+
+
 def test_pipeline_stage_failure_captures_stderr_without_leak(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_experiment_promote.py
+++ b/tests/test_experiment_promote.py
@@ -3,13 +3,31 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+import shutil
+import subprocess
 
 import pytest
 
 import scripts.orchestration.context_pack as context_pack
 import scripts.orchestration.experiment_contract as experiment_contract
 import scripts.orchestration.experiment_promote as experiment_promote
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    git_binary = shutil.which("git")
+    if not git_binary:
+        raise AssertionError("git binary is required for experiment promotion tests.")
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    return subprocess.run(
+        [git_binary, *args],
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
 
 
 def _init_repo(tmp_path: Path) -> Path:
@@ -35,6 +53,11 @@ def _init_repo(tmp_path: Path) -> Path:
         "# Experiment Protocol\n",
         encoding="utf-8",
     )
+    _git(tmp_path, "init", "--quiet", str(repo))
+    _git(repo, "config", "user.email", "pulseplate@pm.me")
+    _git(repo, "config", "user.name", "PulsePlate Experiment Runner")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "--quiet", "-m", "init")
     return repo
 
 
@@ -107,10 +130,12 @@ def _result(
     status: str = "accepted",
     failure_class: str | None = None,
     shared_tree_untouched: bool = True,
+    runner_mode: str = "candidate_patch",
 ) -> dict[str, object]:
     return {
         "schema_version": "1.0",
         "experiment_id": experiment_id,
+        "runner_mode": runner_mode,
         "candidate_patch": "candidate.patch",
         "status": status,
         "failure_class": failure_class,
@@ -257,6 +282,45 @@ def test_rejected_result_with_non_backlog_target_fails(
     )
 
     with pytest.raises(experiment_promote.ExperimentPromotionError, match="backlog_entry"):
+        experiment_promote.build_promotion_decision(packet, result)
+
+
+def test_oracle_only_governance_reviewer_result_never_promotes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    packet = {
+        **_packet(promotion_target="audit_artifact"),
+        "runner_mode": "oracle_only_governance_reviewer",
+    }
+    result = experiment_contract.validate_experiment_result(
+        {
+            **_result(runner_mode="oracle_only_governance_reviewer"),
+            "candidate_patch": "oracle_only_governance_reviewer",
+            "mutated_paths": [],
+            "promotion_ready": False,
+        }
+    )
+
+    with pytest.raises(experiment_promote.ExperimentPromotionError, match="advisory"):
+        experiment_promote.build_promotion_decision(packet, result)
+
+
+def test_oracle_only_packet_cannot_pair_with_legacy_result_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    packet = {
+        **_packet(promotion_target="audit_artifact"),
+        "runner_mode": "oracle_only_governance_reviewer",
+    }
+    result = experiment_contract.validate_experiment_result(_result())
+
+    with pytest.raises(experiment_promote.ExperimentPromotionError, match="runner_mode"):
         experiment_promote.build_promotion_decision(packet, result)
 
 

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -270,6 +270,24 @@ def test_validate_oracle_only_context_ignores_parent_git_index_env(
     assert validated["mutable_candidate_surface"] == ["core/rag/allowed.py"]
 
 
+def test_validate_oracle_only_context_rejects_git_pathspec_magic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Git pathspec magic must not expand oracle-only tracked-context checks."""
+
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    packet = _base_packet(
+        mutable_path=":(glob)core/rag/*.py",
+        oracle_command='python3 -c "import sys; sys.exit(0)"',
+        runner_mode="oracle_only_governance_reviewer",
+    )
+
+    with pytest.raises(ValueError, match="tracked by git"):
+        experiment_contract.validate_experiment_packet(packet)
+
+
 def test_validate_packet_rejects_governance_prompt_surface_in_candidate_mode() -> None:
     """Governance docs can be immutable oracles, not runner-mutable prompt docs."""
 

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -414,10 +414,74 @@ def test_evaluate_candidate_rejects_oracle_only_direct_api_patch(
 
     assert result["status"] == "rejected"
     assert result["runner_mode"] == "oracle_only_governance_reviewer"
+    assert result["candidate_patch"] == "oracle_only_governance_reviewer"
     assert result["failure_class"] == "policy_violation"
     assert result["mutated_paths"] == []
     assert result["oracle_results"] == []
     assert "must not evaluate candidate patches" in result["budget_observations"]["runner_error"]
+    assert experiment_contract.validate_experiment_result(result)["runner_mode"] == (
+        "oracle_only_governance_reviewer"
+    )
+
+
+def test_evaluate_candidate_invalid_oracle_only_packet_result_is_schema_valid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    patch_path = _write_patch(
+        repo,
+        "core/rag/allowed.py",
+        "def candidate_value() -> int:\n" "    return 2\n",
+        tmp_path / "oracle-only-invalid-packet.patch",
+    )
+    packet = _base_packet(
+        mutable_path="artifacts/not-tracked.json",
+        oracle_command='python3 -c "import sys; sys.exit(0)"',
+        runner_mode="oracle_only_governance_reviewer",
+    )
+
+    result = experiment_runner.evaluate_candidate(packet, patch_path)
+
+    assert result["status"] == "rejected"
+    assert result["runner_mode"] == "oracle_only_governance_reviewer"
+    assert result["candidate_patch"] == "oracle_only_governance_reviewer"
+    assert result["failure_class"] == "policy_violation"
+    assert "repo-relative tracked surfaces" in result["budget_observations"]["runner_error"]
+    assert experiment_contract.validate_experiment_result(result)["runner_mode"] == (
+        "oracle_only_governance_reviewer"
+    )
+
+
+def test_evaluate_candidate_invalid_runner_mode_result_is_schema_valid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    patch_path = _write_patch(
+        repo,
+        "core/rag/allowed.py",
+        "def candidate_value() -> int:\n" "    return 2\n",
+        tmp_path / "invalid-runner-mode.patch",
+    )
+    packet = _base_packet(
+        mutable_path="core/rag/allowed.py",
+        oracle_command='python3 -c "import sys; sys.exit(0)"',
+        runner_mode="oracle-only",
+    )
+
+    result = experiment_runner.evaluate_candidate(packet, patch_path)
+
+    assert result["status"] == "rejected"
+    assert result["runner_mode"] == "candidate_patch"
+    assert result["candidate_patch"]
+    assert result["failure_class"] == "policy_violation"
+    assert "runner_mode must be one of" in result["budget_observations"]["runner_error"]
+    assert experiment_contract.validate_experiment_result(result)["runner_mode"] == (
+        "candidate_patch"
+    )
 
 
 def test_evaluate_candidate_rejects_traversal_patch_path(

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -38,12 +38,41 @@ def _init_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     (repo / "core" / "rag").mkdir(parents=True)
     (repo / "docs" / "orchestration").mkdir(parents=True)
+    (repo / "docs" / "review").mkdir(parents=True)
+    (repo / "scripts" / "ci").mkdir(parents=True)
+    (repo / "scripts" / "orchestration").mkdir(parents=True)
+    (repo / "tests").mkdir(parents=True)
+    (repo / "AGENTS.md").write_text("# Agent rules\n", encoding="utf-8")
     (repo / "core" / "rag" / "allowed.py").write_text(
         "def candidate_value() -> int:\n" "    return 1\n",
         encoding="utf-8",
     )
     (repo / "docs" / "orchestration" / "workflow.md").write_text(
         "# Workflow\n",
+        encoding="utf-8",
+    )
+    (repo / "docs" / "review" / "PR_1_FIXED_MAPPING.md").write_text(
+        "# Mapping\n",
+        encoding="utf-8",
+    )
+    (repo / "scripts" / "ci" / "check_gate.py").write_text(
+        "raise SystemExit(0)\n",
+        encoding="utf-8",
+    )
+    (repo / "scripts" / "orchestration" / "check_merge_ready.py").write_text(
+        "raise SystemExit(0)\n",
+        encoding="utf-8",
+    )
+    (repo / "scripts" / "orchestration" / "experiment_runner.py").write_text(
+        "raise SystemExit(0)\n",
+        encoding="utf-8",
+    )
+    (repo / "scripts" / "orchestration" / "check_review_threads_disposition.py").write_text(
+        "raise SystemExit(0)\n",
+        encoding="utf-8",
+    )
+    (repo / "tests" / "test_oracle.py").write_text(
+        "def test_oracle() -> None:\n" "    assert True\n",
         encoding="utf-8",
     )
 
@@ -66,11 +95,16 @@ def _write_patch(repo: Path, relative_path: str, new_text: str, patch_path: Path
 
 
 def _base_packet(
-    *, mutable_path: str, oracle_command: str, experiment_id: str = "exp-test"
+    *,
+    mutable_path: str,
+    oracle_command: str,
+    experiment_id: str = "exp-test",
+    runner_mode: str = "candidate_patch",
 ) -> dict[str, object]:
     return {
         "schema_version": "1.0",
         "experiment_id": experiment_id,
+        "runner_mode": runner_mode,
         "decision_question": "Evaluate bounded candidate patch",
         "task_class": "Experimentation",
         "mutable_candidate_surface": [mutable_path],
@@ -201,6 +235,53 @@ def test_validate_packet_rejects_unknown_budget_keys() -> None:
         experiment_contract.validate_experiment_packet(packet)
 
 
+def test_validate_packet_accepts_oracle_only_governance_reviewer_mode() -> None:
+    """Oracle-only PR participation is advisory and does not expand mutable surfaces."""
+
+    packet = _base_packet(
+        mutable_path="scripts/orchestration/experiment_runner.py",
+        oracle_command='python3 -c "import sys; sys.exit(0)"',
+        runner_mode="oracle_only_governance_reviewer",
+    )
+
+    validated = experiment_contract.validate_experiment_packet(packet)
+
+    assert validated["runner_mode"] == "oracle_only_governance_reviewer"
+    assert validated["mutable_candidate_surface"] == ["scripts/orchestration/experiment_runner.py"]
+
+
+def test_validate_oracle_only_context_ignores_parent_git_index_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tracked-context validation must not inherit pre-commit parent git state."""
+
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    monkeypatch.setenv("GIT_INDEX_FILE", str(tmp_path / "parent-hook-index"))
+    packet = _base_packet(
+        mutable_path="core/rag/allowed.py",
+        oracle_command='python3 -c "import sys; sys.exit(0)"',
+        runner_mode="oracle_only_governance_reviewer",
+    )
+
+    validated = experiment_contract.validate_experiment_packet(packet)
+
+    assert validated["mutable_candidate_surface"] == ["core/rag/allowed.py"]
+
+
+def test_validate_packet_rejects_governance_prompt_surface_in_candidate_mode() -> None:
+    """Governance docs can be immutable oracles, not runner-mutable prompt docs."""
+
+    packet = _base_packet(
+        mutable_path="docs/orchestration/prompts/governance.program.md",
+        oracle_command='python3 -c "import sys; sys.exit(0)"',
+    )
+
+    with pytest.raises(ValueError, match="Invalid paths|must not include governance"):
+        experiment_contract.validate_experiment_packet(packet)
+
+
 def test_evaluate_candidate_accepts_allowlisted_patch(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -258,6 +339,67 @@ def test_evaluate_candidate_rejects_forbidden_patch_target(
     assert result["status"] == "rejected"
     assert result["failure_class"] == "policy_violation"
     assert result["shared_tree_untouched"] is True
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "AGENTS.md",
+        "docs/review/PR_1_FIXED_MAPPING.md",
+        "scripts/ci/check_gate.py",
+        "scripts/orchestration/check_merge_ready.py",
+        "scripts/orchestration/check_review_threads_disposition.py",
+        "tests/test_oracle.py",
+    ],
+)
+def test_validate_candidate_packet_rejects_governance_mutation_surfaces(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    relative_path: str,
+) -> None:
+    """Candidate-patch packets must not make governance oracles mutable."""
+
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    packet = _base_packet(
+        mutable_path=relative_path,
+        oracle_command='python3 -c "import sys; sys.exit(0)"',
+    )
+
+    with pytest.raises(ValueError, match="Invalid paths|must not include governance"):
+        experiment_contract.validate_experiment_packet(packet)
+
+
+def test_evaluate_candidate_rejects_oracle_only_direct_api_patch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct helper calls must preserve the same oracle-only boundary as the CLI."""
+
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    patch_path = _write_patch(
+        repo,
+        "core/rag/allowed.py",
+        "def candidate_value() -> int:\n" "    return 2\n",
+        tmp_path / "oracle-only-direct.patch",
+    )
+    packet = _validate_packet(
+        _base_packet(
+            mutable_path="core/rag/allowed.py",
+            oracle_command='python3 -c "import sys; sys.exit(0)"',
+            runner_mode="oracle_only_governance_reviewer",
+        )
+    )
+
+    result = experiment_runner.evaluate_candidate(packet, patch_path)
+
+    assert result["status"] == "rejected"
+    assert result["runner_mode"] == "oracle_only_governance_reviewer"
+    assert result["failure_class"] == "policy_violation"
+    assert result["mutated_paths"] == []
+    assert result["oracle_results"] == []
+    assert "must not evaluate candidate patches" in result["budget_observations"]["runner_error"]
 
 
 def test_evaluate_candidate_rejects_traversal_patch_path(
@@ -906,6 +1048,255 @@ def test_main_writes_result_inside_artifact_dir(
             Path("artifacts/orchestration/experiments/results") / "nested" / "result.json"
         ).as_posix()
     )
+
+
+def test_main_writes_oracle_only_governance_reviewer_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    result_dir = _configure_runner_repo(monkeypatch, repo)
+    packet_path = tmp_path / "oracle-only-packet.json"
+    packet_path.write_text(
+        json.dumps(
+            _base_packet(
+                mutable_path="core/rag/allowed.py",
+                oracle_command='python3 -c "import sys; sys.exit(0)"',
+                experiment_id="exp-oracle-only",
+                runner_mode="oracle_only_governance_reviewer",
+            ),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = experiment_runner.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--output",
+            "oracle/result.json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    result_path = result_dir / "oracle" / "result.json"
+    assert exit_code == 0
+    written = json.loads(result_path.read_text(encoding="utf-8"))
+    assert written["experiment_id"] == "exp-oracle-only"
+    assert written["status"] == "accepted"
+    assert written["candidate_patch"] == "oracle_only_governance_reviewer"
+    assert written["mutated_paths"] == []
+    assert written["promotion_ready"] is False
+    assert written["shared_tree_untouched"] is True
+    assert json.loads(captured.out)["status"] == "accepted"
+
+
+def test_oracle_only_governance_reviewer_applies_current_tracked_diff(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Oracle-only evidence must cover the current tracked PR diff, not stale HEAD."""
+
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    (repo / "core" / "rag" / "allowed.py").write_text(
+        "def candidate_value() -> int:\n" "    return 2\n",
+        encoding="utf-8",
+    )
+    packet = _validate_packet(
+        _base_packet(
+            mutable_path="core/rag/allowed.py",
+            oracle_command=(
+                'python3 -c "from pathlib import Path; import sys; '
+                "sys.exit(0 if 'return 2' in Path('core/rag/allowed.py').read_text() else 1)\""
+            ),
+            runner_mode="oracle_only_governance_reviewer",
+        )
+    )
+
+    result = experiment_runner.evaluate_oracle_only_governance_reviewer(packet)
+
+    assert result["status"] == "accepted"
+    assert result["mutated_paths"] == []
+    assert result["budget_observations"]["source_diff_applied"] is True
+    assert _git(repo, "status", "--short").stdout.strip() == "M core/rag/allowed.py"
+
+
+def test_oracle_only_governance_reviewer_rejects_unowned_tracked_diff(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Oracle-only evidence must not silently include dirty paths outside context."""
+
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    (repo / "core" / "rag" / "allowed.py").write_text(
+        "def candidate_value() -> int:\n" "    return 2\n",
+        encoding="utf-8",
+    )
+    packet = _validate_packet(
+        _base_packet(
+            mutable_path="scripts/orchestration/experiment_runner.py",
+            oracle_command='python3 -c "import sys; sys.exit(0)"',
+            runner_mode="oracle_only_governance_reviewer",
+        )
+    )
+
+    result = experiment_runner.evaluate_oracle_only_governance_reviewer(packet)
+
+    assert result["status"] == "rejected"
+    assert result["failure_class"] == "policy_violation"
+    assert result["mutated_paths"] == []
+    assert result["budget_observations"]["source_diff_paths"] == ["core/rag/allowed.py"]
+    assert (
+        "must stay within packet context surface" in result["budget_observations"]["runner_error"]
+    )
+
+
+def test_oracle_only_context_surface_must_be_tracked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    packet = _base_packet(
+        mutable_path="does/not/exist.py",
+        oracle_command='python3 -c "import sys; sys.exit(0)"',
+        runner_mode="oracle_only_governance_reviewer",
+    )
+
+    with pytest.raises(ValueError, match="tracked by git"):
+        experiment_contract.validate_experiment_packet(packet)
+
+
+def test_oracle_only_direct_api_validates_raw_packet(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    packet = _base_packet(
+        mutable_path="artifacts/not-tracked.json",
+        oracle_command='python3 -c "import sys; sys.exit(0)"',
+        runner_mode="oracle_only_governance_reviewer",
+    )
+
+    result = experiment_runner.evaluate_oracle_only_governance_reviewer(packet)
+
+    assert result["status"] == "rejected"
+    assert result["failure_class"] == "policy_violation"
+    assert result["shared_tree_untouched"] is False
+    assert "repo-relative tracked surfaces" in result["budget_observations"]["runner_error"]
+
+
+def test_main_rejects_missing_candidate_patch_for_candidate_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    packet_path = tmp_path / "candidate-packet.json"
+    packet_path.write_text(
+        json.dumps(
+            _base_packet(
+                mutable_path="core/rag/allowed.py",
+                oracle_command='python3 -c "import sys; sys.exit(0)"',
+            ),
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = experiment_runner.main(["--packet", str(packet_path)])
+
+    assert exit_code == 1
+    assert "--candidate-patch is required" in capsys.readouterr().out
+
+
+def test_main_rejects_candidate_patch_for_oracle_only_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    packet_path = tmp_path / "oracle-only-packet.json"
+    patch_path = _write_patch(
+        repo,
+        "core/rag/allowed.py",
+        "def candidate_value() -> int:\n" "    return 2\n",
+        tmp_path / "should-not-apply.patch",
+    )
+    packet_path.write_text(
+        json.dumps(
+            _base_packet(
+                mutable_path="core/rag/allowed.py",
+                oracle_command='python3 -c "import sys; sys.exit(0)"',
+                runner_mode="oracle_only_governance_reviewer",
+            ),
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = experiment_runner.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--candidate-patch",
+            str(patch_path),
+        ]
+    )
+
+    assert exit_code == 1
+    assert "does not accept --candidate-patch" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "override,match",
+    [
+        ({"mutated_paths": ["core/rag/allowed.py"]}, "must not record mutated_paths"),
+        ({"promotion_ready": True}, "must not be promotion_ready"),
+        ({"candidate_patch": "candidate.patch"}, "stable candidate_patch marker"),
+    ],
+)
+def test_validate_result_rejects_malformed_oracle_only_artifacts(
+    override: dict[str, object],
+    match: str,
+) -> None:
+    result = {
+        "schema_version": "1.0",
+        "experiment_id": "exp-oracle-only",
+        "runner_mode": "oracle_only_governance_reviewer",
+        "candidate_patch": "oracle_only_governance_reviewer",
+        "status": "accepted",
+        "failure_class": None,
+        "mutated_paths": [],
+        "oracle_results": [
+            {
+                "command": 'python3 -c "import sys; sys.exit(0)"',
+                "returncode": 0,
+                "timed_out": False,
+                "truncated": False,
+                "stdout": "",
+                "stderr": "",
+                "cwd": ".",
+            }
+        ],
+        "budget_observations": {"attempts": 1},
+        "shared_tree_untouched": True,
+        "promotion_ready": False,
+        **override,
+    }
+
+    with pytest.raises(ValueError, match=match):
+        experiment_contract.validate_experiment_result(result)
 
 
 def test_resolve_output_path_rejects_default_experiment_id_escape(

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import shutil
 import subprocess
 import tempfile
+from typing import Any, cast
 
 import pytest
 
@@ -479,6 +480,35 @@ def test_evaluate_candidate_invalid_runner_mode_result_is_schema_valid(
     assert result["candidate_patch"]
     assert result["failure_class"] == "policy_violation"
     assert "runner_mode must be one of" in result["budget_observations"]["runner_error"]
+    assert experiment_contract.validate_experiment_result(result)["runner_mode"] == (
+        "candidate_patch"
+    )
+
+
+def test_evaluate_candidate_non_dict_packet_result_is_schema_valid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    patch_path = _write_patch(
+        repo,
+        "core/rag/allowed.py",
+        "def candidate_value() -> int:\n" "    return 2\n",
+        tmp_path / "non-dict-packet.patch",
+    )
+    packet = cast(dict[str, Any], ["not", "a", "packet"])
+
+    result = experiment_runner.evaluate_candidate(packet, patch_path)
+
+    assert result["status"] == "rejected"
+    assert result["experiment_id"] == "invalid-experiment"
+    assert result["runner_mode"] == "candidate_patch"
+    assert result["candidate_patch"]
+    assert result["failure_class"] == "policy_violation"
+    assert (
+        "Experiment packet must be a JSON object" in result["budget_observations"]["runner_error"]
+    )
     assert experiment_contract.validate_experiment_result(result)["runner_mode"] == (
         "candidate_patch"
     )

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -251,6 +251,12 @@ def test_validate_packet_accepts_oracle_only_governance_reviewer_mode() -> None:
     assert validated["mutable_candidate_surface"] == ["scripts/orchestration/experiment_runner.py"]
 
 
+@pytest.mark.parametrize("runner_mode", [False, 0, [], ""])
+def test_validate_runner_mode_rejects_explicit_invalid_values(runner_mode: object) -> None:
+    with pytest.raises(ValueError, match="runner_mode must be one of"):
+        experiment_contract.validate_runner_mode(runner_mode)
+
+
 def test_validate_oracle_only_context_ignores_parent_git_index_env(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -482,6 +488,36 @@ def test_evaluate_candidate_invalid_runner_mode_result_is_schema_valid(
     assert "runner_mode must be one of" in result["budget_observations"]["runner_error"]
     assert experiment_contract.validate_experiment_result(result)["runner_mode"] == (
         "candidate_patch"
+    )
+
+
+def test_evaluate_candidate_invalid_experiment_id_result_is_schema_valid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_runner_repo(monkeypatch, repo)
+    patch_path = _write_patch(
+        repo,
+        "core/rag/allowed.py",
+        "def candidate_value() -> int:\n" "    return 2\n",
+        tmp_path / "invalid-experiment-id.patch",
+    )
+    packet = _base_packet(
+        mutable_path="core/rag/allowed.py",
+        oracle_command='python3 -c "import sys; sys.exit(0)"',
+    )
+    packet["experiment_id"] = "invalid id"
+
+    result = experiment_runner.evaluate_candidate(packet, patch_path)
+
+    assert result["status"] == "rejected"
+    assert result["experiment_id"] == "invalid-experiment"
+    assert result["runner_mode"] == "candidate_patch"
+    assert result["failure_class"] == "policy_violation"
+    assert "experiment_id must contain" in result["budget_observations"]["runner_error"]
+    assert experiment_contract.validate_experiment_result(result)["experiment_id"] == (
+        "invalid-experiment"
     )
 
 


### PR DESCRIPTION
## Goal
Add an explicit `oracle_only_governance_reviewer` mode so Experiment Runner can participate in tooling/governance PRs through advisory local evidence without autonomous mutation authority.

## Business Reason
Experiment Runner should contribute to every non-trivial PR lane, but governance validators and merge/review surfaces must stay protected until a separate threat-model PR opens narrower mutation access.

## Scope
- Document oracle-only governance reviewer participation and canonical co-author semantics.
- Add runner-mode validation to Experiment Runner packets/results.
- Allow oracle-only local result artifacts while forcing `mutated_paths: []` and `promotion_ready: false`.
- Reject oracle-only packets from candidate patch evaluation, promotion, and completion pipeline.
- Add regression coverage for forbidden governance mutation surfaces, tracked context validation, mode mismatch, identity guardrails, and advisory-only result shape.

## Out of Scope
- No runner mutation access to `scripts/ci/**`, `docs/review/**`, `AGENTS.md`, merge gates, review-thread scripts, tests, fixtures, or policy docs.
- No hard merge gate requiring an Experiment Runner artifact on every PR yet.
- No review-thread resolution, PR body mutation, or merge-readiness authority for Experiment Runner.

## Split Justification
This PR is larger than the normal governance threshold because the safe mode requires one coherent contract change across docs, packet/result validation, runner CLI behavior, promotion/notification/pipeline blockers, and regression tests. Splitting docs from enforcement would create a misleading window where the protocol promises oracle-only participation without code-level fail-closed behavior, while splitting tests from code would weaken the governance proof for protected surfaces.

## Files Changed / Likely Touched
- `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`
- `docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.md`
- `scripts/AGENTS.md`
- `scripts/orchestration/experiment_bootstrap.py`
- `scripts/orchestration/experiment_contract.py`
- `scripts/orchestration/experiment_runner.py`
- `scripts/orchestration/experiment_promote.py`
- `scripts/orchestration/experiment_notify.py`
- `scripts/orchestration/experiment_pipeline.py`
- `tests/test_experiment_*.py`
- `docs/review/PR_1773_FIXED_MAPPING.md`

## Key Decisions
- Oracle-only mode treats `mutable_candidate_surface` as tracked PR context, not mutation permission.
- Candidate-patch mode keeps the existing patch requirement and now explicitly rejects governance/review/test/policy surfaces.
- Promotion and notification require packet/result runner-mode alignment.
- Internal git tracking checks sanitize inherited `GIT_*` state so pre-commit parent indexes cannot corrupt temp-repo validation.

## Experiment Runner Evidence
Local oracle-only artifact generated before push:
- Packet: `artifacts/orchestration/experiments/artifacts/orchestration/experiments/packets/oracle-only-pr-participation.json`
- Result: `artifacts/orchestration/experiments/results/artifacts/orchestration/experiments/results/oracle-only-pr-participation.json`
- Status: accepted
- Runner mode: `oracle_only_governance_reviewer`
- Mutated paths: `[]`
- Promotion ready: `false`
- Source diff applied in isolated checkout: `true`
- Oracle return codes: `0, 0, 0`

## Tests / Validation
- `python3 scripts/orchestration/check_preflight.py --path docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md --path docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.md --path scripts/AGENTS.md --path scripts/orchestration/experiment_runner.py --path tests/test_experiment_runner.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/orchestration/check_experiment_runner_identity.py`
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_experiment_runner.py tests/test_experiment_bootstrap.py tests/test_experiment_promote.py tests/test_experiment_notify.py tests/test_experiment_pipeline.py tests/test_experiment_runner_identity_policy.py`
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/guards/test_nosec_policy_guard.py tests/guards/test_subprocess_uses_absolute_binaries.py tests/test_experiment_runner_identity_policy.py`
- `make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python`
- `pre-commit run --all-files`
- Push hooks passed: changed-file mypy, pip-audit, backend tests, full-repo Bandit, docker build test.

Note: bare `make validate-changed` in this secondary worktree forced `VENV_PYTHON="python3"` and failed on missing `fastapi`; the repo-vendored interpreter override above is the successful equivalent for this worktree.

## Security Notes
This PR does not grant mutation authority over governance validators. It adds fail-closed checks for oracle-only mode, packet/result mode mismatch, promotion attempts, pipeline entry, untracked context paths, and inherited git-index contamination.

## Risks / Rollback
Rollback is straightforward: revert this commit to remove the new runner mode and tests. Existing default `candidate_patch` behavior remains the backward-compatible default.

## Deferred / Follow-ups
- A later threat-model PR is required before any runner mutation access to validator scripts or governance surfaces.
- A later hardening PR can decide whether Experiment Runner evidence becomes a hard PR gate after advisory mode proves stable.

## AGENTS.md / Agent Instruction Updates
`scripts/AGENTS.md` now distinguishes default candidate-patch mode from oracle-only governance reviewer mode. This does not remove preflight, task bootstrap, or coordinator-first orchestration.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1773_FIXED_MAPPING.md`

## Merge Readiness
Merge-ready by repo governance for head `efa06b2e68141583c9d64331512e678ae2e14a55` after the final mapping artifact update.

Evidence:
- Current-head CI run `26145193564` passed: `lint`, `security`, `OpenAPI sync`, `test-pr (3.13)`, `coverage-pr`, `diff-coverage`, docs gates, and CI merge-readiness gate.
- Strict local wrapper passed: `GH_TOKEN="$(gh auth token)" GITHUB_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_merge_ready.py --pr-number 1773 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`.
- Review-thread disposition passed: all 9 resolved review threads have disposition proof and commit-after-comment evidence.
- GitHub merge state is `CLEAN`; CodeRabbit, Cubic, Codecov patch, CodeQL, Trivy, Workers, and current-head CI checks are non-blocking clean/pass. Sourcery is `SKIPPED` after weekly diff-character quota exhaustion and posted no new actionable finding.

## Next Best Step
Merge with the canonical repo flow, then fetch/ff-only sync local `main`, remove only this slice worktree, and run post-merge sanity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Oracle-only governance reviewer mode for advisory experiment runs: produces local evidence artifacts, forbids patch application/promotion, propagates runner mode through packets/results, and enforces mode-matching across pipeline steps and notifications.
  * CLI runner-mode option with mode-aware argument rules and validation.

* **Documentation**
  * Expanded governance protocol and identity participation guidance; clarified immutable governance validators and extended forbidden autonomous-mutation surfaces; updated artifact semantics.

* **Tests**
  * Broad coverage for runner modes, packet/result validation, CLI behavior, pipeline/promote guards, notifications, and artifact outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
