### PR TITLE
Experiment Runner PR participation advisory gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -436,7 +436,7 @@ Rules:
 All non-trivial PR work must follow this coordinator-owned lifecycle:
 
 1. **Start**: run preflight, inspect the governing docs, and let coordinator define scope, risks, and required agents before editing code or docs.
-2. **Open / keep draft**: keep the PR in draft until the branch has a coherent scope, the canonical artifact path is known, and local validation is ready to begin.
+2. **Open non-draft by default**: open PRs as ready-for-review once the branch has a coherent scope, initial PR body, and canonical artifact path. Draft PRs require an explicit operator exception because they suppress or delay bot review and current-head merge verification.
 3. **Push cycle**: before each push, run `pre-commit run --all-files` and the applicable local gates; after each push, watch the **current-head** CI state, not stale historical runs.
 4. **Review cycle**: treat every new human or bot comment as coordinator input; record disposition in `docs/review/PR_<N>_FIXED_MAPPING.md` first, update the PR-body mirror second, and re-run merge-readiness checks after the latest activity.
 5. **Merge cycle**: claim merge readiness only after the strict wrapper passes, required current-head checks are green with no pending jobs, no actionable bot comments remain, and the mandatory wait-window has elapsed.

--- a/RUNBOOK_AGENT.md
+++ b/RUNBOOK_AGENT.md
@@ -424,8 +424,9 @@ Use this as the canonical operating loop from branch creation to merge window:
    - Run `python3 scripts/orchestration/check_preflight.py`
    - Read `AGENTS.md`, `RUNBOOK_AGENT.md`, and the nearest scoped `AGENTS.md`
    - Decide scope, risk, and which sub-agents or helpers are needed before edits
-2. **Open / maintain draft**
-   - Keep the PR in draft while scope, artifact strategy, or local gates are still unstable
+2. **Open non-draft by default**
+   - Open the PR ready-for-review once scope, artifact strategy, and initial local gates are coherent so bots and current-head checks run
+   - Use draft only with an explicit operator exception when review/check suppression is intentional
    - Create or confirm the canonical artifact path `docs/review/PR_<N>_FIXED_MAPPING.md`
 3. **Post-open review entry**
    - Once the PR exists, run the mandatory post-open reviewer path declared by the lane packet/runbook before calling the lane stable

--- a/docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md
+++ b/docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md
@@ -50,6 +50,9 @@ This creates the isolated worktree, runs analyze preflight, runs
 `task_bootstrap.py`, and prints the non-blocking plugin/runtime checklist, the
 bootstrap packet summary, and a Codex-ready coordinator-start prompt. It does
 not push, open a PR, install host plugins, or auto-start a raw Codex session.
+When the branch is ready to publish, open the PR non-draft by default so bot
+review and current-head checks run; draft mode is an explicit operator
+exception.
 
 Optional raw-session helper when you only need preflight plus a printed
 bootstrap recipe:

--- a/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
@@ -112,6 +112,12 @@ Rules:
   advisory evidence: either a local oracle-only result artifact or a documented
   `not applicable` reason in the PR lane notes. This is not a merge-readiness
   gate until a later hardening PR explicitly promotes it.
+- PR body mirrors or fixed-mapping artifacts should include
+  `## Experiment Runner Evidence` with either:
+  `Artifact: artifacts/orchestration/experiments/results/<id>.json` or
+  `Not applicable: <reason>`. Phase2 validation reports missing evidence as an
+  advisory diagnostic in the first hardening wave; malformed evidence is a
+  normal gate error because it creates false governance proof.
 - Slack identity is not a cryptographic Git identity. A Slack bot/display
   identity remains a separate security-governed follow-up, not part of this
   experimentation protocol.
@@ -190,6 +196,27 @@ Validator-script mutation access, including any runner mutation of
 `scripts/ci/**`, requires a separate threat-model PR with an explicit allowlist,
 forbidden-surface regression tests, identity/trailer checks, rollback notes, and
 coordinator approval.
+
+### Validator-script mutation threat model (deferred)
+
+This protocol does not grant active Experiment Runner mutation access to
+`scripts/ci/**`. That surface can change the validators that decide whether a
+PR is safe, so it is treated as "rewrite the exam" authority.
+
+A later PR may propose a narrow, disabled-by-default allowlist only if it also
+defines:
+
+- exact validator script paths and purpose;
+- forbidden surfaces that remain immutable, including `AGENTS.md`,
+  `docs/review/**`, merge gates, review-thread scripts, tests, fixtures,
+  policy docs, secrets/config, and CI auth files;
+- deterministic tests proving forbidden surfaces reject candidate patches;
+- identity and co-author trailer checks for any runner-shaped commit;
+- rollback notes and an operator-owned disable path.
+
+Until that later PR lands, candidate-patch mode must continue to reject
+`scripts/ci/**`, and oracle-only mode may evaluate validators only as immutable
+oracles.
 
 ---
 

--- a/docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md
+++ b/docs/orchestration/COORDINATOR_MERGE_READINESS_RULES.md
@@ -83,7 +83,8 @@ Before the final checklist above, coordinator should run the full PR lifecycle e
 
 1. **Initialize the PR correctly**
    - Start with preflight and task analysis.
-   - Keep the PR in draft while scope, artifacts, or local gates are still moving.
+   - Open non-draft by default once scope, initial artifacts, and first local gates are coherent so bot review and current-head checks run.
+   - Use draft only with an explicit operator exception when review/check suppression is intentional.
 2. **Control each push cycle**
    - Run the required local checks before pushing.
    - Watch the latest-head CI run after pushing; do not reason from stale job history alone.
@@ -102,6 +103,7 @@ This lifecycle is mandatory operating behavior, not just a recommendation. The f
 
 - `## Discussion Thread Pass` with checkboxes completed.
 - `### Fixed in Commit Mapping` present as a mirror section for human review.
+- `## Experiment Runner Evidence` with either a local result artifact path or an explicit `Not applicable:` reason. Missing evidence is advisory in the first hardening wave; malformed evidence is a Phase2 error.
 - `## Merge Readiness` section.
 
 Canonical review-thread mappings live in `docs/review/PR_<N>_FIXED_MAPPING.md`. The PR body no longer needs late-cycle URL→SHA duplication once the canonical artifact exists.

--- a/docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.json
+++ b/docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.json
@@ -18,6 +18,27 @@
     "can_push_without_human_review": false,
     "allowed_commit_context": "repo_local_pr_lane_only"
   },
+  "validator_mutation_boundary": {
+    "status": "threat_model_only",
+    "active_mutation_access": false,
+    "requires_later_security_pr": true,
+    "allowlisted_validator_scripts": [],
+    "forbidden_surface_prefixes": [
+      "AGENTS.md",
+      ".github/workflows/",
+      ".env",
+      ".env.",
+      "docs/orchestration/",
+      "docs/review/",
+      "fixtures/",
+      "scripts/ci/",
+      "scripts/orchestration/check_merge_ready.py",
+      "scripts/orchestration/check_review_threads_disposition.py",
+      "tests/"
+    ],
+    "rollback_notes_required": true,
+    "identity_checks_required": true
+  },
   "cryptographic_boundary": {
     "status": "operator_managed_external",
     "verified_account_required": true,

--- a/docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.md
+++ b/docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.md
@@ -44,6 +44,9 @@ Forbidden in this repository:
 - treating a Git email address as proof of machine authorship,
 - granting the Experiment Runner merge rights,
 - allowing the Experiment Runner to resolve review threads or claim merge readiness.
+- allowing the Experiment Runner to mutate `scripts/ci/**` validator scripts
+  without a later threat-model PR that defines a narrow allowlist, forbidden
+  surfaces, tests, identity checks, and rollback notes.
 
 The Experiment Runner may be a co-author or local PR-lane author only when a human/coordinator-owned process keeps normal PR governance in force.
 
@@ -51,6 +54,13 @@ For oracle-only PR participation, attribution is evidence-based. Add the
 canonical co-author trailer only when the local Experiment Runner result
 artifact materially shaped the human-reviewed commit. Do not add the trailer to
 unrelated human-only commits merely because the PR lane ran the advisory oracle.
+
+Every non-trivial PR lane should record Experiment Runner participation in an
+`Experiment Runner Evidence` block: either a local oracle-only result artifact
+under `artifacts/orchestration/experiments/results/` or an explicit
+`Not applicable:` reason. This evidence is advisory until the merge-readiness
+gate is deliberately promoted in a later PR; malformed evidence is still
+rejected because it can misrepresent runner participation.
 
 ## Notification Boundary
 

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -48,6 +48,7 @@ PR body **may mirror** the same review-governance sections for human review and 
 - `### Fixed in Commit Mapping`
 - completed checkboxes matching the artifact
 - full URL→SHA mapping lines are required only in the canonical artifact when `pr_number` is available
+- optional advisory `## Experiment Runner Evidence` in the PR body mirror or canonical artifact
 
 Canonical runtime behavior is artifact-first when `pr_number` is available.
 PR-body parsing is a temporary compatibility seam for local/body-only checks and human-readable review context. When `pr_number` is available, Phase 2 treats the artifact as authoritative and the PR body as an optional mirror-only surface.
@@ -69,6 +70,7 @@ Required sections:
 - Checkbox contract (completed / mapping completed)
 - `## Fixed in Commit Mapping` in the canonical artifact
 - `### Fixed in Commit Mapping` in the optional PR-body mirror
+- Advisory `## Experiment Runner Evidence` with `Artifact: artifacts/orchestration/experiments/results/<id>.json` or `Not applicable: <reason>` in either the PR body mirror or canonical artifact; missing evidence is advisory until a later PR promotes it to a hard gate, while malformed evidence is rejected.
 
 Valid mapping forms in the canonical artifact:
 

--- a/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
+++ b/docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md
@@ -64,7 +64,7 @@ Exit criteria for removing PR-body fallback:
 2. Local tooling supports deterministic artifact lookup without PR-body parsing.
 3. The fallback branch in `scripts/ci/check_pr_body_phase2_gates.py` can be removed without losing local validation ergonomics.
 
-Required sections:
+Phase 2 sections and advisory evidence:
 
 - `## Discussion Thread Pass`
 - Checkbox contract (completed / mapping completed)

--- a/docs/review/PR_1775_FIXED_MAPPING.md
+++ b/docs/review/PR_1775_FIXED_MAPPING.md
@@ -45,9 +45,13 @@ Local oracle-only artifact, gitignored and not committed. Runner mode:
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#pullrequestreview-4327750134 -> 1b2db1285
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#discussion_r3273330030 -> 1b2db1285
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#discussion_r3273330040 -> 1b2db1285
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#pullrequestreview-4327886137 -> 8a4a1922d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#discussion_r3273437604 -> 8a4a1922d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#pullrequestreview-4327924616 -> 8a4a1922d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#discussion_r3273469191 -> 8a4a1922d
 Disposition: FIXED
-Commit: 1b2db1285
-Evidence: scripts/ci/check_pr_body_phase2_gates.py routes Experiment Runner advisory warnings through checker results and reuses a shared markdown section extractor.
+Commit: 1b2db1285, 8a4a1922d
+Evidence: scripts/ci/check_pr_body_phase2_gates.py routes Experiment Runner advisory warnings through checker results, reuses a shared markdown section extractor, and stops mapping extraction before sibling h3 sections. docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md clarifies advisory evidence wording. docs/review/PR_1775_FIXED_MAPPING.md uses portable validation command paths.
 
 ## Deferred / Follow-ups
 

--- a/docs/review/PR_1775_FIXED_MAPPING.md
+++ b/docs/review/PR_1775_FIXED_MAPPING.md
@@ -45,13 +45,17 @@ Local oracle-only artifact, gitignored and not committed. Runner mode:
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#pullrequestreview-4327750134 -> 1b2db1285
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#discussion_r3273330030 -> 1b2db1285
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#discussion_r3273330040 -> 1b2db1285
+Disposition: FIXED
+Commit: 1b2db1285
+Evidence: scripts/ci/check_pr_body_phase2_gates.py routes Experiment Runner advisory warnings through checker results and reuses a shared markdown section extractor.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#pullrequestreview-4327886137 -> 8a4a1922d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#discussion_r3273437604 -> 8a4a1922d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#pullrequestreview-4327924616 -> 8a4a1922d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#discussion_r3273469191 -> 8a4a1922d
 Disposition: FIXED
-Commit: 1b2db1285, 8a4a1922d
-Evidence: scripts/ci/check_pr_body_phase2_gates.py routes Experiment Runner advisory warnings through checker results, reuses a shared markdown section extractor, and stops mapping extraction before sibling h3 sections. docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md clarifies advisory evidence wording. docs/review/PR_1775_FIXED_MAPPING.md uses portable validation command paths.
+Commit: 8a4a1922d
+Evidence: scripts/ci/check_pr_body_phase2_gates.py stops mapping extraction before sibling h3 sections. docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md clarifies advisory evidence wording. docs/review/PR_1775_FIXED_MAPPING.md uses portable validation command paths.
 
 ## Deferred / Follow-ups
 

--- a/docs/review/PR_1775_FIXED_MAPPING.md
+++ b/docs/review/PR_1775_FIXED_MAPPING.md
@@ -57,6 +57,14 @@ Disposition: FIXED
 Commit: 8a4a1922d
 Evidence: scripts/ci/check_pr_body_phase2_gates.py:136 stops mapping extraction before sibling h3 sections; tests/test_pr_body_phase2_gates.py:120 validates that sibling h3 content is not parsed as mapping. docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:67 clarifies advisory evidence wording. docs/review/PR_1775_FIXED_MAPPING.md:24 uses portable validation command paths. Validation: `python3 -m pytest -q tests/test_pr_body_phase2_gates.py` -> PASS.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#pullrequestreview-4328106978 -> dbf193ce5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#discussion_r3273618860 -> dbf193ce5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#discussion_r3273557874 -> dbf193ce5
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#discussion_r3273557883 -> dbf193ce5
+Disposition: FIXED
+Commit: dbf193ce5
+Evidence: scripts/ci/check_pr_body_phase2_gates.py:156 rejects empty artifact basenames and Windows-style backslash traversal; scripts/ci/check_pr_body_phase2_gates.py:333 skips optional mirror checklist enforcement when artifact-first mode has no Phase2 mirror block. tests/test_pr_body_phase2_gates.py:164 covers empty artifact basenames; tests/test_pr_body_phase2_gates.py:173 covers Windows-style traversal; tests/test_pr_body_phase2_gates.py:403 covers artifact-first PR bodies without mirrors. docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-experiment-runner-pr-evidence-hard-gate and docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-experiment-runner-validator-mutation-threat-model track deferred follow-ups. Validation: `python3 -m pytest -q tests/test_pr_body_phase2_gates.py` -> PASS.
+
 ## Deferred / Follow-ups
 
 - Later PR: hard merge gate requiring Experiment Runner evidence for every non-trivial PR after advisory signal proves stable. Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-experiment-runner-pr-evidence-hard-gate

--- a/docs/review/PR_1775_FIXED_MAPPING.md
+++ b/docs/review/PR_1775_FIXED_MAPPING.md
@@ -42,7 +42,10 @@ Local oracle-only artifact, gitignored and not committed. Runner mode:
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#pullrequestreview-4327750134 -> 1b2db1285
+Disposition: FIXED
+Commit: 1b2db1285
+Evidence: scripts/ci/check_pr_body_phase2_gates.py routes Experiment Runner advisory warnings through checker results and reuses a shared markdown section extractor.
 
 ## Deferred / Follow-ups
 

--- a/docs/review/PR_1775_FIXED_MAPPING.md
+++ b/docs/review/PR_1775_FIXED_MAPPING.md
@@ -43,6 +43,8 @@ Local oracle-only artifact, gitignored and not committed. Runner mode:
 ## Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#pullrequestreview-4327750134 -> 1b2db1285
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#discussion_r3273330030 -> 1b2db1285
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#discussion_r3273330040 -> 1b2db1285
 Disposition: FIXED
 Commit: 1b2db1285
 Evidence: scripts/ci/check_pr_body_phase2_gates.py routes Experiment Runner advisory warnings through checker results and reuses a shared markdown section extractor.

--- a/docs/review/PR_1775_FIXED_MAPPING.md
+++ b/docs/review/PR_1775_FIXED_MAPPING.md
@@ -21,9 +21,9 @@ Local oracle-only artifact, gitignored and not committed. Runner mode:
 - `python3 scripts/orchestration/check_preflight.py --path <changed paths>` - PASS
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS
 - `python3 scripts/orchestration/check_experiment_runner_identity.py` - PASS
-- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_render_codex_start_prompt.py tests/test_local_session_bootstrap.py tests/test_pr_body_phase2_gates.py tests/test_start_pr_lane.py tests/test_experiment_runner.py tests/test_experiment_runner_identity_policy.py tests/test_orchestration_merge_ready.py` - PASS
-- `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` - PASS
-- `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH PRE_COMMIT_HOME=/tmp/pulseplate-precommit-experiment-runner-gate pre-commit run --all-files` - PASS
+- `python3 -m pytest -q tests/test_render_codex_start_prompt.py tests/test_local_session_bootstrap.py tests/test_pr_body_phase2_gates.py tests/test_start_pr_lane.py tests/test_experiment_runner.py tests/test_experiment_runner_identity_policy.py tests/test_orchestration_merge_ready.py` - PASS
+- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed` - PASS
+- `PATH=.venv/bin:$PATH PRE_COMMIT_HOME=/tmp/pulseplate-precommit-experiment-runner-gate pre-commit run --all-files` - PASS
 - Pre-push hook - PASS: changed-file mypy, pip-audit, backend pytest, full-repo Bandit, docker build test
 
 ## Role Review

--- a/docs/review/PR_1775_FIXED_MAPPING.md
+++ b/docs/review/PR_1775_FIXED_MAPPING.md
@@ -37,12 +37,12 @@ Local oracle-only artifact, gitignored and not committed. Runner mode:
 
 ## Discussion Thread Pass
 
-- [x] Initial discussion-thread pass completed before opening.
-- [x] No actionable review comments existed at PR open time.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-- No review-thread fixes are claimed yet.
+- No actionable review comments
 
 ## Deferred / Follow-ups
 

--- a/docs/review/PR_1775_FIXED_MAPPING.md
+++ b/docs/review/PR_1775_FIXED_MAPPING.md
@@ -55,12 +55,12 @@ Evidence: scripts/ci/check_pr_body_phase2_gates.py routes Experiment Runner advi
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1775#discussion_r3273469191 -> 8a4a1922d
 Disposition: FIXED
 Commit: 8a4a1922d
-Evidence: scripts/ci/check_pr_body_phase2_gates.py stops mapping extraction before sibling h3 sections. docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md clarifies advisory evidence wording. docs/review/PR_1775_FIXED_MAPPING.md uses portable validation command paths.
+Evidence: scripts/ci/check_pr_body_phase2_gates.py:136 stops mapping extraction before sibling h3 sections; tests/test_pr_body_phase2_gates.py:120 validates that sibling h3 content is not parsed as mapping. docs/orchestration/PR_ORCHESTRATION_CONTRACT_MATRIX.md:67 clarifies advisory evidence wording. docs/review/PR_1775_FIXED_MAPPING.md:24 uses portable validation command paths. Validation: `python3 -m pytest -q tests/test_pr_body_phase2_gates.py` -> PASS.
 
 ## Deferred / Follow-ups
 
-- Later PR: hard merge gate requiring Experiment Runner evidence for every non-trivial PR after advisory signal proves stable.
-- Later PR: controlled validator-script mutation access threat model with allowlist, forbidden-surface tests, identity checks, and rollback notes.
+- Later PR: hard merge gate requiring Experiment Runner evidence for every non-trivial PR after advisory signal proves stable. Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-experiment-runner-pr-evidence-hard-gate
+- Later PR: controlled validator-script mutation access threat model with allowlist, forbidden-surface tests, identity checks, and rollback notes. Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-experiment-runner-validator-mutation-threat-model
 
 ## Merge Readiness
 

--- a/docs/review/PR_1775_FIXED_MAPPING.md
+++ b/docs/review/PR_1775_FIXED_MAPPING.md
@@ -1,0 +1,55 @@
+# PR #1775 - Fixed in Commit Mapping
+
+## Scope
+
+Experiment Runner PR participation advisory gate and threat-model-only bootstrap for
+future validator-script mutation access.
+
+## Implementation Commits
+
+- `741b20708` - `chore(orchestration): add experiment runner PR evidence gate`
+
+## Experiment Runner Evidence
+
+Artifact: artifacts/orchestration/experiments/results/exp-65d109111b8a.json
+
+Local oracle-only artifact, gitignored and not committed. Runner mode:
+`oracle_only_governance_reviewer`; `mutated_paths: []`; `promotion_ready: false`.
+
+## Local Validation
+
+- `python3 scripts/orchestration/check_preflight.py --path <changed paths>` - PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` - PASS
+- `python3 scripts/orchestration/check_experiment_runner_identity.py` - PASS
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_render_codex_start_prompt.py tests/test_local_session_bootstrap.py tests/test_pr_body_phase2_gates.py tests/test_start_pr_lane.py tests/test_experiment_runner.py tests/test_experiment_runner_identity_policy.py tests/test_orchestration_merge_ready.py` - PASS
+- `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` - PASS
+- `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH PRE_COMMIT_HOME=/tmp/pulseplate-precommit-experiment-runner-gate pre-commit run --all-files` - PASS
+- Pre-push hook - PASS: changed-file mypy, pip-audit, backend pytest, full-repo Bandit, docker build test
+
+## Role Review
+
+- agent-coordinator: PASS - scope kept to governance/tooling, advisory evidence, and fail-closed mutation boundary.
+- architecture-specialist: FIXED - starter prompt now separates requested role seed from the default PR review checklist.
+- security-auditor: FIXED - governed identity policy requires `scripts/ci/` as a forbidden runner mutation surface.
+- qa-engineer-agent: FIXED - starter prompt tests cover coordinator-first repo commands and non-draft default.
+- bug-hunter: NOT-A-BUG - Experiment Runner evidence may be supplied by PR body or fixed-mapping artifact per approved Phase2 advisory contract.
+- dev-operator: PASS - branch push and non-draft PR open path verified.
+
+## Discussion Thread Pass
+
+- [x] Initial discussion-thread pass completed before opening.
+- [x] No actionable review comments existed at PR open time.
+
+## Fixed in Commit Mapping
+
+- No review-thread fixes are claimed yet.
+
+## Deferred / Follow-ups
+
+- Later PR: hard merge gate requiring Experiment Runner evidence for every non-trivial PR after advisory signal proves stable.
+- Later PR: controlled validator-script mutation access threat model with allowlist, forbidden-surface tests, identity checks, and rollback notes.
+
+## Merge Readiness
+
+Not claimed. Current-head PR CI, bot review, post-open review-thread disposition,
+wait-window, and strict merge wrapper remain required before merge readiness.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -9939,6 +9939,34 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Immutable oracle mutation is rejected fail-closed
     - Runner outputs candidate result artifacts, not autonomous merge-ready commits
 
+<a id="ledger-p2-experiment-runner-pr-evidence-hard-gate"></a>
+- [ ] P2: Promote Experiment Runner PR evidence from advisory to hard gate
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2 (review-governance hardening after advisory signal proves stable)
+  - Target PR: Future governance PR after PR #1775 advisory rollout
+  - Status: 📋 Deferred from PR #1775
+  - Dependencies:
+    - [P1: PR3 experiment runner MVP for bounded candidate loops](#ledger-p1-agent-experiment-runner)
+  - Reason (EN): PR #1775 introduces Phase2 advisory Experiment Runner evidence for non-trivial PR lanes. A later PR should promote that evidence to a hard merge gate only after the advisory signal is stable and false-positive behavior is understood.
+  - DoD:
+    - `check_merge_ready.py` blocks non-trivial PRs missing valid Experiment Runner evidence or an explicit not-applicable reason
+    - PR-body and fixed-mapping validators share one parser contract for artifact paths and not-applicable reasons
+    - Rollback notes document how to return the gate to advisory mode if review throughput regresses
+
+<a id="ledger-p2-experiment-runner-validator-mutation-threat-model"></a>
+- [ ] P2: Threat-model controlled Experiment Runner validator-script mutation access
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P2 (privileged governance-surface safety)
+  - Target PR: Future security-reviewed governance PR after PR #1775
+  - Status: 📋 Deferred from PR #1775
+  - Dependencies:
+    - [P1: PR3 experiment runner MVP for bounded candidate loops](#ledger-p1-agent-experiment-runner)
+  - Reason (EN): PR #1775 keeps `scripts/ci/**` mutation access disabled and fail-closed. Any future mutation access needs a separate threat model, explicit allowlist shape, forbidden-surface regression tests, identity/trailer checks, and rollback notes before the runner can touch validator scripts.
+  - DoD:
+    - Security threat model covers validator-script authority, review-thread authority, merge-gate authority, and rollback
+    - Allowlist defaults to empty/fail-closed and has regression tests for forbidden governance surfaces
+    - Identity checks require `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>` when runner artifacts materially shape commits
+
 <a id="ledger-p1-agent-experiment-promotion"></a>
 - [x] P1: PR4 experiment promotion and telemetry integration
   - Owner: @katsiaryna_kavaleuskaya

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -31,6 +31,10 @@
   gates, review-thread scripts, tests, fixtures, or policy docs is forbidden
   unless a separate threat-model PR explicitly opens a narrow allowlist with
   tests and rollback notes.
+- The current validator-script mutation threat model is fail-closed: no active
+  runner mutation of `scripts/ci/**` is allowed until a later PR promotes a
+  reviewed allowlist, forbidden-surface tests, identity checks, and rollback
+  notes.
 - Result artifacts stay local under `artifacts/orchestration/experiments/results/` and are evidence only, not merge-ready or promotion-ready output.
 - `experiment_notify.py` follows the notification contract in
   `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`: local artifact output

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -57,6 +57,11 @@ EXPERIMENT_RUNNER_ARTIFACT_RE = re.compile(
 )
 EXPERIMENT_RUNNER_NA_RE = re.compile(r"(?im)^\s*(?:-\s*)?Not applicable:\s*(?P<reason>\S.+?)\s*$")
 EXPERIMENT_RUNNER_ARTIFACT_PREFIX = "artifacts/orchestration/experiments/results/"
+MISSING_EXPERIMENT_RUNNER_EVIDENCE_WARNING = (
+    "Advisory: missing `## Experiment Runner Evidence` section with "
+    "`Artifact: artifacts/orchestration/experiments/results/<id>.json` "
+    "or `Not applicable: <reason>`."
+)
 
 
 class BodyValidationMode(str, Enum):
@@ -110,29 +115,42 @@ def _extract_pr_body(event_path: Path) -> str:
     return body if isinstance(body, str) else ""
 
 
-def _extract_mapping_section(text: str) -> str:
-    """Return content of the last ### Fixed in Commit Mapping section."""
-    matches = list(MAPPING_SECTION_RE.finditer(text))
+def _extract_markdown_section(
+    text: str,
+    *,
+    level: str,
+    title: str,
+    stop_at_heading_level: int,
+) -> str:
+    """Return content of the last matching markdown section."""
+    matches = list(_section_heading_re(level, title).finditer(text))
     if not matches:
         return ""
     match = matches[-1]
     start = match.end()
-    next_h2 = re.search(r"(?im)^\s*##\s+", text[start:])
-    end = start + next_h2.start() if next_h2 else len(text)
+    next_heading = re.search(rf"(?im)^\s*#{{1,{stop_at_heading_level}}}\s+", text[start:])
+    end = start + next_heading.start() if next_heading else len(text)
     return text[start:end]
+
+
+def _extract_mapping_section(text: str) -> str:
+    """Return content of the last ### Fixed in Commit Mapping section."""
+    return _extract_markdown_section(
+        text,
+        level="###",
+        title=str(PHASE2_CONFIG["mapping_heading"]),
+        stop_at_heading_level=2,
+    )
 
 
 def _extract_section_by_h2(text: str, heading: str) -> str:
     """Return content of the last matching H2 section."""
-    heading_re = _section_heading_re("##", heading)
-    matches = list(heading_re.finditer(text))
-    if not matches:
-        return ""
-    match = matches[-1]
-    start = match.end()
-    next_h2 = re.search(r"(?im)^\s*##\s+", text[start:])
-    end = start + next_h2.start() if next_h2 else len(text)
-    return text[start:end]
+    return _extract_markdown_section(
+        text,
+        level="##",
+        title=heading,
+        stop_at_heading_level=2,
+    )
 
 
 def _valid_experiment_runner_artifact_path(path: str) -> bool:
@@ -158,11 +176,7 @@ def check_experiment_runner_evidence(text: str) -> tuple[list[str], list[str]]:
     cleaned = _strip_fenced_code_blocks(text)
     section = _extract_section_by_h2(cleaned, str(PHASE2_CONFIG["experiment_runner_heading"]))
     if not section:
-        return [], [
-            "Advisory: missing `## Experiment Runner Evidence` section with "
-            "`Artifact: artifacts/orchestration/experiments/results/<id>.json` "
-            "or `Not applicable: <reason>`."
-        ]
+        return [], [MISSING_EXPERIMENT_RUNNER_EVIDENCE_WARNING]
 
     artifact_matches = list(EXPERIMENT_RUNNER_ARTIFACT_RE.finditer(section))
     na_matches = list(EXPERIMENT_RUNNER_NA_RE.finditer(section))
@@ -290,6 +304,7 @@ def main() -> int:
     artifact_errors: list[str] = []
     body_errors: list[str] = []
     advisory_warnings: list[str] = []
+    evidence_warning_candidates: list[str] = []
     experiment_runner_evidence_seen = False
 
     if pr_number is not None:
@@ -302,6 +317,7 @@ def main() -> int:
         artifact_errors.extend(validate_mapping_artifact_text(artifact_text))
         evidence_errors, evidence_warnings = check_experiment_runner_evidence(artifact_text)
         artifact_errors.extend(evidence_errors)
+        evidence_warning_candidates.extend(evidence_warnings)
         if not evidence_errors and not evidence_warnings:
             experiment_runner_evidence_seen = True
 
@@ -315,6 +331,7 @@ def main() -> int:
         )
         evidence_errors, evidence_warnings = check_experiment_runner_evidence(body)
         body_errors.extend(evidence_errors)
+        evidence_warning_candidates.extend(evidence_warnings)
         if not evidence_errors and not evidence_warnings:
             experiment_runner_evidence_seen = True
     elif not artifact_checked:
@@ -322,11 +339,7 @@ def main() -> int:
         return 1
 
     if not experiment_runner_evidence_seen:
-        advisory_warnings.append(
-            "Advisory: missing `## Experiment Runner Evidence` section with "
-            "`Artifact: artifacts/orchestration/experiments/results/<id>.json` "
-            "or `Not applicable: <reason>`."
-        )
+        advisory_warnings.extend(dict.fromkeys(evidence_warning_candidates))
 
     errors = [*artifact_errors, *body_errors]
     if errors:

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -156,13 +156,22 @@ def _extract_section_by_h2(text: str, heading: str) -> str:
 def _valid_experiment_runner_artifact_path(path: str) -> bool:
     """Return True for local Experiment Runner result artifacts only."""
     cleaned = path.strip().strip("`")
+    if "\\" in cleaned:
+        return False
     if not cleaned.endswith(".json"):
         return False
     if cleaned.startswith(("/", "../", "./")):
         return False
     if "/../" in cleaned or cleaned.endswith("/.."):
         return False
-    return cleaned.startswith(EXPERIMENT_RUNNER_ARTIFACT_PREFIX)
+    if not cleaned.startswith(EXPERIMENT_RUNNER_ARTIFACT_PREFIX):
+        return False
+
+    relative_path = cleaned.removeprefix(EXPERIMENT_RUNNER_ARTIFACT_PREFIX)
+    path_parts = relative_path.split("/")
+    if any(part in ("", ".", "..") for part in path_parts):
+        return False
+    return len(path_parts[-1].removesuffix(".json")) > 0
 
 
 def check_experiment_runner_evidence(text: str) -> tuple[list[str], list[str]]:
@@ -322,14 +331,21 @@ def main() -> int:
             experiment_runner_evidence_seen = True
 
     if body.strip():
-        body_checked = True
-        body_errors.extend(
-            check_pr_body_phase2_gates(
-                body=body,
-                mode=_select_body_validation_mode(artifact_checked=artifact_checked),
-            )
+        cleaned_body = _strip_fenced_code_blocks(body)
+        has_phase2_mirror = bool(
+            DISCUSSION_SECTION_RE.search(cleaned_body) or MAPPING_SECTION_RE.search(cleaned_body)
         )
+        if not artifact_checked or has_phase2_mirror:
+            body_checked = True
+            body_errors.extend(
+                check_pr_body_phase2_gates(
+                    body=body,
+                    mode=_select_body_validation_mode(artifact_checked=artifact_checked),
+                )
+            )
         evidence_errors, evidence_warnings = check_experiment_runner_evidence(body)
+        if evidence_errors:
+            body_checked = True
         body_errors.extend(evidence_errors)
         evidence_warning_candidates.extend(evidence_warnings)
         if not evidence_errors and not evidence_warnings:

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -139,7 +139,7 @@ def _extract_mapping_section(text: str) -> str:
         text,
         level="###",
         title=str(PHASE2_CONFIG["mapping_heading"]),
-        stop_at_heading_level=2,
+        stop_at_heading_level=3,
     )
 
 

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -21,6 +21,7 @@ from scripts.orchestration.review_mapping_artifact import (
 PHASE2_CONFIG = {
     "discussion_heading": "Discussion Thread Pass",
     "mapping_heading": "Fixed in Commit Mapping",
+    "experiment_runner_heading": "Experiment Runner Evidence",
     "discussion_checkbox_label": "Discussion-thread pass completed",
     "mapping_checkbox_label": "Fixed in commit mapping completed",
     "mapping_na_alternatives": ("N/A", "No actionable review comments"),
@@ -39,6 +40,9 @@ def _checkbox_re(label: str) -> re.Pattern[str]:
 
 DISCUSSION_SECTION_RE = _section_heading_re("##", str(PHASE2_CONFIG["discussion_heading"]))
 MAPPING_SECTION_RE = _section_heading_re("###", str(PHASE2_CONFIG["mapping_heading"]))
+EXPERIMENT_RUNNER_SECTION_RE = _section_heading_re(
+    "##", str(PHASE2_CONFIG["experiment_runner_heading"])
+)
 DISCUSSION_CHECKBOX_RE = _checkbox_re(str(PHASE2_CONFIG["discussion_checkbox_label"]))
 MAPPING_CHECKBOX_RE = _checkbox_re(str(PHASE2_CONFIG["mapping_checkbox_label"]))
 
@@ -48,6 +52,11 @@ MAPPING_ENTRY_RE = re.compile(
 THREAD_ENTRY_RE = re.compile(r"(?im)^\s*-\s*`?(https?://[^\s`]+)`?\s*$")
 _na_alternatives = "|".join(re.escape(a) for a in PHASE2_CONFIG["mapping_na_alternatives"])
 MAPPING_NA_RE = re.compile(rf"(?im)^\s*-\s*(?:{_na_alternatives})\s*$")
+EXPERIMENT_RUNNER_ARTIFACT_RE = re.compile(
+    r"(?im)^\s*(?:-\s*)?Artifact:\s*`?(?P<path>[^`\s]+)`?\s*$"
+)
+EXPERIMENT_RUNNER_NA_RE = re.compile(r"(?im)^\s*(?:-\s*)?Not applicable:\s*(?P<reason>\S.+?)\s*$")
+EXPERIMENT_RUNNER_ARTIFACT_PREFIX = "artifacts/orchestration/experiments/results/"
 
 
 class BodyValidationMode(str, Enum):
@@ -111,6 +120,86 @@ def _extract_mapping_section(text: str) -> str:
     next_h2 = re.search(r"(?im)^\s*##\s+", text[start:])
     end = start + next_h2.start() if next_h2 else len(text)
     return text[start:end]
+
+
+def _extract_section_by_h2(text: str, heading: str) -> str:
+    """Return content of the last matching H2 section."""
+    heading_re = _section_heading_re("##", heading)
+    matches = list(heading_re.finditer(text))
+    if not matches:
+        return ""
+    match = matches[-1]
+    start = match.end()
+    next_h2 = re.search(r"(?im)^\s*##\s+", text[start:])
+    end = start + next_h2.start() if next_h2 else len(text)
+    return text[start:end]
+
+
+def _valid_experiment_runner_artifact_path(path: str) -> bool:
+    """Return True for local Experiment Runner result artifacts only."""
+    cleaned = path.strip().strip("`")
+    if not cleaned.endswith(".json"):
+        return False
+    if cleaned.startswith(("/", "../", "./")):
+        return False
+    if "/../" in cleaned or cleaned.endswith("/.."):
+        return False
+    return cleaned.startswith(EXPERIMENT_RUNNER_ARTIFACT_PREFIX)
+
+
+def check_experiment_runner_evidence(text: str) -> tuple[list[str], list[str]]:
+    """Validate advisory Experiment Runner evidence.
+
+    Missing evidence is a warning for this PR series. Malformed evidence is an
+    error because an invalid path or empty N/A reason creates false governance
+    proof.
+    """
+
+    cleaned = _strip_fenced_code_blocks(text)
+    section = _extract_section_by_h2(cleaned, str(PHASE2_CONFIG["experiment_runner_heading"]))
+    if not section:
+        return [], [
+            "Advisory: missing `## Experiment Runner Evidence` section with "
+            "`Artifact: artifacts/orchestration/experiments/results/<id>.json` "
+            "or `Not applicable: <reason>`."
+        ]
+
+    artifact_matches = list(EXPERIMENT_RUNNER_ARTIFACT_RE.finditer(section))
+    na_matches = list(EXPERIMENT_RUNNER_NA_RE.finditer(section))
+    errors: list[str] = []
+
+    if artifact_matches and na_matches:
+        errors.append(
+            "Experiment Runner Evidence must use either Artifact or Not applicable, not both."
+        )
+
+    if artifact_matches:
+        invalid_paths = [
+            match.group("path")
+            for match in artifact_matches
+            if not _valid_experiment_runner_artifact_path(match.group("path"))
+        ]
+        if invalid_paths:
+            errors.append(
+                "Experiment Runner artifact path must stay under "
+                f"`{EXPERIMENT_RUNNER_ARTIFACT_PREFIX}` and end with `.json`: "
+                + ", ".join(invalid_paths)
+            )
+
+    if na_matches:
+        empty_reasons = [
+            match.group("reason") for match in na_matches if len(match.group("reason").strip()) < 8
+        ]
+        if empty_reasons:
+            errors.append("Experiment Runner not-applicable reason must be explicit.")
+
+    if not artifact_matches and not na_matches:
+        errors.append(
+            "Experiment Runner Evidence must include `Artifact: ...` or "
+            "`Not applicable: <reason>`."
+        )
+
+    return errors, []
 
 
 def _select_body_validation_mode(*, artifact_checked: bool) -> BodyValidationMode:
@@ -200,6 +289,8 @@ def main() -> int:
     body_checked = False
     artifact_errors: list[str] = []
     body_errors: list[str] = []
+    advisory_warnings: list[str] = []
+    experiment_runner_evidence_seen = False
 
     if pr_number is not None:
         try:
@@ -209,6 +300,10 @@ def main() -> int:
             return 1
         artifact_checked = True
         artifact_errors.extend(validate_mapping_artifact_text(artifact_text))
+        evidence_errors, evidence_warnings = check_experiment_runner_evidence(artifact_text)
+        artifact_errors.extend(evidence_errors)
+        if not evidence_errors and not evidence_warnings:
+            experiment_runner_evidence_seen = True
 
     if body.strip():
         body_checked = True
@@ -218,9 +313,20 @@ def main() -> int:
                 mode=_select_body_validation_mode(artifact_checked=artifact_checked),
             )
         )
+        evidence_errors, evidence_warnings = check_experiment_runner_evidence(body)
+        body_errors.extend(evidence_errors)
+        if not evidence_errors and not evidence_warnings:
+            experiment_runner_evidence_seen = True
     elif not artifact_checked:
         print("ERROR: Empty PR body. Fill the required Phase2 checklist sections.")
         return 1
+
+    if not experiment_runner_evidence_seen:
+        advisory_warnings.append(
+            "Advisory: missing `## Experiment Runner Evidence` section with "
+            "`Artifact: artifacts/orchestration/experiments/results/<id>.json` "
+            "or `Not applicable: <reason>`."
+        )
 
     errors = [*artifact_errors, *body_errors]
     if errors:
@@ -232,6 +338,9 @@ def main() -> int:
         for item in errors:
             print(f"- {item}")
         return 1
+
+    for item in advisory_warnings:
+        print(f"WARNING: {item}")
 
     if artifact_checked and body_checked:
         print("phase2-pr-body-gates: canonical mapping artifact and PR body mirror passed.")

--- a/scripts/orchestration/check_experiment_runner_identity.py
+++ b/scripts/orchestration/check_experiment_runner_identity.py
@@ -81,6 +81,7 @@ CANONICAL_BOUNDARY_KEYS = frozenset(
         "git_attribution",
         "notification_boundary",
         "slack_identity",
+        "validator_mutation_boundary",
     }
 )
 
@@ -316,6 +317,42 @@ def validate_identity_policy(payload: dict[str, Any]) -> dict[str, Any]:
     if authority_boundary.get("allowed_commit_context") != "repo_local_pr_lane_only":
         raise IdentityPolicyError(
             "authority_boundary.allowed_commit_context must be repo_local_pr_lane_only."
+        )
+
+    validator_boundary = _require_mapping(payload, "validator_mutation_boundary")
+    if validator_boundary.get("status") != "threat_model_only":
+        raise IdentityPolicyError("validator_mutation_boundary.status must be threat_model_only.")
+    _require_bool(validator_boundary, "active_mutation_access", False)
+    _require_bool(validator_boundary, "requires_later_security_pr", True)
+    _require_bool(validator_boundary, "rollback_notes_required", True)
+    _require_bool(validator_boundary, "identity_checks_required", True)
+    allowlisted = validator_boundary.get("allowlisted_validator_scripts")
+    if allowlisted != []:
+        raise IdentityPolicyError(
+            "validator_mutation_boundary.allowlisted_validator_scripts must be empty."
+        )
+    forbidden = validator_boundary.get("forbidden_surface_prefixes")
+    if not isinstance(forbidden, list) or not all(isinstance(item, str) for item in forbidden):
+        raise IdentityPolicyError(
+            "validator_mutation_boundary.forbidden_surface_prefixes must be a list of strings."
+        )
+    required_forbidden = {
+        "AGENTS.md",
+        ".github/workflows/",
+        ".env",
+        ".env.",
+        "docs/orchestration/",
+        "docs/review/",
+        "fixtures/",
+        "scripts/ci/",
+        "scripts/orchestration/check_merge_ready.py",
+        "scripts/orchestration/check_review_threads_disposition.py",
+        "tests/",
+    }
+    if not required_forbidden.issubset(set(forbidden)):
+        raise IdentityPolicyError(
+            "validator_mutation_boundary.forbidden_surface_prefixes is missing required "
+            "governance surfaces."
         )
 
     cryptographic_boundary = _require_mapping(payload, "cryptographic_boundary")

--- a/scripts/orchestration/check_merge_ready.py
+++ b/scripts/orchestration/check_merge_ready.py
@@ -270,6 +270,10 @@ def _print_merge_ready_bundle() -> None:
         )
     print("Advisory / external signals:")
     print("- third-party review bots remain advisory unless GitHub branch protection promotes them")
+    print(
+        "- Experiment Runner Evidence is advisory in this phase; Phase2 reports missing "
+        "oracle-only artifact or not-applicable reason without blocking merge readiness"
+    )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/orchestration/render_codex_start_prompt.py
+++ b/scripts/orchestration/render_codex_start_prompt.py
@@ -10,6 +10,14 @@ from pathlib import Path
 from typing import Any, Iterable
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_PR_REVIEW_CHECKLIST = (
+    "agent-coordinator",
+    "architecture-specialist",
+    "security-auditor",
+    "qa-engineer-agent",
+    "bug-hunter",
+    "dev-operator",
+)
 
 
 class PromptError(ValueError):
@@ -142,10 +150,13 @@ def render_packet_prompt(
             f"Worktree: {_prompt_text(worktree, '<worktree unavailable>')}",
             f"Path scope: {_prompt_list(candidate_paths, '<no explicit paths>')}",
             f"Role order: {_prompt_list(role_order, 'agent-coordinator')}",
+            f"Default PR review checklist: {_prompt_list(list(DEFAULT_PR_REVIEW_CHECKLIST), 'agent-coordinator')}",
             f"Advisory/no-spawn roles still require closure input: {_prompt_list(advisory_roles, '<none>')}",
             f"Passive skills from packet: {_prompt_list(recommended_skills, '<none>')}",
             "",
+            "Open the PR non-draft by default so GitHub, CodeRabbit, Cubic, Sourcery, and current-head checks can run; draft requires an explicit operator exception.",
             "Skills are passive/discovery-only; they do not replace agent-coordinator, task_bootstrap.py, review governance, or merge-readiness gates.",
+            "Experiment Runner evidence: run oracle-only mode when useful, then record `## Experiment Runner Evidence` with a local result artifact path or an explicit `Not applicable:` reason.",
             "Premortem closure rule: every premortem finding must be fixed in code/docs/tests or formally dispositioned as NOT-A-BUG/DEFERRED with evidence/backlog. No finding may be ignored as advisory.",
             "For local Python gates in the worktree, run: . .venv/bin/activate",
             "Then run only the scoped validation bundle required by the lane before any readiness claim.",
@@ -188,9 +199,12 @@ def render_recipe_prompt(
             f"Worktree: {_prompt_text(worktree, '<worktree unavailable>')}",
             f"Path scope: {_prompt_list(paths, '<no explicit paths>')}",
             f"Requested role order seed: {_prompt_list(agents, 'agent-coordinator')}",
+            f"Default PR review checklist: {_prompt_list(list(DEFAULT_PR_REVIEW_CHECKLIST), 'agent-coordinator')}",
             "",
             "Next required repo command: run task_bootstrap.py with the printed arguments, then follow the generated packet.",
+            "Open the PR non-draft by default so bot review and current-head checks run; draft requires an explicit operator exception.",
             "Skills are passive/discovery-only; they do not replace agent-coordinator, task_bootstrap.py, review governance, or merge-readiness gates.",
+            "After bootstrap, create oracle-only Experiment Runner evidence when useful and record it under `## Experiment Runner Evidence`.",
             "Premortem closure rule: every premortem finding must be fixed in code/docs/tests or formally dispositioned as NOT-A-BUG/DEFERRED with evidence/backlog. No finding may be ignored as advisory.",
             "For local Python gates in the worktree, run: . .venv/bin/activate",
         ]

--- a/scripts/orchestration/start_pr_lane.sh
+++ b/scripts/orchestration/start_pr_lane.sh
@@ -8,13 +8,14 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 cd "${REPO_ROOT}"
 
 DEFAULT_PLUGINS=(
-    "Browser Use"
-    "Computer Use"
     "GitHub"
+    "CodeRabbit"
+    "Codex Security"
+    "Browser"
+    "Chrome"
+    "Computer Use"
     "Hugging Face"
     "Life Science Research"
-    "Plugin Eval"
-    "CodeRabbit"
 )
 
 usage() {
@@ -38,6 +39,7 @@ Options:
   -h, --help                 Show this help.
 
 The plugin list is a checklist only. Missing host/runtime plugins do not fail repo startup.
+Open the PR non-draft by default so bot review and current-head checks run.
 EOF
 }
 
@@ -258,6 +260,7 @@ echo "Plugin/runtime checklist (operator-confirmed, non-blocking):"
 for plugin in "${PLUGIN_ARGS[@]}"; do
     echo "  - ${plugin}"
 done
+echo "PR open mode: non-draft by default; draft requires explicit operator exception."
 echo ""
 
 if [[ "${DRY_RUN}" -eq 1 ]]; then
@@ -355,4 +358,4 @@ echo ""
 echo "Next steps:"
 echo "  1. cd ${WORKTREE_REL}"
 echo "  2. Follow the generated task packet before implementation."
-echo "  3. Do not push or open the PR until local validation and PR body/mapping are ready."
+echo "  3. Open the PR non-draft after local validation and initial PR body/mapping are ready."

--- a/tests/test_experiment_runner_identity_policy.py
+++ b/tests/test_experiment_runner_identity_policy.py
@@ -26,6 +26,8 @@ def test_default_policy_validates() -> None:
         == "Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>"
     )
     assert policy["slack_identity"]["status"] == "deferred"
+    assert policy["validator_mutation_boundary"]["status"] == "threat_model_only"
+    assert policy["validator_mutation_boundary"]["active_mutation_access"] is False
 
 
 def test_default_co_author_guidance_validates() -> None:
@@ -310,6 +312,44 @@ def test_rejects_authority_drift_outside_main_boundary() -> None:
     }
 
     with pytest.raises(identity_check.IdentityPolicyError, match="must not grant"):
+        identity_check.validate_identity_policy(policy)
+
+
+def test_rejects_active_validator_mutation_access() -> None:
+    policy = _valid_policy()
+    policy["validator_mutation_boundary"]["active_mutation_access"] = True
+
+    with pytest.raises(identity_check.IdentityPolicyError, match="active_mutation_access"):
+        identity_check.validate_identity_policy(policy)
+
+
+def test_rejects_validator_mutation_allowlist_in_threat_model_phase() -> None:
+    policy = _valid_policy()
+    policy["validator_mutation_boundary"]["allowlisted_validator_scripts"] = [
+        "scripts/ci/check_pr_body_phase2_gates.py"
+    ]
+
+    with pytest.raises(identity_check.IdentityPolicyError, match="allowlisted_validator_scripts"):
+        identity_check.validate_identity_policy(policy)
+
+
+def test_rejects_validator_mutation_boundary_without_forbidden_surfaces() -> None:
+    policy = _valid_policy()
+    policy["validator_mutation_boundary"]["forbidden_surface_prefixes"] = ["tests/"]
+
+    with pytest.raises(identity_check.IdentityPolicyError, match="forbidden_surface_prefixes"):
+        identity_check.validate_identity_policy(policy)
+
+
+def test_rejects_validator_mutation_boundary_without_scripts_ci() -> None:
+    policy = _valid_policy()
+    policy["validator_mutation_boundary"]["forbidden_surface_prefixes"] = [
+        item
+        for item in policy["validator_mutation_boundary"]["forbidden_surface_prefixes"]
+        if item != "scripts/ci/"
+    ]
+
+    with pytest.raises(identity_check.IdentityPolicyError, match="forbidden_surface_prefixes"):
         identity_check.validate_identity_policy(policy)
 
 

--- a/tests/test_orchestration_merge_ready.py
+++ b/tests/test_orchestration_merge_ready.py
@@ -259,6 +259,7 @@ def test_merge_ready_bundle_uses_declared_blocking_policy(
     captured = capsys.readouterr()
     assert "phase2-pr-body-gates: class=hard, lane=pr-governance, blocking=yes" in captured.out
     assert "merge-readiness-gate: class=hard, lane=review-governance, blocking=no" in captured.out
+    assert "Experiment Runner Evidence is advisory in this phase" in captured.out
 
 
 def test_wrapper_fails_when_disposition_gate_skips_in_advisory_mode(

--- a/tests/test_pr_body_phase2_gates.py
+++ b/tests/test_pr_body_phase2_gates.py
@@ -168,6 +168,24 @@ Artifact: artifacts/orchestration/task_packets/packet.json
     assert any("artifacts/orchestration/experiments/results/" in error for error in errors)
 
 
+def test_experiment_runner_evidence_rejects_empty_artifact_basename() -> None:
+    errors, warnings = gates.check_experiment_runner_evidence("""## Experiment Runner Evidence
+Artifact: artifacts/orchestration/experiments/results/.json
+""")
+
+    assert warnings == []
+    assert any("artifacts/orchestration/experiments/results/" in error for error in errors)
+
+
+def test_experiment_runner_evidence_rejects_windows_parent_traversal() -> None:
+    errors, warnings = gates.check_experiment_runner_evidence(r"""## Experiment Runner Evidence
+Artifact: artifacts/orchestration/experiments/results/..\outside.json
+""")
+
+    assert warnings == []
+    assert any("artifacts/orchestration/experiments/results/" in error for error in errors)
+
+
 def test_experiment_runner_evidence_rejects_mixed_artifact_and_not_applicable() -> None:
     errors, warnings = gates.check_experiment_runner_evidence("""## Experiment Runner Evidence
 Artifact: artifacts/orchestration/experiments/results/exp.json
@@ -382,9 +400,52 @@ Commit: abc1234
     assert "canonical mapping artifact passed" in result.stdout
 
 
-def test_phase2_rejects_invalid_pr_body_even_when_artifact_is_valid(tmp_path: Path) -> None:
-    """Artifact success must not bypass required body mirror sections."""
+def test_phase2_accepts_non_mirror_body_when_artifact_is_valid(tmp_path: Path) -> None:
+    """Artifact-first mode should not force optional PR body mirrors."""
     event = {"pull_request": {"number": 998, "body": "minimal"}}
+    (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
+    artifact_content = """# PR 998 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: abc1234
+- https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
+
+## Experiment Runner Evidence
+Not applicable: fixture artifact only checks body mirror failure behavior.
+"""
+    (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
+    repo_root = Path(__file__).resolve().parents[1]
+    env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/ci/check_pr_body_phase2_gates.py",
+            "--event-path",
+            str(tmp_path / "event.json"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=env,
+    )
+    assert result.returncode == 0
+    assert "canonical mapping artifact passed" in result.stdout
+
+
+def test_phase2_rejects_invalid_present_body_mirror_when_artifact_is_valid(
+    tmp_path: Path,
+) -> None:
+    event = {
+        "pull_request": {
+            "number": 998,
+            "body": "## Discussion Thread Pass\n- [ ] Discussion-thread pass completed\n",
+        }
+    }
     (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
     artifact_content = """# PR 998 — Fixed in Commit Mapping
 
@@ -417,7 +478,7 @@ Not applicable: fixture artifact only checks body mirror failure behavior.
     )
     assert result.returncode == 1
     assert "PR body validation failed" in result.stdout
-    assert "Missing required section" in result.stdout
+    assert "Checklist item must be checked" in result.stdout
 
 
 def test_phase2_accepts_pr_number_without_explicit_body_when_artifact_is_valid(
@@ -458,7 +519,12 @@ Artifact: artifacts/orchestration/experiments/results/exp-998.json
 
 def test_phase2_failure_output_only_reports_failing_scope(tmp_path: Path) -> None:
     """Failure summary should mention only the scope that actually failed."""
-    event = {"pull_request": {"number": 998, "body": "minimal"}}
+    event = {
+        "pull_request": {
+            "number": 998,
+            "body": "### Fixed in Commit Mapping\n- canonical artifact: docs/review/PR_998_FIXED_MAPPING.md\n",
+        }
+    }
     (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
     artifact_content = """# PR 998 — Fixed in Commit Mapping
 

--- a/tests/test_pr_body_phase2_gates.py
+++ b/tests/test_pr_body_phase2_gates.py
@@ -117,6 +117,23 @@ def test_select_body_validation_mode_prefers_mirror_when_artifact_exists() -> No
     )
 
 
+def test_mapping_section_stops_before_sibling_h3() -> None:
+    section = gates._extract_mapping_section("""## Discussion Thread Pass
+
+### Fixed in Commit Mapping
+- No actionable review comments
+
+### Other Details
+- should not be parsed as mapping
+
+## Merge Readiness
+Not claimed.
+""")
+
+    assert "- No actionable review comments" in section
+    assert "should not be parsed as mapping" not in section
+
+
 def test_experiment_runner_evidence_accepts_valid_artifact_path() -> None:
     errors, warnings = gates.check_experiment_runner_evidence("""## Experiment Runner Evidence
 Artifact: artifacts/orchestration/experiments/results/nested/result.json

--- a/tests/test_pr_body_phase2_gates.py
+++ b/tests/test_pr_body_phase2_gates.py
@@ -19,6 +19,9 @@ Phase2 PR body gate implementation.
 
 ### Fixed in Commit Mapping
 - https://github.com/org/repo/pull/719#issuecomment-123 -> 28069fd4
+
+## Experiment Runner Evidence
+Artifact: artifacts/orchestration/experiments/results/exp-719.json
 """
 
 VALID_BODY_MIRROR_ONLY = """## Summary
@@ -30,6 +33,9 @@ Phase2 PR body gate implementation.
 
 ### Fixed in Commit Mapping
 - canonical artifact: `docs/review/PR_998_FIXED_MAPPING.md`
+
+## Experiment Runner Evidence
+Artifact: artifacts/orchestration/experiments/results/exp-998.json
 """
 
 
@@ -109,6 +115,50 @@ def test_select_body_validation_mode_prefers_mirror_when_artifact_exists() -> No
         gates._select_body_validation_mode(artifact_checked=False)
         is gates.BodyValidationMode.FULL_MAPPING
     )
+
+
+def test_experiment_runner_evidence_accepts_valid_artifact_path() -> None:
+    errors, warnings = gates.check_experiment_runner_evidence("""## Experiment Runner Evidence
+Artifact: artifacts/orchestration/experiments/results/nested/result.json
+""")
+
+    assert errors == []
+    assert warnings == []
+
+
+def test_experiment_runner_evidence_accepts_not_applicable_reason() -> None:
+    errors, warnings = gates.check_experiment_runner_evidence("""## Experiment Runner Evidence
+Not applicable: docs-only operator exception with no runner signal.
+""")
+
+    assert errors == []
+    assert warnings == []
+
+
+def test_experiment_runner_evidence_missing_is_advisory_warning() -> None:
+    errors, warnings = gates.check_experiment_runner_evidence("## Summary\nNo evidence.\n")
+
+    assert errors == []
+    assert any("missing `## Experiment Runner Evidence`" in warning for warning in warnings)
+
+
+def test_experiment_runner_evidence_rejects_artifact_outside_results() -> None:
+    errors, warnings = gates.check_experiment_runner_evidence("""## Experiment Runner Evidence
+Artifact: artifacts/orchestration/task_packets/packet.json
+""")
+
+    assert warnings == []
+    assert any("artifacts/orchestration/experiments/results/" in error for error in errors)
+
+
+def test_experiment_runner_evidence_rejects_mixed_artifact_and_not_applicable() -> None:
+    errors, warnings = gates.check_experiment_runner_evidence("""## Experiment Runner Evidence
+Artifact: artifacts/orchestration/experiments/results/exp.json
+Not applicable: this should not be mixed with an artifact.
+""")
+
+    assert warnings == []
+    assert any("not both" in error for error in errors)
 
 
 def test_phase2_guard_rejects_missing_sections() -> None:
@@ -278,6 +328,7 @@ Commit: abc1234
     )
     assert result.returncode == 0
     assert "canonical mapping artifact and PR body mirror passed" in result.stdout
+    assert "WARNING:" not in result.stdout
 
 
 def test_phase2_accepts_empty_pr_body_when_artifact_is_valid(tmp_path: Path) -> None:
@@ -328,6 +379,9 @@ def test_phase2_rejects_invalid_pr_body_even_when_artifact_is_valid(tmp_path: Pa
 Disposition: FIXED
 Commit: abc1234
 - https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
+
+## Experiment Runner Evidence
+Not applicable: fixture artifact only checks body mirror failure behavior.
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
     repo_root = Path(__file__).resolve().parents[1]
@@ -362,6 +416,9 @@ def test_phase2_accepts_pr_number_without_explicit_body_when_artifact_is_valid(
 Disposition: FIXED
 Commit: abc1234
 - https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
+
+## Experiment Runner Evidence
+Artifact: artifacts/orchestration/experiments/results/exp-998.json
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
     repo_root = Path(__file__).resolve().parents[1]
@@ -396,6 +453,9 @@ def test_phase2_failure_output_only_reports_failing_scope(tmp_path: Path) -> Non
 Disposition: FIXED
 Commit: abc1234
 - https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
+
+## Experiment Runner Evidence
+Not applicable: fixture artifact only checks body mirror failure behavior.
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
     repo_root = Path(__file__).resolve().parents[1]

--- a/tests/test_start_pr_lane.py
+++ b/tests/test_start_pr_lane.py
@@ -138,6 +138,12 @@ def test_start_pr_lane_dry_run_prints_stable_commands_and_plugins() -> None:
     assert "Premortem closure rule: every premortem finding must be fixed" in result.stdout
     assert "No finding may be ignored as advisory." in result.stdout
     assert ". .venv/bin/activate" in result.stdout
+    assert "Open the PR non-draft by default" in result.stdout
+    assert "Experiment Runner evidence" in result.stdout
+    assert (
+        "Default PR review checklist: agent-coordinator, architecture-specialist, "
+        "security-auditor, qa-engineer-agent, bug-hunter, dev-operator"
+    ) in result.stdout
     assert "automatically start" not in result.stdout.lower()
 
 
@@ -231,6 +237,8 @@ esac
     assert "Role order: agent-coordinator, backend-engineer, qa-engineer-agent" in result.stdout
     assert "Passive skills from packet: pulseplate-premortem-risk-review" in result.stdout
     assert ". .venv/bin/activate" in result.stdout
+    assert "Open the PR non-draft by default" in result.stdout
+    assert "Experiment Runner evidence" in result.stdout
     assert "did not run authoritative task_bootstrap.py" not in result.stdout
     assert "auto-start" not in result.stdout.lower()
 
@@ -242,17 +250,19 @@ def test_start_pr_lane_dry_run_uses_default_plugin_checklist() -> None:
 
     assert result.returncode == 0, result.stderr
     default_plugins = (
-        "Browser Use",
-        "Computer Use",
         "GitHub",
+        "CodeRabbit",
+        "Codex Security",
+        "Browser",
+        "Chrome",
+        "Computer Use",
         "Hugging Face",
         "Life Science Research",
-        "Plugin Eval",
-        "CodeRabbit",
     )
     for plugin in default_plugins:
         assert f"  - {plugin}" in result.stdout
-    assert result.stdout.index("  - Browser Use") < result.stdout.index("  - CodeRabbit")
+    assert result.stdout.index("  - GitHub") < result.stdout.index("  - CodeRabbit")
+    assert "PR open mode: non-draft by default" in result.stdout
 
 
 def test_start_pr_lane_rejects_local_only_scope_paths() -> None:


### PR DESCRIPTION
## Goal
Make Experiment Runner participation explicit for non-trivial PR lanes as Phase2 advisory evidence, while keeping strict merge blocking deferred.

## Business reason
PulsePlate relies on coordinator-first governance and bot review signals for non-trivial work. This PR gives Experiment Runner a safe oracle-only contribution path for each lane without granting autonomous mutation authority.

## Scope
- Add Phase2 parsing for `## Experiment Runner Evidence` in PR body or fixed-mapping artifacts.
- Accept either `Artifact: artifacts/orchestration/experiments/results/...json` or `Not applicable: <reason>`.
- Keep missing Experiment Runner evidence advisory/diagnostic only in this PR.
- Reject malformed evidence paths and keep result artifacts local/gitignored.
- Document future `scripts/ci/**` mutation access as threat-model-only and fail-closed.
- Update coordinator-first starter prompts and lifecycle docs so PRs are non-draft by default.

## Out of scope
- No active runner mutation of `scripts/ci/**`.
- No strict hard gate requiring every PR to provide Experiment Runner evidence yet.
- No Chronicle/plugin authority over repo governance.

## Key decisions
- Repo governance remains authority: `AGENTS.md`, scoped `AGENTS.md`, `RUNBOOK_AGENT.md`, task packets, and merge gates.
- Draft PRs are explicit operator exceptions only; default PR open mode is ready-for-review so bot/review signals run.
- Experiment Runner evidence can live in the PR body mirror or the canonical mapping artifact.
- Malformed evidence is still a Phase2 error; missing evidence is advisory during this rollout.

## Experiment Runner Evidence
Artifact: artifacts/orchestration/experiments/results/exp-65d109111b8a.json

Local oracle-only artifact, gitignored and not committed. Runner mode: `oracle_only_governance_reviewer`; `mutated_paths: []`; `promotion_ready: false`.

## Tests / validation
- `python3 scripts/orchestration/check_preflight.py --path <changed paths>`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/orchestration/check_experiment_runner_identity.py`
- `python3 -m pytest -q tests/test_render_codex_start_prompt.py tests/test_local_session_bootstrap.py tests/test_pr_body_phase2_gates.py tests/test_start_pr_lane.py tests/test_experiment_runner.py tests/test_experiment_runner_identity_policy.py tests/test_orchestration_merge_ready.py`
- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed`
- `PATH=.venv/bin:$PATH PRE_COMMIT_HOME=/tmp/pulseplate-precommit-experiment-runner-gate pre-commit run --all-files`
- Pre-push hook passed: changed-file mypy, pip-audit, backend pytest, full-repo Bandit, docker build test.

## Security notes
Future validator-script mutation remains disabled. The governed identity JSON now requires threat-model-only status, empty allowlist, later security PR, rollback notes, identity checks, and forbidden surfaces including `scripts/ci/`.

## Risks / rollback
Rollback is a docs/tooling revert of the Phase2 parser, starter prompt text, and identity policy JSON addition. Current behavior is advisory for missing evidence, so rollout risk is limited to malformed evidence diagnostics and starter text.

## Deferred / follow-ups
- Later PR: hard merge gate that requires Experiment Runner evidence for every non-trivial PR after advisory signal proves stable. Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-experiment-runner-pr-evidence-hard-gate
- Later PR: separate threat model and allowlist for any controlled validator-script mutation access. Backlog: docs/roadmap/BACKLOG_LEDGER.md#ledger-p2-experiment-runner-validator-mutation-threat-model

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1775_FIXED_MAPPING.md`

## Merge Readiness
Not claimed. Current-head PR CI, bot review, post-open review disposition, wait-window, and strict merge wrapper are still required before merge readiness.