### PR TITLE
docs(philosophy): add admission policy oracle

### DIFF
--- a/.cursor/agents/philosophy-agent.md
+++ b/.cursor/agents/philosophy-agent.md
@@ -28,6 +28,12 @@ You are the Philosophy Agent for PulsePlate. Your job is to make AI outputs:
 - **Do not reduce semantic policies to one-off phrases**. For claim validators,
   define the forbidden proposition class first, then name its subject/action/object,
   tense/aspect/modality, polarity, and state-status variants.
+- **For Philosophy semantic-cache admission work, review policy-spec first**:
+  update the canonical claim family in
+  `docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json`
+  and regenerate the oracle fixture before adding any new isolated regex/test
+  phrase. Treat fresh reviewer wording as evidence of a missing family
+  dimension unless repo evidence proves it is `NOT-A-BUG`.
 
 ## When invoked
 

--- a/.cursor/agents/philosophy-agent.md
+++ b/.cursor/agents/philosophy-agent.md
@@ -31,9 +31,11 @@ You are the Philosophy Agent for PulsePlate. Your job is to make AI outputs:
 - **For Philosophy semantic-cache admission work, review policy-spec first**:
   update the canonical claim family in
   `docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json`
-  and regenerate the oracle fixture before adding any new isolated regex/test
-  phrase. Treat fresh reviewer wording as evidence of a missing family
-  dimension unless repo evidence proves it is `NOT-A-BUG`.
+  and regenerate the oracle fixture at
+  `tests/fixtures/orchestration/philosophy_admission_claim_oracle.json` before
+  adding any new isolated regex/test phrase. Treat fresh reviewer wording as
+  evidence of a missing family dimension unless repo evidence proves it is
+  `NOT-A-BUG`.
 
 ## When invoked
 

--- a/.cursor/agents/qa-engineer-agent.md
+++ b/.cursor/agents/qa-engineer-agent.md
@@ -28,6 +28,11 @@ description: Acceptance and regression owner for PulsePlate. Designs verificatio
   coverage. Exact reviewer phrases are seed examples only; acceptance must include
   deterministic generated cases across subject/action/object, tense/aspect, modality,
   polarity, voice, and state/status wording, plus explicit negative controls.
+- For Philosophy semantic-cache admission validators, require policy-spec-first
+  QA. New reviewer wording should update the canonical policy family and
+  regenerated oracle fixture before a one-off regex is accepted. Verify that
+  mutable policy inputs, generated oracle fixtures, and deterministic checkers
+  stay separated, and that no runtime semantic-cache behavior is activated.
 
 ## When Invoked
 
@@ -42,5 +47,6 @@ description: Acceptance and regression owner for PulsePlate. Designs verificatio
 - Regression matrix
 - Generated/equivalence-class matrix for claim validators when the changed behavior
   protects semantics rather than a single literal string
+- Policy/oracle drift check for Philosophy semantic-cache admission work
 - Required commands and expected pass/fail outcomes
 - Residual risks and blocked scenarios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,9 @@ jobs:
           while IFS= read -r -d '' path; do
             PHASE1_CHANGED_FILES+=("$path")
           done < <(git diff --name-only -z --diff-filter=AMRT "$BASE_REF"...HEAD -- \
-            'docs/orchestration/contracts/*.schema.json')
+            'docs/orchestration/contracts/*.schema.json' \
+            'docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json' \
+            'tests/fixtures/orchestration/philosophy_admission_claim_oracle.json')
 
           if [ "${#PHASE1_CHANGED_FILES[@]}" -eq 0 ] && [ "${#LINT_MD[@]}" -eq 0 ]; then
             echo "No changed markdown or Phase1 schema files; skipping docs Phase1 gates."
@@ -684,6 +686,7 @@ jobs:
                   tests/test_paywall_exposure_ledger_service.py \
                   tests/test_semantic_cache_bounded_insight_experiment_contract.py \
                   tests/test_semantic_cache_backend_selection_contract.py \
+                  tests/test_philosophy_admission_policy_oracle.py \
                   tests/test_semantic_cache_observability_contract.py \
                   tests/test_semantic_cache_scaffold_contract.py
                 ;;
@@ -933,6 +936,7 @@ jobs:
                   tests/test_paywall_exposure_ledger_service.py \
                   tests/test_semantic_cache_bounded_insight_experiment_contract.py \
                   tests/test_semantic_cache_backend_selection_contract.py \
+                  tests/test_philosophy_admission_policy_oracle.py \
                   tests/test_semantic_cache_observability_contract.py \
                   tests/test_semantic_cache_scaffold_contract.py
                 ;;

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,7 +166,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 575
+        "line_number": 577
       }
     ],
     ".github/workflows/frontend-ci.yml": [
@@ -1750,5 +1750,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-19T21:23:50Z"
+  "generated_at": "2026-05-20T12:06:27Z"
 }

--- a/docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+++ b/docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
@@ -1,0 +1,199 @@
+# Philosophy Epic V2 PR-2 Policy Oracle Packet
+
+Date: 2026-05-20
+
+Branch: `codex/philosophy-epic-v2-pr2-policy-oracle`
+
+Worktree: `worktrees/philosophy-epic-v2-pr2-policy-oracle`
+
+## Goal
+
+Create the Philosophy Epic V2 PR-2 admission policy spec generator / claim-family
+oracle. This PR is governance and test infrastructure only. It makes the PR-1
+semantic-cache admission forbidden-claim policy data-driven, generates a
+deterministic oracle fixture, and fails closed when policy, schema, checker, or
+fixture drift would recreate review loops.
+
+## Scope
+
+In scope:
+
+- Canonical JSON policy:
+  `docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json`
+- Policy JSON schema:
+  `docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.schema.json`
+- Generated oracle fixture:
+  `tests/fixtures/orchestration/philosophy_admission_claim_oracle.json`
+- Deterministic generator/check path in `scripts/ci/check_semantic_cache_gate.py`
+- Policy/oracle regression tests
+- Ledger and narrow role-agent guidance updates needed to prevent repeated
+  semantic claim-loop fixes
+
+Out of scope:
+
+- No semantic-cache gate opening
+- No runtime activation
+- No Redis, GPTCache, embeddings, vector search, provider/client, DB, OpenAPI,
+  frontend, iOS, `/insight`, connection-string, or cache-adapter changes
+- No promotion of PDFs, design input, browser evidence, or research output into
+  runtime truth
+
+## Coordinator Role Order
+
+Pre-open role order:
+
+1. `agent-coordinator`
+2. `architecture-specialist`
+3. `philosophy-agent`
+4. `qa-engineer-agent`
+5. `security-auditor`
+6. `bug-hunter`
+
+Post-open mandatory lane:
+
+1. `qa-engineer-agent`
+2. `bug-hunter`
+3. security / `codex-security` style diff scan
+
+No role may be skipped unless the coordinator updates this packet.
+
+## Research Basis
+
+External sources are reference-only and untrusted until translated into repo
+contracts and tests. The PR-2 policy uses them as design rationale, not runtime
+truth.
+
+| Source | Design use in PR-2 |
+| --- | --- |
+| Kuhn, "A Survey and Classification of Controlled Natural Languages", ACL Anthology, 2014: <https://aclanthology.org/J14-1005/> | Treat admission claims as controlled language with finite subject, predicate, polarity, modal, and temporal axes. |
+| Claessen and Hughes, "QuickCheck: a lightweight tool for random testing of Haskell programs", ICFP 2000: <https://doi.org/10.1145/351240.351266> | Generate deterministic property-style cases from claim-family dimensions instead of adding one-off reviewer phrases. |
+| Chen et al., "Metamorphic Testing: A Review of Challenges and Opportunities", ACM Computing Surveys 2018: <https://i.cs.hku.hk/~tse/Papers/2010s/hlmtCSUR.html> | Pair forbidden claims with allowed negative controls to expose oracle-gap regressions. |
+| Open Policy Agent policy language docs: <https://www.openpolicyagent.org/docs/policy-language> | Keep policy inputs as structured auditable data, while the repo checker remains Python/stdlib. |
+| NIST AI 600-1 Generative AI Profile: <https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf> | Treat red-team brainstorming as adversarial coverage before readiness, not as shipped behavior. |
+| Stanford Encyclopedia of Philosophy, "Temporal Logic": <https://plato.stanford.edu/entries/logic-temporal/> and "Modal Logic": <https://plato.stanford.edu/entries/logic-modal/> | Encode temporal/modal drift such as `now`, `still`, `became`, `has been`, `will`, `may`, `must`, and `required to`. |
+
+## Policy Model
+
+The canonical policy data defines:
+
+- claim-family id
+- risk rail
+- canonical meaning
+- forbidden polarity
+- detector labels
+- controlled subjects
+- assertive predicates
+- modal predicates
+- temporal predicates
+- seed regressions from PR-1 review loops
+- allowed negative controls
+
+The JSON policy stores no arbitrary regex. The checker compiles exact,
+deterministic `re.escape` patterns from generated oracle claims and preserves the
+existing PR-1 static detector safety net.
+
+## Oracle Boundary Clarification
+
+PR-2 uses `oracle` in the narrow governance/CI sense: a deterministic generated
+fixture plus checker path that adjudicates admission-policy claims. It is not a
+new LLM, RAG, semantic-cache, Experiment Runner, or runtime oracle component.
+
+The current oracle analysis reinforces the Experiment Runner invariant
+`O intersect M = empty`: immutable oracle surfaces must not become mutable patch
+targets. PR-2 keeps that discipline by separating:
+
+1. mutable policy source:
+   `docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json`
+2. generated oracle fixture:
+   `tests/fixtures/orchestration/philosophy_admission_claim_oracle.json`
+3. deterministic adjudicator:
+   `scripts/ci/check_semantic_cache_gate.py`
+
+Philosophical, RAG, or LLM work may generate hypotheses and reviewer wording, but
+admission truth is constrained by the policy/spec/generator and the deterministic
+checker. This PR does not alter Experiment Runner, immutable experiment oracles,
+promotion mechanics, or runtime semantic-cache behavior. Future Experiment Runner
+oracle-manifest work belongs in a separate coordinator-owned lane.
+
+## Red-Team / Brainstorming Protocol
+
+For each claim family, reviewers should ask:
+
+- What sentence would wrongly make the gate open, live, approved, serving, or
+  runtime-enabled?
+- What modal operator changes the force of the claim: `can`, `may`, `must`,
+  `should`, `would`, `required to`, or `has to`?
+- What temporal operator changes status: `now`, `still`, `remains`, `became`,
+  `has been`, `will`, or `future`?
+- What exact negative-control sentence should remain allowed?
+
+If a new review wave finds another same-class phrase, fix the policy family or
+generator relation first, then regenerate the oracle fixture and add the
+regression there. Do not add another isolated regex branch as the primary fix.
+
+## Premortem Closure Contract
+
+`pulseplate-premortem-risk-review` is mandatory before readiness. Every finding
+must close as:
+
+- `FIXED`: real code/docs/tests/governance fix with evidence
+- `NOT-A-BUG`: repo evidence proving no change is needed
+- `DEFERRED`: backlog link plus PR-body follow-up
+
+No advisory-only finding may be silently ignored. Runtime/code findings from
+premortem, QA, bug-hunter, security-auditor, CodeRabbit, Cubic, Sourcery, or
+`codex-security` style review must be fixed in code/tests before fixed mapping
+or thread resolution.
+
+## Premortem Findings And Closure
+
+- `FIXED` - Same-class review waves could continue if new comments are patched
+  with isolated regex branches. Evidence: canonical policy data plus generated
+  oracle fixture now own the claim-family dimensions, and philosophy/QA agent
+  guidance requires policy-spec-first review before one-off regex changes.
+- `FIXED` - Policy, schema, fixture, and downstream docs could drift apart.
+  Evidence: `check_semantic_cache_gate.py` validates policy/schema/oracle drift,
+  `check_docs_phase1_gates.py` wires the policy artifacts into PR-scoped docs
+  gates, and `tests/test_philosophy_admission_policy_oracle.py` rejects fixture
+  drift.
+- `FIXED` - A governance PR could accidentally imply runtime semantic-cache
+  activation. Evidence: the policy requires `gate_status: closed`,
+  `runtime_allowed: false`, and `implementation_allowed: false`; the packet keeps
+  Redis, GPTCache, embeddings, providers, clients, DB, OpenAPI, frontend, iOS,
+  `/insight`, and cache adapters out of scope.
+- `FIXED` - Oracle generation could become an unsafe write primitive. Evidence:
+  write mode is confined to `tests/fixtures/orchestration`, and the regression
+  test rejects writing the oracle fixture outside that root.
+- `FIXED` - The term `oracle` could be confused with an Experiment Runner or LLM
+  runtime authority. Evidence: the Oracle Boundary Clarification above separates
+  mutable policy source, generated fixture, deterministic checker, Experiment
+  Runner oracles, and future runtime promotion.
+
+## Validation Plan
+
+Focused gates:
+
+```bash
+python3 scripts/ci/check_semantic_cache_gate.py --check-philosophy-admission-oracle-drift
+/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_philosophy_admission_policy_oracle.py tests/test_philosophy_semantic_cache_admission_contract.py tests/test_semantic_cache_gate.py
+python3 scripts/orchestration/check_agent_consistency.py
+DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed
+pre-commit run --all-files
+```
+
+Post-open gates:
+
+- `task_bootstrap.py --pr-phase post_open_review`
+- mandatory `qa-engineer-agent -> bug-hunter`
+- security / `codex-security` style scan of `origin/main...HEAD`
+- fixed mapping only after underlying fixes/dispositions are complete
+
+## Definition Of Done
+
+- Policy JSON and schema validate fail-closed
+- Generated oracle fixture is byte-stable and checked by CI-local tooling
+- Every claim family has forbidden and allowed cases
+- Downstream Philosophy docs continue to reject forbidden admission claims
+- The semantic-cache gate remains closed and runtime/implementation false
+- No runtime/cache/provider/client surfaces are touched
+- Premortem and role-agent findings are closed before readiness claims

--- a/docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+++ b/docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
@@ -189,9 +189,9 @@ Focused gates:
 
 ```bash
 python3 scripts/ci/check_semantic_cache_gate.py --check-philosophy-admission-oracle-drift
-/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_philosophy_admission_policy_oracle.py tests/test_philosophy_semantic_cache_admission_contract.py tests/test_semantic_cache_gate.py
+.venv/bin/python -m pytest -q tests/test_philosophy_admission_policy_oracle.py tests/test_philosophy_semantic_cache_admission_contract.py tests/test_semantic_cache_gate.py
 python3 scripts/orchestration/check_agent_consistency.py
-DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed
+DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed
 pre-commit run --all-files
 ```
 

--- a/docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+++ b/docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
@@ -115,6 +115,20 @@ checker. This PR does not alter Experiment Runner, immutable experiment oracles,
 promotion mechanics, or runtime semantic-cache behavior. Future Experiment Runner
 oracle-manifest work belongs in a separate coordinator-owned lane.
 
+## Review-Loop Root Cause Closure
+
+The current oracle analysis treats PR-1761's repeated review waves as a
+semantic-detection architecture problem, not as an Experiment Runner problem.
+PR-2 closes that failure mode with deterministic governance infrastructure:
+
+| Review-loop root cause | PR-2 countermeasure |
+| --- | --- |
+| Hand-expanded wording regexes produced new gaps for each tense, modality, subject order, or provider phrase. | Claim families now live in canonical policy JSON, and the oracle generator expands modal, temporal, provider, and polarity dimensions from data. |
+| Allowed negative controls could be checked only against the current family and miss false positives from another detector. | Oracle tests now fail any allowed case that triggers any downstream Philosophy admission error. |
+| Policy, schema, and oracle fixtures could drift because only some changed paths reached docs gates. | CI/docs wiring passes the policy JSON, schema, and generated oracle fixture together, and workflow-contract tests guard that routing. |
+| Oracle regeneration could overwrite fixtures even after policy validation had already failed. | Write mode is fail-closed: it writes only after policy/schema/oracle validation has no errors and only under `tests/fixtures/orchestration`. |
+| Review governance could become a separate loop of stale or ambiguous proof. | Findings are fixed in code/tests first, then mapped in `docs/review/PR_1777_FIXED_MAPPING.md`; broader Experiment Runner oracle-manifest and mapping-reachability work stay separate lanes. |
+
 ## Red-Team / Brainstorming Protocol
 
 For each claim family, reviewers should ask:

--- a/docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json
+++ b/docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json
@@ -1,0 +1,382 @@
+{
+  "$schema": "PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.schema.json",
+  "policy_id": "philosophy_semantic_cache_admission_policy",
+  "policy_version": "2026-05-20",
+  "rollout_phase": "PHILOSOPHY-PR2",
+  "gate_status": "closed",
+  "runtime_allowed": false,
+  "implementation_allowed": false,
+  "source_contract": "docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_CONTRACT.md",
+  "modal_operators": [
+    "can",
+    "may",
+    "must",
+    "should",
+    "could",
+    "would",
+    "might",
+    "will",
+    "is required to",
+    "has to"
+  ],
+  "temporal_operators": [
+    "now",
+    "still",
+    "remains",
+    "became",
+    "has been",
+    "will",
+    "future"
+  ],
+  "research_basis": [
+    "Kuhn 2014 controlled natural language: restrict vocabulary and grammar to reduce ambiguity",
+    "QuickCheck property testing: generated cases exercise property classes instead of hand examples only",
+    "metamorphic testing: oracle-gap coverage through paired forbidden and allowed transformations",
+    "OPA/Rego policy-as-data: structured JSON-like data keeps policy inputs auditable",
+    "NIST AI RMF red-teaming: adversarial role-play and chaos testing surface failure modes before rollout",
+    "temporal/modal logic: tense and modality change claim force even when terms are reused"
+  ],
+  "claim_families": [
+    {
+      "id": "claim_class_gate_open_equivalence",
+      "risk_rail": "semantic_cache_gate_integrity",
+      "canonical_meaning": "Philosophy admission, PR-1, PR-2, or the claim-family oracle is equivalent to opening, unlocking, enabling, or keeping open the semantic-cache gate.",
+      "forbidden_polarity": "affirmative permission, activation, equivalence, double-negative, or temporal drift that makes the gate open now, still open, or open in this PR",
+      "detector_labels": [
+        "philosophy admission opens gate"
+      ],
+      "subjects": [
+        "PR-1",
+        "PR-2",
+        "Philosophy admission",
+        "The admission contract",
+        "The admission policy",
+        "The claim-family oracle",
+        "The semantic-cache gate",
+        "The global gate"
+      ],
+      "assertive_predicates": [
+        "opens the semantic-cache gate",
+        "unlocks the semantic-cache gate",
+        "enables the global gate",
+        "is equivalent to opening the semantic-cache gate",
+        "keeps the semantic-cache gate open"
+      ],
+      "modal_predicates": [
+        "open the semantic-cache gate",
+        "unlock the semantic-cache gate",
+        "enable the global gate",
+        "be equivalent to opening the semantic-cache gate"
+      ],
+      "temporal_predicates": [
+        "has opened the semantic-cache gate",
+        "became sufficient to open the semantic-cache gate",
+        "remains enough to open the global gate",
+        "is now opening the semantic-cache gate",
+        "still keeps the semantic-cache gate open"
+      ],
+      "seed_regressions": [
+        "The claim-family oracle became sufficient to open the semantic-cache gate.",
+        "PR-2 does not only open the semantic-cache gate.",
+        "The semantic-cache gate is now being opened for PR-2."
+      ],
+      "allowed_negative_controls": [
+        "This policy does not open the semantic-cache gate.",
+        "No semantic-cache gate is opened by PR-2.",
+        "The future gate-open PR must review semantic-cache admission before runtime use."
+      ]
+    },
+    {
+      "id": "claim_class_live_philosophy_cache",
+      "risk_rail": "runtime_serving_integrity",
+      "canonical_meaning": "Philosophical semantic-cache serving, cache reads, or live cache status is present before the global semantic-cache gate opens.",
+      "forbidden_polarity": "affirmative live, serving, active, ready, open, or still-live runtime cache status",
+      "detector_labels": [
+        "philosophical semantic cache live"
+      ],
+      "subjects": [
+        "Philosophical semantic-cache",
+        "Philosophy cache",
+        "Philosophy admission cache",
+        "PR-2 cache path",
+        "The policy oracle"
+      ],
+      "assertive_predicates": [
+        "is live",
+        "is active",
+        "serves cached responses",
+        "serves philosophy cache hits",
+        "keeps semantic-cache serving live"
+      ],
+      "modal_predicates": [
+        "serve cached responses",
+        "keep semantic-cache serving live",
+        "return philosophy cache hits",
+        "run as a live cache"
+      ],
+      "temporal_predicates": [
+        "has been live",
+        "became live",
+        "remains live",
+        "is still serving cached responses",
+        "will serve cached responses"
+      ],
+      "seed_regressions": [
+        "The admission policy still keeps semantic-cache serving live.",
+        "Philosophy admission has been live since PR-1.",
+        "Future philosophy PRs may now serve cached responses."
+      ],
+      "allowed_negative_controls": [
+        "Philosophical semantic-cache is not live.",
+        "The policy oracle does not serve cached responses.",
+        "Future PR may evaluate cache serving only after the gate opens."
+      ]
+    },
+    {
+      "id": "claim_class_provider_rollout_approved",
+      "risk_rail": "provider_and_dependency_integrity",
+      "canonical_meaning": "PR-1 or PR-2 approves Redis, GPTCache, embeddings, vector search, connection strings, cache adapters, or provider-backed cache runtime.",
+      "forbidden_polarity": "affirmative permission, support, import, wiring, connection, provider call, or temporal provider rollout approval",
+      "detector_labels": [
+        "redis philosophical cache approved",
+        "gptcache philosophical cache approved",
+        "redis imports allowed in pr-1",
+        "gptcache imports allowed in pr-1",
+        "embeddings allowed in pr-1",
+        "insight cache wiring allowed in pr-1",
+        "vector search allowed in pr-1",
+        "connection strings allowed in pr-1",
+        "cache adapters allowed in pr-1"
+      ],
+      "subjects": [
+        "PR-1",
+        "PR-2",
+        "Philosophy admission",
+        "The admission policy",
+        "The claim-family oracle"
+      ],
+      "assertive_predicates": [
+        "allows Redis imports",
+        "allows GPTCache imports",
+        "enables embeddings for philosophy admission",
+        "wires /insight cache behavior",
+        "opens Redis connection strings"
+      ],
+      "modal_predicates": [
+        "use Redis clients",
+        "use GPTCache clients",
+        "wire embeddings",
+        "open Redis connections",
+        "enable provider-backed cache"
+      ],
+      "temporal_predicates": [
+        "has used Redis imports for philosophy admission",
+        "became approved for GPTCache imports",
+        "still allows embeddings",
+        "will wire /insight cache behavior",
+        "has been opening Redis connections"
+      ],
+      "seed_regressions": [
+        "Future philosophy PRs may now serve GPTCache responses.",
+        "Philosophy admission has been required to enable Redis cache I/O.",
+        "PR-2 has GPTCache import for philosophy admission."
+      ],
+      "allowed_negative_controls": [
+        "No Redis imports are allowed in PR-2.",
+        "GPTCache imports remain blocked for philosophy admission.",
+        "The policy oracle does not enable provider-backed cache."
+      ]
+    },
+    {
+      "id": "claim_class_verification_bundle_skipped",
+      "risk_rail": "verification_bundle_integrity",
+      "canonical_meaning": "Semantic-cache admission or knowledge promotion may skip, waive, omit, or make optional the required verification bundle.",
+      "forbidden_polarity": "affirmative waiver, optionality, omission, bypass, not-required, or temporal loosening of verification-bundle requirements",
+      "detector_labels": [
+        "verification bundle optional",
+        "cache admission without verification bundle"
+      ],
+      "subjects": [
+        "Semantic-cache admission",
+        "Cache admission",
+        "Knowledge promotion",
+        "Philosophy admission",
+        "The admission policy"
+      ],
+      "assertive_predicates": [
+        "does not require a verification bundle",
+        "bypasses verification bundles",
+        "waives verification bundle requirements",
+        "makes verification bundles optional",
+        "promotes knowledge without a verification bundle"
+      ],
+      "modal_predicates": [
+        "skip verification bundles",
+        "omit the verification bundle",
+        "waive verification bundle requirements",
+        "promote knowledge without a verification bundle"
+      ],
+      "temporal_predicates": [
+        "has bypassed verification bundles",
+        "became exempt from verification bundles",
+        "remains optional for verification bundles",
+        "is now waiving verification bundle requirements",
+        "will promote knowledge without a verification bundle"
+      ],
+      "seed_regressions": [
+        "Semantic-cache admission may omit the verification bundle.",
+        "Verification bundle requirements remain optional for semantic-cache admission.",
+        "PR-2 is promoting knowledge without a verification bundle."
+      ],
+      "allowed_negative_controls": [
+        "No semantic-cache admission may omit the verification bundle.",
+        "Cache admission requires a passed verification bundle.",
+        "Future PR may evaluate semantic-cache admission after verification."
+      ]
+    },
+    {
+      "id": "claim_class_production_live_cache_key_behavior",
+      "risk_rail": "production_cache_key_integrity",
+      "canonical_meaning": "Philosophy admission ships production-live cache-key behavior or raw prompt/response cache persistence.",
+      "forbidden_polarity": "affirmative production-live cache keys, raw prompt cache keys, raw responses, persistence, or temporal shipping language",
+      "detector_labels": [
+        "production-live philosophical cache-key behavior"
+      ],
+      "subjects": [
+        "PR-1",
+        "PR-2",
+        "Philosophy admission",
+        "The admission policy",
+        "The claim-family oracle"
+      ],
+      "assertive_predicates": [
+        "ships production cache keys",
+        "stores raw prompts as cache keys",
+        "caches raw model responses",
+        "enables live cache-key behavior",
+        "persists philosophy cache keys"
+      ],
+      "modal_predicates": [
+        "ship production cache keys",
+        "store raw prompts as cache keys",
+        "cache raw model responses",
+        "enable live cache-key behavior"
+      ],
+      "temporal_predicates": [
+        "has shipped production cache keys",
+        "became live for cache-key behavior",
+        "still stores raw prompts as cache keys",
+        "will cache raw model responses",
+        "is now persisting philosophy cache keys"
+      ],
+      "seed_regressions": [
+        "PR-2 stores raw prompts as cache keys.",
+        "Philosophy admission has shipped production cache-key behavior.",
+        "The admission policy will cache raw model responses."
+      ],
+      "allowed_negative_controls": [
+        "PR-2 does not ship production cache keys.",
+        "No raw prompts are stored as cache keys.",
+        "Philosophy admission blocks live cache-key behavior."
+      ]
+    },
+    {
+      "id": "claim_class_pdf_design_intake_gate_override",
+      "risk_rail": "repo_truth_integrity",
+      "canonical_meaning": "PDF, design, browser, Drive, or research intake overrides repository gate markers, merge truth, or contract truth.",
+      "forbidden_polarity": "affirmative override, bypass, replacement, supersession, or temporal dominance over repo-reviewed gate markers",
+      "detector_labels": [
+        "design intake overrides gate markers"
+      ],
+      "subjects": [
+        "PDF intake",
+        "Design intake",
+        "Drive research",
+        "Browser evidence",
+        "The admission policy"
+      ],
+      "assertive_predicates": [
+        "overrides repo gate markers",
+        "bypasses repo-reviewed contracts",
+        "replaces merge truth",
+        "supersedes semantic-cache gate markers",
+        "authorizes runtime behavior over repo truth"
+      ],
+      "modal_predicates": [
+        "override repo gate markers",
+        "bypass repo-reviewed contracts",
+        "replace merge truth",
+        "supersede semantic-cache gate markers"
+      ],
+      "temporal_predicates": [
+        "has overridden repo gate markers",
+        "became the source of runtime truth",
+        "still overrides semantic-cache gate markers",
+        "will bypass repo-reviewed contracts",
+        "is now replacing merge truth"
+      ],
+      "seed_regressions": [
+        "Design/PDF intake can override repo gate markers.",
+        "PDF intake has overridden semantic-cache gate markers.",
+        "Browser evidence became the source of runtime truth."
+      ],
+      "allowed_negative_controls": [
+        "Design/PDF intake cannot override repo gate markers.",
+        "Research intake remains evidence-only.",
+        "Repo-reviewed contracts remain the source of gate truth."
+      ]
+    },
+    {
+      "id": "claim_class_runtime_expansion_approved",
+      "risk_rail": "runtime_scope_integrity",
+      "canonical_meaning": "Philosophy admission or PR-2 authorizes runtime expansion, backend selection, blocked-surface admission, cache I/O, or cache-adjacent writes.",
+      "forbidden_polarity": "affirmative runtime approval, backend authorization, blocked-surface eligibility, cache read/write, or temporal runtime expansion",
+      "detector_labels": [
+        "runtime allowed in pr-1",
+        "backend selection authorized by philosophy admission",
+        "cache IO allowed in pr-1",
+        "blocked surface cache admission allowed"
+      ],
+      "subjects": [
+        "PR-1",
+        "PR-2",
+        "Philosophy admission",
+        "The admission policy",
+        "The claim-family oracle",
+        "Billing truth",
+        "Therapy routing"
+      ],
+      "assertive_predicates": [
+        "authorizes backend selection",
+        "enables runtime expansion",
+        "writes cache entries",
+        "reads semantic-cache entries",
+        "becomes cache eligible for semantic-cache admission"
+      ],
+      "modal_predicates": [
+        "authorize backend selection",
+        "enable runtime expansion",
+        "write cache entries",
+        "read semantic-cache entries",
+        "be cache eligible for semantic-cache admission"
+      ],
+      "temporal_predicates": [
+        "has authorized backend selection",
+        "became cache eligible for semantic-cache admission",
+        "remains cache eligible for semantic-cache admission",
+        "is now writing cache entries",
+        "will enable runtime expansion"
+      ],
+      "seed_regressions": [
+        "The policy spec authorizes backend selection without SC-G5.",
+        "Billing truth remained cache eligible for semantic-cache admission.",
+        "PR-2 must write cache entries."
+      ],
+      "allowed_negative_controls": [
+        "The policy spec does not authorize backend selection.",
+        "Billing truth remains blocked_from_cache.",
+        "PR-2 must not write cache entries."
+      ]
+    }
+  ]
+}

--- a/docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json
+++ b/docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json
@@ -156,6 +156,9 @@
         "The claim-family oracle"
       ],
       "assertive_predicates": [
+        "approves Redis rollout for philosophy admission",
+        "approves GPTCache rollout for philosophy admission",
+        "approves provider-backed cache runtime",
         "allows Redis imports",
         "allows GPTCache imports",
         "enables embeddings for philosophy admission",
@@ -163,6 +166,9 @@
         "opens Redis connection strings"
       ],
       "modal_predicates": [
+        "approve Redis rollout for philosophy admission",
+        "approve GPTCache rollout for philosophy admission",
+        "approve provider-backed cache runtime",
         "use Redis clients",
         "use GPTCache clients",
         "wire embeddings",
@@ -170,6 +176,8 @@
         "enable provider-backed cache"
       ],
       "temporal_predicates": [
+        "has approved Redis rollout for philosophy admission",
+        "became approved for provider-backed cache runtime",
         "has used Redis imports for philosophy admission",
         "became approved for GPTCache imports",
         "still allows embeddings",
@@ -177,6 +185,9 @@
         "has been opening Redis connections"
       ],
       "seed_regressions": [
+        "PR-2 approves Redis rollout for philosophy admission.",
+        "PR-2 approves GPTCache rollout for philosophy admission.",
+        "The admission policy approves provider-backed cache runtime.",
         "Future philosophy PRs may now serve GPTCache responses.",
         "Philosophy admission has been required to enable Redis cache I/O.",
         "PR-2 has GPTCache import for philosophy admission."

--- a/docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json
+++ b/docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json
@@ -242,6 +242,7 @@
       "allowed_negative_controls": [
         "No semantic-cache admission may omit the verification bundle.",
         "Cache admission requires a passed verification bundle.",
+        "Do not claim that the admission policy may omit the verification bundle.",
         "Future PR may evaluate semantic-cache admission after verification."
       ]
     },

--- a/docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.schema.json
+++ b/docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PhilosophySemanticCacheAdmissionPolicy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "claim_families",
+    "gate_status",
+    "implementation_allowed",
+    "modal_operators",
+    "policy_id",
+    "policy_version",
+    "research_basis",
+    "rollout_phase",
+    "runtime_allowed",
+    "source_contract",
+    "temporal_operators"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.schema.json"
+    },
+    "policy_id": {
+      "type": "string",
+      "const": "philosophy_semantic_cache_admission_policy"
+    },
+    "policy_version": {
+      "type": "string",
+      "const": "2026-05-20"
+    },
+    "rollout_phase": {
+      "type": "string",
+      "const": "PHILOSOPHY-PR2"
+    },
+    "gate_status": {
+      "type": "string",
+      "const": "closed"
+    },
+    "runtime_allowed": {
+      "type": "boolean",
+      "const": false
+    },
+    "implementation_allowed": {
+      "type": "boolean",
+      "const": false
+    },
+    "source_contract": {
+      "type": "string",
+      "const": "docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_CONTRACT.md"
+    },
+    "modal_operators": {
+      "type": "array",
+      "minItems": 10,
+      "uniqueItems": true,
+      "items": { "type": "string" }
+    },
+    "temporal_operators": {
+      "type": "array",
+      "minItems": 7,
+      "uniqueItems": true,
+      "items": { "type": "string" }
+    },
+    "research_basis": {
+      "type": "array",
+      "minItems": 6,
+      "uniqueItems": true,
+      "items": { "type": "string" }
+    },
+    "claim_families": {
+      "type": "array",
+      "minItems": 7,
+      "maxItems": 7,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "allowed_negative_controls",
+          "assertive_predicates",
+          "canonical_meaning",
+          "detector_labels",
+          "forbidden_polarity",
+          "id",
+          "modal_predicates",
+          "risk_rail",
+          "seed_regressions",
+          "subjects",
+          "temporal_predicates"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "enum": [
+              "claim_class_gate_open_equivalence",
+              "claim_class_live_philosophy_cache",
+              "claim_class_provider_rollout_approved",
+              "claim_class_verification_bundle_skipped",
+              "claim_class_production_live_cache_key_behavior",
+              "claim_class_pdf_design_intake_gate_override",
+              "claim_class_runtime_expansion_approved"
+            ]
+          },
+          "risk_rail": { "type": "string" },
+          "canonical_meaning": { "type": "string" },
+          "forbidden_polarity": { "type": "string" },
+          "detector_labels": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "type": "string" }
+          },
+          "subjects": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "type": "string" }
+          },
+          "assertive_predicates": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "type": "string" }
+          },
+          "modal_predicates": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "type": "string" }
+          },
+          "temporal_predicates": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "type": "string" }
+          },
+          "seed_regressions": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "type": "string" }
+          },
+          "allowed_negative_controls": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/review/PR_1777_FIXED_MAPPING.md
+++ b/docs/review/PR_1777_FIXED_MAPPING.md
@@ -10,7 +10,30 @@ oracle.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: 92083c466
+Evidence: CI/docs routing now passes the Philosophy admission policy JSON, schema, and generated oracle fixture into Docs Phase1 gates, and `tests/test_ci_workflow_pr_size_governance_contract.py` guards the workflow contract; this closes the Codex/Cubic finding that policy-only diffs could skip the new Phase1 checks.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#pullrequestreview-4328165585 -> 92083c466
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#discussion_r3273668187 -> 92083c466
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#discussion_r3273691727 -> 92083c466
+
+Disposition: FIXED
+Commit: 50de520c7
+Evidence: Bot findings from Sourcery, CodeRabbit, and cubic were closed in code/docs/tests: detector-label mismatch errors include expected/actual sets; oracle drift guidance no longer hard-codes the default policy filename; allowed oracle cases fail on any downstream false positive; merged PR-1 ledger state and PR-2 target PR are synced; Philosophy agent guidance names the exact oracle fixture path; oracle fixture write mode is blocked when validation already failed. Focused local proof: `python3 scripts/ci/check_semantic_cache_gate.py --check-philosophy-admission-oracle-drift`; `.venv/bin/python -m pytest -q tests/test_philosophy_admission_policy_oracle.py tests/test_ci_workflow_pr_size_governance_contract.py`; `git diff --check`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#discussion_r3273641024 -> 50de520c7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#discussion_r3273641038 -> 50de520c7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#pullrequestreview-4328170555 -> 50de520c7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#discussion_r3273672603 -> 50de520c7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#discussion_r3273672626 -> 50de520c7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#pullrequestreview-4328193097 -> 50de520c7
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#discussion_r3273691732 -> 50de520c7
+
+Disposition: NOT-A-BUG
+Evidence: Sourcery's review-level extraction comments are advisory refactor feedback, not correctness defects for this PR-2 governance/test-infrastructure scope. The policy/oracle logic intentionally remains in the existing semantic-cache gate entrypoint for this PR so the new guard cannot drift from the existing gate-closed admission checker. The root loop risk is addressed by policy-as-data, generated oracle drift checks, docs/CI wiring, and agent guidance; broader Experiment Runner oracle-manifest or helper-module extraction belongs in a separate coordinator-owned lane.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#pullrequestreview-4328132580
 
 ## Role-Agent / Premortem Pass
 

--- a/docs/review/PR_1777_FIXED_MAPPING.md
+++ b/docs/review/PR_1777_FIXED_MAPPING.md
@@ -34,6 +34,10 @@ Evidence: Negated prohibition guidance such as `Do not claim that the admission 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#pullrequestreview-4328397344 -> c220482fd
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#discussion_r3273859141 -> c220482fd
 
+Disposition: FIXED
+Commit: 954a788ba
+Evidence: Current-head `test-main` failed because Phase 1 downstream docs tests saw duplicate errors for the same legacy and policy-oracle claim. The fix keeps the legacy detector message and suppresses policy-oracle duplicates only when the detector label is already reported, with regression coverage in `tests/test_philosophy_admission_policy_oracle.py::test_policy_oracle_does_not_duplicate_legacy_detector_error`. Focused local proof: `python3 scripts/ci/check_semantic_cache_gate.py --check-philosophy-admission-oracle-drift`; `.venv/bin/python -m pytest -q tests/test_docs_phase1_gates.py tests/test_philosophy_admission_policy_oracle.py tests/test_philosophy_semantic_cache_admission_contract.py tests/test_semantic_cache_gate.py`.
+
 Disposition: NOT-A-BUG
 Evidence: Sourcery's review-level extraction comments are advisory refactor feedback, not correctness defects for this PR-2 governance/test-infrastructure scope. The policy/oracle logic intentionally remains in the existing semantic-cache gate entrypoint for this PR so the new guard cannot drift from the existing gate-closed admission checker. The root loop risk is addressed by policy-as-data, generated oracle drift checks, docs/CI wiring, and agent guidance; broader Experiment Runner oracle-manifest or helper-module extraction belongs in a separate coordinator-owned lane.
 Reason: The review-level helper extraction suggestion is a maintainability idea, while the concrete actionable Sourcery inline suggestions were fixed in `50de520c7`; extracting modules here would widen the PR beyond the approved governance/test-infrastructure scope.
@@ -90,6 +94,8 @@ Reason: The review-level helper extraction suggestion is a maintainability idea,
   - PASS.
 - `.venv/bin/python -m pytest -q tests/test_philosophy_admission_policy_oracle.py tests/test_philosophy_semantic_cache_admission_contract.py tests/test_semantic_cache_gate.py`
   - PASS.
+- `.venv/bin/python -m pytest -q tests/test_docs_phase1_gates.py tests/test_philosophy_admission_policy_oracle.py tests/test_philosophy_semantic_cache_admission_contract.py tests/test_semantic_cache_gate.py`
+  - PASS after fixing duplicate legacy/policy-oracle downstream errors.
 - `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed`
   - PASS.
 - `pre-commit run --all-files` - PASS.
@@ -98,12 +104,9 @@ Reason: The review-level helper extraction suggestion is a maintainability idea,
 
 ## Current CI / Review State
 
-- Initial PR #1777 current-head CI is not merge-ready. `PR Body Phase2 gates`
-  failed before this canonical mapping artifact existed.
-- `pr_scope_guard` failed through PR size governance because this governance/test
-  infrastructure PR is above 800 changed lines and needs an explicit PR-body
-  `## Split Justification`.
-- Bot review is still in progress. This artifact must be updated if CodeRabbit,
+- Current-head CI after merge-from-main exposed duplicate legacy/policy-oracle
+  downstream errors in `test-main`; fixed in `954a788ba`.
+- Bot review is still monitored. This artifact must be updated if CodeRabbit,
   Sourcery, Cubic, Codex, or human review adds actionable comments.
 
 ## Machine-Heavy Gate Note

--- a/docs/review/PR_1777_FIXED_MAPPING.md
+++ b/docs/review/PR_1777_FIXED_MAPPING.md
@@ -31,6 +31,12 @@ oracle.
   rejects the five false-green examples from QA; focused pytest passed locally.
 - `security-auditor` - pre-open pass completed; post-open diff-scoped security
   scan is running after PR creation.
+- `security-auditor` / `codex-security` style post-open diff scan - completed;
+  no security-actionable findings. Evidence: scan checked path/write primitives,
+  JSON-driven regex injection, ReDoS shape, CI weakening, subprocess/network
+  additions, runtime activation drift, and secrets/baseline drift; `git diff
+  --check`, semantic-cache gate drift, docs phase gate, `make validate-changed`,
+  and `pre-commit run --all-files` passed locally.
 - `bug-hunter` - pre-open pass completed; post-open pass is pending after QA per
   role order.
 - `bug-hunter` post-open provider-approval finding - FIXED in commit

--- a/docs/review/PR_1777_FIXED_MAPPING.md
+++ b/docs/review/PR_1777_FIXED_MAPPING.md
@@ -1,0 +1,69 @@
+# PR #1777 - Fixed in Commit Mapping
+
+**Scope:** Philosophy Epic V2 PR-2 admission policy spec generator / claim-family
+oracle.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Role-Agent / Premortem Pass
+
+- `agent-coordinator` start gate - completed before implementation through
+  `check_preflight.py` and `task_bootstrap.py --pr-phase pre_open`.
+- `pulseplate-premortem-risk-review` - completed and closed in
+  `docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md`;
+  decision: proceed with fixes captured as `FIXED`.
+- `architecture-specialist` - completed; policy-as-data, schema parity, drift
+  checks, and no-runtime boundaries are implemented.
+- `philosophy-agent` - completed; claim-family semantics now live in canonical
+  policy data with temporal/modal dimensions and allowed negative controls.
+- `qa-engineer-agent` - pre-open pass completed; post-open pass is running after
+  PR creation.
+- `qa-engineer-agent` post-open finding - FIXED in commit `6120393bd`.
+  Evidence: `scripts/ci/check_semantic_cache_gate.py` now generates modal and
+  temporal cross-product oracle cases; `tests/test_philosophy_admission_policy_oracle.py`
+  rejects the five false-green examples from QA; focused pytest passed locally.
+- `security-auditor` - pre-open pass completed; post-open diff-scoped security
+  scan is running after PR creation.
+- `bug-hunter` - pre-open pass completed; post-open pass is pending after QA per
+  role order.
+
+## Local Validation
+
+- `python3 scripts/orchestration/check_preflight.py --mode analyze --path docs/orchestration --path docs/roadmap --path scripts/ci --path tests --path .cursor/agents`
+  - PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
+- `python3 scripts/ci/check_semantic_cache_gate.py --check-philosophy-admission-oracle-drift`
+  - PASS.
+- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md docs/roadmap/BACKLOG_LEDGER.md docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.schema.json tests/fixtures/orchestration/philosophy_admission_claim_oracle.json`
+  - PASS.
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_philosophy_admission_policy_oracle.py tests/test_philosophy_semantic_cache_admission_contract.py tests/test_semantic_cache_gate.py`
+  - PASS.
+- `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
+  - PASS.
+- `pre-commit run --all-files` - PASS.
+- Pre-push hooks - PASS, including mypy, pip-audit, backend tests, full-repo
+  bandit, and docker build test.
+
+## Current CI / Review State
+
+- Initial PR #1777 current-head CI is not merge-ready. `PR Body Phase2 gates`
+  failed before this canonical mapping artifact existed.
+- `pr_scope_guard` failed through PR size governance because this governance/test
+  infrastructure PR is above 800 changed lines and needs an explicit PR-body
+  `## Split Justification`.
+- Bot review is still in progress. This artifact must be updated if CodeRabbit,
+  Sourcery, Cubic, Codex, or human review adds actionable comments.
+
+## Machine-Heavy Gate Note
+
+Full local `make verify` is not claimed for this PR. The user requested
+`make validate-changed` rather than full `make verify`; merge readiness remains
+blocked until current-head CI, post-open role checks, review-thread disposition,
+fixed mapping/body mirror, and strict merge wrapper pass.

--- a/docs/review/PR_1777_FIXED_MAPPING.md
+++ b/docs/review/PR_1777_FIXED_MAPPING.md
@@ -33,6 +33,18 @@ oracle.
   scan is running after PR creation.
 - `bug-hunter` - pre-open pass completed; post-open pass is pending after QA per
   role order.
+- `bug-hunter` post-open provider-approval finding - FIXED in commit
+  `92083c466`. Evidence:
+  `docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json`
+  adds Redis/GPTCache/provider-backed approval predicates and seed regressions,
+  the oracle fixture was regenerated, and
+  `tests/test_philosophy_admission_policy_oracle.py` now rejects those examples.
+- `bug-hunter` post-open CI-wiring finding - FIXED in commit `92083c466`.
+  Evidence: `.github/workflows/ci.yml` now passes the policy JSON and generated
+  oracle fixture into Docs Phase1 gates and includes
+  `tests/test_philosophy_admission_policy_oracle.py` in route contract safety
+  suites; `tests/test_ci_workflow_pr_size_governance_contract.py` guards both
+  workflow contracts.
 
 ## Local Validation
 

--- a/docs/review/PR_1777_FIXED_MAPPING.md
+++ b/docs/review/PR_1777_FIXED_MAPPING.md
@@ -28,6 +28,12 @@ Evidence: Bot findings from Sourcery, CodeRabbit, and cubic were closed in code/
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#pullrequestreview-4328193097 -> 50de520c7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#discussion_r3273691732 -> 50de520c7
 
+Disposition: FIXED
+Commit: c220482fd
+Evidence: Negated prohibition guidance such as `Do not claim that the admission policy may omit the verification bundle.` is now handled before policy-oracle claim matches. Evidence: `PHILOSOPHY_NEGATED_ASSERTION_PREFIX_RE` in `scripts/ci/check_semantic_cache_gate.py`, the policy allowed negative control, regenerated oracle fixture, and `tests/test_philosophy_admission_policy_oracle.py::test_negated_prohibition_guidance_does_not_trip_policy_oracle`; focused pytest and oracle drift check passed locally.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#pullrequestreview-4328397344 -> c220482fd
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#discussion_r3273859141 -> c220482fd
+
 Disposition: NOT-A-BUG
 Evidence: Sourcery's review-level extraction comments are advisory refactor feedback, not correctness defects for this PR-2 governance/test-infrastructure scope. The policy/oracle logic intentionally remains in the existing semantic-cache gate entrypoint for this PR so the new guard cannot drift from the existing gate-closed admission checker. The root loop risk is addressed by policy-as-data, generated oracle drift checks, docs/CI wiring, and agent guidance; broader Experiment Runner oracle-manifest or helper-module extraction belongs in a separate coordinator-owned lane.
 Reason: The review-level helper extraction suggestion is a maintainability idea, while the concrete actionable Sourcery inline suggestions were fixed in `50de520c7`; extracting modules here would widen the PR beyond the approved governance/test-infrastructure scope.

--- a/docs/review/PR_1777_FIXED_MAPPING.md
+++ b/docs/review/PR_1777_FIXED_MAPPING.md
@@ -13,7 +13,6 @@ oracle.
 Disposition: FIXED
 Commit: 92083c466
 Evidence: CI/docs routing now passes the Philosophy admission policy JSON, schema, and generated oracle fixture into Docs Phase1 gates, and `tests/test_ci_workflow_pr_size_governance_contract.py` guards the workflow contract; this closes the Codex/Cubic finding that policy-only diffs could skip the new Phase1 checks.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#pullrequestreview-4328165585 -> 92083c466
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#discussion_r3273668187 -> 92083c466
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#discussion_r3273691727 -> 92083c466
@@ -21,7 +20,6 @@ Evidence: CI/docs routing now passes the Philosophy admission policy JSON, schem
 Disposition: FIXED
 Commit: 50de520c7
 Evidence: Bot findings from Sourcery, CodeRabbit, and cubic were closed in code/docs/tests: detector-label mismatch errors include expected/actual sets; oracle drift guidance no longer hard-codes the default policy filename; allowed oracle cases fail on any downstream false positive; merged PR-1 ledger state and PR-2 target PR are synced; Philosophy agent guidance names the exact oracle fixture path; oracle fixture write mode is blocked when validation already failed. Focused local proof: `python3 scripts/ci/check_semantic_cache_gate.py --check-philosophy-admission-oracle-drift`; `.venv/bin/python -m pytest -q tests/test_philosophy_admission_policy_oracle.py tests/test_ci_workflow_pr_size_governance_contract.py`; `git diff --check`.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#discussion_r3273641024 -> 50de520c7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#discussion_r3273641038 -> 50de520c7
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#pullrequestreview-4328170555 -> 50de520c7
@@ -32,7 +30,7 @@ Evidence: Bot findings from Sourcery, CodeRabbit, and cubic were closed in code/
 
 Disposition: NOT-A-BUG
 Evidence: Sourcery's review-level extraction comments are advisory refactor feedback, not correctness defects for this PR-2 governance/test-infrastructure scope. The policy/oracle logic intentionally remains in the existing semantic-cache gate entrypoint for this PR so the new guard cannot drift from the existing gate-closed admission checker. The root loop risk is addressed by policy-as-data, generated oracle drift checks, docs/CI wiring, and agent guidance; broader Experiment Runner oracle-manifest or helper-module extraction belongs in a separate coordinator-owned lane.
-
+Reason: The review-level helper extraction suggestion is a maintainability idea, while the concrete actionable Sourcery inline suggestions were fixed in `50de520c7`; extracting modules here would widen the PR beyond the approved governance/test-infrastructure scope.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1777#pullrequestreview-4328132580
 
 ## Role-Agent / Premortem Pass

--- a/docs/review/PR_1777_FIXED_MAPPING.md
+++ b/docs/review/PR_1777_FIXED_MAPPING.md
@@ -88,9 +88,9 @@ Reason: The review-level helper extraction suggestion is a maintainability idea,
   - PASS.
 - `python3 scripts/ci/check_docs_phase1_gates.py --files docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md docs/roadmap/BACKLOG_LEDGER.md docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.schema.json tests/fixtures/orchestration/philosophy_admission_claim_oracle.json`
   - PASS.
-- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_philosophy_admission_policy_oracle.py tests/test_philosophy_semantic_cache_admission_contract.py tests/test_semantic_cache_gate.py`
+- `.venv/bin/python -m pytest -q tests/test_philosophy_admission_policy_oracle.py tests/test_philosophy_semantic_cache_admission_contract.py tests/test_semantic_cache_gate.py`
   - PASS.
-- `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
+- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed`
   - PASS.
 - `pre-commit run --all-files` - PASS.
 - Pre-push hooks - PASS, including mypy, pip-audit, backend tests, full-repo

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2882,7 +2882,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: #1761 (`codex/philosophy-epic-v2-pr1-admission-contract`)
-  - Status: 🟡 In review / merge-ready stabilization after #1766 main security gate
+  - Status: ✅ Merged PR #1761 on 2026-05-20 (`b837a683914e3439de8a61a3102e1e1b3c9ad006`)
   - Area: AI / RAG / philosophy / semantic-cache governance
   - Finding Type: admission-contract and gate-closed governance
   - Reason (EN): PR #1742 merged the SC-G5 backend-selection contract as an offline, label-only, non-serving semantic-cache governance layer. Philosophy Epic V2 PR-1 must add the higher-level philosophical admission contract that defines runtime-only, blocked, verification-bundle-required, and future-deferred request classes without opening the semantic-cache gate, duplicating SC-G5 backend-selection ranking, or adding Redis/GPTCache, embeddings, storage, serving, providers, OpenAPI, DB, frontend, or iOS changes.
@@ -2899,6 +2899,30 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Focused validators and tests remain static/read-only and add no runtime cache dependencies
     - All premortem, architecture, philosophy, security, QA, and bug-hunter findings are dispositioned before readiness claims
     - PR body mirrors review-thread disposition, deferred/follow-up, and merge-readiness sections after PR open
+
+<a id="ledger-p1-philosophy-epic-v2-pr2-policy-oracle"></a>
+- [ ] P1: Philosophy Epic V2 PR-2 admission policy spec generator / claim-family oracle
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: `codex/philosophy-epic-v2-pr2-policy-oracle`
+  - Status: 🟡 Active in PR-2 branch
+  - Area: AI / RAG / philosophy / semantic-cache governance / test infrastructure
+  - Finding Type: false-green prevention, policy-as-data oracle, temporal/modal claim drift guard
+  - Reason (EN): PR #1761 closed the Philosophy PR-1 admission contract but review loops exposed a systemic failure mode: hand-expanded regexes and test grammars made the same semantic claim family reappear as fresh comments. PR-2 makes the admission claim policy canonical JSON data, generates deterministic oracle fixtures, and checks policy/schema/fixture drift before runtime semantic-cache work resumes.
+  - Links:
+    - `docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_CONTRACT.md`
+    - `docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json`
+    - `docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.schema.json`
+    - `tests/fixtures/orchestration/philosophy_admission_claim_oracle.json`
+    - `scripts/ci/check_semantic_cache_gate.py`
+    - `tests/test_philosophy_admission_policy_oracle.py`
+  - DoD:
+    - Canonical JSON policy defines every Philosophy admission forbidden-claim family with detector labels, modal/temporal drift examples, seed regressions, and allowed negative controls
+    - Generated oracle fixture is byte-stable and fails drift checks when policy/spec/test cases diverge
+    - Policy-driven checker preserves gate-closed behavior and does not add Redis, GPTCache, embeddings, vector search, provider/client, DB, OpenAPI, frontend, iOS, or runtime cache wiring
+    - Phase 1 docs gates validate the policy, schema, and oracle fixture, and downstream Philosophy docs still reject forbidden admission claims while allowing explicitly negative examples
+    - PR-2 documents the deterministic oracle boundary: semantic/research input may generate hypotheses, but admission truth is decided by policy/spec/oracle checks and does not mutate Experiment Runner or runtime oracle surfaces
+    - Premortem, architecture, philosophy, QA, security, and bug-hunter findings are fixed or formally dispositioned before readiness claims
 
 
 <a id="ledger-p1-recursive-methods"></a>

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2878,7 +2878,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docs/review/PR_<N>_FIXED_MAPPING.md` is added after the PR number exists and mirrored into the PR body
 
 <a id="ledger-p1-philosophy-epic-v2-pr1-admission"></a>
-- [ ] P1: Philosophy Epic V2 PR-1 semantic-cache admission contract
+- [x] P1: Philosophy Epic V2 PR-1 semantic-cache admission contract
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: #1761 (`codex/philosophy-epic-v2-pr1-admission-contract`)
@@ -2904,7 +2904,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Philosophy Epic V2 PR-2 admission policy spec generator / claim-family oracle
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: `codex/philosophy-epic-v2-pr2-policy-oracle`
+  - Target PR: #1777 (`codex/philosophy-epic-v2-pr2-policy-oracle`)
   - Status: 🟡 Active in PR-2 branch
   - Area: AI / RAG / philosophy / semantic-cache governance / test infrastructure
   - Finding Type: false-green prevention, policy-as-data oracle, temporal/modal claim drift guard

--- a/scripts/ci/check_docs_phase1_gates.py
+++ b/scripts/ci/check_docs_phase1_gates.py
@@ -23,6 +23,8 @@ try:
         validate_exact_fuzzy_scaffold_contract as _validate_exact_fuzzy_scaffold_contract,
         validate_philosophy_semantic_cache_admission_contract as _validate_philosophy_admission_contract,
         validate_philosophy_semantic_cache_admission_downstream_text as _validate_philosophy_admission_downstream_text,
+        validate_philosophy_semantic_cache_admission_policy as _validate_philosophy_admission_policy,
+        validate_philosophy_admission_oracle_fixture as _validate_philosophy_admission_oracle_fixture,
         validate_philosophy_semantic_cache_admission_schema as _validate_philosophy_admission_schema,
         validate_semantic_cache_backend_selection_contract as _validate_backend_selection_contract,
         validate_semantic_cache_backend_selection_schema as _validate_backend_selection_schema,
@@ -36,6 +38,8 @@ except ModuleNotFoundError:
         validate_exact_fuzzy_scaffold_contract as _validate_exact_fuzzy_scaffold_contract,
         validate_philosophy_semantic_cache_admission_contract as _validate_philosophy_admission_contract,
         validate_philosophy_semantic_cache_admission_downstream_text as _validate_philosophy_admission_downstream_text,
+        validate_philosophy_semantic_cache_admission_policy as _validate_philosophy_admission_policy,
+        validate_philosophy_admission_oracle_fixture as _validate_philosophy_admission_oracle_fixture,
         validate_philosophy_semantic_cache_admission_schema as _validate_philosophy_admission_schema,
         validate_semantic_cache_backend_selection_contract as _validate_backend_selection_contract,
         validate_semantic_cache_backend_selection_schema as _validate_backend_selection_schema,
@@ -66,6 +70,15 @@ PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_CONTRACT_DOC = (
 PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_CONTRACT_SCHEMA = (
     "docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_CONTRACT.schema.json"
 )
+PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY = (
+    "docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json"
+)
+PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY_SCHEMA = (
+    "docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.schema.json"
+)
+PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_ORACLE = (
+    "tests/fixtures/orchestration/philosophy_admission_claim_oracle.json"
+)
 PHILOSOPHY_DOWNSTREAM_DOC_PREFIXES: tuple[str, ...] = (
     "docs/orchestration/PHILOSOPHY_",
     "docs/orchestration/contracts/PHILOSOPHY_",
@@ -91,6 +104,10 @@ SemanticCacheGateValidator = Callable[[str], list[str]]
 
 class ContractSchemaValidator(Protocol):
     def __call__(self, *, schema_text: str, contract_text: str) -> list[str]: ...
+
+
+class PolicySchemaValidator(Protocol):
+    def __call__(self, *, policy_text: str, schema_text: str) -> list[str]: ...
 
 
 def _as_semantic_cache_gate_validator(validator: Any) -> SemanticCacheGateValidator:
@@ -145,6 +162,18 @@ def _load_philosophy_admission_schema_validator() -> ContractSchemaValidator:
     return _as_contract_schema_validator(
         _validate_philosophy_admission_schema,
     )
+
+
+def _load_philosophy_admission_policy_validator() -> PolicySchemaValidator:
+    return cast(PolicySchemaValidator, _validate_philosophy_admission_policy)
+
+
+class OracleFixtureValidator(Protocol):
+    def __call__(self, *, policy_text: str, fixture_text: str) -> list[str]: ...
+
+
+def _load_philosophy_admission_oracle_fixture_validator() -> OracleFixtureValidator:
+    return cast(OracleFixtureValidator, _validate_philosophy_admission_oracle_fixture)
 
 
 def _read_text(relpath: str) -> str:
@@ -311,6 +340,76 @@ def check_docs_phase1_guards(markdown_files: list[str]) -> list[str]:
                     for error in validate_philosophy_admission_schema(
                         schema_text=content,
                         contract_text=contract_text,
+                    )
+                )
+
+        if relpath == PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY:
+            validate_philosophy_admission_policy = _load_philosophy_admission_policy_validator()
+            try:
+                schema_text = _read_text(PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY_SCHEMA)
+            except FileNotFoundError:
+                errors.append(
+                    f"{relpath}: missing companion file "
+                    f"{PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY_SCHEMA}"
+                )
+            else:
+                errors.extend(
+                    f"{relpath}: {error}"
+                    for error in validate_philosophy_admission_policy(
+                        schema_text=schema_text,
+                        policy_text=content,
+                    )
+                )
+            validate_oracle_fixture = _load_philosophy_admission_oracle_fixture_validator()
+            try:
+                fixture_text = _read_text(PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_ORACLE)
+            except FileNotFoundError:
+                errors.append(
+                    f"{relpath}: missing companion file "
+                    f"{PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_ORACLE}"
+                )
+            else:
+                errors.extend(
+                    f"{relpath}: {error}"
+                    for error in validate_oracle_fixture(
+                        policy_text=content,
+                        fixture_text=fixture_text,
+                    )
+                )
+
+        if relpath == PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY_SCHEMA:
+            validate_philosophy_admission_policy = _load_philosophy_admission_policy_validator()
+            try:
+                policy_text = _read_text(PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY)
+            except FileNotFoundError:
+                errors.append(
+                    f"{relpath}: missing companion file "
+                    f"{PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY}"
+                )
+            else:
+                errors.extend(
+                    f"{relpath}: {error}"
+                    for error in validate_philosophy_admission_policy(
+                        schema_text=content,
+                        policy_text=policy_text,
+                    )
+                )
+
+        if relpath == PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_ORACLE:
+            validate_oracle_fixture = _load_philosophy_admission_oracle_fixture_validator()
+            try:
+                policy_text = _read_text(PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY)
+            except FileNotFoundError:
+                errors.append(
+                    f"{relpath}: missing companion file "
+                    f"{PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY}"
+                )
+            else:
+                errors.extend(
+                    f"{relpath}: {error}"
+                    for error in validate_oracle_fixture(
+                        policy_text=policy_text,
+                        fixture_text=content,
                     )
                 )
 

--- a/scripts/ci/check_semantic_cache_gate.py
+++ b/scripts/ci/check_semantic_cache_gate.py
@@ -49,6 +49,19 @@ DEFAULT_PHILOSOPHY_ADMISSION_CONTRACT = (
 DEFAULT_PHILOSOPHY_ADMISSION_SCHEMA = DEFAULT_PHILOSOPHY_ADMISSION_CONTRACT.with_suffix(
     ".schema.json"
 )
+DEFAULT_PHILOSOPHY_ADMISSION_POLICY = (
+    REPO_ROOT
+    / "docs"
+    / "orchestration"
+    / "contracts"
+    / "PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json"
+)
+DEFAULT_PHILOSOPHY_ADMISSION_POLICY_SCHEMA = DEFAULT_PHILOSOPHY_ADMISSION_POLICY.with_suffix(
+    ".schema.json"
+)
+DEFAULT_PHILOSOPHY_ADMISSION_ORACLE = (
+    REPO_ROOT / "tests" / "fixtures" / "orchestration" / "philosophy_admission_claim_oracle.json"
+)
 
 REQUIRED_MARKERS = {
     "SEMANTIC_CACHE_GATE_STATUS": "closed",
@@ -1674,6 +1687,578 @@ PHILOSOPHY_FORBIDDEN_CLAIM_PATTERN_LABELS = {
     "claim_class_pdf_design_intake_gate_override": ("design intake overrides gate markers",),
 }
 
+PHILOSOPHY_ADMISSION_POLICY_ID = "philosophy_semantic_cache_admission_policy"
+PHILOSOPHY_ADMISSION_POLICY_VERSION = "2026-05-20"
+PHILOSOPHY_ADMISSION_POLICY_PHASE = "PHILOSOPHY-PR2"
+PHILOSOPHY_ADMISSION_POLICY_REQUIRED_TOP_LEVEL_KEYS = {
+    "$schema",
+    "claim_families",
+    "gate_status",
+    "implementation_allowed",
+    "modal_operators",
+    "policy_id",
+    "policy_version",
+    "research_basis",
+    "rollout_phase",
+    "runtime_allowed",
+    "source_contract",
+    "temporal_operators",
+}
+PHILOSOPHY_ADMISSION_POLICY_REQUIRED_FAMILY_KEYS = {
+    "allowed_negative_controls",
+    "assertive_predicates",
+    "canonical_meaning",
+    "detector_labels",
+    "forbidden_polarity",
+    "id",
+    "modal_predicates",
+    "risk_rail",
+    "seed_regressions",
+    "subjects",
+    "temporal_predicates",
+}
+PHILOSOPHY_ADMISSION_POLICY_STRING_LIST_KEYS = {
+    "allowed_negative_controls",
+    "assertive_predicates",
+    "detector_labels",
+    "modal_predicates",
+    "seed_regressions",
+    "subjects",
+    "temporal_predicates",
+}
+
+_DEFAULT_PHILOSOPHY_ADMISSION_POLICY_CACHE: tuple[float, object, list[str]] | None = None
+_DEFAULT_PHILOSOPHY_ADMISSION_POLICY_PATTERNS_CACHE: (
+    tuple[float, tuple[tuple[str, str, re.Pattern[str]], ...]] | None
+) = None
+
+
+def _load_json_no_duplicate_keys(
+    text: str,
+    *,
+    invalid_prefix: str,
+    duplicate_prefix: str,
+) -> tuple[object, list[str]]:
+    duplicate_keys: list[str] = []
+
+    def reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        parsed: dict[str, object] = {}
+        for key, value in pairs:
+            if key in parsed and key not in duplicate_keys:
+                duplicate_keys.append(key)
+            parsed[key] = value
+        return parsed
+
+    try:
+        payload = json.loads(text, object_pairs_hook=reject_duplicate_keys)
+    except json.JSONDecodeError as exc:
+        return None, [f"{invalid_prefix}: {exc.msg}"]
+    if duplicate_keys:
+        return payload, [f"{duplicate_prefix}: {key}" for key in sorted(duplicate_keys)]
+    return payload, []
+
+
+def _require_string_list(
+    payload: dict[str, object],
+    key: str,
+    *,
+    prefix: str,
+    allow_empty: bool = False,
+) -> list[str]:
+    value = payload.get(key)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        return [f"{prefix} {key} must be a string list"]
+    if not allow_empty and not value:
+        return [f"{prefix} {key} must not be empty"]
+    if len(value) != len(set(value)):
+        return [f"{prefix} {key} contains duplicates"]
+    return []
+
+
+def _validate_philosophy_admission_policy_schema(
+    *,
+    schema: object,
+    policy: dict[str, object],
+) -> list[str]:
+    if not isinstance(schema, dict):
+        return ["philosophy admission policy schema must be an object"]
+    errors: list[str] = []
+    if schema.get("type") != "object":
+        errors.append("philosophy admission policy schema root type must be object")
+    if schema.get("additionalProperties") is not False:
+        errors.append("philosophy admission policy schema must set additionalProperties false")
+
+    required = schema.get("required")
+    properties = schema.get("properties")
+    if not isinstance(required, list) or not all(isinstance(item, str) for item in required):
+        errors.append("philosophy admission policy schema required must be a string list")
+        required = []
+    elif len(required) != len(set(required)):
+        errors.append("philosophy admission policy schema required contains duplicates")
+    if not isinstance(properties, dict):
+        errors.append("philosophy admission policy schema properties must be an object")
+        properties = {}
+
+    required_set = set(required)
+    policy_keys = set(policy)
+    property_keys = set(properties)
+    for key in sorted(policy_keys - required_set):
+        errors.append(f"philosophy admission policy key missing from schema required: {key}")
+    for key in sorted(required_set - policy_keys):
+        errors.append(f"philosophy admission policy schema required key missing from policy: {key}")
+    for key in sorted(policy_keys - property_keys):
+        errors.append(f"philosophy admission policy key missing from schema properties: {key}")
+    for key in sorted(property_keys - policy_keys):
+        errors.append(f"philosophy admission policy schema property missing from policy: {key}")
+
+    root_const_keys = {
+        "gate_status",
+        "implementation_allowed",
+        "policy_id",
+        "policy_version",
+        "rollout_phase",
+        "runtime_allowed",
+        "source_contract",
+    }
+    for key in root_const_keys:
+        spec = properties.get(key)
+        if not isinstance(spec, dict):
+            errors.append(f"philosophy admission policy schema property must be object for {key}")
+            continue
+        if "const" not in spec:
+            errors.append(f"philosophy admission policy schema const missing for {key}")
+            continue
+        if spec["const"] != policy.get(key):
+            errors.append(
+                f"philosophy admission policy schema const mismatch for {key}: "
+                f"expected {spec['const']!r}, got {policy.get(key)!r}"
+            )
+    families_spec = properties.get("claim_families")
+    if isinstance(families_spec, dict):
+        min_items = families_spec.get("minItems")
+        max_items = families_spec.get("maxItems")
+        policy_families = policy.get("claim_families", [])
+        family_count = len(policy_families) if isinstance(policy_families, list) else 0
+        if min_items != family_count:
+            errors.append(
+                "philosophy admission policy schema minItems mismatch for "
+                f"claim_families: expected {family_count}"
+            )
+        if max_items != family_count:
+            errors.append(
+                "philosophy admission policy schema maxItems mismatch for "
+                f"claim_families: expected {family_count}"
+            )
+        if families_spec.get("uniqueItems") is not True:
+            errors.append(
+                "philosophy admission policy schema uniqueItems missing for claim_families"
+            )
+    else:
+        errors.append("philosophy admission policy schema claim_families property must be object")
+    return errors
+
+
+def validate_philosophy_semantic_cache_admission_policy(
+    *,
+    policy_text: str,
+    schema_text: str,
+) -> list[str]:
+    """Validate the canonical Philosophy PR-2 claim-family policy spec."""
+    policy_obj, policy_parse_errors = _load_json_no_duplicate_keys(
+        policy_text,
+        invalid_prefix="philosophy admission policy invalid JSON",
+        duplicate_prefix="philosophy admission policy duplicate key",
+    )
+    if policy_parse_errors:
+        return policy_parse_errors
+    schema_obj, schema_parse_errors = _load_json_no_duplicate_keys(
+        schema_text,
+        invalid_prefix="philosophy admission policy schema invalid JSON",
+        duplicate_prefix="philosophy admission policy schema duplicate key",
+    )
+    if schema_parse_errors:
+        return schema_parse_errors
+    if not isinstance(policy_obj, dict):
+        return ["philosophy admission policy must be an object"]
+
+    errors: list[str] = []
+    actual_keys = set(policy_obj)
+    for key in sorted(PHILOSOPHY_ADMISSION_POLICY_REQUIRED_TOP_LEVEL_KEYS - actual_keys):
+        errors.append(f"philosophy admission policy missing required key: {key}")
+    for key in sorted(actual_keys - PHILOSOPHY_ADMISSION_POLICY_REQUIRED_TOP_LEVEL_KEYS):
+        errors.append(f"philosophy admission policy unexpected key: {key}")
+
+    expected_scalars = {
+        "gate_status": "closed",
+        "implementation_allowed": False,
+        "policy_id": PHILOSOPHY_ADMISSION_POLICY_ID,
+        "policy_version": PHILOSOPHY_ADMISSION_POLICY_VERSION,
+        "rollout_phase": PHILOSOPHY_ADMISSION_POLICY_PHASE,
+        "runtime_allowed": False,
+        "source_contract": str(DEFAULT_PHILOSOPHY_ADMISSION_CONTRACT.relative_to(REPO_ROOT)),
+    }
+    for key, expected in expected_scalars.items():
+        if policy_obj.get(key) != expected:
+            errors.append(
+                f"philosophy admission policy {key}: expected {expected!r}, "
+                f"got {policy_obj.get(key)!r}"
+            )
+
+    for key in ("modal_operators", "temporal_operators", "research_basis"):
+        errors.extend(_require_string_list(policy_obj, key, prefix="philosophy admission policy"))
+
+    families = policy_obj.get("claim_families")
+    if not isinstance(families, list) or not all(isinstance(item, dict) for item in families):
+        errors.append("philosophy admission policy claim_families must be an object list")
+        families = []
+    elif not families:
+        errors.append("philosophy admission policy claim_families must not be empty")
+
+    family_ids: list[str] = []
+    active_pattern_labels = {label for label, _pattern in PHILOSOPHY_ADMISSION_FORBIDDEN_PATTERNS}
+    mapped_family_ids = set(PHILOSOPHY_FORBIDDEN_CLAIM_PATTERN_LABELS)
+    for index, family_obj in enumerate(families):
+        family: dict[str, object] = dict(family_obj)
+        prefix = f"philosophy admission policy claim_families[{index}]"
+        actual_family_keys = set(family)
+        for key in sorted(PHILOSOPHY_ADMISSION_POLICY_REQUIRED_FAMILY_KEYS - actual_family_keys):
+            errors.append(f"{prefix} missing required key: {key}")
+        for key in sorted(actual_family_keys - PHILOSOPHY_ADMISSION_POLICY_REQUIRED_FAMILY_KEYS):
+            errors.append(f"{prefix} unexpected key: {key}")
+        family_id = family.get("id")
+        if not isinstance(family_id, str) or not family_id:
+            errors.append(f"{prefix} id must be a non-empty string")
+            continue
+        family_ids.append(family_id)
+        if family_id not in mapped_family_ids:
+            errors.append(f"{prefix} id is not a governed forbidden claim class: {family_id}")
+        for key in ("canonical_meaning", "forbidden_polarity", "risk_rail"):
+            if not isinstance(family.get(key), str) or not family.get(key):
+                errors.append(f"{prefix} {key} must be a non-empty string")
+        for key in PHILOSOPHY_ADMISSION_POLICY_STRING_LIST_KEYS:
+            errors.extend(_require_string_list(family, key, prefix=prefix))
+
+        detector_labels = family.get("detector_labels")
+        expected_labels = set(PHILOSOPHY_FORBIDDEN_CLAIM_PATTERN_LABELS.get(family_id, ()))
+        if isinstance(detector_labels, list) and all(
+            isinstance(item, str) for item in detector_labels
+        ):
+            if set(detector_labels) != expected_labels:
+                errors.append(f"{prefix} detector_labels set mismatch")
+            for label in detector_labels:
+                if label not in active_pattern_labels:
+                    errors.append(f"{prefix} detector label lacks active detector: {label}")
+    if len(family_ids) != len(set(family_ids)):
+        errors.append("philosophy admission policy claim_families contains duplicate ids")
+    if set(family_ids) != mapped_family_ids:
+        for missing in sorted(mapped_family_ids - set(family_ids)):
+            errors.append(f"philosophy admission policy missing claim family: {missing}")
+        for unexpected in sorted(set(family_ids) - mapped_family_ids):
+            errors.append(f"philosophy admission policy unexpected claim family: {unexpected}")
+
+    if isinstance(schema_obj, dict):
+        errors.extend(
+            _validate_philosophy_admission_policy_schema(schema=schema_obj, policy=policy_obj)
+        )
+    else:
+        errors.append("philosophy admission policy schema must be an object")
+    return errors
+
+
+def _load_philosophy_admission_policy_object(
+    policy_text: str,
+) -> tuple[dict[str, object], list[str]]:
+    policy_obj, parse_errors = _load_json_no_duplicate_keys(
+        policy_text,
+        invalid_prefix="philosophy admission policy invalid JSON",
+        duplicate_prefix="philosophy admission policy duplicate key",
+    )
+    if parse_errors:
+        return {}, parse_errors
+    if not isinstance(policy_obj, dict):
+        return {}, ["philosophy admission policy must be an object"]
+    return policy_obj, []
+
+
+def generate_philosophy_admission_oracle_cases(
+    policy: dict[str, object],
+) -> dict[str, object]:
+    """Generate deterministic claim-family oracle cases from the policy spec."""
+    generated_at = "static-2026-05-20"
+    cases: list[dict[str, object]] = []
+    families = policy.get("claim_families")
+    if not isinstance(families, list):
+        families = []
+    for family_obj in families:
+        if not isinstance(family_obj, dict):
+            continue
+        family_id = str(family_obj.get("id", "unknown"))
+        detector_labels = [
+            item for item in family_obj.get("detector_labels", []) if isinstance(item, str)
+        ]
+        expected_detector_label = detector_labels[0] if detector_labels else ""
+        subjects = [item for item in family_obj.get("subjects", []) if isinstance(item, str)]
+        assertive_predicates = [
+            item for item in family_obj.get("assertive_predicates", []) if isinstance(item, str)
+        ]
+        modal_predicates = [
+            item for item in family_obj.get("modal_predicates", []) if isinstance(item, str)
+        ]
+        temporal_predicates = [
+            item for item in family_obj.get("temporal_predicates", []) if isinstance(item, str)
+        ]
+        modal_operator_values = policy.get("modal_operators", [])
+        if not isinstance(modal_operator_values, list):
+            modal_operator_values = []
+        modal_operators = [item for item in modal_operator_values if isinstance(item, str)]
+        for subject in subjects:
+            for predicate in assertive_predicates:
+                cases.append(
+                    {
+                        "claim": f"{subject} {predicate}.",
+                        "claim_family": family_id,
+                        "expected": "forbidden",
+                        "expected_detector_label": expected_detector_label,
+                        "source": "policy.assertive_predicates",
+                    }
+                )
+        for index, modal in enumerate(modal_operators):
+            subject = subjects[index % len(subjects)] if subjects else "Philosophy admission"
+            predicate = (
+                modal_predicates[index % len(modal_predicates)]
+                if modal_predicates
+                else "open the semantic-cache gate"
+            )
+            cases.append(
+                {
+                    "claim": f"{subject} {modal} {predicate}.",
+                    "claim_family": family_id,
+                    "expected": "forbidden",
+                    "expected_detector_label": expected_detector_label,
+                    "source": "policy.modal_predicates",
+                }
+            )
+        for index, predicate in enumerate(temporal_predicates):
+            subject = subjects[index % len(subjects)] if subjects else "Philosophy admission"
+            cases.append(
+                {
+                    "claim": f"{subject} {predicate}.",
+                    "claim_family": family_id,
+                    "expected": "forbidden",
+                    "expected_detector_label": expected_detector_label,
+                    "source": "policy.temporal_predicates",
+                }
+            )
+        for claim in [
+            item for item in family_obj.get("seed_regressions", []) if isinstance(item, str)
+        ]:
+            cases.append(
+                {
+                    "claim": claim,
+                    "claim_family": family_id,
+                    "expected": "forbidden",
+                    "expected_detector_label": expected_detector_label,
+                    "source": "policy.seed_regressions",
+                }
+            )
+        for claim in [
+            item
+            for item in family_obj.get("allowed_negative_controls", [])
+            if isinstance(item, str)
+        ]:
+            cases.append(
+                {
+                    "claim": claim,
+                    "claim_family": family_id,
+                    "expected": "allowed",
+                    "expected_detector_label": expected_detector_label,
+                    "source": "policy.allowed_negative_controls",
+                }
+            )
+
+    deduped_cases: list[dict[str, object]] = []
+    seen: set[tuple[object, object, object]] = set()
+    for case in cases:
+        dedupe_key = (case["claim_family"], case["expected"], case["claim"])
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        deduped_cases.append(case)
+    deduped_cases.sort(
+        key=lambda item: (str(item["claim_family"]), str(item["expected"]), str(item["claim"]))
+    )
+    for index, case in enumerate(deduped_cases, start=1):
+        case["id"] = f"philosophy-admission-oracle-{index:04d}"
+    return {
+        "generated_at": generated_at,
+        "gate_status": policy.get("gate_status"),
+        "implementation_allowed": policy.get("implementation_allowed"),
+        "oracle_id": "philosophy_admission_claim_family_oracle",
+        "policy_id": policy.get("policy_id"),
+        "policy_version": policy.get("policy_version"),
+        "runtime_allowed": policy.get("runtime_allowed"),
+        "cases": deduped_cases,
+    }
+
+
+def render_philosophy_admission_oracle_fixture(policy_text: str) -> tuple[str, list[str]]:
+    policy, errors = _load_philosophy_admission_policy_object(policy_text)
+    if errors:
+        return "", errors
+    fixture = generate_philosophy_admission_oracle_cases(policy)
+    return json.dumps(fixture, indent=2, ensure_ascii=False) + "\n", []
+
+
+def _load_philosophy_admission_oracle_fixture(
+    fixture_text: str,
+) -> tuple[dict[str, object], list[str]]:
+    fixture_obj, parse_errors = _load_json_no_duplicate_keys(
+        fixture_text,
+        invalid_prefix="philosophy admission oracle fixture invalid JSON",
+        duplicate_prefix="philosophy admission oracle fixture duplicate key",
+    )
+    if parse_errors:
+        return {}, parse_errors
+    if not isinstance(fixture_obj, dict):
+        return {}, ["philosophy admission oracle fixture must be an object"]
+    return fixture_obj, []
+
+
+def validate_philosophy_admission_oracle_fixture(
+    *,
+    policy_text: str,
+    fixture_text: str,
+) -> list[str]:
+    """Fail when the tracked claim-family oracle drifts from the policy spec."""
+    expected_text, render_errors = render_philosophy_admission_oracle_fixture(policy_text)
+    if render_errors:
+        return render_errors
+    fixture, fixture_errors = _load_philosophy_admission_oracle_fixture(fixture_text)
+    if fixture_errors:
+        return fixture_errors
+    expected, expected_errors = _load_philosophy_admission_oracle_fixture(expected_text)
+    if expected_errors:
+        return expected_errors
+    errors: list[str] = []
+    if fixture != expected:
+        errors.append(
+            "philosophy admission oracle fixture drift: regenerate from "
+            "PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json"
+        )
+    cases = fixture.get("cases")
+    if not isinstance(cases, list) or not cases:
+        errors.append("philosophy admission oracle fixture cases must be a non-empty list")
+        return errors
+    case_ids: list[str] = []
+    by_family: dict[str, set[str]] = {}
+    for index, case_obj in enumerate(cases):
+        if not isinstance(case_obj, dict):
+            errors.append(f"philosophy admission oracle fixture cases[{index}] must be an object")
+            continue
+        case_id = case_obj.get("id")
+        if not isinstance(case_id, str) or not case_id:
+            errors.append(f"philosophy admission oracle fixture cases[{index}] id missing")
+        else:
+            case_ids.append(case_id)
+        family = case_obj.get("claim_family")
+        expected_result = case_obj.get("expected")
+        claim = case_obj.get("claim")
+        if not isinstance(family, str) or family not in PHILOSOPHY_FORBIDDEN_CLAIM_PATTERN_LABELS:
+            errors.append(f"philosophy admission oracle fixture cases[{index}] invalid family")
+            continue
+        if expected_result not in {"forbidden", "allowed"}:
+            errors.append(f"philosophy admission oracle fixture cases[{index}] invalid expected")
+            continue
+        if not isinstance(claim, str) or not claim.strip():
+            errors.append(f"philosophy admission oracle fixture cases[{index}] claim missing")
+        by_family.setdefault(family, set()).add(str(expected_result))
+    if len(case_ids) != len(set(case_ids)):
+        errors.append("philosophy admission oracle fixture case ids contain duplicates")
+    for family in PHILOSOPHY_FORBIDDEN_CLAIM_PATTERN_LABELS:
+        outcomes = by_family.get(family, set())
+        if "forbidden" not in outcomes:
+            errors.append(
+                f"philosophy admission oracle fixture missing forbidden case for {family}"
+            )
+        if "allowed" not in outcomes:
+            errors.append(f"philosophy admission oracle fixture missing allowed case for {family}")
+    return errors
+
+
+def _default_philosophy_admission_policy() -> tuple[dict[str, object], list[str]]:
+    global _DEFAULT_PHILOSOPHY_ADMISSION_POLICY_CACHE
+    try:
+        stat = DEFAULT_PHILOSOPHY_ADMISSION_POLICY.stat()
+    except FileNotFoundError:
+        return {}, [f"philosophy admission policy missing: {DEFAULT_PHILOSOPHY_ADMISSION_POLICY}"]
+    if (
+        _DEFAULT_PHILOSOPHY_ADMISSION_POLICY_CACHE is not None
+        and _DEFAULT_PHILOSOPHY_ADMISSION_POLICY_CACHE[0] == stat.st_mtime
+    ):
+        cached_policy = _DEFAULT_PHILOSOPHY_ADMISSION_POLICY_CACHE[1]
+        cached_errors = _DEFAULT_PHILOSOPHY_ADMISSION_POLICY_CACHE[2]
+        if isinstance(cached_policy, dict):
+            return cached_policy, list(cached_errors)
+        return {}, list(cached_errors)
+
+    policy, errors = _load_philosophy_admission_policy_object(
+        DEFAULT_PHILOSOPHY_ADMISSION_POLICY.read_text(encoding="utf-8")
+    )
+    _DEFAULT_PHILOSOPHY_ADMISSION_POLICY_CACHE = (stat.st_mtime, policy, errors)
+    return policy, list(errors)
+
+
+def compile_philosophy_admission_policy_patterns(
+    policy: dict[str, object],
+) -> tuple[tuple[str, str, re.Pattern[str]], ...]:
+    """Compile exact deterministic policy-oracle patterns from data, not JSON regex."""
+    patterns: list[tuple[str, str, re.Pattern[str]]] = []
+    fixture = generate_philosophy_admission_oracle_cases(policy)
+    cases = fixture.get("cases", [])
+    if not isinstance(cases, list):
+        return ()
+    for case_obj in cases:
+        if not isinstance(case_obj, dict) or case_obj.get("expected") != "forbidden":
+            continue
+        claim = case_obj.get("claim")
+        family = case_obj.get("claim_family")
+        if not isinstance(claim, str) or not isinstance(family, str):
+            continue
+        normalized_claim = _normalize_text(claim).rstrip(".")
+        if not normalized_claim:
+            continue
+        pattern = re.compile(r"(?<![\w-])" + re.escape(normalized_claim) + r"\.?(?![\w-])")
+        patterns.append((family, str(case_obj.get("expected_detector_label", "")), pattern))
+    return tuple(patterns)
+
+
+def _philosophy_admission_policy_forbidden_claim_errors(text: str) -> list[str]:
+    global _DEFAULT_PHILOSOPHY_ADMISSION_POLICY_PATTERNS_CACHE
+    policy, policy_errors = _default_philosophy_admission_policy()
+    if policy_errors:
+        return policy_errors
+    stat = DEFAULT_PHILOSOPHY_ADMISSION_POLICY.stat()
+    if (
+        _DEFAULT_PHILOSOPHY_ADMISSION_POLICY_PATTERNS_CACHE is not None
+        and _DEFAULT_PHILOSOPHY_ADMISSION_POLICY_PATTERNS_CACHE[0] == stat.st_mtime
+    ):
+        patterns = _DEFAULT_PHILOSOPHY_ADMISSION_POLICY_PATTERNS_CACHE[1]
+    else:
+        patterns = compile_philosophy_admission_policy_patterns(policy)
+        _DEFAULT_PHILOSOPHY_ADMISSION_POLICY_PATTERNS_CACHE = (stat.st_mtime, patterns)
+    errors: list[str] = []
+    for claim_family, detector_label, pattern in patterns:
+        for match in pattern.finditer(text):
+            if _is_negated_philosophy_permission_claim(text, match):
+                continue
+            label = detector_label or claim_family
+            errors.append(
+                "forbidden philosophy admission policy claim: " f"{claim_family} ({label})"
+            )
+            break
+    return errors
+
+
 MARKER_RE = re.compile(r"<!--\s*(?P<key>SEMANTIC_CACHE_[A-Z_]+):\s*(?P<value>.*?)\s*-->")
 MACHINE_JSON_RE = re.compile(r"```json\s*(?P<payload>\{.*?\})\s*```", re.DOTALL)
 MARKDOWN_BULLET_PREFIX_RE = re.compile(r"^(?:[-*+]|\d+[.)])\s+")
@@ -1749,6 +2334,7 @@ def _philosophy_admission_forbidden_claim_errors(text: str) -> list[str]:
                 continue
             errors.append(f"forbidden philosophy admission contract claim: {label}")
             break
+    errors.extend(_philosophy_admission_policy_forbidden_claim_errors(text))
     return errors
 
 
@@ -2956,6 +3542,34 @@ def main(argv: list[str] | None = None) -> int:
         default=DEFAULT_PHILOSOPHY_ADMISSION_SCHEMA,
         help="Philosophy PR-1 admission JSON schema to validate.",
     )
+    parser.add_argument(
+        "--philosophy-admission-policy",
+        type=Path,
+        default=DEFAULT_PHILOSOPHY_ADMISSION_POLICY,
+        help="Philosophy PR-2 admission claim-family policy JSON to validate.",
+    )
+    parser.add_argument(
+        "--philosophy-admission-policy-schema",
+        type=Path,
+        default=DEFAULT_PHILOSOPHY_ADMISSION_POLICY_SCHEMA,
+        help="Philosophy PR-2 admission claim-family policy JSON schema to validate.",
+    )
+    parser.add_argument(
+        "--philosophy-admission-oracle",
+        type=Path,
+        default=DEFAULT_PHILOSOPHY_ADMISSION_ORACLE,
+        help="Generated Philosophy PR-2 admission claim-family oracle fixture.",
+    )
+    parser.add_argument(
+        "--check-philosophy-admission-oracle-drift",
+        action="store_true",
+        help="Fail if the tracked Philosophy admission oracle fixture drifts from policy JSON.",
+    )
+    parser.add_argument(
+        "--write-philosophy-admission-oracle",
+        action="store_true",
+        help="Rewrite the tracked Philosophy admission oracle fixture from policy JSON.",
+    )
     args = parser.parse_args(argv)
 
     doc = args.doc
@@ -3021,6 +3635,28 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
+    philosophy_admission_policy = args.philosophy_admission_policy
+    if not philosophy_admission_policy.exists():
+        print(
+            f"ERROR: philosophy admission policy missing: {philosophy_admission_policy}",
+            file=sys.stderr,
+        )
+        return 1
+    philosophy_admission_policy_schema = args.philosophy_admission_policy_schema
+    if not philosophy_admission_policy_schema.exists():
+        print(
+            "ERROR: philosophy admission policy schema missing: "
+            f"{philosophy_admission_policy_schema}",
+            file=sys.stderr,
+        )
+        return 1
+    philosophy_admission_oracle = args.philosophy_admission_oracle
+    if not philosophy_admission_oracle.exists() and not args.write_philosophy_admission_oracle:
+        print(
+            f"ERROR: philosophy admission oracle fixture missing: {philosophy_admission_oracle}",
+            file=sys.stderr,
+        )
+        return 1
 
     errors = validate_semantic_cache_gate(doc.read_text(encoding="utf-8"))
     errors.extend(validate_semantic_cache_rollout_contract(contract.read_text(encoding="utf-8")))
@@ -3053,6 +3689,35 @@ def main(argv: list[str] | None = None) -> int:
             contract_text=philosophy_admission_text,
         )
     )
+    philosophy_policy_text = philosophy_admission_policy.read_text(encoding="utf-8")
+    errors.extend(
+        validate_philosophy_semantic_cache_admission_policy(
+            policy_text=philosophy_policy_text,
+            schema_text=philosophy_admission_policy_schema.read_text(encoding="utf-8"),
+        )
+    )
+    if args.write_philosophy_admission_oracle:
+        rendered, render_errors = render_philosophy_admission_oracle_fixture(philosophy_policy_text)
+        errors.extend(render_errors)
+        if not render_errors:
+            oracle_path = philosophy_admission_oracle.resolve()
+            allowed_root = (REPO_ROOT / "tests" / "fixtures" / "orchestration").resolve()
+            if not oracle_path.is_relative_to(allowed_root):
+                errors.append(
+                    "philosophy admission oracle write path must stay under "
+                    "tests/fixtures/orchestration"
+                )
+            else:
+                oracle_path.parent.mkdir(parents=True, exist_ok=True)
+                oracle_path.write_text(rendered, encoding="utf-8")
+    if args.check_philosophy_admission_oracle_drift or not args.write_philosophy_admission_oracle:
+        if philosophy_admission_oracle.exists():
+            errors.extend(
+                validate_philosophy_admission_oracle_fixture(
+                    policy_text=philosophy_policy_text,
+                    fixture_text=philosophy_admission_oracle.read_text(encoding="utf-8"),
+                )
+            )
     if errors:
         for error in errors:
             print(f"ERROR: {error}", file=sys.stderr)
@@ -3065,6 +3730,8 @@ def main(argv: list[str] | None = None) -> int:
     print(f"bounded insight experiment contract closed: {bounded_insight_contract}")
     print(f"backend selection contract closed: {backend_selection_contract}")
     print(f"philosophy admission contract closed: {philosophy_admission_contract}")
+    print(f"philosophy admission policy closed: {philosophy_admission_policy}")
+    print(f"philosophy admission oracle fixture current: {philosophy_admission_oracle}")
     return 0
 
 

--- a/scripts/ci/check_semantic_cache_gate.py
+++ b/scripts/ci/check_semantic_cache_gate.py
@@ -1650,6 +1650,12 @@ PHILOSOPHY_NEGATED_PERMISSION_PREFIX_RE = re.compile(
     r"should\s+not|must\s+not|does\s+not|do\s+not)\b"
     r"(?:\s+(?:currently|yet|formally|actually|explicitly)){0,3}\s*$"
 )
+PHILOSOPHY_NEGATED_ASSERTION_PREFIX_RE = re.compile(
+    r"(?:^|\s)(?:no|not|never|can't|cannot|won't|shouldn't|mustn't|doesn't|don't|"
+    r"should\s+not|must\s+not|does\s+not|do\s+not)\b"
+    r"(?:\s+(?:currently|yet|formally|actually|explicitly)){0,3}"
+    r"\s+(?:claim|state|assert|say|write|imply|suggest)(?:\s+that)?\s*$"
+)
 PHILOSOPHY_NEGATED_PERMISSION_DOMAIN_RE = re.compile(
     r"\b(?:pr-1|philosophy admission|semantic[- ]cache gate|global gate|redis|"
     r"gptcache|backend[- ]selection|serving|runtime|providers?|storage|cache|"
@@ -2306,6 +2312,8 @@ def _is_negated_philosophy_duplication_claim(text: str, match: re.Match[str]) ->
 
 def _is_negated_philosophy_permission_claim(text: str, match: re.Match[str]) -> bool:
     prefix = text[max(0, match.start() - 80) : match.start()]
+    if PHILOSOPHY_NEGATED_ASSERTION_PREFIX_RE.search(prefix) is not None:
+        return True
     if PHILOSOPHY_NEGATED_PERMISSION_PREFIX_RE.search(prefix) is None:
         return False
     token_count = len(prefix.strip().split())

--- a/scripts/ci/check_semantic_cache_gate.py
+++ b/scripts/ci/check_semantic_cache_gate.py
@@ -2022,33 +2022,29 @@ def generate_philosophy_admission_oracle_cases(
                         "source": "policy.assertive_predicates",
                     }
                 )
-        for index, modal in enumerate(modal_operators):
-            subject = subjects[index % len(subjects)] if subjects else "Philosophy admission"
-            predicate = (
-                modal_predicates[index % len(modal_predicates)]
-                if modal_predicates
-                else "open the semantic-cache gate"
-            )
-            cases.append(
-                {
-                    "claim": f"{subject} {modal} {predicate}.",
-                    "claim_family": family_id,
-                    "expected": "forbidden",
-                    "expected_detector_label": expected_detector_label,
-                    "source": "policy.modal_predicates",
-                }
-            )
-        for index, predicate in enumerate(temporal_predicates):
-            subject = subjects[index % len(subjects)] if subjects else "Philosophy admission"
-            cases.append(
-                {
-                    "claim": f"{subject} {predicate}.",
-                    "claim_family": family_id,
-                    "expected": "forbidden",
-                    "expected_detector_label": expected_detector_label,
-                    "source": "policy.temporal_predicates",
-                }
-            )
+        for subject in subjects:
+            for modal in modal_operators:
+                for predicate in modal_predicates:
+                    cases.append(
+                        {
+                            "claim": f"{subject} {modal} {predicate}.",
+                            "claim_family": family_id,
+                            "expected": "forbidden",
+                            "expected_detector_label": expected_detector_label,
+                            "source": "policy.modal_predicates.cross_product",
+                        }
+                    )
+        for subject in subjects:
+            for predicate in temporal_predicates:
+                cases.append(
+                    {
+                        "claim": f"{subject} {predicate}.",
+                        "claim_family": family_id,
+                        "expected": "forbidden",
+                        "expected_detector_label": expected_detector_label,
+                        "source": "policy.temporal_predicates.cross_product",
+                    }
+                )
         for claim in [
             item for item in family_obj.get("seed_regressions", []) if isinstance(item, str)
         ]:

--- a/scripts/ci/check_semantic_cache_gate.py
+++ b/scripts/ci/check_semantic_cache_gate.py
@@ -2238,7 +2238,11 @@ def compile_philosophy_admission_policy_patterns(
     return tuple(patterns)
 
 
-def _philosophy_admission_policy_forbidden_claim_errors(text: str) -> list[str]:
+def _philosophy_admission_policy_forbidden_claim_errors(
+    text: str,
+    *,
+    suppressed_detector_labels: set[str] | None = None,
+) -> list[str]:
     global _DEFAULT_PHILOSOPHY_ADMISSION_POLICY_PATTERNS_CACHE
     policy, policy_errors = _default_philosophy_admission_policy()
     if policy_errors:
@@ -2258,6 +2262,8 @@ def _philosophy_admission_policy_forbidden_claim_errors(text: str) -> list[str]:
             if _is_negated_philosophy_permission_claim(text, match):
                 continue
             label = detector_label or claim_family
+            if suppressed_detector_labels is not None and label in suppressed_detector_labels:
+                continue
             errors.append(
                 "forbidden philosophy admission policy claim: " f"{claim_family} ({label})"
             )
@@ -2322,6 +2328,7 @@ def _is_negated_philosophy_permission_claim(text: str, match: re.Match[str]) -> 
 
 def _philosophy_admission_forbidden_claim_errors(text: str) -> list[str]:
     errors: list[str] = []
+    legacy_detector_labels: set[str] = set()
     for label, pattern in PHILOSOPHY_ADMISSION_FORBIDDEN_PATTERNS:
         for match in pattern.finditer(text):
             if label in PHILOSOPHY_SC_G5_LABEL_DUPLICATION_PATTERN_LABELS and (
@@ -2341,8 +2348,14 @@ def _philosophy_admission_forbidden_claim_errors(text: str) -> list[str]:
             ):
                 continue
             errors.append(f"forbidden philosophy admission contract claim: {label}")
+            legacy_detector_labels.add(label)
             break
-    errors.extend(_philosophy_admission_policy_forbidden_claim_errors(text))
+    errors.extend(
+        _philosophy_admission_policy_forbidden_claim_errors(
+            text,
+            suppressed_detector_labels=legacy_detector_labels,
+        )
+    )
     return errors
 
 

--- a/scripts/ci/check_semantic_cache_gate.py
+++ b/scripts/ci/check_semantic_cache_gate.py
@@ -1943,8 +1943,12 @@ def validate_philosophy_semantic_cache_admission_policy(
         if isinstance(detector_labels, list) and all(
             isinstance(item, str) for item in detector_labels
         ):
-            if set(detector_labels) != expected_labels:
-                errors.append(f"{prefix} detector_labels set mismatch")
+            actual_labels = set(detector_labels)
+            if actual_labels != expected_labels:
+                errors.append(
+                    f"{prefix} detector_labels set mismatch: "
+                    f"expected={sorted(expected_labels)}, actual={sorted(actual_labels)}"
+                )
             for label in detector_labels:
                 if label not in active_pattern_labels:
                     errors.append(f"{prefix} detector label lacks active detector: {label}")
@@ -2138,8 +2142,8 @@ def validate_philosophy_admission_oracle_fixture(
     errors: list[str] = []
     if fixture != expected:
         errors.append(
-            "philosophy admission oracle fixture drift: regenerate from "
-            "PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json"
+            "philosophy admission oracle fixture drift: regenerate from the policy JSON "
+            "used in this check"
         )
     cases = fixture.get("cases")
     if not isinstance(cases, list) or not cases:
@@ -3693,9 +3697,15 @@ def main(argv: list[str] | None = None) -> int:
         )
     )
     if args.write_philosophy_admission_oracle:
-        rendered, render_errors = render_philosophy_admission_oracle_fixture(philosophy_policy_text)
-        errors.extend(render_errors)
-        if not render_errors:
+        if not errors:
+            rendered, render_errors = render_philosophy_admission_oracle_fixture(
+                philosophy_policy_text
+            )
+            errors.extend(render_errors)
+        else:
+            rendered = ""
+            render_errors = []
+        if not errors and not render_errors:
             oracle_path = philosophy_admission_oracle.resolve()
             allowed_root = (REPO_ROOT / "tests" / "fixtures" / "orchestration").resolve()
             if not oracle_path.is_relative_to(allowed_root):

--- a/tests/fixtures/orchestration/philosophy_admission_claim_oracle.json
+++ b/tests/fixtures/orchestration/philosophy_admission_claim_oracle.json
@@ -32,12 +32,76 @@
       "id": "philosophy-admission-oracle-0003"
     },
     {
+      "claim": "PR-1 became sufficient to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0004"
+    },
+    {
+      "claim": "PR-1 can be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0005"
+    },
+    {
+      "claim": "PR-1 can enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0006"
+    },
+    {
       "claim": "PR-1 can open the semantic-cache gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0004"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0007"
+    },
+    {
+      "claim": "PR-1 can unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0008"
+    },
+    {
+      "claim": "PR-1 could be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0009"
+    },
+    {
+      "claim": "PR-1 could enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0010"
+    },
+    {
+      "claim": "PR-1 could open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0011"
+    },
+    {
+      "claim": "PR-1 could unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0012"
     },
     {
       "claim": "PR-1 enables the global gate.",
@@ -45,15 +109,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0005"
+      "id": "philosophy-admission-oracle-0013"
     },
     {
       "claim": "PR-1 has opened the semantic-cache gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0006"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0014"
+    },
+    {
+      "claim": "PR-1 has to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0015"
+    },
+    {
+      "claim": "PR-1 has to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0016"
+    },
+    {
+      "claim": "PR-1 has to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0017"
+    },
+    {
+      "claim": "PR-1 has to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0018"
     },
     {
       "claim": "PR-1 is equivalent to opening the semantic-cache gate.",
@@ -61,15 +157,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0007"
+      "id": "philosophy-admission-oracle-0019"
+    },
+    {
+      "claim": "PR-1 is now opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0020"
+    },
+    {
+      "claim": "PR-1 is required to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0021"
+    },
+    {
+      "claim": "PR-1 is required to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0022"
     },
     {
       "claim": "PR-1 is required to open the semantic-cache gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0008"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0023"
+    },
+    {
+      "claim": "PR-1 is required to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0024"
     },
     {
       "claim": "PR-1 keeps the semantic-cache gate open.",
@@ -77,7 +205,103 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0009"
+      "id": "philosophy-admission-oracle-0025"
+    },
+    {
+      "claim": "PR-1 may be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0026"
+    },
+    {
+      "claim": "PR-1 may enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0027"
+    },
+    {
+      "claim": "PR-1 may open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0028"
+    },
+    {
+      "claim": "PR-1 may unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0029"
+    },
+    {
+      "claim": "PR-1 might be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0030"
+    },
+    {
+      "claim": "PR-1 might enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0031"
+    },
+    {
+      "claim": "PR-1 might open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0032"
+    },
+    {
+      "claim": "PR-1 might unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0033"
+    },
+    {
+      "claim": "PR-1 must be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0034"
+    },
+    {
+      "claim": "PR-1 must enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0035"
+    },
+    {
+      "claim": "PR-1 must open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0036"
+    },
+    {
+      "claim": "PR-1 must unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0037"
     },
     {
       "claim": "PR-1 opens the semantic-cache gate.",
@@ -85,7 +309,55 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0010"
+      "id": "philosophy-admission-oracle-0038"
+    },
+    {
+      "claim": "PR-1 remains enough to open the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0039"
+    },
+    {
+      "claim": "PR-1 should be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0040"
+    },
+    {
+      "claim": "PR-1 should enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0041"
+    },
+    {
+      "claim": "PR-1 should open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0042"
+    },
+    {
+      "claim": "PR-1 should unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0043"
+    },
+    {
+      "claim": "PR-1 still keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0044"
     },
     {
       "claim": "PR-1 unlocks the semantic-cache gate.",
@@ -93,15 +365,143 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0011"
+      "id": "philosophy-admission-oracle-0045"
+    },
+    {
+      "claim": "PR-1 will be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0046"
+    },
+    {
+      "claim": "PR-1 will enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0047"
+    },
+    {
+      "claim": "PR-1 will open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0048"
+    },
+    {
+      "claim": "PR-1 will unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0049"
+    },
+    {
+      "claim": "PR-1 would be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0050"
+    },
+    {
+      "claim": "PR-1 would enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0051"
+    },
+    {
+      "claim": "PR-1 would open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0052"
+    },
+    {
+      "claim": "PR-1 would unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0053"
     },
     {
       "claim": "PR-2 became sufficient to open the semantic-cache gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0012"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0054"
+    },
+    {
+      "claim": "PR-2 can be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0055"
+    },
+    {
+      "claim": "PR-2 can enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0056"
+    },
+    {
+      "claim": "PR-2 can open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0057"
+    },
+    {
+      "claim": "PR-2 can unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0058"
+    },
+    {
+      "claim": "PR-2 could be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0059"
+    },
+    {
+      "claim": "PR-2 could enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0060"
+    },
+    {
+      "claim": "PR-2 could open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0061"
+    },
+    {
+      "claim": "PR-2 could unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0062"
     },
     {
       "claim": "PR-2 does not only open the semantic-cache gate.",
@@ -109,7 +509,7 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0013"
+      "id": "philosophy-admission-oracle-0063"
     },
     {
       "claim": "PR-2 enables the global gate.",
@@ -117,15 +517,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0014"
+      "id": "philosophy-admission-oracle-0064"
+    },
+    {
+      "claim": "PR-2 has opened the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0065"
+    },
+    {
+      "claim": "PR-2 has to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0066"
+    },
+    {
+      "claim": "PR-2 has to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0067"
+    },
+    {
+      "claim": "PR-2 has to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0068"
     },
     {
       "claim": "PR-2 has to unlock the semantic-cache gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0015"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0069"
     },
     {
       "claim": "PR-2 is equivalent to opening the semantic-cache gate.",
@@ -133,7 +565,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0016"
+      "id": "philosophy-admission-oracle-0070"
+    },
+    {
+      "claim": "PR-2 is now opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0071"
+    },
+    {
+      "claim": "PR-2 is required to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0072"
+    },
+    {
+      "claim": "PR-2 is required to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0073"
+    },
+    {
+      "claim": "PR-2 is required to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0074"
+    },
+    {
+      "claim": "PR-2 is required to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0075"
     },
     {
       "claim": "PR-2 keeps the semantic-cache gate open.",
@@ -141,15 +613,103 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0017"
+      "id": "philosophy-admission-oracle-0076"
+    },
+    {
+      "claim": "PR-2 may be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0077"
+    },
+    {
+      "claim": "PR-2 may enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0078"
+    },
+    {
+      "claim": "PR-2 may open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0079"
     },
     {
       "claim": "PR-2 may unlock the semantic-cache gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0018"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0080"
+    },
+    {
+      "claim": "PR-2 might be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0081"
+    },
+    {
+      "claim": "PR-2 might enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0082"
+    },
+    {
+      "claim": "PR-2 might open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0083"
+    },
+    {
+      "claim": "PR-2 might unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0084"
+    },
+    {
+      "claim": "PR-2 must be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0085"
+    },
+    {
+      "claim": "PR-2 must enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0086"
+    },
+    {
+      "claim": "PR-2 must open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0087"
+    },
+    {
+      "claim": "PR-2 must unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0088"
     },
     {
       "claim": "PR-2 opens the semantic-cache gate.",
@@ -157,7 +717,55 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0019"
+      "id": "philosophy-admission-oracle-0089"
+    },
+    {
+      "claim": "PR-2 remains enough to open the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0090"
+    },
+    {
+      "claim": "PR-2 should be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0091"
+    },
+    {
+      "claim": "PR-2 should enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0092"
+    },
+    {
+      "claim": "PR-2 should open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0093"
+    },
+    {
+      "claim": "PR-2 should unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0094"
+    },
+    {
+      "claim": "PR-2 still keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0095"
     },
     {
       "claim": "PR-2 unlocks the semantic-cache gate.",
@@ -165,7 +773,143 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0020"
+      "id": "philosophy-admission-oracle-0096"
+    },
+    {
+      "claim": "PR-2 will be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0097"
+    },
+    {
+      "claim": "PR-2 will enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0098"
+    },
+    {
+      "claim": "PR-2 will open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0099"
+    },
+    {
+      "claim": "PR-2 will unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0100"
+    },
+    {
+      "claim": "PR-2 would be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0101"
+    },
+    {
+      "claim": "PR-2 would enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0102"
+    },
+    {
+      "claim": "PR-2 would open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0103"
+    },
+    {
+      "claim": "PR-2 would unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0104"
+    },
+    {
+      "claim": "Philosophy admission became sufficient to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0105"
+    },
+    {
+      "claim": "Philosophy admission can be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0106"
+    },
+    {
+      "claim": "Philosophy admission can enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0107"
+    },
+    {
+      "claim": "Philosophy admission can open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0108"
+    },
+    {
+      "claim": "Philosophy admission can unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0109"
+    },
+    {
+      "claim": "Philosophy admission could be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0110"
+    },
+    {
+      "claim": "Philosophy admission could enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0111"
+    },
+    {
+      "claim": "Philosophy admission could open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0112"
+    },
+    {
+      "claim": "Philosophy admission could unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0113"
     },
     {
       "claim": "Philosophy admission enables the global gate.",
@@ -173,7 +917,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0021"
+      "id": "philosophy-admission-oracle-0114"
+    },
+    {
+      "claim": "Philosophy admission has opened the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0115"
+    },
+    {
+      "claim": "Philosophy admission has to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0116"
+    },
+    {
+      "claim": "Philosophy admission has to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0117"
+    },
+    {
+      "claim": "Philosophy admission has to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0118"
+    },
+    {
+      "claim": "Philosophy admission has to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0119"
     },
     {
       "claim": "Philosophy admission is equivalent to opening the semantic-cache gate.",
@@ -181,7 +965,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0022"
+      "id": "philosophy-admission-oracle-0120"
+    },
+    {
+      "claim": "Philosophy admission is now opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0121"
+    },
+    {
+      "claim": "Philosophy admission is required to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0122"
+    },
+    {
+      "claim": "Philosophy admission is required to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0123"
+    },
+    {
+      "claim": "Philosophy admission is required to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0124"
+    },
+    {
+      "claim": "Philosophy admission is required to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0125"
     },
     {
       "claim": "Philosophy admission keeps the semantic-cache gate open.",
@@ -189,15 +1013,103 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0023"
+      "id": "philosophy-admission-oracle-0126"
+    },
+    {
+      "claim": "Philosophy admission may be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0127"
+    },
+    {
+      "claim": "Philosophy admission may enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0128"
+    },
+    {
+      "claim": "Philosophy admission may open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0129"
+    },
+    {
+      "claim": "Philosophy admission may unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0130"
+    },
+    {
+      "claim": "Philosophy admission might be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0131"
+    },
+    {
+      "claim": "Philosophy admission might enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0132"
+    },
+    {
+      "claim": "Philosophy admission might open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0133"
+    },
+    {
+      "claim": "Philosophy admission might unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0134"
+    },
+    {
+      "claim": "Philosophy admission must be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0135"
     },
     {
       "claim": "Philosophy admission must enable the global gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0024"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0136"
+    },
+    {
+      "claim": "Philosophy admission must open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0137"
+    },
+    {
+      "claim": "Philosophy admission must unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0138"
     },
     {
       "claim": "Philosophy admission opens the semantic-cache gate.",
@@ -205,15 +1117,55 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0025"
+      "id": "philosophy-admission-oracle-0139"
     },
     {
       "claim": "Philosophy admission remains enough to open the global gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0026"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0140"
+    },
+    {
+      "claim": "Philosophy admission should be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0141"
+    },
+    {
+      "claim": "Philosophy admission should enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0142"
+    },
+    {
+      "claim": "Philosophy admission should open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0143"
+    },
+    {
+      "claim": "Philosophy admission should unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0144"
+    },
+    {
+      "claim": "Philosophy admission still keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0145"
     },
     {
       "claim": "Philosophy admission unlocks the semantic-cache gate.",
@@ -221,7 +1173,143 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0027"
+      "id": "philosophy-admission-oracle-0146"
+    },
+    {
+      "claim": "Philosophy admission will be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0147"
+    },
+    {
+      "claim": "Philosophy admission will enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0148"
+    },
+    {
+      "claim": "Philosophy admission will open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0149"
+    },
+    {
+      "claim": "Philosophy admission will unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0150"
+    },
+    {
+      "claim": "Philosophy admission would be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0151"
+    },
+    {
+      "claim": "Philosophy admission would enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0152"
+    },
+    {
+      "claim": "Philosophy admission would open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0153"
+    },
+    {
+      "claim": "Philosophy admission would unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0154"
+    },
+    {
+      "claim": "The admission contract became sufficient to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0155"
+    },
+    {
+      "claim": "The admission contract can be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0156"
+    },
+    {
+      "claim": "The admission contract can enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0157"
+    },
+    {
+      "claim": "The admission contract can open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0158"
+    },
+    {
+      "claim": "The admission contract can unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0159"
+    },
+    {
+      "claim": "The admission contract could be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0160"
+    },
+    {
+      "claim": "The admission contract could enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0161"
+    },
+    {
+      "claim": "The admission contract could open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0162"
+    },
+    {
+      "claim": "The admission contract could unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0163"
     },
     {
       "claim": "The admission contract enables the global gate.",
@@ -229,7 +1317,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0028"
+      "id": "philosophy-admission-oracle-0164"
+    },
+    {
+      "claim": "The admission contract has opened the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0165"
+    },
+    {
+      "claim": "The admission contract has to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0166"
+    },
+    {
+      "claim": "The admission contract has to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0167"
+    },
+    {
+      "claim": "The admission contract has to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0168"
+    },
+    {
+      "claim": "The admission contract has to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0169"
     },
     {
       "claim": "The admission contract is equivalent to opening the semantic-cache gate.",
@@ -237,15 +1365,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0029"
+      "id": "philosophy-admission-oracle-0170"
     },
     {
       "claim": "The admission contract is now opening the semantic-cache gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0030"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0171"
+    },
+    {
+      "claim": "The admission contract is required to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0172"
+    },
+    {
+      "claim": "The admission contract is required to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0173"
+    },
+    {
+      "claim": "The admission contract is required to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0174"
+    },
+    {
+      "claim": "The admission contract is required to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0175"
     },
     {
       "claim": "The admission contract keeps the semantic-cache gate open.",
@@ -253,7 +1413,103 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0031"
+      "id": "philosophy-admission-oracle-0176"
+    },
+    {
+      "claim": "The admission contract may be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0177"
+    },
+    {
+      "claim": "The admission contract may enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0178"
+    },
+    {
+      "claim": "The admission contract may open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0179"
+    },
+    {
+      "claim": "The admission contract may unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0180"
+    },
+    {
+      "claim": "The admission contract might be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0181"
+    },
+    {
+      "claim": "The admission contract might enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0182"
+    },
+    {
+      "claim": "The admission contract might open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0183"
+    },
+    {
+      "claim": "The admission contract might unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0184"
+    },
+    {
+      "claim": "The admission contract must be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0185"
+    },
+    {
+      "claim": "The admission contract must enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0186"
+    },
+    {
+      "claim": "The admission contract must open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0187"
+    },
+    {
+      "claim": "The admission contract must unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0188"
     },
     {
       "claim": "The admission contract opens the semantic-cache gate.",
@@ -261,15 +1517,55 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0032"
+      "id": "philosophy-admission-oracle-0189"
+    },
+    {
+      "claim": "The admission contract remains enough to open the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0190"
     },
     {
       "claim": "The admission contract should be equivalent to opening the semantic-cache gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0033"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0191"
+    },
+    {
+      "claim": "The admission contract should enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0192"
+    },
+    {
+      "claim": "The admission contract should open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0193"
+    },
+    {
+      "claim": "The admission contract should unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0194"
+    },
+    {
+      "claim": "The admission contract still keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0195"
     },
     {
       "claim": "The admission contract unlocks the semantic-cache gate.",
@@ -277,15 +1573,143 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0034"
+      "id": "philosophy-admission-oracle-0196"
+    },
+    {
+      "claim": "The admission contract will be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0197"
+    },
+    {
+      "claim": "The admission contract will enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0198"
+    },
+    {
+      "claim": "The admission contract will open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0199"
+    },
+    {
+      "claim": "The admission contract will unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0200"
+    },
+    {
+      "claim": "The admission contract would be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0201"
+    },
+    {
+      "claim": "The admission contract would enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0202"
+    },
+    {
+      "claim": "The admission contract would open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0203"
+    },
+    {
+      "claim": "The admission contract would unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0204"
+    },
+    {
+      "claim": "The admission policy became sufficient to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0205"
+    },
+    {
+      "claim": "The admission policy can be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0206"
+    },
+    {
+      "claim": "The admission policy can enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0207"
+    },
+    {
+      "claim": "The admission policy can open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0208"
+    },
+    {
+      "claim": "The admission policy can unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0209"
+    },
+    {
+      "claim": "The admission policy could be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0210"
+    },
+    {
+      "claim": "The admission policy could enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0211"
     },
     {
       "claim": "The admission policy could open the semantic-cache gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0035"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0212"
+    },
+    {
+      "claim": "The admission policy could unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0213"
     },
     {
       "claim": "The admission policy enables the global gate.",
@@ -293,7 +1717,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0036"
+      "id": "philosophy-admission-oracle-0214"
+    },
+    {
+      "claim": "The admission policy has opened the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0215"
+    },
+    {
+      "claim": "The admission policy has to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0216"
+    },
+    {
+      "claim": "The admission policy has to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0217"
+    },
+    {
+      "claim": "The admission policy has to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0218"
+    },
+    {
+      "claim": "The admission policy has to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0219"
     },
     {
       "claim": "The admission policy is equivalent to opening the semantic-cache gate.",
@@ -301,7 +1765,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0037"
+      "id": "philosophy-admission-oracle-0220"
+    },
+    {
+      "claim": "The admission policy is now opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0221"
+    },
+    {
+      "claim": "The admission policy is required to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0222"
+    },
+    {
+      "claim": "The admission policy is required to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0223"
+    },
+    {
+      "claim": "The admission policy is required to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0224"
+    },
+    {
+      "claim": "The admission policy is required to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0225"
     },
     {
       "claim": "The admission policy keeps the semantic-cache gate open.",
@@ -309,7 +1813,103 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0038"
+      "id": "philosophy-admission-oracle-0226"
+    },
+    {
+      "claim": "The admission policy may be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0227"
+    },
+    {
+      "claim": "The admission policy may enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0228"
+    },
+    {
+      "claim": "The admission policy may open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0229"
+    },
+    {
+      "claim": "The admission policy may unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0230"
+    },
+    {
+      "claim": "The admission policy might be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0231"
+    },
+    {
+      "claim": "The admission policy might enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0232"
+    },
+    {
+      "claim": "The admission policy might open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0233"
+    },
+    {
+      "claim": "The admission policy might unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0234"
+    },
+    {
+      "claim": "The admission policy must be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0235"
+    },
+    {
+      "claim": "The admission policy must enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0236"
+    },
+    {
+      "claim": "The admission policy must open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0237"
+    },
+    {
+      "claim": "The admission policy must unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0238"
     },
     {
       "claim": "The admission policy opens the semantic-cache gate.",
@@ -317,15 +1917,55 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0039"
+      "id": "philosophy-admission-oracle-0239"
+    },
+    {
+      "claim": "The admission policy remains enough to open the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0240"
+    },
+    {
+      "claim": "The admission policy should be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0241"
+    },
+    {
+      "claim": "The admission policy should enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0242"
+    },
+    {
+      "claim": "The admission policy should open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0243"
+    },
+    {
+      "claim": "The admission policy should unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0244"
     },
     {
       "claim": "The admission policy still keeps the semantic-cache gate open.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0040"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0245"
     },
     {
       "claim": "The admission policy unlocks the semantic-cache gate.",
@@ -333,15 +1973,143 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0041"
+      "id": "philosophy-admission-oracle-0246"
+    },
+    {
+      "claim": "The admission policy will be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0247"
+    },
+    {
+      "claim": "The admission policy will enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0248"
+    },
+    {
+      "claim": "The admission policy will open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0249"
+    },
+    {
+      "claim": "The admission policy will unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0250"
+    },
+    {
+      "claim": "The admission policy would be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0251"
+    },
+    {
+      "claim": "The admission policy would enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0252"
+    },
+    {
+      "claim": "The admission policy would open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0253"
+    },
+    {
+      "claim": "The admission policy would unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0254"
     },
     {
       "claim": "The claim-family oracle became sufficient to open the semantic-cache gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0042"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0255"
+    },
+    {
+      "claim": "The claim-family oracle can be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0256"
+    },
+    {
+      "claim": "The claim-family oracle can enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0257"
+    },
+    {
+      "claim": "The claim-family oracle can open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0258"
+    },
+    {
+      "claim": "The claim-family oracle can unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0259"
+    },
+    {
+      "claim": "The claim-family oracle could be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0260"
+    },
+    {
+      "claim": "The claim-family oracle could enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0261"
+    },
+    {
+      "claim": "The claim-family oracle could open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0262"
+    },
+    {
+      "claim": "The claim-family oracle could unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0263"
     },
     {
       "claim": "The claim-family oracle enables the global gate.",
@@ -349,7 +2117,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0043"
+      "id": "philosophy-admission-oracle-0264"
+    },
+    {
+      "claim": "The claim-family oracle has opened the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0265"
+    },
+    {
+      "claim": "The claim-family oracle has to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0266"
+    },
+    {
+      "claim": "The claim-family oracle has to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0267"
+    },
+    {
+      "claim": "The claim-family oracle has to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0268"
+    },
+    {
+      "claim": "The claim-family oracle has to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0269"
     },
     {
       "claim": "The claim-family oracle is equivalent to opening the semantic-cache gate.",
@@ -357,7 +2165,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0044"
+      "id": "philosophy-admission-oracle-0270"
+    },
+    {
+      "claim": "The claim-family oracle is now opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0271"
+    },
+    {
+      "claim": "The claim-family oracle is required to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0272"
+    },
+    {
+      "claim": "The claim-family oracle is required to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0273"
+    },
+    {
+      "claim": "The claim-family oracle is required to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0274"
+    },
+    {
+      "claim": "The claim-family oracle is required to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0275"
     },
     {
       "claim": "The claim-family oracle keeps the semantic-cache gate open.",
@@ -365,7 +2213,103 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0045"
+      "id": "philosophy-admission-oracle-0276"
+    },
+    {
+      "claim": "The claim-family oracle may be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0277"
+    },
+    {
+      "claim": "The claim-family oracle may enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0278"
+    },
+    {
+      "claim": "The claim-family oracle may open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0279"
+    },
+    {
+      "claim": "The claim-family oracle may unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0280"
+    },
+    {
+      "claim": "The claim-family oracle might be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0281"
+    },
+    {
+      "claim": "The claim-family oracle might enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0282"
+    },
+    {
+      "claim": "The claim-family oracle might open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0283"
+    },
+    {
+      "claim": "The claim-family oracle might unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0284"
+    },
+    {
+      "claim": "The claim-family oracle must be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0285"
+    },
+    {
+      "claim": "The claim-family oracle must enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0286"
+    },
+    {
+      "claim": "The claim-family oracle must open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0287"
+    },
+    {
+      "claim": "The claim-family oracle must unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0288"
     },
     {
       "claim": "The claim-family oracle opens the semantic-cache gate.",
@@ -373,7 +2317,55 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0046"
+      "id": "philosophy-admission-oracle-0289"
+    },
+    {
+      "claim": "The claim-family oracle remains enough to open the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0290"
+    },
+    {
+      "claim": "The claim-family oracle should be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0291"
+    },
+    {
+      "claim": "The claim-family oracle should enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0292"
+    },
+    {
+      "claim": "The claim-family oracle should open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0293"
+    },
+    {
+      "claim": "The claim-family oracle should unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0294"
+    },
+    {
+      "claim": "The claim-family oracle still keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0295"
     },
     {
       "claim": "The claim-family oracle unlocks the semantic-cache gate.",
@@ -381,15 +2373,143 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0047"
+      "id": "philosophy-admission-oracle-0296"
+    },
+    {
+      "claim": "The claim-family oracle will be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0297"
+    },
+    {
+      "claim": "The claim-family oracle will enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0298"
+    },
+    {
+      "claim": "The claim-family oracle will open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0299"
+    },
+    {
+      "claim": "The claim-family oracle will unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0300"
+    },
+    {
+      "claim": "The claim-family oracle would be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0301"
+    },
+    {
+      "claim": "The claim-family oracle would enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0302"
+    },
+    {
+      "claim": "The claim-family oracle would open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0303"
     },
     {
       "claim": "The claim-family oracle would unlock the semantic-cache gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0048"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0304"
+    },
+    {
+      "claim": "The global gate became sufficient to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0305"
+    },
+    {
+      "claim": "The global gate can be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0306"
+    },
+    {
+      "claim": "The global gate can enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0307"
+    },
+    {
+      "claim": "The global gate can open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0308"
+    },
+    {
+      "claim": "The global gate can unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0309"
+    },
+    {
+      "claim": "The global gate could be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0310"
+    },
+    {
+      "claim": "The global gate could enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0311"
+    },
+    {
+      "claim": "The global gate could open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0312"
+    },
+    {
+      "claim": "The global gate could unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0313"
     },
     {
       "claim": "The global gate enables the global gate.",
@@ -397,7 +2517,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0049"
+      "id": "philosophy-admission-oracle-0314"
+    },
+    {
+      "claim": "The global gate has opened the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0315"
+    },
+    {
+      "claim": "The global gate has to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0316"
+    },
+    {
+      "claim": "The global gate has to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0317"
+    },
+    {
+      "claim": "The global gate has to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0318"
+    },
+    {
+      "claim": "The global gate has to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0319"
     },
     {
       "claim": "The global gate is equivalent to opening the semantic-cache gate.",
@@ -405,7 +2565,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0050"
+      "id": "philosophy-admission-oracle-0320"
+    },
+    {
+      "claim": "The global gate is now opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0321"
+    },
+    {
+      "claim": "The global gate is required to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0322"
+    },
+    {
+      "claim": "The global gate is required to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0323"
+    },
+    {
+      "claim": "The global gate is required to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0324"
+    },
+    {
+      "claim": "The global gate is required to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0325"
     },
     {
       "claim": "The global gate keeps the semantic-cache gate open.",
@@ -413,7 +2613,103 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0051"
+      "id": "philosophy-admission-oracle-0326"
+    },
+    {
+      "claim": "The global gate may be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0327"
+    },
+    {
+      "claim": "The global gate may enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0328"
+    },
+    {
+      "claim": "The global gate may open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0329"
+    },
+    {
+      "claim": "The global gate may unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0330"
+    },
+    {
+      "claim": "The global gate might be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0331"
+    },
+    {
+      "claim": "The global gate might enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0332"
+    },
+    {
+      "claim": "The global gate might open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0333"
+    },
+    {
+      "claim": "The global gate might unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0334"
+    },
+    {
+      "claim": "The global gate must be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0335"
+    },
+    {
+      "claim": "The global gate must enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0336"
+    },
+    {
+      "claim": "The global gate must open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0337"
+    },
+    {
+      "claim": "The global gate must unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0338"
     },
     {
       "claim": "The global gate opens the semantic-cache gate.",
@@ -421,7 +2717,55 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0052"
+      "id": "philosophy-admission-oracle-0339"
+    },
+    {
+      "claim": "The global gate remains enough to open the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0340"
+    },
+    {
+      "claim": "The global gate should be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0341"
+    },
+    {
+      "claim": "The global gate should enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0342"
+    },
+    {
+      "claim": "The global gate should open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0343"
+    },
+    {
+      "claim": "The global gate should unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0344"
+    },
+    {
+      "claim": "The global gate still keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0345"
     },
     {
       "claim": "The global gate unlocks the semantic-cache gate.",
@@ -429,15 +2773,143 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0053"
+      "id": "philosophy-admission-oracle-0346"
     },
     {
       "claim": "The global gate will be equivalent to opening the semantic-cache gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0054"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0347"
+    },
+    {
+      "claim": "The global gate will enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0348"
+    },
+    {
+      "claim": "The global gate will open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0349"
+    },
+    {
+      "claim": "The global gate will unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0350"
+    },
+    {
+      "claim": "The global gate would be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0351"
+    },
+    {
+      "claim": "The global gate would enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0352"
+    },
+    {
+      "claim": "The global gate would open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0353"
+    },
+    {
+      "claim": "The global gate would unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0354"
+    },
+    {
+      "claim": "The semantic-cache gate became sufficient to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0355"
+    },
+    {
+      "claim": "The semantic-cache gate can be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0356"
+    },
+    {
+      "claim": "The semantic-cache gate can enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0357"
+    },
+    {
+      "claim": "The semantic-cache gate can open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0358"
+    },
+    {
+      "claim": "The semantic-cache gate can unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0359"
+    },
+    {
+      "claim": "The semantic-cache gate could be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0360"
+    },
+    {
+      "claim": "The semantic-cache gate could enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0361"
+    },
+    {
+      "claim": "The semantic-cache gate could open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0362"
+    },
+    {
+      "claim": "The semantic-cache gate could unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0363"
     },
     {
       "claim": "The semantic-cache gate enables the global gate.",
@@ -445,7 +2917,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0055"
+      "id": "philosophy-admission-oracle-0364"
+    },
+    {
+      "claim": "The semantic-cache gate has opened the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0365"
+    },
+    {
+      "claim": "The semantic-cache gate has to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0366"
+    },
+    {
+      "claim": "The semantic-cache gate has to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0367"
+    },
+    {
+      "claim": "The semantic-cache gate has to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0368"
+    },
+    {
+      "claim": "The semantic-cache gate has to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0369"
     },
     {
       "claim": "The semantic-cache gate is equivalent to opening the semantic-cache gate.",
@@ -453,7 +2965,7 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0056"
+      "id": "philosophy-admission-oracle-0370"
     },
     {
       "claim": "The semantic-cache gate is now being opened for PR-2.",
@@ -461,7 +2973,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0057"
+      "id": "philosophy-admission-oracle-0371"
+    },
+    {
+      "claim": "The semantic-cache gate is now opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0372"
+    },
+    {
+      "claim": "The semantic-cache gate is required to be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0373"
+    },
+    {
+      "claim": "The semantic-cache gate is required to enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0374"
+    },
+    {
+      "claim": "The semantic-cache gate is required to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0375"
+    },
+    {
+      "claim": "The semantic-cache gate is required to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0376"
     },
     {
       "claim": "The semantic-cache gate keeps the semantic-cache gate open.",
@@ -469,15 +3021,103 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0058"
+      "id": "philosophy-admission-oracle-0377"
+    },
+    {
+      "claim": "The semantic-cache gate may be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0378"
+    },
+    {
+      "claim": "The semantic-cache gate may enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0379"
+    },
+    {
+      "claim": "The semantic-cache gate may open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0380"
+    },
+    {
+      "claim": "The semantic-cache gate may unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0381"
+    },
+    {
+      "claim": "The semantic-cache gate might be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0382"
     },
     {
       "claim": "The semantic-cache gate might enable the global gate.",
       "claim_family": "claim_class_gate_open_equivalence",
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0059"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0383"
+    },
+    {
+      "claim": "The semantic-cache gate might open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0384"
+    },
+    {
+      "claim": "The semantic-cache gate might unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0385"
+    },
+    {
+      "claim": "The semantic-cache gate must be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0386"
+    },
+    {
+      "claim": "The semantic-cache gate must enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0387"
+    },
+    {
+      "claim": "The semantic-cache gate must open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0388"
+    },
+    {
+      "claim": "The semantic-cache gate must unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0389"
     },
     {
       "claim": "The semantic-cache gate opens the semantic-cache gate.",
@@ -485,7 +3125,55 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0060"
+      "id": "philosophy-admission-oracle-0390"
+    },
+    {
+      "claim": "The semantic-cache gate remains enough to open the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0391"
+    },
+    {
+      "claim": "The semantic-cache gate should be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0392"
+    },
+    {
+      "claim": "The semantic-cache gate should enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0393"
+    },
+    {
+      "claim": "The semantic-cache gate should open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0394"
+    },
+    {
+      "claim": "The semantic-cache gate should unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0395"
+    },
+    {
+      "claim": "The semantic-cache gate still keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0396"
     },
     {
       "claim": "The semantic-cache gate unlocks the semantic-cache gate.",
@@ -493,7 +3181,71 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophy admission opens gate",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0061"
+      "id": "philosophy-admission-oracle-0397"
+    },
+    {
+      "claim": "The semantic-cache gate will be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0398"
+    },
+    {
+      "claim": "The semantic-cache gate will enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0399"
+    },
+    {
+      "claim": "The semantic-cache gate will open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0400"
+    },
+    {
+      "claim": "The semantic-cache gate will unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0401"
+    },
+    {
+      "claim": "The semantic-cache gate would be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0402"
+    },
+    {
+      "claim": "The semantic-cache gate would enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0403"
+    },
+    {
+      "claim": "The semantic-cache gate would open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0404"
+    },
+    {
+      "claim": "The semantic-cache gate would unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0405"
     },
     {
       "claim": "Future PR may evaluate cache serving only after the gate opens.",
@@ -501,7 +3253,7 @@
       "expected": "allowed",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0062"
+      "id": "philosophy-admission-oracle-0406"
     },
     {
       "claim": "Philosophical semantic-cache is not live.",
@@ -509,7 +3261,7 @@
       "expected": "allowed",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0063"
+      "id": "philosophy-admission-oracle-0407"
     },
     {
       "claim": "The policy oracle does not serve cached responses.",
@@ -517,7 +3269,7 @@
       "expected": "allowed",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0064"
+      "id": "philosophy-admission-oracle-0408"
     },
     {
       "claim": "Future philosophy PRs may now serve cached responses.",
@@ -525,7 +3277,119 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0065"
+      "id": "philosophy-admission-oracle-0409"
+    },
+    {
+      "claim": "PR-2 cache path became live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0410"
+    },
+    {
+      "claim": "PR-2 cache path can keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0411"
+    },
+    {
+      "claim": "PR-2 cache path can return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0412"
+    },
+    {
+      "claim": "PR-2 cache path can run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0413"
+    },
+    {
+      "claim": "PR-2 cache path can serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0414"
+    },
+    {
+      "claim": "PR-2 cache path could keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0415"
+    },
+    {
+      "claim": "PR-2 cache path could return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0416"
+    },
+    {
+      "claim": "PR-2 cache path could run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0417"
+    },
+    {
+      "claim": "PR-2 cache path could serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0418"
+    },
+    {
+      "claim": "PR-2 cache path has been live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0419"
+    },
+    {
+      "claim": "PR-2 cache path has to keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0420"
+    },
+    {
+      "claim": "PR-2 cache path has to return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0421"
+    },
+    {
+      "claim": "PR-2 cache path has to run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0422"
+    },
+    {
+      "claim": "PR-2 cache path has to serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0423"
     },
     {
       "claim": "PR-2 cache path is active.",
@@ -533,7 +3397,7 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0066"
+      "id": "philosophy-admission-oracle-0424"
     },
     {
       "claim": "PR-2 cache path is live.",
@@ -541,23 +3405,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0067"
+      "id": "philosophy-admission-oracle-0425"
+    },
+    {
+      "claim": "PR-2 cache path is required to keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0426"
+    },
+    {
+      "claim": "PR-2 cache path is required to return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0427"
+    },
+    {
+      "claim": "PR-2 cache path is required to run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0428"
     },
     {
       "claim": "PR-2 cache path is required to serve cached responses.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0068"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0429"
     },
     {
       "claim": "PR-2 cache path is still serving cached responses.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0069"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0430"
     },
     {
       "claim": "PR-2 cache path keeps semantic-cache serving live.",
@@ -565,7 +3453,111 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0070"
+      "id": "philosophy-admission-oracle-0431"
+    },
+    {
+      "claim": "PR-2 cache path may keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0432"
+    },
+    {
+      "claim": "PR-2 cache path may return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0433"
+    },
+    {
+      "claim": "PR-2 cache path may run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0434"
+    },
+    {
+      "claim": "PR-2 cache path may serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0435"
+    },
+    {
+      "claim": "PR-2 cache path might keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0436"
+    },
+    {
+      "claim": "PR-2 cache path might return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0437"
+    },
+    {
+      "claim": "PR-2 cache path might run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0438"
+    },
+    {
+      "claim": "PR-2 cache path might serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0439"
+    },
+    {
+      "claim": "PR-2 cache path must keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0440"
+    },
+    {
+      "claim": "PR-2 cache path must return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0441"
+    },
+    {
+      "claim": "PR-2 cache path must run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0442"
+    },
+    {
+      "claim": "PR-2 cache path must serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0443"
+    },
+    {
+      "claim": "PR-2 cache path remains live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0444"
     },
     {
       "claim": "PR-2 cache path serves cached responses.",
@@ -573,7 +3565,7 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0071"
+      "id": "philosophy-admission-oracle-0445"
     },
     {
       "claim": "PR-2 cache path serves philosophy cache hits.",
@@ -581,31 +3573,215 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0072"
+      "id": "philosophy-admission-oracle-0446"
+    },
+    {
+      "claim": "PR-2 cache path should keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0447"
+    },
+    {
+      "claim": "PR-2 cache path should return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0448"
     },
     {
       "claim": "PR-2 cache path should run as a live cache.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0073"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0449"
+    },
+    {
+      "claim": "PR-2 cache path should serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0450"
+    },
+    {
+      "claim": "PR-2 cache path will keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0451"
+    },
+    {
+      "claim": "PR-2 cache path will return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0452"
+    },
+    {
+      "claim": "PR-2 cache path will run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0453"
+    },
+    {
+      "claim": "PR-2 cache path will serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0454"
+    },
+    {
+      "claim": "PR-2 cache path would keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0455"
+    },
+    {
+      "claim": "PR-2 cache path would return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0456"
+    },
+    {
+      "claim": "PR-2 cache path would run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0457"
+    },
+    {
+      "claim": "PR-2 cache path would serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0458"
+    },
+    {
+      "claim": "Philosophical semantic-cache became live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0459"
+    },
+    {
+      "claim": "Philosophical semantic-cache can keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0460"
+    },
+    {
+      "claim": "Philosophical semantic-cache can return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0461"
+    },
+    {
+      "claim": "Philosophical semantic-cache can run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0462"
     },
     {
       "claim": "Philosophical semantic-cache can serve cached responses.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0074"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0463"
+    },
+    {
+      "claim": "Philosophical semantic-cache could keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0464"
+    },
+    {
+      "claim": "Philosophical semantic-cache could return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0465"
+    },
+    {
+      "claim": "Philosophical semantic-cache could run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0466"
+    },
+    {
+      "claim": "Philosophical semantic-cache could serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0467"
     },
     {
       "claim": "Philosophical semantic-cache has been live.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0075"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0468"
+    },
+    {
+      "claim": "Philosophical semantic-cache has to keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0469"
+    },
+    {
+      "claim": "Philosophical semantic-cache has to return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0470"
+    },
+    {
+      "claim": "Philosophical semantic-cache has to run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0471"
+    },
+    {
+      "claim": "Philosophical semantic-cache has to serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0472"
     },
     {
       "claim": "Philosophical semantic-cache is active.",
@@ -613,7 +3789,7 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0076"
+      "id": "philosophy-admission-oracle-0473"
     },
     {
       "claim": "Philosophical semantic-cache is live.",
@@ -621,7 +3797,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0077"
+      "id": "philosophy-admission-oracle-0474"
+    },
+    {
+      "claim": "Philosophical semantic-cache is required to keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0475"
+    },
+    {
+      "claim": "Philosophical semantic-cache is required to return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0476"
+    },
+    {
+      "claim": "Philosophical semantic-cache is required to run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0477"
+    },
+    {
+      "claim": "Philosophical semantic-cache is required to serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0478"
+    },
+    {
+      "claim": "Philosophical semantic-cache is still serving cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0479"
     },
     {
       "claim": "Philosophical semantic-cache keeps semantic-cache serving live.",
@@ -629,7 +3845,111 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0078"
+      "id": "philosophy-admission-oracle-0480"
+    },
+    {
+      "claim": "Philosophical semantic-cache may keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0481"
+    },
+    {
+      "claim": "Philosophical semantic-cache may return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0482"
+    },
+    {
+      "claim": "Philosophical semantic-cache may run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0483"
+    },
+    {
+      "claim": "Philosophical semantic-cache may serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0484"
+    },
+    {
+      "claim": "Philosophical semantic-cache might keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0485"
+    },
+    {
+      "claim": "Philosophical semantic-cache might return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0486"
+    },
+    {
+      "claim": "Philosophical semantic-cache might run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0487"
+    },
+    {
+      "claim": "Philosophical semantic-cache might serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0488"
+    },
+    {
+      "claim": "Philosophical semantic-cache must keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0489"
+    },
+    {
+      "claim": "Philosophical semantic-cache must return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0490"
+    },
+    {
+      "claim": "Philosophical semantic-cache must run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0491"
+    },
+    {
+      "claim": "Philosophical semantic-cache must serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0492"
+    },
+    {
+      "claim": "Philosophical semantic-cache remains live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0493"
     },
     {
       "claim": "Philosophical semantic-cache serves cached responses.",
@@ -637,7 +3957,7 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0079"
+      "id": "philosophy-admission-oracle-0494"
     },
     {
       "claim": "Philosophical semantic-cache serves philosophy cache hits.",
@@ -645,15 +3965,215 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0080"
+      "id": "philosophy-admission-oracle-0495"
+    },
+    {
+      "claim": "Philosophical semantic-cache should keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0496"
+    },
+    {
+      "claim": "Philosophical semantic-cache should return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0497"
+    },
+    {
+      "claim": "Philosophical semantic-cache should run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0498"
+    },
+    {
+      "claim": "Philosophical semantic-cache should serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0499"
+    },
+    {
+      "claim": "Philosophical semantic-cache will keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0500"
+    },
+    {
+      "claim": "Philosophical semantic-cache will return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0501"
+    },
+    {
+      "claim": "Philosophical semantic-cache will run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0502"
+    },
+    {
+      "claim": "Philosophical semantic-cache will serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0503"
     },
     {
       "claim": "Philosophical semantic-cache would keep semantic-cache serving live.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0081"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0504"
+    },
+    {
+      "claim": "Philosophical semantic-cache would return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0505"
+    },
+    {
+      "claim": "Philosophical semantic-cache would run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0506"
+    },
+    {
+      "claim": "Philosophical semantic-cache would serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0507"
+    },
+    {
+      "claim": "Philosophy admission cache became live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0508"
+    },
+    {
+      "claim": "Philosophy admission cache can keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0509"
+    },
+    {
+      "claim": "Philosophy admission cache can return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0510"
+    },
+    {
+      "claim": "Philosophy admission cache can run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0511"
+    },
+    {
+      "claim": "Philosophy admission cache can serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0512"
+    },
+    {
+      "claim": "Philosophy admission cache could keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0513"
+    },
+    {
+      "claim": "Philosophy admission cache could return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0514"
+    },
+    {
+      "claim": "Philosophy admission cache could run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0515"
+    },
+    {
+      "claim": "Philosophy admission cache could serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0516"
+    },
+    {
+      "claim": "Philosophy admission cache has been live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0517"
+    },
+    {
+      "claim": "Philosophy admission cache has to keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0518"
+    },
+    {
+      "claim": "Philosophy admission cache has to return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0519"
+    },
+    {
+      "claim": "Philosophy admission cache has to run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0520"
+    },
+    {
+      "claim": "Philosophy admission cache has to serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0521"
     },
     {
       "claim": "Philosophy admission cache is active.",
@@ -661,7 +4181,7 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0082"
+      "id": "philosophy-admission-oracle-0522"
     },
     {
       "claim": "Philosophy admission cache is live.",
@@ -669,7 +4189,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0083"
+      "id": "philosophy-admission-oracle-0523"
+    },
+    {
+      "claim": "Philosophy admission cache is required to keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0524"
+    },
+    {
+      "claim": "Philosophy admission cache is required to return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0525"
+    },
+    {
+      "claim": "Philosophy admission cache is required to run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0526"
+    },
+    {
+      "claim": "Philosophy admission cache is required to serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0527"
+    },
+    {
+      "claim": "Philosophy admission cache is still serving cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0528"
     },
     {
       "claim": "Philosophy admission cache keeps semantic-cache serving live.",
@@ -677,23 +4237,111 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0084"
+      "id": "philosophy-admission-oracle-0529"
+    },
+    {
+      "claim": "Philosophy admission cache may keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0530"
+    },
+    {
+      "claim": "Philosophy admission cache may return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0531"
+    },
+    {
+      "claim": "Philosophy admission cache may run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0532"
+    },
+    {
+      "claim": "Philosophy admission cache may serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0533"
+    },
+    {
+      "claim": "Philosophy admission cache might keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0534"
+    },
+    {
+      "claim": "Philosophy admission cache might return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0535"
+    },
+    {
+      "claim": "Philosophy admission cache might run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0536"
+    },
+    {
+      "claim": "Philosophy admission cache might serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0537"
+    },
+    {
+      "claim": "Philosophy admission cache must keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0538"
     },
     {
       "claim": "Philosophy admission cache must return philosophy cache hits.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0085"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0539"
+    },
+    {
+      "claim": "Philosophy admission cache must run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0540"
+    },
+    {
+      "claim": "Philosophy admission cache must serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0541"
     },
     {
       "claim": "Philosophy admission cache remains live.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0086"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0542"
     },
     {
       "claim": "Philosophy admission cache serves cached responses.",
@@ -701,7 +4349,7 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0087"
+      "id": "philosophy-admission-oracle-0543"
     },
     {
       "claim": "Philosophy admission cache serves philosophy cache hits.",
@@ -709,15 +4357,103 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0088"
+      "id": "philosophy-admission-oracle-0544"
+    },
+    {
+      "claim": "Philosophy admission cache should keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0545"
+    },
+    {
+      "claim": "Philosophy admission cache should return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0546"
+    },
+    {
+      "claim": "Philosophy admission cache should run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0547"
+    },
+    {
+      "claim": "Philosophy admission cache should serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0548"
+    },
+    {
+      "claim": "Philosophy admission cache will keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0549"
+    },
+    {
+      "claim": "Philosophy admission cache will return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0550"
     },
     {
       "claim": "Philosophy admission cache will run as a live cache.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0089"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0551"
+    },
+    {
+      "claim": "Philosophy admission cache will serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0552"
+    },
+    {
+      "claim": "Philosophy admission cache would keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0553"
+    },
+    {
+      "claim": "Philosophy admission cache would return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0554"
+    },
+    {
+      "claim": "Philosophy admission cache would run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0555"
+    },
+    {
+      "claim": "Philosophy admission cache would serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0556"
     },
     {
       "claim": "Philosophy admission has been live since PR-1.",
@@ -725,15 +4461,119 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0090"
+      "id": "philosophy-admission-oracle-0557"
     },
     {
       "claim": "Philosophy cache became live.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0091"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0558"
+    },
+    {
+      "claim": "Philosophy cache can keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0559"
+    },
+    {
+      "claim": "Philosophy cache can return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0560"
+    },
+    {
+      "claim": "Philosophy cache can run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0561"
+    },
+    {
+      "claim": "Philosophy cache can serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0562"
+    },
+    {
+      "claim": "Philosophy cache could keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0563"
+    },
+    {
+      "claim": "Philosophy cache could return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0564"
+    },
+    {
+      "claim": "Philosophy cache could run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0565"
+    },
+    {
+      "claim": "Philosophy cache could serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0566"
+    },
+    {
+      "claim": "Philosophy cache has been live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0567"
+    },
+    {
+      "claim": "Philosophy cache has to keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0568"
+    },
+    {
+      "claim": "Philosophy cache has to return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0569"
+    },
+    {
+      "claim": "Philosophy cache has to run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0570"
+    },
+    {
+      "claim": "Philosophy cache has to serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0571"
     },
     {
       "claim": "Philosophy cache is active.",
@@ -741,7 +4581,7 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0092"
+      "id": "philosophy-admission-oracle-0572"
     },
     {
       "claim": "Philosophy cache is live.",
@@ -749,7 +4589,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0093"
+      "id": "philosophy-admission-oracle-0573"
+    },
+    {
+      "claim": "Philosophy cache is required to keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0574"
+    },
+    {
+      "claim": "Philosophy cache is required to return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0575"
+    },
+    {
+      "claim": "Philosophy cache is required to run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0576"
+    },
+    {
+      "claim": "Philosophy cache is required to serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0577"
+    },
+    {
+      "claim": "Philosophy cache is still serving cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0578"
     },
     {
       "claim": "Philosophy cache keeps semantic-cache serving live.",
@@ -757,23 +4637,111 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0094"
+      "id": "philosophy-admission-oracle-0579"
     },
     {
       "claim": "Philosophy cache may keep semantic-cache serving live.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0095"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0580"
+    },
+    {
+      "claim": "Philosophy cache may return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0581"
+    },
+    {
+      "claim": "Philosophy cache may run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0582"
+    },
+    {
+      "claim": "Philosophy cache may serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0583"
+    },
+    {
+      "claim": "Philosophy cache might keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0584"
     },
     {
       "claim": "Philosophy cache might return philosophy cache hits.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0096"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0585"
+    },
+    {
+      "claim": "Philosophy cache might run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0586"
+    },
+    {
+      "claim": "Philosophy cache might serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0587"
+    },
+    {
+      "claim": "Philosophy cache must keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0588"
+    },
+    {
+      "claim": "Philosophy cache must return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0589"
+    },
+    {
+      "claim": "Philosophy cache must run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0590"
+    },
+    {
+      "claim": "Philosophy cache must serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0591"
+    },
+    {
+      "claim": "Philosophy cache remains live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0592"
     },
     {
       "claim": "Philosophy cache serves cached responses.",
@@ -781,7 +4749,7 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0097"
+      "id": "philosophy-admission-oracle-0593"
     },
     {
       "claim": "Philosophy cache serves philosophy cache hits.",
@@ -789,7 +4757,103 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0098"
+      "id": "philosophy-admission-oracle-0594"
+    },
+    {
+      "claim": "Philosophy cache should keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0595"
+    },
+    {
+      "claim": "Philosophy cache should return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0596"
+    },
+    {
+      "claim": "Philosophy cache should run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0597"
+    },
+    {
+      "claim": "Philosophy cache should serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0598"
+    },
+    {
+      "claim": "Philosophy cache will keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0599"
+    },
+    {
+      "claim": "Philosophy cache will return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0600"
+    },
+    {
+      "claim": "Philosophy cache will run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0601"
+    },
+    {
+      "claim": "Philosophy cache will serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0602"
+    },
+    {
+      "claim": "Philosophy cache would keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0603"
+    },
+    {
+      "claim": "Philosophy cache would return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0604"
+    },
+    {
+      "claim": "Philosophy cache would run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0605"
+    },
+    {
+      "claim": "Philosophy cache would serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0606"
     },
     {
       "claim": "The admission policy still keeps semantic-cache serving live.",
@@ -797,23 +4861,119 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0099"
+      "id": "philosophy-admission-oracle-0607"
+    },
+    {
+      "claim": "The policy oracle became live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0608"
+    },
+    {
+      "claim": "The policy oracle can keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0609"
+    },
+    {
+      "claim": "The policy oracle can return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0610"
+    },
+    {
+      "claim": "The policy oracle can run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0611"
+    },
+    {
+      "claim": "The policy oracle can serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0612"
+    },
+    {
+      "claim": "The policy oracle could keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0613"
+    },
+    {
+      "claim": "The policy oracle could return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0614"
+    },
+    {
+      "claim": "The policy oracle could run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0615"
     },
     {
       "claim": "The policy oracle could serve cached responses.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0100"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0616"
+    },
+    {
+      "claim": "The policy oracle has been live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0617"
     },
     {
       "claim": "The policy oracle has to keep semantic-cache serving live.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0101"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0618"
+    },
+    {
+      "claim": "The policy oracle has to return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0619"
+    },
+    {
+      "claim": "The policy oracle has to run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0620"
+    },
+    {
+      "claim": "The policy oracle has to serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0621"
     },
     {
       "claim": "The policy oracle is active.",
@@ -821,7 +4981,7 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0102"
+      "id": "philosophy-admission-oracle-0622"
     },
     {
       "claim": "The policy oracle is live.",
@@ -829,7 +4989,47 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0103"
+      "id": "philosophy-admission-oracle-0623"
+    },
+    {
+      "claim": "The policy oracle is required to keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0624"
+    },
+    {
+      "claim": "The policy oracle is required to return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0625"
+    },
+    {
+      "claim": "The policy oracle is required to run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0626"
+    },
+    {
+      "claim": "The policy oracle is required to serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0627"
+    },
+    {
+      "claim": "The policy oracle is still serving cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0628"
     },
     {
       "claim": "The policy oracle keeps semantic-cache serving live.",
@@ -837,7 +5037,111 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0104"
+      "id": "philosophy-admission-oracle-0629"
+    },
+    {
+      "claim": "The policy oracle may keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0630"
+    },
+    {
+      "claim": "The policy oracle may return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0631"
+    },
+    {
+      "claim": "The policy oracle may run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0632"
+    },
+    {
+      "claim": "The policy oracle may serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0633"
+    },
+    {
+      "claim": "The policy oracle might keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0634"
+    },
+    {
+      "claim": "The policy oracle might return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0635"
+    },
+    {
+      "claim": "The policy oracle might run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0636"
+    },
+    {
+      "claim": "The policy oracle might serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0637"
+    },
+    {
+      "claim": "The policy oracle must keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0638"
+    },
+    {
+      "claim": "The policy oracle must return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0639"
+    },
+    {
+      "claim": "The policy oracle must run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0640"
+    },
+    {
+      "claim": "The policy oracle must serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0641"
+    },
+    {
+      "claim": "The policy oracle remains live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0642"
     },
     {
       "claim": "The policy oracle serves cached responses.",
@@ -845,7 +5149,7 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0105"
+      "id": "philosophy-admission-oracle-0643"
     },
     {
       "claim": "The policy oracle serves philosophy cache hits.",
@@ -853,15 +5157,103 @@
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0106"
+      "id": "philosophy-admission-oracle-0644"
+    },
+    {
+      "claim": "The policy oracle should keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0645"
+    },
+    {
+      "claim": "The policy oracle should return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0646"
+    },
+    {
+      "claim": "The policy oracle should run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0647"
+    },
+    {
+      "claim": "The policy oracle should serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0648"
+    },
+    {
+      "claim": "The policy oracle will keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0649"
+    },
+    {
+      "claim": "The policy oracle will return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0650"
+    },
+    {
+      "claim": "The policy oracle will run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0651"
     },
     {
       "claim": "The policy oracle will serve cached responses.",
       "claim_family": "claim_class_live_philosophy_cache",
       "expected": "forbidden",
       "expected_detector_label": "philosophical semantic cache live",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0107"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0652"
+    },
+    {
+      "claim": "The policy oracle would keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0653"
+    },
+    {
+      "claim": "The policy oracle would return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0654"
+    },
+    {
+      "claim": "The policy oracle would run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0655"
+    },
+    {
+      "claim": "The policy oracle would serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0656"
     },
     {
       "claim": "Design/PDF intake cannot override repo gate markers.",
@@ -869,7 +5261,7 @@
       "expected": "allowed",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0108"
+      "id": "philosophy-admission-oracle-0657"
     },
     {
       "claim": "Repo-reviewed contracts remain the source of gate truth.",
@@ -877,7 +5269,7 @@
       "expected": "allowed",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0109"
+      "id": "philosophy-admission-oracle-0658"
     },
     {
       "claim": "Research intake remains evidence-only.",
@@ -885,7 +5277,7 @@
       "expected": "allowed",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0110"
+      "id": "philosophy-admission-oracle-0659"
     },
     {
       "claim": "Browser evidence authorizes runtime behavior over repo truth.",
@@ -893,15 +5285,15 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0111"
+      "id": "philosophy-admission-oracle-0660"
     },
     {
       "claim": "Browser evidence became the source of runtime truth.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0112"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0661"
     },
     {
       "claim": "Browser evidence bypasses repo-reviewed contracts.",
@@ -909,15 +5301,247 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0113"
+      "id": "philosophy-admission-oracle-0662"
+    },
+    {
+      "claim": "Browser evidence can bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0663"
+    },
+    {
+      "claim": "Browser evidence can override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0664"
+    },
+    {
+      "claim": "Browser evidence can replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0665"
+    },
+    {
+      "claim": "Browser evidence can supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0666"
+    },
+    {
+      "claim": "Browser evidence could bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0667"
+    },
+    {
+      "claim": "Browser evidence could override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0668"
+    },
+    {
+      "claim": "Browser evidence could replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0669"
+    },
+    {
+      "claim": "Browser evidence could supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0670"
+    },
+    {
+      "claim": "Browser evidence has overridden repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0671"
+    },
+    {
+      "claim": "Browser evidence has to bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0672"
+    },
+    {
+      "claim": "Browser evidence has to override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0673"
+    },
+    {
+      "claim": "Browser evidence has to replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0674"
+    },
+    {
+      "claim": "Browser evidence has to supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0675"
+    },
+    {
+      "claim": "Browser evidence is now replacing merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0676"
+    },
+    {
+      "claim": "Browser evidence is required to bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0677"
     },
     {
       "claim": "Browser evidence is required to override repo gate markers.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0114"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0678"
+    },
+    {
+      "claim": "Browser evidence is required to replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0679"
+    },
+    {
+      "claim": "Browser evidence is required to supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0680"
+    },
+    {
+      "claim": "Browser evidence may bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0681"
+    },
+    {
+      "claim": "Browser evidence may override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0682"
+    },
+    {
+      "claim": "Browser evidence may replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0683"
+    },
+    {
+      "claim": "Browser evidence may supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0684"
+    },
+    {
+      "claim": "Browser evidence might bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0685"
+    },
+    {
+      "claim": "Browser evidence might override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0686"
+    },
+    {
+      "claim": "Browser evidence might replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0687"
+    },
+    {
+      "claim": "Browser evidence might supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0688"
+    },
+    {
+      "claim": "Browser evidence must bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0689"
+    },
+    {
+      "claim": "Browser evidence must override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0690"
+    },
+    {
+      "claim": "Browser evidence must replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0691"
+    },
+    {
+      "claim": "Browser evidence must supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0692"
     },
     {
       "claim": "Browser evidence overrides repo gate markers.",
@@ -925,7 +5549,7 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0115"
+      "id": "philosophy-admission-oracle-0693"
     },
     {
       "claim": "Browser evidence replaces merge truth.",
@@ -933,15 +5557,47 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0116"
+      "id": "philosophy-admission-oracle-0694"
+    },
+    {
+      "claim": "Browser evidence should bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0695"
+    },
+    {
+      "claim": "Browser evidence should override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0696"
+    },
+    {
+      "claim": "Browser evidence should replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0697"
     },
     {
       "claim": "Browser evidence should supersede semantic-cache gate markers.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0117"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0698"
+    },
+    {
+      "claim": "Browser evidence still overrides semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0699"
     },
     {
       "claim": "Browser evidence supersedes semantic-cache gate markers.",
@@ -949,15 +5605,71 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0118"
+      "id": "philosophy-admission-oracle-0700"
     },
     {
       "claim": "Browser evidence will bypass repo-reviewed contracts.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0119"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0701"
+    },
+    {
+      "claim": "Browser evidence will override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0702"
+    },
+    {
+      "claim": "Browser evidence will replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0703"
+    },
+    {
+      "claim": "Browser evidence will supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0704"
+    },
+    {
+      "claim": "Browser evidence would bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0705"
+    },
+    {
+      "claim": "Browser evidence would override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0706"
+    },
+    {
+      "claim": "Browser evidence would replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0707"
+    },
+    {
+      "claim": "Browser evidence would supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0708"
     },
     {
       "claim": "Design intake authorizes runtime behavior over repo truth.",
@@ -965,15 +5677,15 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0120"
+      "id": "philosophy-admission-oracle-0709"
     },
     {
       "claim": "Design intake became the source of runtime truth.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0121"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0710"
     },
     {
       "claim": "Design intake bypasses repo-reviewed contracts.",
@@ -981,23 +5693,247 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0122"
+      "id": "philosophy-admission-oracle-0711"
+    },
+    {
+      "claim": "Design intake can bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0712"
+    },
+    {
+      "claim": "Design intake can override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0713"
+    },
+    {
+      "claim": "Design intake can replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0714"
+    },
+    {
+      "claim": "Design intake can supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0715"
+    },
+    {
+      "claim": "Design intake could bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0716"
+    },
+    {
+      "claim": "Design intake could override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0717"
+    },
+    {
+      "claim": "Design intake could replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0718"
+    },
+    {
+      "claim": "Design intake could supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0719"
+    },
+    {
+      "claim": "Design intake has overridden repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0720"
+    },
+    {
+      "claim": "Design intake has to bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0721"
+    },
+    {
+      "claim": "Design intake has to override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0722"
+    },
+    {
+      "claim": "Design intake has to replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0723"
+    },
+    {
+      "claim": "Design intake has to supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0724"
+    },
+    {
+      "claim": "Design intake is now replacing merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0725"
+    },
+    {
+      "claim": "Design intake is required to bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0726"
+    },
+    {
+      "claim": "Design intake is required to override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0727"
+    },
+    {
+      "claim": "Design intake is required to replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0728"
+    },
+    {
+      "claim": "Design intake is required to supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0729"
     },
     {
       "claim": "Design intake may bypass repo-reviewed contracts.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0123"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0730"
+    },
+    {
+      "claim": "Design intake may override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0731"
+    },
+    {
+      "claim": "Design intake may replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0732"
+    },
+    {
+      "claim": "Design intake may supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0733"
+    },
+    {
+      "claim": "Design intake might bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0734"
+    },
+    {
+      "claim": "Design intake might override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0735"
     },
     {
       "claim": "Design intake might replace merge truth.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0124"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0736"
+    },
+    {
+      "claim": "Design intake might supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0737"
+    },
+    {
+      "claim": "Design intake must bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0738"
+    },
+    {
+      "claim": "Design intake must override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0739"
+    },
+    {
+      "claim": "Design intake must replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0740"
+    },
+    {
+      "claim": "Design intake must supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0741"
     },
     {
       "claim": "Design intake overrides repo gate markers.",
@@ -1005,7 +5941,7 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0125"
+      "id": "philosophy-admission-oracle-0742"
     },
     {
       "claim": "Design intake replaces merge truth.",
@@ -1013,7 +5949,47 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0126"
+      "id": "philosophy-admission-oracle-0743"
+    },
+    {
+      "claim": "Design intake should bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0744"
+    },
+    {
+      "claim": "Design intake should override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0745"
+    },
+    {
+      "claim": "Design intake should replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0746"
+    },
+    {
+      "claim": "Design intake should supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0747"
+    },
+    {
+      "claim": "Design intake still overrides semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0748"
     },
     {
       "claim": "Design intake supersedes semantic-cache gate markers.",
@@ -1021,7 +5997,71 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0127"
+      "id": "philosophy-admission-oracle-0749"
+    },
+    {
+      "claim": "Design intake will bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0750"
+    },
+    {
+      "claim": "Design intake will override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0751"
+    },
+    {
+      "claim": "Design intake will replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0752"
+    },
+    {
+      "claim": "Design intake will supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0753"
+    },
+    {
+      "claim": "Design intake would bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0754"
+    },
+    {
+      "claim": "Design intake would override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0755"
+    },
+    {
+      "claim": "Design intake would replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0756"
+    },
+    {
+      "claim": "Design intake would supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0757"
     },
     {
       "claim": "Design/PDF intake can override repo gate markers.",
@@ -1029,7 +6069,7 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0128"
+      "id": "philosophy-admission-oracle-0758"
     },
     {
       "claim": "Drive research authorizes runtime behavior over repo truth.",
@@ -1037,7 +6077,15 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0129"
+      "id": "philosophy-admission-oracle-0759"
+    },
+    {
+      "claim": "Drive research became the source of runtime truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0760"
     },
     {
       "claim": "Drive research bypasses repo-reviewed contracts.",
@@ -1045,15 +6093,247 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0130"
+      "id": "philosophy-admission-oracle-0761"
+    },
+    {
+      "claim": "Drive research can bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0762"
+    },
+    {
+      "claim": "Drive research can override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0763"
+    },
+    {
+      "claim": "Drive research can replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0764"
+    },
+    {
+      "claim": "Drive research can supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0765"
+    },
+    {
+      "claim": "Drive research could bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0766"
+    },
+    {
+      "claim": "Drive research could override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0767"
+    },
+    {
+      "claim": "Drive research could replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0768"
+    },
+    {
+      "claim": "Drive research could supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0769"
+    },
+    {
+      "claim": "Drive research has overridden repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0770"
+    },
+    {
+      "claim": "Drive research has to bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0771"
+    },
+    {
+      "claim": "Drive research has to override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0772"
+    },
+    {
+      "claim": "Drive research has to replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0773"
+    },
+    {
+      "claim": "Drive research has to supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0774"
+    },
+    {
+      "claim": "Drive research is now replacing merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0775"
+    },
+    {
+      "claim": "Drive research is required to bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0776"
+    },
+    {
+      "claim": "Drive research is required to override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0777"
+    },
+    {
+      "claim": "Drive research is required to replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0778"
+    },
+    {
+      "claim": "Drive research is required to supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0779"
+    },
+    {
+      "claim": "Drive research may bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0780"
+    },
+    {
+      "claim": "Drive research may override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0781"
+    },
+    {
+      "claim": "Drive research may replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0782"
+    },
+    {
+      "claim": "Drive research may supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0783"
+    },
+    {
+      "claim": "Drive research might bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0784"
+    },
+    {
+      "claim": "Drive research might override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0785"
+    },
+    {
+      "claim": "Drive research might replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0786"
+    },
+    {
+      "claim": "Drive research might supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0787"
+    },
+    {
+      "claim": "Drive research must bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0788"
+    },
+    {
+      "claim": "Drive research must override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0789"
     },
     {
       "claim": "Drive research must replace merge truth.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0131"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0790"
+    },
+    {
+      "claim": "Drive research must supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0791"
     },
     {
       "claim": "Drive research overrides repo gate markers.",
@@ -1061,7 +6341,7 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0132"
+      "id": "philosophy-admission-oracle-0792"
     },
     {
       "claim": "Drive research replaces merge truth.",
@@ -1069,15 +6349,47 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0133"
+      "id": "philosophy-admission-oracle-0793"
+    },
+    {
+      "claim": "Drive research should bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0794"
+    },
+    {
+      "claim": "Drive research should override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0795"
+    },
+    {
+      "claim": "Drive research should replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0796"
+    },
+    {
+      "claim": "Drive research should supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0797"
     },
     {
       "claim": "Drive research still overrides semantic-cache gate markers.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0134"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0798"
     },
     {
       "claim": "Drive research supersedes semantic-cache gate markers.",
@@ -1085,15 +6397,71 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0135"
+      "id": "philosophy-admission-oracle-0799"
+    },
+    {
+      "claim": "Drive research will bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0800"
+    },
+    {
+      "claim": "Drive research will override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0801"
+    },
+    {
+      "claim": "Drive research will replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0802"
     },
     {
       "claim": "Drive research will supersede semantic-cache gate markers.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0136"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0803"
+    },
+    {
+      "claim": "Drive research would bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0804"
+    },
+    {
+      "claim": "Drive research would override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0805"
+    },
+    {
+      "claim": "Drive research would replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0806"
+    },
+    {
+      "claim": "Drive research would supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0807"
     },
     {
       "claim": "PDF intake authorizes runtime behavior over repo truth.",
@@ -1101,7 +6469,15 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0137"
+      "id": "philosophy-admission-oracle-0808"
+    },
+    {
+      "claim": "PDF intake became the source of runtime truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0809"
     },
     {
       "claim": "PDF intake bypasses repo-reviewed contracts.",
@@ -1109,23 +6485,79 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0138"
+      "id": "philosophy-admission-oracle-0810"
+    },
+    {
+      "claim": "PDF intake can bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0811"
     },
     {
       "claim": "PDF intake can override repo gate markers.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0139"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0812"
+    },
+    {
+      "claim": "PDF intake can replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0813"
+    },
+    {
+      "claim": "PDF intake can supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0814"
+    },
+    {
+      "claim": "PDF intake could bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0815"
+    },
+    {
+      "claim": "PDF intake could override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0816"
+    },
+    {
+      "claim": "PDF intake could replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0817"
+    },
+    {
+      "claim": "PDF intake could supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0818"
     },
     {
       "claim": "PDF intake has overridden repo gate markers.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0140"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0819"
     },
     {
       "claim": "PDF intake has overridden semantic-cache gate markers.",
@@ -1133,7 +6565,175 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0141"
+      "id": "philosophy-admission-oracle-0820"
+    },
+    {
+      "claim": "PDF intake has to bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0821"
+    },
+    {
+      "claim": "PDF intake has to override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0822"
+    },
+    {
+      "claim": "PDF intake has to replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0823"
+    },
+    {
+      "claim": "PDF intake has to supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0824"
+    },
+    {
+      "claim": "PDF intake is now replacing merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0825"
+    },
+    {
+      "claim": "PDF intake is required to bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0826"
+    },
+    {
+      "claim": "PDF intake is required to override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0827"
+    },
+    {
+      "claim": "PDF intake is required to replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0828"
+    },
+    {
+      "claim": "PDF intake is required to supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0829"
+    },
+    {
+      "claim": "PDF intake may bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0830"
+    },
+    {
+      "claim": "PDF intake may override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0831"
+    },
+    {
+      "claim": "PDF intake may replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0832"
+    },
+    {
+      "claim": "PDF intake may supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0833"
+    },
+    {
+      "claim": "PDF intake might bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0834"
+    },
+    {
+      "claim": "PDF intake might override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0835"
+    },
+    {
+      "claim": "PDF intake might replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0836"
+    },
+    {
+      "claim": "PDF intake might supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0837"
+    },
+    {
+      "claim": "PDF intake must bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0838"
+    },
+    {
+      "claim": "PDF intake must override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0839"
+    },
+    {
+      "claim": "PDF intake must replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0840"
+    },
+    {
+      "claim": "PDF intake must supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0841"
     },
     {
       "claim": "PDF intake overrides repo gate markers.",
@@ -1141,7 +6741,7 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0142"
+      "id": "philosophy-admission-oracle-0842"
     },
     {
       "claim": "PDF intake replaces merge truth.",
@@ -1149,7 +6749,47 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0143"
+      "id": "philosophy-admission-oracle-0843"
+    },
+    {
+      "claim": "PDF intake should bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0844"
+    },
+    {
+      "claim": "PDF intake should override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0845"
+    },
+    {
+      "claim": "PDF intake should replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0846"
+    },
+    {
+      "claim": "PDF intake should supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0847"
+    },
+    {
+      "claim": "PDF intake still overrides semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0848"
     },
     {
       "claim": "PDF intake supersedes semantic-cache gate markers.",
@@ -1157,15 +6797,71 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0144"
+      "id": "philosophy-admission-oracle-0849"
+    },
+    {
+      "claim": "PDF intake will bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0850"
+    },
+    {
+      "claim": "PDF intake will override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0851"
+    },
+    {
+      "claim": "PDF intake will replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0852"
+    },
+    {
+      "claim": "PDF intake will supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0853"
     },
     {
       "claim": "PDF intake would bypass repo-reviewed contracts.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0145"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0854"
+    },
+    {
+      "claim": "PDF intake would override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0855"
+    },
+    {
+      "claim": "PDF intake would replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0856"
+    },
+    {
+      "claim": "PDF intake would supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0857"
     },
     {
       "claim": "The admission policy authorizes runtime behavior over repo truth.",
@@ -1173,7 +6869,15 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0146"
+      "id": "philosophy-admission-oracle-0858"
+    },
+    {
+      "claim": "The admission policy became the source of runtime truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0859"
     },
     {
       "claim": "The admission policy bypasses repo-reviewed contracts.",
@@ -1181,31 +6885,247 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0147"
+      "id": "philosophy-admission-oracle-0860"
+    },
+    {
+      "claim": "The admission policy can bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0861"
+    },
+    {
+      "claim": "The admission policy can override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0862"
+    },
+    {
+      "claim": "The admission policy can replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0863"
+    },
+    {
+      "claim": "The admission policy can supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0864"
+    },
+    {
+      "claim": "The admission policy could bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0865"
     },
     {
       "claim": "The admission policy could override repo gate markers.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0148"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0866"
+    },
+    {
+      "claim": "The admission policy could replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0867"
+    },
+    {
+      "claim": "The admission policy could supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0868"
+    },
+    {
+      "claim": "The admission policy has overridden repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0869"
     },
     {
       "claim": "The admission policy has to bypass repo-reviewed contracts.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0149"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0870"
+    },
+    {
+      "claim": "The admission policy has to override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0871"
+    },
+    {
+      "claim": "The admission policy has to replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0872"
+    },
+    {
+      "claim": "The admission policy has to supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0873"
     },
     {
       "claim": "The admission policy is now replacing merge truth.",
       "claim_family": "claim_class_pdf_design_intake_gate_override",
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0150"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0874"
+    },
+    {
+      "claim": "The admission policy is required to bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0875"
+    },
+    {
+      "claim": "The admission policy is required to override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0876"
+    },
+    {
+      "claim": "The admission policy is required to replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0877"
+    },
+    {
+      "claim": "The admission policy is required to supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0878"
+    },
+    {
+      "claim": "The admission policy may bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0879"
+    },
+    {
+      "claim": "The admission policy may override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0880"
+    },
+    {
+      "claim": "The admission policy may replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0881"
+    },
+    {
+      "claim": "The admission policy may supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0882"
+    },
+    {
+      "claim": "The admission policy might bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0883"
+    },
+    {
+      "claim": "The admission policy might override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0884"
+    },
+    {
+      "claim": "The admission policy might replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0885"
+    },
+    {
+      "claim": "The admission policy might supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0886"
+    },
+    {
+      "claim": "The admission policy must bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0887"
+    },
+    {
+      "claim": "The admission policy must override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0888"
+    },
+    {
+      "claim": "The admission policy must replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0889"
+    },
+    {
+      "claim": "The admission policy must supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0890"
     },
     {
       "claim": "The admission policy overrides repo gate markers.",
@@ -1213,7 +7133,7 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0151"
+      "id": "philosophy-admission-oracle-0891"
     },
     {
       "claim": "The admission policy replaces merge truth.",
@@ -1221,7 +7141,47 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0152"
+      "id": "philosophy-admission-oracle-0892"
+    },
+    {
+      "claim": "The admission policy should bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0893"
+    },
+    {
+      "claim": "The admission policy should override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0894"
+    },
+    {
+      "claim": "The admission policy should replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0895"
+    },
+    {
+      "claim": "The admission policy should supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0896"
+    },
+    {
+      "claim": "The admission policy still overrides semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0897"
     },
     {
       "claim": "The admission policy supersedes semantic-cache gate markers.",
@@ -1229,7 +7189,71 @@
       "expected": "forbidden",
       "expected_detector_label": "design intake overrides gate markers",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0153"
+      "id": "philosophy-admission-oracle-0898"
+    },
+    {
+      "claim": "The admission policy will bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0899"
+    },
+    {
+      "claim": "The admission policy will override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0900"
+    },
+    {
+      "claim": "The admission policy will replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0901"
+    },
+    {
+      "claim": "The admission policy will supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0902"
+    },
+    {
+      "claim": "The admission policy would bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0903"
+    },
+    {
+      "claim": "The admission policy would override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0904"
+    },
+    {
+      "claim": "The admission policy would replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0905"
+    },
+    {
+      "claim": "The admission policy would supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0906"
     },
     {
       "claim": "No raw prompts are stored as cache keys.",
@@ -1237,7 +7261,7 @@
       "expected": "allowed",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0154"
+      "id": "philosophy-admission-oracle-0907"
     },
     {
       "claim": "PR-2 does not ship production cache keys.",
@@ -1245,7 +7269,7 @@
       "expected": "allowed",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0155"
+      "id": "philosophy-admission-oracle-0908"
     },
     {
       "claim": "Philosophy admission blocks live cache-key behavior.",
@@ -1253,7 +7277,15 @@
       "expected": "allowed",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0156"
+      "id": "philosophy-admission-oracle-0909"
+    },
+    {
+      "claim": "PR-1 became live for cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0910"
     },
     {
       "claim": "PR-1 caches raw model responses.",
@@ -1261,15 +7293,71 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0157"
+      "id": "philosophy-admission-oracle-0911"
+    },
+    {
+      "claim": "PR-1 can cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0912"
+    },
+    {
+      "claim": "PR-1 can enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0913"
     },
     {
       "claim": "PR-1 can ship production cache keys.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0158"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0914"
+    },
+    {
+      "claim": "PR-1 can store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0915"
+    },
+    {
+      "claim": "PR-1 could cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0916"
+    },
+    {
+      "claim": "PR-1 could enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0917"
+    },
+    {
+      "claim": "PR-1 could ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0918"
+    },
+    {
+      "claim": "PR-1 could store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0919"
     },
     {
       "claim": "PR-1 enables live cache-key behavior.",
@@ -1277,15 +7365,183 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0159"
+      "id": "philosophy-admission-oracle-0920"
     },
     {
       "claim": "PR-1 has shipped production cache keys.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0160"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0921"
+    },
+    {
+      "claim": "PR-1 has to cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0922"
+    },
+    {
+      "claim": "PR-1 has to enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0923"
+    },
+    {
+      "claim": "PR-1 has to ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0924"
+    },
+    {
+      "claim": "PR-1 has to store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0925"
+    },
+    {
+      "claim": "PR-1 is now persisting philosophy cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0926"
+    },
+    {
+      "claim": "PR-1 is required to cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0927"
+    },
+    {
+      "claim": "PR-1 is required to enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0928"
+    },
+    {
+      "claim": "PR-1 is required to ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0929"
+    },
+    {
+      "claim": "PR-1 is required to store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0930"
+    },
+    {
+      "claim": "PR-1 may cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0931"
+    },
+    {
+      "claim": "PR-1 may enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0932"
+    },
+    {
+      "claim": "PR-1 may ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0933"
+    },
+    {
+      "claim": "PR-1 may store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0934"
+    },
+    {
+      "claim": "PR-1 might cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0935"
+    },
+    {
+      "claim": "PR-1 might enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0936"
+    },
+    {
+      "claim": "PR-1 might ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0937"
+    },
+    {
+      "claim": "PR-1 might store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0938"
+    },
+    {
+      "claim": "PR-1 must cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0939"
+    },
+    {
+      "claim": "PR-1 must enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0940"
+    },
+    {
+      "claim": "PR-1 must ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0941"
+    },
+    {
+      "claim": "PR-1 must store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0942"
     },
     {
       "claim": "PR-1 persists philosophy cache keys.",
@@ -1293,7 +7549,7 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0161"
+      "id": "philosophy-admission-oracle-0943"
     },
     {
       "claim": "PR-1 ships production cache keys.",
@@ -1301,7 +7557,47 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0162"
+      "id": "philosophy-admission-oracle-0944"
+    },
+    {
+      "claim": "PR-1 should cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0945"
+    },
+    {
+      "claim": "PR-1 should enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0946"
+    },
+    {
+      "claim": "PR-1 should ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0947"
+    },
+    {
+      "claim": "PR-1 should store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0948"
+    },
+    {
+      "claim": "PR-1 still stores raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0949"
     },
     {
       "claim": "PR-1 stores raw prompts as cache keys.",
@@ -1309,23 +7605,79 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0163"
+      "id": "philosophy-admission-oracle-0950"
+    },
+    {
+      "claim": "PR-1 will cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0951"
+    },
+    {
+      "claim": "PR-1 will enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0952"
+    },
+    {
+      "claim": "PR-1 will ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0953"
+    },
+    {
+      "claim": "PR-1 will store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0954"
+    },
+    {
+      "claim": "PR-1 would cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0955"
+    },
+    {
+      "claim": "PR-1 would enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0956"
+    },
+    {
+      "claim": "PR-1 would ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0957"
     },
     {
       "claim": "PR-1 would store raw prompts as cache keys.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0164"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0958"
     },
     {
       "claim": "PR-2 became live for cache-key behavior.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0165"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0959"
     },
     {
       "claim": "PR-2 caches raw model responses.",
@@ -1333,7 +7685,71 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0166"
+      "id": "philosophy-admission-oracle-0960"
+    },
+    {
+      "claim": "PR-2 can cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0961"
+    },
+    {
+      "claim": "PR-2 can enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0962"
+    },
+    {
+      "claim": "PR-2 can ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0963"
+    },
+    {
+      "claim": "PR-2 can store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0964"
+    },
+    {
+      "claim": "PR-2 could cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0965"
+    },
+    {
+      "claim": "PR-2 could enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0966"
+    },
+    {
+      "claim": "PR-2 could ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0967"
+    },
+    {
+      "claim": "PR-2 could store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0968"
     },
     {
       "claim": "PR-2 enables live cache-key behavior.",
@@ -1341,23 +7757,183 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0167"
+      "id": "philosophy-admission-oracle-0969"
+    },
+    {
+      "claim": "PR-2 has shipped production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0970"
+    },
+    {
+      "claim": "PR-2 has to cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0971"
+    },
+    {
+      "claim": "PR-2 has to enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0972"
+    },
+    {
+      "claim": "PR-2 has to ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0973"
+    },
+    {
+      "claim": "PR-2 has to store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0974"
+    },
+    {
+      "claim": "PR-2 is now persisting philosophy cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0975"
+    },
+    {
+      "claim": "PR-2 is required to cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0976"
+    },
+    {
+      "claim": "PR-2 is required to enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0977"
+    },
+    {
+      "claim": "PR-2 is required to ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0978"
+    },
+    {
+      "claim": "PR-2 is required to store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0979"
+    },
+    {
+      "claim": "PR-2 may cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0980"
+    },
+    {
+      "claim": "PR-2 may enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0981"
+    },
+    {
+      "claim": "PR-2 may ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0982"
     },
     {
       "claim": "PR-2 may store raw prompts as cache keys.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0168"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0983"
     },
     {
       "claim": "PR-2 might cache raw model responses.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0169"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0984"
+    },
+    {
+      "claim": "PR-2 might enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0985"
+    },
+    {
+      "claim": "PR-2 might ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0986"
+    },
+    {
+      "claim": "PR-2 might store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0987"
+    },
+    {
+      "claim": "PR-2 must cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0988"
+    },
+    {
+      "claim": "PR-2 must enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0989"
+    },
+    {
+      "claim": "PR-2 must ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0990"
+    },
+    {
+      "claim": "PR-2 must store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0991"
     },
     {
       "claim": "PR-2 persists philosophy cache keys.",
@@ -1365,7 +7941,7 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0170"
+      "id": "philosophy-admission-oracle-0992"
     },
     {
       "claim": "PR-2 ships production cache keys.",
@@ -1373,7 +7949,47 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0171"
+      "id": "philosophy-admission-oracle-0993"
+    },
+    {
+      "claim": "PR-2 should cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0994"
+    },
+    {
+      "claim": "PR-2 should enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0995"
+    },
+    {
+      "claim": "PR-2 should ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0996"
+    },
+    {
+      "claim": "PR-2 should store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0997"
+    },
+    {
+      "claim": "PR-2 still stores raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-0998"
     },
     {
       "claim": "PR-2 stores raw prompts as cache keys.",
@@ -1381,7 +7997,79 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0172"
+      "id": "philosophy-admission-oracle-0999"
+    },
+    {
+      "claim": "PR-2 will cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1000"
+    },
+    {
+      "claim": "PR-2 will enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1001"
+    },
+    {
+      "claim": "PR-2 will ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1002"
+    },
+    {
+      "claim": "PR-2 will store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1003"
+    },
+    {
+      "claim": "PR-2 would cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1004"
+    },
+    {
+      "claim": "PR-2 would enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1005"
+    },
+    {
+      "claim": "PR-2 would ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1006"
+    },
+    {
+      "claim": "PR-2 would store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1007"
+    },
+    {
+      "claim": "Philosophy admission became live for cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1008"
     },
     {
       "claim": "Philosophy admission caches raw model responses.",
@@ -1389,7 +8077,71 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0173"
+      "id": "philosophy-admission-oracle-1009"
+    },
+    {
+      "claim": "Philosophy admission can cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1010"
+    },
+    {
+      "claim": "Philosophy admission can enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1011"
+    },
+    {
+      "claim": "Philosophy admission can ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1012"
+    },
+    {
+      "claim": "Philosophy admission can store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1013"
+    },
+    {
+      "claim": "Philosophy admission could cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1014"
+    },
+    {
+      "claim": "Philosophy admission could enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1015"
+    },
+    {
+      "claim": "Philosophy admission could ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1016"
+    },
+    {
+      "claim": "Philosophy admission could store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1017"
     },
     {
       "claim": "Philosophy admission enables live cache-key behavior.",
@@ -1397,7 +8149,15 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0174"
+      "id": "philosophy-admission-oracle-1018"
+    },
+    {
+      "claim": "Philosophy admission has shipped production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1019"
     },
     {
       "claim": "Philosophy admission has shipped production cache-key behavior.",
@@ -1405,15 +8165,175 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0175"
+      "id": "philosophy-admission-oracle-1020"
+    },
+    {
+      "claim": "Philosophy admission has to cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1021"
+    },
+    {
+      "claim": "Philosophy admission has to enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1022"
+    },
+    {
+      "claim": "Philosophy admission has to ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1023"
+    },
+    {
+      "claim": "Philosophy admission has to store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1024"
+    },
+    {
+      "claim": "Philosophy admission is now persisting philosophy cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1025"
+    },
+    {
+      "claim": "Philosophy admission is required to cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1026"
+    },
+    {
+      "claim": "Philosophy admission is required to enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1027"
+    },
+    {
+      "claim": "Philosophy admission is required to ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1028"
+    },
+    {
+      "claim": "Philosophy admission is required to store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1029"
+    },
+    {
+      "claim": "Philosophy admission may cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1030"
+    },
+    {
+      "claim": "Philosophy admission may enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1031"
+    },
+    {
+      "claim": "Philosophy admission may ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1032"
+    },
+    {
+      "claim": "Philosophy admission may store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1033"
+    },
+    {
+      "claim": "Philosophy admission might cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1034"
+    },
+    {
+      "claim": "Philosophy admission might enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1035"
+    },
+    {
+      "claim": "Philosophy admission might ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1036"
+    },
+    {
+      "claim": "Philosophy admission might store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1037"
     },
     {
       "claim": "Philosophy admission must cache raw model responses.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0176"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1038"
+    },
+    {
+      "claim": "Philosophy admission must enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1039"
+    },
+    {
+      "claim": "Philosophy admission must ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1040"
+    },
+    {
+      "claim": "Philosophy admission must store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1041"
     },
     {
       "claim": "Philosophy admission persists philosophy cache keys.",
@@ -1421,7 +8341,7 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0177"
+      "id": "philosophy-admission-oracle-1042"
     },
     {
       "claim": "Philosophy admission ships production cache keys.",
@@ -1429,15 +8349,47 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0178"
+      "id": "philosophy-admission-oracle-1043"
+    },
+    {
+      "claim": "Philosophy admission should cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1044"
+    },
+    {
+      "claim": "Philosophy admission should enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1045"
+    },
+    {
+      "claim": "Philosophy admission should ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1046"
+    },
+    {
+      "claim": "Philosophy admission should store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1047"
     },
     {
       "claim": "Philosophy admission still stores raw prompts as cache keys.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0179"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1048"
     },
     {
       "claim": "Philosophy admission stores raw prompts as cache keys.",
@@ -1445,15 +8397,79 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0180"
+      "id": "philosophy-admission-oracle-1049"
+    },
+    {
+      "claim": "Philosophy admission will cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1050"
     },
     {
       "claim": "Philosophy admission will enable live cache-key behavior.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0181"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1051"
+    },
+    {
+      "claim": "Philosophy admission will ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1052"
+    },
+    {
+      "claim": "Philosophy admission will store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1053"
+    },
+    {
+      "claim": "Philosophy admission would cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1054"
+    },
+    {
+      "claim": "Philosophy admission would enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1055"
+    },
+    {
+      "claim": "Philosophy admission would ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1056"
+    },
+    {
+      "claim": "Philosophy admission would store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1057"
+    },
+    {
+      "claim": "The admission policy became live for cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1058"
     },
     {
       "claim": "The admission policy caches raw model responses.",
@@ -1461,7 +8477,71 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0182"
+      "id": "philosophy-admission-oracle-1059"
+    },
+    {
+      "claim": "The admission policy can cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1060"
+    },
+    {
+      "claim": "The admission policy can enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1061"
+    },
+    {
+      "claim": "The admission policy can ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1062"
+    },
+    {
+      "claim": "The admission policy can store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1063"
+    },
+    {
+      "claim": "The admission policy could cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1064"
+    },
+    {
+      "claim": "The admission policy could enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1065"
+    },
+    {
+      "claim": "The admission policy could ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1066"
+    },
+    {
+      "claim": "The admission policy could store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1067"
     },
     {
       "claim": "The admission policy enables live cache-key behavior.",
@@ -1469,15 +8549,183 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0183"
+      "id": "philosophy-admission-oracle-1068"
+    },
+    {
+      "claim": "The admission policy has shipped production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1069"
+    },
+    {
+      "claim": "The admission policy has to cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1070"
+    },
+    {
+      "claim": "The admission policy has to enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1071"
+    },
+    {
+      "claim": "The admission policy has to ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1072"
+    },
+    {
+      "claim": "The admission policy has to store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1073"
+    },
+    {
+      "claim": "The admission policy is now persisting philosophy cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1074"
+    },
+    {
+      "claim": "The admission policy is required to cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1075"
+    },
+    {
+      "claim": "The admission policy is required to enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1076"
     },
     {
       "claim": "The admission policy is required to ship production cache keys.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0184"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1077"
+    },
+    {
+      "claim": "The admission policy is required to store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1078"
+    },
+    {
+      "claim": "The admission policy may cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1079"
+    },
+    {
+      "claim": "The admission policy may enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1080"
+    },
+    {
+      "claim": "The admission policy may ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1081"
+    },
+    {
+      "claim": "The admission policy may store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1082"
+    },
+    {
+      "claim": "The admission policy might cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1083"
+    },
+    {
+      "claim": "The admission policy might enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1084"
+    },
+    {
+      "claim": "The admission policy might ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1085"
+    },
+    {
+      "claim": "The admission policy might store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1086"
+    },
+    {
+      "claim": "The admission policy must cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1087"
+    },
+    {
+      "claim": "The admission policy must enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1088"
+    },
+    {
+      "claim": "The admission policy must ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1089"
+    },
+    {
+      "claim": "The admission policy must store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1090"
     },
     {
       "claim": "The admission policy persists philosophy cache keys.",
@@ -1485,7 +8733,7 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0185"
+      "id": "philosophy-admission-oracle-1091"
     },
     {
       "claim": "The admission policy ships production cache keys.",
@@ -1493,15 +8741,47 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0186"
+      "id": "philosophy-admission-oracle-1092"
+    },
+    {
+      "claim": "The admission policy should cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1093"
     },
     {
       "claim": "The admission policy should enable live cache-key behavior.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0187"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1094"
+    },
+    {
+      "claim": "The admission policy should ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1095"
+    },
+    {
+      "claim": "The admission policy should store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1096"
+    },
+    {
+      "claim": "The admission policy still stores raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1097"
     },
     {
       "claim": "The admission policy stores raw prompts as cache keys.",
@@ -1509,15 +8789,79 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0188"
+      "id": "philosophy-admission-oracle-1098"
     },
     {
       "claim": "The admission policy will cache raw model responses.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0189"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1099"
+    },
+    {
+      "claim": "The admission policy will enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1100"
+    },
+    {
+      "claim": "The admission policy will ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1101"
+    },
+    {
+      "claim": "The admission policy will store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1102"
+    },
+    {
+      "claim": "The admission policy would cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1103"
+    },
+    {
+      "claim": "The admission policy would enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1104"
+    },
+    {
+      "claim": "The admission policy would ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1105"
+    },
+    {
+      "claim": "The admission policy would store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1106"
+    },
+    {
+      "claim": "The claim-family oracle became live for cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1107"
     },
     {
       "claim": "The claim-family oracle caches raw model responses.",
@@ -1525,15 +8869,71 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0190"
+      "id": "philosophy-admission-oracle-1108"
+    },
+    {
+      "claim": "The claim-family oracle can cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1109"
+    },
+    {
+      "claim": "The claim-family oracle can enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1110"
+    },
+    {
+      "claim": "The claim-family oracle can ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1111"
+    },
+    {
+      "claim": "The claim-family oracle can store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1112"
+    },
+    {
+      "claim": "The claim-family oracle could cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1113"
+    },
+    {
+      "claim": "The claim-family oracle could enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1114"
     },
     {
       "claim": "The claim-family oracle could ship production cache keys.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0191"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1115"
+    },
+    {
+      "claim": "The claim-family oracle could store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1116"
     },
     {
       "claim": "The claim-family oracle enables live cache-key behavior.",
@@ -1541,23 +8941,183 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0192"
+      "id": "philosophy-admission-oracle-1117"
+    },
+    {
+      "claim": "The claim-family oracle has shipped production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1118"
+    },
+    {
+      "claim": "The claim-family oracle has to cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1119"
+    },
+    {
+      "claim": "The claim-family oracle has to enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1120"
+    },
+    {
+      "claim": "The claim-family oracle has to ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1121"
     },
     {
       "claim": "The claim-family oracle has to store raw prompts as cache keys.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0193"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1122"
     },
     {
       "claim": "The claim-family oracle is now persisting philosophy cache keys.",
       "claim_family": "claim_class_production_live_cache_key_behavior",
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0194"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1123"
+    },
+    {
+      "claim": "The claim-family oracle is required to cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1124"
+    },
+    {
+      "claim": "The claim-family oracle is required to enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1125"
+    },
+    {
+      "claim": "The claim-family oracle is required to ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1126"
+    },
+    {
+      "claim": "The claim-family oracle is required to store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1127"
+    },
+    {
+      "claim": "The claim-family oracle may cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1128"
+    },
+    {
+      "claim": "The claim-family oracle may enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1129"
+    },
+    {
+      "claim": "The claim-family oracle may ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1130"
+    },
+    {
+      "claim": "The claim-family oracle may store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1131"
+    },
+    {
+      "claim": "The claim-family oracle might cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1132"
+    },
+    {
+      "claim": "The claim-family oracle might enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1133"
+    },
+    {
+      "claim": "The claim-family oracle might ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1134"
+    },
+    {
+      "claim": "The claim-family oracle might store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1135"
+    },
+    {
+      "claim": "The claim-family oracle must cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1136"
+    },
+    {
+      "claim": "The claim-family oracle must enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1137"
+    },
+    {
+      "claim": "The claim-family oracle must ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1138"
+    },
+    {
+      "claim": "The claim-family oracle must store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1139"
     },
     {
       "claim": "The claim-family oracle persists philosophy cache keys.",
@@ -1565,7 +9125,7 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0195"
+      "id": "philosophy-admission-oracle-1140"
     },
     {
       "claim": "The claim-family oracle ships production cache keys.",
@@ -1573,7 +9133,47 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0196"
+      "id": "philosophy-admission-oracle-1141"
+    },
+    {
+      "claim": "The claim-family oracle should cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1142"
+    },
+    {
+      "claim": "The claim-family oracle should enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1143"
+    },
+    {
+      "claim": "The claim-family oracle should ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1144"
+    },
+    {
+      "claim": "The claim-family oracle should store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1145"
+    },
+    {
+      "claim": "The claim-family oracle still stores raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1146"
     },
     {
       "claim": "The claim-family oracle stores raw prompts as cache keys.",
@@ -1581,7 +9181,71 @@
       "expected": "forbidden",
       "expected_detector_label": "production-live philosophical cache-key behavior",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0197"
+      "id": "philosophy-admission-oracle-1147"
+    },
+    {
+      "claim": "The claim-family oracle will cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1148"
+    },
+    {
+      "claim": "The claim-family oracle will enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1149"
+    },
+    {
+      "claim": "The claim-family oracle will ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1150"
+    },
+    {
+      "claim": "The claim-family oracle will store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1151"
+    },
+    {
+      "claim": "The claim-family oracle would cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1152"
+    },
+    {
+      "claim": "The claim-family oracle would enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1153"
+    },
+    {
+      "claim": "The claim-family oracle would ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1154"
+    },
+    {
+      "claim": "The claim-family oracle would store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1155"
     },
     {
       "claim": "GPTCache imports remain blocked for philosophy admission.",
@@ -1589,7 +9253,7 @@
       "expected": "allowed",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0198"
+      "id": "philosophy-admission-oracle-1156"
     },
     {
       "claim": "No Redis imports are allowed in PR-2.",
@@ -1597,7 +9261,7 @@
       "expected": "allowed",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0199"
+      "id": "philosophy-admission-oracle-1157"
     },
     {
       "claim": "The policy oracle does not enable provider-backed cache.",
@@ -1605,7 +9269,7 @@
       "expected": "allowed",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0200"
+      "id": "philosophy-admission-oracle-1158"
     },
     {
       "claim": "Future philosophy PRs may now serve GPTCache responses.",
@@ -1613,7 +9277,7 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0201"
+      "id": "philosophy-admission-oracle-1159"
     },
     {
       "claim": "PR-1 allows GPTCache imports.",
@@ -1621,7 +9285,7 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0202"
+      "id": "philosophy-admission-oracle-1160"
     },
     {
       "claim": "PR-1 allows Redis imports.",
@@ -1629,15 +9293,95 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0203"
+      "id": "philosophy-admission-oracle-1161"
+    },
+    {
+      "claim": "PR-1 became approved for GPTCache imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1162"
+    },
+    {
+      "claim": "PR-1 can enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1163"
+    },
+    {
+      "claim": "PR-1 can open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1164"
+    },
+    {
+      "claim": "PR-1 can use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1165"
     },
     {
       "claim": "PR-1 can use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0204"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1166"
+    },
+    {
+      "claim": "PR-1 can wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1167"
+    },
+    {
+      "claim": "PR-1 could enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1168"
+    },
+    {
+      "claim": "PR-1 could open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1169"
+    },
+    {
+      "claim": "PR-1 could use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1170"
+    },
+    {
+      "claim": "PR-1 could use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1171"
+    },
+    {
+      "claim": "PR-1 could wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1172"
     },
     {
       "claim": "PR-1 enables embeddings for philosophy admission.",
@@ -1645,15 +9389,223 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0205"
+      "id": "philosophy-admission-oracle-1173"
+    },
+    {
+      "claim": "PR-1 has been opening Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1174"
+    },
+    {
+      "claim": "PR-1 has to enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1175"
+    },
+    {
+      "claim": "PR-1 has to open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1176"
+    },
+    {
+      "claim": "PR-1 has to use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1177"
+    },
+    {
+      "claim": "PR-1 has to use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1178"
+    },
+    {
+      "claim": "PR-1 has to wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1179"
     },
     {
       "claim": "PR-1 has used Redis imports for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0206"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1180"
+    },
+    {
+      "claim": "PR-1 is required to enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1181"
+    },
+    {
+      "claim": "PR-1 is required to open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1182"
+    },
+    {
+      "claim": "PR-1 is required to use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1183"
+    },
+    {
+      "claim": "PR-1 is required to use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1184"
+    },
+    {
+      "claim": "PR-1 is required to wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1185"
+    },
+    {
+      "claim": "PR-1 may enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1186"
+    },
+    {
+      "claim": "PR-1 may open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1187"
+    },
+    {
+      "claim": "PR-1 may use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1188"
+    },
+    {
+      "claim": "PR-1 may use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1189"
+    },
+    {
+      "claim": "PR-1 may wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1190"
+    },
+    {
+      "claim": "PR-1 might enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1191"
+    },
+    {
+      "claim": "PR-1 might open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1192"
+    },
+    {
+      "claim": "PR-1 might use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1193"
+    },
+    {
+      "claim": "PR-1 might use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1194"
+    },
+    {
+      "claim": "PR-1 might wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1195"
+    },
+    {
+      "claim": "PR-1 must enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1196"
+    },
+    {
+      "claim": "PR-1 must open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1197"
+    },
+    {
+      "claim": "PR-1 must use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1198"
+    },
+    {
+      "claim": "PR-1 must use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1199"
+    },
+    {
+      "claim": "PR-1 must wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1200"
     },
     {
       "claim": "PR-1 opens Redis connection strings.",
@@ -1661,7 +9613,103 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0207"
+      "id": "philosophy-admission-oracle-1201"
+    },
+    {
+      "claim": "PR-1 should enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1202"
+    },
+    {
+      "claim": "PR-1 should open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1203"
+    },
+    {
+      "claim": "PR-1 should use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1204"
+    },
+    {
+      "claim": "PR-1 should use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1205"
+    },
+    {
+      "claim": "PR-1 should wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1206"
+    },
+    {
+      "claim": "PR-1 still allows embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1207"
+    },
+    {
+      "claim": "PR-1 will enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1208"
+    },
+    {
+      "claim": "PR-1 will open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1209"
+    },
+    {
+      "claim": "PR-1 will use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1210"
+    },
+    {
+      "claim": "PR-1 will use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1211"
+    },
+    {
+      "claim": "PR-1 will wire /insight cache behavior.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1212"
+    },
+    {
+      "claim": "PR-1 will wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1213"
     },
     {
       "claim": "PR-1 wires /insight cache behavior.",
@@ -1669,15 +9717,47 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0208"
+      "id": "philosophy-admission-oracle-1214"
+    },
+    {
+      "claim": "PR-1 would enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1215"
+    },
+    {
+      "claim": "PR-1 would open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1216"
+    },
+    {
+      "claim": "PR-1 would use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1217"
     },
     {
       "claim": "PR-1 would use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0209"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1218"
+    },
+    {
+      "claim": "PR-1 would wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1219"
     },
     {
       "claim": "PR-2 allows GPTCache imports.",
@@ -1685,7 +9765,7 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0210"
+      "id": "philosophy-admission-oracle-1220"
     },
     {
       "claim": "PR-2 allows Redis imports.",
@@ -1693,15 +9773,95 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0211"
+      "id": "philosophy-admission-oracle-1221"
     },
     {
       "claim": "PR-2 became approved for GPTCache imports.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0212"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1222"
+    },
+    {
+      "claim": "PR-2 can enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1223"
+    },
+    {
+      "claim": "PR-2 can open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1224"
+    },
+    {
+      "claim": "PR-2 can use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1225"
+    },
+    {
+      "claim": "PR-2 can use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1226"
+    },
+    {
+      "claim": "PR-2 can wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1227"
+    },
+    {
+      "claim": "PR-2 could enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1228"
+    },
+    {
+      "claim": "PR-2 could open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1229"
+    },
+    {
+      "claim": "PR-2 could use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1230"
+    },
+    {
+      "claim": "PR-2 could use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1231"
+    },
+    {
+      "claim": "PR-2 could wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1232"
     },
     {
       "claim": "PR-2 enables embeddings for philosophy admission.",
@@ -1709,7 +9869,7 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0213"
+      "id": "philosophy-admission-oracle-1233"
     },
     {
       "claim": "PR-2 has GPTCache import for philosophy admission.",
@@ -1717,23 +9877,223 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0214"
+      "id": "philosophy-admission-oracle-1234"
+    },
+    {
+      "claim": "PR-2 has been opening Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1235"
+    },
+    {
+      "claim": "PR-2 has to enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1236"
+    },
+    {
+      "claim": "PR-2 has to open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1237"
+    },
+    {
+      "claim": "PR-2 has to use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1238"
+    },
+    {
+      "claim": "PR-2 has to use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1239"
+    },
+    {
+      "claim": "PR-2 has to wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1240"
+    },
+    {
+      "claim": "PR-2 has used Redis imports for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1241"
+    },
+    {
+      "claim": "PR-2 is required to enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1242"
+    },
+    {
+      "claim": "PR-2 is required to open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1243"
+    },
+    {
+      "claim": "PR-2 is required to use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1244"
+    },
+    {
+      "claim": "PR-2 is required to use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1245"
+    },
+    {
+      "claim": "PR-2 is required to wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1246"
+    },
+    {
+      "claim": "PR-2 may enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1247"
+    },
+    {
+      "claim": "PR-2 may open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1248"
     },
     {
       "claim": "PR-2 may use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0215"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1249"
+    },
+    {
+      "claim": "PR-2 may use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1250"
+    },
+    {
+      "claim": "PR-2 may wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1251"
+    },
+    {
+      "claim": "PR-2 might enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1252"
+    },
+    {
+      "claim": "PR-2 might open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1253"
     },
     {
       "claim": "PR-2 might use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0216"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1254"
+    },
+    {
+      "claim": "PR-2 might use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1255"
+    },
+    {
+      "claim": "PR-2 might wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1256"
+    },
+    {
+      "claim": "PR-2 must enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1257"
+    },
+    {
+      "claim": "PR-2 must open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1258"
+    },
+    {
+      "claim": "PR-2 must use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1259"
+    },
+    {
+      "claim": "PR-2 must use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1260"
+    },
+    {
+      "claim": "PR-2 must wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1261"
     },
     {
       "claim": "PR-2 opens Redis connection strings.",
@@ -1741,7 +10101,103 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0217"
+      "id": "philosophy-admission-oracle-1262"
+    },
+    {
+      "claim": "PR-2 should enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1263"
+    },
+    {
+      "claim": "PR-2 should open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1264"
+    },
+    {
+      "claim": "PR-2 should use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1265"
+    },
+    {
+      "claim": "PR-2 should use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1266"
+    },
+    {
+      "claim": "PR-2 should wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1267"
+    },
+    {
+      "claim": "PR-2 still allows embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1268"
+    },
+    {
+      "claim": "PR-2 will enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1269"
+    },
+    {
+      "claim": "PR-2 will open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1270"
+    },
+    {
+      "claim": "PR-2 will use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1271"
+    },
+    {
+      "claim": "PR-2 will use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1272"
+    },
+    {
+      "claim": "PR-2 will wire /insight cache behavior.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1273"
+    },
+    {
+      "claim": "PR-2 will wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1274"
     },
     {
       "claim": "PR-2 wires /insight cache behavior.",
@@ -1749,7 +10205,47 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0218"
+      "id": "philosophy-admission-oracle-1275"
+    },
+    {
+      "claim": "PR-2 would enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1276"
+    },
+    {
+      "claim": "PR-2 would open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1277"
+    },
+    {
+      "claim": "PR-2 would use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1278"
+    },
+    {
+      "claim": "PR-2 would use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1279"
+    },
+    {
+      "claim": "PR-2 would wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1280"
     },
     {
       "claim": "Philosophy admission allows GPTCache imports.",
@@ -1757,7 +10253,7 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0219"
+      "id": "philosophy-admission-oracle-1281"
     },
     {
       "claim": "Philosophy admission allows Redis imports.",
@@ -1765,7 +10261,95 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0220"
+      "id": "philosophy-admission-oracle-1282"
+    },
+    {
+      "claim": "Philosophy admission became approved for GPTCache imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1283"
+    },
+    {
+      "claim": "Philosophy admission can enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1284"
+    },
+    {
+      "claim": "Philosophy admission can open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1285"
+    },
+    {
+      "claim": "Philosophy admission can use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1286"
+    },
+    {
+      "claim": "Philosophy admission can use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1287"
+    },
+    {
+      "claim": "Philosophy admission can wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1288"
+    },
+    {
+      "claim": "Philosophy admission could enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1289"
+    },
+    {
+      "claim": "Philosophy admission could open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1290"
+    },
+    {
+      "claim": "Philosophy admission could use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1291"
+    },
+    {
+      "claim": "Philosophy admission could use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1292"
+    },
+    {
+      "claim": "Philosophy admission could wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1293"
     },
     {
       "claim": "Philosophy admission enables embeddings for philosophy admission.",
@@ -1773,7 +10357,15 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0221"
+      "id": "philosophy-admission-oracle-1294"
+    },
+    {
+      "claim": "Philosophy admission has been opening Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1295"
     },
     {
       "claim": "Philosophy admission has been required to enable Redis cache I/O.",
@@ -1781,15 +10373,215 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0222"
+      "id": "philosophy-admission-oracle-1296"
+    },
+    {
+      "claim": "Philosophy admission has to enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1297"
+    },
+    {
+      "claim": "Philosophy admission has to open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1298"
+    },
+    {
+      "claim": "Philosophy admission has to use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1299"
+    },
+    {
+      "claim": "Philosophy admission has to use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1300"
+    },
+    {
+      "claim": "Philosophy admission has to wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1301"
+    },
+    {
+      "claim": "Philosophy admission has used Redis imports for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1302"
+    },
+    {
+      "claim": "Philosophy admission is required to enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1303"
+    },
+    {
+      "claim": "Philosophy admission is required to open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1304"
+    },
+    {
+      "claim": "Philosophy admission is required to use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1305"
+    },
+    {
+      "claim": "Philosophy admission is required to use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1306"
+    },
+    {
+      "claim": "Philosophy admission is required to wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1307"
+    },
+    {
+      "claim": "Philosophy admission may enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1308"
+    },
+    {
+      "claim": "Philosophy admission may open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1309"
+    },
+    {
+      "claim": "Philosophy admission may use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1310"
+    },
+    {
+      "claim": "Philosophy admission may use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1311"
+    },
+    {
+      "claim": "Philosophy admission may wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1312"
+    },
+    {
+      "claim": "Philosophy admission might enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1313"
+    },
+    {
+      "claim": "Philosophy admission might open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1314"
+    },
+    {
+      "claim": "Philosophy admission might use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1315"
+    },
+    {
+      "claim": "Philosophy admission might use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1316"
+    },
+    {
+      "claim": "Philosophy admission might wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1317"
+    },
+    {
+      "claim": "Philosophy admission must enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1318"
+    },
+    {
+      "claim": "Philosophy admission must open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1319"
+    },
+    {
+      "claim": "Philosophy admission must use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1320"
+    },
+    {
+      "claim": "Philosophy admission must use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1321"
     },
     {
       "claim": "Philosophy admission must wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0223"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1322"
     },
     {
       "claim": "Philosophy admission opens Redis connection strings.",
@@ -1797,23 +10589,103 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0224"
+      "id": "philosophy-admission-oracle-1323"
+    },
+    {
+      "claim": "Philosophy admission should enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1324"
+    },
+    {
+      "claim": "Philosophy admission should open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1325"
+    },
+    {
+      "claim": "Philosophy admission should use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1326"
+    },
+    {
+      "claim": "Philosophy admission should use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1327"
+    },
+    {
+      "claim": "Philosophy admission should wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1328"
     },
     {
       "claim": "Philosophy admission still allows embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0225"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1329"
+    },
+    {
+      "claim": "Philosophy admission will enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1330"
+    },
+    {
+      "claim": "Philosophy admission will open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1331"
+    },
+    {
+      "claim": "Philosophy admission will use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1332"
+    },
+    {
+      "claim": "Philosophy admission will use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1333"
+    },
+    {
+      "claim": "Philosophy admission will wire /insight cache behavior.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1334"
     },
     {
       "claim": "Philosophy admission will wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0226"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1335"
     },
     {
       "claim": "Philosophy admission wires /insight cache behavior.",
@@ -1821,7 +10693,47 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0227"
+      "id": "philosophy-admission-oracle-1336"
+    },
+    {
+      "claim": "Philosophy admission would enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1337"
+    },
+    {
+      "claim": "Philosophy admission would open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1338"
+    },
+    {
+      "claim": "Philosophy admission would use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1339"
+    },
+    {
+      "claim": "Philosophy admission would use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1340"
+    },
+    {
+      "claim": "Philosophy admission would wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1341"
     },
     {
       "claim": "The admission policy allows GPTCache imports.",
@@ -1829,7 +10741,7 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0228"
+      "id": "philosophy-admission-oracle-1342"
     },
     {
       "claim": "The admission policy allows Redis imports.",
@@ -1837,7 +10749,95 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0229"
+      "id": "philosophy-admission-oracle-1343"
+    },
+    {
+      "claim": "The admission policy became approved for GPTCache imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1344"
+    },
+    {
+      "claim": "The admission policy can enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1345"
+    },
+    {
+      "claim": "The admission policy can open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1346"
+    },
+    {
+      "claim": "The admission policy can use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1347"
+    },
+    {
+      "claim": "The admission policy can use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1348"
+    },
+    {
+      "claim": "The admission policy can wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1349"
+    },
+    {
+      "claim": "The admission policy could enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1350"
+    },
+    {
+      "claim": "The admission policy could open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1351"
+    },
+    {
+      "claim": "The admission policy could use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1352"
+    },
+    {
+      "claim": "The admission policy could use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1353"
+    },
+    {
+      "claim": "The admission policy could wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1354"
     },
     {
       "claim": "The admission policy enables embeddings for philosophy admission.",
@@ -1845,15 +10845,223 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0230"
+      "id": "philosophy-admission-oracle-1355"
+    },
+    {
+      "claim": "The admission policy has been opening Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1356"
+    },
+    {
+      "claim": "The admission policy has to enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1357"
+    },
+    {
+      "claim": "The admission policy has to open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1358"
+    },
+    {
+      "claim": "The admission policy has to use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1359"
+    },
+    {
+      "claim": "The admission policy has to use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1360"
+    },
+    {
+      "claim": "The admission policy has to wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1361"
+    },
+    {
+      "claim": "The admission policy has used Redis imports for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1362"
+    },
+    {
+      "claim": "The admission policy is required to enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1363"
     },
     {
       "claim": "The admission policy is required to open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0231"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1364"
+    },
+    {
+      "claim": "The admission policy is required to use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1365"
+    },
+    {
+      "claim": "The admission policy is required to use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1366"
+    },
+    {
+      "claim": "The admission policy is required to wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1367"
+    },
+    {
+      "claim": "The admission policy may enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1368"
+    },
+    {
+      "claim": "The admission policy may open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1369"
+    },
+    {
+      "claim": "The admission policy may use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1370"
+    },
+    {
+      "claim": "The admission policy may use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1371"
+    },
+    {
+      "claim": "The admission policy may wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1372"
+    },
+    {
+      "claim": "The admission policy might enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1373"
+    },
+    {
+      "claim": "The admission policy might open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1374"
+    },
+    {
+      "claim": "The admission policy might use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1375"
+    },
+    {
+      "claim": "The admission policy might use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1376"
+    },
+    {
+      "claim": "The admission policy might wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1377"
+    },
+    {
+      "claim": "The admission policy must enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1378"
+    },
+    {
+      "claim": "The admission policy must open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1379"
+    },
+    {
+      "claim": "The admission policy must use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1380"
+    },
+    {
+      "claim": "The admission policy must use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1381"
+    },
+    {
+      "claim": "The admission policy must wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1382"
     },
     {
       "claim": "The admission policy opens Redis connection strings.",
@@ -1861,23 +11069,103 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0232"
+      "id": "philosophy-admission-oracle-1383"
+    },
+    {
+      "claim": "The admission policy should enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1384"
     },
     {
       "claim": "The admission policy should open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0233"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1385"
+    },
+    {
+      "claim": "The admission policy should use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1386"
+    },
+    {
+      "claim": "The admission policy should use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1387"
+    },
+    {
+      "claim": "The admission policy should wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1388"
+    },
+    {
+      "claim": "The admission policy still allows embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1389"
+    },
+    {
+      "claim": "The admission policy will enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1390"
+    },
+    {
+      "claim": "The admission policy will open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1391"
+    },
+    {
+      "claim": "The admission policy will use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1392"
+    },
+    {
+      "claim": "The admission policy will use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1393"
     },
     {
       "claim": "The admission policy will wire /insight cache behavior.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0234"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1394"
+    },
+    {
+      "claim": "The admission policy will wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1395"
     },
     {
       "claim": "The admission policy wires /insight cache behavior.",
@@ -1885,7 +11173,47 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0235"
+      "id": "philosophy-admission-oracle-1396"
+    },
+    {
+      "claim": "The admission policy would enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1397"
+    },
+    {
+      "claim": "The admission policy would open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1398"
+    },
+    {
+      "claim": "The admission policy would use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1399"
+    },
+    {
+      "claim": "The admission policy would use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1400"
+    },
+    {
+      "claim": "The admission policy would wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1401"
     },
     {
       "claim": "The claim-family oracle allows GPTCache imports.",
@@ -1893,7 +11221,7 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0236"
+      "id": "philosophy-admission-oracle-1402"
     },
     {
       "claim": "The claim-family oracle allows Redis imports.",
@@ -1901,15 +11229,95 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0237"
+      "id": "philosophy-admission-oracle-1403"
+    },
+    {
+      "claim": "The claim-family oracle became approved for GPTCache imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1404"
+    },
+    {
+      "claim": "The claim-family oracle can enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1405"
+    },
+    {
+      "claim": "The claim-family oracle can open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1406"
+    },
+    {
+      "claim": "The claim-family oracle can use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1407"
+    },
+    {
+      "claim": "The claim-family oracle can use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1408"
+    },
+    {
+      "claim": "The claim-family oracle can wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1409"
     },
     {
       "claim": "The claim-family oracle could enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0238"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1410"
+    },
+    {
+      "claim": "The claim-family oracle could open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1411"
+    },
+    {
+      "claim": "The claim-family oracle could use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1412"
+    },
+    {
+      "claim": "The claim-family oracle could use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1413"
+    },
+    {
+      "claim": "The claim-family oracle could wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1414"
     },
     {
       "claim": "The claim-family oracle enables embeddings for philosophy admission.",
@@ -1917,23 +11325,223 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0239"
+      "id": "philosophy-admission-oracle-1415"
     },
     {
       "claim": "The claim-family oracle has been opening Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0240"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1416"
     },
     {
       "claim": "The claim-family oracle has to enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0241"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1417"
+    },
+    {
+      "claim": "The claim-family oracle has to open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1418"
+    },
+    {
+      "claim": "The claim-family oracle has to use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1419"
+    },
+    {
+      "claim": "The claim-family oracle has to use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1420"
+    },
+    {
+      "claim": "The claim-family oracle has to wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1421"
+    },
+    {
+      "claim": "The claim-family oracle has used Redis imports for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1422"
+    },
+    {
+      "claim": "The claim-family oracle is required to enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1423"
+    },
+    {
+      "claim": "The claim-family oracle is required to open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1424"
+    },
+    {
+      "claim": "The claim-family oracle is required to use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1425"
+    },
+    {
+      "claim": "The claim-family oracle is required to use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1426"
+    },
+    {
+      "claim": "The claim-family oracle is required to wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1427"
+    },
+    {
+      "claim": "The claim-family oracle may enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1428"
+    },
+    {
+      "claim": "The claim-family oracle may open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1429"
+    },
+    {
+      "claim": "The claim-family oracle may use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1430"
+    },
+    {
+      "claim": "The claim-family oracle may use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1431"
+    },
+    {
+      "claim": "The claim-family oracle may wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1432"
+    },
+    {
+      "claim": "The claim-family oracle might enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1433"
+    },
+    {
+      "claim": "The claim-family oracle might open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1434"
+    },
+    {
+      "claim": "The claim-family oracle might use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1435"
+    },
+    {
+      "claim": "The claim-family oracle might use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1436"
+    },
+    {
+      "claim": "The claim-family oracle might wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1437"
+    },
+    {
+      "claim": "The claim-family oracle must enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1438"
+    },
+    {
+      "claim": "The claim-family oracle must open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1439"
+    },
+    {
+      "claim": "The claim-family oracle must use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1440"
+    },
+    {
+      "claim": "The claim-family oracle must use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1441"
+    },
+    {
+      "claim": "The claim-family oracle must wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1442"
     },
     {
       "claim": "The claim-family oracle opens Redis connection strings.",
@@ -1941,7 +11549,103 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0242"
+      "id": "philosophy-admission-oracle-1443"
+    },
+    {
+      "claim": "The claim-family oracle should enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1444"
+    },
+    {
+      "claim": "The claim-family oracle should open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1445"
+    },
+    {
+      "claim": "The claim-family oracle should use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1446"
+    },
+    {
+      "claim": "The claim-family oracle should use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1447"
+    },
+    {
+      "claim": "The claim-family oracle should wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1448"
+    },
+    {
+      "claim": "The claim-family oracle still allows embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1449"
+    },
+    {
+      "claim": "The claim-family oracle will enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1450"
+    },
+    {
+      "claim": "The claim-family oracle will open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1451"
+    },
+    {
+      "claim": "The claim-family oracle will use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1452"
+    },
+    {
+      "claim": "The claim-family oracle will use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1453"
+    },
+    {
+      "claim": "The claim-family oracle will wire /insight cache behavior.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1454"
+    },
+    {
+      "claim": "The claim-family oracle will wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1455"
     },
     {
       "claim": "The claim-family oracle wires /insight cache behavior.",
@@ -1949,7 +11653,47 @@
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0243"
+      "id": "philosophy-admission-oracle-1456"
+    },
+    {
+      "claim": "The claim-family oracle would enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1457"
+    },
+    {
+      "claim": "The claim-family oracle would open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1458"
+    },
+    {
+      "claim": "The claim-family oracle would use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1459"
+    },
+    {
+      "claim": "The claim-family oracle would use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1460"
+    },
+    {
+      "claim": "The claim-family oracle would wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1461"
     },
     {
       "claim": "Billing truth remains blocked_from_cache.",
@@ -1957,7 +11701,7 @@
       "expected": "allowed",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0244"
+      "id": "philosophy-admission-oracle-1462"
     },
     {
       "claim": "PR-2 must not write cache entries.",
@@ -1965,7 +11709,7 @@
       "expected": "allowed",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0245"
+      "id": "philosophy-admission-oracle-1463"
     },
     {
       "claim": "The policy spec does not authorize backend selection.",
@@ -1973,7 +11717,7 @@
       "expected": "allowed",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0246"
+      "id": "philosophy-admission-oracle-1464"
     },
     {
       "claim": "Billing truth authorizes backend selection.",
@@ -1981,7 +11725,15 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0247"
+      "id": "philosophy-admission-oracle-1465"
+    },
+    {
+      "claim": "Billing truth became cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1466"
     },
     {
       "claim": "Billing truth becomes cache eligible for semantic-cache admission.",
@@ -1989,7 +11741,87 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0248"
+      "id": "philosophy-admission-oracle-1467"
+    },
+    {
+      "claim": "Billing truth can authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1468"
+    },
+    {
+      "claim": "Billing truth can be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1469"
+    },
+    {
+      "claim": "Billing truth can enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1470"
+    },
+    {
+      "claim": "Billing truth can read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1471"
+    },
+    {
+      "claim": "Billing truth can write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1472"
+    },
+    {
+      "claim": "Billing truth could authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1473"
+    },
+    {
+      "claim": "Billing truth could be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1474"
+    },
+    {
+      "claim": "Billing truth could enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1475"
+    },
+    {
+      "claim": "Billing truth could read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1476"
+    },
+    {
+      "claim": "Billing truth could write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1477"
     },
     {
       "claim": "Billing truth enables runtime expansion.",
@@ -1997,7 +11829,223 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0249"
+      "id": "philosophy-admission-oracle-1478"
+    },
+    {
+      "claim": "Billing truth has authorized backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1479"
+    },
+    {
+      "claim": "Billing truth has to authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1480"
+    },
+    {
+      "claim": "Billing truth has to be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1481"
+    },
+    {
+      "claim": "Billing truth has to enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1482"
+    },
+    {
+      "claim": "Billing truth has to read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1483"
+    },
+    {
+      "claim": "Billing truth has to write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1484"
+    },
+    {
+      "claim": "Billing truth is now writing cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1485"
+    },
+    {
+      "claim": "Billing truth is required to authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1486"
+    },
+    {
+      "claim": "Billing truth is required to be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1487"
+    },
+    {
+      "claim": "Billing truth is required to enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1488"
+    },
+    {
+      "claim": "Billing truth is required to read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1489"
+    },
+    {
+      "claim": "Billing truth is required to write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1490"
+    },
+    {
+      "claim": "Billing truth may authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1491"
+    },
+    {
+      "claim": "Billing truth may be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1492"
+    },
+    {
+      "claim": "Billing truth may enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1493"
+    },
+    {
+      "claim": "Billing truth may read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1494"
+    },
+    {
+      "claim": "Billing truth may write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1495"
+    },
+    {
+      "claim": "Billing truth might authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1496"
+    },
+    {
+      "claim": "Billing truth might be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1497"
+    },
+    {
+      "claim": "Billing truth might enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1498"
+    },
+    {
+      "claim": "Billing truth might read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1499"
+    },
+    {
+      "claim": "Billing truth might write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1500"
+    },
+    {
+      "claim": "Billing truth must authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1501"
+    },
+    {
+      "claim": "Billing truth must be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1502"
+    },
+    {
+      "claim": "Billing truth must enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1503"
+    },
+    {
+      "claim": "Billing truth must read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1504"
+    },
+    {
+      "claim": "Billing truth must write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1505"
     },
     {
       "claim": "Billing truth reads semantic-cache entries.",
@@ -2005,7 +12053,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0250"
+      "id": "philosophy-admission-oracle-1506"
     },
     {
       "claim": "Billing truth remained cache eligible for semantic-cache admission.",
@@ -2013,15 +12061,135 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0251"
+      "id": "philosophy-admission-oracle-1507"
+    },
+    {
+      "claim": "Billing truth remains cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1508"
+    },
+    {
+      "claim": "Billing truth should authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1509"
+    },
+    {
+      "claim": "Billing truth should be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1510"
+    },
+    {
+      "claim": "Billing truth should enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1511"
+    },
+    {
+      "claim": "Billing truth should read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1512"
+    },
+    {
+      "claim": "Billing truth should write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1513"
+    },
+    {
+      "claim": "Billing truth will authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1514"
+    },
+    {
+      "claim": "Billing truth will be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1515"
+    },
+    {
+      "claim": "Billing truth will enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1516"
+    },
+    {
+      "claim": "Billing truth will read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1517"
+    },
+    {
+      "claim": "Billing truth will write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1518"
     },
     {
       "claim": "Billing truth would authorize backend selection.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0252"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1519"
+    },
+    {
+      "claim": "Billing truth would be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1520"
+    },
+    {
+      "claim": "Billing truth would enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1521"
+    },
+    {
+      "claim": "Billing truth would read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1522"
+    },
+    {
+      "claim": "Billing truth would write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1523"
     },
     {
       "claim": "Billing truth writes cache entries.",
@@ -2029,7 +12197,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0253"
+      "id": "philosophy-admission-oracle-1524"
     },
     {
       "claim": "PR-1 authorizes backend selection.",
@@ -2037,7 +12205,15 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0254"
+      "id": "philosophy-admission-oracle-1525"
+    },
+    {
+      "claim": "PR-1 became cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1526"
     },
     {
       "claim": "PR-1 becomes cache eligible for semantic-cache admission.",
@@ -2045,15 +12221,87 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0255"
+      "id": "philosophy-admission-oracle-1527"
     },
     {
       "claim": "PR-1 can authorize backend selection.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0256"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1528"
+    },
+    {
+      "claim": "PR-1 can be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1529"
+    },
+    {
+      "claim": "PR-1 can enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1530"
+    },
+    {
+      "claim": "PR-1 can read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1531"
+    },
+    {
+      "claim": "PR-1 can write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1532"
+    },
+    {
+      "claim": "PR-1 could authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1533"
+    },
+    {
+      "claim": "PR-1 could be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1534"
+    },
+    {
+      "claim": "PR-1 could enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1535"
+    },
+    {
+      "claim": "PR-1 could read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1536"
+    },
+    {
+      "claim": "PR-1 could write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1537"
     },
     {
       "claim": "PR-1 enables runtime expansion.",
@@ -2061,15 +12309,223 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0257"
+      "id": "philosophy-admission-oracle-1538"
     },
     {
       "claim": "PR-1 has authorized backend selection.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0258"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1539"
+    },
+    {
+      "claim": "PR-1 has to authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1540"
+    },
+    {
+      "claim": "PR-1 has to be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1541"
+    },
+    {
+      "claim": "PR-1 has to enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1542"
+    },
+    {
+      "claim": "PR-1 has to read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1543"
+    },
+    {
+      "claim": "PR-1 has to write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1544"
+    },
+    {
+      "claim": "PR-1 is now writing cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1545"
+    },
+    {
+      "claim": "PR-1 is required to authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1546"
+    },
+    {
+      "claim": "PR-1 is required to be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1547"
+    },
+    {
+      "claim": "PR-1 is required to enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1548"
+    },
+    {
+      "claim": "PR-1 is required to read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1549"
+    },
+    {
+      "claim": "PR-1 is required to write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1550"
+    },
+    {
+      "claim": "PR-1 may authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1551"
+    },
+    {
+      "claim": "PR-1 may be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1552"
+    },
+    {
+      "claim": "PR-1 may enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1553"
+    },
+    {
+      "claim": "PR-1 may read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1554"
+    },
+    {
+      "claim": "PR-1 may write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1555"
+    },
+    {
+      "claim": "PR-1 might authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1556"
+    },
+    {
+      "claim": "PR-1 might be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1557"
+    },
+    {
+      "claim": "PR-1 might enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1558"
+    },
+    {
+      "claim": "PR-1 might read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1559"
+    },
+    {
+      "claim": "PR-1 might write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1560"
+    },
+    {
+      "claim": "PR-1 must authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1561"
+    },
+    {
+      "claim": "PR-1 must be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1562"
+    },
+    {
+      "claim": "PR-1 must enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1563"
+    },
+    {
+      "claim": "PR-1 must read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1564"
+    },
+    {
+      "claim": "PR-1 must write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1565"
     },
     {
       "claim": "PR-1 reads semantic-cache entries.",
@@ -2077,15 +12533,135 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0259"
+      "id": "philosophy-admission-oracle-1566"
+    },
+    {
+      "claim": "PR-1 remains cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1567"
+    },
+    {
+      "claim": "PR-1 should authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1568"
+    },
+    {
+      "claim": "PR-1 should be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1569"
+    },
+    {
+      "claim": "PR-1 should enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1570"
+    },
+    {
+      "claim": "PR-1 should read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1571"
+    },
+    {
+      "claim": "PR-1 should write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1572"
+    },
+    {
+      "claim": "PR-1 will authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1573"
+    },
+    {
+      "claim": "PR-1 will be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1574"
+    },
+    {
+      "claim": "PR-1 will enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1575"
+    },
+    {
+      "claim": "PR-1 will read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1576"
     },
     {
       "claim": "PR-1 will write cache entries.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0260"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1577"
+    },
+    {
+      "claim": "PR-1 would authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1578"
+    },
+    {
+      "claim": "PR-1 would be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1579"
+    },
+    {
+      "claim": "PR-1 would enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1580"
+    },
+    {
+      "claim": "PR-1 would read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1581"
+    },
+    {
+      "claim": "PR-1 would write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1582"
     },
     {
       "claim": "PR-1 writes cache entries.",
@@ -2093,7 +12669,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0261"
+      "id": "philosophy-admission-oracle-1583"
     },
     {
       "claim": "PR-2 authorizes backend selection.",
@@ -2101,15 +12677,15 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0262"
+      "id": "philosophy-admission-oracle-1584"
     },
     {
       "claim": "PR-2 became cache eligible for semantic-cache admission.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0263"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1585"
     },
     {
       "claim": "PR-2 becomes cache eligible for semantic-cache admission.",
@@ -2117,7 +12693,87 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0264"
+      "id": "philosophy-admission-oracle-1586"
+    },
+    {
+      "claim": "PR-2 can authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1587"
+    },
+    {
+      "claim": "PR-2 can be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1588"
+    },
+    {
+      "claim": "PR-2 can enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1589"
+    },
+    {
+      "claim": "PR-2 can read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1590"
+    },
+    {
+      "claim": "PR-2 can write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1591"
+    },
+    {
+      "claim": "PR-2 could authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1592"
+    },
+    {
+      "claim": "PR-2 could be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1593"
+    },
+    {
+      "claim": "PR-2 could enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1594"
+    },
+    {
+      "claim": "PR-2 could read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1595"
+    },
+    {
+      "claim": "PR-2 could write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1596"
     },
     {
       "claim": "PR-2 enables runtime expansion.",
@@ -2125,31 +12781,223 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0265"
+      "id": "philosophy-admission-oracle-1597"
+    },
+    {
+      "claim": "PR-2 has authorized backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1598"
+    },
+    {
+      "claim": "PR-2 has to authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1599"
+    },
+    {
+      "claim": "PR-2 has to be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1600"
+    },
+    {
+      "claim": "PR-2 has to enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1601"
+    },
+    {
+      "claim": "PR-2 has to read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1602"
+    },
+    {
+      "claim": "PR-2 has to write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1603"
+    },
+    {
+      "claim": "PR-2 is now writing cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1604"
+    },
+    {
+      "claim": "PR-2 is required to authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1605"
+    },
+    {
+      "claim": "PR-2 is required to be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1606"
+    },
+    {
+      "claim": "PR-2 is required to enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1607"
     },
     {
       "claim": "PR-2 is required to read semantic-cache entries.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0266"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1608"
+    },
+    {
+      "claim": "PR-2 is required to write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1609"
+    },
+    {
+      "claim": "PR-2 may authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1610"
+    },
+    {
+      "claim": "PR-2 may be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1611"
     },
     {
       "claim": "PR-2 may enable runtime expansion.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0267"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1612"
+    },
+    {
+      "claim": "PR-2 may read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1613"
+    },
+    {
+      "claim": "PR-2 may write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1614"
+    },
+    {
+      "claim": "PR-2 might authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1615"
+    },
+    {
+      "claim": "PR-2 might be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1616"
+    },
+    {
+      "claim": "PR-2 might enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1617"
+    },
+    {
+      "claim": "PR-2 might read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1618"
+    },
+    {
+      "claim": "PR-2 might write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1619"
+    },
+    {
+      "claim": "PR-2 must authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1620"
+    },
+    {
+      "claim": "PR-2 must be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1621"
+    },
+    {
+      "claim": "PR-2 must enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1622"
+    },
+    {
+      "claim": "PR-2 must read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1623"
     },
     {
       "claim": "PR-2 must write cache entries.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0268"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1624"
     },
     {
       "claim": "PR-2 reads semantic-cache entries.",
@@ -2157,7 +13005,135 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0269"
+      "id": "philosophy-admission-oracle-1625"
+    },
+    {
+      "claim": "PR-2 remains cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1626"
+    },
+    {
+      "claim": "PR-2 should authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1627"
+    },
+    {
+      "claim": "PR-2 should be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1628"
+    },
+    {
+      "claim": "PR-2 should enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1629"
+    },
+    {
+      "claim": "PR-2 should read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1630"
+    },
+    {
+      "claim": "PR-2 should write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1631"
+    },
+    {
+      "claim": "PR-2 will authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1632"
+    },
+    {
+      "claim": "PR-2 will be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1633"
+    },
+    {
+      "claim": "PR-2 will enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1634"
+    },
+    {
+      "claim": "PR-2 will read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1635"
+    },
+    {
+      "claim": "PR-2 will write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1636"
+    },
+    {
+      "claim": "PR-2 would authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1637"
+    },
+    {
+      "claim": "PR-2 would be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1638"
+    },
+    {
+      "claim": "PR-2 would enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1639"
+    },
+    {
+      "claim": "PR-2 would read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1640"
+    },
+    {
+      "claim": "PR-2 would write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1641"
     },
     {
       "claim": "PR-2 writes cache entries.",
@@ -2165,7 +13141,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0270"
+      "id": "philosophy-admission-oracle-1642"
     },
     {
       "claim": "Philosophy admission authorizes backend selection.",
@@ -2173,7 +13149,15 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0271"
+      "id": "philosophy-admission-oracle-1643"
+    },
+    {
+      "claim": "Philosophy admission became cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1644"
     },
     {
       "claim": "Philosophy admission becomes cache eligible for semantic-cache admission.",
@@ -2181,7 +13165,87 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0272"
+      "id": "philosophy-admission-oracle-1645"
+    },
+    {
+      "claim": "Philosophy admission can authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1646"
+    },
+    {
+      "claim": "Philosophy admission can be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1647"
+    },
+    {
+      "claim": "Philosophy admission can enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1648"
+    },
+    {
+      "claim": "Philosophy admission can read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1649"
+    },
+    {
+      "claim": "Philosophy admission can write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1650"
+    },
+    {
+      "claim": "Philosophy admission could authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1651"
+    },
+    {
+      "claim": "Philosophy admission could be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1652"
+    },
+    {
+      "claim": "Philosophy admission could enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1653"
+    },
+    {
+      "claim": "Philosophy admission could read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1654"
+    },
+    {
+      "claim": "Philosophy admission could write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1655"
     },
     {
       "claim": "Philosophy admission enables runtime expansion.",
@@ -2189,23 +13253,223 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0273"
+      "id": "philosophy-admission-oracle-1656"
+    },
+    {
+      "claim": "Philosophy admission has authorized backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1657"
+    },
+    {
+      "claim": "Philosophy admission has to authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1658"
     },
     {
       "claim": "Philosophy admission has to be cache eligible for semantic-cache admission.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0274"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1659"
+    },
+    {
+      "claim": "Philosophy admission has to enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1660"
+    },
+    {
+      "claim": "Philosophy admission has to read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1661"
+    },
+    {
+      "claim": "Philosophy admission has to write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1662"
+    },
+    {
+      "claim": "Philosophy admission is now writing cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1663"
+    },
+    {
+      "claim": "Philosophy admission is required to authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1664"
+    },
+    {
+      "claim": "Philosophy admission is required to be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1665"
+    },
+    {
+      "claim": "Philosophy admission is required to enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1666"
+    },
+    {
+      "claim": "Philosophy admission is required to read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1667"
+    },
+    {
+      "claim": "Philosophy admission is required to write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1668"
+    },
+    {
+      "claim": "Philosophy admission may authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1669"
+    },
+    {
+      "claim": "Philosophy admission may be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1670"
+    },
+    {
+      "claim": "Philosophy admission may enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1671"
+    },
+    {
+      "claim": "Philosophy admission may read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1672"
+    },
+    {
+      "claim": "Philosophy admission may write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1673"
+    },
+    {
+      "claim": "Philosophy admission might authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1674"
+    },
+    {
+      "claim": "Philosophy admission might be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1675"
+    },
+    {
+      "claim": "Philosophy admission might enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1676"
+    },
+    {
+      "claim": "Philosophy admission might read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1677"
+    },
+    {
+      "claim": "Philosophy admission might write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1678"
+    },
+    {
+      "claim": "Philosophy admission must authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1679"
+    },
+    {
+      "claim": "Philosophy admission must be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1680"
+    },
+    {
+      "claim": "Philosophy admission must enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1681"
+    },
+    {
+      "claim": "Philosophy admission must read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1682"
     },
     {
       "claim": "Philosophy admission must write cache entries.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0275"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1683"
     },
     {
       "claim": "Philosophy admission reads semantic-cache entries.",
@@ -2213,15 +13477,135 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0276"
+      "id": "philosophy-admission-oracle-1684"
     },
     {
       "claim": "Philosophy admission remains cache eligible for semantic-cache admission.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0277"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1685"
+    },
+    {
+      "claim": "Philosophy admission should authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1686"
+    },
+    {
+      "claim": "Philosophy admission should be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1687"
+    },
+    {
+      "claim": "Philosophy admission should enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1688"
+    },
+    {
+      "claim": "Philosophy admission should read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1689"
+    },
+    {
+      "claim": "Philosophy admission should write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1690"
+    },
+    {
+      "claim": "Philosophy admission will authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1691"
+    },
+    {
+      "claim": "Philosophy admission will be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1692"
+    },
+    {
+      "claim": "Philosophy admission will enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1693"
+    },
+    {
+      "claim": "Philosophy admission will read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1694"
+    },
+    {
+      "claim": "Philosophy admission will write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1695"
+    },
+    {
+      "claim": "Philosophy admission would authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1696"
+    },
+    {
+      "claim": "Philosophy admission would be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1697"
+    },
+    {
+      "claim": "Philosophy admission would enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1698"
+    },
+    {
+      "claim": "Philosophy admission would read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1699"
+    },
+    {
+      "claim": "Philosophy admission would write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1700"
     },
     {
       "claim": "Philosophy admission writes cache entries.",
@@ -2229,7 +13613,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0278"
+      "id": "philosophy-admission-oracle-1701"
     },
     {
       "claim": "The admission policy authorizes backend selection.",
@@ -2237,7 +13621,15 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0279"
+      "id": "philosophy-admission-oracle-1702"
+    },
+    {
+      "claim": "The admission policy became cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1703"
     },
     {
       "claim": "The admission policy becomes cache eligible for semantic-cache admission.",
@@ -2245,7 +13637,87 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0280"
+      "id": "philosophy-admission-oracle-1704"
+    },
+    {
+      "claim": "The admission policy can authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1705"
+    },
+    {
+      "claim": "The admission policy can be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1706"
+    },
+    {
+      "claim": "The admission policy can enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1707"
+    },
+    {
+      "claim": "The admission policy can read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1708"
+    },
+    {
+      "claim": "The admission policy can write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1709"
+    },
+    {
+      "claim": "The admission policy could authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1710"
+    },
+    {
+      "claim": "The admission policy could be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1711"
+    },
+    {
+      "claim": "The admission policy could enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1712"
+    },
+    {
+      "claim": "The admission policy could read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1713"
+    },
+    {
+      "claim": "The admission policy could write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1714"
     },
     {
       "claim": "The admission policy enables runtime expansion.",
@@ -2253,15 +13725,223 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0281"
+      "id": "philosophy-admission-oracle-1715"
+    },
+    {
+      "claim": "The admission policy has authorized backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1716"
+    },
+    {
+      "claim": "The admission policy has to authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1717"
+    },
+    {
+      "claim": "The admission policy has to be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1718"
+    },
+    {
+      "claim": "The admission policy has to enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1719"
+    },
+    {
+      "claim": "The admission policy has to read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1720"
+    },
+    {
+      "claim": "The admission policy has to write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1721"
     },
     {
       "claim": "The admission policy is now writing cache entries.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0282"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1722"
+    },
+    {
+      "claim": "The admission policy is required to authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1723"
+    },
+    {
+      "claim": "The admission policy is required to be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1724"
+    },
+    {
+      "claim": "The admission policy is required to enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1725"
+    },
+    {
+      "claim": "The admission policy is required to read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1726"
+    },
+    {
+      "claim": "The admission policy is required to write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1727"
+    },
+    {
+      "claim": "The admission policy may authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1728"
+    },
+    {
+      "claim": "The admission policy may be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1729"
+    },
+    {
+      "claim": "The admission policy may enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1730"
+    },
+    {
+      "claim": "The admission policy may read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1731"
+    },
+    {
+      "claim": "The admission policy may write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1732"
+    },
+    {
+      "claim": "The admission policy might authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1733"
+    },
+    {
+      "claim": "The admission policy might be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1734"
+    },
+    {
+      "claim": "The admission policy might enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1735"
+    },
+    {
+      "claim": "The admission policy might read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1736"
+    },
+    {
+      "claim": "The admission policy might write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1737"
+    },
+    {
+      "claim": "The admission policy must authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1738"
+    },
+    {
+      "claim": "The admission policy must be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1739"
+    },
+    {
+      "claim": "The admission policy must enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1740"
+    },
+    {
+      "claim": "The admission policy must read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1741"
+    },
+    {
+      "claim": "The admission policy must write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1742"
     },
     {
       "claim": "The admission policy reads semantic-cache entries.",
@@ -2269,15 +13949,135 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0283"
+      "id": "philosophy-admission-oracle-1743"
+    },
+    {
+      "claim": "The admission policy remains cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1744"
+    },
+    {
+      "claim": "The admission policy should authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1745"
+    },
+    {
+      "claim": "The admission policy should be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1746"
+    },
+    {
+      "claim": "The admission policy should enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1747"
     },
     {
       "claim": "The admission policy should read semantic-cache entries.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0284"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1748"
+    },
+    {
+      "claim": "The admission policy should write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1749"
+    },
+    {
+      "claim": "The admission policy will authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1750"
+    },
+    {
+      "claim": "The admission policy will be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1751"
+    },
+    {
+      "claim": "The admission policy will enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1752"
+    },
+    {
+      "claim": "The admission policy will read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1753"
+    },
+    {
+      "claim": "The admission policy will write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1754"
+    },
+    {
+      "claim": "The admission policy would authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1755"
+    },
+    {
+      "claim": "The admission policy would be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1756"
+    },
+    {
+      "claim": "The admission policy would enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1757"
+    },
+    {
+      "claim": "The admission policy would read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1758"
+    },
+    {
+      "claim": "The admission policy would write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1759"
     },
     {
       "claim": "The admission policy writes cache entries.",
@@ -2285,7 +14085,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0285"
+      "id": "philosophy-admission-oracle-1760"
     },
     {
       "claim": "The claim-family oracle authorizes backend selection.",
@@ -2293,7 +14093,15 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0286"
+      "id": "philosophy-admission-oracle-1761"
+    },
+    {
+      "claim": "The claim-family oracle became cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1762"
     },
     {
       "claim": "The claim-family oracle becomes cache eligible for semantic-cache admission.",
@@ -2301,15 +14109,87 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0287"
+      "id": "philosophy-admission-oracle-1763"
+    },
+    {
+      "claim": "The claim-family oracle can authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1764"
+    },
+    {
+      "claim": "The claim-family oracle can be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1765"
+    },
+    {
+      "claim": "The claim-family oracle can enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1766"
+    },
+    {
+      "claim": "The claim-family oracle can read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1767"
+    },
+    {
+      "claim": "The claim-family oracle can write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1768"
+    },
+    {
+      "claim": "The claim-family oracle could authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1769"
     },
     {
       "claim": "The claim-family oracle could be cache eligible for semantic-cache admission.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0288"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1770"
+    },
+    {
+      "claim": "The claim-family oracle could enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1771"
+    },
+    {
+      "claim": "The claim-family oracle could read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1772"
+    },
+    {
+      "claim": "The claim-family oracle could write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1773"
     },
     {
       "claim": "The claim-family oracle enables runtime expansion.",
@@ -2317,7 +14197,223 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0289"
+      "id": "philosophy-admission-oracle-1774"
+    },
+    {
+      "claim": "The claim-family oracle has authorized backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1775"
+    },
+    {
+      "claim": "The claim-family oracle has to authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1776"
+    },
+    {
+      "claim": "The claim-family oracle has to be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1777"
+    },
+    {
+      "claim": "The claim-family oracle has to enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1778"
+    },
+    {
+      "claim": "The claim-family oracle has to read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1779"
+    },
+    {
+      "claim": "The claim-family oracle has to write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1780"
+    },
+    {
+      "claim": "The claim-family oracle is now writing cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1781"
+    },
+    {
+      "claim": "The claim-family oracle is required to authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1782"
+    },
+    {
+      "claim": "The claim-family oracle is required to be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1783"
+    },
+    {
+      "claim": "The claim-family oracle is required to enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1784"
+    },
+    {
+      "claim": "The claim-family oracle is required to read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1785"
+    },
+    {
+      "claim": "The claim-family oracle is required to write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1786"
+    },
+    {
+      "claim": "The claim-family oracle may authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1787"
+    },
+    {
+      "claim": "The claim-family oracle may be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1788"
+    },
+    {
+      "claim": "The claim-family oracle may enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1789"
+    },
+    {
+      "claim": "The claim-family oracle may read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1790"
+    },
+    {
+      "claim": "The claim-family oracle may write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1791"
+    },
+    {
+      "claim": "The claim-family oracle might authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1792"
+    },
+    {
+      "claim": "The claim-family oracle might be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1793"
+    },
+    {
+      "claim": "The claim-family oracle might enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1794"
+    },
+    {
+      "claim": "The claim-family oracle might read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1795"
+    },
+    {
+      "claim": "The claim-family oracle might write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1796"
+    },
+    {
+      "claim": "The claim-family oracle must authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1797"
+    },
+    {
+      "claim": "The claim-family oracle must be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1798"
+    },
+    {
+      "claim": "The claim-family oracle must enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1799"
+    },
+    {
+      "claim": "The claim-family oracle must read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1800"
+    },
+    {
+      "claim": "The claim-family oracle must write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1801"
     },
     {
       "claim": "The claim-family oracle reads semantic-cache entries.",
@@ -2325,15 +14421,135 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0290"
+      "id": "philosophy-admission-oracle-1802"
+    },
+    {
+      "claim": "The claim-family oracle remains cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1803"
+    },
+    {
+      "claim": "The claim-family oracle should authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1804"
+    },
+    {
+      "claim": "The claim-family oracle should be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1805"
+    },
+    {
+      "claim": "The claim-family oracle should enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1806"
+    },
+    {
+      "claim": "The claim-family oracle should read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1807"
+    },
+    {
+      "claim": "The claim-family oracle should write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1808"
+    },
+    {
+      "claim": "The claim-family oracle will authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1809"
+    },
+    {
+      "claim": "The claim-family oracle will be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1810"
     },
     {
       "claim": "The claim-family oracle will enable runtime expansion.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0291"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1811"
+    },
+    {
+      "claim": "The claim-family oracle will read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1812"
+    },
+    {
+      "claim": "The claim-family oracle will write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1813"
+    },
+    {
+      "claim": "The claim-family oracle would authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1814"
+    },
+    {
+      "claim": "The claim-family oracle would be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1815"
+    },
+    {
+      "claim": "The claim-family oracle would enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1816"
+    },
+    {
+      "claim": "The claim-family oracle would read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1817"
+    },
+    {
+      "claim": "The claim-family oracle would write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1818"
     },
     {
       "claim": "The claim-family oracle writes cache entries.",
@@ -2341,7 +14557,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0292"
+      "id": "philosophy-admission-oracle-1819"
     },
     {
       "claim": "The policy spec authorizes backend selection without SC-G5.",
@@ -2349,7 +14565,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0293"
+      "id": "philosophy-admission-oracle-1820"
     },
     {
       "claim": "Therapy routing authorizes backend selection.",
@@ -2357,7 +14573,15 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0294"
+      "id": "philosophy-admission-oracle-1821"
+    },
+    {
+      "claim": "Therapy routing became cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1822"
     },
     {
       "claim": "Therapy routing becomes cache eligible for semantic-cache admission.",
@@ -2365,7 +14589,87 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0295"
+      "id": "philosophy-admission-oracle-1823"
+    },
+    {
+      "claim": "Therapy routing can authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1824"
+    },
+    {
+      "claim": "Therapy routing can be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1825"
+    },
+    {
+      "claim": "Therapy routing can enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1826"
+    },
+    {
+      "claim": "Therapy routing can read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1827"
+    },
+    {
+      "claim": "Therapy routing can write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1828"
+    },
+    {
+      "claim": "Therapy routing could authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1829"
+    },
+    {
+      "claim": "Therapy routing could be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1830"
+    },
+    {
+      "claim": "Therapy routing could enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1831"
+    },
+    {
+      "claim": "Therapy routing could read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1832"
+    },
+    {
+      "claim": "Therapy routing could write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1833"
     },
     {
       "claim": "Therapy routing enables runtime expansion.",
@@ -2373,15 +14677,223 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0296"
+      "id": "philosophy-admission-oracle-1834"
+    },
+    {
+      "claim": "Therapy routing has authorized backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1835"
+    },
+    {
+      "claim": "Therapy routing has to authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1836"
+    },
+    {
+      "claim": "Therapy routing has to be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1837"
+    },
+    {
+      "claim": "Therapy routing has to enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1838"
+    },
+    {
+      "claim": "Therapy routing has to read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1839"
+    },
+    {
+      "claim": "Therapy routing has to write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1840"
+    },
+    {
+      "claim": "Therapy routing is now writing cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1841"
+    },
+    {
+      "claim": "Therapy routing is required to authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1842"
+    },
+    {
+      "claim": "Therapy routing is required to be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1843"
+    },
+    {
+      "claim": "Therapy routing is required to enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1844"
+    },
+    {
+      "claim": "Therapy routing is required to read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1845"
+    },
+    {
+      "claim": "Therapy routing is required to write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1846"
+    },
+    {
+      "claim": "Therapy routing may authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1847"
+    },
+    {
+      "claim": "Therapy routing may be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1848"
+    },
+    {
+      "claim": "Therapy routing may enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1849"
+    },
+    {
+      "claim": "Therapy routing may read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1850"
+    },
+    {
+      "claim": "Therapy routing may write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1851"
+    },
+    {
+      "claim": "Therapy routing might authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1852"
+    },
+    {
+      "claim": "Therapy routing might be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1853"
     },
     {
       "claim": "Therapy routing might enable runtime expansion.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0297"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1854"
+    },
+    {
+      "claim": "Therapy routing might read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1855"
+    },
+    {
+      "claim": "Therapy routing might write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1856"
+    },
+    {
+      "claim": "Therapy routing must authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1857"
+    },
+    {
+      "claim": "Therapy routing must be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1858"
+    },
+    {
+      "claim": "Therapy routing must enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1859"
+    },
+    {
+      "claim": "Therapy routing must read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1860"
+    },
+    {
+      "claim": "Therapy routing must write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1861"
     },
     {
       "claim": "Therapy routing reads semantic-cache entries.",
@@ -2389,7 +14901,135 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0298"
+      "id": "philosophy-admission-oracle-1862"
+    },
+    {
+      "claim": "Therapy routing remains cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1863"
+    },
+    {
+      "claim": "Therapy routing should authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1864"
+    },
+    {
+      "claim": "Therapy routing should be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1865"
+    },
+    {
+      "claim": "Therapy routing should enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1866"
+    },
+    {
+      "claim": "Therapy routing should read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1867"
+    },
+    {
+      "claim": "Therapy routing should write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1868"
+    },
+    {
+      "claim": "Therapy routing will authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1869"
+    },
+    {
+      "claim": "Therapy routing will be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1870"
+    },
+    {
+      "claim": "Therapy routing will enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1871"
+    },
+    {
+      "claim": "Therapy routing will read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1872"
+    },
+    {
+      "claim": "Therapy routing will write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1873"
+    },
+    {
+      "claim": "Therapy routing would authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1874"
+    },
+    {
+      "claim": "Therapy routing would be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1875"
+    },
+    {
+      "claim": "Therapy routing would enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1876"
+    },
+    {
+      "claim": "Therapy routing would read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1877"
+    },
+    {
+      "claim": "Therapy routing would write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1878"
     },
     {
       "claim": "Therapy routing writes cache entries.",
@@ -2397,7 +15037,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0299"
+      "id": "philosophy-admission-oracle-1879"
     },
     {
       "claim": "Cache admission requires a passed verification bundle.",
@@ -2405,7 +15045,7 @@
       "expected": "allowed",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0300"
+      "id": "philosophy-admission-oracle-1880"
     },
     {
       "claim": "Future PR may evaluate semantic-cache admission after verification.",
@@ -2413,7 +15053,7 @@
       "expected": "allowed",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0301"
+      "id": "philosophy-admission-oracle-1881"
     },
     {
       "claim": "No semantic-cache admission may omit the verification bundle.",
@@ -2421,15 +15061,15 @@
       "expected": "allowed",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-0302"
+      "id": "philosophy-admission-oracle-1882"
     },
     {
       "claim": "Cache admission became exempt from verification bundles.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0303"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1883"
     },
     {
       "claim": "Cache admission bypasses verification bundles.",
@@ -2437,7 +15077,71 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0304"
+      "id": "philosophy-admission-oracle-1884"
+    },
+    {
+      "claim": "Cache admission can omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1885"
+    },
+    {
+      "claim": "Cache admission can promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1886"
+    },
+    {
+      "claim": "Cache admission can skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1887"
+    },
+    {
+      "claim": "Cache admission can waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1888"
+    },
+    {
+      "claim": "Cache admission could omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1889"
+    },
+    {
+      "claim": "Cache admission could promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1890"
+    },
+    {
+      "claim": "Cache admission could skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1891"
+    },
+    {
+      "claim": "Cache admission could waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1892"
     },
     {
       "claim": "Cache admission does not require a verification bundle.",
@@ -2445,7 +15149,87 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0305"
+      "id": "philosophy-admission-oracle-1893"
+    },
+    {
+      "claim": "Cache admission has bypassed verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1894"
+    },
+    {
+      "claim": "Cache admission has to omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1895"
+    },
+    {
+      "claim": "Cache admission has to promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1896"
+    },
+    {
+      "claim": "Cache admission has to skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1897"
+    },
+    {
+      "claim": "Cache admission has to waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1898"
+    },
+    {
+      "claim": "Cache admission is now waiving verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1899"
+    },
+    {
+      "claim": "Cache admission is required to omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1900"
+    },
+    {
+      "claim": "Cache admission is required to promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1901"
+    },
+    {
+      "claim": "Cache admission is required to skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1902"
+    },
+    {
+      "claim": "Cache admission is required to waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1903"
     },
     {
       "claim": "Cache admission makes verification bundles optional.",
@@ -2453,23 +15237,103 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0306"
+      "id": "philosophy-admission-oracle-1904"
     },
     {
       "claim": "Cache admission may omit the verification bundle.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0307"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1905"
+    },
+    {
+      "claim": "Cache admission may promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1906"
+    },
+    {
+      "claim": "Cache admission may skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1907"
+    },
+    {
+      "claim": "Cache admission may waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1908"
+    },
+    {
+      "claim": "Cache admission might omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1909"
+    },
+    {
+      "claim": "Cache admission might promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1910"
+    },
+    {
+      "claim": "Cache admission might skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1911"
     },
     {
       "claim": "Cache admission might waive verification bundle requirements.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0308"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1912"
+    },
+    {
+      "claim": "Cache admission must omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1913"
+    },
+    {
+      "claim": "Cache admission must promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1914"
+    },
+    {
+      "claim": "Cache admission must skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1915"
+    },
+    {
+      "claim": "Cache admission must waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1916"
     },
     {
       "claim": "Cache admission promotes knowledge without a verification bundle.",
@@ -2477,7 +15341,47 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0309"
+      "id": "philosophy-admission-oracle-1917"
+    },
+    {
+      "claim": "Cache admission remains optional for verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1918"
+    },
+    {
+      "claim": "Cache admission should omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1919"
+    },
+    {
+      "claim": "Cache admission should promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1920"
+    },
+    {
+      "claim": "Cache admission should skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1921"
+    },
+    {
+      "claim": "Cache admission should waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1922"
     },
     {
       "claim": "Cache admission waives verification bundle requirements.",
@@ -2485,7 +15389,79 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0310"
+      "id": "philosophy-admission-oracle-1923"
+    },
+    {
+      "claim": "Cache admission will omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1924"
+    },
+    {
+      "claim": "Cache admission will promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1925"
+    },
+    {
+      "claim": "Cache admission will skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1926"
+    },
+    {
+      "claim": "Cache admission will waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1927"
+    },
+    {
+      "claim": "Cache admission would omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1928"
+    },
+    {
+      "claim": "Cache admission would promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1929"
+    },
+    {
+      "claim": "Cache admission would skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1930"
+    },
+    {
+      "claim": "Cache admission would waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1931"
+    },
+    {
+      "claim": "Knowledge promotion became exempt from verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1932"
     },
     {
       "claim": "Knowledge promotion bypasses verification bundles.",
@@ -2493,7 +15469,71 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0311"
+      "id": "philosophy-admission-oracle-1933"
+    },
+    {
+      "claim": "Knowledge promotion can omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1934"
+    },
+    {
+      "claim": "Knowledge promotion can promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1935"
+    },
+    {
+      "claim": "Knowledge promotion can skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1936"
+    },
+    {
+      "claim": "Knowledge promotion can waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1937"
+    },
+    {
+      "claim": "Knowledge promotion could omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1938"
+    },
+    {
+      "claim": "Knowledge promotion could promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1939"
+    },
+    {
+      "claim": "Knowledge promotion could skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1940"
+    },
+    {
+      "claim": "Knowledge promotion could waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1941"
     },
     {
       "claim": "Knowledge promotion does not require a verification bundle.",
@@ -2501,7 +15541,87 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0312"
+      "id": "philosophy-admission-oracle-1942"
+    },
+    {
+      "claim": "Knowledge promotion has bypassed verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1943"
+    },
+    {
+      "claim": "Knowledge promotion has to omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1944"
+    },
+    {
+      "claim": "Knowledge promotion has to promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1945"
+    },
+    {
+      "claim": "Knowledge promotion has to skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1946"
+    },
+    {
+      "claim": "Knowledge promotion has to waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1947"
+    },
+    {
+      "claim": "Knowledge promotion is now waiving verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1948"
+    },
+    {
+      "claim": "Knowledge promotion is required to omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1949"
+    },
+    {
+      "claim": "Knowledge promotion is required to promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1950"
+    },
+    {
+      "claim": "Knowledge promotion is required to skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1951"
+    },
+    {
+      "claim": "Knowledge promotion is required to waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1952"
     },
     {
       "claim": "Knowledge promotion makes verification bundles optional.",
@@ -2509,15 +15629,103 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0313"
+      "id": "philosophy-admission-oracle-1953"
+    },
+    {
+      "claim": "Knowledge promotion may omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1954"
+    },
+    {
+      "claim": "Knowledge promotion may promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1955"
+    },
+    {
+      "claim": "Knowledge promotion may skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1956"
+    },
+    {
+      "claim": "Knowledge promotion may waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1957"
+    },
+    {
+      "claim": "Knowledge promotion might omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1958"
+    },
+    {
+      "claim": "Knowledge promotion might promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1959"
+    },
+    {
+      "claim": "Knowledge promotion might skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1960"
+    },
+    {
+      "claim": "Knowledge promotion might waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1961"
+    },
+    {
+      "claim": "Knowledge promotion must omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1962"
+    },
+    {
+      "claim": "Knowledge promotion must promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1963"
+    },
+    {
+      "claim": "Knowledge promotion must skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1964"
     },
     {
       "claim": "Knowledge promotion must waive verification bundle requirements.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0314"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1965"
     },
     {
       "claim": "Knowledge promotion promotes knowledge without a verification bundle.",
@@ -2525,15 +15733,47 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0315"
+      "id": "philosophy-admission-oracle-1966"
     },
     {
       "claim": "Knowledge promotion remains optional for verification bundles.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0316"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1967"
+    },
+    {
+      "claim": "Knowledge promotion should omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1968"
+    },
+    {
+      "claim": "Knowledge promotion should promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1969"
+    },
+    {
+      "claim": "Knowledge promotion should skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1970"
+    },
+    {
+      "claim": "Knowledge promotion should waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1971"
     },
     {
       "claim": "Knowledge promotion waives verification bundle requirements.",
@@ -2541,15 +15781,71 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0317"
+      "id": "philosophy-admission-oracle-1972"
+    },
+    {
+      "claim": "Knowledge promotion will omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1973"
     },
     {
       "claim": "Knowledge promotion will promote knowledge without a verification bundle.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0318"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1974"
+    },
+    {
+      "claim": "Knowledge promotion will skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1975"
+    },
+    {
+      "claim": "Knowledge promotion will waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1976"
+    },
+    {
+      "claim": "Knowledge promotion would omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1977"
+    },
+    {
+      "claim": "Knowledge promotion would promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1978"
+    },
+    {
+      "claim": "Knowledge promotion would skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1979"
+    },
+    {
+      "claim": "Knowledge promotion would waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1980"
     },
     {
       "claim": "PR-2 is promoting knowledge without a verification bundle.",
@@ -2557,7 +15853,15 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0319"
+      "id": "philosophy-admission-oracle-1981"
+    },
+    {
+      "claim": "Philosophy admission became exempt from verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1982"
     },
     {
       "claim": "Philosophy admission bypasses verification bundles.",
@@ -2565,7 +15869,71 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0320"
+      "id": "philosophy-admission-oracle-1983"
+    },
+    {
+      "claim": "Philosophy admission can omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1984"
+    },
+    {
+      "claim": "Philosophy admission can promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1985"
+    },
+    {
+      "claim": "Philosophy admission can skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1986"
+    },
+    {
+      "claim": "Philosophy admission can waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1987"
+    },
+    {
+      "claim": "Philosophy admission could omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1988"
+    },
+    {
+      "claim": "Philosophy admission could promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1989"
+    },
+    {
+      "claim": "Philosophy admission could skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1990"
+    },
+    {
+      "claim": "Philosophy admission could waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1991"
     },
     {
       "claim": "Philosophy admission does not require a verification bundle.",
@@ -2573,23 +15941,87 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0321"
+      "id": "philosophy-admission-oracle-1992"
+    },
+    {
+      "claim": "Philosophy admission has bypassed verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1993"
+    },
+    {
+      "claim": "Philosophy admission has to omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1994"
+    },
+    {
+      "claim": "Philosophy admission has to promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1995"
+    },
+    {
+      "claim": "Philosophy admission has to skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1996"
+    },
+    {
+      "claim": "Philosophy admission has to waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1997"
     },
     {
       "claim": "Philosophy admission is now waiving verification bundle requirements.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0322"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1998"
+    },
+    {
+      "claim": "Philosophy admission is required to omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1999"
+    },
+    {
+      "claim": "Philosophy admission is required to promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2000"
     },
     {
       "claim": "Philosophy admission is required to skip verification bundles.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0323"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2001"
+    },
+    {
+      "claim": "Philosophy admission is required to waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2002"
     },
     {
       "claim": "Philosophy admission makes verification bundles optional.",
@@ -2597,7 +16029,103 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0324"
+      "id": "philosophy-admission-oracle-2003"
+    },
+    {
+      "claim": "Philosophy admission may omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2004"
+    },
+    {
+      "claim": "Philosophy admission may promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2005"
+    },
+    {
+      "claim": "Philosophy admission may skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2006"
+    },
+    {
+      "claim": "Philosophy admission may waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2007"
+    },
+    {
+      "claim": "Philosophy admission might omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2008"
+    },
+    {
+      "claim": "Philosophy admission might promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2009"
+    },
+    {
+      "claim": "Philosophy admission might skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2010"
+    },
+    {
+      "claim": "Philosophy admission might waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2011"
+    },
+    {
+      "claim": "Philosophy admission must omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2012"
+    },
+    {
+      "claim": "Philosophy admission must promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2013"
+    },
+    {
+      "claim": "Philosophy admission must skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2014"
+    },
+    {
+      "claim": "Philosophy admission must waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2015"
     },
     {
       "claim": "Philosophy admission promotes knowledge without a verification bundle.",
@@ -2605,15 +16133,47 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0325"
+      "id": "philosophy-admission-oracle-2016"
+    },
+    {
+      "claim": "Philosophy admission remains optional for verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2017"
+    },
+    {
+      "claim": "Philosophy admission should omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2018"
     },
     {
       "claim": "Philosophy admission should promote knowledge without a verification bundle.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0326"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2019"
+    },
+    {
+      "claim": "Philosophy admission should skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2020"
+    },
+    {
+      "claim": "Philosophy admission should waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2021"
     },
     {
       "claim": "Philosophy admission waives verification bundle requirements.",
@@ -2621,7 +16181,79 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0327"
+      "id": "philosophy-admission-oracle-2022"
+    },
+    {
+      "claim": "Philosophy admission will omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2023"
+    },
+    {
+      "claim": "Philosophy admission will promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2024"
+    },
+    {
+      "claim": "Philosophy admission will skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2025"
+    },
+    {
+      "claim": "Philosophy admission will waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2026"
+    },
+    {
+      "claim": "Philosophy admission would omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2027"
+    },
+    {
+      "claim": "Philosophy admission would promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2028"
+    },
+    {
+      "claim": "Philosophy admission would skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2029"
+    },
+    {
+      "claim": "Philosophy admission would waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2030"
+    },
+    {
+      "claim": "Semantic-cache admission became exempt from verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2031"
     },
     {
       "claim": "Semantic-cache admission bypasses verification bundles.",
@@ -2629,15 +16261,71 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0328"
+      "id": "philosophy-admission-oracle-2032"
+    },
+    {
+      "claim": "Semantic-cache admission can omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2033"
+    },
+    {
+      "claim": "Semantic-cache admission can promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2034"
     },
     {
       "claim": "Semantic-cache admission can skip verification bundles.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0329"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2035"
+    },
+    {
+      "claim": "Semantic-cache admission can waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2036"
+    },
+    {
+      "claim": "Semantic-cache admission could omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2037"
+    },
+    {
+      "claim": "Semantic-cache admission could promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2038"
+    },
+    {
+      "claim": "Semantic-cache admission could skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2039"
+    },
+    {
+      "claim": "Semantic-cache admission could waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2040"
     },
     {
       "claim": "Semantic-cache admission does not require a verification bundle.",
@@ -2645,15 +16333,87 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0330"
+      "id": "philosophy-admission-oracle-2041"
     },
     {
       "claim": "Semantic-cache admission has bypassed verification bundles.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0331"
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2042"
+    },
+    {
+      "claim": "Semantic-cache admission has to omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2043"
+    },
+    {
+      "claim": "Semantic-cache admission has to promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2044"
+    },
+    {
+      "claim": "Semantic-cache admission has to skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2045"
+    },
+    {
+      "claim": "Semantic-cache admission has to waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2046"
+    },
+    {
+      "claim": "Semantic-cache admission is now waiving verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2047"
+    },
+    {
+      "claim": "Semantic-cache admission is required to omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2048"
+    },
+    {
+      "claim": "Semantic-cache admission is required to promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2049"
+    },
+    {
+      "claim": "Semantic-cache admission is required to skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2050"
+    },
+    {
+      "claim": "Semantic-cache admission is required to waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2051"
     },
     {
       "claim": "Semantic-cache admission makes verification bundles optional.",
@@ -2661,15 +16421,103 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0332"
+      "id": "philosophy-admission-oracle-2052"
     },
     {
       "claim": "Semantic-cache admission may omit the verification bundle.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0333"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2053"
+    },
+    {
+      "claim": "Semantic-cache admission may promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2054"
+    },
+    {
+      "claim": "Semantic-cache admission may skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2055"
+    },
+    {
+      "claim": "Semantic-cache admission may waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2056"
+    },
+    {
+      "claim": "Semantic-cache admission might omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2057"
+    },
+    {
+      "claim": "Semantic-cache admission might promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2058"
+    },
+    {
+      "claim": "Semantic-cache admission might skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2059"
+    },
+    {
+      "claim": "Semantic-cache admission might waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2060"
+    },
+    {
+      "claim": "Semantic-cache admission must omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2061"
+    },
+    {
+      "claim": "Semantic-cache admission must promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2062"
+    },
+    {
+      "claim": "Semantic-cache admission must skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2063"
+    },
+    {
+      "claim": "Semantic-cache admission must waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2064"
     },
     {
       "claim": "Semantic-cache admission promotes knowledge without a verification bundle.",
@@ -2677,7 +16525,47 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0334"
+      "id": "philosophy-admission-oracle-2065"
+    },
+    {
+      "claim": "Semantic-cache admission remains optional for verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2066"
+    },
+    {
+      "claim": "Semantic-cache admission should omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2067"
+    },
+    {
+      "claim": "Semantic-cache admission should promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2068"
+    },
+    {
+      "claim": "Semantic-cache admission should skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2069"
+    },
+    {
+      "claim": "Semantic-cache admission should waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2070"
     },
     {
       "claim": "Semantic-cache admission waives verification bundle requirements.",
@@ -2685,15 +16573,79 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0335"
+      "id": "philosophy-admission-oracle-2071"
+    },
+    {
+      "claim": "Semantic-cache admission will omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2072"
+    },
+    {
+      "claim": "Semantic-cache admission will promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2073"
+    },
+    {
+      "claim": "Semantic-cache admission will skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2074"
+    },
+    {
+      "claim": "Semantic-cache admission will waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2075"
     },
     {
       "claim": "Semantic-cache admission would omit the verification bundle.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0336"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2076"
+    },
+    {
+      "claim": "Semantic-cache admission would promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2077"
+    },
+    {
+      "claim": "Semantic-cache admission would skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2078"
+    },
+    {
+      "claim": "Semantic-cache admission would waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2079"
+    },
+    {
+      "claim": "The admission policy became exempt from verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2080"
     },
     {
       "claim": "The admission policy bypasses verification bundles.",
@@ -2701,15 +16653,71 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0337"
+      "id": "philosophy-admission-oracle-2081"
+    },
+    {
+      "claim": "The admission policy can omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2082"
+    },
+    {
+      "claim": "The admission policy can promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2083"
+    },
+    {
+      "claim": "The admission policy can skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2084"
+    },
+    {
+      "claim": "The admission policy can waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2085"
+    },
+    {
+      "claim": "The admission policy could omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2086"
+    },
+    {
+      "claim": "The admission policy could promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2087"
     },
     {
       "claim": "The admission policy could skip verification bundles.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0338"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2088"
+    },
+    {
+      "claim": "The admission policy could waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2089"
     },
     {
       "claim": "The admission policy does not require a verification bundle.",
@@ -2717,15 +16725,87 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0339"
+      "id": "philosophy-admission-oracle-2090"
+    },
+    {
+      "claim": "The admission policy has bypassed verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2091"
     },
     {
       "claim": "The admission policy has to omit the verification bundle.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.modal_predicates",
-      "id": "philosophy-admission-oracle-0340"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2092"
+    },
+    {
+      "claim": "The admission policy has to promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2093"
+    },
+    {
+      "claim": "The admission policy has to skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2094"
+    },
+    {
+      "claim": "The admission policy has to waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2095"
+    },
+    {
+      "claim": "The admission policy is now waiving verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2096"
+    },
+    {
+      "claim": "The admission policy is required to omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2097"
+    },
+    {
+      "claim": "The admission policy is required to promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2098"
+    },
+    {
+      "claim": "The admission policy is required to skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2099"
+    },
+    {
+      "claim": "The admission policy is required to waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2100"
     },
     {
       "claim": "The admission policy makes verification bundles optional.",
@@ -2733,7 +16813,103 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0341"
+      "id": "philosophy-admission-oracle-2101"
+    },
+    {
+      "claim": "The admission policy may omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2102"
+    },
+    {
+      "claim": "The admission policy may promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2103"
+    },
+    {
+      "claim": "The admission policy may skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2104"
+    },
+    {
+      "claim": "The admission policy may waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2105"
+    },
+    {
+      "claim": "The admission policy might omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2106"
+    },
+    {
+      "claim": "The admission policy might promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2107"
+    },
+    {
+      "claim": "The admission policy might skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2108"
+    },
+    {
+      "claim": "The admission policy might waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2109"
+    },
+    {
+      "claim": "The admission policy must omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2110"
+    },
+    {
+      "claim": "The admission policy must promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2111"
+    },
+    {
+      "claim": "The admission policy must skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2112"
+    },
+    {
+      "claim": "The admission policy must waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2113"
     },
     {
       "claim": "The admission policy promotes knowledge without a verification bundle.",
@@ -2741,7 +16917,47 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0342"
+      "id": "philosophy-admission-oracle-2114"
+    },
+    {
+      "claim": "The admission policy remains optional for verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2115"
+    },
+    {
+      "claim": "The admission policy should omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2116"
+    },
+    {
+      "claim": "The admission policy should promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2117"
+    },
+    {
+      "claim": "The admission policy should skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2118"
+    },
+    {
+      "claim": "The admission policy should waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2119"
     },
     {
       "claim": "The admission policy waives verification bundle requirements.",
@@ -2749,15 +16965,71 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-0343"
+      "id": "philosophy-admission-oracle-2120"
+    },
+    {
+      "claim": "The admission policy will omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2121"
     },
     {
       "claim": "The admission policy will promote knowledge without a verification bundle.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
-      "source": "policy.temporal_predicates",
-      "id": "philosophy-admission-oracle-0344"
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2122"
+    },
+    {
+      "claim": "The admission policy will skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2123"
+    },
+    {
+      "claim": "The admission policy will waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2124"
+    },
+    {
+      "claim": "The admission policy would omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2125"
+    },
+    {
+      "claim": "The admission policy would promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2126"
+    },
+    {
+      "claim": "The admission policy would skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2127"
+    },
+    {
+      "claim": "The admission policy would waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-2128"
     },
     {
       "claim": "Verification bundle requirements remain optional for semantic-cache admission.",
@@ -2765,7 +17037,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-0345"
+      "id": "philosophy-admission-oracle-2129"
     }
   ]
 }

--- a/tests/fixtures/orchestration/philosophy_admission_claim_oracle.json
+++ b/tests/fixtures/orchestration/philosophy_admission_claim_oracle.json
@@ -1,0 +1,2771 @@
+{
+  "generated_at": "static-2026-05-20",
+  "gate_status": "closed",
+  "implementation_allowed": false,
+  "oracle_id": "philosophy_admission_claim_family_oracle",
+  "policy_id": "philosophy_semantic_cache_admission_policy",
+  "policy_version": "2026-05-20",
+  "runtime_allowed": false,
+  "cases": [
+    {
+      "claim": "No semantic-cache gate is opened by PR-2.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "allowed",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0001"
+    },
+    {
+      "claim": "The future gate-open PR must review semantic-cache admission before runtime use.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "allowed",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0002"
+    },
+    {
+      "claim": "This policy does not open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "allowed",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0003"
+    },
+    {
+      "claim": "PR-1 can open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0004"
+    },
+    {
+      "claim": "PR-1 enables the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0005"
+    },
+    {
+      "claim": "PR-1 has opened the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0006"
+    },
+    {
+      "claim": "PR-1 is equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0007"
+    },
+    {
+      "claim": "PR-1 is required to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0008"
+    },
+    {
+      "claim": "PR-1 keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0009"
+    },
+    {
+      "claim": "PR-1 opens the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0010"
+    },
+    {
+      "claim": "PR-1 unlocks the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0011"
+    },
+    {
+      "claim": "PR-2 became sufficient to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0012"
+    },
+    {
+      "claim": "PR-2 does not only open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0013"
+    },
+    {
+      "claim": "PR-2 enables the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0014"
+    },
+    {
+      "claim": "PR-2 has to unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0015"
+    },
+    {
+      "claim": "PR-2 is equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0016"
+    },
+    {
+      "claim": "PR-2 keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0017"
+    },
+    {
+      "claim": "PR-2 may unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0018"
+    },
+    {
+      "claim": "PR-2 opens the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0019"
+    },
+    {
+      "claim": "PR-2 unlocks the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0020"
+    },
+    {
+      "claim": "Philosophy admission enables the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0021"
+    },
+    {
+      "claim": "Philosophy admission is equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0022"
+    },
+    {
+      "claim": "Philosophy admission keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0023"
+    },
+    {
+      "claim": "Philosophy admission must enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0024"
+    },
+    {
+      "claim": "Philosophy admission opens the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0025"
+    },
+    {
+      "claim": "Philosophy admission remains enough to open the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0026"
+    },
+    {
+      "claim": "Philosophy admission unlocks the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0027"
+    },
+    {
+      "claim": "The admission contract enables the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0028"
+    },
+    {
+      "claim": "The admission contract is equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0029"
+    },
+    {
+      "claim": "The admission contract is now opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0030"
+    },
+    {
+      "claim": "The admission contract keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0031"
+    },
+    {
+      "claim": "The admission contract opens the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0032"
+    },
+    {
+      "claim": "The admission contract should be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0033"
+    },
+    {
+      "claim": "The admission contract unlocks the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0034"
+    },
+    {
+      "claim": "The admission policy could open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0035"
+    },
+    {
+      "claim": "The admission policy enables the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0036"
+    },
+    {
+      "claim": "The admission policy is equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0037"
+    },
+    {
+      "claim": "The admission policy keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0038"
+    },
+    {
+      "claim": "The admission policy opens the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0039"
+    },
+    {
+      "claim": "The admission policy still keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0040"
+    },
+    {
+      "claim": "The admission policy unlocks the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0041"
+    },
+    {
+      "claim": "The claim-family oracle became sufficient to open the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0042"
+    },
+    {
+      "claim": "The claim-family oracle enables the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0043"
+    },
+    {
+      "claim": "The claim-family oracle is equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0044"
+    },
+    {
+      "claim": "The claim-family oracle keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0045"
+    },
+    {
+      "claim": "The claim-family oracle opens the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0046"
+    },
+    {
+      "claim": "The claim-family oracle unlocks the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0047"
+    },
+    {
+      "claim": "The claim-family oracle would unlock the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0048"
+    },
+    {
+      "claim": "The global gate enables the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0049"
+    },
+    {
+      "claim": "The global gate is equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0050"
+    },
+    {
+      "claim": "The global gate keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0051"
+    },
+    {
+      "claim": "The global gate opens the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0052"
+    },
+    {
+      "claim": "The global gate unlocks the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0053"
+    },
+    {
+      "claim": "The global gate will be equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0054"
+    },
+    {
+      "claim": "The semantic-cache gate enables the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0055"
+    },
+    {
+      "claim": "The semantic-cache gate is equivalent to opening the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0056"
+    },
+    {
+      "claim": "The semantic-cache gate is now being opened for PR-2.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0057"
+    },
+    {
+      "claim": "The semantic-cache gate keeps the semantic-cache gate open.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0058"
+    },
+    {
+      "claim": "The semantic-cache gate might enable the global gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0059"
+    },
+    {
+      "claim": "The semantic-cache gate opens the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0060"
+    },
+    {
+      "claim": "The semantic-cache gate unlocks the semantic-cache gate.",
+      "claim_family": "claim_class_gate_open_equivalence",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophy admission opens gate",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0061"
+    },
+    {
+      "claim": "Future PR may evaluate cache serving only after the gate opens.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "allowed",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0062"
+    },
+    {
+      "claim": "Philosophical semantic-cache is not live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "allowed",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0063"
+    },
+    {
+      "claim": "The policy oracle does not serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "allowed",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0064"
+    },
+    {
+      "claim": "Future philosophy PRs may now serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0065"
+    },
+    {
+      "claim": "PR-2 cache path is active.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0066"
+    },
+    {
+      "claim": "PR-2 cache path is live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0067"
+    },
+    {
+      "claim": "PR-2 cache path is required to serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0068"
+    },
+    {
+      "claim": "PR-2 cache path is still serving cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0069"
+    },
+    {
+      "claim": "PR-2 cache path keeps semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0070"
+    },
+    {
+      "claim": "PR-2 cache path serves cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0071"
+    },
+    {
+      "claim": "PR-2 cache path serves philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0072"
+    },
+    {
+      "claim": "PR-2 cache path should run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0073"
+    },
+    {
+      "claim": "Philosophical semantic-cache can serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0074"
+    },
+    {
+      "claim": "Philosophical semantic-cache has been live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0075"
+    },
+    {
+      "claim": "Philosophical semantic-cache is active.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0076"
+    },
+    {
+      "claim": "Philosophical semantic-cache is live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0077"
+    },
+    {
+      "claim": "Philosophical semantic-cache keeps semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0078"
+    },
+    {
+      "claim": "Philosophical semantic-cache serves cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0079"
+    },
+    {
+      "claim": "Philosophical semantic-cache serves philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0080"
+    },
+    {
+      "claim": "Philosophical semantic-cache would keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0081"
+    },
+    {
+      "claim": "Philosophy admission cache is active.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0082"
+    },
+    {
+      "claim": "Philosophy admission cache is live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0083"
+    },
+    {
+      "claim": "Philosophy admission cache keeps semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0084"
+    },
+    {
+      "claim": "Philosophy admission cache must return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0085"
+    },
+    {
+      "claim": "Philosophy admission cache remains live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0086"
+    },
+    {
+      "claim": "Philosophy admission cache serves cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0087"
+    },
+    {
+      "claim": "Philosophy admission cache serves philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0088"
+    },
+    {
+      "claim": "Philosophy admission cache will run as a live cache.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0089"
+    },
+    {
+      "claim": "Philosophy admission has been live since PR-1.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0090"
+    },
+    {
+      "claim": "Philosophy cache became live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0091"
+    },
+    {
+      "claim": "Philosophy cache is active.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0092"
+    },
+    {
+      "claim": "Philosophy cache is live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0093"
+    },
+    {
+      "claim": "Philosophy cache keeps semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0094"
+    },
+    {
+      "claim": "Philosophy cache may keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0095"
+    },
+    {
+      "claim": "Philosophy cache might return philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0096"
+    },
+    {
+      "claim": "Philosophy cache serves cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0097"
+    },
+    {
+      "claim": "Philosophy cache serves philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0098"
+    },
+    {
+      "claim": "The admission policy still keeps semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0099"
+    },
+    {
+      "claim": "The policy oracle could serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0100"
+    },
+    {
+      "claim": "The policy oracle has to keep semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0101"
+    },
+    {
+      "claim": "The policy oracle is active.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0102"
+    },
+    {
+      "claim": "The policy oracle is live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0103"
+    },
+    {
+      "claim": "The policy oracle keeps semantic-cache serving live.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0104"
+    },
+    {
+      "claim": "The policy oracle serves cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0105"
+    },
+    {
+      "claim": "The policy oracle serves philosophy cache hits.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0106"
+    },
+    {
+      "claim": "The policy oracle will serve cached responses.",
+      "claim_family": "claim_class_live_philosophy_cache",
+      "expected": "forbidden",
+      "expected_detector_label": "philosophical semantic cache live",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0107"
+    },
+    {
+      "claim": "Design/PDF intake cannot override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "allowed",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0108"
+    },
+    {
+      "claim": "Repo-reviewed contracts remain the source of gate truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "allowed",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0109"
+    },
+    {
+      "claim": "Research intake remains evidence-only.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "allowed",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0110"
+    },
+    {
+      "claim": "Browser evidence authorizes runtime behavior over repo truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0111"
+    },
+    {
+      "claim": "Browser evidence became the source of runtime truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0112"
+    },
+    {
+      "claim": "Browser evidence bypasses repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0113"
+    },
+    {
+      "claim": "Browser evidence is required to override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0114"
+    },
+    {
+      "claim": "Browser evidence overrides repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0115"
+    },
+    {
+      "claim": "Browser evidence replaces merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0116"
+    },
+    {
+      "claim": "Browser evidence should supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0117"
+    },
+    {
+      "claim": "Browser evidence supersedes semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0118"
+    },
+    {
+      "claim": "Browser evidence will bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0119"
+    },
+    {
+      "claim": "Design intake authorizes runtime behavior over repo truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0120"
+    },
+    {
+      "claim": "Design intake became the source of runtime truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0121"
+    },
+    {
+      "claim": "Design intake bypasses repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0122"
+    },
+    {
+      "claim": "Design intake may bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0123"
+    },
+    {
+      "claim": "Design intake might replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0124"
+    },
+    {
+      "claim": "Design intake overrides repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0125"
+    },
+    {
+      "claim": "Design intake replaces merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0126"
+    },
+    {
+      "claim": "Design intake supersedes semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0127"
+    },
+    {
+      "claim": "Design/PDF intake can override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0128"
+    },
+    {
+      "claim": "Drive research authorizes runtime behavior over repo truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0129"
+    },
+    {
+      "claim": "Drive research bypasses repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0130"
+    },
+    {
+      "claim": "Drive research must replace merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0131"
+    },
+    {
+      "claim": "Drive research overrides repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0132"
+    },
+    {
+      "claim": "Drive research replaces merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0133"
+    },
+    {
+      "claim": "Drive research still overrides semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0134"
+    },
+    {
+      "claim": "Drive research supersedes semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0135"
+    },
+    {
+      "claim": "Drive research will supersede semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0136"
+    },
+    {
+      "claim": "PDF intake authorizes runtime behavior over repo truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0137"
+    },
+    {
+      "claim": "PDF intake bypasses repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0138"
+    },
+    {
+      "claim": "PDF intake can override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0139"
+    },
+    {
+      "claim": "PDF intake has overridden repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0140"
+    },
+    {
+      "claim": "PDF intake has overridden semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0141"
+    },
+    {
+      "claim": "PDF intake overrides repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0142"
+    },
+    {
+      "claim": "PDF intake replaces merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0143"
+    },
+    {
+      "claim": "PDF intake supersedes semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0144"
+    },
+    {
+      "claim": "PDF intake would bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0145"
+    },
+    {
+      "claim": "The admission policy authorizes runtime behavior over repo truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0146"
+    },
+    {
+      "claim": "The admission policy bypasses repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0147"
+    },
+    {
+      "claim": "The admission policy could override repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0148"
+    },
+    {
+      "claim": "The admission policy has to bypass repo-reviewed contracts.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0149"
+    },
+    {
+      "claim": "The admission policy is now replacing merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0150"
+    },
+    {
+      "claim": "The admission policy overrides repo gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0151"
+    },
+    {
+      "claim": "The admission policy replaces merge truth.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0152"
+    },
+    {
+      "claim": "The admission policy supersedes semantic-cache gate markers.",
+      "claim_family": "claim_class_pdf_design_intake_gate_override",
+      "expected": "forbidden",
+      "expected_detector_label": "design intake overrides gate markers",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0153"
+    },
+    {
+      "claim": "No raw prompts are stored as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "allowed",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0154"
+    },
+    {
+      "claim": "PR-2 does not ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "allowed",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0155"
+    },
+    {
+      "claim": "Philosophy admission blocks live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "allowed",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0156"
+    },
+    {
+      "claim": "PR-1 caches raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0157"
+    },
+    {
+      "claim": "PR-1 can ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0158"
+    },
+    {
+      "claim": "PR-1 enables live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0159"
+    },
+    {
+      "claim": "PR-1 has shipped production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0160"
+    },
+    {
+      "claim": "PR-1 persists philosophy cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0161"
+    },
+    {
+      "claim": "PR-1 ships production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0162"
+    },
+    {
+      "claim": "PR-1 stores raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0163"
+    },
+    {
+      "claim": "PR-1 would store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0164"
+    },
+    {
+      "claim": "PR-2 became live for cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0165"
+    },
+    {
+      "claim": "PR-2 caches raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0166"
+    },
+    {
+      "claim": "PR-2 enables live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0167"
+    },
+    {
+      "claim": "PR-2 may store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0168"
+    },
+    {
+      "claim": "PR-2 might cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0169"
+    },
+    {
+      "claim": "PR-2 persists philosophy cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0170"
+    },
+    {
+      "claim": "PR-2 ships production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0171"
+    },
+    {
+      "claim": "PR-2 stores raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0172"
+    },
+    {
+      "claim": "Philosophy admission caches raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0173"
+    },
+    {
+      "claim": "Philosophy admission enables live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0174"
+    },
+    {
+      "claim": "Philosophy admission has shipped production cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0175"
+    },
+    {
+      "claim": "Philosophy admission must cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0176"
+    },
+    {
+      "claim": "Philosophy admission persists philosophy cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0177"
+    },
+    {
+      "claim": "Philosophy admission ships production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0178"
+    },
+    {
+      "claim": "Philosophy admission still stores raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0179"
+    },
+    {
+      "claim": "Philosophy admission stores raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0180"
+    },
+    {
+      "claim": "Philosophy admission will enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0181"
+    },
+    {
+      "claim": "The admission policy caches raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0182"
+    },
+    {
+      "claim": "The admission policy enables live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0183"
+    },
+    {
+      "claim": "The admission policy is required to ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0184"
+    },
+    {
+      "claim": "The admission policy persists philosophy cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0185"
+    },
+    {
+      "claim": "The admission policy ships production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0186"
+    },
+    {
+      "claim": "The admission policy should enable live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0187"
+    },
+    {
+      "claim": "The admission policy stores raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0188"
+    },
+    {
+      "claim": "The admission policy will cache raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0189"
+    },
+    {
+      "claim": "The claim-family oracle caches raw model responses.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0190"
+    },
+    {
+      "claim": "The claim-family oracle could ship production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0191"
+    },
+    {
+      "claim": "The claim-family oracle enables live cache-key behavior.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0192"
+    },
+    {
+      "claim": "The claim-family oracle has to store raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0193"
+    },
+    {
+      "claim": "The claim-family oracle is now persisting philosophy cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0194"
+    },
+    {
+      "claim": "The claim-family oracle persists philosophy cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0195"
+    },
+    {
+      "claim": "The claim-family oracle ships production cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0196"
+    },
+    {
+      "claim": "The claim-family oracle stores raw prompts as cache keys.",
+      "claim_family": "claim_class_production_live_cache_key_behavior",
+      "expected": "forbidden",
+      "expected_detector_label": "production-live philosophical cache-key behavior",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0197"
+    },
+    {
+      "claim": "GPTCache imports remain blocked for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "allowed",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0198"
+    },
+    {
+      "claim": "No Redis imports are allowed in PR-2.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "allowed",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0199"
+    },
+    {
+      "claim": "The policy oracle does not enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "allowed",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0200"
+    },
+    {
+      "claim": "Future philosophy PRs may now serve GPTCache responses.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0201"
+    },
+    {
+      "claim": "PR-1 allows GPTCache imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0202"
+    },
+    {
+      "claim": "PR-1 allows Redis imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0203"
+    },
+    {
+      "claim": "PR-1 can use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0204"
+    },
+    {
+      "claim": "PR-1 enables embeddings for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0205"
+    },
+    {
+      "claim": "PR-1 has used Redis imports for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0206"
+    },
+    {
+      "claim": "PR-1 opens Redis connection strings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0207"
+    },
+    {
+      "claim": "PR-1 wires /insight cache behavior.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0208"
+    },
+    {
+      "claim": "PR-1 would use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0209"
+    },
+    {
+      "claim": "PR-2 allows GPTCache imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0210"
+    },
+    {
+      "claim": "PR-2 allows Redis imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0211"
+    },
+    {
+      "claim": "PR-2 became approved for GPTCache imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0212"
+    },
+    {
+      "claim": "PR-2 enables embeddings for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0213"
+    },
+    {
+      "claim": "PR-2 has GPTCache import for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0214"
+    },
+    {
+      "claim": "PR-2 may use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0215"
+    },
+    {
+      "claim": "PR-2 might use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0216"
+    },
+    {
+      "claim": "PR-2 opens Redis connection strings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0217"
+    },
+    {
+      "claim": "PR-2 wires /insight cache behavior.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0218"
+    },
+    {
+      "claim": "Philosophy admission allows GPTCache imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0219"
+    },
+    {
+      "claim": "Philosophy admission allows Redis imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0220"
+    },
+    {
+      "claim": "Philosophy admission enables embeddings for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0221"
+    },
+    {
+      "claim": "Philosophy admission has been required to enable Redis cache I/O.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0222"
+    },
+    {
+      "claim": "Philosophy admission must wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0223"
+    },
+    {
+      "claim": "Philosophy admission opens Redis connection strings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0224"
+    },
+    {
+      "claim": "Philosophy admission still allows embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0225"
+    },
+    {
+      "claim": "Philosophy admission will wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0226"
+    },
+    {
+      "claim": "Philosophy admission wires /insight cache behavior.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0227"
+    },
+    {
+      "claim": "The admission policy allows GPTCache imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0228"
+    },
+    {
+      "claim": "The admission policy allows Redis imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0229"
+    },
+    {
+      "claim": "The admission policy enables embeddings for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0230"
+    },
+    {
+      "claim": "The admission policy is required to open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0231"
+    },
+    {
+      "claim": "The admission policy opens Redis connection strings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0232"
+    },
+    {
+      "claim": "The admission policy should open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0233"
+    },
+    {
+      "claim": "The admission policy will wire /insight cache behavior.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0234"
+    },
+    {
+      "claim": "The admission policy wires /insight cache behavior.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0235"
+    },
+    {
+      "claim": "The claim-family oracle allows GPTCache imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0236"
+    },
+    {
+      "claim": "The claim-family oracle allows Redis imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0237"
+    },
+    {
+      "claim": "The claim-family oracle could enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0238"
+    },
+    {
+      "claim": "The claim-family oracle enables embeddings for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0239"
+    },
+    {
+      "claim": "The claim-family oracle has been opening Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0240"
+    },
+    {
+      "claim": "The claim-family oracle has to enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0241"
+    },
+    {
+      "claim": "The claim-family oracle opens Redis connection strings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0242"
+    },
+    {
+      "claim": "The claim-family oracle wires /insight cache behavior.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0243"
+    },
+    {
+      "claim": "Billing truth remains blocked_from_cache.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "allowed",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0244"
+    },
+    {
+      "claim": "PR-2 must not write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "allowed",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0245"
+    },
+    {
+      "claim": "The policy spec does not authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "allowed",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0246"
+    },
+    {
+      "claim": "Billing truth authorizes backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0247"
+    },
+    {
+      "claim": "Billing truth becomes cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0248"
+    },
+    {
+      "claim": "Billing truth enables runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0249"
+    },
+    {
+      "claim": "Billing truth reads semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0250"
+    },
+    {
+      "claim": "Billing truth remained cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0251"
+    },
+    {
+      "claim": "Billing truth would authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0252"
+    },
+    {
+      "claim": "Billing truth writes cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0253"
+    },
+    {
+      "claim": "PR-1 authorizes backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0254"
+    },
+    {
+      "claim": "PR-1 becomes cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0255"
+    },
+    {
+      "claim": "PR-1 can authorize backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0256"
+    },
+    {
+      "claim": "PR-1 enables runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0257"
+    },
+    {
+      "claim": "PR-1 has authorized backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0258"
+    },
+    {
+      "claim": "PR-1 reads semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0259"
+    },
+    {
+      "claim": "PR-1 will write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0260"
+    },
+    {
+      "claim": "PR-1 writes cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0261"
+    },
+    {
+      "claim": "PR-2 authorizes backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0262"
+    },
+    {
+      "claim": "PR-2 became cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0263"
+    },
+    {
+      "claim": "PR-2 becomes cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0264"
+    },
+    {
+      "claim": "PR-2 enables runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0265"
+    },
+    {
+      "claim": "PR-2 is required to read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0266"
+    },
+    {
+      "claim": "PR-2 may enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0267"
+    },
+    {
+      "claim": "PR-2 must write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0268"
+    },
+    {
+      "claim": "PR-2 reads semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0269"
+    },
+    {
+      "claim": "PR-2 writes cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0270"
+    },
+    {
+      "claim": "Philosophy admission authorizes backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0271"
+    },
+    {
+      "claim": "Philosophy admission becomes cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0272"
+    },
+    {
+      "claim": "Philosophy admission enables runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0273"
+    },
+    {
+      "claim": "Philosophy admission has to be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0274"
+    },
+    {
+      "claim": "Philosophy admission must write cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0275"
+    },
+    {
+      "claim": "Philosophy admission reads semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0276"
+    },
+    {
+      "claim": "Philosophy admission remains cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0277"
+    },
+    {
+      "claim": "Philosophy admission writes cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0278"
+    },
+    {
+      "claim": "The admission policy authorizes backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0279"
+    },
+    {
+      "claim": "The admission policy becomes cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0280"
+    },
+    {
+      "claim": "The admission policy enables runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0281"
+    },
+    {
+      "claim": "The admission policy is now writing cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0282"
+    },
+    {
+      "claim": "The admission policy reads semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0283"
+    },
+    {
+      "claim": "The admission policy should read semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0284"
+    },
+    {
+      "claim": "The admission policy writes cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0285"
+    },
+    {
+      "claim": "The claim-family oracle authorizes backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0286"
+    },
+    {
+      "claim": "The claim-family oracle becomes cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0287"
+    },
+    {
+      "claim": "The claim-family oracle could be cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0288"
+    },
+    {
+      "claim": "The claim-family oracle enables runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0289"
+    },
+    {
+      "claim": "The claim-family oracle reads semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0290"
+    },
+    {
+      "claim": "The claim-family oracle will enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0291"
+    },
+    {
+      "claim": "The claim-family oracle writes cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0292"
+    },
+    {
+      "claim": "The policy spec authorizes backend selection without SC-G5.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0293"
+    },
+    {
+      "claim": "Therapy routing authorizes backend selection.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0294"
+    },
+    {
+      "claim": "Therapy routing becomes cache eligible for semantic-cache admission.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0295"
+    },
+    {
+      "claim": "Therapy routing enables runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0296"
+    },
+    {
+      "claim": "Therapy routing might enable runtime expansion.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0297"
+    },
+    {
+      "claim": "Therapy routing reads semantic-cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0298"
+    },
+    {
+      "claim": "Therapy routing writes cache entries.",
+      "claim_family": "claim_class_runtime_expansion_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "runtime allowed in pr-1",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0299"
+    },
+    {
+      "claim": "Cache admission requires a passed verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "allowed",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0300"
+    },
+    {
+      "claim": "Future PR may evaluate semantic-cache admission after verification.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "allowed",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0301"
+    },
+    {
+      "claim": "No semantic-cache admission may omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "allowed",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-0302"
+    },
+    {
+      "claim": "Cache admission became exempt from verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0303"
+    },
+    {
+      "claim": "Cache admission bypasses verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0304"
+    },
+    {
+      "claim": "Cache admission does not require a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0305"
+    },
+    {
+      "claim": "Cache admission makes verification bundles optional.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0306"
+    },
+    {
+      "claim": "Cache admission may omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0307"
+    },
+    {
+      "claim": "Cache admission might waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0308"
+    },
+    {
+      "claim": "Cache admission promotes knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0309"
+    },
+    {
+      "claim": "Cache admission waives verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0310"
+    },
+    {
+      "claim": "Knowledge promotion bypasses verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0311"
+    },
+    {
+      "claim": "Knowledge promotion does not require a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0312"
+    },
+    {
+      "claim": "Knowledge promotion makes verification bundles optional.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0313"
+    },
+    {
+      "claim": "Knowledge promotion must waive verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0314"
+    },
+    {
+      "claim": "Knowledge promotion promotes knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0315"
+    },
+    {
+      "claim": "Knowledge promotion remains optional for verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0316"
+    },
+    {
+      "claim": "Knowledge promotion waives verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0317"
+    },
+    {
+      "claim": "Knowledge promotion will promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0318"
+    },
+    {
+      "claim": "PR-2 is promoting knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0319"
+    },
+    {
+      "claim": "Philosophy admission bypasses verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0320"
+    },
+    {
+      "claim": "Philosophy admission does not require a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0321"
+    },
+    {
+      "claim": "Philosophy admission is now waiving verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0322"
+    },
+    {
+      "claim": "Philosophy admission is required to skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0323"
+    },
+    {
+      "claim": "Philosophy admission makes verification bundles optional.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0324"
+    },
+    {
+      "claim": "Philosophy admission promotes knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0325"
+    },
+    {
+      "claim": "Philosophy admission should promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0326"
+    },
+    {
+      "claim": "Philosophy admission waives verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0327"
+    },
+    {
+      "claim": "Semantic-cache admission bypasses verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0328"
+    },
+    {
+      "claim": "Semantic-cache admission can skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0329"
+    },
+    {
+      "claim": "Semantic-cache admission does not require a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0330"
+    },
+    {
+      "claim": "Semantic-cache admission has bypassed verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0331"
+    },
+    {
+      "claim": "Semantic-cache admission makes verification bundles optional.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0332"
+    },
+    {
+      "claim": "Semantic-cache admission may omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0333"
+    },
+    {
+      "claim": "Semantic-cache admission promotes knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0334"
+    },
+    {
+      "claim": "Semantic-cache admission waives verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0335"
+    },
+    {
+      "claim": "Semantic-cache admission would omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0336"
+    },
+    {
+      "claim": "The admission policy bypasses verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0337"
+    },
+    {
+      "claim": "The admission policy could skip verification bundles.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0338"
+    },
+    {
+      "claim": "The admission policy does not require a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0339"
+    },
+    {
+      "claim": "The admission policy has to omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.modal_predicates",
+      "id": "philosophy-admission-oracle-0340"
+    },
+    {
+      "claim": "The admission policy makes verification bundles optional.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0341"
+    },
+    {
+      "claim": "The admission policy promotes knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0342"
+    },
+    {
+      "claim": "The admission policy waives verification bundle requirements.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-0343"
+    },
+    {
+      "claim": "The admission policy will promote knowledge without a verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.temporal_predicates",
+      "id": "philosophy-admission-oracle-0344"
+    },
+    {
+      "claim": "Verification bundle requirements remain optional for semantic-cache admission.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "forbidden",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.seed_regressions",
+      "id": "philosophy-admission-oracle-0345"
+    }
+  ]
+}

--- a/tests/fixtures/orchestration/philosophy_admission_claim_oracle.json
+++ b/tests/fixtures/orchestration/philosophy_admission_claim_oracle.json
@@ -16448,7 +16448,7 @@
       "id": "philosophy-admission-oracle-2055"
     },
     {
-      "claim": "Future PR may evaluate semantic-cache admission after verification.",
+      "claim": "Do not claim that the admission policy may omit the verification bundle.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "allowed",
       "expected_detector_label": "verification bundle optional",
@@ -16456,7 +16456,7 @@
       "id": "philosophy-admission-oracle-2056"
     },
     {
-      "claim": "No semantic-cache admission may omit the verification bundle.",
+      "claim": "Future PR may evaluate semantic-cache admission after verification.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "allowed",
       "expected_detector_label": "verification bundle optional",
@@ -16464,12 +16464,20 @@
       "id": "philosophy-admission-oracle-2057"
     },
     {
+      "claim": "No semantic-cache admission may omit the verification bundle.",
+      "claim_family": "claim_class_verification_bundle_skipped",
+      "expected": "allowed",
+      "expected_detector_label": "verification bundle optional",
+      "source": "policy.allowed_negative_controls",
+      "id": "philosophy-admission-oracle-2058"
+    },
+    {
       "claim": "Cache admission became exempt from verification bundles.",
       "claim_family": "claim_class_verification_bundle_skipped",
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2058"
+      "id": "philosophy-admission-oracle-2059"
     },
     {
       "claim": "Cache admission bypasses verification bundles.",
@@ -16477,7 +16485,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2059"
+      "id": "philosophy-admission-oracle-2060"
     },
     {
       "claim": "Cache admission can omit the verification bundle.",
@@ -16485,7 +16493,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2060"
+      "id": "philosophy-admission-oracle-2061"
     },
     {
       "claim": "Cache admission can promote knowledge without a verification bundle.",
@@ -16493,7 +16501,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2061"
+      "id": "philosophy-admission-oracle-2062"
     },
     {
       "claim": "Cache admission can skip verification bundles.",
@@ -16501,7 +16509,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2062"
+      "id": "philosophy-admission-oracle-2063"
     },
     {
       "claim": "Cache admission can waive verification bundle requirements.",
@@ -16509,7 +16517,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2063"
+      "id": "philosophy-admission-oracle-2064"
     },
     {
       "claim": "Cache admission could omit the verification bundle.",
@@ -16517,7 +16525,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2064"
+      "id": "philosophy-admission-oracle-2065"
     },
     {
       "claim": "Cache admission could promote knowledge without a verification bundle.",
@@ -16525,7 +16533,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2065"
+      "id": "philosophy-admission-oracle-2066"
     },
     {
       "claim": "Cache admission could skip verification bundles.",
@@ -16533,7 +16541,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2066"
+      "id": "philosophy-admission-oracle-2067"
     },
     {
       "claim": "Cache admission could waive verification bundle requirements.",
@@ -16541,7 +16549,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2067"
+      "id": "philosophy-admission-oracle-2068"
     },
     {
       "claim": "Cache admission does not require a verification bundle.",
@@ -16549,7 +16557,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2068"
+      "id": "philosophy-admission-oracle-2069"
     },
     {
       "claim": "Cache admission has bypassed verification bundles.",
@@ -16557,7 +16565,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2069"
+      "id": "philosophy-admission-oracle-2070"
     },
     {
       "claim": "Cache admission has to omit the verification bundle.",
@@ -16565,7 +16573,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2070"
+      "id": "philosophy-admission-oracle-2071"
     },
     {
       "claim": "Cache admission has to promote knowledge without a verification bundle.",
@@ -16573,7 +16581,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2071"
+      "id": "philosophy-admission-oracle-2072"
     },
     {
       "claim": "Cache admission has to skip verification bundles.",
@@ -16581,7 +16589,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2072"
+      "id": "philosophy-admission-oracle-2073"
     },
     {
       "claim": "Cache admission has to waive verification bundle requirements.",
@@ -16589,7 +16597,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2073"
+      "id": "philosophy-admission-oracle-2074"
     },
     {
       "claim": "Cache admission is now waiving verification bundle requirements.",
@@ -16597,7 +16605,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2074"
+      "id": "philosophy-admission-oracle-2075"
     },
     {
       "claim": "Cache admission is required to omit the verification bundle.",
@@ -16605,7 +16613,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2075"
+      "id": "philosophy-admission-oracle-2076"
     },
     {
       "claim": "Cache admission is required to promote knowledge without a verification bundle.",
@@ -16613,7 +16621,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2076"
+      "id": "philosophy-admission-oracle-2077"
     },
     {
       "claim": "Cache admission is required to skip verification bundles.",
@@ -16621,7 +16629,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2077"
+      "id": "philosophy-admission-oracle-2078"
     },
     {
       "claim": "Cache admission is required to waive verification bundle requirements.",
@@ -16629,7 +16637,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2078"
+      "id": "philosophy-admission-oracle-2079"
     },
     {
       "claim": "Cache admission makes verification bundles optional.",
@@ -16637,7 +16645,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2079"
+      "id": "philosophy-admission-oracle-2080"
     },
     {
       "claim": "Cache admission may omit the verification bundle.",
@@ -16645,7 +16653,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2080"
+      "id": "philosophy-admission-oracle-2081"
     },
     {
       "claim": "Cache admission may promote knowledge without a verification bundle.",
@@ -16653,7 +16661,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2081"
+      "id": "philosophy-admission-oracle-2082"
     },
     {
       "claim": "Cache admission may skip verification bundles.",
@@ -16661,7 +16669,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2082"
+      "id": "philosophy-admission-oracle-2083"
     },
     {
       "claim": "Cache admission may waive verification bundle requirements.",
@@ -16669,7 +16677,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2083"
+      "id": "philosophy-admission-oracle-2084"
     },
     {
       "claim": "Cache admission might omit the verification bundle.",
@@ -16677,7 +16685,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2084"
+      "id": "philosophy-admission-oracle-2085"
     },
     {
       "claim": "Cache admission might promote knowledge without a verification bundle.",
@@ -16685,7 +16693,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2085"
+      "id": "philosophy-admission-oracle-2086"
     },
     {
       "claim": "Cache admission might skip verification bundles.",
@@ -16693,7 +16701,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2086"
+      "id": "philosophy-admission-oracle-2087"
     },
     {
       "claim": "Cache admission might waive verification bundle requirements.",
@@ -16701,7 +16709,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2087"
+      "id": "philosophy-admission-oracle-2088"
     },
     {
       "claim": "Cache admission must omit the verification bundle.",
@@ -16709,7 +16717,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2088"
+      "id": "philosophy-admission-oracle-2089"
     },
     {
       "claim": "Cache admission must promote knowledge without a verification bundle.",
@@ -16717,7 +16725,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2089"
+      "id": "philosophy-admission-oracle-2090"
     },
     {
       "claim": "Cache admission must skip verification bundles.",
@@ -16725,7 +16733,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2090"
+      "id": "philosophy-admission-oracle-2091"
     },
     {
       "claim": "Cache admission must waive verification bundle requirements.",
@@ -16733,7 +16741,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2091"
+      "id": "philosophy-admission-oracle-2092"
     },
     {
       "claim": "Cache admission promotes knowledge without a verification bundle.",
@@ -16741,7 +16749,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2092"
+      "id": "philosophy-admission-oracle-2093"
     },
     {
       "claim": "Cache admission remains optional for verification bundles.",
@@ -16749,7 +16757,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2093"
+      "id": "philosophy-admission-oracle-2094"
     },
     {
       "claim": "Cache admission should omit the verification bundle.",
@@ -16757,7 +16765,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2094"
+      "id": "philosophy-admission-oracle-2095"
     },
     {
       "claim": "Cache admission should promote knowledge without a verification bundle.",
@@ -16765,7 +16773,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2095"
+      "id": "philosophy-admission-oracle-2096"
     },
     {
       "claim": "Cache admission should skip verification bundles.",
@@ -16773,7 +16781,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2096"
+      "id": "philosophy-admission-oracle-2097"
     },
     {
       "claim": "Cache admission should waive verification bundle requirements.",
@@ -16781,7 +16789,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2097"
+      "id": "philosophy-admission-oracle-2098"
     },
     {
       "claim": "Cache admission waives verification bundle requirements.",
@@ -16789,7 +16797,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2098"
+      "id": "philosophy-admission-oracle-2099"
     },
     {
       "claim": "Cache admission will omit the verification bundle.",
@@ -16797,7 +16805,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2099"
+      "id": "philosophy-admission-oracle-2100"
     },
     {
       "claim": "Cache admission will promote knowledge without a verification bundle.",
@@ -16805,7 +16813,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2100"
+      "id": "philosophy-admission-oracle-2101"
     },
     {
       "claim": "Cache admission will skip verification bundles.",
@@ -16813,7 +16821,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2101"
+      "id": "philosophy-admission-oracle-2102"
     },
     {
       "claim": "Cache admission will waive verification bundle requirements.",
@@ -16821,7 +16829,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2102"
+      "id": "philosophy-admission-oracle-2103"
     },
     {
       "claim": "Cache admission would omit the verification bundle.",
@@ -16829,7 +16837,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2103"
+      "id": "philosophy-admission-oracle-2104"
     },
     {
       "claim": "Cache admission would promote knowledge without a verification bundle.",
@@ -16837,7 +16845,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2104"
+      "id": "philosophy-admission-oracle-2105"
     },
     {
       "claim": "Cache admission would skip verification bundles.",
@@ -16845,7 +16853,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2105"
+      "id": "philosophy-admission-oracle-2106"
     },
     {
       "claim": "Cache admission would waive verification bundle requirements.",
@@ -16853,7 +16861,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2106"
+      "id": "philosophy-admission-oracle-2107"
     },
     {
       "claim": "Knowledge promotion became exempt from verification bundles.",
@@ -16861,7 +16869,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2107"
+      "id": "philosophy-admission-oracle-2108"
     },
     {
       "claim": "Knowledge promotion bypasses verification bundles.",
@@ -16869,7 +16877,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2108"
+      "id": "philosophy-admission-oracle-2109"
     },
     {
       "claim": "Knowledge promotion can omit the verification bundle.",
@@ -16877,7 +16885,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2109"
+      "id": "philosophy-admission-oracle-2110"
     },
     {
       "claim": "Knowledge promotion can promote knowledge without a verification bundle.",
@@ -16885,7 +16893,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2110"
+      "id": "philosophy-admission-oracle-2111"
     },
     {
       "claim": "Knowledge promotion can skip verification bundles.",
@@ -16893,7 +16901,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2111"
+      "id": "philosophy-admission-oracle-2112"
     },
     {
       "claim": "Knowledge promotion can waive verification bundle requirements.",
@@ -16901,7 +16909,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2112"
+      "id": "philosophy-admission-oracle-2113"
     },
     {
       "claim": "Knowledge promotion could omit the verification bundle.",
@@ -16909,7 +16917,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2113"
+      "id": "philosophy-admission-oracle-2114"
     },
     {
       "claim": "Knowledge promotion could promote knowledge without a verification bundle.",
@@ -16917,7 +16925,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2114"
+      "id": "philosophy-admission-oracle-2115"
     },
     {
       "claim": "Knowledge promotion could skip verification bundles.",
@@ -16925,7 +16933,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2115"
+      "id": "philosophy-admission-oracle-2116"
     },
     {
       "claim": "Knowledge promotion could waive verification bundle requirements.",
@@ -16933,7 +16941,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2116"
+      "id": "philosophy-admission-oracle-2117"
     },
     {
       "claim": "Knowledge promotion does not require a verification bundle.",
@@ -16941,7 +16949,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2117"
+      "id": "philosophy-admission-oracle-2118"
     },
     {
       "claim": "Knowledge promotion has bypassed verification bundles.",
@@ -16949,7 +16957,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2118"
+      "id": "philosophy-admission-oracle-2119"
     },
     {
       "claim": "Knowledge promotion has to omit the verification bundle.",
@@ -16957,7 +16965,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2119"
+      "id": "philosophy-admission-oracle-2120"
     },
     {
       "claim": "Knowledge promotion has to promote knowledge without a verification bundle.",
@@ -16965,7 +16973,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2120"
+      "id": "philosophy-admission-oracle-2121"
     },
     {
       "claim": "Knowledge promotion has to skip verification bundles.",
@@ -16973,7 +16981,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2121"
+      "id": "philosophy-admission-oracle-2122"
     },
     {
       "claim": "Knowledge promotion has to waive verification bundle requirements.",
@@ -16981,7 +16989,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2122"
+      "id": "philosophy-admission-oracle-2123"
     },
     {
       "claim": "Knowledge promotion is now waiving verification bundle requirements.",
@@ -16989,7 +16997,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2123"
+      "id": "philosophy-admission-oracle-2124"
     },
     {
       "claim": "Knowledge promotion is required to omit the verification bundle.",
@@ -16997,7 +17005,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2124"
+      "id": "philosophy-admission-oracle-2125"
     },
     {
       "claim": "Knowledge promotion is required to promote knowledge without a verification bundle.",
@@ -17005,7 +17013,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2125"
+      "id": "philosophy-admission-oracle-2126"
     },
     {
       "claim": "Knowledge promotion is required to skip verification bundles.",
@@ -17013,7 +17021,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2126"
+      "id": "philosophy-admission-oracle-2127"
     },
     {
       "claim": "Knowledge promotion is required to waive verification bundle requirements.",
@@ -17021,7 +17029,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2127"
+      "id": "philosophy-admission-oracle-2128"
     },
     {
       "claim": "Knowledge promotion makes verification bundles optional.",
@@ -17029,7 +17037,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2128"
+      "id": "philosophy-admission-oracle-2129"
     },
     {
       "claim": "Knowledge promotion may omit the verification bundle.",
@@ -17037,7 +17045,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2129"
+      "id": "philosophy-admission-oracle-2130"
     },
     {
       "claim": "Knowledge promotion may promote knowledge without a verification bundle.",
@@ -17045,7 +17053,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2130"
+      "id": "philosophy-admission-oracle-2131"
     },
     {
       "claim": "Knowledge promotion may skip verification bundles.",
@@ -17053,7 +17061,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2131"
+      "id": "philosophy-admission-oracle-2132"
     },
     {
       "claim": "Knowledge promotion may waive verification bundle requirements.",
@@ -17061,7 +17069,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2132"
+      "id": "philosophy-admission-oracle-2133"
     },
     {
       "claim": "Knowledge promotion might omit the verification bundle.",
@@ -17069,7 +17077,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2133"
+      "id": "philosophy-admission-oracle-2134"
     },
     {
       "claim": "Knowledge promotion might promote knowledge without a verification bundle.",
@@ -17077,7 +17085,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2134"
+      "id": "philosophy-admission-oracle-2135"
     },
     {
       "claim": "Knowledge promotion might skip verification bundles.",
@@ -17085,7 +17093,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2135"
+      "id": "philosophy-admission-oracle-2136"
     },
     {
       "claim": "Knowledge promotion might waive verification bundle requirements.",
@@ -17093,7 +17101,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2136"
+      "id": "philosophy-admission-oracle-2137"
     },
     {
       "claim": "Knowledge promotion must omit the verification bundle.",
@@ -17101,7 +17109,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2137"
+      "id": "philosophy-admission-oracle-2138"
     },
     {
       "claim": "Knowledge promotion must promote knowledge without a verification bundle.",
@@ -17109,7 +17117,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2138"
+      "id": "philosophy-admission-oracle-2139"
     },
     {
       "claim": "Knowledge promotion must skip verification bundles.",
@@ -17117,7 +17125,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2139"
+      "id": "philosophy-admission-oracle-2140"
     },
     {
       "claim": "Knowledge promotion must waive verification bundle requirements.",
@@ -17125,7 +17133,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2140"
+      "id": "philosophy-admission-oracle-2141"
     },
     {
       "claim": "Knowledge promotion promotes knowledge without a verification bundle.",
@@ -17133,7 +17141,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2141"
+      "id": "philosophy-admission-oracle-2142"
     },
     {
       "claim": "Knowledge promotion remains optional for verification bundles.",
@@ -17141,7 +17149,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2142"
+      "id": "philosophy-admission-oracle-2143"
     },
     {
       "claim": "Knowledge promotion should omit the verification bundle.",
@@ -17149,7 +17157,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2143"
+      "id": "philosophy-admission-oracle-2144"
     },
     {
       "claim": "Knowledge promotion should promote knowledge without a verification bundle.",
@@ -17157,7 +17165,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2144"
+      "id": "philosophy-admission-oracle-2145"
     },
     {
       "claim": "Knowledge promotion should skip verification bundles.",
@@ -17165,7 +17173,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2145"
+      "id": "philosophy-admission-oracle-2146"
     },
     {
       "claim": "Knowledge promotion should waive verification bundle requirements.",
@@ -17173,7 +17181,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2146"
+      "id": "philosophy-admission-oracle-2147"
     },
     {
       "claim": "Knowledge promotion waives verification bundle requirements.",
@@ -17181,7 +17189,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2147"
+      "id": "philosophy-admission-oracle-2148"
     },
     {
       "claim": "Knowledge promotion will omit the verification bundle.",
@@ -17189,7 +17197,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2148"
+      "id": "philosophy-admission-oracle-2149"
     },
     {
       "claim": "Knowledge promotion will promote knowledge without a verification bundle.",
@@ -17197,7 +17205,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2149"
+      "id": "philosophy-admission-oracle-2150"
     },
     {
       "claim": "Knowledge promotion will skip verification bundles.",
@@ -17205,7 +17213,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2150"
+      "id": "philosophy-admission-oracle-2151"
     },
     {
       "claim": "Knowledge promotion will waive verification bundle requirements.",
@@ -17213,7 +17221,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2151"
+      "id": "philosophy-admission-oracle-2152"
     },
     {
       "claim": "Knowledge promotion would omit the verification bundle.",
@@ -17221,7 +17229,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2152"
+      "id": "philosophy-admission-oracle-2153"
     },
     {
       "claim": "Knowledge promotion would promote knowledge without a verification bundle.",
@@ -17229,7 +17237,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2153"
+      "id": "philosophy-admission-oracle-2154"
     },
     {
       "claim": "Knowledge promotion would skip verification bundles.",
@@ -17237,7 +17245,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2154"
+      "id": "philosophy-admission-oracle-2155"
     },
     {
       "claim": "Knowledge promotion would waive verification bundle requirements.",
@@ -17245,7 +17253,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2155"
+      "id": "philosophy-admission-oracle-2156"
     },
     {
       "claim": "PR-2 is promoting knowledge without a verification bundle.",
@@ -17253,7 +17261,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-2156"
+      "id": "philosophy-admission-oracle-2157"
     },
     {
       "claim": "Philosophy admission became exempt from verification bundles.",
@@ -17261,7 +17269,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2157"
+      "id": "philosophy-admission-oracle-2158"
     },
     {
       "claim": "Philosophy admission bypasses verification bundles.",
@@ -17269,7 +17277,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2158"
+      "id": "philosophy-admission-oracle-2159"
     },
     {
       "claim": "Philosophy admission can omit the verification bundle.",
@@ -17277,7 +17285,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2159"
+      "id": "philosophy-admission-oracle-2160"
     },
     {
       "claim": "Philosophy admission can promote knowledge without a verification bundle.",
@@ -17285,7 +17293,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2160"
+      "id": "philosophy-admission-oracle-2161"
     },
     {
       "claim": "Philosophy admission can skip verification bundles.",
@@ -17293,7 +17301,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2161"
+      "id": "philosophy-admission-oracle-2162"
     },
     {
       "claim": "Philosophy admission can waive verification bundle requirements.",
@@ -17301,7 +17309,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2162"
+      "id": "philosophy-admission-oracle-2163"
     },
     {
       "claim": "Philosophy admission could omit the verification bundle.",
@@ -17309,7 +17317,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2163"
+      "id": "philosophy-admission-oracle-2164"
     },
     {
       "claim": "Philosophy admission could promote knowledge without a verification bundle.",
@@ -17317,7 +17325,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2164"
+      "id": "philosophy-admission-oracle-2165"
     },
     {
       "claim": "Philosophy admission could skip verification bundles.",
@@ -17325,7 +17333,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2165"
+      "id": "philosophy-admission-oracle-2166"
     },
     {
       "claim": "Philosophy admission could waive verification bundle requirements.",
@@ -17333,7 +17341,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2166"
+      "id": "philosophy-admission-oracle-2167"
     },
     {
       "claim": "Philosophy admission does not require a verification bundle.",
@@ -17341,7 +17349,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2167"
+      "id": "philosophy-admission-oracle-2168"
     },
     {
       "claim": "Philosophy admission has bypassed verification bundles.",
@@ -17349,7 +17357,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2168"
+      "id": "philosophy-admission-oracle-2169"
     },
     {
       "claim": "Philosophy admission has to omit the verification bundle.",
@@ -17357,7 +17365,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2169"
+      "id": "philosophy-admission-oracle-2170"
     },
     {
       "claim": "Philosophy admission has to promote knowledge without a verification bundle.",
@@ -17365,7 +17373,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2170"
+      "id": "philosophy-admission-oracle-2171"
     },
     {
       "claim": "Philosophy admission has to skip verification bundles.",
@@ -17373,7 +17381,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2171"
+      "id": "philosophy-admission-oracle-2172"
     },
     {
       "claim": "Philosophy admission has to waive verification bundle requirements.",
@@ -17381,7 +17389,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2172"
+      "id": "philosophy-admission-oracle-2173"
     },
     {
       "claim": "Philosophy admission is now waiving verification bundle requirements.",
@@ -17389,7 +17397,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2173"
+      "id": "philosophy-admission-oracle-2174"
     },
     {
       "claim": "Philosophy admission is required to omit the verification bundle.",
@@ -17397,7 +17405,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2174"
+      "id": "philosophy-admission-oracle-2175"
     },
     {
       "claim": "Philosophy admission is required to promote knowledge without a verification bundle.",
@@ -17405,7 +17413,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2175"
+      "id": "philosophy-admission-oracle-2176"
     },
     {
       "claim": "Philosophy admission is required to skip verification bundles.",
@@ -17413,7 +17421,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2176"
+      "id": "philosophy-admission-oracle-2177"
     },
     {
       "claim": "Philosophy admission is required to waive verification bundle requirements.",
@@ -17421,7 +17429,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2177"
+      "id": "philosophy-admission-oracle-2178"
     },
     {
       "claim": "Philosophy admission makes verification bundles optional.",
@@ -17429,7 +17437,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2178"
+      "id": "philosophy-admission-oracle-2179"
     },
     {
       "claim": "Philosophy admission may omit the verification bundle.",
@@ -17437,7 +17445,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2179"
+      "id": "philosophy-admission-oracle-2180"
     },
     {
       "claim": "Philosophy admission may promote knowledge without a verification bundle.",
@@ -17445,7 +17453,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2180"
+      "id": "philosophy-admission-oracle-2181"
     },
     {
       "claim": "Philosophy admission may skip verification bundles.",
@@ -17453,7 +17461,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2181"
+      "id": "philosophy-admission-oracle-2182"
     },
     {
       "claim": "Philosophy admission may waive verification bundle requirements.",
@@ -17461,7 +17469,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2182"
+      "id": "philosophy-admission-oracle-2183"
     },
     {
       "claim": "Philosophy admission might omit the verification bundle.",
@@ -17469,7 +17477,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2183"
+      "id": "philosophy-admission-oracle-2184"
     },
     {
       "claim": "Philosophy admission might promote knowledge without a verification bundle.",
@@ -17477,7 +17485,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2184"
+      "id": "philosophy-admission-oracle-2185"
     },
     {
       "claim": "Philosophy admission might skip verification bundles.",
@@ -17485,7 +17493,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2185"
+      "id": "philosophy-admission-oracle-2186"
     },
     {
       "claim": "Philosophy admission might waive verification bundle requirements.",
@@ -17493,7 +17501,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2186"
+      "id": "philosophy-admission-oracle-2187"
     },
     {
       "claim": "Philosophy admission must omit the verification bundle.",
@@ -17501,7 +17509,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2187"
+      "id": "philosophy-admission-oracle-2188"
     },
     {
       "claim": "Philosophy admission must promote knowledge without a verification bundle.",
@@ -17509,7 +17517,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2188"
+      "id": "philosophy-admission-oracle-2189"
     },
     {
       "claim": "Philosophy admission must skip verification bundles.",
@@ -17517,7 +17525,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2189"
+      "id": "philosophy-admission-oracle-2190"
     },
     {
       "claim": "Philosophy admission must waive verification bundle requirements.",
@@ -17525,7 +17533,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2190"
+      "id": "philosophy-admission-oracle-2191"
     },
     {
       "claim": "Philosophy admission promotes knowledge without a verification bundle.",
@@ -17533,7 +17541,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2191"
+      "id": "philosophy-admission-oracle-2192"
     },
     {
       "claim": "Philosophy admission remains optional for verification bundles.",
@@ -17541,7 +17549,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2192"
+      "id": "philosophy-admission-oracle-2193"
     },
     {
       "claim": "Philosophy admission should omit the verification bundle.",
@@ -17549,7 +17557,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2193"
+      "id": "philosophy-admission-oracle-2194"
     },
     {
       "claim": "Philosophy admission should promote knowledge without a verification bundle.",
@@ -17557,7 +17565,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2194"
+      "id": "philosophy-admission-oracle-2195"
     },
     {
       "claim": "Philosophy admission should skip verification bundles.",
@@ -17565,7 +17573,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2195"
+      "id": "philosophy-admission-oracle-2196"
     },
     {
       "claim": "Philosophy admission should waive verification bundle requirements.",
@@ -17573,7 +17581,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2196"
+      "id": "philosophy-admission-oracle-2197"
     },
     {
       "claim": "Philosophy admission waives verification bundle requirements.",
@@ -17581,7 +17589,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2197"
+      "id": "philosophy-admission-oracle-2198"
     },
     {
       "claim": "Philosophy admission will omit the verification bundle.",
@@ -17589,7 +17597,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2198"
+      "id": "philosophy-admission-oracle-2199"
     },
     {
       "claim": "Philosophy admission will promote knowledge without a verification bundle.",
@@ -17597,7 +17605,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2199"
+      "id": "philosophy-admission-oracle-2200"
     },
     {
       "claim": "Philosophy admission will skip verification bundles.",
@@ -17605,7 +17613,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2200"
+      "id": "philosophy-admission-oracle-2201"
     },
     {
       "claim": "Philosophy admission will waive verification bundle requirements.",
@@ -17613,7 +17621,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2201"
+      "id": "philosophy-admission-oracle-2202"
     },
     {
       "claim": "Philosophy admission would omit the verification bundle.",
@@ -17621,7 +17629,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2202"
+      "id": "philosophy-admission-oracle-2203"
     },
     {
       "claim": "Philosophy admission would promote knowledge without a verification bundle.",
@@ -17629,7 +17637,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2203"
+      "id": "philosophy-admission-oracle-2204"
     },
     {
       "claim": "Philosophy admission would skip verification bundles.",
@@ -17637,7 +17645,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2204"
+      "id": "philosophy-admission-oracle-2205"
     },
     {
       "claim": "Philosophy admission would waive verification bundle requirements.",
@@ -17645,7 +17653,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2205"
+      "id": "philosophy-admission-oracle-2206"
     },
     {
       "claim": "Semantic-cache admission became exempt from verification bundles.",
@@ -17653,7 +17661,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2206"
+      "id": "philosophy-admission-oracle-2207"
     },
     {
       "claim": "Semantic-cache admission bypasses verification bundles.",
@@ -17661,7 +17669,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2207"
+      "id": "philosophy-admission-oracle-2208"
     },
     {
       "claim": "Semantic-cache admission can omit the verification bundle.",
@@ -17669,7 +17677,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2208"
+      "id": "philosophy-admission-oracle-2209"
     },
     {
       "claim": "Semantic-cache admission can promote knowledge without a verification bundle.",
@@ -17677,7 +17685,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2209"
+      "id": "philosophy-admission-oracle-2210"
     },
     {
       "claim": "Semantic-cache admission can skip verification bundles.",
@@ -17685,7 +17693,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2210"
+      "id": "philosophy-admission-oracle-2211"
     },
     {
       "claim": "Semantic-cache admission can waive verification bundle requirements.",
@@ -17693,7 +17701,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2211"
+      "id": "philosophy-admission-oracle-2212"
     },
     {
       "claim": "Semantic-cache admission could omit the verification bundle.",
@@ -17701,7 +17709,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2212"
+      "id": "philosophy-admission-oracle-2213"
     },
     {
       "claim": "Semantic-cache admission could promote knowledge without a verification bundle.",
@@ -17709,7 +17717,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2213"
+      "id": "philosophy-admission-oracle-2214"
     },
     {
       "claim": "Semantic-cache admission could skip verification bundles.",
@@ -17717,7 +17725,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2214"
+      "id": "philosophy-admission-oracle-2215"
     },
     {
       "claim": "Semantic-cache admission could waive verification bundle requirements.",
@@ -17725,7 +17733,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2215"
+      "id": "philosophy-admission-oracle-2216"
     },
     {
       "claim": "Semantic-cache admission does not require a verification bundle.",
@@ -17733,7 +17741,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2216"
+      "id": "philosophy-admission-oracle-2217"
     },
     {
       "claim": "Semantic-cache admission has bypassed verification bundles.",
@@ -17741,7 +17749,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2217"
+      "id": "philosophy-admission-oracle-2218"
     },
     {
       "claim": "Semantic-cache admission has to omit the verification bundle.",
@@ -17749,7 +17757,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2218"
+      "id": "philosophy-admission-oracle-2219"
     },
     {
       "claim": "Semantic-cache admission has to promote knowledge without a verification bundle.",
@@ -17757,7 +17765,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2219"
+      "id": "philosophy-admission-oracle-2220"
     },
     {
       "claim": "Semantic-cache admission has to skip verification bundles.",
@@ -17765,7 +17773,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2220"
+      "id": "philosophy-admission-oracle-2221"
     },
     {
       "claim": "Semantic-cache admission has to waive verification bundle requirements.",
@@ -17773,7 +17781,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2221"
+      "id": "philosophy-admission-oracle-2222"
     },
     {
       "claim": "Semantic-cache admission is now waiving verification bundle requirements.",
@@ -17781,7 +17789,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2222"
+      "id": "philosophy-admission-oracle-2223"
     },
     {
       "claim": "Semantic-cache admission is required to omit the verification bundle.",
@@ -17789,7 +17797,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2223"
+      "id": "philosophy-admission-oracle-2224"
     },
     {
       "claim": "Semantic-cache admission is required to promote knowledge without a verification bundle.",
@@ -17797,7 +17805,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2224"
+      "id": "philosophy-admission-oracle-2225"
     },
     {
       "claim": "Semantic-cache admission is required to skip verification bundles.",
@@ -17805,7 +17813,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2225"
+      "id": "philosophy-admission-oracle-2226"
     },
     {
       "claim": "Semantic-cache admission is required to waive verification bundle requirements.",
@@ -17813,7 +17821,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2226"
+      "id": "philosophy-admission-oracle-2227"
     },
     {
       "claim": "Semantic-cache admission makes verification bundles optional.",
@@ -17821,7 +17829,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2227"
+      "id": "philosophy-admission-oracle-2228"
     },
     {
       "claim": "Semantic-cache admission may omit the verification bundle.",
@@ -17829,7 +17837,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2228"
+      "id": "philosophy-admission-oracle-2229"
     },
     {
       "claim": "Semantic-cache admission may promote knowledge without a verification bundle.",
@@ -17837,7 +17845,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2229"
+      "id": "philosophy-admission-oracle-2230"
     },
     {
       "claim": "Semantic-cache admission may skip verification bundles.",
@@ -17845,7 +17853,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2230"
+      "id": "philosophy-admission-oracle-2231"
     },
     {
       "claim": "Semantic-cache admission may waive verification bundle requirements.",
@@ -17853,7 +17861,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2231"
+      "id": "philosophy-admission-oracle-2232"
     },
     {
       "claim": "Semantic-cache admission might omit the verification bundle.",
@@ -17861,7 +17869,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2232"
+      "id": "philosophy-admission-oracle-2233"
     },
     {
       "claim": "Semantic-cache admission might promote knowledge without a verification bundle.",
@@ -17869,7 +17877,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2233"
+      "id": "philosophy-admission-oracle-2234"
     },
     {
       "claim": "Semantic-cache admission might skip verification bundles.",
@@ -17877,7 +17885,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2234"
+      "id": "philosophy-admission-oracle-2235"
     },
     {
       "claim": "Semantic-cache admission might waive verification bundle requirements.",
@@ -17885,7 +17893,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2235"
+      "id": "philosophy-admission-oracle-2236"
     },
     {
       "claim": "Semantic-cache admission must omit the verification bundle.",
@@ -17893,7 +17901,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2236"
+      "id": "philosophy-admission-oracle-2237"
     },
     {
       "claim": "Semantic-cache admission must promote knowledge without a verification bundle.",
@@ -17901,7 +17909,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2237"
+      "id": "philosophy-admission-oracle-2238"
     },
     {
       "claim": "Semantic-cache admission must skip verification bundles.",
@@ -17909,7 +17917,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2238"
+      "id": "philosophy-admission-oracle-2239"
     },
     {
       "claim": "Semantic-cache admission must waive verification bundle requirements.",
@@ -17917,7 +17925,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2239"
+      "id": "philosophy-admission-oracle-2240"
     },
     {
       "claim": "Semantic-cache admission promotes knowledge without a verification bundle.",
@@ -17925,7 +17933,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2240"
+      "id": "philosophy-admission-oracle-2241"
     },
     {
       "claim": "Semantic-cache admission remains optional for verification bundles.",
@@ -17933,7 +17941,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2241"
+      "id": "philosophy-admission-oracle-2242"
     },
     {
       "claim": "Semantic-cache admission should omit the verification bundle.",
@@ -17941,7 +17949,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2242"
+      "id": "philosophy-admission-oracle-2243"
     },
     {
       "claim": "Semantic-cache admission should promote knowledge without a verification bundle.",
@@ -17949,7 +17957,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2243"
+      "id": "philosophy-admission-oracle-2244"
     },
     {
       "claim": "Semantic-cache admission should skip verification bundles.",
@@ -17957,7 +17965,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2244"
+      "id": "philosophy-admission-oracle-2245"
     },
     {
       "claim": "Semantic-cache admission should waive verification bundle requirements.",
@@ -17965,7 +17973,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2245"
+      "id": "philosophy-admission-oracle-2246"
     },
     {
       "claim": "Semantic-cache admission waives verification bundle requirements.",
@@ -17973,7 +17981,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2246"
+      "id": "philosophy-admission-oracle-2247"
     },
     {
       "claim": "Semantic-cache admission will omit the verification bundle.",
@@ -17981,7 +17989,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2247"
+      "id": "philosophy-admission-oracle-2248"
     },
     {
       "claim": "Semantic-cache admission will promote knowledge without a verification bundle.",
@@ -17989,7 +17997,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2248"
+      "id": "philosophy-admission-oracle-2249"
     },
     {
       "claim": "Semantic-cache admission will skip verification bundles.",
@@ -17997,7 +18005,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2249"
+      "id": "philosophy-admission-oracle-2250"
     },
     {
       "claim": "Semantic-cache admission will waive verification bundle requirements.",
@@ -18005,7 +18013,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2250"
+      "id": "philosophy-admission-oracle-2251"
     },
     {
       "claim": "Semantic-cache admission would omit the verification bundle.",
@@ -18013,7 +18021,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2251"
+      "id": "philosophy-admission-oracle-2252"
     },
     {
       "claim": "Semantic-cache admission would promote knowledge without a verification bundle.",
@@ -18021,7 +18029,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2252"
+      "id": "philosophy-admission-oracle-2253"
     },
     {
       "claim": "Semantic-cache admission would skip verification bundles.",
@@ -18029,7 +18037,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2253"
+      "id": "philosophy-admission-oracle-2254"
     },
     {
       "claim": "Semantic-cache admission would waive verification bundle requirements.",
@@ -18037,7 +18045,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2254"
+      "id": "philosophy-admission-oracle-2255"
     },
     {
       "claim": "The admission policy became exempt from verification bundles.",
@@ -18045,7 +18053,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2255"
+      "id": "philosophy-admission-oracle-2256"
     },
     {
       "claim": "The admission policy bypasses verification bundles.",
@@ -18053,7 +18061,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2256"
+      "id": "philosophy-admission-oracle-2257"
     },
     {
       "claim": "The admission policy can omit the verification bundle.",
@@ -18061,7 +18069,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2257"
+      "id": "philosophy-admission-oracle-2258"
     },
     {
       "claim": "The admission policy can promote knowledge without a verification bundle.",
@@ -18069,7 +18077,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2258"
+      "id": "philosophy-admission-oracle-2259"
     },
     {
       "claim": "The admission policy can skip verification bundles.",
@@ -18077,7 +18085,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2259"
+      "id": "philosophy-admission-oracle-2260"
     },
     {
       "claim": "The admission policy can waive verification bundle requirements.",
@@ -18085,7 +18093,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2260"
+      "id": "philosophy-admission-oracle-2261"
     },
     {
       "claim": "The admission policy could omit the verification bundle.",
@@ -18093,7 +18101,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2261"
+      "id": "philosophy-admission-oracle-2262"
     },
     {
       "claim": "The admission policy could promote knowledge without a verification bundle.",
@@ -18101,7 +18109,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2262"
+      "id": "philosophy-admission-oracle-2263"
     },
     {
       "claim": "The admission policy could skip verification bundles.",
@@ -18109,7 +18117,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2263"
+      "id": "philosophy-admission-oracle-2264"
     },
     {
       "claim": "The admission policy could waive verification bundle requirements.",
@@ -18117,7 +18125,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2264"
+      "id": "philosophy-admission-oracle-2265"
     },
     {
       "claim": "The admission policy does not require a verification bundle.",
@@ -18125,7 +18133,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2265"
+      "id": "philosophy-admission-oracle-2266"
     },
     {
       "claim": "The admission policy has bypassed verification bundles.",
@@ -18133,7 +18141,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2266"
+      "id": "philosophy-admission-oracle-2267"
     },
     {
       "claim": "The admission policy has to omit the verification bundle.",
@@ -18141,7 +18149,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2267"
+      "id": "philosophy-admission-oracle-2268"
     },
     {
       "claim": "The admission policy has to promote knowledge without a verification bundle.",
@@ -18149,7 +18157,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2268"
+      "id": "philosophy-admission-oracle-2269"
     },
     {
       "claim": "The admission policy has to skip verification bundles.",
@@ -18157,7 +18165,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2269"
+      "id": "philosophy-admission-oracle-2270"
     },
     {
       "claim": "The admission policy has to waive verification bundle requirements.",
@@ -18165,7 +18173,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2270"
+      "id": "philosophy-admission-oracle-2271"
     },
     {
       "claim": "The admission policy is now waiving verification bundle requirements.",
@@ -18173,7 +18181,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2271"
+      "id": "philosophy-admission-oracle-2272"
     },
     {
       "claim": "The admission policy is required to omit the verification bundle.",
@@ -18181,7 +18189,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2272"
+      "id": "philosophy-admission-oracle-2273"
     },
     {
       "claim": "The admission policy is required to promote knowledge without a verification bundle.",
@@ -18189,7 +18197,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2273"
+      "id": "philosophy-admission-oracle-2274"
     },
     {
       "claim": "The admission policy is required to skip verification bundles.",
@@ -18197,7 +18205,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2274"
+      "id": "philosophy-admission-oracle-2275"
     },
     {
       "claim": "The admission policy is required to waive verification bundle requirements.",
@@ -18205,7 +18213,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2275"
+      "id": "philosophy-admission-oracle-2276"
     },
     {
       "claim": "The admission policy makes verification bundles optional.",
@@ -18213,7 +18221,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2276"
+      "id": "philosophy-admission-oracle-2277"
     },
     {
       "claim": "The admission policy may omit the verification bundle.",
@@ -18221,7 +18229,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2277"
+      "id": "philosophy-admission-oracle-2278"
     },
     {
       "claim": "The admission policy may promote knowledge without a verification bundle.",
@@ -18229,7 +18237,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2278"
+      "id": "philosophy-admission-oracle-2279"
     },
     {
       "claim": "The admission policy may skip verification bundles.",
@@ -18237,7 +18245,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2279"
+      "id": "philosophy-admission-oracle-2280"
     },
     {
       "claim": "The admission policy may waive verification bundle requirements.",
@@ -18245,7 +18253,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2280"
+      "id": "philosophy-admission-oracle-2281"
     },
     {
       "claim": "The admission policy might omit the verification bundle.",
@@ -18253,7 +18261,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2281"
+      "id": "philosophy-admission-oracle-2282"
     },
     {
       "claim": "The admission policy might promote knowledge without a verification bundle.",
@@ -18261,7 +18269,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2282"
+      "id": "philosophy-admission-oracle-2283"
     },
     {
       "claim": "The admission policy might skip verification bundles.",
@@ -18269,7 +18277,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2283"
+      "id": "philosophy-admission-oracle-2284"
     },
     {
       "claim": "The admission policy might waive verification bundle requirements.",
@@ -18277,7 +18285,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2284"
+      "id": "philosophy-admission-oracle-2285"
     },
     {
       "claim": "The admission policy must omit the verification bundle.",
@@ -18285,7 +18293,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2285"
+      "id": "philosophy-admission-oracle-2286"
     },
     {
       "claim": "The admission policy must promote knowledge without a verification bundle.",
@@ -18293,7 +18301,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2286"
+      "id": "philosophy-admission-oracle-2287"
     },
     {
       "claim": "The admission policy must skip verification bundles.",
@@ -18301,7 +18309,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2287"
+      "id": "philosophy-admission-oracle-2288"
     },
     {
       "claim": "The admission policy must waive verification bundle requirements.",
@@ -18309,7 +18317,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2288"
+      "id": "philosophy-admission-oracle-2289"
     },
     {
       "claim": "The admission policy promotes knowledge without a verification bundle.",
@@ -18317,7 +18325,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2289"
+      "id": "philosophy-admission-oracle-2290"
     },
     {
       "claim": "The admission policy remains optional for verification bundles.",
@@ -18325,7 +18333,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2290"
+      "id": "philosophy-admission-oracle-2291"
     },
     {
       "claim": "The admission policy should omit the verification bundle.",
@@ -18333,7 +18341,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2291"
+      "id": "philosophy-admission-oracle-2292"
     },
     {
       "claim": "The admission policy should promote knowledge without a verification bundle.",
@@ -18341,7 +18349,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2292"
+      "id": "philosophy-admission-oracle-2293"
     },
     {
       "claim": "The admission policy should skip verification bundles.",
@@ -18349,7 +18357,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2293"
+      "id": "philosophy-admission-oracle-2294"
     },
     {
       "claim": "The admission policy should waive verification bundle requirements.",
@@ -18357,7 +18365,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2294"
+      "id": "philosophy-admission-oracle-2295"
     },
     {
       "claim": "The admission policy waives verification bundle requirements.",
@@ -18365,7 +18373,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2295"
+      "id": "philosophy-admission-oracle-2296"
     },
     {
       "claim": "The admission policy will omit the verification bundle.",
@@ -18373,7 +18381,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2296"
+      "id": "philosophy-admission-oracle-2297"
     },
     {
       "claim": "The admission policy will promote knowledge without a verification bundle.",
@@ -18381,7 +18389,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2297"
+      "id": "philosophy-admission-oracle-2298"
     },
     {
       "claim": "The admission policy will skip verification bundles.",
@@ -18389,7 +18397,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2298"
+      "id": "philosophy-admission-oracle-2299"
     },
     {
       "claim": "The admission policy will waive verification bundle requirements.",
@@ -18397,7 +18405,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2299"
+      "id": "philosophy-admission-oracle-2300"
     },
     {
       "claim": "The admission policy would omit the verification bundle.",
@@ -18405,7 +18413,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2300"
+      "id": "philosophy-admission-oracle-2301"
     },
     {
       "claim": "The admission policy would promote knowledge without a verification bundle.",
@@ -18413,7 +18421,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2301"
+      "id": "philosophy-admission-oracle-2302"
     },
     {
       "claim": "The admission policy would skip verification bundles.",
@@ -18421,7 +18429,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2302"
+      "id": "philosophy-admission-oracle-2303"
     },
     {
       "claim": "The admission policy would waive verification bundle requirements.",
@@ -18429,7 +18437,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2303"
+      "id": "philosophy-admission-oracle-2304"
     },
     {
       "claim": "Verification bundle requirements remain optional for semantic-cache admission.",
@@ -18437,7 +18445,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-2304"
+      "id": "philosophy-admission-oracle-2305"
     }
   ]
 }

--- a/tests/fixtures/orchestration/philosophy_admission_claim_oracle.json
+++ b/tests/fixtures/orchestration/philosophy_admission_claim_oracle.json
@@ -9296,47 +9296,47 @@
       "id": "philosophy-admission-oracle-1161"
     },
     {
+      "claim": "PR-1 approves GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1162"
+    },
+    {
+      "claim": "PR-1 approves Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1163"
+    },
+    {
+      "claim": "PR-1 approves provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1164"
+    },
+    {
       "claim": "PR-1 became approved for GPTCache imports.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1162"
-    },
-    {
-      "claim": "PR-1 can enable provider-backed cache.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1163"
-    },
-    {
-      "claim": "PR-1 can open Redis connections.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1164"
-    },
-    {
-      "claim": "PR-1 can use GPTCache clients.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1165"
     },
     {
-      "claim": "PR-1 can use Redis clients.",
+      "claim": "PR-1 became approved for provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1166"
     },
     {
-      "claim": "PR-1 can wire embeddings.",
+      "claim": "PR-1 can approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9344,7 +9344,7 @@
       "id": "philosophy-admission-oracle-1167"
     },
     {
-      "claim": "PR-1 could enable provider-backed cache.",
+      "claim": "PR-1 can approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9352,7 +9352,7 @@
       "id": "philosophy-admission-oracle-1168"
     },
     {
-      "claim": "PR-1 could open Redis connections.",
+      "claim": "PR-1 can approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9360,7 +9360,7 @@
       "id": "philosophy-admission-oracle-1169"
     },
     {
-      "claim": "PR-1 could use GPTCache clients.",
+      "claim": "PR-1 can enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9368,7 +9368,7 @@
       "id": "philosophy-admission-oracle-1170"
     },
     {
-      "claim": "PR-1 could use Redis clients.",
+      "claim": "PR-1 can open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9376,7 +9376,7 @@
       "id": "philosophy-admission-oracle-1171"
     },
     {
-      "claim": "PR-1 could wire embeddings.",
+      "claim": "PR-1 can use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9384,23 +9384,23 @@
       "id": "philosophy-admission-oracle-1172"
     },
     {
-      "claim": "PR-1 enables embeddings for philosophy admission.",
+      "claim": "PR-1 can use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1173"
     },
     {
-      "claim": "PR-1 has been opening Redis connections.",
+      "claim": "PR-1 can wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1174"
     },
     {
-      "claim": "PR-1 has to enable provider-backed cache.",
+      "claim": "PR-1 could approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9408,7 +9408,7 @@
       "id": "philosophy-admission-oracle-1175"
     },
     {
-      "claim": "PR-1 has to open Redis connections.",
+      "claim": "PR-1 could approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9416,7 +9416,7 @@
       "id": "philosophy-admission-oracle-1176"
     },
     {
-      "claim": "PR-1 has to use GPTCache clients.",
+      "claim": "PR-1 could approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9424,7 +9424,7 @@
       "id": "philosophy-admission-oracle-1177"
     },
     {
-      "claim": "PR-1 has to use Redis clients.",
+      "claim": "PR-1 could enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9432,7 +9432,7 @@
       "id": "philosophy-admission-oracle-1178"
     },
     {
-      "claim": "PR-1 has to wire embeddings.",
+      "claim": "PR-1 could open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9440,15 +9440,15 @@
       "id": "philosophy-admission-oracle-1179"
     },
     {
-      "claim": "PR-1 has used Redis imports for philosophy admission.",
+      "claim": "PR-1 could use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1180"
     },
     {
-      "claim": "PR-1 is required to enable provider-backed cache.",
+      "claim": "PR-1 could use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9456,7 +9456,7 @@
       "id": "philosophy-admission-oracle-1181"
     },
     {
-      "claim": "PR-1 is required to open Redis connections.",
+      "claim": "PR-1 could wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9464,31 +9464,31 @@
       "id": "philosophy-admission-oracle-1182"
     },
     {
-      "claim": "PR-1 is required to use GPTCache clients.",
+      "claim": "PR-1 enables embeddings for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1183"
     },
     {
-      "claim": "PR-1 is required to use Redis clients.",
+      "claim": "PR-1 has approved Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1184"
     },
     {
-      "claim": "PR-1 is required to wire embeddings.",
+      "claim": "PR-1 has been opening Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1185"
     },
     {
-      "claim": "PR-1 may enable provider-backed cache.",
+      "claim": "PR-1 has to approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9496,7 +9496,7 @@
       "id": "philosophy-admission-oracle-1186"
     },
     {
-      "claim": "PR-1 may open Redis connections.",
+      "claim": "PR-1 has to approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9504,7 +9504,7 @@
       "id": "philosophy-admission-oracle-1187"
     },
     {
-      "claim": "PR-1 may use GPTCache clients.",
+      "claim": "PR-1 has to approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9512,7 +9512,7 @@
       "id": "philosophy-admission-oracle-1188"
     },
     {
-      "claim": "PR-1 may use Redis clients.",
+      "claim": "PR-1 has to enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9520,7 +9520,7 @@
       "id": "philosophy-admission-oracle-1189"
     },
     {
-      "claim": "PR-1 may wire embeddings.",
+      "claim": "PR-1 has to open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9528,7 +9528,7 @@
       "id": "philosophy-admission-oracle-1190"
     },
     {
-      "claim": "PR-1 might enable provider-backed cache.",
+      "claim": "PR-1 has to use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9536,7 +9536,7 @@
       "id": "philosophy-admission-oracle-1191"
     },
     {
-      "claim": "PR-1 might open Redis connections.",
+      "claim": "PR-1 has to use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9544,7 +9544,7 @@
       "id": "philosophy-admission-oracle-1192"
     },
     {
-      "claim": "PR-1 might use GPTCache clients.",
+      "claim": "PR-1 has to wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9552,15 +9552,15 @@
       "id": "philosophy-admission-oracle-1193"
     },
     {
-      "claim": "PR-1 might use Redis clients.",
+      "claim": "PR-1 has used Redis imports for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1194"
     },
     {
-      "claim": "PR-1 might wire embeddings.",
+      "claim": "PR-1 is required to approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9568,7 +9568,7 @@
       "id": "philosophy-admission-oracle-1195"
     },
     {
-      "claim": "PR-1 must enable provider-backed cache.",
+      "claim": "PR-1 is required to approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9576,7 +9576,7 @@
       "id": "philosophy-admission-oracle-1196"
     },
     {
-      "claim": "PR-1 must open Redis connections.",
+      "claim": "PR-1 is required to approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9584,7 +9584,7 @@
       "id": "philosophy-admission-oracle-1197"
     },
     {
-      "claim": "PR-1 must use GPTCache clients.",
+      "claim": "PR-1 is required to enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9592,7 +9592,7 @@
       "id": "philosophy-admission-oracle-1198"
     },
     {
-      "claim": "PR-1 must use Redis clients.",
+      "claim": "PR-1 is required to open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9600,7 +9600,7 @@
       "id": "philosophy-admission-oracle-1199"
     },
     {
-      "claim": "PR-1 must wire embeddings.",
+      "claim": "PR-1 is required to use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9608,15 +9608,15 @@
       "id": "philosophy-admission-oracle-1200"
     },
     {
-      "claim": "PR-1 opens Redis connection strings.",
+      "claim": "PR-1 is required to use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1201"
     },
     {
-      "claim": "PR-1 should enable provider-backed cache.",
+      "claim": "PR-1 is required to wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9624,7 +9624,7 @@
       "id": "philosophy-admission-oracle-1202"
     },
     {
-      "claim": "PR-1 should open Redis connections.",
+      "claim": "PR-1 may approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9632,7 +9632,7 @@
       "id": "philosophy-admission-oracle-1203"
     },
     {
-      "claim": "PR-1 should use GPTCache clients.",
+      "claim": "PR-1 may approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9640,7 +9640,7 @@
       "id": "philosophy-admission-oracle-1204"
     },
     {
-      "claim": "PR-1 should use Redis clients.",
+      "claim": "PR-1 may approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9648,7 +9648,7 @@
       "id": "philosophy-admission-oracle-1205"
     },
     {
-      "claim": "PR-1 should wire embeddings.",
+      "claim": "PR-1 may enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9656,15 +9656,15 @@
       "id": "philosophy-admission-oracle-1206"
     },
     {
-      "claim": "PR-1 still allows embeddings.",
+      "claim": "PR-1 may open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1207"
     },
     {
-      "claim": "PR-1 will enable provider-backed cache.",
+      "claim": "PR-1 may use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9672,7 +9672,7 @@
       "id": "philosophy-admission-oracle-1208"
     },
     {
-      "claim": "PR-1 will open Redis connections.",
+      "claim": "PR-1 may use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9680,7 +9680,7 @@
       "id": "philosophy-admission-oracle-1209"
     },
     {
-      "claim": "PR-1 will use GPTCache clients.",
+      "claim": "PR-1 may wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9688,7 +9688,7 @@
       "id": "philosophy-admission-oracle-1210"
     },
     {
-      "claim": "PR-1 will use Redis clients.",
+      "claim": "PR-1 might approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9696,15 +9696,15 @@
       "id": "philosophy-admission-oracle-1211"
     },
     {
-      "claim": "PR-1 will wire /insight cache behavior.",
+      "claim": "PR-1 might approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1212"
     },
     {
-      "claim": "PR-1 will wire embeddings.",
+      "claim": "PR-1 might approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9712,15 +9712,15 @@
       "id": "philosophy-admission-oracle-1213"
     },
     {
-      "claim": "PR-1 wires /insight cache behavior.",
+      "claim": "PR-1 might enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1214"
     },
     {
-      "claim": "PR-1 would enable provider-backed cache.",
+      "claim": "PR-1 might open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9728,7 +9728,7 @@
       "id": "philosophy-admission-oracle-1215"
     },
     {
-      "claim": "PR-1 would open Redis connections.",
+      "claim": "PR-1 might use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9736,7 +9736,7 @@
       "id": "philosophy-admission-oracle-1216"
     },
     {
-      "claim": "PR-1 would use GPTCache clients.",
+      "claim": "PR-1 might use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9744,7 +9744,7 @@
       "id": "philosophy-admission-oracle-1217"
     },
     {
-      "claim": "PR-1 would use Redis clients.",
+      "claim": "PR-1 might wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9752,7 +9752,7 @@
       "id": "philosophy-admission-oracle-1218"
     },
     {
-      "claim": "PR-1 would wire embeddings.",
+      "claim": "PR-1 must approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9760,31 +9760,31 @@
       "id": "philosophy-admission-oracle-1219"
     },
     {
-      "claim": "PR-2 allows GPTCache imports.",
+      "claim": "PR-1 must approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1220"
     },
     {
-      "claim": "PR-2 allows Redis imports.",
+      "claim": "PR-1 must approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1221"
     },
     {
-      "claim": "PR-2 became approved for GPTCache imports.",
+      "claim": "PR-1 must enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1222"
     },
     {
-      "claim": "PR-2 can enable provider-backed cache.",
+      "claim": "PR-1 must open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9792,7 +9792,7 @@
       "id": "philosophy-admission-oracle-1223"
     },
     {
-      "claim": "PR-2 can open Redis connections.",
+      "claim": "PR-1 must use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9800,7 +9800,7 @@
       "id": "philosophy-admission-oracle-1224"
     },
     {
-      "claim": "PR-2 can use GPTCache clients.",
+      "claim": "PR-1 must use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9808,7 +9808,7 @@
       "id": "philosophy-admission-oracle-1225"
     },
     {
-      "claim": "PR-2 can use Redis clients.",
+      "claim": "PR-1 must wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9816,15 +9816,15 @@
       "id": "philosophy-admission-oracle-1226"
     },
     {
-      "claim": "PR-2 can wire embeddings.",
+      "claim": "PR-1 opens Redis connection strings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1227"
     },
     {
-      "claim": "PR-2 could enable provider-backed cache.",
+      "claim": "PR-1 should approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9832,7 +9832,7 @@
       "id": "philosophy-admission-oracle-1228"
     },
     {
-      "claim": "PR-2 could open Redis connections.",
+      "claim": "PR-1 should approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9840,7 +9840,7 @@
       "id": "philosophy-admission-oracle-1229"
     },
     {
-      "claim": "PR-2 could use GPTCache clients.",
+      "claim": "PR-1 should approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9848,7 +9848,7 @@
       "id": "philosophy-admission-oracle-1230"
     },
     {
-      "claim": "PR-2 could use Redis clients.",
+      "claim": "PR-1 should enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9856,7 +9856,7 @@
       "id": "philosophy-admission-oracle-1231"
     },
     {
-      "claim": "PR-2 could wire embeddings.",
+      "claim": "PR-1 should open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9864,39 +9864,39 @@
       "id": "philosophy-admission-oracle-1232"
     },
     {
-      "claim": "PR-2 enables embeddings for philosophy admission.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1233"
-    },
-    {
-      "claim": "PR-2 has GPTCache import for philosophy admission.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-1234"
-    },
-    {
-      "claim": "PR-2 has been opening Redis connections.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1235"
-    },
-    {
-      "claim": "PR-2 has to enable provider-backed cache.",
+      "claim": "PR-1 should use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1233"
+    },
+    {
+      "claim": "PR-1 should use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1234"
+    },
+    {
+      "claim": "PR-1 should wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1235"
+    },
+    {
+      "claim": "PR-1 still allows embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1236"
     },
     {
-      "claim": "PR-2 has to open Redis connections.",
+      "claim": "PR-1 will approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9904,7 +9904,7 @@
       "id": "philosophy-admission-oracle-1237"
     },
     {
-      "claim": "PR-2 has to use GPTCache clients.",
+      "claim": "PR-1 will approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9912,7 +9912,7 @@
       "id": "philosophy-admission-oracle-1238"
     },
     {
-      "claim": "PR-2 has to use Redis clients.",
+      "claim": "PR-1 will approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9920,7 +9920,7 @@
       "id": "philosophy-admission-oracle-1239"
     },
     {
-      "claim": "PR-2 has to wire embeddings.",
+      "claim": "PR-1 will enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9928,15 +9928,15 @@
       "id": "philosophy-admission-oracle-1240"
     },
     {
-      "claim": "PR-2 has used Redis imports for philosophy admission.",
+      "claim": "PR-1 will open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1241"
     },
     {
-      "claim": "PR-2 is required to enable provider-backed cache.",
+      "claim": "PR-1 will use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9944,7 +9944,7 @@
       "id": "philosophy-admission-oracle-1242"
     },
     {
-      "claim": "PR-2 is required to open Redis connections.",
+      "claim": "PR-1 will use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9952,15 +9952,15 @@
       "id": "philosophy-admission-oracle-1243"
     },
     {
-      "claim": "PR-2 is required to use GPTCache clients.",
+      "claim": "PR-1 will wire /insight cache behavior.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1244"
     },
     {
-      "claim": "PR-2 is required to use Redis clients.",
+      "claim": "PR-1 will wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9968,15 +9968,15 @@
       "id": "philosophy-admission-oracle-1245"
     },
     {
-      "claim": "PR-2 is required to wire embeddings.",
+      "claim": "PR-1 wires /insight cache behavior.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1246"
     },
     {
-      "claim": "PR-2 may enable provider-backed cache.",
+      "claim": "PR-1 would approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9984,7 +9984,7 @@
       "id": "philosophy-admission-oracle-1247"
     },
     {
-      "claim": "PR-2 may open Redis connections.",
+      "claim": "PR-1 would approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -9992,7 +9992,7 @@
       "id": "philosophy-admission-oracle-1248"
     },
     {
-      "claim": "PR-2 may use GPTCache clients.",
+      "claim": "PR-1 would approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10000,7 +10000,7 @@
       "id": "philosophy-admission-oracle-1249"
     },
     {
-      "claim": "PR-2 may use Redis clients.",
+      "claim": "PR-1 would enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10008,7 +10008,7 @@
       "id": "philosophy-admission-oracle-1250"
     },
     {
-      "claim": "PR-2 may wire embeddings.",
+      "claim": "PR-1 would open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10016,7 +10016,7 @@
       "id": "philosophy-admission-oracle-1251"
     },
     {
-      "claim": "PR-2 might enable provider-backed cache.",
+      "claim": "PR-1 would use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10024,7 +10024,7 @@
       "id": "philosophy-admission-oracle-1252"
     },
     {
-      "claim": "PR-2 might open Redis connections.",
+      "claim": "PR-1 would use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10032,7 +10032,7 @@
       "id": "philosophy-admission-oracle-1253"
     },
     {
-      "claim": "PR-2 might use GPTCache clients.",
+      "claim": "PR-1 would wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10040,71 +10040,71 @@
       "id": "philosophy-admission-oracle-1254"
     },
     {
-      "claim": "PR-2 might use Redis clients.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1255"
-    },
-    {
-      "claim": "PR-2 might wire embeddings.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1256"
-    },
-    {
-      "claim": "PR-2 must enable provider-backed cache.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1257"
-    },
-    {
-      "claim": "PR-2 must open Redis connections.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1258"
-    },
-    {
-      "claim": "PR-2 must use GPTCache clients.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1259"
-    },
-    {
-      "claim": "PR-2 must use Redis clients.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1260"
-    },
-    {
-      "claim": "PR-2 must wire embeddings.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1261"
-    },
-    {
-      "claim": "PR-2 opens Redis connection strings.",
+      "claim": "PR-2 allows GPTCache imports.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1255"
+    },
+    {
+      "claim": "PR-2 allows Redis imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1256"
+    },
+    {
+      "claim": "PR-2 approves GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1257"
+    },
+    {
+      "claim": "PR-2 approves Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1258"
+    },
+    {
+      "claim": "PR-2 approves provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1259"
+    },
+    {
+      "claim": "PR-2 became approved for GPTCache imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1260"
+    },
+    {
+      "claim": "PR-2 became approved for provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1261"
+    },
+    {
+      "claim": "PR-2 can approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1262"
     },
     {
-      "claim": "PR-2 should enable provider-backed cache.",
+      "claim": "PR-2 can approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10112,7 +10112,7 @@
       "id": "philosophy-admission-oracle-1263"
     },
     {
-      "claim": "PR-2 should open Redis connections.",
+      "claim": "PR-2 can approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10120,7 +10120,7 @@
       "id": "philosophy-admission-oracle-1264"
     },
     {
-      "claim": "PR-2 should use GPTCache clients.",
+      "claim": "PR-2 can enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10128,7 +10128,7 @@
       "id": "philosophy-admission-oracle-1265"
     },
     {
-      "claim": "PR-2 should use Redis clients.",
+      "claim": "PR-2 can open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10136,7 +10136,7 @@
       "id": "philosophy-admission-oracle-1266"
     },
     {
-      "claim": "PR-2 should wire embeddings.",
+      "claim": "PR-2 can use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10144,15 +10144,15 @@
       "id": "philosophy-admission-oracle-1267"
     },
     {
-      "claim": "PR-2 still allows embeddings.",
+      "claim": "PR-2 can use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1268"
     },
     {
-      "claim": "PR-2 will enable provider-backed cache.",
+      "claim": "PR-2 can wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10160,7 +10160,7 @@
       "id": "philosophy-admission-oracle-1269"
     },
     {
-      "claim": "PR-2 will open Redis connections.",
+      "claim": "PR-2 could approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10168,7 +10168,7 @@
       "id": "philosophy-admission-oracle-1270"
     },
     {
-      "claim": "PR-2 will use GPTCache clients.",
+      "claim": "PR-2 could approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10176,7 +10176,7 @@
       "id": "philosophy-admission-oracle-1271"
     },
     {
-      "claim": "PR-2 will use Redis clients.",
+      "claim": "PR-2 could approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10184,15 +10184,15 @@
       "id": "philosophy-admission-oracle-1272"
     },
     {
-      "claim": "PR-2 will wire /insight cache behavior.",
+      "claim": "PR-2 could enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1273"
     },
     {
-      "claim": "PR-2 will wire embeddings.",
+      "claim": "PR-2 could open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10200,15 +10200,15 @@
       "id": "philosophy-admission-oracle-1274"
     },
     {
-      "claim": "PR-2 wires /insight cache behavior.",
+      "claim": "PR-2 could use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1275"
     },
     {
-      "claim": "PR-2 would enable provider-backed cache.",
+      "claim": "PR-2 could use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10216,7 +10216,7 @@
       "id": "philosophy-admission-oracle-1276"
     },
     {
-      "claim": "PR-2 would open Redis connections.",
+      "claim": "PR-2 could wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10224,55 +10224,55 @@
       "id": "philosophy-admission-oracle-1277"
     },
     {
-      "claim": "PR-2 would use GPTCache clients.",
+      "claim": "PR-2 enables embeddings for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1278"
     },
     {
-      "claim": "PR-2 would use Redis clients.",
+      "claim": "PR-2 has GPTCache import for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.seed_regressions",
       "id": "philosophy-admission-oracle-1279"
     },
     {
-      "claim": "PR-2 would wire embeddings.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1280"
-    },
-    {
-      "claim": "Philosophy admission allows GPTCache imports.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1281"
-    },
-    {
-      "claim": "Philosophy admission allows Redis imports.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1282"
-    },
-    {
-      "claim": "Philosophy admission became approved for GPTCache imports.",
+      "claim": "PR-2 has approved Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1280"
+    },
+    {
+      "claim": "PR-2 has been opening Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1281"
+    },
+    {
+      "claim": "PR-2 has to approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1282"
+    },
+    {
+      "claim": "PR-2 has to approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1283"
     },
     {
-      "claim": "Philosophy admission can enable provider-backed cache.",
+      "claim": "PR-2 has to approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10280,7 +10280,7 @@
       "id": "philosophy-admission-oracle-1284"
     },
     {
-      "claim": "Philosophy admission can open Redis connections.",
+      "claim": "PR-2 has to enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10288,7 +10288,7 @@
       "id": "philosophy-admission-oracle-1285"
     },
     {
-      "claim": "Philosophy admission can use GPTCache clients.",
+      "claim": "PR-2 has to open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10296,7 +10296,7 @@
       "id": "philosophy-admission-oracle-1286"
     },
     {
-      "claim": "Philosophy admission can use Redis clients.",
+      "claim": "PR-2 has to use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10304,7 +10304,7 @@
       "id": "philosophy-admission-oracle-1287"
     },
     {
-      "claim": "Philosophy admission can wire embeddings.",
+      "claim": "PR-2 has to use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10312,7 +10312,7 @@
       "id": "philosophy-admission-oracle-1288"
     },
     {
-      "claim": "Philosophy admission could enable provider-backed cache.",
+      "claim": "PR-2 has to wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10320,15 +10320,15 @@
       "id": "philosophy-admission-oracle-1289"
     },
     {
-      "claim": "Philosophy admission could open Redis connections.",
+      "claim": "PR-2 has used Redis imports for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1290"
     },
     {
-      "claim": "Philosophy admission could use GPTCache clients.",
+      "claim": "PR-2 is required to approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10336,7 +10336,7 @@
       "id": "philosophy-admission-oracle-1291"
     },
     {
-      "claim": "Philosophy admission could use Redis clients.",
+      "claim": "PR-2 is required to approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10344,7 +10344,7 @@
       "id": "philosophy-admission-oracle-1292"
     },
     {
-      "claim": "Philosophy admission could wire embeddings.",
+      "claim": "PR-2 is required to approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10352,31 +10352,31 @@
       "id": "philosophy-admission-oracle-1293"
     },
     {
-      "claim": "Philosophy admission enables embeddings for philosophy admission.",
+      "claim": "PR-2 is required to enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1294"
     },
     {
-      "claim": "Philosophy admission has been opening Redis connections.",
+      "claim": "PR-2 is required to open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1295"
     },
     {
-      "claim": "Philosophy admission has been required to enable Redis cache I/O.",
+      "claim": "PR-2 is required to use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.seed_regressions",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1296"
     },
     {
-      "claim": "Philosophy admission has to enable provider-backed cache.",
+      "claim": "PR-2 is required to use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10384,7 +10384,7 @@
       "id": "philosophy-admission-oracle-1297"
     },
     {
-      "claim": "Philosophy admission has to open Redis connections.",
+      "claim": "PR-2 is required to wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10392,7 +10392,7 @@
       "id": "philosophy-admission-oracle-1298"
     },
     {
-      "claim": "Philosophy admission has to use GPTCache clients.",
+      "claim": "PR-2 may approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10400,7 +10400,7 @@
       "id": "philosophy-admission-oracle-1299"
     },
     {
-      "claim": "Philosophy admission has to use Redis clients.",
+      "claim": "PR-2 may approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10408,7 +10408,7 @@
       "id": "philosophy-admission-oracle-1300"
     },
     {
-      "claim": "Philosophy admission has to wire embeddings.",
+      "claim": "PR-2 may approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10416,15 +10416,15 @@
       "id": "philosophy-admission-oracle-1301"
     },
     {
-      "claim": "Philosophy admission has used Redis imports for philosophy admission.",
+      "claim": "PR-2 may enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1302"
     },
     {
-      "claim": "Philosophy admission is required to enable provider-backed cache.",
+      "claim": "PR-2 may open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10432,7 +10432,7 @@
       "id": "philosophy-admission-oracle-1303"
     },
     {
-      "claim": "Philosophy admission is required to open Redis connections.",
+      "claim": "PR-2 may use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10440,7 +10440,7 @@
       "id": "philosophy-admission-oracle-1304"
     },
     {
-      "claim": "Philosophy admission is required to use GPTCache clients.",
+      "claim": "PR-2 may use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10448,7 +10448,7 @@
       "id": "philosophy-admission-oracle-1305"
     },
     {
-      "claim": "Philosophy admission is required to use Redis clients.",
+      "claim": "PR-2 may wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10456,7 +10456,7 @@
       "id": "philosophy-admission-oracle-1306"
     },
     {
-      "claim": "Philosophy admission is required to wire embeddings.",
+      "claim": "PR-2 might approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10464,7 +10464,7 @@
       "id": "philosophy-admission-oracle-1307"
     },
     {
-      "claim": "Philosophy admission may enable provider-backed cache.",
+      "claim": "PR-2 might approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10472,7 +10472,7 @@
       "id": "philosophy-admission-oracle-1308"
     },
     {
-      "claim": "Philosophy admission may open Redis connections.",
+      "claim": "PR-2 might approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10480,7 +10480,7 @@
       "id": "philosophy-admission-oracle-1309"
     },
     {
-      "claim": "Philosophy admission may use GPTCache clients.",
+      "claim": "PR-2 might enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10488,7 +10488,7 @@
       "id": "philosophy-admission-oracle-1310"
     },
     {
-      "claim": "Philosophy admission may use Redis clients.",
+      "claim": "PR-2 might open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10496,7 +10496,7 @@
       "id": "philosophy-admission-oracle-1311"
     },
     {
-      "claim": "Philosophy admission may wire embeddings.",
+      "claim": "PR-2 might use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10504,7 +10504,7 @@
       "id": "philosophy-admission-oracle-1312"
     },
     {
-      "claim": "Philosophy admission might enable provider-backed cache.",
+      "claim": "PR-2 might use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10512,7 +10512,7 @@
       "id": "philosophy-admission-oracle-1313"
     },
     {
-      "claim": "Philosophy admission might open Redis connections.",
+      "claim": "PR-2 might wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10520,7 +10520,7 @@
       "id": "philosophy-admission-oracle-1314"
     },
     {
-      "claim": "Philosophy admission might use GPTCache clients.",
+      "claim": "PR-2 must approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10528,7 +10528,7 @@
       "id": "philosophy-admission-oracle-1315"
     },
     {
-      "claim": "Philosophy admission might use Redis clients.",
+      "claim": "PR-2 must approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10536,7 +10536,7 @@
       "id": "philosophy-admission-oracle-1316"
     },
     {
-      "claim": "Philosophy admission might wire embeddings.",
+      "claim": "PR-2 must approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10544,7 +10544,7 @@
       "id": "philosophy-admission-oracle-1317"
     },
     {
-      "claim": "Philosophy admission must enable provider-backed cache.",
+      "claim": "PR-2 must enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10552,7 +10552,7 @@
       "id": "philosophy-admission-oracle-1318"
     },
     {
-      "claim": "Philosophy admission must open Redis connections.",
+      "claim": "PR-2 must open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10560,7 +10560,7 @@
       "id": "philosophy-admission-oracle-1319"
     },
     {
-      "claim": "Philosophy admission must use GPTCache clients.",
+      "claim": "PR-2 must use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10568,7 +10568,7 @@
       "id": "philosophy-admission-oracle-1320"
     },
     {
-      "claim": "Philosophy admission must use Redis clients.",
+      "claim": "PR-2 must use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10576,7 +10576,7 @@
       "id": "philosophy-admission-oracle-1321"
     },
     {
-      "claim": "Philosophy admission must wire embeddings.",
+      "claim": "PR-2 must wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10584,7 +10584,7 @@
       "id": "philosophy-admission-oracle-1322"
     },
     {
-      "claim": "Philosophy admission opens Redis connection strings.",
+      "claim": "PR-2 opens Redis connection strings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10592,7 +10592,7 @@
       "id": "philosophy-admission-oracle-1323"
     },
     {
-      "claim": "Philosophy admission should enable provider-backed cache.",
+      "claim": "PR-2 should approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10600,7 +10600,7 @@
       "id": "philosophy-admission-oracle-1324"
     },
     {
-      "claim": "Philosophy admission should open Redis connections.",
+      "claim": "PR-2 should approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10608,7 +10608,7 @@
       "id": "philosophy-admission-oracle-1325"
     },
     {
-      "claim": "Philosophy admission should use GPTCache clients.",
+      "claim": "PR-2 should approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10616,7 +10616,7 @@
       "id": "philosophy-admission-oracle-1326"
     },
     {
-      "claim": "Philosophy admission should use Redis clients.",
+      "claim": "PR-2 should enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10624,7 +10624,7 @@
       "id": "philosophy-admission-oracle-1327"
     },
     {
-      "claim": "Philosophy admission should wire embeddings.",
+      "claim": "PR-2 should open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10632,15 +10632,15 @@
       "id": "philosophy-admission-oracle-1328"
     },
     {
-      "claim": "Philosophy admission still allows embeddings.",
+      "claim": "PR-2 should use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1329"
     },
     {
-      "claim": "Philosophy admission will enable provider-backed cache.",
+      "claim": "PR-2 should use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10648,7 +10648,7 @@
       "id": "philosophy-admission-oracle-1330"
     },
     {
-      "claim": "Philosophy admission will open Redis connections.",
+      "claim": "PR-2 should wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10656,15 +10656,15 @@
       "id": "philosophy-admission-oracle-1331"
     },
     {
-      "claim": "Philosophy admission will use GPTCache clients.",
+      "claim": "PR-2 still allows embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1332"
     },
     {
-      "claim": "Philosophy admission will use Redis clients.",
+      "claim": "PR-2 will approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10672,15 +10672,15 @@
       "id": "philosophy-admission-oracle-1333"
     },
     {
-      "claim": "Philosophy admission will wire /insight cache behavior.",
+      "claim": "PR-2 will approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1334"
     },
     {
-      "claim": "Philosophy admission will wire embeddings.",
+      "claim": "PR-2 will approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10688,15 +10688,15 @@
       "id": "philosophy-admission-oracle-1335"
     },
     {
-      "claim": "Philosophy admission wires /insight cache behavior.",
+      "claim": "PR-2 will enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1336"
     },
     {
-      "claim": "Philosophy admission would enable provider-backed cache.",
+      "claim": "PR-2 will open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10704,7 +10704,7 @@
       "id": "philosophy-admission-oracle-1337"
     },
     {
-      "claim": "Philosophy admission would open Redis connections.",
+      "claim": "PR-2 will use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10712,7 +10712,7 @@
       "id": "philosophy-admission-oracle-1338"
     },
     {
-      "claim": "Philosophy admission would use GPTCache clients.",
+      "claim": "PR-2 will use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10720,15 +10720,15 @@
       "id": "philosophy-admission-oracle-1339"
     },
     {
-      "claim": "Philosophy admission would use Redis clients.",
+      "claim": "PR-2 will wire /insight cache behavior.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1340"
     },
     {
-      "claim": "Philosophy admission would wire embeddings.",
+      "claim": "PR-2 will wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10736,7 +10736,7 @@
       "id": "philosophy-admission-oracle-1341"
     },
     {
-      "claim": "The admission policy allows GPTCache imports.",
+      "claim": "PR-2 wires /insight cache behavior.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10744,23 +10744,23 @@
       "id": "philosophy-admission-oracle-1342"
     },
     {
-      "claim": "The admission policy allows Redis imports.",
+      "claim": "PR-2 would approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1343"
     },
     {
-      "claim": "The admission policy became approved for GPTCache imports.",
+      "claim": "PR-2 would approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1344"
     },
     {
-      "claim": "The admission policy can enable provider-backed cache.",
+      "claim": "PR-2 would approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10768,7 +10768,7 @@
       "id": "philosophy-admission-oracle-1345"
     },
     {
-      "claim": "The admission policy can open Redis connections.",
+      "claim": "PR-2 would enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10776,7 +10776,7 @@
       "id": "philosophy-admission-oracle-1346"
     },
     {
-      "claim": "The admission policy can use GPTCache clients.",
+      "claim": "PR-2 would open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10784,7 +10784,7 @@
       "id": "philosophy-admission-oracle-1347"
     },
     {
-      "claim": "The admission policy can use Redis clients.",
+      "claim": "PR-2 would use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10792,7 +10792,7 @@
       "id": "philosophy-admission-oracle-1348"
     },
     {
-      "claim": "The admission policy can wire embeddings.",
+      "claim": "PR-2 would use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10800,7 +10800,7 @@
       "id": "philosophy-admission-oracle-1349"
     },
     {
-      "claim": "The admission policy could enable provider-backed cache.",
+      "claim": "PR-2 would wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10808,39 +10808,39 @@
       "id": "philosophy-admission-oracle-1350"
     },
     {
-      "claim": "The admission policy could open Redis connections.",
+      "claim": "Philosophy admission allows GPTCache imports.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1351"
     },
     {
-      "claim": "The admission policy could use GPTCache clients.",
+      "claim": "Philosophy admission allows Redis imports.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1352"
     },
     {
-      "claim": "The admission policy could use Redis clients.",
+      "claim": "Philosophy admission approves GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1353"
     },
     {
-      "claim": "The admission policy could wire embeddings.",
+      "claim": "Philosophy admission approves Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1354"
     },
     {
-      "claim": "The admission policy enables embeddings for philosophy admission.",
+      "claim": "Philosophy admission approves provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10848,7 +10848,7 @@
       "id": "philosophy-admission-oracle-1355"
     },
     {
-      "claim": "The admission policy has been opening Redis connections.",
+      "claim": "Philosophy admission became approved for GPTCache imports.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10856,15 +10856,15 @@
       "id": "philosophy-admission-oracle-1356"
     },
     {
-      "claim": "The admission policy has to enable provider-backed cache.",
+      "claim": "Philosophy admission became approved for provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1357"
     },
     {
-      "claim": "The admission policy has to open Redis connections.",
+      "claim": "Philosophy admission can approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10872,7 +10872,7 @@
       "id": "philosophy-admission-oracle-1358"
     },
     {
-      "claim": "The admission policy has to use GPTCache clients.",
+      "claim": "Philosophy admission can approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10880,7 +10880,7 @@
       "id": "philosophy-admission-oracle-1359"
     },
     {
-      "claim": "The admission policy has to use Redis clients.",
+      "claim": "Philosophy admission can approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10888,7 +10888,7 @@
       "id": "philosophy-admission-oracle-1360"
     },
     {
-      "claim": "The admission policy has to wire embeddings.",
+      "claim": "Philosophy admission can enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10896,15 +10896,15 @@
       "id": "philosophy-admission-oracle-1361"
     },
     {
-      "claim": "The admission policy has used Redis imports for philosophy admission.",
+      "claim": "Philosophy admission can open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1362"
     },
     {
-      "claim": "The admission policy is required to enable provider-backed cache.",
+      "claim": "Philosophy admission can use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10912,7 +10912,7 @@
       "id": "philosophy-admission-oracle-1363"
     },
     {
-      "claim": "The admission policy is required to open Redis connections.",
+      "claim": "Philosophy admission can use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10920,7 +10920,7 @@
       "id": "philosophy-admission-oracle-1364"
     },
     {
-      "claim": "The admission policy is required to use GPTCache clients.",
+      "claim": "Philosophy admission can wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10928,7 +10928,7 @@
       "id": "philosophy-admission-oracle-1365"
     },
     {
-      "claim": "The admission policy is required to use Redis clients.",
+      "claim": "Philosophy admission could approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10936,7 +10936,7 @@
       "id": "philosophy-admission-oracle-1366"
     },
     {
-      "claim": "The admission policy is required to wire embeddings.",
+      "claim": "Philosophy admission could approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10944,7 +10944,7 @@
       "id": "philosophy-admission-oracle-1367"
     },
     {
-      "claim": "The admission policy may enable provider-backed cache.",
+      "claim": "Philosophy admission could approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10952,7 +10952,7 @@
       "id": "philosophy-admission-oracle-1368"
     },
     {
-      "claim": "The admission policy may open Redis connections.",
+      "claim": "Philosophy admission could enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10960,7 +10960,7 @@
       "id": "philosophy-admission-oracle-1369"
     },
     {
-      "claim": "The admission policy may use GPTCache clients.",
+      "claim": "Philosophy admission could open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10968,7 +10968,7 @@
       "id": "philosophy-admission-oracle-1370"
     },
     {
-      "claim": "The admission policy may use Redis clients.",
+      "claim": "Philosophy admission could use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10976,7 +10976,7 @@
       "id": "philosophy-admission-oracle-1371"
     },
     {
-      "claim": "The admission policy may wire embeddings.",
+      "claim": "Philosophy admission could use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10984,7 +10984,7 @@
       "id": "philosophy-admission-oracle-1372"
     },
     {
-      "claim": "The admission policy might enable provider-backed cache.",
+      "claim": "Philosophy admission could wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -10992,39 +10992,39 @@
       "id": "philosophy-admission-oracle-1373"
     },
     {
-      "claim": "The admission policy might open Redis connections.",
+      "claim": "Philosophy admission enables embeddings for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1374"
     },
     {
-      "claim": "The admission policy might use GPTCache clients.",
+      "claim": "Philosophy admission has approved Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1375"
     },
     {
-      "claim": "The admission policy might use Redis clients.",
+      "claim": "Philosophy admission has been opening Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1376"
     },
     {
-      "claim": "The admission policy might wire embeddings.",
+      "claim": "Philosophy admission has been required to enable Redis cache I/O.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.seed_regressions",
       "id": "philosophy-admission-oracle-1377"
     },
     {
-      "claim": "The admission policy must enable provider-backed cache.",
+      "claim": "Philosophy admission has to approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11032,7 +11032,7 @@
       "id": "philosophy-admission-oracle-1378"
     },
     {
-      "claim": "The admission policy must open Redis connections.",
+      "claim": "Philosophy admission has to approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11040,7 +11040,7 @@
       "id": "philosophy-admission-oracle-1379"
     },
     {
-      "claim": "The admission policy must use GPTCache clients.",
+      "claim": "Philosophy admission has to approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11048,7 +11048,7 @@
       "id": "philosophy-admission-oracle-1380"
     },
     {
-      "claim": "The admission policy must use Redis clients.",
+      "claim": "Philosophy admission has to enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11056,7 +11056,7 @@
       "id": "philosophy-admission-oracle-1381"
     },
     {
-      "claim": "The admission policy must wire embeddings.",
+      "claim": "Philosophy admission has to open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11064,15 +11064,15 @@
       "id": "philosophy-admission-oracle-1382"
     },
     {
-      "claim": "The admission policy opens Redis connection strings.",
+      "claim": "Philosophy admission has to use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1383"
     },
     {
-      "claim": "The admission policy should enable provider-backed cache.",
+      "claim": "Philosophy admission has to use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11080,7 +11080,7 @@
       "id": "philosophy-admission-oracle-1384"
     },
     {
-      "claim": "The admission policy should open Redis connections.",
+      "claim": "Philosophy admission has to wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11088,15 +11088,15 @@
       "id": "philosophy-admission-oracle-1385"
     },
     {
-      "claim": "The admission policy should use GPTCache clients.",
+      "claim": "Philosophy admission has used Redis imports for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1386"
     },
     {
-      "claim": "The admission policy should use Redis clients.",
+      "claim": "Philosophy admission is required to approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11104,7 +11104,7 @@
       "id": "philosophy-admission-oracle-1387"
     },
     {
-      "claim": "The admission policy should wire embeddings.",
+      "claim": "Philosophy admission is required to approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11112,15 +11112,15 @@
       "id": "philosophy-admission-oracle-1388"
     },
     {
-      "claim": "The admission policy still allows embeddings.",
+      "claim": "Philosophy admission is required to approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1389"
     },
     {
-      "claim": "The admission policy will enable provider-backed cache.",
+      "claim": "Philosophy admission is required to enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11128,7 +11128,7 @@
       "id": "philosophy-admission-oracle-1390"
     },
     {
-      "claim": "The admission policy will open Redis connections.",
+      "claim": "Philosophy admission is required to open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11136,7 +11136,7 @@
       "id": "philosophy-admission-oracle-1391"
     },
     {
-      "claim": "The admission policy will use GPTCache clients.",
+      "claim": "Philosophy admission is required to use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11144,7 +11144,7 @@
       "id": "philosophy-admission-oracle-1392"
     },
     {
-      "claim": "The admission policy will use Redis clients.",
+      "claim": "Philosophy admission is required to use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11152,15 +11152,15 @@
       "id": "philosophy-admission-oracle-1393"
     },
     {
-      "claim": "The admission policy will wire /insight cache behavior.",
+      "claim": "Philosophy admission is required to wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1394"
     },
     {
-      "claim": "The admission policy will wire embeddings.",
+      "claim": "Philosophy admission may approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11168,15 +11168,15 @@
       "id": "philosophy-admission-oracle-1395"
     },
     {
-      "claim": "The admission policy wires /insight cache behavior.",
+      "claim": "Philosophy admission may approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1396"
     },
     {
-      "claim": "The admission policy would enable provider-backed cache.",
+      "claim": "Philosophy admission may approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11184,7 +11184,7 @@
       "id": "philosophy-admission-oracle-1397"
     },
     {
-      "claim": "The admission policy would open Redis connections.",
+      "claim": "Philosophy admission may enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11192,7 +11192,7 @@
       "id": "philosophy-admission-oracle-1398"
     },
     {
-      "claim": "The admission policy would use GPTCache clients.",
+      "claim": "Philosophy admission may open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11200,7 +11200,7 @@
       "id": "philosophy-admission-oracle-1399"
     },
     {
-      "claim": "The admission policy would use Redis clients.",
+      "claim": "Philosophy admission may use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11208,7 +11208,7 @@
       "id": "philosophy-admission-oracle-1400"
     },
     {
-      "claim": "The admission policy would wire embeddings.",
+      "claim": "Philosophy admission may use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11216,31 +11216,31 @@
       "id": "philosophy-admission-oracle-1401"
     },
     {
-      "claim": "The claim-family oracle allows GPTCache imports.",
+      "claim": "Philosophy admission may wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1402"
     },
     {
-      "claim": "The claim-family oracle allows Redis imports.",
+      "claim": "Philosophy admission might approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1403"
     },
     {
-      "claim": "The claim-family oracle became approved for GPTCache imports.",
+      "claim": "Philosophy admission might approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1404"
     },
     {
-      "claim": "The claim-family oracle can enable provider-backed cache.",
+      "claim": "Philosophy admission might approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11248,7 +11248,7 @@
       "id": "philosophy-admission-oracle-1405"
     },
     {
-      "claim": "The claim-family oracle can open Redis connections.",
+      "claim": "Philosophy admission might enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11256,7 +11256,7 @@
       "id": "philosophy-admission-oracle-1406"
     },
     {
-      "claim": "The claim-family oracle can use GPTCache clients.",
+      "claim": "Philosophy admission might open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11264,7 +11264,7 @@
       "id": "philosophy-admission-oracle-1407"
     },
     {
-      "claim": "The claim-family oracle can use Redis clients.",
+      "claim": "Philosophy admission might use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11272,7 +11272,7 @@
       "id": "philosophy-admission-oracle-1408"
     },
     {
-      "claim": "The claim-family oracle can wire embeddings.",
+      "claim": "Philosophy admission might use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11280,7 +11280,7 @@
       "id": "philosophy-admission-oracle-1409"
     },
     {
-      "claim": "The claim-family oracle could enable provider-backed cache.",
+      "claim": "Philosophy admission might wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11288,7 +11288,7 @@
       "id": "philosophy-admission-oracle-1410"
     },
     {
-      "claim": "The claim-family oracle could open Redis connections.",
+      "claim": "Philosophy admission must approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11296,7 +11296,7 @@
       "id": "philosophy-admission-oracle-1411"
     },
     {
-      "claim": "The claim-family oracle could use GPTCache clients.",
+      "claim": "Philosophy admission must approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11304,7 +11304,7 @@
       "id": "philosophy-admission-oracle-1412"
     },
     {
-      "claim": "The claim-family oracle could use Redis clients.",
+      "claim": "Philosophy admission must approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11312,7 +11312,7 @@
       "id": "philosophy-admission-oracle-1413"
     },
     {
-      "claim": "The claim-family oracle could wire embeddings.",
+      "claim": "Philosophy admission must enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11320,23 +11320,23 @@
       "id": "philosophy-admission-oracle-1414"
     },
     {
-      "claim": "The claim-family oracle enables embeddings for philosophy admission.",
+      "claim": "Philosophy admission must open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1415"
     },
     {
-      "claim": "The claim-family oracle has been opening Redis connections.",
+      "claim": "Philosophy admission must use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1416"
     },
     {
-      "claim": "The claim-family oracle has to enable provider-backed cache.",
+      "claim": "Philosophy admission must use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11344,7 +11344,7 @@
       "id": "philosophy-admission-oracle-1417"
     },
     {
-      "claim": "The claim-family oracle has to open Redis connections.",
+      "claim": "Philosophy admission must wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11352,15 +11352,15 @@
       "id": "philosophy-admission-oracle-1418"
     },
     {
-      "claim": "The claim-family oracle has to use GPTCache clients.",
+      "claim": "Philosophy admission opens Redis connection strings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1419"
     },
     {
-      "claim": "The claim-family oracle has to use Redis clients.",
+      "claim": "Philosophy admission should approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11368,7 +11368,7 @@
       "id": "philosophy-admission-oracle-1420"
     },
     {
-      "claim": "The claim-family oracle has to wire embeddings.",
+      "claim": "Philosophy admission should approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11376,15 +11376,15 @@
       "id": "philosophy-admission-oracle-1421"
     },
     {
-      "claim": "The claim-family oracle has used Redis imports for philosophy admission.",
+      "claim": "Philosophy admission should approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1422"
     },
     {
-      "claim": "The claim-family oracle is required to enable provider-backed cache.",
+      "claim": "Philosophy admission should enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11392,7 +11392,7 @@
       "id": "philosophy-admission-oracle-1423"
     },
     {
-      "claim": "The claim-family oracle is required to open Redis connections.",
+      "claim": "Philosophy admission should open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11400,7 +11400,7 @@
       "id": "philosophy-admission-oracle-1424"
     },
     {
-      "claim": "The claim-family oracle is required to use GPTCache clients.",
+      "claim": "Philosophy admission should use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11408,7 +11408,7 @@
       "id": "philosophy-admission-oracle-1425"
     },
     {
-      "claim": "The claim-family oracle is required to use Redis clients.",
+      "claim": "Philosophy admission should use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11416,7 +11416,7 @@
       "id": "philosophy-admission-oracle-1426"
     },
     {
-      "claim": "The claim-family oracle is required to wire embeddings.",
+      "claim": "Philosophy admission should wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11424,15 +11424,15 @@
       "id": "philosophy-admission-oracle-1427"
     },
     {
-      "claim": "The claim-family oracle may enable provider-backed cache.",
+      "claim": "Philosophy admission still allows embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1428"
     },
     {
-      "claim": "The claim-family oracle may open Redis connections.",
+      "claim": "Philosophy admission will approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11440,7 +11440,7 @@
       "id": "philosophy-admission-oracle-1429"
     },
     {
-      "claim": "The claim-family oracle may use GPTCache clients.",
+      "claim": "Philosophy admission will approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11448,7 +11448,7 @@
       "id": "philosophy-admission-oracle-1430"
     },
     {
-      "claim": "The claim-family oracle may use Redis clients.",
+      "claim": "Philosophy admission will approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11456,7 +11456,7 @@
       "id": "philosophy-admission-oracle-1431"
     },
     {
-      "claim": "The claim-family oracle may wire embeddings.",
+      "claim": "Philosophy admission will enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11464,7 +11464,7 @@
       "id": "philosophy-admission-oracle-1432"
     },
     {
-      "claim": "The claim-family oracle might enable provider-backed cache.",
+      "claim": "Philosophy admission will open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11472,7 +11472,7 @@
       "id": "philosophy-admission-oracle-1433"
     },
     {
-      "claim": "The claim-family oracle might open Redis connections.",
+      "claim": "Philosophy admission will use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11480,7 +11480,7 @@
       "id": "philosophy-admission-oracle-1434"
     },
     {
-      "claim": "The claim-family oracle might use GPTCache clients.",
+      "claim": "Philosophy admission will use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11488,15 +11488,15 @@
       "id": "philosophy-admission-oracle-1435"
     },
     {
-      "claim": "The claim-family oracle might use Redis clients.",
+      "claim": "Philosophy admission will wire /insight cache behavior.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.temporal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1436"
     },
     {
-      "claim": "The claim-family oracle might wire embeddings.",
+      "claim": "Philosophy admission will wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11504,15 +11504,15 @@
       "id": "philosophy-admission-oracle-1437"
     },
     {
-      "claim": "The claim-family oracle must enable provider-backed cache.",
+      "claim": "Philosophy admission wires /insight cache behavior.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1438"
     },
     {
-      "claim": "The claim-family oracle must open Redis connections.",
+      "claim": "Philosophy admission would approve GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11520,7 +11520,7 @@
       "id": "philosophy-admission-oracle-1439"
     },
     {
-      "claim": "The claim-family oracle must use GPTCache clients.",
+      "claim": "Philosophy admission would approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11528,7 +11528,7 @@
       "id": "philosophy-admission-oracle-1440"
     },
     {
-      "claim": "The claim-family oracle must use Redis clients.",
+      "claim": "Philosophy admission would approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11536,7 +11536,7 @@
       "id": "philosophy-admission-oracle-1441"
     },
     {
-      "claim": "The claim-family oracle must wire embeddings.",
+      "claim": "Philosophy admission would enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11544,15 +11544,15 @@
       "id": "philosophy-admission-oracle-1442"
     },
     {
-      "claim": "The claim-family oracle opens Redis connection strings.",
+      "claim": "Philosophy admission would open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1443"
     },
     {
-      "claim": "The claim-family oracle should enable provider-backed cache.",
+      "claim": "Philosophy admission would use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11560,7 +11560,7 @@
       "id": "philosophy-admission-oracle-1444"
     },
     {
-      "claim": "The claim-family oracle should open Redis connections.",
+      "claim": "Philosophy admission would use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11568,7 +11568,7 @@
       "id": "philosophy-admission-oracle-1445"
     },
     {
-      "claim": "The claim-family oracle should use GPTCache clients.",
+      "claim": "Philosophy admission would wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11576,71 +11576,71 @@
       "id": "philosophy-admission-oracle-1446"
     },
     {
-      "claim": "The claim-family oracle should use Redis clients.",
+      "claim": "The admission policy allows GPTCache imports.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1447"
     },
     {
-      "claim": "The claim-family oracle should wire embeddings.",
+      "claim": "The admission policy allows Redis imports.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1448"
     },
     {
-      "claim": "The claim-family oracle still allows embeddings.",
+      "claim": "The admission policy approves GPTCache rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.temporal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1449"
     },
     {
-      "claim": "The claim-family oracle will enable provider-backed cache.",
+      "claim": "The admission policy approves Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1450"
     },
     {
-      "claim": "The claim-family oracle will open Redis connections.",
+      "claim": "The admission policy approves provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
+      "source": "policy.assertive_predicates",
       "id": "philosophy-admission-oracle-1451"
     },
     {
-      "claim": "The claim-family oracle will use GPTCache clients.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1452"
-    },
-    {
-      "claim": "The claim-family oracle will use Redis clients.",
-      "claim_family": "claim_class_provider_rollout_approved",
-      "expected": "forbidden",
-      "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1453"
-    },
-    {
-      "claim": "The claim-family oracle will wire /insight cache behavior.",
+      "claim": "The admission policy became approved for GPTCache imports.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
       "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1452"
+    },
+    {
+      "claim": "The admission policy became approved for provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1453"
+    },
+    {
+      "claim": "The admission policy can approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1454"
     },
     {
-      "claim": "The claim-family oracle will wire embeddings.",
+      "claim": "The admission policy can approve Redis rollout for philosophy admission.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11648,15 +11648,15 @@
       "id": "philosophy-admission-oracle-1455"
     },
     {
-      "claim": "The claim-family oracle wires /insight cache behavior.",
+      "claim": "The admission policy can approve provider-backed cache runtime.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
-      "source": "policy.assertive_predicates",
+      "source": "policy.modal_predicates.cross_product",
       "id": "philosophy-admission-oracle-1456"
     },
     {
-      "claim": "The claim-family oracle would enable provider-backed cache.",
+      "claim": "The admission policy can enable provider-backed cache.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11664,7 +11664,7 @@
       "id": "philosophy-admission-oracle-1457"
     },
     {
-      "claim": "The claim-family oracle would open Redis connections.",
+      "claim": "The admission policy can open Redis connections.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11672,7 +11672,7 @@
       "id": "philosophy-admission-oracle-1458"
     },
     {
-      "claim": "The claim-family oracle would use GPTCache clients.",
+      "claim": "The admission policy can use GPTCache clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11680,7 +11680,7 @@
       "id": "philosophy-admission-oracle-1459"
     },
     {
-      "claim": "The claim-family oracle would use Redis clients.",
+      "claim": "The admission policy can use Redis clients.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11688,7 +11688,7 @@
       "id": "philosophy-admission-oracle-1460"
     },
     {
-      "claim": "The claim-family oracle would wire embeddings.",
+      "claim": "The admission policy can wire embeddings.",
       "claim_family": "claim_class_provider_rollout_approved",
       "expected": "forbidden",
       "expected_detector_label": "redis philosophical cache approved",
@@ -11696,12 +11696,1412 @@
       "id": "philosophy-admission-oracle-1461"
     },
     {
+      "claim": "The admission policy could approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1462"
+    },
+    {
+      "claim": "The admission policy could approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1463"
+    },
+    {
+      "claim": "The admission policy could approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1464"
+    },
+    {
+      "claim": "The admission policy could enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1465"
+    },
+    {
+      "claim": "The admission policy could open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1466"
+    },
+    {
+      "claim": "The admission policy could use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1467"
+    },
+    {
+      "claim": "The admission policy could use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1468"
+    },
+    {
+      "claim": "The admission policy could wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1469"
+    },
+    {
+      "claim": "The admission policy enables embeddings for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1470"
+    },
+    {
+      "claim": "The admission policy has approved Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1471"
+    },
+    {
+      "claim": "The admission policy has been opening Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1472"
+    },
+    {
+      "claim": "The admission policy has to approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1473"
+    },
+    {
+      "claim": "The admission policy has to approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1474"
+    },
+    {
+      "claim": "The admission policy has to approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1475"
+    },
+    {
+      "claim": "The admission policy has to enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1476"
+    },
+    {
+      "claim": "The admission policy has to open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1477"
+    },
+    {
+      "claim": "The admission policy has to use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1478"
+    },
+    {
+      "claim": "The admission policy has to use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1479"
+    },
+    {
+      "claim": "The admission policy has to wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1480"
+    },
+    {
+      "claim": "The admission policy has used Redis imports for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1481"
+    },
+    {
+      "claim": "The admission policy is required to approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1482"
+    },
+    {
+      "claim": "The admission policy is required to approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1483"
+    },
+    {
+      "claim": "The admission policy is required to approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1484"
+    },
+    {
+      "claim": "The admission policy is required to enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1485"
+    },
+    {
+      "claim": "The admission policy is required to open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1486"
+    },
+    {
+      "claim": "The admission policy is required to use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1487"
+    },
+    {
+      "claim": "The admission policy is required to use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1488"
+    },
+    {
+      "claim": "The admission policy is required to wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1489"
+    },
+    {
+      "claim": "The admission policy may approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1490"
+    },
+    {
+      "claim": "The admission policy may approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1491"
+    },
+    {
+      "claim": "The admission policy may approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1492"
+    },
+    {
+      "claim": "The admission policy may enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1493"
+    },
+    {
+      "claim": "The admission policy may open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1494"
+    },
+    {
+      "claim": "The admission policy may use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1495"
+    },
+    {
+      "claim": "The admission policy may use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1496"
+    },
+    {
+      "claim": "The admission policy may wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1497"
+    },
+    {
+      "claim": "The admission policy might approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1498"
+    },
+    {
+      "claim": "The admission policy might approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1499"
+    },
+    {
+      "claim": "The admission policy might approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1500"
+    },
+    {
+      "claim": "The admission policy might enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1501"
+    },
+    {
+      "claim": "The admission policy might open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1502"
+    },
+    {
+      "claim": "The admission policy might use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1503"
+    },
+    {
+      "claim": "The admission policy might use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1504"
+    },
+    {
+      "claim": "The admission policy might wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1505"
+    },
+    {
+      "claim": "The admission policy must approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1506"
+    },
+    {
+      "claim": "The admission policy must approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1507"
+    },
+    {
+      "claim": "The admission policy must approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1508"
+    },
+    {
+      "claim": "The admission policy must enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1509"
+    },
+    {
+      "claim": "The admission policy must open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1510"
+    },
+    {
+      "claim": "The admission policy must use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1511"
+    },
+    {
+      "claim": "The admission policy must use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1512"
+    },
+    {
+      "claim": "The admission policy must wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1513"
+    },
+    {
+      "claim": "The admission policy opens Redis connection strings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1514"
+    },
+    {
+      "claim": "The admission policy should approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1515"
+    },
+    {
+      "claim": "The admission policy should approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1516"
+    },
+    {
+      "claim": "The admission policy should approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1517"
+    },
+    {
+      "claim": "The admission policy should enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1518"
+    },
+    {
+      "claim": "The admission policy should open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1519"
+    },
+    {
+      "claim": "The admission policy should use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1520"
+    },
+    {
+      "claim": "The admission policy should use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1521"
+    },
+    {
+      "claim": "The admission policy should wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1522"
+    },
+    {
+      "claim": "The admission policy still allows embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1523"
+    },
+    {
+      "claim": "The admission policy will approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1524"
+    },
+    {
+      "claim": "The admission policy will approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1525"
+    },
+    {
+      "claim": "The admission policy will approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1526"
+    },
+    {
+      "claim": "The admission policy will enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1527"
+    },
+    {
+      "claim": "The admission policy will open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1528"
+    },
+    {
+      "claim": "The admission policy will use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1529"
+    },
+    {
+      "claim": "The admission policy will use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1530"
+    },
+    {
+      "claim": "The admission policy will wire /insight cache behavior.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1531"
+    },
+    {
+      "claim": "The admission policy will wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1532"
+    },
+    {
+      "claim": "The admission policy wires /insight cache behavior.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1533"
+    },
+    {
+      "claim": "The admission policy would approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1534"
+    },
+    {
+      "claim": "The admission policy would approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1535"
+    },
+    {
+      "claim": "The admission policy would approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1536"
+    },
+    {
+      "claim": "The admission policy would enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1537"
+    },
+    {
+      "claim": "The admission policy would open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1538"
+    },
+    {
+      "claim": "The admission policy would use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1539"
+    },
+    {
+      "claim": "The admission policy would use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1540"
+    },
+    {
+      "claim": "The admission policy would wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1541"
+    },
+    {
+      "claim": "The claim-family oracle allows GPTCache imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1542"
+    },
+    {
+      "claim": "The claim-family oracle allows Redis imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1543"
+    },
+    {
+      "claim": "The claim-family oracle approves GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1544"
+    },
+    {
+      "claim": "The claim-family oracle approves Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1545"
+    },
+    {
+      "claim": "The claim-family oracle approves provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1546"
+    },
+    {
+      "claim": "The claim-family oracle became approved for GPTCache imports.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1547"
+    },
+    {
+      "claim": "The claim-family oracle became approved for provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1548"
+    },
+    {
+      "claim": "The claim-family oracle can approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1549"
+    },
+    {
+      "claim": "The claim-family oracle can approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1550"
+    },
+    {
+      "claim": "The claim-family oracle can approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1551"
+    },
+    {
+      "claim": "The claim-family oracle can enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1552"
+    },
+    {
+      "claim": "The claim-family oracle can open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1553"
+    },
+    {
+      "claim": "The claim-family oracle can use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1554"
+    },
+    {
+      "claim": "The claim-family oracle can use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1555"
+    },
+    {
+      "claim": "The claim-family oracle can wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1556"
+    },
+    {
+      "claim": "The claim-family oracle could approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1557"
+    },
+    {
+      "claim": "The claim-family oracle could approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1558"
+    },
+    {
+      "claim": "The claim-family oracle could approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1559"
+    },
+    {
+      "claim": "The claim-family oracle could enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1560"
+    },
+    {
+      "claim": "The claim-family oracle could open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1561"
+    },
+    {
+      "claim": "The claim-family oracle could use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1562"
+    },
+    {
+      "claim": "The claim-family oracle could use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1563"
+    },
+    {
+      "claim": "The claim-family oracle could wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1564"
+    },
+    {
+      "claim": "The claim-family oracle enables embeddings for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1565"
+    },
+    {
+      "claim": "The claim-family oracle has approved Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1566"
+    },
+    {
+      "claim": "The claim-family oracle has been opening Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1567"
+    },
+    {
+      "claim": "The claim-family oracle has to approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1568"
+    },
+    {
+      "claim": "The claim-family oracle has to approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1569"
+    },
+    {
+      "claim": "The claim-family oracle has to approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1570"
+    },
+    {
+      "claim": "The claim-family oracle has to enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1571"
+    },
+    {
+      "claim": "The claim-family oracle has to open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1572"
+    },
+    {
+      "claim": "The claim-family oracle has to use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1573"
+    },
+    {
+      "claim": "The claim-family oracle has to use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1574"
+    },
+    {
+      "claim": "The claim-family oracle has to wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1575"
+    },
+    {
+      "claim": "The claim-family oracle has used Redis imports for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1576"
+    },
+    {
+      "claim": "The claim-family oracle is required to approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1577"
+    },
+    {
+      "claim": "The claim-family oracle is required to approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1578"
+    },
+    {
+      "claim": "The claim-family oracle is required to approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1579"
+    },
+    {
+      "claim": "The claim-family oracle is required to enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1580"
+    },
+    {
+      "claim": "The claim-family oracle is required to open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1581"
+    },
+    {
+      "claim": "The claim-family oracle is required to use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1582"
+    },
+    {
+      "claim": "The claim-family oracle is required to use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1583"
+    },
+    {
+      "claim": "The claim-family oracle is required to wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1584"
+    },
+    {
+      "claim": "The claim-family oracle may approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1585"
+    },
+    {
+      "claim": "The claim-family oracle may approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1586"
+    },
+    {
+      "claim": "The claim-family oracle may approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1587"
+    },
+    {
+      "claim": "The claim-family oracle may enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1588"
+    },
+    {
+      "claim": "The claim-family oracle may open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1589"
+    },
+    {
+      "claim": "The claim-family oracle may use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1590"
+    },
+    {
+      "claim": "The claim-family oracle may use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1591"
+    },
+    {
+      "claim": "The claim-family oracle may wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1592"
+    },
+    {
+      "claim": "The claim-family oracle might approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1593"
+    },
+    {
+      "claim": "The claim-family oracle might approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1594"
+    },
+    {
+      "claim": "The claim-family oracle might approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1595"
+    },
+    {
+      "claim": "The claim-family oracle might enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1596"
+    },
+    {
+      "claim": "The claim-family oracle might open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1597"
+    },
+    {
+      "claim": "The claim-family oracle might use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1598"
+    },
+    {
+      "claim": "The claim-family oracle might use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1599"
+    },
+    {
+      "claim": "The claim-family oracle might wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1600"
+    },
+    {
+      "claim": "The claim-family oracle must approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1601"
+    },
+    {
+      "claim": "The claim-family oracle must approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1602"
+    },
+    {
+      "claim": "The claim-family oracle must approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1603"
+    },
+    {
+      "claim": "The claim-family oracle must enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1604"
+    },
+    {
+      "claim": "The claim-family oracle must open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1605"
+    },
+    {
+      "claim": "The claim-family oracle must use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1606"
+    },
+    {
+      "claim": "The claim-family oracle must use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1607"
+    },
+    {
+      "claim": "The claim-family oracle must wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1608"
+    },
+    {
+      "claim": "The claim-family oracle opens Redis connection strings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1609"
+    },
+    {
+      "claim": "The claim-family oracle should approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1610"
+    },
+    {
+      "claim": "The claim-family oracle should approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1611"
+    },
+    {
+      "claim": "The claim-family oracle should approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1612"
+    },
+    {
+      "claim": "The claim-family oracle should enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1613"
+    },
+    {
+      "claim": "The claim-family oracle should open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1614"
+    },
+    {
+      "claim": "The claim-family oracle should use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1615"
+    },
+    {
+      "claim": "The claim-family oracle should use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1616"
+    },
+    {
+      "claim": "The claim-family oracle should wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1617"
+    },
+    {
+      "claim": "The claim-family oracle still allows embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1618"
+    },
+    {
+      "claim": "The claim-family oracle will approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1619"
+    },
+    {
+      "claim": "The claim-family oracle will approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1620"
+    },
+    {
+      "claim": "The claim-family oracle will approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1621"
+    },
+    {
+      "claim": "The claim-family oracle will enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1622"
+    },
+    {
+      "claim": "The claim-family oracle will open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1623"
+    },
+    {
+      "claim": "The claim-family oracle will use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1624"
+    },
+    {
+      "claim": "The claim-family oracle will use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1625"
+    },
+    {
+      "claim": "The claim-family oracle will wire /insight cache behavior.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.temporal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1626"
+    },
+    {
+      "claim": "The claim-family oracle will wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1627"
+    },
+    {
+      "claim": "The claim-family oracle wires /insight cache behavior.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.assertive_predicates",
+      "id": "philosophy-admission-oracle-1628"
+    },
+    {
+      "claim": "The claim-family oracle would approve GPTCache rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1629"
+    },
+    {
+      "claim": "The claim-family oracle would approve Redis rollout for philosophy admission.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1630"
+    },
+    {
+      "claim": "The claim-family oracle would approve provider-backed cache runtime.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1631"
+    },
+    {
+      "claim": "The claim-family oracle would enable provider-backed cache.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1632"
+    },
+    {
+      "claim": "The claim-family oracle would open Redis connections.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1633"
+    },
+    {
+      "claim": "The claim-family oracle would use GPTCache clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1634"
+    },
+    {
+      "claim": "The claim-family oracle would use Redis clients.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1635"
+    },
+    {
+      "claim": "The claim-family oracle would wire embeddings.",
+      "claim_family": "claim_class_provider_rollout_approved",
+      "expected": "forbidden",
+      "expected_detector_label": "redis philosophical cache approved",
+      "source": "policy.modal_predicates.cross_product",
+      "id": "philosophy-admission-oracle-1636"
+    },
+    {
       "claim": "Billing truth remains blocked_from_cache.",
       "claim_family": "claim_class_runtime_expansion_approved",
       "expected": "allowed",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-1462"
+      "id": "philosophy-admission-oracle-1637"
     },
     {
       "claim": "PR-2 must not write cache entries.",
@@ -11709,7 +13109,7 @@
       "expected": "allowed",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-1463"
+      "id": "philosophy-admission-oracle-1638"
     },
     {
       "claim": "The policy spec does not authorize backend selection.",
@@ -11717,7 +13117,7 @@
       "expected": "allowed",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-1464"
+      "id": "philosophy-admission-oracle-1639"
     },
     {
       "claim": "Billing truth authorizes backend selection.",
@@ -11725,7 +13125,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1465"
+      "id": "philosophy-admission-oracle-1640"
     },
     {
       "claim": "Billing truth became cache eligible for semantic-cache admission.",
@@ -11733,7 +13133,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1466"
+      "id": "philosophy-admission-oracle-1641"
     },
     {
       "claim": "Billing truth becomes cache eligible for semantic-cache admission.",
@@ -11741,7 +13141,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1467"
+      "id": "philosophy-admission-oracle-1642"
     },
     {
       "claim": "Billing truth can authorize backend selection.",
@@ -11749,7 +13149,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1468"
+      "id": "philosophy-admission-oracle-1643"
     },
     {
       "claim": "Billing truth can be cache eligible for semantic-cache admission.",
@@ -11757,7 +13157,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1469"
+      "id": "philosophy-admission-oracle-1644"
     },
     {
       "claim": "Billing truth can enable runtime expansion.",
@@ -11765,7 +13165,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1470"
+      "id": "philosophy-admission-oracle-1645"
     },
     {
       "claim": "Billing truth can read semantic-cache entries.",
@@ -11773,7 +13173,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1471"
+      "id": "philosophy-admission-oracle-1646"
     },
     {
       "claim": "Billing truth can write cache entries.",
@@ -11781,7 +13181,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1472"
+      "id": "philosophy-admission-oracle-1647"
     },
     {
       "claim": "Billing truth could authorize backend selection.",
@@ -11789,7 +13189,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1473"
+      "id": "philosophy-admission-oracle-1648"
     },
     {
       "claim": "Billing truth could be cache eligible for semantic-cache admission.",
@@ -11797,7 +13197,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1474"
+      "id": "philosophy-admission-oracle-1649"
     },
     {
       "claim": "Billing truth could enable runtime expansion.",
@@ -11805,7 +13205,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1475"
+      "id": "philosophy-admission-oracle-1650"
     },
     {
       "claim": "Billing truth could read semantic-cache entries.",
@@ -11813,7 +13213,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1476"
+      "id": "philosophy-admission-oracle-1651"
     },
     {
       "claim": "Billing truth could write cache entries.",
@@ -11821,7 +13221,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1477"
+      "id": "philosophy-admission-oracle-1652"
     },
     {
       "claim": "Billing truth enables runtime expansion.",
@@ -11829,7 +13229,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1478"
+      "id": "philosophy-admission-oracle-1653"
     },
     {
       "claim": "Billing truth has authorized backend selection.",
@@ -11837,7 +13237,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1479"
+      "id": "philosophy-admission-oracle-1654"
     },
     {
       "claim": "Billing truth has to authorize backend selection.",
@@ -11845,7 +13245,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1480"
+      "id": "philosophy-admission-oracle-1655"
     },
     {
       "claim": "Billing truth has to be cache eligible for semantic-cache admission.",
@@ -11853,7 +13253,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1481"
+      "id": "philosophy-admission-oracle-1656"
     },
     {
       "claim": "Billing truth has to enable runtime expansion.",
@@ -11861,7 +13261,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1482"
+      "id": "philosophy-admission-oracle-1657"
     },
     {
       "claim": "Billing truth has to read semantic-cache entries.",
@@ -11869,7 +13269,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1483"
+      "id": "philosophy-admission-oracle-1658"
     },
     {
       "claim": "Billing truth has to write cache entries.",
@@ -11877,7 +13277,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1484"
+      "id": "philosophy-admission-oracle-1659"
     },
     {
       "claim": "Billing truth is now writing cache entries.",
@@ -11885,7 +13285,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1485"
+      "id": "philosophy-admission-oracle-1660"
     },
     {
       "claim": "Billing truth is required to authorize backend selection.",
@@ -11893,7 +13293,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1486"
+      "id": "philosophy-admission-oracle-1661"
     },
     {
       "claim": "Billing truth is required to be cache eligible for semantic-cache admission.",
@@ -11901,7 +13301,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1487"
+      "id": "philosophy-admission-oracle-1662"
     },
     {
       "claim": "Billing truth is required to enable runtime expansion.",
@@ -11909,7 +13309,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1488"
+      "id": "philosophy-admission-oracle-1663"
     },
     {
       "claim": "Billing truth is required to read semantic-cache entries.",
@@ -11917,7 +13317,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1489"
+      "id": "philosophy-admission-oracle-1664"
     },
     {
       "claim": "Billing truth is required to write cache entries.",
@@ -11925,7 +13325,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1490"
+      "id": "philosophy-admission-oracle-1665"
     },
     {
       "claim": "Billing truth may authorize backend selection.",
@@ -11933,7 +13333,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1491"
+      "id": "philosophy-admission-oracle-1666"
     },
     {
       "claim": "Billing truth may be cache eligible for semantic-cache admission.",
@@ -11941,7 +13341,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1492"
+      "id": "philosophy-admission-oracle-1667"
     },
     {
       "claim": "Billing truth may enable runtime expansion.",
@@ -11949,7 +13349,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1493"
+      "id": "philosophy-admission-oracle-1668"
     },
     {
       "claim": "Billing truth may read semantic-cache entries.",
@@ -11957,7 +13357,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1494"
+      "id": "philosophy-admission-oracle-1669"
     },
     {
       "claim": "Billing truth may write cache entries.",
@@ -11965,7 +13365,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1495"
+      "id": "philosophy-admission-oracle-1670"
     },
     {
       "claim": "Billing truth might authorize backend selection.",
@@ -11973,7 +13373,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1496"
+      "id": "philosophy-admission-oracle-1671"
     },
     {
       "claim": "Billing truth might be cache eligible for semantic-cache admission.",
@@ -11981,7 +13381,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1497"
+      "id": "philosophy-admission-oracle-1672"
     },
     {
       "claim": "Billing truth might enable runtime expansion.",
@@ -11989,7 +13389,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1498"
+      "id": "philosophy-admission-oracle-1673"
     },
     {
       "claim": "Billing truth might read semantic-cache entries.",
@@ -11997,7 +13397,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1499"
+      "id": "philosophy-admission-oracle-1674"
     },
     {
       "claim": "Billing truth might write cache entries.",
@@ -12005,7 +13405,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1500"
+      "id": "philosophy-admission-oracle-1675"
     },
     {
       "claim": "Billing truth must authorize backend selection.",
@@ -12013,7 +13413,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1501"
+      "id": "philosophy-admission-oracle-1676"
     },
     {
       "claim": "Billing truth must be cache eligible for semantic-cache admission.",
@@ -12021,7 +13421,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1502"
+      "id": "philosophy-admission-oracle-1677"
     },
     {
       "claim": "Billing truth must enable runtime expansion.",
@@ -12029,7 +13429,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1503"
+      "id": "philosophy-admission-oracle-1678"
     },
     {
       "claim": "Billing truth must read semantic-cache entries.",
@@ -12037,7 +13437,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1504"
+      "id": "philosophy-admission-oracle-1679"
     },
     {
       "claim": "Billing truth must write cache entries.",
@@ -12045,7 +13445,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1505"
+      "id": "philosophy-admission-oracle-1680"
     },
     {
       "claim": "Billing truth reads semantic-cache entries.",
@@ -12053,7 +13453,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1506"
+      "id": "philosophy-admission-oracle-1681"
     },
     {
       "claim": "Billing truth remained cache eligible for semantic-cache admission.",
@@ -12061,7 +13461,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-1507"
+      "id": "philosophy-admission-oracle-1682"
     },
     {
       "claim": "Billing truth remains cache eligible for semantic-cache admission.",
@@ -12069,7 +13469,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1508"
+      "id": "philosophy-admission-oracle-1683"
     },
     {
       "claim": "Billing truth should authorize backend selection.",
@@ -12077,7 +13477,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1509"
+      "id": "philosophy-admission-oracle-1684"
     },
     {
       "claim": "Billing truth should be cache eligible for semantic-cache admission.",
@@ -12085,7 +13485,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1510"
+      "id": "philosophy-admission-oracle-1685"
     },
     {
       "claim": "Billing truth should enable runtime expansion.",
@@ -12093,7 +13493,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1511"
+      "id": "philosophy-admission-oracle-1686"
     },
     {
       "claim": "Billing truth should read semantic-cache entries.",
@@ -12101,7 +13501,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1512"
+      "id": "philosophy-admission-oracle-1687"
     },
     {
       "claim": "Billing truth should write cache entries.",
@@ -12109,7 +13509,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1513"
+      "id": "philosophy-admission-oracle-1688"
     },
     {
       "claim": "Billing truth will authorize backend selection.",
@@ -12117,7 +13517,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1514"
+      "id": "philosophy-admission-oracle-1689"
     },
     {
       "claim": "Billing truth will be cache eligible for semantic-cache admission.",
@@ -12125,7 +13525,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1515"
+      "id": "philosophy-admission-oracle-1690"
     },
     {
       "claim": "Billing truth will enable runtime expansion.",
@@ -12133,7 +13533,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1516"
+      "id": "philosophy-admission-oracle-1691"
     },
     {
       "claim": "Billing truth will read semantic-cache entries.",
@@ -12141,7 +13541,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1517"
+      "id": "philosophy-admission-oracle-1692"
     },
     {
       "claim": "Billing truth will write cache entries.",
@@ -12149,7 +13549,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1518"
+      "id": "philosophy-admission-oracle-1693"
     },
     {
       "claim": "Billing truth would authorize backend selection.",
@@ -12157,7 +13557,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1519"
+      "id": "philosophy-admission-oracle-1694"
     },
     {
       "claim": "Billing truth would be cache eligible for semantic-cache admission.",
@@ -12165,7 +13565,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1520"
+      "id": "philosophy-admission-oracle-1695"
     },
     {
       "claim": "Billing truth would enable runtime expansion.",
@@ -12173,7 +13573,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1521"
+      "id": "philosophy-admission-oracle-1696"
     },
     {
       "claim": "Billing truth would read semantic-cache entries.",
@@ -12181,7 +13581,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1522"
+      "id": "philosophy-admission-oracle-1697"
     },
     {
       "claim": "Billing truth would write cache entries.",
@@ -12189,7 +13589,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1523"
+      "id": "philosophy-admission-oracle-1698"
     },
     {
       "claim": "Billing truth writes cache entries.",
@@ -12197,7 +13597,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1524"
+      "id": "philosophy-admission-oracle-1699"
     },
     {
       "claim": "PR-1 authorizes backend selection.",
@@ -12205,7 +13605,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1525"
+      "id": "philosophy-admission-oracle-1700"
     },
     {
       "claim": "PR-1 became cache eligible for semantic-cache admission.",
@@ -12213,7 +13613,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1526"
+      "id": "philosophy-admission-oracle-1701"
     },
     {
       "claim": "PR-1 becomes cache eligible for semantic-cache admission.",
@@ -12221,7 +13621,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1527"
+      "id": "philosophy-admission-oracle-1702"
     },
     {
       "claim": "PR-1 can authorize backend selection.",
@@ -12229,7 +13629,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1528"
+      "id": "philosophy-admission-oracle-1703"
     },
     {
       "claim": "PR-1 can be cache eligible for semantic-cache admission.",
@@ -12237,7 +13637,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1529"
+      "id": "philosophy-admission-oracle-1704"
     },
     {
       "claim": "PR-1 can enable runtime expansion.",
@@ -12245,7 +13645,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1530"
+      "id": "philosophy-admission-oracle-1705"
     },
     {
       "claim": "PR-1 can read semantic-cache entries.",
@@ -12253,7 +13653,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1531"
+      "id": "philosophy-admission-oracle-1706"
     },
     {
       "claim": "PR-1 can write cache entries.",
@@ -12261,7 +13661,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1532"
+      "id": "philosophy-admission-oracle-1707"
     },
     {
       "claim": "PR-1 could authorize backend selection.",
@@ -12269,7 +13669,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1533"
+      "id": "philosophy-admission-oracle-1708"
     },
     {
       "claim": "PR-1 could be cache eligible for semantic-cache admission.",
@@ -12277,7 +13677,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1534"
+      "id": "philosophy-admission-oracle-1709"
     },
     {
       "claim": "PR-1 could enable runtime expansion.",
@@ -12285,7 +13685,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1535"
+      "id": "philosophy-admission-oracle-1710"
     },
     {
       "claim": "PR-1 could read semantic-cache entries.",
@@ -12293,7 +13693,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1536"
+      "id": "philosophy-admission-oracle-1711"
     },
     {
       "claim": "PR-1 could write cache entries.",
@@ -12301,7 +13701,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1537"
+      "id": "philosophy-admission-oracle-1712"
     },
     {
       "claim": "PR-1 enables runtime expansion.",
@@ -12309,7 +13709,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1538"
+      "id": "philosophy-admission-oracle-1713"
     },
     {
       "claim": "PR-1 has authorized backend selection.",
@@ -12317,7 +13717,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1539"
+      "id": "philosophy-admission-oracle-1714"
     },
     {
       "claim": "PR-1 has to authorize backend selection.",
@@ -12325,7 +13725,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1540"
+      "id": "philosophy-admission-oracle-1715"
     },
     {
       "claim": "PR-1 has to be cache eligible for semantic-cache admission.",
@@ -12333,7 +13733,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1541"
+      "id": "philosophy-admission-oracle-1716"
     },
     {
       "claim": "PR-1 has to enable runtime expansion.",
@@ -12341,7 +13741,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1542"
+      "id": "philosophy-admission-oracle-1717"
     },
     {
       "claim": "PR-1 has to read semantic-cache entries.",
@@ -12349,7 +13749,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1543"
+      "id": "philosophy-admission-oracle-1718"
     },
     {
       "claim": "PR-1 has to write cache entries.",
@@ -12357,7 +13757,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1544"
+      "id": "philosophy-admission-oracle-1719"
     },
     {
       "claim": "PR-1 is now writing cache entries.",
@@ -12365,7 +13765,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1545"
+      "id": "philosophy-admission-oracle-1720"
     },
     {
       "claim": "PR-1 is required to authorize backend selection.",
@@ -12373,7 +13773,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1546"
+      "id": "philosophy-admission-oracle-1721"
     },
     {
       "claim": "PR-1 is required to be cache eligible for semantic-cache admission.",
@@ -12381,7 +13781,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1547"
+      "id": "philosophy-admission-oracle-1722"
     },
     {
       "claim": "PR-1 is required to enable runtime expansion.",
@@ -12389,7 +13789,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1548"
+      "id": "philosophy-admission-oracle-1723"
     },
     {
       "claim": "PR-1 is required to read semantic-cache entries.",
@@ -12397,7 +13797,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1549"
+      "id": "philosophy-admission-oracle-1724"
     },
     {
       "claim": "PR-1 is required to write cache entries.",
@@ -12405,7 +13805,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1550"
+      "id": "philosophy-admission-oracle-1725"
     },
     {
       "claim": "PR-1 may authorize backend selection.",
@@ -12413,7 +13813,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1551"
+      "id": "philosophy-admission-oracle-1726"
     },
     {
       "claim": "PR-1 may be cache eligible for semantic-cache admission.",
@@ -12421,7 +13821,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1552"
+      "id": "philosophy-admission-oracle-1727"
     },
     {
       "claim": "PR-1 may enable runtime expansion.",
@@ -12429,7 +13829,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1553"
+      "id": "philosophy-admission-oracle-1728"
     },
     {
       "claim": "PR-1 may read semantic-cache entries.",
@@ -12437,7 +13837,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1554"
+      "id": "philosophy-admission-oracle-1729"
     },
     {
       "claim": "PR-1 may write cache entries.",
@@ -12445,7 +13845,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1555"
+      "id": "philosophy-admission-oracle-1730"
     },
     {
       "claim": "PR-1 might authorize backend selection.",
@@ -12453,7 +13853,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1556"
+      "id": "philosophy-admission-oracle-1731"
     },
     {
       "claim": "PR-1 might be cache eligible for semantic-cache admission.",
@@ -12461,7 +13861,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1557"
+      "id": "philosophy-admission-oracle-1732"
     },
     {
       "claim": "PR-1 might enable runtime expansion.",
@@ -12469,7 +13869,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1558"
+      "id": "philosophy-admission-oracle-1733"
     },
     {
       "claim": "PR-1 might read semantic-cache entries.",
@@ -12477,7 +13877,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1559"
+      "id": "philosophy-admission-oracle-1734"
     },
     {
       "claim": "PR-1 might write cache entries.",
@@ -12485,7 +13885,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1560"
+      "id": "philosophy-admission-oracle-1735"
     },
     {
       "claim": "PR-1 must authorize backend selection.",
@@ -12493,7 +13893,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1561"
+      "id": "philosophy-admission-oracle-1736"
     },
     {
       "claim": "PR-1 must be cache eligible for semantic-cache admission.",
@@ -12501,7 +13901,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1562"
+      "id": "philosophy-admission-oracle-1737"
     },
     {
       "claim": "PR-1 must enable runtime expansion.",
@@ -12509,7 +13909,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1563"
+      "id": "philosophy-admission-oracle-1738"
     },
     {
       "claim": "PR-1 must read semantic-cache entries.",
@@ -12517,7 +13917,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1564"
+      "id": "philosophy-admission-oracle-1739"
     },
     {
       "claim": "PR-1 must write cache entries.",
@@ -12525,7 +13925,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1565"
+      "id": "philosophy-admission-oracle-1740"
     },
     {
       "claim": "PR-1 reads semantic-cache entries.",
@@ -12533,7 +13933,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1566"
+      "id": "philosophy-admission-oracle-1741"
     },
     {
       "claim": "PR-1 remains cache eligible for semantic-cache admission.",
@@ -12541,7 +13941,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1567"
+      "id": "philosophy-admission-oracle-1742"
     },
     {
       "claim": "PR-1 should authorize backend selection.",
@@ -12549,7 +13949,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1568"
+      "id": "philosophy-admission-oracle-1743"
     },
     {
       "claim": "PR-1 should be cache eligible for semantic-cache admission.",
@@ -12557,7 +13957,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1569"
+      "id": "philosophy-admission-oracle-1744"
     },
     {
       "claim": "PR-1 should enable runtime expansion.",
@@ -12565,7 +13965,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1570"
+      "id": "philosophy-admission-oracle-1745"
     },
     {
       "claim": "PR-1 should read semantic-cache entries.",
@@ -12573,7 +13973,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1571"
+      "id": "philosophy-admission-oracle-1746"
     },
     {
       "claim": "PR-1 should write cache entries.",
@@ -12581,7 +13981,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1572"
+      "id": "philosophy-admission-oracle-1747"
     },
     {
       "claim": "PR-1 will authorize backend selection.",
@@ -12589,7 +13989,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1573"
+      "id": "philosophy-admission-oracle-1748"
     },
     {
       "claim": "PR-1 will be cache eligible for semantic-cache admission.",
@@ -12597,7 +13997,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1574"
+      "id": "philosophy-admission-oracle-1749"
     },
     {
       "claim": "PR-1 will enable runtime expansion.",
@@ -12605,7 +14005,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1575"
+      "id": "philosophy-admission-oracle-1750"
     },
     {
       "claim": "PR-1 will read semantic-cache entries.",
@@ -12613,7 +14013,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1576"
+      "id": "philosophy-admission-oracle-1751"
     },
     {
       "claim": "PR-1 will write cache entries.",
@@ -12621,7 +14021,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1577"
+      "id": "philosophy-admission-oracle-1752"
     },
     {
       "claim": "PR-1 would authorize backend selection.",
@@ -12629,7 +14029,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1578"
+      "id": "philosophy-admission-oracle-1753"
     },
     {
       "claim": "PR-1 would be cache eligible for semantic-cache admission.",
@@ -12637,7 +14037,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1579"
+      "id": "philosophy-admission-oracle-1754"
     },
     {
       "claim": "PR-1 would enable runtime expansion.",
@@ -12645,7 +14045,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1580"
+      "id": "philosophy-admission-oracle-1755"
     },
     {
       "claim": "PR-1 would read semantic-cache entries.",
@@ -12653,7 +14053,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1581"
+      "id": "philosophy-admission-oracle-1756"
     },
     {
       "claim": "PR-1 would write cache entries.",
@@ -12661,7 +14061,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1582"
+      "id": "philosophy-admission-oracle-1757"
     },
     {
       "claim": "PR-1 writes cache entries.",
@@ -12669,7 +14069,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1583"
+      "id": "philosophy-admission-oracle-1758"
     },
     {
       "claim": "PR-2 authorizes backend selection.",
@@ -12677,7 +14077,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1584"
+      "id": "philosophy-admission-oracle-1759"
     },
     {
       "claim": "PR-2 became cache eligible for semantic-cache admission.",
@@ -12685,7 +14085,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1585"
+      "id": "philosophy-admission-oracle-1760"
     },
     {
       "claim": "PR-2 becomes cache eligible for semantic-cache admission.",
@@ -12693,7 +14093,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1586"
+      "id": "philosophy-admission-oracle-1761"
     },
     {
       "claim": "PR-2 can authorize backend selection.",
@@ -12701,7 +14101,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1587"
+      "id": "philosophy-admission-oracle-1762"
     },
     {
       "claim": "PR-2 can be cache eligible for semantic-cache admission.",
@@ -12709,7 +14109,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1588"
+      "id": "philosophy-admission-oracle-1763"
     },
     {
       "claim": "PR-2 can enable runtime expansion.",
@@ -12717,7 +14117,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1589"
+      "id": "philosophy-admission-oracle-1764"
     },
     {
       "claim": "PR-2 can read semantic-cache entries.",
@@ -12725,7 +14125,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1590"
+      "id": "philosophy-admission-oracle-1765"
     },
     {
       "claim": "PR-2 can write cache entries.",
@@ -12733,7 +14133,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1591"
+      "id": "philosophy-admission-oracle-1766"
     },
     {
       "claim": "PR-2 could authorize backend selection.",
@@ -12741,7 +14141,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1592"
+      "id": "philosophy-admission-oracle-1767"
     },
     {
       "claim": "PR-2 could be cache eligible for semantic-cache admission.",
@@ -12749,7 +14149,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1593"
+      "id": "philosophy-admission-oracle-1768"
     },
     {
       "claim": "PR-2 could enable runtime expansion.",
@@ -12757,7 +14157,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1594"
+      "id": "philosophy-admission-oracle-1769"
     },
     {
       "claim": "PR-2 could read semantic-cache entries.",
@@ -12765,7 +14165,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1595"
+      "id": "philosophy-admission-oracle-1770"
     },
     {
       "claim": "PR-2 could write cache entries.",
@@ -12773,7 +14173,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1596"
+      "id": "philosophy-admission-oracle-1771"
     },
     {
       "claim": "PR-2 enables runtime expansion.",
@@ -12781,7 +14181,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1597"
+      "id": "philosophy-admission-oracle-1772"
     },
     {
       "claim": "PR-2 has authorized backend selection.",
@@ -12789,7 +14189,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1598"
+      "id": "philosophy-admission-oracle-1773"
     },
     {
       "claim": "PR-2 has to authorize backend selection.",
@@ -12797,7 +14197,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1599"
+      "id": "philosophy-admission-oracle-1774"
     },
     {
       "claim": "PR-2 has to be cache eligible for semantic-cache admission.",
@@ -12805,7 +14205,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1600"
+      "id": "philosophy-admission-oracle-1775"
     },
     {
       "claim": "PR-2 has to enable runtime expansion.",
@@ -12813,7 +14213,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1601"
+      "id": "philosophy-admission-oracle-1776"
     },
     {
       "claim": "PR-2 has to read semantic-cache entries.",
@@ -12821,7 +14221,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1602"
+      "id": "philosophy-admission-oracle-1777"
     },
     {
       "claim": "PR-2 has to write cache entries.",
@@ -12829,7 +14229,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1603"
+      "id": "philosophy-admission-oracle-1778"
     },
     {
       "claim": "PR-2 is now writing cache entries.",
@@ -12837,7 +14237,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1604"
+      "id": "philosophy-admission-oracle-1779"
     },
     {
       "claim": "PR-2 is required to authorize backend selection.",
@@ -12845,7 +14245,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1605"
+      "id": "philosophy-admission-oracle-1780"
     },
     {
       "claim": "PR-2 is required to be cache eligible for semantic-cache admission.",
@@ -12853,7 +14253,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1606"
+      "id": "philosophy-admission-oracle-1781"
     },
     {
       "claim": "PR-2 is required to enable runtime expansion.",
@@ -12861,7 +14261,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1607"
+      "id": "philosophy-admission-oracle-1782"
     },
     {
       "claim": "PR-2 is required to read semantic-cache entries.",
@@ -12869,7 +14269,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1608"
+      "id": "philosophy-admission-oracle-1783"
     },
     {
       "claim": "PR-2 is required to write cache entries.",
@@ -12877,7 +14277,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1609"
+      "id": "philosophy-admission-oracle-1784"
     },
     {
       "claim": "PR-2 may authorize backend selection.",
@@ -12885,7 +14285,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1610"
+      "id": "philosophy-admission-oracle-1785"
     },
     {
       "claim": "PR-2 may be cache eligible for semantic-cache admission.",
@@ -12893,7 +14293,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1611"
+      "id": "philosophy-admission-oracle-1786"
     },
     {
       "claim": "PR-2 may enable runtime expansion.",
@@ -12901,7 +14301,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1612"
+      "id": "philosophy-admission-oracle-1787"
     },
     {
       "claim": "PR-2 may read semantic-cache entries.",
@@ -12909,7 +14309,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1613"
+      "id": "philosophy-admission-oracle-1788"
     },
     {
       "claim": "PR-2 may write cache entries.",
@@ -12917,7 +14317,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1614"
+      "id": "philosophy-admission-oracle-1789"
     },
     {
       "claim": "PR-2 might authorize backend selection.",
@@ -12925,7 +14325,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1615"
+      "id": "philosophy-admission-oracle-1790"
     },
     {
       "claim": "PR-2 might be cache eligible for semantic-cache admission.",
@@ -12933,7 +14333,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1616"
+      "id": "philosophy-admission-oracle-1791"
     },
     {
       "claim": "PR-2 might enable runtime expansion.",
@@ -12941,7 +14341,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1617"
+      "id": "philosophy-admission-oracle-1792"
     },
     {
       "claim": "PR-2 might read semantic-cache entries.",
@@ -12949,7 +14349,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1618"
+      "id": "philosophy-admission-oracle-1793"
     },
     {
       "claim": "PR-2 might write cache entries.",
@@ -12957,7 +14357,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1619"
+      "id": "philosophy-admission-oracle-1794"
     },
     {
       "claim": "PR-2 must authorize backend selection.",
@@ -12965,7 +14365,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1620"
+      "id": "philosophy-admission-oracle-1795"
     },
     {
       "claim": "PR-2 must be cache eligible for semantic-cache admission.",
@@ -12973,7 +14373,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1621"
+      "id": "philosophy-admission-oracle-1796"
     },
     {
       "claim": "PR-2 must enable runtime expansion.",
@@ -12981,7 +14381,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1622"
+      "id": "philosophy-admission-oracle-1797"
     },
     {
       "claim": "PR-2 must read semantic-cache entries.",
@@ -12989,7 +14389,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1623"
+      "id": "philosophy-admission-oracle-1798"
     },
     {
       "claim": "PR-2 must write cache entries.",
@@ -12997,7 +14397,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1624"
+      "id": "philosophy-admission-oracle-1799"
     },
     {
       "claim": "PR-2 reads semantic-cache entries.",
@@ -13005,7 +14405,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1625"
+      "id": "philosophy-admission-oracle-1800"
     },
     {
       "claim": "PR-2 remains cache eligible for semantic-cache admission.",
@@ -13013,7 +14413,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1626"
+      "id": "philosophy-admission-oracle-1801"
     },
     {
       "claim": "PR-2 should authorize backend selection.",
@@ -13021,7 +14421,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1627"
+      "id": "philosophy-admission-oracle-1802"
     },
     {
       "claim": "PR-2 should be cache eligible for semantic-cache admission.",
@@ -13029,7 +14429,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1628"
+      "id": "philosophy-admission-oracle-1803"
     },
     {
       "claim": "PR-2 should enable runtime expansion.",
@@ -13037,7 +14437,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1629"
+      "id": "philosophy-admission-oracle-1804"
     },
     {
       "claim": "PR-2 should read semantic-cache entries.",
@@ -13045,7 +14445,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1630"
+      "id": "philosophy-admission-oracle-1805"
     },
     {
       "claim": "PR-2 should write cache entries.",
@@ -13053,7 +14453,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1631"
+      "id": "philosophy-admission-oracle-1806"
     },
     {
       "claim": "PR-2 will authorize backend selection.",
@@ -13061,7 +14461,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1632"
+      "id": "philosophy-admission-oracle-1807"
     },
     {
       "claim": "PR-2 will be cache eligible for semantic-cache admission.",
@@ -13069,7 +14469,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1633"
+      "id": "philosophy-admission-oracle-1808"
     },
     {
       "claim": "PR-2 will enable runtime expansion.",
@@ -13077,7 +14477,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1634"
+      "id": "philosophy-admission-oracle-1809"
     },
     {
       "claim": "PR-2 will read semantic-cache entries.",
@@ -13085,7 +14485,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1635"
+      "id": "philosophy-admission-oracle-1810"
     },
     {
       "claim": "PR-2 will write cache entries.",
@@ -13093,7 +14493,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1636"
+      "id": "philosophy-admission-oracle-1811"
     },
     {
       "claim": "PR-2 would authorize backend selection.",
@@ -13101,7 +14501,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1637"
+      "id": "philosophy-admission-oracle-1812"
     },
     {
       "claim": "PR-2 would be cache eligible for semantic-cache admission.",
@@ -13109,7 +14509,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1638"
+      "id": "philosophy-admission-oracle-1813"
     },
     {
       "claim": "PR-2 would enable runtime expansion.",
@@ -13117,7 +14517,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1639"
+      "id": "philosophy-admission-oracle-1814"
     },
     {
       "claim": "PR-2 would read semantic-cache entries.",
@@ -13125,7 +14525,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1640"
+      "id": "philosophy-admission-oracle-1815"
     },
     {
       "claim": "PR-2 would write cache entries.",
@@ -13133,7 +14533,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1641"
+      "id": "philosophy-admission-oracle-1816"
     },
     {
       "claim": "PR-2 writes cache entries.",
@@ -13141,7 +14541,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1642"
+      "id": "philosophy-admission-oracle-1817"
     },
     {
       "claim": "Philosophy admission authorizes backend selection.",
@@ -13149,7 +14549,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1643"
+      "id": "philosophy-admission-oracle-1818"
     },
     {
       "claim": "Philosophy admission became cache eligible for semantic-cache admission.",
@@ -13157,7 +14557,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1644"
+      "id": "philosophy-admission-oracle-1819"
     },
     {
       "claim": "Philosophy admission becomes cache eligible for semantic-cache admission.",
@@ -13165,7 +14565,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1645"
+      "id": "philosophy-admission-oracle-1820"
     },
     {
       "claim": "Philosophy admission can authorize backend selection.",
@@ -13173,7 +14573,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1646"
+      "id": "philosophy-admission-oracle-1821"
     },
     {
       "claim": "Philosophy admission can be cache eligible for semantic-cache admission.",
@@ -13181,7 +14581,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1647"
+      "id": "philosophy-admission-oracle-1822"
     },
     {
       "claim": "Philosophy admission can enable runtime expansion.",
@@ -13189,7 +14589,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1648"
+      "id": "philosophy-admission-oracle-1823"
     },
     {
       "claim": "Philosophy admission can read semantic-cache entries.",
@@ -13197,7 +14597,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1649"
+      "id": "philosophy-admission-oracle-1824"
     },
     {
       "claim": "Philosophy admission can write cache entries.",
@@ -13205,7 +14605,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1650"
+      "id": "philosophy-admission-oracle-1825"
     },
     {
       "claim": "Philosophy admission could authorize backend selection.",
@@ -13213,7 +14613,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1651"
+      "id": "philosophy-admission-oracle-1826"
     },
     {
       "claim": "Philosophy admission could be cache eligible for semantic-cache admission.",
@@ -13221,7 +14621,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1652"
+      "id": "philosophy-admission-oracle-1827"
     },
     {
       "claim": "Philosophy admission could enable runtime expansion.",
@@ -13229,7 +14629,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1653"
+      "id": "philosophy-admission-oracle-1828"
     },
     {
       "claim": "Philosophy admission could read semantic-cache entries.",
@@ -13237,7 +14637,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1654"
+      "id": "philosophy-admission-oracle-1829"
     },
     {
       "claim": "Philosophy admission could write cache entries.",
@@ -13245,7 +14645,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1655"
+      "id": "philosophy-admission-oracle-1830"
     },
     {
       "claim": "Philosophy admission enables runtime expansion.",
@@ -13253,7 +14653,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1656"
+      "id": "philosophy-admission-oracle-1831"
     },
     {
       "claim": "Philosophy admission has authorized backend selection.",
@@ -13261,7 +14661,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1657"
+      "id": "philosophy-admission-oracle-1832"
     },
     {
       "claim": "Philosophy admission has to authorize backend selection.",
@@ -13269,7 +14669,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1658"
+      "id": "philosophy-admission-oracle-1833"
     },
     {
       "claim": "Philosophy admission has to be cache eligible for semantic-cache admission.",
@@ -13277,7 +14677,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1659"
+      "id": "philosophy-admission-oracle-1834"
     },
     {
       "claim": "Philosophy admission has to enable runtime expansion.",
@@ -13285,7 +14685,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1660"
+      "id": "philosophy-admission-oracle-1835"
     },
     {
       "claim": "Philosophy admission has to read semantic-cache entries.",
@@ -13293,7 +14693,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1661"
+      "id": "philosophy-admission-oracle-1836"
     },
     {
       "claim": "Philosophy admission has to write cache entries.",
@@ -13301,7 +14701,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1662"
+      "id": "philosophy-admission-oracle-1837"
     },
     {
       "claim": "Philosophy admission is now writing cache entries.",
@@ -13309,7 +14709,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1663"
+      "id": "philosophy-admission-oracle-1838"
     },
     {
       "claim": "Philosophy admission is required to authorize backend selection.",
@@ -13317,7 +14717,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1664"
+      "id": "philosophy-admission-oracle-1839"
     },
     {
       "claim": "Philosophy admission is required to be cache eligible for semantic-cache admission.",
@@ -13325,7 +14725,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1665"
+      "id": "philosophy-admission-oracle-1840"
     },
     {
       "claim": "Philosophy admission is required to enable runtime expansion.",
@@ -13333,7 +14733,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1666"
+      "id": "philosophy-admission-oracle-1841"
     },
     {
       "claim": "Philosophy admission is required to read semantic-cache entries.",
@@ -13341,7 +14741,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1667"
+      "id": "philosophy-admission-oracle-1842"
     },
     {
       "claim": "Philosophy admission is required to write cache entries.",
@@ -13349,7 +14749,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1668"
+      "id": "philosophy-admission-oracle-1843"
     },
     {
       "claim": "Philosophy admission may authorize backend selection.",
@@ -13357,7 +14757,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1669"
+      "id": "philosophy-admission-oracle-1844"
     },
     {
       "claim": "Philosophy admission may be cache eligible for semantic-cache admission.",
@@ -13365,7 +14765,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1670"
+      "id": "philosophy-admission-oracle-1845"
     },
     {
       "claim": "Philosophy admission may enable runtime expansion.",
@@ -13373,7 +14773,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1671"
+      "id": "philosophy-admission-oracle-1846"
     },
     {
       "claim": "Philosophy admission may read semantic-cache entries.",
@@ -13381,7 +14781,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1672"
+      "id": "philosophy-admission-oracle-1847"
     },
     {
       "claim": "Philosophy admission may write cache entries.",
@@ -13389,7 +14789,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1673"
+      "id": "philosophy-admission-oracle-1848"
     },
     {
       "claim": "Philosophy admission might authorize backend selection.",
@@ -13397,7 +14797,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1674"
+      "id": "philosophy-admission-oracle-1849"
     },
     {
       "claim": "Philosophy admission might be cache eligible for semantic-cache admission.",
@@ -13405,7 +14805,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1675"
+      "id": "philosophy-admission-oracle-1850"
     },
     {
       "claim": "Philosophy admission might enable runtime expansion.",
@@ -13413,7 +14813,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1676"
+      "id": "philosophy-admission-oracle-1851"
     },
     {
       "claim": "Philosophy admission might read semantic-cache entries.",
@@ -13421,7 +14821,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1677"
+      "id": "philosophy-admission-oracle-1852"
     },
     {
       "claim": "Philosophy admission might write cache entries.",
@@ -13429,7 +14829,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1678"
+      "id": "philosophy-admission-oracle-1853"
     },
     {
       "claim": "Philosophy admission must authorize backend selection.",
@@ -13437,7 +14837,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1679"
+      "id": "philosophy-admission-oracle-1854"
     },
     {
       "claim": "Philosophy admission must be cache eligible for semantic-cache admission.",
@@ -13445,7 +14845,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1680"
+      "id": "philosophy-admission-oracle-1855"
     },
     {
       "claim": "Philosophy admission must enable runtime expansion.",
@@ -13453,7 +14853,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1681"
+      "id": "philosophy-admission-oracle-1856"
     },
     {
       "claim": "Philosophy admission must read semantic-cache entries.",
@@ -13461,7 +14861,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1682"
+      "id": "philosophy-admission-oracle-1857"
     },
     {
       "claim": "Philosophy admission must write cache entries.",
@@ -13469,7 +14869,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1683"
+      "id": "philosophy-admission-oracle-1858"
     },
     {
       "claim": "Philosophy admission reads semantic-cache entries.",
@@ -13477,7 +14877,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1684"
+      "id": "philosophy-admission-oracle-1859"
     },
     {
       "claim": "Philosophy admission remains cache eligible for semantic-cache admission.",
@@ -13485,7 +14885,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1685"
+      "id": "philosophy-admission-oracle-1860"
     },
     {
       "claim": "Philosophy admission should authorize backend selection.",
@@ -13493,7 +14893,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1686"
+      "id": "philosophy-admission-oracle-1861"
     },
     {
       "claim": "Philosophy admission should be cache eligible for semantic-cache admission.",
@@ -13501,7 +14901,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1687"
+      "id": "philosophy-admission-oracle-1862"
     },
     {
       "claim": "Philosophy admission should enable runtime expansion.",
@@ -13509,7 +14909,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1688"
+      "id": "philosophy-admission-oracle-1863"
     },
     {
       "claim": "Philosophy admission should read semantic-cache entries.",
@@ -13517,7 +14917,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1689"
+      "id": "philosophy-admission-oracle-1864"
     },
     {
       "claim": "Philosophy admission should write cache entries.",
@@ -13525,7 +14925,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1690"
+      "id": "philosophy-admission-oracle-1865"
     },
     {
       "claim": "Philosophy admission will authorize backend selection.",
@@ -13533,7 +14933,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1691"
+      "id": "philosophy-admission-oracle-1866"
     },
     {
       "claim": "Philosophy admission will be cache eligible for semantic-cache admission.",
@@ -13541,7 +14941,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1692"
+      "id": "philosophy-admission-oracle-1867"
     },
     {
       "claim": "Philosophy admission will enable runtime expansion.",
@@ -13549,7 +14949,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1693"
+      "id": "philosophy-admission-oracle-1868"
     },
     {
       "claim": "Philosophy admission will read semantic-cache entries.",
@@ -13557,7 +14957,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1694"
+      "id": "philosophy-admission-oracle-1869"
     },
     {
       "claim": "Philosophy admission will write cache entries.",
@@ -13565,7 +14965,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1695"
+      "id": "philosophy-admission-oracle-1870"
     },
     {
       "claim": "Philosophy admission would authorize backend selection.",
@@ -13573,7 +14973,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1696"
+      "id": "philosophy-admission-oracle-1871"
     },
     {
       "claim": "Philosophy admission would be cache eligible for semantic-cache admission.",
@@ -13581,7 +14981,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1697"
+      "id": "philosophy-admission-oracle-1872"
     },
     {
       "claim": "Philosophy admission would enable runtime expansion.",
@@ -13589,7 +14989,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1698"
+      "id": "philosophy-admission-oracle-1873"
     },
     {
       "claim": "Philosophy admission would read semantic-cache entries.",
@@ -13597,7 +14997,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1699"
+      "id": "philosophy-admission-oracle-1874"
     },
     {
       "claim": "Philosophy admission would write cache entries.",
@@ -13605,7 +15005,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1700"
+      "id": "philosophy-admission-oracle-1875"
     },
     {
       "claim": "Philosophy admission writes cache entries.",
@@ -13613,7 +15013,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1701"
+      "id": "philosophy-admission-oracle-1876"
     },
     {
       "claim": "The admission policy authorizes backend selection.",
@@ -13621,7 +15021,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1702"
+      "id": "philosophy-admission-oracle-1877"
     },
     {
       "claim": "The admission policy became cache eligible for semantic-cache admission.",
@@ -13629,7 +15029,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1703"
+      "id": "philosophy-admission-oracle-1878"
     },
     {
       "claim": "The admission policy becomes cache eligible for semantic-cache admission.",
@@ -13637,7 +15037,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1704"
+      "id": "philosophy-admission-oracle-1879"
     },
     {
       "claim": "The admission policy can authorize backend selection.",
@@ -13645,7 +15045,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1705"
+      "id": "philosophy-admission-oracle-1880"
     },
     {
       "claim": "The admission policy can be cache eligible for semantic-cache admission.",
@@ -13653,7 +15053,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1706"
+      "id": "philosophy-admission-oracle-1881"
     },
     {
       "claim": "The admission policy can enable runtime expansion.",
@@ -13661,7 +15061,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1707"
+      "id": "philosophy-admission-oracle-1882"
     },
     {
       "claim": "The admission policy can read semantic-cache entries.",
@@ -13669,7 +15069,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1708"
+      "id": "philosophy-admission-oracle-1883"
     },
     {
       "claim": "The admission policy can write cache entries.",
@@ -13677,7 +15077,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1709"
+      "id": "philosophy-admission-oracle-1884"
     },
     {
       "claim": "The admission policy could authorize backend selection.",
@@ -13685,7 +15085,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1710"
+      "id": "philosophy-admission-oracle-1885"
     },
     {
       "claim": "The admission policy could be cache eligible for semantic-cache admission.",
@@ -13693,7 +15093,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1711"
+      "id": "philosophy-admission-oracle-1886"
     },
     {
       "claim": "The admission policy could enable runtime expansion.",
@@ -13701,7 +15101,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1712"
+      "id": "philosophy-admission-oracle-1887"
     },
     {
       "claim": "The admission policy could read semantic-cache entries.",
@@ -13709,7 +15109,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1713"
+      "id": "philosophy-admission-oracle-1888"
     },
     {
       "claim": "The admission policy could write cache entries.",
@@ -13717,7 +15117,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1714"
+      "id": "philosophy-admission-oracle-1889"
     },
     {
       "claim": "The admission policy enables runtime expansion.",
@@ -13725,7 +15125,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1715"
+      "id": "philosophy-admission-oracle-1890"
     },
     {
       "claim": "The admission policy has authorized backend selection.",
@@ -13733,7 +15133,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1716"
+      "id": "philosophy-admission-oracle-1891"
     },
     {
       "claim": "The admission policy has to authorize backend selection.",
@@ -13741,7 +15141,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1717"
+      "id": "philosophy-admission-oracle-1892"
     },
     {
       "claim": "The admission policy has to be cache eligible for semantic-cache admission.",
@@ -13749,7 +15149,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1718"
+      "id": "philosophy-admission-oracle-1893"
     },
     {
       "claim": "The admission policy has to enable runtime expansion.",
@@ -13757,7 +15157,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1719"
+      "id": "philosophy-admission-oracle-1894"
     },
     {
       "claim": "The admission policy has to read semantic-cache entries.",
@@ -13765,7 +15165,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1720"
+      "id": "philosophy-admission-oracle-1895"
     },
     {
       "claim": "The admission policy has to write cache entries.",
@@ -13773,7 +15173,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1721"
+      "id": "philosophy-admission-oracle-1896"
     },
     {
       "claim": "The admission policy is now writing cache entries.",
@@ -13781,7 +15181,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1722"
+      "id": "philosophy-admission-oracle-1897"
     },
     {
       "claim": "The admission policy is required to authorize backend selection.",
@@ -13789,7 +15189,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1723"
+      "id": "philosophy-admission-oracle-1898"
     },
     {
       "claim": "The admission policy is required to be cache eligible for semantic-cache admission.",
@@ -13797,7 +15197,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1724"
+      "id": "philosophy-admission-oracle-1899"
     },
     {
       "claim": "The admission policy is required to enable runtime expansion.",
@@ -13805,7 +15205,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1725"
+      "id": "philosophy-admission-oracle-1900"
     },
     {
       "claim": "The admission policy is required to read semantic-cache entries.",
@@ -13813,7 +15213,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1726"
+      "id": "philosophy-admission-oracle-1901"
     },
     {
       "claim": "The admission policy is required to write cache entries.",
@@ -13821,7 +15221,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1727"
+      "id": "philosophy-admission-oracle-1902"
     },
     {
       "claim": "The admission policy may authorize backend selection.",
@@ -13829,7 +15229,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1728"
+      "id": "philosophy-admission-oracle-1903"
     },
     {
       "claim": "The admission policy may be cache eligible for semantic-cache admission.",
@@ -13837,7 +15237,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1729"
+      "id": "philosophy-admission-oracle-1904"
     },
     {
       "claim": "The admission policy may enable runtime expansion.",
@@ -13845,7 +15245,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1730"
+      "id": "philosophy-admission-oracle-1905"
     },
     {
       "claim": "The admission policy may read semantic-cache entries.",
@@ -13853,7 +15253,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1731"
+      "id": "philosophy-admission-oracle-1906"
     },
     {
       "claim": "The admission policy may write cache entries.",
@@ -13861,7 +15261,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1732"
+      "id": "philosophy-admission-oracle-1907"
     },
     {
       "claim": "The admission policy might authorize backend selection.",
@@ -13869,7 +15269,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1733"
+      "id": "philosophy-admission-oracle-1908"
     },
     {
       "claim": "The admission policy might be cache eligible for semantic-cache admission.",
@@ -13877,7 +15277,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1734"
+      "id": "philosophy-admission-oracle-1909"
     },
     {
       "claim": "The admission policy might enable runtime expansion.",
@@ -13885,7 +15285,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1735"
+      "id": "philosophy-admission-oracle-1910"
     },
     {
       "claim": "The admission policy might read semantic-cache entries.",
@@ -13893,7 +15293,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1736"
+      "id": "philosophy-admission-oracle-1911"
     },
     {
       "claim": "The admission policy might write cache entries.",
@@ -13901,7 +15301,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1737"
+      "id": "philosophy-admission-oracle-1912"
     },
     {
       "claim": "The admission policy must authorize backend selection.",
@@ -13909,7 +15309,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1738"
+      "id": "philosophy-admission-oracle-1913"
     },
     {
       "claim": "The admission policy must be cache eligible for semantic-cache admission.",
@@ -13917,7 +15317,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1739"
+      "id": "philosophy-admission-oracle-1914"
     },
     {
       "claim": "The admission policy must enable runtime expansion.",
@@ -13925,7 +15325,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1740"
+      "id": "philosophy-admission-oracle-1915"
     },
     {
       "claim": "The admission policy must read semantic-cache entries.",
@@ -13933,7 +15333,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1741"
+      "id": "philosophy-admission-oracle-1916"
     },
     {
       "claim": "The admission policy must write cache entries.",
@@ -13941,7 +15341,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1742"
+      "id": "philosophy-admission-oracle-1917"
     },
     {
       "claim": "The admission policy reads semantic-cache entries.",
@@ -13949,7 +15349,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1743"
+      "id": "philosophy-admission-oracle-1918"
     },
     {
       "claim": "The admission policy remains cache eligible for semantic-cache admission.",
@@ -13957,7 +15357,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1744"
+      "id": "philosophy-admission-oracle-1919"
     },
     {
       "claim": "The admission policy should authorize backend selection.",
@@ -13965,7 +15365,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1745"
+      "id": "philosophy-admission-oracle-1920"
     },
     {
       "claim": "The admission policy should be cache eligible for semantic-cache admission.",
@@ -13973,7 +15373,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1746"
+      "id": "philosophy-admission-oracle-1921"
     },
     {
       "claim": "The admission policy should enable runtime expansion.",
@@ -13981,7 +15381,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1747"
+      "id": "philosophy-admission-oracle-1922"
     },
     {
       "claim": "The admission policy should read semantic-cache entries.",
@@ -13989,7 +15389,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1748"
+      "id": "philosophy-admission-oracle-1923"
     },
     {
       "claim": "The admission policy should write cache entries.",
@@ -13997,7 +15397,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1749"
+      "id": "philosophy-admission-oracle-1924"
     },
     {
       "claim": "The admission policy will authorize backend selection.",
@@ -14005,7 +15405,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1750"
+      "id": "philosophy-admission-oracle-1925"
     },
     {
       "claim": "The admission policy will be cache eligible for semantic-cache admission.",
@@ -14013,7 +15413,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1751"
+      "id": "philosophy-admission-oracle-1926"
     },
     {
       "claim": "The admission policy will enable runtime expansion.",
@@ -14021,7 +15421,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1752"
+      "id": "philosophy-admission-oracle-1927"
     },
     {
       "claim": "The admission policy will read semantic-cache entries.",
@@ -14029,7 +15429,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1753"
+      "id": "philosophy-admission-oracle-1928"
     },
     {
       "claim": "The admission policy will write cache entries.",
@@ -14037,7 +15437,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1754"
+      "id": "philosophy-admission-oracle-1929"
     },
     {
       "claim": "The admission policy would authorize backend selection.",
@@ -14045,7 +15445,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1755"
+      "id": "philosophy-admission-oracle-1930"
     },
     {
       "claim": "The admission policy would be cache eligible for semantic-cache admission.",
@@ -14053,7 +15453,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1756"
+      "id": "philosophy-admission-oracle-1931"
     },
     {
       "claim": "The admission policy would enable runtime expansion.",
@@ -14061,7 +15461,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1757"
+      "id": "philosophy-admission-oracle-1932"
     },
     {
       "claim": "The admission policy would read semantic-cache entries.",
@@ -14069,7 +15469,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1758"
+      "id": "philosophy-admission-oracle-1933"
     },
     {
       "claim": "The admission policy would write cache entries.",
@@ -14077,7 +15477,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1759"
+      "id": "philosophy-admission-oracle-1934"
     },
     {
       "claim": "The admission policy writes cache entries.",
@@ -14085,7 +15485,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1760"
+      "id": "philosophy-admission-oracle-1935"
     },
     {
       "claim": "The claim-family oracle authorizes backend selection.",
@@ -14093,7 +15493,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1761"
+      "id": "philosophy-admission-oracle-1936"
     },
     {
       "claim": "The claim-family oracle became cache eligible for semantic-cache admission.",
@@ -14101,7 +15501,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1762"
+      "id": "philosophy-admission-oracle-1937"
     },
     {
       "claim": "The claim-family oracle becomes cache eligible for semantic-cache admission.",
@@ -14109,7 +15509,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1763"
+      "id": "philosophy-admission-oracle-1938"
     },
     {
       "claim": "The claim-family oracle can authorize backend selection.",
@@ -14117,7 +15517,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1764"
+      "id": "philosophy-admission-oracle-1939"
     },
     {
       "claim": "The claim-family oracle can be cache eligible for semantic-cache admission.",
@@ -14125,7 +15525,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1765"
+      "id": "philosophy-admission-oracle-1940"
     },
     {
       "claim": "The claim-family oracle can enable runtime expansion.",
@@ -14133,7 +15533,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1766"
+      "id": "philosophy-admission-oracle-1941"
     },
     {
       "claim": "The claim-family oracle can read semantic-cache entries.",
@@ -14141,7 +15541,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1767"
+      "id": "philosophy-admission-oracle-1942"
     },
     {
       "claim": "The claim-family oracle can write cache entries.",
@@ -14149,7 +15549,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1768"
+      "id": "philosophy-admission-oracle-1943"
     },
     {
       "claim": "The claim-family oracle could authorize backend selection.",
@@ -14157,7 +15557,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1769"
+      "id": "philosophy-admission-oracle-1944"
     },
     {
       "claim": "The claim-family oracle could be cache eligible for semantic-cache admission.",
@@ -14165,7 +15565,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1770"
+      "id": "philosophy-admission-oracle-1945"
     },
     {
       "claim": "The claim-family oracle could enable runtime expansion.",
@@ -14173,7 +15573,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1771"
+      "id": "philosophy-admission-oracle-1946"
     },
     {
       "claim": "The claim-family oracle could read semantic-cache entries.",
@@ -14181,7 +15581,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1772"
+      "id": "philosophy-admission-oracle-1947"
     },
     {
       "claim": "The claim-family oracle could write cache entries.",
@@ -14189,7 +15589,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1773"
+      "id": "philosophy-admission-oracle-1948"
     },
     {
       "claim": "The claim-family oracle enables runtime expansion.",
@@ -14197,7 +15597,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1774"
+      "id": "philosophy-admission-oracle-1949"
     },
     {
       "claim": "The claim-family oracle has authorized backend selection.",
@@ -14205,7 +15605,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1775"
+      "id": "philosophy-admission-oracle-1950"
     },
     {
       "claim": "The claim-family oracle has to authorize backend selection.",
@@ -14213,7 +15613,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1776"
+      "id": "philosophy-admission-oracle-1951"
     },
     {
       "claim": "The claim-family oracle has to be cache eligible for semantic-cache admission.",
@@ -14221,7 +15621,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1777"
+      "id": "philosophy-admission-oracle-1952"
     },
     {
       "claim": "The claim-family oracle has to enable runtime expansion.",
@@ -14229,7 +15629,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1778"
+      "id": "philosophy-admission-oracle-1953"
     },
     {
       "claim": "The claim-family oracle has to read semantic-cache entries.",
@@ -14237,7 +15637,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1779"
+      "id": "philosophy-admission-oracle-1954"
     },
     {
       "claim": "The claim-family oracle has to write cache entries.",
@@ -14245,7 +15645,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1780"
+      "id": "philosophy-admission-oracle-1955"
     },
     {
       "claim": "The claim-family oracle is now writing cache entries.",
@@ -14253,7 +15653,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1781"
+      "id": "philosophy-admission-oracle-1956"
     },
     {
       "claim": "The claim-family oracle is required to authorize backend selection.",
@@ -14261,7 +15661,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1782"
+      "id": "philosophy-admission-oracle-1957"
     },
     {
       "claim": "The claim-family oracle is required to be cache eligible for semantic-cache admission.",
@@ -14269,7 +15669,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1783"
+      "id": "philosophy-admission-oracle-1958"
     },
     {
       "claim": "The claim-family oracle is required to enable runtime expansion.",
@@ -14277,7 +15677,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1784"
+      "id": "philosophy-admission-oracle-1959"
     },
     {
       "claim": "The claim-family oracle is required to read semantic-cache entries.",
@@ -14285,7 +15685,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1785"
+      "id": "philosophy-admission-oracle-1960"
     },
     {
       "claim": "The claim-family oracle is required to write cache entries.",
@@ -14293,7 +15693,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1786"
+      "id": "philosophy-admission-oracle-1961"
     },
     {
       "claim": "The claim-family oracle may authorize backend selection.",
@@ -14301,7 +15701,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1787"
+      "id": "philosophy-admission-oracle-1962"
     },
     {
       "claim": "The claim-family oracle may be cache eligible for semantic-cache admission.",
@@ -14309,7 +15709,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1788"
+      "id": "philosophy-admission-oracle-1963"
     },
     {
       "claim": "The claim-family oracle may enable runtime expansion.",
@@ -14317,7 +15717,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1789"
+      "id": "philosophy-admission-oracle-1964"
     },
     {
       "claim": "The claim-family oracle may read semantic-cache entries.",
@@ -14325,7 +15725,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1790"
+      "id": "philosophy-admission-oracle-1965"
     },
     {
       "claim": "The claim-family oracle may write cache entries.",
@@ -14333,7 +15733,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1791"
+      "id": "philosophy-admission-oracle-1966"
     },
     {
       "claim": "The claim-family oracle might authorize backend selection.",
@@ -14341,7 +15741,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1792"
+      "id": "philosophy-admission-oracle-1967"
     },
     {
       "claim": "The claim-family oracle might be cache eligible for semantic-cache admission.",
@@ -14349,7 +15749,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1793"
+      "id": "philosophy-admission-oracle-1968"
     },
     {
       "claim": "The claim-family oracle might enable runtime expansion.",
@@ -14357,7 +15757,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1794"
+      "id": "philosophy-admission-oracle-1969"
     },
     {
       "claim": "The claim-family oracle might read semantic-cache entries.",
@@ -14365,7 +15765,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1795"
+      "id": "philosophy-admission-oracle-1970"
     },
     {
       "claim": "The claim-family oracle might write cache entries.",
@@ -14373,7 +15773,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1796"
+      "id": "philosophy-admission-oracle-1971"
     },
     {
       "claim": "The claim-family oracle must authorize backend selection.",
@@ -14381,7 +15781,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1797"
+      "id": "philosophy-admission-oracle-1972"
     },
     {
       "claim": "The claim-family oracle must be cache eligible for semantic-cache admission.",
@@ -14389,7 +15789,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1798"
+      "id": "philosophy-admission-oracle-1973"
     },
     {
       "claim": "The claim-family oracle must enable runtime expansion.",
@@ -14397,7 +15797,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1799"
+      "id": "philosophy-admission-oracle-1974"
     },
     {
       "claim": "The claim-family oracle must read semantic-cache entries.",
@@ -14405,7 +15805,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1800"
+      "id": "philosophy-admission-oracle-1975"
     },
     {
       "claim": "The claim-family oracle must write cache entries.",
@@ -14413,7 +15813,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1801"
+      "id": "philosophy-admission-oracle-1976"
     },
     {
       "claim": "The claim-family oracle reads semantic-cache entries.",
@@ -14421,7 +15821,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1802"
+      "id": "philosophy-admission-oracle-1977"
     },
     {
       "claim": "The claim-family oracle remains cache eligible for semantic-cache admission.",
@@ -14429,7 +15829,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1803"
+      "id": "philosophy-admission-oracle-1978"
     },
     {
       "claim": "The claim-family oracle should authorize backend selection.",
@@ -14437,7 +15837,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1804"
+      "id": "philosophy-admission-oracle-1979"
     },
     {
       "claim": "The claim-family oracle should be cache eligible for semantic-cache admission.",
@@ -14445,7 +15845,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1805"
+      "id": "philosophy-admission-oracle-1980"
     },
     {
       "claim": "The claim-family oracle should enable runtime expansion.",
@@ -14453,7 +15853,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1806"
+      "id": "philosophy-admission-oracle-1981"
     },
     {
       "claim": "The claim-family oracle should read semantic-cache entries.",
@@ -14461,7 +15861,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1807"
+      "id": "philosophy-admission-oracle-1982"
     },
     {
       "claim": "The claim-family oracle should write cache entries.",
@@ -14469,7 +15869,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1808"
+      "id": "philosophy-admission-oracle-1983"
     },
     {
       "claim": "The claim-family oracle will authorize backend selection.",
@@ -14477,7 +15877,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1809"
+      "id": "philosophy-admission-oracle-1984"
     },
     {
       "claim": "The claim-family oracle will be cache eligible for semantic-cache admission.",
@@ -14485,7 +15885,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1810"
+      "id": "philosophy-admission-oracle-1985"
     },
     {
       "claim": "The claim-family oracle will enable runtime expansion.",
@@ -14493,7 +15893,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1811"
+      "id": "philosophy-admission-oracle-1986"
     },
     {
       "claim": "The claim-family oracle will read semantic-cache entries.",
@@ -14501,7 +15901,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1812"
+      "id": "philosophy-admission-oracle-1987"
     },
     {
       "claim": "The claim-family oracle will write cache entries.",
@@ -14509,7 +15909,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1813"
+      "id": "philosophy-admission-oracle-1988"
     },
     {
       "claim": "The claim-family oracle would authorize backend selection.",
@@ -14517,7 +15917,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1814"
+      "id": "philosophy-admission-oracle-1989"
     },
     {
       "claim": "The claim-family oracle would be cache eligible for semantic-cache admission.",
@@ -14525,7 +15925,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1815"
+      "id": "philosophy-admission-oracle-1990"
     },
     {
       "claim": "The claim-family oracle would enable runtime expansion.",
@@ -14533,7 +15933,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1816"
+      "id": "philosophy-admission-oracle-1991"
     },
     {
       "claim": "The claim-family oracle would read semantic-cache entries.",
@@ -14541,7 +15941,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1817"
+      "id": "philosophy-admission-oracle-1992"
     },
     {
       "claim": "The claim-family oracle would write cache entries.",
@@ -14549,7 +15949,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1818"
+      "id": "philosophy-admission-oracle-1993"
     },
     {
       "claim": "The claim-family oracle writes cache entries.",
@@ -14557,7 +15957,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1819"
+      "id": "philosophy-admission-oracle-1994"
     },
     {
       "claim": "The policy spec authorizes backend selection without SC-G5.",
@@ -14565,7 +15965,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-1820"
+      "id": "philosophy-admission-oracle-1995"
     },
     {
       "claim": "Therapy routing authorizes backend selection.",
@@ -14573,7 +15973,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1821"
+      "id": "philosophy-admission-oracle-1996"
     },
     {
       "claim": "Therapy routing became cache eligible for semantic-cache admission.",
@@ -14581,7 +15981,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1822"
+      "id": "philosophy-admission-oracle-1997"
     },
     {
       "claim": "Therapy routing becomes cache eligible for semantic-cache admission.",
@@ -14589,7 +15989,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1823"
+      "id": "philosophy-admission-oracle-1998"
     },
     {
       "claim": "Therapy routing can authorize backend selection.",
@@ -14597,7 +15997,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1824"
+      "id": "philosophy-admission-oracle-1999"
     },
     {
       "claim": "Therapy routing can be cache eligible for semantic-cache admission.",
@@ -14605,7 +16005,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1825"
+      "id": "philosophy-admission-oracle-2000"
     },
     {
       "claim": "Therapy routing can enable runtime expansion.",
@@ -14613,7 +16013,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1826"
+      "id": "philosophy-admission-oracle-2001"
     },
     {
       "claim": "Therapy routing can read semantic-cache entries.",
@@ -14621,7 +16021,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1827"
+      "id": "philosophy-admission-oracle-2002"
     },
     {
       "claim": "Therapy routing can write cache entries.",
@@ -14629,7 +16029,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1828"
+      "id": "philosophy-admission-oracle-2003"
     },
     {
       "claim": "Therapy routing could authorize backend selection.",
@@ -14637,7 +16037,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1829"
+      "id": "philosophy-admission-oracle-2004"
     },
     {
       "claim": "Therapy routing could be cache eligible for semantic-cache admission.",
@@ -14645,7 +16045,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1830"
+      "id": "philosophy-admission-oracle-2005"
     },
     {
       "claim": "Therapy routing could enable runtime expansion.",
@@ -14653,7 +16053,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1831"
+      "id": "philosophy-admission-oracle-2006"
     },
     {
       "claim": "Therapy routing could read semantic-cache entries.",
@@ -14661,7 +16061,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1832"
+      "id": "philosophy-admission-oracle-2007"
     },
     {
       "claim": "Therapy routing could write cache entries.",
@@ -14669,7 +16069,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1833"
+      "id": "philosophy-admission-oracle-2008"
     },
     {
       "claim": "Therapy routing enables runtime expansion.",
@@ -14677,7 +16077,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1834"
+      "id": "philosophy-admission-oracle-2009"
     },
     {
       "claim": "Therapy routing has authorized backend selection.",
@@ -14685,7 +16085,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1835"
+      "id": "philosophy-admission-oracle-2010"
     },
     {
       "claim": "Therapy routing has to authorize backend selection.",
@@ -14693,7 +16093,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1836"
+      "id": "philosophy-admission-oracle-2011"
     },
     {
       "claim": "Therapy routing has to be cache eligible for semantic-cache admission.",
@@ -14701,7 +16101,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1837"
+      "id": "philosophy-admission-oracle-2012"
     },
     {
       "claim": "Therapy routing has to enable runtime expansion.",
@@ -14709,7 +16109,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1838"
+      "id": "philosophy-admission-oracle-2013"
     },
     {
       "claim": "Therapy routing has to read semantic-cache entries.",
@@ -14717,7 +16117,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1839"
+      "id": "philosophy-admission-oracle-2014"
     },
     {
       "claim": "Therapy routing has to write cache entries.",
@@ -14725,7 +16125,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1840"
+      "id": "philosophy-admission-oracle-2015"
     },
     {
       "claim": "Therapy routing is now writing cache entries.",
@@ -14733,7 +16133,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1841"
+      "id": "philosophy-admission-oracle-2016"
     },
     {
       "claim": "Therapy routing is required to authorize backend selection.",
@@ -14741,7 +16141,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1842"
+      "id": "philosophy-admission-oracle-2017"
     },
     {
       "claim": "Therapy routing is required to be cache eligible for semantic-cache admission.",
@@ -14749,7 +16149,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1843"
+      "id": "philosophy-admission-oracle-2018"
     },
     {
       "claim": "Therapy routing is required to enable runtime expansion.",
@@ -14757,7 +16157,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1844"
+      "id": "philosophy-admission-oracle-2019"
     },
     {
       "claim": "Therapy routing is required to read semantic-cache entries.",
@@ -14765,7 +16165,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1845"
+      "id": "philosophy-admission-oracle-2020"
     },
     {
       "claim": "Therapy routing is required to write cache entries.",
@@ -14773,7 +16173,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1846"
+      "id": "philosophy-admission-oracle-2021"
     },
     {
       "claim": "Therapy routing may authorize backend selection.",
@@ -14781,7 +16181,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1847"
+      "id": "philosophy-admission-oracle-2022"
     },
     {
       "claim": "Therapy routing may be cache eligible for semantic-cache admission.",
@@ -14789,7 +16189,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1848"
+      "id": "philosophy-admission-oracle-2023"
     },
     {
       "claim": "Therapy routing may enable runtime expansion.",
@@ -14797,7 +16197,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1849"
+      "id": "philosophy-admission-oracle-2024"
     },
     {
       "claim": "Therapy routing may read semantic-cache entries.",
@@ -14805,7 +16205,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1850"
+      "id": "philosophy-admission-oracle-2025"
     },
     {
       "claim": "Therapy routing may write cache entries.",
@@ -14813,7 +16213,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1851"
+      "id": "philosophy-admission-oracle-2026"
     },
     {
       "claim": "Therapy routing might authorize backend selection.",
@@ -14821,7 +16221,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1852"
+      "id": "philosophy-admission-oracle-2027"
     },
     {
       "claim": "Therapy routing might be cache eligible for semantic-cache admission.",
@@ -14829,7 +16229,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1853"
+      "id": "philosophy-admission-oracle-2028"
     },
     {
       "claim": "Therapy routing might enable runtime expansion.",
@@ -14837,7 +16237,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1854"
+      "id": "philosophy-admission-oracle-2029"
     },
     {
       "claim": "Therapy routing might read semantic-cache entries.",
@@ -14845,7 +16245,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1855"
+      "id": "philosophy-admission-oracle-2030"
     },
     {
       "claim": "Therapy routing might write cache entries.",
@@ -14853,7 +16253,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1856"
+      "id": "philosophy-admission-oracle-2031"
     },
     {
       "claim": "Therapy routing must authorize backend selection.",
@@ -14861,7 +16261,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1857"
+      "id": "philosophy-admission-oracle-2032"
     },
     {
       "claim": "Therapy routing must be cache eligible for semantic-cache admission.",
@@ -14869,7 +16269,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1858"
+      "id": "philosophy-admission-oracle-2033"
     },
     {
       "claim": "Therapy routing must enable runtime expansion.",
@@ -14877,7 +16277,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1859"
+      "id": "philosophy-admission-oracle-2034"
     },
     {
       "claim": "Therapy routing must read semantic-cache entries.",
@@ -14885,7 +16285,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1860"
+      "id": "philosophy-admission-oracle-2035"
     },
     {
       "claim": "Therapy routing must write cache entries.",
@@ -14893,7 +16293,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1861"
+      "id": "philosophy-admission-oracle-2036"
     },
     {
       "claim": "Therapy routing reads semantic-cache entries.",
@@ -14901,7 +16301,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1862"
+      "id": "philosophy-admission-oracle-2037"
     },
     {
       "claim": "Therapy routing remains cache eligible for semantic-cache admission.",
@@ -14909,7 +16309,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1863"
+      "id": "philosophy-admission-oracle-2038"
     },
     {
       "claim": "Therapy routing should authorize backend selection.",
@@ -14917,7 +16317,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1864"
+      "id": "philosophy-admission-oracle-2039"
     },
     {
       "claim": "Therapy routing should be cache eligible for semantic-cache admission.",
@@ -14925,7 +16325,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1865"
+      "id": "philosophy-admission-oracle-2040"
     },
     {
       "claim": "Therapy routing should enable runtime expansion.",
@@ -14933,7 +16333,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1866"
+      "id": "philosophy-admission-oracle-2041"
     },
     {
       "claim": "Therapy routing should read semantic-cache entries.",
@@ -14941,7 +16341,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1867"
+      "id": "philosophy-admission-oracle-2042"
     },
     {
       "claim": "Therapy routing should write cache entries.",
@@ -14949,7 +16349,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1868"
+      "id": "philosophy-admission-oracle-2043"
     },
     {
       "claim": "Therapy routing will authorize backend selection.",
@@ -14957,7 +16357,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1869"
+      "id": "philosophy-admission-oracle-2044"
     },
     {
       "claim": "Therapy routing will be cache eligible for semantic-cache admission.",
@@ -14965,7 +16365,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1870"
+      "id": "philosophy-admission-oracle-2045"
     },
     {
       "claim": "Therapy routing will enable runtime expansion.",
@@ -14973,7 +16373,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1871"
+      "id": "philosophy-admission-oracle-2046"
     },
     {
       "claim": "Therapy routing will read semantic-cache entries.",
@@ -14981,7 +16381,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1872"
+      "id": "philosophy-admission-oracle-2047"
     },
     {
       "claim": "Therapy routing will write cache entries.",
@@ -14989,7 +16389,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1873"
+      "id": "philosophy-admission-oracle-2048"
     },
     {
       "claim": "Therapy routing would authorize backend selection.",
@@ -14997,7 +16397,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1874"
+      "id": "philosophy-admission-oracle-2049"
     },
     {
       "claim": "Therapy routing would be cache eligible for semantic-cache admission.",
@@ -15005,7 +16405,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1875"
+      "id": "philosophy-admission-oracle-2050"
     },
     {
       "claim": "Therapy routing would enable runtime expansion.",
@@ -15013,7 +16413,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1876"
+      "id": "philosophy-admission-oracle-2051"
     },
     {
       "claim": "Therapy routing would read semantic-cache entries.",
@@ -15021,7 +16421,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1877"
+      "id": "philosophy-admission-oracle-2052"
     },
     {
       "claim": "Therapy routing would write cache entries.",
@@ -15029,7 +16429,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1878"
+      "id": "philosophy-admission-oracle-2053"
     },
     {
       "claim": "Therapy routing writes cache entries.",
@@ -15037,7 +16437,7 @@
       "expected": "forbidden",
       "expected_detector_label": "runtime allowed in pr-1",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1879"
+      "id": "philosophy-admission-oracle-2054"
     },
     {
       "claim": "Cache admission requires a passed verification bundle.",
@@ -15045,7 +16445,7 @@
       "expected": "allowed",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-1880"
+      "id": "philosophy-admission-oracle-2055"
     },
     {
       "claim": "Future PR may evaluate semantic-cache admission after verification.",
@@ -15053,7 +16453,7 @@
       "expected": "allowed",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-1881"
+      "id": "philosophy-admission-oracle-2056"
     },
     {
       "claim": "No semantic-cache admission may omit the verification bundle.",
@@ -15061,7 +16461,7 @@
       "expected": "allowed",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.allowed_negative_controls",
-      "id": "philosophy-admission-oracle-1882"
+      "id": "philosophy-admission-oracle-2057"
     },
     {
       "claim": "Cache admission became exempt from verification bundles.",
@@ -15069,7 +16469,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1883"
+      "id": "philosophy-admission-oracle-2058"
     },
     {
       "claim": "Cache admission bypasses verification bundles.",
@@ -15077,7 +16477,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1884"
+      "id": "philosophy-admission-oracle-2059"
     },
     {
       "claim": "Cache admission can omit the verification bundle.",
@@ -15085,7 +16485,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1885"
+      "id": "philosophy-admission-oracle-2060"
     },
     {
       "claim": "Cache admission can promote knowledge without a verification bundle.",
@@ -15093,7 +16493,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1886"
+      "id": "philosophy-admission-oracle-2061"
     },
     {
       "claim": "Cache admission can skip verification bundles.",
@@ -15101,7 +16501,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1887"
+      "id": "philosophy-admission-oracle-2062"
     },
     {
       "claim": "Cache admission can waive verification bundle requirements.",
@@ -15109,7 +16509,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1888"
+      "id": "philosophy-admission-oracle-2063"
     },
     {
       "claim": "Cache admission could omit the verification bundle.",
@@ -15117,7 +16517,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1889"
+      "id": "philosophy-admission-oracle-2064"
     },
     {
       "claim": "Cache admission could promote knowledge without a verification bundle.",
@@ -15125,7 +16525,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1890"
+      "id": "philosophy-admission-oracle-2065"
     },
     {
       "claim": "Cache admission could skip verification bundles.",
@@ -15133,7 +16533,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1891"
+      "id": "philosophy-admission-oracle-2066"
     },
     {
       "claim": "Cache admission could waive verification bundle requirements.",
@@ -15141,7 +16541,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1892"
+      "id": "philosophy-admission-oracle-2067"
     },
     {
       "claim": "Cache admission does not require a verification bundle.",
@@ -15149,7 +16549,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1893"
+      "id": "philosophy-admission-oracle-2068"
     },
     {
       "claim": "Cache admission has bypassed verification bundles.",
@@ -15157,7 +16557,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1894"
+      "id": "philosophy-admission-oracle-2069"
     },
     {
       "claim": "Cache admission has to omit the verification bundle.",
@@ -15165,7 +16565,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1895"
+      "id": "philosophy-admission-oracle-2070"
     },
     {
       "claim": "Cache admission has to promote knowledge without a verification bundle.",
@@ -15173,7 +16573,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1896"
+      "id": "philosophy-admission-oracle-2071"
     },
     {
       "claim": "Cache admission has to skip verification bundles.",
@@ -15181,7 +16581,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1897"
+      "id": "philosophy-admission-oracle-2072"
     },
     {
       "claim": "Cache admission has to waive verification bundle requirements.",
@@ -15189,7 +16589,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1898"
+      "id": "philosophy-admission-oracle-2073"
     },
     {
       "claim": "Cache admission is now waiving verification bundle requirements.",
@@ -15197,7 +16597,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1899"
+      "id": "philosophy-admission-oracle-2074"
     },
     {
       "claim": "Cache admission is required to omit the verification bundle.",
@@ -15205,7 +16605,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1900"
+      "id": "philosophy-admission-oracle-2075"
     },
     {
       "claim": "Cache admission is required to promote knowledge without a verification bundle.",
@@ -15213,7 +16613,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1901"
+      "id": "philosophy-admission-oracle-2076"
     },
     {
       "claim": "Cache admission is required to skip verification bundles.",
@@ -15221,7 +16621,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1902"
+      "id": "philosophy-admission-oracle-2077"
     },
     {
       "claim": "Cache admission is required to waive verification bundle requirements.",
@@ -15229,7 +16629,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1903"
+      "id": "philosophy-admission-oracle-2078"
     },
     {
       "claim": "Cache admission makes verification bundles optional.",
@@ -15237,7 +16637,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1904"
+      "id": "philosophy-admission-oracle-2079"
     },
     {
       "claim": "Cache admission may omit the verification bundle.",
@@ -15245,7 +16645,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1905"
+      "id": "philosophy-admission-oracle-2080"
     },
     {
       "claim": "Cache admission may promote knowledge without a verification bundle.",
@@ -15253,7 +16653,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1906"
+      "id": "philosophy-admission-oracle-2081"
     },
     {
       "claim": "Cache admission may skip verification bundles.",
@@ -15261,7 +16661,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1907"
+      "id": "philosophy-admission-oracle-2082"
     },
     {
       "claim": "Cache admission may waive verification bundle requirements.",
@@ -15269,7 +16669,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1908"
+      "id": "philosophy-admission-oracle-2083"
     },
     {
       "claim": "Cache admission might omit the verification bundle.",
@@ -15277,7 +16677,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1909"
+      "id": "philosophy-admission-oracle-2084"
     },
     {
       "claim": "Cache admission might promote knowledge without a verification bundle.",
@@ -15285,7 +16685,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1910"
+      "id": "philosophy-admission-oracle-2085"
     },
     {
       "claim": "Cache admission might skip verification bundles.",
@@ -15293,7 +16693,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1911"
+      "id": "philosophy-admission-oracle-2086"
     },
     {
       "claim": "Cache admission might waive verification bundle requirements.",
@@ -15301,7 +16701,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1912"
+      "id": "philosophy-admission-oracle-2087"
     },
     {
       "claim": "Cache admission must omit the verification bundle.",
@@ -15309,7 +16709,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1913"
+      "id": "philosophy-admission-oracle-2088"
     },
     {
       "claim": "Cache admission must promote knowledge without a verification bundle.",
@@ -15317,7 +16717,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1914"
+      "id": "philosophy-admission-oracle-2089"
     },
     {
       "claim": "Cache admission must skip verification bundles.",
@@ -15325,7 +16725,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1915"
+      "id": "philosophy-admission-oracle-2090"
     },
     {
       "claim": "Cache admission must waive verification bundle requirements.",
@@ -15333,7 +16733,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1916"
+      "id": "philosophy-admission-oracle-2091"
     },
     {
       "claim": "Cache admission promotes knowledge without a verification bundle.",
@@ -15341,7 +16741,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1917"
+      "id": "philosophy-admission-oracle-2092"
     },
     {
       "claim": "Cache admission remains optional for verification bundles.",
@@ -15349,7 +16749,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1918"
+      "id": "philosophy-admission-oracle-2093"
     },
     {
       "claim": "Cache admission should omit the verification bundle.",
@@ -15357,7 +16757,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1919"
+      "id": "philosophy-admission-oracle-2094"
     },
     {
       "claim": "Cache admission should promote knowledge without a verification bundle.",
@@ -15365,7 +16765,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1920"
+      "id": "philosophy-admission-oracle-2095"
     },
     {
       "claim": "Cache admission should skip verification bundles.",
@@ -15373,7 +16773,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1921"
+      "id": "philosophy-admission-oracle-2096"
     },
     {
       "claim": "Cache admission should waive verification bundle requirements.",
@@ -15381,7 +16781,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1922"
+      "id": "philosophy-admission-oracle-2097"
     },
     {
       "claim": "Cache admission waives verification bundle requirements.",
@@ -15389,7 +16789,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1923"
+      "id": "philosophy-admission-oracle-2098"
     },
     {
       "claim": "Cache admission will omit the verification bundle.",
@@ -15397,7 +16797,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1924"
+      "id": "philosophy-admission-oracle-2099"
     },
     {
       "claim": "Cache admission will promote knowledge without a verification bundle.",
@@ -15405,7 +16805,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1925"
+      "id": "philosophy-admission-oracle-2100"
     },
     {
       "claim": "Cache admission will skip verification bundles.",
@@ -15413,7 +16813,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1926"
+      "id": "philosophy-admission-oracle-2101"
     },
     {
       "claim": "Cache admission will waive verification bundle requirements.",
@@ -15421,7 +16821,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1927"
+      "id": "philosophy-admission-oracle-2102"
     },
     {
       "claim": "Cache admission would omit the verification bundle.",
@@ -15429,7 +16829,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1928"
+      "id": "philosophy-admission-oracle-2103"
     },
     {
       "claim": "Cache admission would promote knowledge without a verification bundle.",
@@ -15437,7 +16837,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1929"
+      "id": "philosophy-admission-oracle-2104"
     },
     {
       "claim": "Cache admission would skip verification bundles.",
@@ -15445,7 +16845,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1930"
+      "id": "philosophy-admission-oracle-2105"
     },
     {
       "claim": "Cache admission would waive verification bundle requirements.",
@@ -15453,7 +16853,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1931"
+      "id": "philosophy-admission-oracle-2106"
     },
     {
       "claim": "Knowledge promotion became exempt from verification bundles.",
@@ -15461,7 +16861,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1932"
+      "id": "philosophy-admission-oracle-2107"
     },
     {
       "claim": "Knowledge promotion bypasses verification bundles.",
@@ -15469,7 +16869,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1933"
+      "id": "philosophy-admission-oracle-2108"
     },
     {
       "claim": "Knowledge promotion can omit the verification bundle.",
@@ -15477,7 +16877,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1934"
+      "id": "philosophy-admission-oracle-2109"
     },
     {
       "claim": "Knowledge promotion can promote knowledge without a verification bundle.",
@@ -15485,7 +16885,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1935"
+      "id": "philosophy-admission-oracle-2110"
     },
     {
       "claim": "Knowledge promotion can skip verification bundles.",
@@ -15493,7 +16893,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1936"
+      "id": "philosophy-admission-oracle-2111"
     },
     {
       "claim": "Knowledge promotion can waive verification bundle requirements.",
@@ -15501,7 +16901,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1937"
+      "id": "philosophy-admission-oracle-2112"
     },
     {
       "claim": "Knowledge promotion could omit the verification bundle.",
@@ -15509,7 +16909,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1938"
+      "id": "philosophy-admission-oracle-2113"
     },
     {
       "claim": "Knowledge promotion could promote knowledge without a verification bundle.",
@@ -15517,7 +16917,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1939"
+      "id": "philosophy-admission-oracle-2114"
     },
     {
       "claim": "Knowledge promotion could skip verification bundles.",
@@ -15525,7 +16925,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1940"
+      "id": "philosophy-admission-oracle-2115"
     },
     {
       "claim": "Knowledge promotion could waive verification bundle requirements.",
@@ -15533,7 +16933,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1941"
+      "id": "philosophy-admission-oracle-2116"
     },
     {
       "claim": "Knowledge promotion does not require a verification bundle.",
@@ -15541,7 +16941,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1942"
+      "id": "philosophy-admission-oracle-2117"
     },
     {
       "claim": "Knowledge promotion has bypassed verification bundles.",
@@ -15549,7 +16949,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1943"
+      "id": "philosophy-admission-oracle-2118"
     },
     {
       "claim": "Knowledge promotion has to omit the verification bundle.",
@@ -15557,7 +16957,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1944"
+      "id": "philosophy-admission-oracle-2119"
     },
     {
       "claim": "Knowledge promotion has to promote knowledge without a verification bundle.",
@@ -15565,7 +16965,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1945"
+      "id": "philosophy-admission-oracle-2120"
     },
     {
       "claim": "Knowledge promotion has to skip verification bundles.",
@@ -15573,7 +16973,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1946"
+      "id": "philosophy-admission-oracle-2121"
     },
     {
       "claim": "Knowledge promotion has to waive verification bundle requirements.",
@@ -15581,7 +16981,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1947"
+      "id": "philosophy-admission-oracle-2122"
     },
     {
       "claim": "Knowledge promotion is now waiving verification bundle requirements.",
@@ -15589,7 +16989,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1948"
+      "id": "philosophy-admission-oracle-2123"
     },
     {
       "claim": "Knowledge promotion is required to omit the verification bundle.",
@@ -15597,7 +16997,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1949"
+      "id": "philosophy-admission-oracle-2124"
     },
     {
       "claim": "Knowledge promotion is required to promote knowledge without a verification bundle.",
@@ -15605,7 +17005,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1950"
+      "id": "philosophy-admission-oracle-2125"
     },
     {
       "claim": "Knowledge promotion is required to skip verification bundles.",
@@ -15613,7 +17013,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1951"
+      "id": "philosophy-admission-oracle-2126"
     },
     {
       "claim": "Knowledge promotion is required to waive verification bundle requirements.",
@@ -15621,7 +17021,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1952"
+      "id": "philosophy-admission-oracle-2127"
     },
     {
       "claim": "Knowledge promotion makes verification bundles optional.",
@@ -15629,7 +17029,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1953"
+      "id": "philosophy-admission-oracle-2128"
     },
     {
       "claim": "Knowledge promotion may omit the verification bundle.",
@@ -15637,7 +17037,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1954"
+      "id": "philosophy-admission-oracle-2129"
     },
     {
       "claim": "Knowledge promotion may promote knowledge without a verification bundle.",
@@ -15645,7 +17045,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1955"
+      "id": "philosophy-admission-oracle-2130"
     },
     {
       "claim": "Knowledge promotion may skip verification bundles.",
@@ -15653,7 +17053,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1956"
+      "id": "philosophy-admission-oracle-2131"
     },
     {
       "claim": "Knowledge promotion may waive verification bundle requirements.",
@@ -15661,7 +17061,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1957"
+      "id": "philosophy-admission-oracle-2132"
     },
     {
       "claim": "Knowledge promotion might omit the verification bundle.",
@@ -15669,7 +17069,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1958"
+      "id": "philosophy-admission-oracle-2133"
     },
     {
       "claim": "Knowledge promotion might promote knowledge without a verification bundle.",
@@ -15677,7 +17077,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1959"
+      "id": "philosophy-admission-oracle-2134"
     },
     {
       "claim": "Knowledge promotion might skip verification bundles.",
@@ -15685,7 +17085,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1960"
+      "id": "philosophy-admission-oracle-2135"
     },
     {
       "claim": "Knowledge promotion might waive verification bundle requirements.",
@@ -15693,7 +17093,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1961"
+      "id": "philosophy-admission-oracle-2136"
     },
     {
       "claim": "Knowledge promotion must omit the verification bundle.",
@@ -15701,7 +17101,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1962"
+      "id": "philosophy-admission-oracle-2137"
     },
     {
       "claim": "Knowledge promotion must promote knowledge without a verification bundle.",
@@ -15709,7 +17109,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1963"
+      "id": "philosophy-admission-oracle-2138"
     },
     {
       "claim": "Knowledge promotion must skip verification bundles.",
@@ -15717,7 +17117,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1964"
+      "id": "philosophy-admission-oracle-2139"
     },
     {
       "claim": "Knowledge promotion must waive verification bundle requirements.",
@@ -15725,7 +17125,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1965"
+      "id": "philosophy-admission-oracle-2140"
     },
     {
       "claim": "Knowledge promotion promotes knowledge without a verification bundle.",
@@ -15733,7 +17133,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1966"
+      "id": "philosophy-admission-oracle-2141"
     },
     {
       "claim": "Knowledge promotion remains optional for verification bundles.",
@@ -15741,7 +17141,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1967"
+      "id": "philosophy-admission-oracle-2142"
     },
     {
       "claim": "Knowledge promotion should omit the verification bundle.",
@@ -15749,7 +17149,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1968"
+      "id": "philosophy-admission-oracle-2143"
     },
     {
       "claim": "Knowledge promotion should promote knowledge without a verification bundle.",
@@ -15757,7 +17157,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1969"
+      "id": "philosophy-admission-oracle-2144"
     },
     {
       "claim": "Knowledge promotion should skip verification bundles.",
@@ -15765,7 +17165,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1970"
+      "id": "philosophy-admission-oracle-2145"
     },
     {
       "claim": "Knowledge promotion should waive verification bundle requirements.",
@@ -15773,7 +17173,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1971"
+      "id": "philosophy-admission-oracle-2146"
     },
     {
       "claim": "Knowledge promotion waives verification bundle requirements.",
@@ -15781,7 +17181,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1972"
+      "id": "philosophy-admission-oracle-2147"
     },
     {
       "claim": "Knowledge promotion will omit the verification bundle.",
@@ -15789,7 +17189,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1973"
+      "id": "philosophy-admission-oracle-2148"
     },
     {
       "claim": "Knowledge promotion will promote knowledge without a verification bundle.",
@@ -15797,7 +17197,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1974"
+      "id": "philosophy-admission-oracle-2149"
     },
     {
       "claim": "Knowledge promotion will skip verification bundles.",
@@ -15805,7 +17205,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1975"
+      "id": "philosophy-admission-oracle-2150"
     },
     {
       "claim": "Knowledge promotion will waive verification bundle requirements.",
@@ -15813,7 +17213,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1976"
+      "id": "philosophy-admission-oracle-2151"
     },
     {
       "claim": "Knowledge promotion would omit the verification bundle.",
@@ -15821,7 +17221,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1977"
+      "id": "philosophy-admission-oracle-2152"
     },
     {
       "claim": "Knowledge promotion would promote knowledge without a verification bundle.",
@@ -15829,7 +17229,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1978"
+      "id": "philosophy-admission-oracle-2153"
     },
     {
       "claim": "Knowledge promotion would skip verification bundles.",
@@ -15837,7 +17237,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1979"
+      "id": "philosophy-admission-oracle-2154"
     },
     {
       "claim": "Knowledge promotion would waive verification bundle requirements.",
@@ -15845,7 +17245,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1980"
+      "id": "philosophy-admission-oracle-2155"
     },
     {
       "claim": "PR-2 is promoting knowledge without a verification bundle.",
@@ -15853,7 +17253,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-1981"
+      "id": "philosophy-admission-oracle-2156"
     },
     {
       "claim": "Philosophy admission became exempt from verification bundles.",
@@ -15861,7 +17261,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1982"
+      "id": "philosophy-admission-oracle-2157"
     },
     {
       "claim": "Philosophy admission bypasses verification bundles.",
@@ -15869,7 +17269,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1983"
+      "id": "philosophy-admission-oracle-2158"
     },
     {
       "claim": "Philosophy admission can omit the verification bundle.",
@@ -15877,7 +17277,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1984"
+      "id": "philosophy-admission-oracle-2159"
     },
     {
       "claim": "Philosophy admission can promote knowledge without a verification bundle.",
@@ -15885,7 +17285,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1985"
+      "id": "philosophy-admission-oracle-2160"
     },
     {
       "claim": "Philosophy admission can skip verification bundles.",
@@ -15893,7 +17293,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1986"
+      "id": "philosophy-admission-oracle-2161"
     },
     {
       "claim": "Philosophy admission can waive verification bundle requirements.",
@@ -15901,7 +17301,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1987"
+      "id": "philosophy-admission-oracle-2162"
     },
     {
       "claim": "Philosophy admission could omit the verification bundle.",
@@ -15909,7 +17309,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1988"
+      "id": "philosophy-admission-oracle-2163"
     },
     {
       "claim": "Philosophy admission could promote knowledge without a verification bundle.",
@@ -15917,7 +17317,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1989"
+      "id": "philosophy-admission-oracle-2164"
     },
     {
       "claim": "Philosophy admission could skip verification bundles.",
@@ -15925,7 +17325,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1990"
+      "id": "philosophy-admission-oracle-2165"
     },
     {
       "claim": "Philosophy admission could waive verification bundle requirements.",
@@ -15933,7 +17333,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1991"
+      "id": "philosophy-admission-oracle-2166"
     },
     {
       "claim": "Philosophy admission does not require a verification bundle.",
@@ -15941,7 +17341,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-1992"
+      "id": "philosophy-admission-oracle-2167"
     },
     {
       "claim": "Philosophy admission has bypassed verification bundles.",
@@ -15949,7 +17349,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1993"
+      "id": "philosophy-admission-oracle-2168"
     },
     {
       "claim": "Philosophy admission has to omit the verification bundle.",
@@ -15957,7 +17357,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1994"
+      "id": "philosophy-admission-oracle-2169"
     },
     {
       "claim": "Philosophy admission has to promote knowledge without a verification bundle.",
@@ -15965,7 +17365,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1995"
+      "id": "philosophy-admission-oracle-2170"
     },
     {
       "claim": "Philosophy admission has to skip verification bundles.",
@@ -15973,7 +17373,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1996"
+      "id": "philosophy-admission-oracle-2171"
     },
     {
       "claim": "Philosophy admission has to waive verification bundle requirements.",
@@ -15981,7 +17381,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1997"
+      "id": "philosophy-admission-oracle-2172"
     },
     {
       "claim": "Philosophy admission is now waiving verification bundle requirements.",
@@ -15989,7 +17389,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1998"
+      "id": "philosophy-admission-oracle-2173"
     },
     {
       "claim": "Philosophy admission is required to omit the verification bundle.",
@@ -15997,7 +17397,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-1999"
+      "id": "philosophy-admission-oracle-2174"
     },
     {
       "claim": "Philosophy admission is required to promote knowledge without a verification bundle.",
@@ -16005,7 +17405,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2000"
+      "id": "philosophy-admission-oracle-2175"
     },
     {
       "claim": "Philosophy admission is required to skip verification bundles.",
@@ -16013,7 +17413,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2001"
+      "id": "philosophy-admission-oracle-2176"
     },
     {
       "claim": "Philosophy admission is required to waive verification bundle requirements.",
@@ -16021,7 +17421,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2002"
+      "id": "philosophy-admission-oracle-2177"
     },
     {
       "claim": "Philosophy admission makes verification bundles optional.",
@@ -16029,7 +17429,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2003"
+      "id": "philosophy-admission-oracle-2178"
     },
     {
       "claim": "Philosophy admission may omit the verification bundle.",
@@ -16037,7 +17437,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2004"
+      "id": "philosophy-admission-oracle-2179"
     },
     {
       "claim": "Philosophy admission may promote knowledge without a verification bundle.",
@@ -16045,7 +17445,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2005"
+      "id": "philosophy-admission-oracle-2180"
     },
     {
       "claim": "Philosophy admission may skip verification bundles.",
@@ -16053,7 +17453,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2006"
+      "id": "philosophy-admission-oracle-2181"
     },
     {
       "claim": "Philosophy admission may waive verification bundle requirements.",
@@ -16061,7 +17461,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2007"
+      "id": "philosophy-admission-oracle-2182"
     },
     {
       "claim": "Philosophy admission might omit the verification bundle.",
@@ -16069,7 +17469,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2008"
+      "id": "philosophy-admission-oracle-2183"
     },
     {
       "claim": "Philosophy admission might promote knowledge without a verification bundle.",
@@ -16077,7 +17477,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2009"
+      "id": "philosophy-admission-oracle-2184"
     },
     {
       "claim": "Philosophy admission might skip verification bundles.",
@@ -16085,7 +17485,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2010"
+      "id": "philosophy-admission-oracle-2185"
     },
     {
       "claim": "Philosophy admission might waive verification bundle requirements.",
@@ -16093,7 +17493,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2011"
+      "id": "philosophy-admission-oracle-2186"
     },
     {
       "claim": "Philosophy admission must omit the verification bundle.",
@@ -16101,7 +17501,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2012"
+      "id": "philosophy-admission-oracle-2187"
     },
     {
       "claim": "Philosophy admission must promote knowledge without a verification bundle.",
@@ -16109,7 +17509,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2013"
+      "id": "philosophy-admission-oracle-2188"
     },
     {
       "claim": "Philosophy admission must skip verification bundles.",
@@ -16117,7 +17517,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2014"
+      "id": "philosophy-admission-oracle-2189"
     },
     {
       "claim": "Philosophy admission must waive verification bundle requirements.",
@@ -16125,7 +17525,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2015"
+      "id": "philosophy-admission-oracle-2190"
     },
     {
       "claim": "Philosophy admission promotes knowledge without a verification bundle.",
@@ -16133,7 +17533,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2016"
+      "id": "philosophy-admission-oracle-2191"
     },
     {
       "claim": "Philosophy admission remains optional for verification bundles.",
@@ -16141,7 +17541,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2017"
+      "id": "philosophy-admission-oracle-2192"
     },
     {
       "claim": "Philosophy admission should omit the verification bundle.",
@@ -16149,7 +17549,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2018"
+      "id": "philosophy-admission-oracle-2193"
     },
     {
       "claim": "Philosophy admission should promote knowledge without a verification bundle.",
@@ -16157,7 +17557,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2019"
+      "id": "philosophy-admission-oracle-2194"
     },
     {
       "claim": "Philosophy admission should skip verification bundles.",
@@ -16165,7 +17565,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2020"
+      "id": "philosophy-admission-oracle-2195"
     },
     {
       "claim": "Philosophy admission should waive verification bundle requirements.",
@@ -16173,7 +17573,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2021"
+      "id": "philosophy-admission-oracle-2196"
     },
     {
       "claim": "Philosophy admission waives verification bundle requirements.",
@@ -16181,7 +17581,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2022"
+      "id": "philosophy-admission-oracle-2197"
     },
     {
       "claim": "Philosophy admission will omit the verification bundle.",
@@ -16189,7 +17589,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2023"
+      "id": "philosophy-admission-oracle-2198"
     },
     {
       "claim": "Philosophy admission will promote knowledge without a verification bundle.",
@@ -16197,7 +17597,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2024"
+      "id": "philosophy-admission-oracle-2199"
     },
     {
       "claim": "Philosophy admission will skip verification bundles.",
@@ -16205,7 +17605,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2025"
+      "id": "philosophy-admission-oracle-2200"
     },
     {
       "claim": "Philosophy admission will waive verification bundle requirements.",
@@ -16213,7 +17613,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2026"
+      "id": "philosophy-admission-oracle-2201"
     },
     {
       "claim": "Philosophy admission would omit the verification bundle.",
@@ -16221,7 +17621,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2027"
+      "id": "philosophy-admission-oracle-2202"
     },
     {
       "claim": "Philosophy admission would promote knowledge without a verification bundle.",
@@ -16229,7 +17629,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2028"
+      "id": "philosophy-admission-oracle-2203"
     },
     {
       "claim": "Philosophy admission would skip verification bundles.",
@@ -16237,7 +17637,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2029"
+      "id": "philosophy-admission-oracle-2204"
     },
     {
       "claim": "Philosophy admission would waive verification bundle requirements.",
@@ -16245,7 +17645,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2030"
+      "id": "philosophy-admission-oracle-2205"
     },
     {
       "claim": "Semantic-cache admission became exempt from verification bundles.",
@@ -16253,7 +17653,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2031"
+      "id": "philosophy-admission-oracle-2206"
     },
     {
       "claim": "Semantic-cache admission bypasses verification bundles.",
@@ -16261,7 +17661,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2032"
+      "id": "philosophy-admission-oracle-2207"
     },
     {
       "claim": "Semantic-cache admission can omit the verification bundle.",
@@ -16269,7 +17669,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2033"
+      "id": "philosophy-admission-oracle-2208"
     },
     {
       "claim": "Semantic-cache admission can promote knowledge without a verification bundle.",
@@ -16277,7 +17677,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2034"
+      "id": "philosophy-admission-oracle-2209"
     },
     {
       "claim": "Semantic-cache admission can skip verification bundles.",
@@ -16285,7 +17685,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2035"
+      "id": "philosophy-admission-oracle-2210"
     },
     {
       "claim": "Semantic-cache admission can waive verification bundle requirements.",
@@ -16293,7 +17693,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2036"
+      "id": "philosophy-admission-oracle-2211"
     },
     {
       "claim": "Semantic-cache admission could omit the verification bundle.",
@@ -16301,7 +17701,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2037"
+      "id": "philosophy-admission-oracle-2212"
     },
     {
       "claim": "Semantic-cache admission could promote knowledge without a verification bundle.",
@@ -16309,7 +17709,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2038"
+      "id": "philosophy-admission-oracle-2213"
     },
     {
       "claim": "Semantic-cache admission could skip verification bundles.",
@@ -16317,7 +17717,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2039"
+      "id": "philosophy-admission-oracle-2214"
     },
     {
       "claim": "Semantic-cache admission could waive verification bundle requirements.",
@@ -16325,7 +17725,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2040"
+      "id": "philosophy-admission-oracle-2215"
     },
     {
       "claim": "Semantic-cache admission does not require a verification bundle.",
@@ -16333,7 +17733,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2041"
+      "id": "philosophy-admission-oracle-2216"
     },
     {
       "claim": "Semantic-cache admission has bypassed verification bundles.",
@@ -16341,7 +17741,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2042"
+      "id": "philosophy-admission-oracle-2217"
     },
     {
       "claim": "Semantic-cache admission has to omit the verification bundle.",
@@ -16349,7 +17749,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2043"
+      "id": "philosophy-admission-oracle-2218"
     },
     {
       "claim": "Semantic-cache admission has to promote knowledge without a verification bundle.",
@@ -16357,7 +17757,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2044"
+      "id": "philosophy-admission-oracle-2219"
     },
     {
       "claim": "Semantic-cache admission has to skip verification bundles.",
@@ -16365,7 +17765,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2045"
+      "id": "philosophy-admission-oracle-2220"
     },
     {
       "claim": "Semantic-cache admission has to waive verification bundle requirements.",
@@ -16373,7 +17773,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2046"
+      "id": "philosophy-admission-oracle-2221"
     },
     {
       "claim": "Semantic-cache admission is now waiving verification bundle requirements.",
@@ -16381,7 +17781,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2047"
+      "id": "philosophy-admission-oracle-2222"
     },
     {
       "claim": "Semantic-cache admission is required to omit the verification bundle.",
@@ -16389,7 +17789,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2048"
+      "id": "philosophy-admission-oracle-2223"
     },
     {
       "claim": "Semantic-cache admission is required to promote knowledge without a verification bundle.",
@@ -16397,7 +17797,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2049"
+      "id": "philosophy-admission-oracle-2224"
     },
     {
       "claim": "Semantic-cache admission is required to skip verification bundles.",
@@ -16405,7 +17805,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2050"
+      "id": "philosophy-admission-oracle-2225"
     },
     {
       "claim": "Semantic-cache admission is required to waive verification bundle requirements.",
@@ -16413,7 +17813,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2051"
+      "id": "philosophy-admission-oracle-2226"
     },
     {
       "claim": "Semantic-cache admission makes verification bundles optional.",
@@ -16421,7 +17821,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2052"
+      "id": "philosophy-admission-oracle-2227"
     },
     {
       "claim": "Semantic-cache admission may omit the verification bundle.",
@@ -16429,7 +17829,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2053"
+      "id": "philosophy-admission-oracle-2228"
     },
     {
       "claim": "Semantic-cache admission may promote knowledge without a verification bundle.",
@@ -16437,7 +17837,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2054"
+      "id": "philosophy-admission-oracle-2229"
     },
     {
       "claim": "Semantic-cache admission may skip verification bundles.",
@@ -16445,7 +17845,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2055"
+      "id": "philosophy-admission-oracle-2230"
     },
     {
       "claim": "Semantic-cache admission may waive verification bundle requirements.",
@@ -16453,7 +17853,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2056"
+      "id": "philosophy-admission-oracle-2231"
     },
     {
       "claim": "Semantic-cache admission might omit the verification bundle.",
@@ -16461,7 +17861,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2057"
+      "id": "philosophy-admission-oracle-2232"
     },
     {
       "claim": "Semantic-cache admission might promote knowledge without a verification bundle.",
@@ -16469,7 +17869,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2058"
+      "id": "philosophy-admission-oracle-2233"
     },
     {
       "claim": "Semantic-cache admission might skip verification bundles.",
@@ -16477,7 +17877,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2059"
+      "id": "philosophy-admission-oracle-2234"
     },
     {
       "claim": "Semantic-cache admission might waive verification bundle requirements.",
@@ -16485,7 +17885,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2060"
+      "id": "philosophy-admission-oracle-2235"
     },
     {
       "claim": "Semantic-cache admission must omit the verification bundle.",
@@ -16493,7 +17893,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2061"
+      "id": "philosophy-admission-oracle-2236"
     },
     {
       "claim": "Semantic-cache admission must promote knowledge without a verification bundle.",
@@ -16501,7 +17901,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2062"
+      "id": "philosophy-admission-oracle-2237"
     },
     {
       "claim": "Semantic-cache admission must skip verification bundles.",
@@ -16509,7 +17909,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2063"
+      "id": "philosophy-admission-oracle-2238"
     },
     {
       "claim": "Semantic-cache admission must waive verification bundle requirements.",
@@ -16517,7 +17917,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2064"
+      "id": "philosophy-admission-oracle-2239"
     },
     {
       "claim": "Semantic-cache admission promotes knowledge without a verification bundle.",
@@ -16525,7 +17925,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2065"
+      "id": "philosophy-admission-oracle-2240"
     },
     {
       "claim": "Semantic-cache admission remains optional for verification bundles.",
@@ -16533,7 +17933,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2066"
+      "id": "philosophy-admission-oracle-2241"
     },
     {
       "claim": "Semantic-cache admission should omit the verification bundle.",
@@ -16541,7 +17941,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2067"
+      "id": "philosophy-admission-oracle-2242"
     },
     {
       "claim": "Semantic-cache admission should promote knowledge without a verification bundle.",
@@ -16549,7 +17949,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2068"
+      "id": "philosophy-admission-oracle-2243"
     },
     {
       "claim": "Semantic-cache admission should skip verification bundles.",
@@ -16557,7 +17957,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2069"
+      "id": "philosophy-admission-oracle-2244"
     },
     {
       "claim": "Semantic-cache admission should waive verification bundle requirements.",
@@ -16565,7 +17965,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2070"
+      "id": "philosophy-admission-oracle-2245"
     },
     {
       "claim": "Semantic-cache admission waives verification bundle requirements.",
@@ -16573,7 +17973,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2071"
+      "id": "philosophy-admission-oracle-2246"
     },
     {
       "claim": "Semantic-cache admission will omit the verification bundle.",
@@ -16581,7 +17981,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2072"
+      "id": "philosophy-admission-oracle-2247"
     },
     {
       "claim": "Semantic-cache admission will promote knowledge without a verification bundle.",
@@ -16589,7 +17989,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2073"
+      "id": "philosophy-admission-oracle-2248"
     },
     {
       "claim": "Semantic-cache admission will skip verification bundles.",
@@ -16597,7 +17997,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2074"
+      "id": "philosophy-admission-oracle-2249"
     },
     {
       "claim": "Semantic-cache admission will waive verification bundle requirements.",
@@ -16605,7 +18005,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2075"
+      "id": "philosophy-admission-oracle-2250"
     },
     {
       "claim": "Semantic-cache admission would omit the verification bundle.",
@@ -16613,7 +18013,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2076"
+      "id": "philosophy-admission-oracle-2251"
     },
     {
       "claim": "Semantic-cache admission would promote knowledge without a verification bundle.",
@@ -16621,7 +18021,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2077"
+      "id": "philosophy-admission-oracle-2252"
     },
     {
       "claim": "Semantic-cache admission would skip verification bundles.",
@@ -16629,7 +18029,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2078"
+      "id": "philosophy-admission-oracle-2253"
     },
     {
       "claim": "Semantic-cache admission would waive verification bundle requirements.",
@@ -16637,7 +18037,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2079"
+      "id": "philosophy-admission-oracle-2254"
     },
     {
       "claim": "The admission policy became exempt from verification bundles.",
@@ -16645,7 +18045,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2080"
+      "id": "philosophy-admission-oracle-2255"
     },
     {
       "claim": "The admission policy bypasses verification bundles.",
@@ -16653,7 +18053,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2081"
+      "id": "philosophy-admission-oracle-2256"
     },
     {
       "claim": "The admission policy can omit the verification bundle.",
@@ -16661,7 +18061,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2082"
+      "id": "philosophy-admission-oracle-2257"
     },
     {
       "claim": "The admission policy can promote knowledge without a verification bundle.",
@@ -16669,7 +18069,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2083"
+      "id": "philosophy-admission-oracle-2258"
     },
     {
       "claim": "The admission policy can skip verification bundles.",
@@ -16677,7 +18077,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2084"
+      "id": "philosophy-admission-oracle-2259"
     },
     {
       "claim": "The admission policy can waive verification bundle requirements.",
@@ -16685,7 +18085,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2085"
+      "id": "philosophy-admission-oracle-2260"
     },
     {
       "claim": "The admission policy could omit the verification bundle.",
@@ -16693,7 +18093,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2086"
+      "id": "philosophy-admission-oracle-2261"
     },
     {
       "claim": "The admission policy could promote knowledge without a verification bundle.",
@@ -16701,7 +18101,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2087"
+      "id": "philosophy-admission-oracle-2262"
     },
     {
       "claim": "The admission policy could skip verification bundles.",
@@ -16709,7 +18109,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2088"
+      "id": "philosophy-admission-oracle-2263"
     },
     {
       "claim": "The admission policy could waive verification bundle requirements.",
@@ -16717,7 +18117,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2089"
+      "id": "philosophy-admission-oracle-2264"
     },
     {
       "claim": "The admission policy does not require a verification bundle.",
@@ -16725,7 +18125,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2090"
+      "id": "philosophy-admission-oracle-2265"
     },
     {
       "claim": "The admission policy has bypassed verification bundles.",
@@ -16733,7 +18133,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2091"
+      "id": "philosophy-admission-oracle-2266"
     },
     {
       "claim": "The admission policy has to omit the verification bundle.",
@@ -16741,7 +18141,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2092"
+      "id": "philosophy-admission-oracle-2267"
     },
     {
       "claim": "The admission policy has to promote knowledge without a verification bundle.",
@@ -16749,7 +18149,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2093"
+      "id": "philosophy-admission-oracle-2268"
     },
     {
       "claim": "The admission policy has to skip verification bundles.",
@@ -16757,7 +18157,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2094"
+      "id": "philosophy-admission-oracle-2269"
     },
     {
       "claim": "The admission policy has to waive verification bundle requirements.",
@@ -16765,7 +18165,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2095"
+      "id": "philosophy-admission-oracle-2270"
     },
     {
       "claim": "The admission policy is now waiving verification bundle requirements.",
@@ -16773,7 +18173,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2096"
+      "id": "philosophy-admission-oracle-2271"
     },
     {
       "claim": "The admission policy is required to omit the verification bundle.",
@@ -16781,7 +18181,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2097"
+      "id": "philosophy-admission-oracle-2272"
     },
     {
       "claim": "The admission policy is required to promote knowledge without a verification bundle.",
@@ -16789,7 +18189,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2098"
+      "id": "philosophy-admission-oracle-2273"
     },
     {
       "claim": "The admission policy is required to skip verification bundles.",
@@ -16797,7 +18197,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2099"
+      "id": "philosophy-admission-oracle-2274"
     },
     {
       "claim": "The admission policy is required to waive verification bundle requirements.",
@@ -16805,7 +18205,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2100"
+      "id": "philosophy-admission-oracle-2275"
     },
     {
       "claim": "The admission policy makes verification bundles optional.",
@@ -16813,7 +18213,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2101"
+      "id": "philosophy-admission-oracle-2276"
     },
     {
       "claim": "The admission policy may omit the verification bundle.",
@@ -16821,7 +18221,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2102"
+      "id": "philosophy-admission-oracle-2277"
     },
     {
       "claim": "The admission policy may promote knowledge without a verification bundle.",
@@ -16829,7 +18229,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2103"
+      "id": "philosophy-admission-oracle-2278"
     },
     {
       "claim": "The admission policy may skip verification bundles.",
@@ -16837,7 +18237,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2104"
+      "id": "philosophy-admission-oracle-2279"
     },
     {
       "claim": "The admission policy may waive verification bundle requirements.",
@@ -16845,7 +18245,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2105"
+      "id": "philosophy-admission-oracle-2280"
     },
     {
       "claim": "The admission policy might omit the verification bundle.",
@@ -16853,7 +18253,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2106"
+      "id": "philosophy-admission-oracle-2281"
     },
     {
       "claim": "The admission policy might promote knowledge without a verification bundle.",
@@ -16861,7 +18261,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2107"
+      "id": "philosophy-admission-oracle-2282"
     },
     {
       "claim": "The admission policy might skip verification bundles.",
@@ -16869,7 +18269,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2108"
+      "id": "philosophy-admission-oracle-2283"
     },
     {
       "claim": "The admission policy might waive verification bundle requirements.",
@@ -16877,7 +18277,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2109"
+      "id": "philosophy-admission-oracle-2284"
     },
     {
       "claim": "The admission policy must omit the verification bundle.",
@@ -16885,7 +18285,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2110"
+      "id": "philosophy-admission-oracle-2285"
     },
     {
       "claim": "The admission policy must promote knowledge without a verification bundle.",
@@ -16893,7 +18293,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2111"
+      "id": "philosophy-admission-oracle-2286"
     },
     {
       "claim": "The admission policy must skip verification bundles.",
@@ -16901,7 +18301,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2112"
+      "id": "philosophy-admission-oracle-2287"
     },
     {
       "claim": "The admission policy must waive verification bundle requirements.",
@@ -16909,7 +18309,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2113"
+      "id": "philosophy-admission-oracle-2288"
     },
     {
       "claim": "The admission policy promotes knowledge without a verification bundle.",
@@ -16917,7 +18317,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2114"
+      "id": "philosophy-admission-oracle-2289"
     },
     {
       "claim": "The admission policy remains optional for verification bundles.",
@@ -16925,7 +18325,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.temporal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2115"
+      "id": "philosophy-admission-oracle-2290"
     },
     {
       "claim": "The admission policy should omit the verification bundle.",
@@ -16933,7 +18333,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2116"
+      "id": "philosophy-admission-oracle-2291"
     },
     {
       "claim": "The admission policy should promote knowledge without a verification bundle.",
@@ -16941,7 +18341,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2117"
+      "id": "philosophy-admission-oracle-2292"
     },
     {
       "claim": "The admission policy should skip verification bundles.",
@@ -16949,7 +18349,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2118"
+      "id": "philosophy-admission-oracle-2293"
     },
     {
       "claim": "The admission policy should waive verification bundle requirements.",
@@ -16957,7 +18357,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2119"
+      "id": "philosophy-admission-oracle-2294"
     },
     {
       "claim": "The admission policy waives verification bundle requirements.",
@@ -16965,7 +18365,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.assertive_predicates",
-      "id": "philosophy-admission-oracle-2120"
+      "id": "philosophy-admission-oracle-2295"
     },
     {
       "claim": "The admission policy will omit the verification bundle.",
@@ -16973,7 +18373,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2121"
+      "id": "philosophy-admission-oracle-2296"
     },
     {
       "claim": "The admission policy will promote knowledge without a verification bundle.",
@@ -16981,7 +18381,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2122"
+      "id": "philosophy-admission-oracle-2297"
     },
     {
       "claim": "The admission policy will skip verification bundles.",
@@ -16989,7 +18389,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2123"
+      "id": "philosophy-admission-oracle-2298"
     },
     {
       "claim": "The admission policy will waive verification bundle requirements.",
@@ -16997,7 +18397,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2124"
+      "id": "philosophy-admission-oracle-2299"
     },
     {
       "claim": "The admission policy would omit the verification bundle.",
@@ -17005,7 +18405,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2125"
+      "id": "philosophy-admission-oracle-2300"
     },
     {
       "claim": "The admission policy would promote knowledge without a verification bundle.",
@@ -17013,7 +18413,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2126"
+      "id": "philosophy-admission-oracle-2301"
     },
     {
       "claim": "The admission policy would skip verification bundles.",
@@ -17021,7 +18421,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2127"
+      "id": "philosophy-admission-oracle-2302"
     },
     {
       "claim": "The admission policy would waive verification bundle requirements.",
@@ -17029,7 +18429,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.modal_predicates.cross_product",
-      "id": "philosophy-admission-oracle-2128"
+      "id": "philosophy-admission-oracle-2303"
     },
     {
       "claim": "Verification bundle requirements remain optional for semantic-cache admission.",
@@ -17037,7 +18437,7 @@
       "expected": "forbidden",
       "expected_detector_label": "verification bundle optional",
       "source": "policy.seed_regressions",
-      "id": "philosophy-admission-oracle-2129"
+      "id": "philosophy-admission-oracle-2304"
     }
   ]
 }

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -247,6 +247,14 @@ def test_docs_phase1_gates_include_schema_only_contract_changes() -> None:
     assert "PHASE1_CHANGED_FILES=()" in docs_phase1_section
     assert "'docs/orchestration/contracts/*.schema.json'" in docs_phase1_section
     assert (
+        "'docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json'"
+        in docs_phase1_section
+    )
+    assert (
+        "'tests/fixtures/orchestration/philosophy_admission_claim_oracle.json'"
+        in docs_phase1_section
+    )
+    assert (
         "No changed markdown or Phase1 schema files; skipping docs Phase1 gates."
         in docs_phase1_section
     )
@@ -266,6 +274,13 @@ def test_docs_phase1_gates_include_schema_only_contract_changes() -> None:
         'python scripts/ci/check_docs_phase1_gates.py --files "${CHANGED_DOCS[@]}"'
         not in docs_phase1_section
     )
+
+
+def test_semantic_cache_contract_suites_include_philosophy_policy_oracle() -> None:
+    """Current-head CI must execute the Philosophy policy/oracle drift regressions."""
+
+    workflow_text = CI_WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert workflow_text.count("tests/test_philosophy_admission_policy_oracle.py \\") >= 2
 
 
 def test_changes_job_uses_node24_paths_filter_pin_and_keeps_ios_filters() -> None:

--- a/tests/test_philosophy_admission_policy_oracle.py
+++ b/tests/test_philosophy_admission_policy_oracle.py
@@ -132,6 +132,20 @@ def test_oracle_cases_match_downstream_checker_behavior() -> None:
     assert false_hits == []
 
 
+def test_post_open_qa_modal_temporal_false_green_regressions_are_blocked() -> None:
+    claims = [
+        "PR-2 may open the semantic-cache gate.",
+        "The claim-family oracle may enable the global gate.",
+        "The admission policy may write cache entries.",
+        "PR-2 has to authorize backend selection.",
+        "Billing truth became cache eligible for semantic-cache admission.",
+    ]
+
+    for claim in claims:
+        errors = validate_philosophy_semantic_cache_admission_downstream_text(claim)
+        assert errors, claim
+
+
 def test_oracle_fixture_drift_is_rejected() -> None:
     fixture = _oracle_fixture()
     cases = fixture["cases"]

--- a/tests/test_philosophy_admission_policy_oracle.py
+++ b/tests/test_philosophy_admission_policy_oracle.py
@@ -149,6 +149,12 @@ def test_post_open_qa_modal_temporal_false_green_regressions_are_blocked() -> No
         assert errors, claim
 
 
+def test_negated_prohibition_guidance_does_not_trip_policy_oracle() -> None:
+    text = "Do not claim that the admission policy may omit the verification bundle."
+
+    assert validate_philosophy_semantic_cache_admission_downstream_text(text) == []
+
+
 def test_oracle_fixture_drift_is_rejected() -> None:
     fixture = _oracle_fixture()
     cases = fixture["cases"]

--- a/tests/test_philosophy_admission_policy_oracle.py
+++ b/tests/test_philosophy_admission_policy_oracle.py
@@ -125,7 +125,7 @@ def test_oracle_cases_match_downstream_checker_behavior() -> None:
             if not any(detector_label in error or family in error for error in errors):
                 misses.append((claim, detector_label, errors))
         else:
-            if any(detector_label in error or family in error for error in errors):
+            if errors:
                 false_hits.append((claim, detector_label, errors))
 
     assert misses == []
@@ -162,7 +162,7 @@ def test_oracle_fixture_drift_is_rejected() -> None:
 
     assert (
         "philosophy admission oracle fixture drift: regenerate from "
-        "PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json"
+        "the policy JSON used in this check"
     ) in errors
 
 
@@ -198,6 +198,38 @@ def test_oracle_write_rejects_paths_outside_fixture_root(
     assert exit_code == 1
     assert not outside_fixture_root.exists()
     assert "philosophy admission oracle write path must stay" in captured.err
+
+
+def test_oracle_write_is_blocked_when_policy_validation_fails(
+    tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
+    invalid_policy = tmp_path / "invalid_policy.json"
+    invalid_policy.write_text(
+        _policy_text().replace('"gate_status": "closed"', '"gate_status": "open"', 1),
+        encoding="utf-8",
+    )
+    oracle_target = (
+        REPO_ROOT / "tests" / "fixtures" / "orchestration" / "__tmp_invalid_policy_oracle.json"
+    )
+    oracle_target.unlink(missing_ok=True)
+
+    try:
+        exit_code = semantic_cache_gate_main(
+            [
+                "--write-philosophy-admission-oracle",
+                "--philosophy-admission-policy",
+                str(invalid_policy),
+                "--philosophy-admission-oracle",
+                str(oracle_target),
+            ]
+        )
+        captured = capsys.readouterr()
+
+        assert exit_code == 1
+        assert not oracle_target.exists()
+        assert "philosophy admission policy gate_status" in captured.err
+    finally:
+        oracle_target.unlink(missing_ok=True)
 
 
 def test_phase1_docs_gate_wires_policy_schema_and_oracle() -> None:

--- a/tests/test_philosophy_admission_policy_oracle.py
+++ b/tests/test_philosophy_admission_policy_oracle.py
@@ -139,6 +139,9 @@ def test_post_open_qa_modal_temporal_false_green_regressions_are_blocked() -> No
         "The admission policy may write cache entries.",
         "PR-2 has to authorize backend selection.",
         "Billing truth became cache eligible for semantic-cache admission.",
+        "PR-2 approves Redis rollout for philosophy admission.",
+        "PR-2 approves GPTCache rollout for philosophy admission.",
+        "The admission policy approves provider-backed cache runtime.",
     ]
 
     for claim in claims:

--- a/tests/test_philosophy_admission_policy_oracle.py
+++ b/tests/test_philosophy_admission_policy_oracle.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pytest import CaptureFixture
+
+import scripts.ci.check_docs_phase1_gates as docs_phase1
+from scripts.ci.check_semantic_cache_gate import (
+    compile_philosophy_admission_policy_patterns,
+    main as semantic_cache_gate_main,
+    render_philosophy_admission_oracle_fixture,
+    validate_philosophy_admission_oracle_fixture,
+    validate_philosophy_semantic_cache_admission_downstream_text,
+    validate_philosophy_semantic_cache_admission_policy,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY = (
+    REPO_ROOT
+    / "docs"
+    / "orchestration"
+    / "contracts"
+    / "PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json"
+)
+POLICY_SCHEMA = POLICY.with_suffix(".schema.json")
+ORACLE_FIXTURE = (
+    REPO_ROOT / "tests" / "fixtures" / "orchestration" / "philosophy_admission_claim_oracle.json"
+)
+REL_POLICY = "docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json"
+REL_POLICY_SCHEMA = (
+    "docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.schema.json"
+)
+REL_ORACLE_FIXTURE = "tests/fixtures/orchestration/philosophy_admission_claim_oracle.json"
+
+
+def _policy_text() -> str:
+    return POLICY.read_text(encoding="utf-8")
+
+
+def _policy() -> dict[str, object]:
+    policy = json.loads(_policy_text())
+    assert isinstance(policy, dict)
+    return policy
+
+
+def _oracle_fixture() -> dict[str, object]:
+    fixture = json.loads(ORACLE_FIXTURE.read_text(encoding="utf-8"))
+    assert isinstance(fixture, dict)
+    return fixture
+
+
+def _assert_no_regex_keys(value: object) -> None:
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            assert "regex" not in key.lower()
+            _assert_no_regex_keys(nested_value)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_no_regex_keys(item)
+
+
+def test_policy_schema_and_oracle_fixture_are_current() -> None:
+    errors = validate_philosophy_semantic_cache_admission_policy(
+        policy_text=_policy_text(),
+        schema_text=POLICY_SCHEMA.read_text(encoding="utf-8"),
+    )
+    assert errors == []
+
+    fixture_errors = validate_philosophy_admission_oracle_fixture(
+        policy_text=_policy_text(),
+        fixture_text=ORACLE_FIXTURE.read_text(encoding="utf-8"),
+    )
+    assert fixture_errors == []
+
+
+def test_oracle_render_is_byte_stable() -> None:
+    rendered, errors = render_philosophy_admission_oracle_fixture(_policy_text())
+
+    assert errors == []
+    assert rendered == ORACLE_FIXTURE.read_text(encoding="utf-8")
+
+
+def test_policy_contains_no_json_regex_or_runtime_activation() -> None:
+    policy = _policy()
+
+    _assert_no_regex_keys(policy)
+    assert policy["gate_status"] == "closed"
+    assert policy["runtime_allowed"] is False
+    assert policy["implementation_allowed"] is False
+
+
+def test_policy_generated_patterns_cover_forbidden_oracle_cases() -> None:
+    policy = _policy()
+    patterns = compile_philosophy_admission_policy_patterns(policy)
+    fixture = _oracle_fixture()
+    cases = fixture["cases"]
+    assert isinstance(cases, list)
+
+    forbidden_cases = [case for case in cases if case["expected"] == "forbidden"]
+    allowed_cases = [case for case in cases if case["expected"] == "allowed"]
+    assert forbidden_cases
+    assert allowed_cases
+    assert len(patterns) == len(forbidden_cases)
+
+
+def test_oracle_cases_match_downstream_checker_behavior() -> None:
+    fixture = _oracle_fixture()
+    cases = fixture["cases"]
+    assert isinstance(cases, list)
+    misses: list[tuple[str, str, list[str]]] = []
+    false_hits: list[tuple[str, str, list[str]]] = []
+
+    for case in cases:
+        assert isinstance(case, dict)
+        claim = case["claim"]
+        expected = case["expected"]
+        family = case["claim_family"]
+        detector_label = case["expected_detector_label"]
+        assert isinstance(claim, str)
+        assert isinstance(family, str)
+        assert isinstance(detector_label, str)
+        errors = validate_philosophy_semantic_cache_admission_downstream_text(claim)
+        if expected == "forbidden":
+            if not any(detector_label in error or family in error for error in errors):
+                misses.append((claim, detector_label, errors))
+        else:
+            if any(detector_label in error or family in error for error in errors):
+                false_hits.append((claim, detector_label, errors))
+
+    assert misses == []
+    assert false_hits == []
+
+
+def test_oracle_fixture_drift_is_rejected() -> None:
+    fixture = _oracle_fixture()
+    cases = fixture["cases"]
+    assert isinstance(cases, list)
+    fixture["cases"] = cases[1:]
+
+    errors = validate_philosophy_admission_oracle_fixture(
+        policy_text=_policy_text(),
+        fixture_text=json.dumps(fixture, indent=2) + "\n",
+    )
+
+    assert (
+        "philosophy admission oracle fixture drift: regenerate from "
+        "PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json"
+    ) in errors
+
+
+def test_policy_duplicate_keys_are_rejected() -> None:
+    policy_text = _policy_text().replace(
+        '  "gate_status": "closed",',
+        '  "gate_status": "open",\n  "gate_status": "closed",',
+        1,
+    )
+
+    errors = validate_philosophy_semantic_cache_admission_policy(
+        policy_text=policy_text,
+        schema_text=POLICY_SCHEMA.read_text(encoding="utf-8"),
+    )
+
+    assert "philosophy admission policy duplicate key: gate_status" in errors
+
+
+def test_oracle_write_rejects_paths_outside_fixture_root(
+    tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
+    outside_fixture_root = tmp_path / "philosophy_admission_claim_oracle.json"
+
+    exit_code = semantic_cache_gate_main(
+        [
+            "--write-philosophy-admission-oracle",
+            "--philosophy-admission-oracle",
+            str(outside_fixture_root),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert not outside_fixture_root.exists()
+    assert "philosophy admission oracle write path must stay" in captured.err
+
+
+def test_phase1_docs_gate_wires_policy_schema_and_oracle() -> None:
+    errors = docs_phase1.check_docs_phase1_guards(
+        markdown_files=[REL_POLICY, REL_POLICY_SCHEMA, REL_ORACLE_FIXTURE]
+    )
+
+    assert errors == []

--- a/tests/test_philosophy_admission_policy_oracle.py
+++ b/tests/test_philosophy_admission_policy_oracle.py
@@ -155,6 +155,16 @@ def test_negated_prohibition_guidance_does_not_trip_policy_oracle() -> None:
     assert validate_philosophy_semantic_cache_admission_downstream_text(text) == []
 
 
+def test_policy_oracle_does_not_duplicate_legacy_detector_error() -> None:
+    text = "philosophical semantic-cache is live."
+
+    errors = validate_philosophy_semantic_cache_admission_downstream_text(text)
+
+    assert errors == [
+        "forbidden philosophy admission contract claim: philosophical semantic cache live"
+    ]
+
+
 def test_oracle_fixture_drift_is_rejected() -> None:
     fixture = _oracle_fixture()
     cases = fixture["cases"]


### PR DESCRIPTION
## Summary
- Adds the Philosophy Epic V2 PR-2 admission policy spec generator / claim-family oracle.
- Moves PR-1 forbidden admission claim handling from hand-expanded wording loops toward canonical JSON policy data, generated oracle fixtures, and deterministic drift checks.
- Incorporates the oracle-boundary clarification from current analysis: semantic and research inputs may generate hypotheses, but admission truth is decided by policy/spec/oracle checks; this PR does not change Experiment Runner, runtime semantic cache, Redis, GPTCache, embeddings, providers, clients, DB, OpenAPI, frontend, iOS, or `/insight` behavior.

## Scope
- New policy JSON: `docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json`.
- New companion schema: `docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.schema.json`.
- New generated oracle fixture: `tests/fixtures/orchestration/philosophy_admission_claim_oracle.json`.
- `scripts/ci/check_semantic_cache_gate.py` validates policy/schema, generates/checks oracle drift, and preserves current gate-closed behavior.
- `scripts/ci/check_docs_phase1_gates.py` wires policy/schema/oracle validation into PR-scoped docs gates.
- Agent guidance and backlog packet are updated narrowly for policy-spec-first philosophy admission review.

## Out Of Scope
- No semantic-cache gate opening.
- No runtime activation.
- No Redis, GPTCache, embeddings, vector search, provider/client, DB, OpenAPI, frontend, iOS, `/insight`, connection-string, or cache-adapter changes.
- No promotion of PDFs, design input, browser evidence, or research output into runtime truth.

## Split Justification
This PR intentionally exceeds the 800-line threshold because the canonical policy, schema, generated oracle fixture, checker integration, and regression tests must land together to prevent another PR-1 style wording loop. Splitting the generated fixture from the policy/checker would make the drift guard meaningless, and splitting the tests from the generator would allow false-green policy changes. Runtime, provider, client, DB, OpenAPI, frontend, and iOS surfaces remain out of scope.

## Orchestration
- Preflight/coordinator/bootstrap were run before implementation.
- Role order followed: `agent-coordinator -> architecture-specialist -> philosophy-agent -> qa-engineer-agent -> security-auditor -> bug-hunter`.
- Premortem findings are closed in `docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md` as `FIXED`.
- Post-open lane completed: `task_bootstrap.py --pr-phase post_open_review`, then `qa-engineer-agent -> bug-hunter`, plus security / codex-security style diff scan.

## Validation
- `python3 scripts/orchestration/check_preflight.py --mode analyze --path docs/orchestration --path docs/roadmap --path scripts/ci --path tests --path .cursor/agents`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 scripts/ci/check_semantic_cache_gate.py --check-philosophy-admission-oracle-drift`
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md docs/roadmap/BACKLOG_LEDGER.md docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.schema.json tests/fixtures/orchestration/philosophy_admission_claim_oracle.json`
- `.venv/bin/python -m pytest -q tests/test_philosophy_admission_policy_oracle.py tests/test_philosophy_semantic_cache_admission_contract.py tests/test_semantic_cache_gate.py`
- `.venv/bin/python -m pytest -q tests/test_docs_phase1_gates.py tests/test_philosophy_admission_policy_oracle.py tests/test_philosophy_semantic_cache_admission_contract.py tests/test_semantic_cache_gate.py`
- `DEV_PYTHON=.venv/bin/python VENV_PYTHON=.venv/bin/python make validate-changed`
- `pre-commit run --all-files`
- Pre-push hooks passed on push, including mypy, pip-audit, backend tests, full-repo bandit, and docker build test.
- Local `make lint` without repo venv failed because the pyenv Python lacks `flake8`; `.venv/bin/python -m flake8 scripts/ci/check_semantic_cache_gate.py scripts/ci/check_docs_phase1_gates.py tests/test_philosophy_admission_policy_oracle.py` passed.

## Security Notes
- The oracle generator stores no arbitrary JSON regex and compiles deterministic escaped patterns from generated claims.
- Oracle write mode is confined to `tests/fixtures/orchestration`; regression coverage rejects writes outside that root.
- Policy remains gate-closed with `runtime_allowed: false` and `implementation_allowed: false`.

## Deferred / Follow-ups
- None in this PR.
- Future Experiment Runner oracle-manifest work is separate from this PR and should use its own coordinator-owned lane.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1777_FIXED_MAPPING.md`
- current-head CI follow-up fixed in `954a788ba`: duplicate legacy/policy-oracle downstream errors are suppressed by detector label while preserving policy-only coverage.

## Merge Readiness
- Not claimed yet. Requires current-head CI after `954a788ba` / `4ecc7fa25`, no unresolved actionable comments, fixed mapping/body mirror, and strict merge wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Governance policy + schema and deterministic oracle workflow for Philosophy semantic-cache admission with CLI validation, drift checks, and optional oracle regeneration.

* **Documentation**
  * Added policy JSON, schema, governance packet, backlog/status and review docs; updated agent runbooks with stricter review and drift-prevention guidance.

* **Tests**
  * End-to-end tests for policy/schema/oracle validation, drift detection, duplicate-key rejection, CLI write protections, and CI gate integration.

* **Chores**
  * CI gating and secrets baseline updated to include new policy/oracle checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
