### PR TITLE
test(food-data): stabilize PR17 coverage gates

### DIFF
--- a/docs/review/PR_1780_FIXED_MAPPING.md
+++ b/docs/review/PR_1780_FIXED_MAPPING.md
@@ -47,7 +47,7 @@ Full local `make verify` is deferred for this narrow governance/test-only stabil
 - Mandatory post-open QA -> bug-hunter pass: completed. QA found the Phase2 checkbox governance blocker and no code/test blocker. Bug-hunter confirmed the same blocker and found no false-green regression trap in the test-only diff.
 - CodeRabbit pass: PASS status; walkthrough/docstring warning is NOT-A-BUG for this pytest-only stabilization because repo policy does not require docstrings on test functions and no production docstring surface changed.
 - Sourcery pass: COMMENTED with no actionable findings.
-- Codex Security diff-scoped pass: pending.
+- Codex Security diff-scoped pass: PASS. Report path: `/tmp/codex-security-scans/BMI-App_2025_clean/dee257552_20260520T144058Z/report.md`; discovery found no technically plausible candidates in this test-only diff.
 - Current-head checks: pending; Phase2 checkbox fix is in this mapping update.
 - Review-thread disposition guard: pending rerun after this mapping/body update.
 

--- a/docs/review/PR_1780_FIXED_MAPPING.md
+++ b/docs/review/PR_1780_FIXED_MAPPING.md
@@ -17,6 +17,12 @@ Evidence: Added deterministic PR16/PR17 food-source governance tests for malform
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1780 -> e4dac0c28
 
+Disposition: FIXED
+Commit: 0d601a2f0
+Evidence: Replaced `Phase2` with `Phase 2` in the PR #1780 fixed mapping text after CodeRabbit flagged the spacing/readability issue.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1780#discussion_r3274876234 -> 0d601a2f0
+
 ## Premortem Disposition
 
 - FIXED: Coverage was restored with behavior-targeted negative tests for real validator/report branches, not empty coverage calls.

--- a/docs/review/PR_1780_FIXED_MAPPING.md
+++ b/docs/review/PR_1780_FIXED_MAPPING.md
@@ -1,0 +1,54 @@
+# PR #1780 - Fixed in Commit Mapping
+
+**PR:** test(food-data): stabilize PR17 coverage gates
+**Branch:** `codex/food-data-pr17-main-coverage-stabilization`
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [x] Fixed in commit mapping initialized
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: e4dac0c28
+Evidence: Added deterministic PR16/PR17 food-source governance tests for malformed payloads, typed field rejection, expected reference drift, source-policy drift, missing regional handoff entries, candidate matrix drift, malformed artifact/report handling, and file-only CLI/report invariants. Local proof: focused pytest passed for `tests/test_food_source_preference_mapping_closeout.py` and `tests/test_food_source_regional_catalog_identity.py`; focused coverage for the two affected modules improved from `83.61%` to `95.32%`; `tests/test_repo_policy_guards.py` passed; CLI JSON smokes passed for both PR16 and PR17 gates.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1780 -> e4dac0c28
+
+## Premortem Disposition
+
+- FIXED: Coverage was restored with behavior-targeted negative tests for real validator/report branches, not empty coverage calls.
+- FIXED: Fail-closed behavior is preserved by tests that reject unsafe flags, malformed inputs, source-policy drift, and provider/candidate authority promotion.
+- NOT-A-BUG: No runtime, provider, OpenAPI, DB, cache, source authority, product display, or nutrition authority changes are required for this merged-main coverage fallout.
+- DEFERRED: PR18 `regional_catalog_provider_terms_matrix` remains blocked until PR #1780 merges and current-head `main` is terminal green.
+
+## Validation
+
+- `python3 scripts/orchestration/check_preflight.py` - PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` - PASS
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_food_source_preference_mapping_closeout.py tests/test_food_source_regional_catalog_identity.py` - PASS
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_food_source_preference_mapping_closeout.py tests/test_food_source_regional_catalog_identity.py tests/test_repo_policy_guards.py` - PASS
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m scripts.food_source_preference_mapping_closeout --json` - PASS
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m scripts.food_source_regional_catalog_identity --json` - PASS
+- `make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python` - PASS; branch-diff selector reported no selected Python files, so focused pytest is the behavioral signal.
+- `pre-commit run --all-files` - PASS after black hook reformat.
+- Commit hook with root `.venv` activated - PASS.
+- Pre-push hook - PASS, including pip-audit, backend tests, full-repo Bandit.
+
+## Full Verify Deferral
+
+Full local `make verify` is deferred for this narrow governance/test-only stabilization per operator instruction. Merge readiness requires PR current-head CI parity, including the coverage threshold that failed on merged `main`.
+
+## Post-Open Review
+
+- Post-open bootstrap packet: `artifacts/orchestration/task_packets/4b9a408e9c61.json` (local gitignored artifact).
+- Mandatory post-open QA -> bug-hunter pass: pending.
+- CodeRabbit pass: pending.
+- Codex Security diff-scoped pass: pending.
+- Current-head checks: pending.
+- Review-thread disposition guard: pending.
+
+## Experiment Runner
+
+Not applicable. Experiment Runner did not materially contribute to this commit, so no co-author trailer is required.

--- a/docs/review/PR_1780_FIXED_MAPPING.md
+++ b/docs/review/PR_1780_FIXED_MAPPING.md
@@ -20,6 +20,7 @@ Disposition: FIXED
 Commit: 0d601a2f05fcf148e32ce177a44f72c6d08db374
 Evidence: Replaced `Phase2` with `Phase 2` in the PR #1780 fixed mapping text after CodeRabbit flagged the spacing/readability issue.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1780#discussion_r3274876234 -> 0d601a2f05fcf148e32ce177a44f72c6d08db374
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1780#pullrequestreview-4329571814 -> 0d601a2f05fcf148e32ce177a44f72c6d08db374
 
 ## Premortem Disposition
 

--- a/docs/review/PR_1780_FIXED_MAPPING.md
+++ b/docs/review/PR_1780_FIXED_MAPPING.md
@@ -12,16 +12,14 @@
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
-Commit: e4dac0c28
+Commit: e4dac0c2840831132cec51f69adcc9b90245f9d1
 Evidence: Added deterministic PR16/PR17 food-source governance tests for malformed payloads, typed field rejection, expected reference drift, source-policy drift, missing regional handoff entries, candidate matrix drift, malformed artifact/report handling, and file-only CLI/report invariants. Local proof: focused pytest passed for `tests/test_food_source_preference_mapping_closeout.py` and `tests/test_food_source_regional_catalog_identity.py`; focused coverage for the two affected modules improved from `83.61%` to `95.32%`; `tests/test_repo_policy_guards.py` passed; CLI JSON smokes passed for both PR16 and PR17 gates.
-
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1780 -> e4dac0c28
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1780 -> e4dac0c2840831132cec51f69adcc9b90245f9d1
 
 Disposition: FIXED
-Commit: 0d601a2f0
+Commit: 0d601a2f05fcf148e32ce177a44f72c6d08db374
 Evidence: Replaced `Phase2` with `Phase 2` in the PR #1780 fixed mapping text after CodeRabbit flagged the spacing/readability issue.
-
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1780#discussion_r3274876234 -> 0d601a2f0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1780#discussion_r3274876234 -> 0d601a2f05fcf148e32ce177a44f72c6d08db374
 
 ## Premortem Disposition
 

--- a/docs/review/PR_1780_FIXED_MAPPING.md
+++ b/docs/review/PR_1780_FIXED_MAPPING.md
@@ -5,8 +5,9 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
+- [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping initialized
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
@@ -43,11 +44,12 @@ Full local `make verify` is deferred for this narrow governance/test-only stabil
 ## Post-Open Review
 
 - Post-open bootstrap packet: `artifacts/orchestration/task_packets/4b9a408e9c61.json` (local gitignored artifact).
-- Mandatory post-open QA -> bug-hunter pass: pending.
-- CodeRabbit pass: pending.
+- Mandatory post-open QA -> bug-hunter pass: completed. QA found the Phase2 checkbox governance blocker and no code/test blocker. Bug-hunter confirmed the same blocker and found no false-green regression trap in the test-only diff.
+- CodeRabbit pass: PASS status; walkthrough/docstring warning is NOT-A-BUG for this pytest-only stabilization because repo policy does not require docstrings on test functions and no production docstring surface changed.
+- Sourcery pass: COMMENTED with no actionable findings.
 - Codex Security diff-scoped pass: pending.
-- Current-head checks: pending.
-- Review-thread disposition guard: pending.
+- Current-head checks: pending; Phase2 checkbox fix is in this mapping update.
+- Review-thread disposition guard: pending rerun after this mapping/body update.
 
 ## Experiment Runner
 

--- a/docs/review/PR_1780_FIXED_MAPPING.md
+++ b/docs/review/PR_1780_FIXED_MAPPING.md
@@ -44,11 +44,11 @@ Full local `make verify` is deferred for this narrow governance/test-only stabil
 ## Post-Open Review
 
 - Post-open bootstrap packet: `artifacts/orchestration/task_packets/4b9a408e9c61.json` (local gitignored artifact).
-- Mandatory post-open QA -> bug-hunter pass: completed. QA found the Phase2 checkbox governance blocker and no code/test blocker. Bug-hunter confirmed the same blocker and found no false-green regression trap in the test-only diff.
+- Mandatory post-open QA -> bug-hunter pass: completed. QA found the Phase 2 checkbox governance blocker and no code/test blocker. Bug-hunter confirmed the same blocker and found no false-green regression trap in the test-only diff.
 - CodeRabbit pass: PASS status; walkthrough/docstring warning is NOT-A-BUG for this pytest-only stabilization because repo policy does not require docstrings on test functions and no production docstring surface changed.
 - Sourcery pass: COMMENTED with no actionable findings.
 - Codex Security diff-scoped pass: PASS. Report path: `/tmp/codex-security-scans/BMI-App_2025_clean/dee257552_20260520T144058Z/report.md`; discovery found no technically plausible candidates in this test-only diff.
-- Current-head checks: pending; Phase2 checkbox fix is in this mapping update.
+- Current-head checks: pending; Phase 2 checkbox fix is in this mapping update.
 - Review-thread disposition guard: pending rerun after this mapping/body update.
 
 ## Experiment Runner

--- a/tests/test_food_source_preference_mapping_closeout.py
+++ b/tests/test_food_source_preference_mapping_closeout.py
@@ -472,6 +472,70 @@ def test_preference_mapping_closeout_rejects_file_only_false() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "payload",
+    (
+        [],
+        {1: "bad-key"},
+    ),
+)
+def test_preference_mapping_closeout_rejects_non_mapping_payloads(
+    payload: object,
+) -> None:
+    with pytest.raises(PreferenceMappingCloseoutError):
+        parse_preference_mapping_closeout_governance(
+            payload,
+            preference_mapping=_preference_mapping(),
+            coverage=_coverage(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "bad_value", "match"),
+    (
+        ("schema_version", "", "non-empty string"),
+        ("pr15_merged_pr", True, "integer"),
+        ("api_calls_allowed", "false", "boolean"),
+        ("blocked_methods", "api_call", "list of strings"),
+        ("blocked_methods", ["api_call"], "exactly"),
+        ("generated_on", "2026/05/19", "YYYY-MM-DD"),
+    ),
+)
+def test_preference_mapping_closeout_rejects_typed_field_malformed_values(
+    field_name: str,
+    bad_value: object,
+    match: str,
+) -> None:
+    payload = _closeout_payload()
+    payload[field_name] = bad_value
+
+    with pytest.raises(PreferenceMappingCloseoutError, match=match):
+        parse_preference_mapping_closeout_governance(
+            payload,
+            preference_mapping=_preference_mapping(),
+            coverage=_coverage(),
+        )
+
+
+def test_preference_mapping_closeout_report_rejects_external_catalog_ref_mismatch(
+    tmp_path: Path,
+) -> None:
+    outside_catalog = tmp_path / "catalog.json"
+    outside_catalog.write_text(_CATALOG_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+
+    report = build_preference_mapping_closeout_report(
+        catalog_path=outside_catalog,
+        onboarding_path=_ONBOARDING_PATH,
+        coverage_path=_COVERAGE_PATH,
+        recipe_dish_corpus_path=_RECIPE_DISH_CORPUS_PATH,
+        preference_mapping_path=_PREFERENCE_MAPPING_PATH,
+        closeout_path=_CLOSEOUT_PATH,
+    )
+
+    assert report["success"] is False
+    assert str(outside_catalog.resolve()) in str(report["validation_errors"][0])
+
+
 def test_preference_mapping_closeout_rejects_invalid_calendar_date() -> None:
     payload = _closeout_payload()
     payload["generated_on"] = "2026-99-19"
@@ -509,6 +573,55 @@ def test_preference_mapping_closeout_rejects_handoff_or_lane_drift(
         )
 
 
+@pytest.mark.parametrize(
+    ("field_name", "bad_value"),
+    (
+        ("schema_version", "bad.v1"),
+        ("source", "paid_provider_source"),
+        ("source_classification", "runtime_source"),
+        ("source_family", "paid_provider"),
+        ("evidence_policy", "source_authority_allowed"),
+    ),
+)
+def test_preference_mapping_closeout_rejects_top_level_identity_drift(
+    field_name: str,
+    bad_value: str,
+) -> None:
+    payload = _closeout_payload()
+    payload[field_name] = bad_value
+
+    with pytest.raises(PreferenceMappingCloseoutError):
+        parse_preference_mapping_closeout_governance(
+            payload,
+            preference_mapping=_preference_mapping(),
+            coverage=_coverage(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("expected_kwargs", "match"),
+    (
+        ({"expected_pr15_ref": "docs/architecture/WRONG_PR15.json"}, "pr15_ref"),
+        ({"expected_coverage_ref": "docs/architecture/WRONG_PR11.json"}, "coverage_ref"),
+        (
+            {"expected_recipe_dish_corpus_ref": "docs/architecture/WRONG_PR14.json"},
+            "recipe_dish_corpus_ref",
+        ),
+    ),
+)
+def test_preference_mapping_closeout_rejects_expected_reference_mismatch(
+    expected_kwargs: dict[str, str],
+    match: str,
+) -> None:
+    with pytest.raises(PreferenceMappingCloseoutError, match=match):
+        parse_preference_mapping_closeout_governance(
+            _closeout_payload(),
+            preference_mapping=_preference_mapping(),
+            coverage=_coverage(),
+            **expected_kwargs,
+        )
+
+
 def test_preference_mapping_closeout_rejects_pr15_handoff_drift() -> None:
     payload = _closeout_payload()
     preference_mapping = replace(_preference_mapping(), next_recommended_lane="provider_runtime")
@@ -531,6 +644,29 @@ def test_preference_mapping_closeout_rejects_pr15_handoff_drift() -> None:
     ),
 )
 def test_preference_mapping_closeout_rejects_pr15_identity_handoff_drift(
+    preference_mapping: PreferenceRecipeMappingGovernance,
+) -> None:
+    payload = _closeout_payload()
+
+    with pytest.raises(PreferenceMappingCloseoutError):
+        parse_preference_mapping_closeout_governance(
+            payload,
+            preference_mapping=preference_mapping,
+            coverage=_coverage(),
+        )
+
+
+@pytest.mark.parametrize(
+    "preference_mapping",
+    (
+        replace(_preference_mapping(), source="provider_runtime"),
+        replace(_preference_mapping(), source_classification="runtime_source"),
+        replace(_preference_mapping(), source_family="paid_provider"),
+        replace(_preference_mapping(), blocked_methods=("api_call",)),
+        replace(_preference_mapping(), final_gate_decision="mapping_contract_allows_ingest"),
+    ),
+)
+def test_preference_mapping_closeout_rejects_pr15_source_policy_drift(
     preference_mapping: PreferenceRecipeMappingGovernance,
 ) -> None:
     payload = _closeout_payload()
@@ -991,6 +1127,26 @@ def test_preference_mapping_closeout_rejects_malformed_artifact(tmp_path: Path) 
             preference_mapping=_preference_mapping(),
             coverage=_coverage(),
         )
+
+
+def test_preference_mapping_closeout_report_returns_validation_errors_for_bad_closeout(
+    tmp_path: Path,
+) -> None:
+    payload = _closeout_payload()
+    payload["schema_version"] = "bad.v1"
+    bad_path = _write_payload(tmp_path / "bad-closeout.json", payload)
+
+    report = build_preference_mapping_closeout_report(
+        catalog_path=_CATALOG_PATH,
+        onboarding_path=_ONBOARDING_PATH,
+        coverage_path=_COVERAGE_PATH,
+        recipe_dish_corpus_path=_RECIPE_DISH_CORPUS_PATH,
+        preference_mapping_path=_PREFERENCE_MAPPING_PATH,
+        closeout_path=bad_path,
+    )
+
+    assert report["success"] is False
+    assert report["validation_errors"]
 
 
 def test_preference_mapping_closeout_cli_success_json() -> None:

--- a/tests/test_food_source_regional_catalog_identity.py
+++ b/tests/test_food_source_regional_catalog_identity.py
@@ -102,6 +102,14 @@ def _replace_regional_catalog_entry(**changes: object) -> SourceCatalog:
     return replace(catalog, sources=tuple(sources))
 
 
+def _without_regional_catalog_entry() -> SourceCatalog:
+    catalog = _catalog()
+    return replace(
+        catalog,
+        sources=tuple(source for source in catalog.sources if source.source != "regional_catalogs"),
+    )
+
+
 def _replace_regional_onboarding_entry(**changes: object) -> SourceOnboarding:
     onboarding = _onboarding()
     sources: list[SourceOnboardingEntry] = []
@@ -111,6 +119,16 @@ def _replace_regional_onboarding_entry(**changes: object) -> SourceOnboarding:
         else:
             sources.append(source)
     return replace(onboarding, sources=tuple(sources))
+
+
+def _without_regional_onboarding_entry() -> SourceOnboarding:
+    onboarding = _onboarding()
+    return replace(
+        onboarding,
+        sources=tuple(
+            source for source in onboarding.sources if source.source != "regional_catalogs"
+        ),
+    )
 
 
 def _replace_regional_coverage_domain(**changes: object) -> SourceGapAudit:
@@ -124,6 +142,18 @@ def _replace_regional_coverage_domain(**changes: object) -> SourceGapAudit:
     return replace(coverage, coverage_domains=tuple(domains))
 
 
+def _without_regional_coverage_domain() -> SourceGapAudit:
+    coverage = _coverage()
+    return replace(
+        coverage,
+        coverage_domains=tuple(
+            domain
+            for domain in coverage.coverage_domains
+            if domain.domain != "regional_local_products"
+        ),
+    )
+
+
 def _replace_regional_source_gap(**changes: object) -> SourceGapAudit:
     coverage = _coverage()
     decisions: list[SourceGapDecision] = []
@@ -133,6 +163,18 @@ def _replace_regional_source_gap(**changes: object) -> SourceGapAudit:
         else:
             decisions.append(decision)
     return replace(coverage, source_gap_decisions=tuple(decisions))
+
+
+def _without_regional_source_gap() -> SourceGapAudit:
+    coverage = _coverage()
+    return replace(
+        coverage,
+        source_gap_decisions=tuple(
+            decision
+            for decision in coverage.source_gap_decisions
+            if decision.source != "regional_catalogs"
+        ),
+    )
 
 
 def _pr16_report() -> dict[str, object]:
@@ -340,6 +382,128 @@ def test_regional_catalog_identity_rejects_unexpected_keys() -> None:
     payload["api_use_approved"] = True
 
     with pytest.raises(RegionalCatalogIdentityError, match="unexpected keys"):
+        parse_regional_catalog_identity_governance(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            coverage=_coverage(),
+            pr16_report=_pr16_report(),
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        [],
+        {1: "bad-key"},
+    ),
+)
+def test_regional_catalog_identity_rejects_non_mapping_payloads(
+    payload: object,
+) -> None:
+    with pytest.raises(RegionalCatalogIdentityError):
+        parse_regional_catalog_identity_governance(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            coverage=_coverage(),
+            pr16_report=_pr16_report(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "bad_value", "match"),
+    (
+        ("schema_version", "", "non-empty string"),
+        ("pr16_merged_pr", True, "integer"),
+        ("api_calls_allowed", "false", "boolean"),
+        ("blocked_methods", "api_call", "list of strings"),
+        ("blocked_methods", [], "must not be empty"),
+        ("blocked_methods", ["api_call", "api_call"], "duplicate"),
+        ("blocked_methods", ["api_call"], "exactly"),
+        ("generated_on", "2026/05/19", "YYYY-MM-DD"),
+        ("generated_on", "2026-99-19", "YYYY-MM-DD"),
+        ("budget_first_policy", "", "missing non-empty string"),
+    ),
+)
+def test_regional_catalog_identity_rejects_typed_field_malformed_values(
+    field_name: str,
+    bad_value: object,
+    match: str,
+) -> None:
+    payload = _identity_payload()
+    payload[field_name] = bad_value
+
+    with pytest.raises(RegionalCatalogIdentityError, match=match):
+        parse_regional_catalog_identity_governance(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            coverage=_coverage(),
+            pr16_report=_pr16_report(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "bad_value", "match"),
+    (
+        ("candidate_id", "unknown_provider", "unknown candidate_id"),
+        ("allowed_role", "source_authority", "allowed_role"),
+        ("upstream_evidence_type", "provider_api", "upstream_evidence_type"),
+        ("blocking_reasons", ["identity and license verified"], "blocking_reasons"),
+    ),
+)
+def test_regional_catalog_identity_rejects_candidate_identity_matrix_drift(
+    field_name: str,
+    bad_value: object,
+    match: str,
+) -> None:
+    payload = _identity_payload()
+    _candidate(payload, "kroger")[field_name] = bad_value
+
+    with pytest.raises(RegionalCatalogIdentityError, match=match):
+        parse_regional_catalog_identity_governance(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            coverage=_coverage(),
+            pr16_report=_pr16_report(),
+        )
+
+
+def test_regional_catalog_identity_rejects_empty_candidate_blocking_reason() -> None:
+    payload = _identity_payload()
+    _candidate(payload, "kroger")["blocking_reasons"] = [""]
+
+    with pytest.raises(RegionalCatalogIdentityError, match="blocking_reasons\\[0\\]"):
+        parse_regional_catalog_identity_governance(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            coverage=_coverage(),
+            pr16_report=_pr16_report(),
+        )
+
+
+def test_regional_catalog_identity_rejects_unexpected_candidate_keys() -> None:
+    payload = _identity_payload()
+    _candidate(payload, "kroger")["runtime_ready"] = True
+
+    with pytest.raises(RegionalCatalogIdentityError, match="unexpected candidate keys"):
+        parse_regional_catalog_identity_governance(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            coverage=_coverage(),
+            pr16_report=_pr16_report(),
+        )
+
+
+def test_regional_catalog_identity_rejects_non_list_candidate_reviews() -> None:
+    payload = _identity_payload()
+    payload["candidate_reviews"] = "not-a-list"
+
+    with pytest.raises(RegionalCatalogIdentityError, match="candidate_reviews must be a list"):
         parse_regional_catalog_identity_governance(
             payload,
             catalog=_catalog(),
@@ -892,6 +1056,17 @@ def test_regional_catalog_identity_rejects_pr3_catalog_policy_drift_directly() -
         )
 
 
+def test_regional_catalog_identity_rejects_missing_pr3_catalog_entry() -> None:
+    with pytest.raises(RegionalCatalogIdentityError, match="catalog must include"):
+        parse_regional_catalog_identity_governance(
+            _identity_payload(),
+            catalog=_without_regional_catalog_entry(),
+            onboarding=_onboarding(),
+            coverage=_coverage(),
+            pr16_report=_pr16_report(),
+        )
+
+
 @pytest.mark.parametrize(
     ("key", "value"),
     (
@@ -929,6 +1104,17 @@ def test_regional_catalog_identity_rejects_pr5_onboarding_policy_drift_directly(
             _identity_payload(),
             catalog=_catalog(),
             onboarding=_replace_regional_onboarding_entry(cache_decision="legacy_review_only"),
+            coverage=_coverage(),
+            pr16_report=_pr16_report(),
+        )
+
+
+def test_regional_catalog_identity_rejects_missing_pr5_onboarding_entry() -> None:
+    with pytest.raises(RegionalCatalogIdentityError, match="onboarding must include"):
+        parse_regional_catalog_identity_governance(
+            _identity_payload(),
+            catalog=_catalog(),
+            onboarding=_without_regional_onboarding_entry(),
             coverage=_coverage(),
             pr16_report=_pr16_report(),
         )
@@ -1087,6 +1273,28 @@ def test_regional_catalog_identity_rejects_pr11_source_authority_drift_directly(
         )
 
 
+def test_regional_catalog_identity_rejects_missing_pr11_regional_domain() -> None:
+    with pytest.raises(RegionalCatalogIdentityError, match="regional_local_products"):
+        parse_regional_catalog_identity_governance(
+            _identity_payload(),
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            coverage=_without_regional_coverage_domain(),
+            pr16_report=_pr16_report(),
+        )
+
+
+def test_regional_catalog_identity_rejects_missing_pr11_regional_source() -> None:
+    with pytest.raises(RegionalCatalogIdentityError, match="regional_catalogs source"):
+        parse_regional_catalog_identity_governance(
+            _identity_payload(),
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            coverage=_without_regional_source_gap(),
+            pr16_report=_pr16_report(),
+        )
+
+
 @pytest.mark.parametrize(
     "bad_notes",
     (
@@ -1119,6 +1327,78 @@ def test_regional_catalog_identity_rejects_pr16_handoff_drift() -> None:
     pr16_report["next_substantive_lane"] = "paid_provider_runtime_review"
 
     with pytest.raises(RegionalCatalogIdentityError, match="PR16 next_substantive_lane"):
+        parse_regional_catalog_identity_governance(
+            _identity_payload(),
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            coverage=_coverage(),
+            pr16_report=pr16_report,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "bad_value"),
+    (
+        ("schema_version", "bad.v1"),
+        ("pr16_merged_pr", 0),
+        ("source", "paid_provider_source"),
+        ("source_classification", "runtime_source"),
+        ("source_family", "paid_provider"),
+        ("evidence_policy", "source_authority_allowed"),
+        ("external_research_evidence_role", "source_authority"),
+        ("next_recommended_lane", "provider_runtime"),
+        ("final_gate_decision", "runtime_ready"),
+    ),
+)
+def test_regional_catalog_identity_rejects_top_level_identity_drift(
+    field_name: str,
+    bad_value: object,
+) -> None:
+    payload = _identity_payload()
+    payload[field_name] = bad_value
+
+    with pytest.raises(RegionalCatalogIdentityError):
+        parse_regional_catalog_identity_governance(
+            payload,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            coverage=_coverage(),
+            pr16_report=_pr16_report(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("expected_kwargs", "match"),
+    (
+        ({"expected_catalog_ref": "docs/architecture/WRONG_CATALOG.json"}, "catalog_ref"),
+        ({"expected_onboarding_ref": "docs/architecture/WRONG_ONBOARDING.json"}, "onboarding_ref"),
+        ({"expected_coverage_ref": "docs/architecture/WRONG_PR11.json"}, "coverage_ref"),
+        (
+            {"expected_pr16_closeout_ref": "docs/architecture/WRONG_PR16.json"},
+            "pr16_closeout_ref",
+        ),
+    ),
+)
+def test_regional_catalog_identity_rejects_expected_reference_mismatch(
+    expected_kwargs: dict[str, str],
+    match: str,
+) -> None:
+    with pytest.raises(RegionalCatalogIdentityError, match=match):
+        parse_regional_catalog_identity_governance(
+            _identity_payload(),
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            coverage=_coverage(),
+            pr16_report=_pr16_report(),
+            **expected_kwargs,
+        )
+
+
+def test_regional_catalog_identity_rejects_failed_pr16_report() -> None:
+    pr16_report = _pr16_report()
+    pr16_report["success"] = False
+
+    with pytest.raises(RegionalCatalogIdentityError, match="PR16 closeout report"):
         parse_regional_catalog_identity_governance(
             _identity_payload(),
             catalog=_catalog(),
@@ -1306,6 +1586,20 @@ def test_regional_catalog_identity_cli_returns_nonzero_for_invalid_payload(tmp_p
     assert payload["api_calls_allowed"] is True
 
 
+def test_regional_catalog_identity_rejects_malformed_artifact(tmp_path: Path) -> None:
+    malformed_path = tmp_path / "regional_identity.json"
+    malformed_path.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(RegionalCatalogIdentityError, match="Cannot read"):
+        load_regional_catalog_identity_governance(
+            malformed_path,
+            catalog=_catalog(),
+            onboarding=_onboarding(),
+            coverage=_coverage(),
+            pr16_report=_pr16_report(),
+        )
+
+
 def test_regional_catalog_identity_report_preserves_malformed_safety_flags(
     tmp_path: Path,
 ) -> None:
@@ -1329,6 +1623,48 @@ def test_regional_catalog_identity_report_preserves_malformed_safety_flags(
     assert report["api_calls_allowed"] == "true"
     assert report["file_only"] == "false"
     assert "api_calls_allowed" in str(report["validation_errors"][0])
+
+
+def test_regional_catalog_identity_report_tolerates_unreadable_safety_flags(
+    tmp_path: Path,
+) -> None:
+    bad_path = tmp_path / "bad_identity.json"
+    bad_path.write_text("{not-json", encoding="utf-8")
+
+    report = build_regional_catalog_identity_report(
+        catalog_path=_CATALOG_PATH,
+        onboarding_path=_ONBOARDING_PATH,
+        coverage_path=_COVERAGE_PATH,
+        recipe_dish_corpus_path=_RECIPE_DISH_CORPUS_PATH,
+        preference_mapping_path=_PREFERENCE_MAPPING_PATH,
+        pr16_closeout_path=_PR16_CLOSEOUT_PATH,
+        regional_identity_path=bad_path,
+    )
+
+    assert report["success"] is False
+    assert report["api_calls_allowed"] is False
+    assert report["validation_errors"]
+
+
+def test_regional_catalog_identity_report_ignores_non_mapping_safety_payload(
+    tmp_path: Path,
+) -> None:
+    bad_path = tmp_path / "bad_identity.json"
+    bad_path.write_text("[]", encoding="utf-8")
+
+    report = build_regional_catalog_identity_report(
+        catalog_path=_CATALOG_PATH,
+        onboarding_path=_ONBOARDING_PATH,
+        coverage_path=_COVERAGE_PATH,
+        recipe_dish_corpus_path=_RECIPE_DISH_CORPUS_PATH,
+        preference_mapping_path=_PREFERENCE_MAPPING_PATH,
+        pr16_closeout_path=_PR16_CLOSEOUT_PATH,
+        regional_identity_path=bad_path,
+    )
+
+    assert report["success"] is False
+    assert report["seller_api_use_allowed"] is False
+    assert report["validation_errors"]
 
 
 def test_regional_catalog_identity_cli_prints_validation_errors_without_json(


### PR DESCRIPTION
## Goal
Stabilize `main` after merged PR17 / #1771 before starting PR18.

## Business Reason
The merged-main run `26166348456` on `dd58d1922cfd9ac4af14ea0f542221943d40f179` failed `test-main (3.11, 60)` on coverage only: total `96.89% < 97.00%`. PR18 (`regional_catalog_provider_terms_matrix`) stays blocked until this fallout is fixed and current-head `main` is healthy.

## Scope
- Add deterministic tests for PR16/PR17 food-source governance validators/report builders.
- Cover real fail-closed branches in:
  - `tests/test_food_source_preference_mapping_closeout.py`
  - `tests/test_food_source_regional_catalog_identity.py`
- Preserve file-only governance posture.

## Out Of Scope
- Runtime/API/OpenAPI changes
- DB/schema/importer changes
- Provider/API/scraping/download behavior
- Source authority, cache authority, product display, or nutrition authority
- Dependency-security fixes
- PR18 implementation

## Coordinator / Agents
- Preflight and agent consistency passed before branch creation.
- Coordinator bootstrap packet: `artifacts/orchestration/task_packets/18e1eaa9810b.json` (local gitignored artifact).
- Post-open bootstrap packet: `artifacts/orchestration/task_packets/4b9a408e9c61.json` (local gitignored artifact).
- Coordinator approved a narrow stabilization lane from `origin/main` / `dd58d1922`.
- Role passes run in coordinator order: `agent-coordinator -> architecture-specialist -> security-auditor -> backend-engineer -> qa-engineer-agent -> bug-hunter -> dev-operator`, with `data-scientist-agent` advisory.

## Premortem Status
Frame: 48 hours from now, this hotfix made things worse.

Disposition:
- `FIXED`: coverage stabilization uses behavior-targeted negative tests for real PR16/PR17 validator/report branches, not empty coverage calls.
- `FIXED`: fail-closed safety remains intact; tests assert malformed payloads, unsafe flags, provider/candidate drift, missing handoff entries, and bad reports reject.
- `NOT-A-BUG`: no runtime/provider/OpenAPI/DB changes are needed for this CI fallout.
- `DEFERRED`: PR18 remains blocked until this stabilization merges and current-head `main` is terminal green.

Experiment Runner: Not applicable; it did not materially contribute to this commit.

## Validation
Local gates run:
- `python3 scripts/orchestration/check_preflight.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_food_source_preference_mapping_closeout.py tests/test_food_source_regional_catalog_identity.py` PASS
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_food_source_preference_mapping_closeout.py tests/test_food_source_regional_catalog_identity.py tests/test_repo_policy_guards.py` PASS
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m scripts.food_source_regional_catalog_identity --json` PASS (`success: true`)
- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m scripts.food_source_preference_mapping_closeout --json` PASS (`success: true`)
- Focused coverage evidence for the two affected modules improved from `83.61%` to `95.32%`.
- `make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python` PASS (`No Python files changed on the current branch` from the branch-diff selector; focused pytest above is the behavioral signal)
- `pre-commit run --all-files` PASS after black hook reformat
- Commit hook PASS with root `.venv` activated
- Pre-push hook PASS, including pip-audit, backend tests, full-repo Bandit

## Full Verify Deferral
Full local `make verify` is deferred for this narrow governance/test-only stabilization per operator instruction. Merge readiness must rely on the focused local gates above plus PR current-head CI parity, including the coverage threshold that failed on merged `main`.

## Security Notes
No security-sensitive runtime surface is changed. No network/API/scraping/download/DB/provider authority is introduced. Security-auditor pass found no PR17-scoped security finding and classified dependency-security work as out of scope. Codex Security diff-scoped scan passed with no technically plausible candidates: `/tmp/codex-security-scans/BMI-App_2025_clean/dee257552_20260520T144058Z/report.md`.

## Risks / Rollback
Risk is limited to test-suite and review-mapping changes. Rollback is reverting the PR branch commits through `6357c4791`, returning the branch to merged `main` behavior.

## Deferred / Follow-Ups
- Start PR18 `regional_catalog_provider_terms_matrix` only after this stabilization merges and current-head `main` is terminal green.
- Dependency-security work remains in its own PR lane and is not mixed here.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Canonical artifact: `docs/review/PR_1780_FIXED_MAPPING.md`.

Disposition: FIXED
Commit: `e4dac0c2840831132cec51f69adcc9b90245f9d1`
Evidence: deterministic PR16/PR17 governance tests cover malformed payloads, typed-field rejection, reference drift, source-policy drift, missing regional handoff entries, candidate matrix drift, malformed artifact/report handling, and file-only CLI/report invariants.

Disposition: FIXED
Commit: `0d601a2f05fcf148e32ce177a44f72c6d08db374`
Evidence: CodeRabbit spacing/readability finding fixed by replacing `Phase2` with `Phase 2`.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1780#discussion_r3274876234 -> 0d601a2f05fcf148e32ce177a44f72c6d08db374
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1780#pullrequestreview-4329571814 -> 0d601a2f05fcf148e32ce177a44f72c6d08db374

Disposition: FIXED
Commit: `6357c4791`
Evidence: Canonical fixed mapping includes both the CodeRabbit discussion URL and parent review URL.

## Merge Readiness
Not ready until current-head PR CI is terminal green, review-thread disposition guard passes, and required checks are clean.
