### PR TITLE
feat(philosophy): add alignment rule trust schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,7 @@ jobs:
             'docs/orchestration/contracts/*.schema.json' \
             'docs/orchestration/contracts/PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY.json' \
             'docs/orchestration/contracts/PHILOSOPHY_ADMISSION_DRY_RUN_REPORT.json' \
+            ':(glob)docs/orchestration/contracts/philosophy_alignment_rules/**/*.json' \
             'tests/fixtures/orchestration/philosophy_admission_claim_oracle.json')
 
           if [ "${#PHASE1_CHANGED_FILES[@]}" -eq 0 ] && [ "${#LINT_MD[@]}" -eq 0 ]; then

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,7 +166,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 585
+        "line_number": 586
       }
     ],
     ".github/workflows/frontend-ci.yml": [
@@ -1764,5 +1764,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-21T16:28:24Z"
+  "generated_at": "2026-05-21T21:13:21Z"
 }

--- a/docs/orchestration/contracts/PHILOSOPHY_ALIGNMENT_RULE.schema.json
+++ b/docs/orchestration/contracts/PHILOSOPHY_ALIGNMENT_RULE.schema.json
@@ -1,0 +1,129 @@
+{
+  "$id": "https://pulseplate.app/schemas/philosophy-alignment-rule.v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "assertion_hints": {
+      "additionalProperties": false,
+      "properties": {
+        "boolean_checks": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "regexes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "type": "object"
+    },
+    "created_at": {
+      "format": "date-time",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+      "type": "string"
+    },
+    "created_by": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "notes": {
+      "type": "string"
+    },
+    "provenance": {
+      "additionalProperties": false,
+      "properties": {
+        "anchor_hash": {
+          "minLength": 8,
+          "type": "string"
+        },
+        "source_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "source_type": {
+          "enum": [
+            "repo",
+            "policy_doc",
+            "legal",
+            "spec"
+          ],
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_id",
+        "source_type",
+        "version",
+        "anchor_hash"
+      ],
+      "type": "object"
+    },
+    "rule_id": {
+      "minLength": 1,
+      "pattern": "^[a-z0-9][a-z0-9_.-]*$",
+      "type": "string"
+    },
+    "rule_text": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "rule_type": {
+      "enum": [
+        "privacy",
+        "harm",
+        "misinfo",
+        "wellness_scope",
+        "copyright",
+        "safety_other"
+      ],
+      "type": "string"
+    },
+    "schema_hash": {
+      "pattern": "^[a-f0-9]{64}$",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "v1.0.0",
+      "type": "string"
+    },
+    "severity": {
+      "enum": [
+        "block",
+        "warn",
+        "note"
+      ],
+      "type": "string"
+    },
+    "tags": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    }
+  },
+  "required": [
+    "rule_id",
+    "rule_text",
+    "rule_type",
+    "severity",
+    "provenance",
+    "assertion_hints",
+    "created_by",
+    "created_at",
+    "schema_version",
+    "schema_hash"
+  ],
+  "title": "PhilosophyAlignmentRule",
+  "type": "object"
+}

--- a/docs/review/PR_1789_FIXED_MAPPING.md
+++ b/docs/review/PR_1789_FIXED_MAPPING.md
@@ -47,9 +47,9 @@ OpenAPI/frontend/iOS changes, and no release-manifest mutation.
 ## Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#pullrequestreview-4339796645 -> 94ed4ce2141fbd9160bf3f5c42b93d1f256db943
-  - Disposition: FIXED
-  - Evidence: `scripts/ci/check_philosophy_alignment_rules.py` now preserves JSON decode line/column context by reporting the full `JSONDecodeError`, and `tests/test_philosophy_alignment_rules.py` covers the location-bearing invalid JSON message.
-  - Evidence: `scripts/ci/check_philosophy_alignment_rules.py` removes the unused `schema` parameter from `validate_alignment_rule` and updates the only call site, eliminating the confusing no-op companion-schema check.
+Disposition: FIXED
+Commit: 94ed4ce2141fbd9160bf3f5c42b93d1f256db943
+Evidence: `scripts/ci/check_philosophy_alignment_rules.py` now preserves JSON decode line/column context by reporting the full `JSONDecodeError`, and `tests/test_philosophy_alignment_rules.py` covers the location-bearing invalid JSON message. The same commit removes the unused `schema` parameter from `validate_alignment_rule` and updates the only call site, eliminating the confusing no-op companion-schema check.
 
 ## Local Validation Evidence
 
@@ -61,7 +61,7 @@ OpenAPI/frontend/iOS changes, and no release-manifest mutation.
 - `.venv/bin/python -m pytest -q tests/test_philosophy_alignment_rules.py tests/test_docs_phase1_gates.py -k "alignment or philosophy"` - PASS (`29 passed`)
 - `python3 scripts/ci/check_docs_phase1_gates.py --files docs/orchestration/contracts/PHILOSOPHY_ALIGNMENT_RULE.schema.json docs/roadmap/BACKLOG_LEDGER.md` - PASS
 - `python3 scripts/ci/check_semantic_cache_gate.py` - PASS; semantic-cache gates remain closed
-- `make validate-changed` - PASS (`41 passed`)
+- `make validate-changed` - PASS (`42 passed`)
 - `pre-commit run --all-files` - PASS
 - pre-push hooks - PASS, including mypy, pip-audit, backend pre-push tests, full-repo Bandit, and docker build test
 

--- a/docs/review/PR_1789_FIXED_MAPPING.md
+++ b/docs/review/PR_1789_FIXED_MAPPING.md
@@ -71,10 +71,10 @@ Evidence: `scripts/ci/check_docs_phase1_gates.py` now routes future `docs/orches
 - `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open` - PASS, packet `artifacts/orchestration/task_packets/d2e36e91b405.json`
 - `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review` - PASS, packet `artifacts/orchestration/task_packets/0cd5f8098592.json`
 - `.venv/bin/python scripts/ci/check_philosophy_alignment_rules.py` - PASS, `schema_hash=31d165ca54e37c0255c8103c52d9fbe29c70084398d665b1ada5f98532453f50`
-- `.venv/bin/python -m pytest -q tests/test_philosophy_alignment_rules.py tests/test_docs_phase1_gates.py -k "alignment or philosophy"` - PASS (`29 passed`)
+- `.venv/bin/python -m pytest -q tests/test_philosophy_alignment_rules.py tests/test_docs_phase1_gates.py -k "alignment or philosophy"` - PASS (`34 passed`)
 - `python3 scripts/ci/check_docs_phase1_gates.py --files docs/orchestration/contracts/PHILOSOPHY_ALIGNMENT_RULE.schema.json docs/roadmap/BACKLOG_LEDGER.md` - PASS
 - `python3 scripts/ci/check_semantic_cache_gate.py` - PASS; semantic-cache gates remain closed
-- `make validate-changed` - PASS (`42 passed`)
+- `make validate-changed` - PASS (`47 passed`)
 - `pre-commit run --all-files` - PASS
 - pre-push hooks - PASS, including mypy, pip-audit, backend pre-push tests, full-repo Bandit, and docker build test
 

--- a/docs/review/PR_1789_FIXED_MAPPING.md
+++ b/docs/review/PR_1789_FIXED_MAPPING.md
@@ -1,0 +1,77 @@
+# PR #1789 Fixed in Commit Mapping
+
+## Summary
+
+This PR adds the Philosophy alignment-rule trust schema and deterministic
+validator for future semantic-cache admission rule records. It remains
+governance/test-only: no runtime semantic-cache activation, no Redis/GPTCache,
+no embeddings/vector search, no provider/client wiring, no DB/cache column, no
+OpenAPI/frontend/iOS changes, and no release-manifest mutation.
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/d2e36e91b405.json`
+- Packet: `artifacts/orchestration/task_packets/0cd5f8098592.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+- Role order preserved: `agent-coordinator -> architecture-specialist -> philosophy-agent -> security-auditor -> qa-engineer-agent -> bug-hunter`
+
+## Experiment Runner Evidence
+
+- Artifact: `artifacts/orchestration/experiments/results/exp-cb87fc8b19cc.json`
+- Status: accepted
+- Mode: `oracle_only_governance_reviewer`
+- Mutation boundary: `mutated_paths=[]`, `shared_tree_untouched=true`, `promotion_ready=false`
+- Co-author: not required (`contribution_kind=none`, `coauthor_required=false`)
+- Diagnostic rejected artifact: `artifacts/orchestration/experiments/results/exp-3f10cc3d8c92.json` failed only because the isolated checkout lacked FastAPI for the pytest oracle; it did not shape the commit decision and is not used as readiness evidence.
+
+## Premortem Closure
+
+- Finding: Alignment-rule records could be mistaken for semantic-cache runtime admission.
+  - Disposition: FIXED
+  - Evidence: `docs/roadmap/BACKLOG_LEDGER.md` defers release-manifest `alignment_schema_hash` and cache-row `rule_id` linkage to future reviewed slices; this PR touches no runtime/cache/provider/client surfaces.
+- Finding: Schema weakening could pass Phase1 and create false audit confidence.
+  - Disposition: FIXED
+  - Evidence: `scripts/ci/check_philosophy_alignment_rules.py` validates schema identity, required keys, enum values, string constraints, timestamp pattern/format, provenance constraints, assertion-hint array shape, `tags.uniqueItems`, and schema hash behavior; `tests/test_philosophy_alignment_rules.py` covers drift regressions.
+- Finding: Experiment Runner evidence could be treated as merge-readiness authority.
+  - Disposition: FIXED
+  - Evidence: artifact `artifacts/orchestration/experiments/results/exp-cb87fc8b19cc.json` records `runner_mode=oracle_only_governance_reviewer`, `mutated_paths=[]`, `promotion_ready=false`, and `coauthor_required=false`; merge readiness remains owned by repo gates and review governance.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- Pre-open role review completed in order: `agent-coordinator -> architecture-specialist -> philosophy-agent -> security-auditor -> qa-engineer-agent -> bug-hunter`.
+- Post-open bootstrap completed with packet `artifacts/orchestration/task_packets/0cd5f8098592.json`.
+- No actionable GitHub review threads existed when this artifact was created. Future bot or human actionables must be mapped here before resolution.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Local Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` - PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` - PASS
+- `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open` - PASS, packet `artifacts/orchestration/task_packets/d2e36e91b405.json`
+- `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review` - PASS, packet `artifacts/orchestration/task_packets/0cd5f8098592.json`
+- `.venv/bin/python scripts/ci/check_philosophy_alignment_rules.py` - PASS, `schema_hash=31d165ca54e37c0255c8103c52d9fbe29c70084398d665b1ada5f98532453f50`
+- `.venv/bin/python -m pytest -q tests/test_philosophy_alignment_rules.py tests/test_docs_phase1_gates.py -k "alignment or philosophy"` - PASS (`28 passed`)
+- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/orchestration/contracts/PHILOSOPHY_ALIGNMENT_RULE.schema.json docs/roadmap/BACKLOG_LEDGER.md` - PASS
+- `python3 scripts/ci/check_semantic_cache_gate.py` - PASS; semantic-cache gates remain closed
+- `make validate-changed` - PASS (`41 passed`)
+- `pre-commit run --all-files` - PASS
+- pre-push hooks - PASS, including mypy, pip-audit, backend pre-push tests, full-repo Bandit, and docker build test
+
+## Merge Readiness
+
+- [ ] Current-head CI terminal success confirmed after this artifact commit.
+- [ ] CodeRabbit / Sourcery / Cubic / Codex review actionables checked and mapped.
+- [ ] Strict review-thread disposition passes with auth.
+- [ ] Strict merge-readiness guard passes with auth.
+- [ ] Mandatory wait-window after latest bot/review activity completed.
+
+## Deferred / Follow-ups
+
+- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-philosophy-epic-v2-alignment-rule-trust-schema`
+- Future release-manifest slice: add `alignment_schema_hash` only after the release evidence contract explicitly accepts the field and current-head CI proves deterministic manifest hashing.
+- Future runtime semantic-cache slice: add cache-row `rule_id` linkage only after the global semantic-cache gate opens and a reviewed runtime packet covers DB/cache migration, replay safety, rollback, and verification-bundle admission.

--- a/docs/review/PR_1789_FIXED_MAPPING.md
+++ b/docs/review/PR_1789_FIXED_MAPPING.md
@@ -64,6 +64,13 @@ Commit: c670951654e82f6bd926cb65617f1fe9c2150987
 Evidence: `scripts/ci/check_philosophy_alignment_rules.py` now fails closed on nested `provenance`/`assertion_hints` object type drift, unexpected root/property JSON Schema keywords, and `assertion_hints.required` drift; `tests/test_philosophy_alignment_rules.py` covers each false-green path.
 Evidence: `scripts/ci/check_docs_phase1_gates.py` now routes future `docs/orchestration/contracts/philosophy_alignment_rules/*.json` record edits through `validate_alignment_rules(...)` with the schema plus rule texts; `tests/test_docs_phase1_gates.py` covers the Phase1 rule-record route.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#discussion_r3284280175 -> 65a49b8bb5e9f296f45b842f090f7370f8ea5beb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#discussion_r3284280179 -> 65a49b8bb5e9f296f45b842f090f7370f8ea5beb
+Disposition: FIXED
+Commit: 65a49b8bb5e9f296f45b842f090f7370f8ea5beb
+Evidence: `.github/workflows/ci.yml` now includes the `:(glob)docs/orchestration/contracts/philosophy_alignment_rules/**/*.json` pathspec in `PHASE1_CHANGED_FILES`, so rule-record JSON edits trigger the docs Phase1 gate in CI.
+Evidence: `scripts/ci/check_docs_phase1_gates.py` now uses `records_dir.rglob("*.json")`, so nested alignment-rule records are included in duplicate-ID and record-shape validation. `tests/test_docs_phase1_gates.py` covers nested record collection, and `tests/test_ci_workflow_pr_size_governance_contract.py` pins the workflow pathspec.
+
 ## Local Validation Evidence
 
 - `python3 scripts/orchestration/check_preflight.py` - PASS
@@ -71,7 +78,9 @@ Evidence: `scripts/ci/check_docs_phase1_gates.py` now routes future `docs/orches
 - `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open` - PASS, packet `artifacts/orchestration/task_packets/d2e36e91b405.json`
 - `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review` - PASS, packet `artifacts/orchestration/task_packets/0cd5f8098592.json`
 - `.venv/bin/python scripts/ci/check_philosophy_alignment_rules.py` - PASS, `schema_hash=31d165ca54e37c0255c8103c52d9fbe29c70084398d665b1ada5f98532453f50`
-- `.venv/bin/python -m pytest -q tests/test_philosophy_alignment_rules.py tests/test_docs_phase1_gates.py -k "alignment or philosophy"` - PASS (`34 passed`)
+- `.venv/bin/python -m pytest -q tests/test_philosophy_alignment_rules.py tests/test_docs_phase1_gates.py -k "alignment or philosophy"` - PASS (`35 passed`)
+- `.venv/bin/python -m pytest -q tests/test_ci_workflow_pr_size_governance_contract.py -k docs_phase1_gates_include_schema_only_contract_changes` - PASS
+- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/orchestration/contracts/philosophy_alignment_rules/wellness/scope.json` - PASS
 - `python3 scripts/ci/check_docs_phase1_gates.py --files docs/orchestration/contracts/PHILOSOPHY_ALIGNMENT_RULE.schema.json docs/roadmap/BACKLOG_LEDGER.md` - PASS
 - `python3 scripts/ci/check_semantic_cache_gate.py` - PASS; semantic-cache gates remain closed
 - `make validate-changed` - PASS (`47 passed`)

--- a/docs/review/PR_1789_FIXED_MAPPING.md
+++ b/docs/review/PR_1789_FIXED_MAPPING.md
@@ -42,11 +42,14 @@ OpenAPI/frontend/iOS changes, and no release-manifest mutation.
 - [x] Fixed in commit mapping completed
 - Pre-open role review completed in order: `agent-coordinator -> architecture-specialist -> philosophy-agent -> security-auditor -> qa-engineer-agent -> bug-hunter`.
 - Post-open bootstrap completed with packet `artifacts/orchestration/task_packets/0cd5f8098592.json`.
-- No actionable GitHub review threads existed when this artifact was created. Future bot or human actionables must be mapped here before resolution.
+- Sourcery review actionables were fixed before thread resolution and mapped below.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#pullrequestreview-4339796645 -> 94ed4ce2141fbd9160bf3f5c42b93d1f256db943
+  - Disposition: FIXED
+  - Evidence: `scripts/ci/check_philosophy_alignment_rules.py` now preserves JSON decode line/column context by reporting the full `JSONDecodeError`, and `tests/test_philosophy_alignment_rules.py` covers the location-bearing invalid JSON message.
+  - Evidence: `scripts/ci/check_philosophy_alignment_rules.py` removes the unused `schema` parameter from `validate_alignment_rule` and updates the only call site, eliminating the confusing no-op companion-schema check.
 
 ## Local Validation Evidence
 
@@ -55,7 +58,7 @@ OpenAPI/frontend/iOS changes, and no release-manifest mutation.
 - `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open` - PASS, packet `artifacts/orchestration/task_packets/d2e36e91b405.json`
 - `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review` - PASS, packet `artifacts/orchestration/task_packets/0cd5f8098592.json`
 - `.venv/bin/python scripts/ci/check_philosophy_alignment_rules.py` - PASS, `schema_hash=31d165ca54e37c0255c8103c52d9fbe29c70084398d665b1ada5f98532453f50`
-- `.venv/bin/python -m pytest -q tests/test_philosophy_alignment_rules.py tests/test_docs_phase1_gates.py -k "alignment or philosophy"` - PASS (`28 passed`)
+- `.venv/bin/python -m pytest -q tests/test_philosophy_alignment_rules.py tests/test_docs_phase1_gates.py -k "alignment or philosophy"` - PASS (`29 passed`)
 - `python3 scripts/ci/check_docs_phase1_gates.py --files docs/orchestration/contracts/PHILOSOPHY_ALIGNMENT_RULE.schema.json docs/roadmap/BACKLOG_LEDGER.md` - PASS
 - `python3 scripts/ci/check_semantic_cache_gate.py` - PASS; semantic-cache gates remain closed
 - `make validate-changed` - PASS (`41 passed`)

--- a/docs/review/PR_1789_FIXED_MAPPING.md
+++ b/docs/review/PR_1789_FIXED_MAPPING.md
@@ -53,6 +53,17 @@ Disposition: FIXED
 Commit: 94ed4ce2141fbd9160bf3f5c42b93d1f256db943
 Evidence: `scripts/ci/check_philosophy_alignment_rules.py` now preserves JSON decode line/column context by reporting the full `JSONDecodeError`, and `tests/test_philosophy_alignment_rules.py` covers the location-bearing invalid JSON message. The same commit removes the unused `schema` parameter from `validate_alignment_rule` and updates the only call site, eliminating the confusing no-op companion-schema check.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#discussion_r3283651385 -> c670951654e82f6bd926cb65617f1fe9c2150987
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#discussion_r3284031378 -> c670951654e82f6bd926cb65617f1fe9c2150987
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#discussion_r3284031382 -> c670951654e82f6bd926cb65617f1fe9c2150987
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#discussion_r3284104233 -> c670951654e82f6bd926cb65617f1fe9c2150987
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#discussion_r3284104236 -> c670951654e82f6bd926cb65617f1fe9c2150987
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#discussion_r3284104242 -> c670951654e82f6bd926cb65617f1fe9c2150987
+Disposition: FIXED
+Commit: c670951654e82f6bd926cb65617f1fe9c2150987
+Evidence: `scripts/ci/check_philosophy_alignment_rules.py` now fails closed on nested `provenance`/`assertion_hints` object type drift, unexpected root/property JSON Schema keywords, and `assertion_hints.required` drift; `tests/test_philosophy_alignment_rules.py` covers each false-green path.
+Evidence: `scripts/ci/check_docs_phase1_gates.py` now routes future `docs/orchestration/contracts/philosophy_alignment_rules/*.json` record edits through `validate_alignment_rules(...)` with the schema plus rule texts; `tests/test_docs_phase1_gates.py` covers the Phase1 rule-record route.
+
 ## Local Validation Evidence
 
 - `python3 scripts/orchestration/check_preflight.py` - PASS

--- a/docs/review/PR_1789_FIXED_MAPPING.md
+++ b/docs/review/PR_1789_FIXED_MAPPING.md
@@ -64,10 +64,10 @@ Commit: c670951654e82f6bd926cb65617f1fe9c2150987
 Evidence: `scripts/ci/check_philosophy_alignment_rules.py` now fails closed on nested `provenance`/`assertion_hints` object type drift, unexpected root/property JSON Schema keywords, and `assertion_hints.required` drift; `tests/test_philosophy_alignment_rules.py` covers each false-green path.
 Evidence: `scripts/ci/check_docs_phase1_gates.py` now routes future `docs/orchestration/contracts/philosophy_alignment_rules/*.json` record edits through `validate_alignment_rules(...)` with the schema plus rule texts; `tests/test_docs_phase1_gates.py` covers the Phase1 rule-record route.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#discussion_r3284280175 -> 65a49b8bb5e9f296f45b842f090f7370f8ea5beb
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#discussion_r3284280179 -> 65a49b8bb5e9f296f45b842f090f7370f8ea5beb
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#discussion_r3284280175 -> 65a49b8bbec3403f5e81969bcc167c890fb5ff13
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#discussion_r3284280179 -> 65a49b8bbec3403f5e81969bcc167c890fb5ff13
 Disposition: FIXED
-Commit: 65a49b8bb5e9f296f45b842f090f7370f8ea5beb
+Commit: 65a49b8bbec3403f5e81969bcc167c890fb5ff13
 Evidence: `.github/workflows/ci.yml` now includes the `:(glob)docs/orchestration/contracts/philosophy_alignment_rules/**/*.json` pathspec in `PHASE1_CHANGED_FILES`, so rule-record JSON edits trigger the docs Phase1 gate in CI.
 Evidence: `scripts/ci/check_docs_phase1_gates.py` now uses `records_dir.rglob("*.json")`, so nested alignment-rule records are included in duplicate-ID and record-shape validation. `tests/test_docs_phase1_gates.py` covers nested record collection, and `tests/test_ci_workflow_pr_size_governance_contract.py` pins the workflow pathspec.
 

--- a/docs/review/PR_1789_FIXED_MAPPING.md
+++ b/docs/review/PR_1789_FIXED_MAPPING.md
@@ -46,6 +46,8 @@ OpenAPI/frontend/iOS changes, and no release-manifest mutation.
 
 ## Fixed in Commit Mapping
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#discussion_r3283621254 -> 94ed4ce2141fbd9160bf3f5c42b93d1f256db943
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#discussion_r3283621290 -> 94ed4ce2141fbd9160bf3f5c42b93d1f256db943
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1789#pullrequestreview-4339796645 -> 94ed4ce2141fbd9160bf3f5c42b93d1f256db943
 Disposition: FIXED
 Commit: 94ed4ce2141fbd9160bf3f5c42b93d1f256db943

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2975,7 +2975,7 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
   - Target PR: PR #1784 (`codex/philosophy-epic-v2-pr3-admission-dry-run`)
-  - Status: 🟡 Active in PR #1784
+  - Status: ✅ Merged PR #1784 on 2026-05-21 (`18be0c53c51e2d7d6a085d204c3a0a8f71689980`)
   - Area: AI / RAG / philosophy / semantic-cache governance / verification-bundle adapter
   - Finding Type: false-green prevention, provenance/report drift, gate-closed verification-bundle dry-run
   - Reason (EN): PR #1777 made philosophical admission claims deterministic through policy JSON and a generated oracle fixture. PR-3 adds the next governance guard: a deterministic dry-run report that connects the PR-2 oracle to synthetic verification-bundle states and proves that missing, failed, warning, and passed bundles still do not permit cache read, cache write, or serving while the semantic-cache gate remains closed.
@@ -2997,6 +2997,32 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - No Redis, GPTCache, embeddings, vector search, provider/client, DB, OpenAPI, frontend, iOS, `/insight`, connection-string, cache-adapter, or runtime activation changes are made
     - Premortem, architecture, philosophy, QA, security, and bug-hunter findings are fixed or formally dispositioned before readiness claims
 
+<a id="ledger-p1-philosophy-epic-v2-alignment-rule-trust-schema"></a>
+- [ ] P1: Philosophy Epic V2 alignment-rule trust schema
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: `codex/philosophy-alignment-rule-trust-schema`
+  - Status: 🟡 Active branch
+  - Area: AI / RAG / philosophy / semantic-cache governance / trust schema
+  - Finding Type: provenance, schema-hash, and future admission-rule auditability
+  - Reason (EN): PR #1784 connected the admission oracle to verification-bundle dry-run truth while keeping cache read, cache write, and serving disabled. The next safe slice defines a machine-readable alignment-rule record shape and deterministic validator so future admission-rule artifacts can carry stable provenance, executable assertion hints, schema version, and schema hash before any later release-manifest or runtime semantic-cache linkage is considered.
+  - Links:
+    - `docs/orchestration/contracts/PHILOSOPHY_ALIGNMENT_RULE.schema.json`
+    - `scripts/ci/check_philosophy_alignment_rules.py`
+    - `tests/test_philosophy_alignment_rules.py`
+    - `scripts/ci/check_docs_phase1_gates.py`
+    - `docs/roadmap/PulsePlate_Semantic_Cache_Gate_and_Plan.md`
+    - `docs/orchestration/contracts/PHILOSOPHY_ADMISSION_DRY_RUN_REPORT.json`
+  - Deferred / Follow-ups:
+    - Future release-manifest slice: add `alignment_schema_hash` only after the release evidence contract explicitly accepts the field and current-head CI proves deterministic manifest hashing.
+    - Future runtime semantic-cache slice: add cache-row `rule_id` linkage only after the global semantic-cache gate opens and a reviewed runtime packet covers DB/cache migration, replay safety, rollback, and verification-bundle admission.
+  - DoD:
+    - Alignment-rule JSON schema is repo-native, closed to unknown fields, and requires rule identity, provenance, assertion hints, schema version, and schema hash
+    - Validator computes the schema hash deterministically from canonical sorted JSON bytes and fails closed on mismatched rule records
+    - Validator rejects duplicate `rule_id` values, malformed provenance, unknown keys, and invalid regex hints
+    - Phase 1 docs gates validate the alignment-rule schema when the schema changes
+    - PR stays governance/test-only with no Redis, GPTCache, embeddings, vector search, provider/client, DB, OpenAPI, frontend, iOS, `/insight`, connection-string, cache-adapter, release-manifest mutation, or runtime activation changes
+    - Premortem, architecture, philosophy, QA, security, and bug-hunter findings are fixed or formally dispositioned before readiness claims
 
 <a id="ledger-p1-recursive-methods"></a>
 - [ ] P1: Recursive methods for LLM/RAG/AI assistant (multi-hop retrieval, recursive reasoning, self-refinement, self-verification, learning)

--- a/scripts/ci/check_docs_phase1_gates.py
+++ b/scripts/ci/check_docs_phase1_gates.py
@@ -36,6 +36,9 @@ try:
     from scripts.ci.check_philosophy_admission_dry_run import (
         validate_philosophy_admission_dry_run_report as _validate_philosophy_admission_dry_run_report,
     )
+    from scripts.ci.check_philosophy_alignment_rules import (
+        validate_alignment_rules as _validate_alignment_rules,
+    )
 except ModuleNotFoundError:
     from check_semantic_cache_gate import (  # noqa: E402
         validate_exact_fuzzy_scaffold_contract as _validate_exact_fuzzy_scaffold_contract,
@@ -53,6 +56,9 @@ except ModuleNotFoundError:
     )
     from check_philosophy_admission_dry_run import (  # noqa: E402
         validate_philosophy_admission_dry_run_report as _validate_philosophy_admission_dry_run_report,
+    )
+    from check_philosophy_alignment_rules import (  # noqa: E402
+        validate_alignment_rules as _validate_alignment_rules,
     )
 
 SEMANTIC_CACHE_GATE_DOC = "docs/roadmap/PulsePlate_Semantic_Cache_Gate_and_Plan.md"
@@ -90,6 +96,9 @@ PHILOSOPHY_ADMISSION_DRY_RUN_REPORT = (
 )
 PHILOSOPHY_ADMISSION_DRY_RUN_REPORT_SCHEMA = (
     "docs/orchestration/contracts/PHILOSOPHY_ADMISSION_DRY_RUN_REPORT.schema.json"
+)
+PHILOSOPHY_ALIGNMENT_RULE_SCHEMA = (
+    "docs/orchestration/contracts/PHILOSOPHY_ALIGNMENT_RULE.schema.json"
 )
 PHILOSOPHY_ADMISSION_DRY_RUN_INPUTS: tuple[str, ...] = (
     PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY,
@@ -209,6 +218,19 @@ class DryRunReportValidator(Protocol):
 
 def _load_philosophy_admission_dry_run_report_validator() -> DryRunReportValidator:
     return cast(DryRunReportValidator, _validate_philosophy_admission_dry_run_report)
+
+
+class AlignmentRuleValidator(Protocol):
+    def __call__(
+        self,
+        *,
+        schema_text: str,
+        rule_texts: dict[str, str],
+    ) -> list[str]: ...
+
+
+def _load_philosophy_alignment_rule_validator() -> AlignmentRuleValidator:
+    return cast(AlignmentRuleValidator, _validate_alignment_rules)
 
 
 def _read_text(relpath: str) -> str:
@@ -489,6 +511,13 @@ def check_docs_phase1_guards(markdown_files: list[str]) -> list[str]:
                         oracle_text=oracle_text,
                     )
                 )
+
+        if relpath == PHILOSOPHY_ALIGNMENT_RULE_SCHEMA:
+            validate_alignment_rules = _load_philosophy_alignment_rule_validator()
+            errors.extend(
+                f"{relpath}: {error}"
+                for error in validate_alignment_rules(schema_text=content, rule_texts={})
+            )
 
     return errors
 

--- a/scripts/ci/check_docs_phase1_gates.py
+++ b/scripts/ci/check_docs_phase1_gates.py
@@ -100,6 +100,7 @@ PHILOSOPHY_ADMISSION_DRY_RUN_REPORT_SCHEMA = (
 PHILOSOPHY_ALIGNMENT_RULE_SCHEMA = (
     "docs/orchestration/contracts/PHILOSOPHY_ALIGNMENT_RULE.schema.json"
 )
+PHILOSOPHY_ALIGNMENT_RULE_RECORD_PREFIX = "docs/orchestration/contracts/philosophy_alignment_rules/"
 PHILOSOPHY_ADMISSION_DRY_RUN_INPUTS: tuple[str, ...] = (
     PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY,
     PHILOSOPHY_SEMANTIC_CACHE_ADMISSION_POLICY_SCHEMA,
@@ -231,6 +232,26 @@ class AlignmentRuleValidator(Protocol):
 
 def _load_philosophy_alignment_rule_validator() -> AlignmentRuleValidator:
     return cast(AlignmentRuleValidator, _validate_alignment_rules)
+
+
+def _is_philosophy_alignment_rule_record(path: str) -> bool:
+    return path.startswith(PHILOSOPHY_ALIGNMENT_RULE_RECORD_PREFIX) and path.endswith(".json")
+
+
+def _read_philosophy_alignment_rule_records(
+    *,
+    changed_relpath: str,
+    changed_content: str,
+) -> dict[str, str]:
+    records: dict[str, str] = {}
+    records_dir = REPO_ROOT / PHILOSOPHY_ALIGNMENT_RULE_RECORD_PREFIX
+    if records_dir.is_dir():
+        for path in sorted(records_dir.glob("*.json")):
+            relpath = path.relative_to(REPO_ROOT).as_posix()
+            records[relpath] = path.read_text(encoding="utf-8")
+    if _is_philosophy_alignment_rule_record(changed_relpath):
+        records[changed_relpath] = changed_content
+    return records
 
 
 def _read_text(relpath: str) -> str:
@@ -512,11 +533,24 @@ def check_docs_phase1_guards(markdown_files: list[str]) -> list[str]:
                     )
                 )
 
-        if relpath == PHILOSOPHY_ALIGNMENT_RULE_SCHEMA:
+        if relpath == PHILOSOPHY_ALIGNMENT_RULE_SCHEMA or _is_philosophy_alignment_rule_record(
+            relpath
+        ):
             validate_alignment_rules = _load_philosophy_alignment_rule_validator()
+            schema_text = (
+                content
+                if relpath == PHILOSOPHY_ALIGNMENT_RULE_SCHEMA
+                else _read_text(PHILOSOPHY_ALIGNMENT_RULE_SCHEMA)
+            )
+            rule_texts = _read_philosophy_alignment_rule_records(
+                changed_relpath=relpath,
+                changed_content=content,
+            )
             errors.extend(
                 f"{relpath}: {error}"
-                for error in validate_alignment_rules(schema_text=content, rule_texts={})
+                for error in validate_alignment_rules(
+                    schema_text=schema_text, rule_texts=rule_texts
+                )
             )
 
     return errors

--- a/scripts/ci/check_docs_phase1_gates.py
+++ b/scripts/ci/check_docs_phase1_gates.py
@@ -246,7 +246,7 @@ def _read_philosophy_alignment_rule_records(
     records: dict[str, str] = {}
     records_dir = REPO_ROOT / PHILOSOPHY_ALIGNMENT_RULE_RECORD_PREFIX
     if records_dir.is_dir():
-        for path in sorted(records_dir.glob("*.json")):
+        for path in sorted(records_dir.rglob("*.json")):
             relpath = path.relative_to(REPO_ROOT).as_posix()
             records[relpath] = path.read_text(encoding="utf-8")
     if _is_philosophy_alignment_rule_record(changed_relpath):

--- a/scripts/ci/check_philosophy_alignment_rules.py
+++ b/scripts/ci/check_philosophy_alignment_rules.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""Deterministic guard for Philosophy alignment-rule trust records."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHEMA = (
+    REPO_ROOT / "docs" / "orchestration" / "contracts" / "PHILOSOPHY_ALIGNMENT_RULE.schema.json"
+)
+
+SCHEMA_VERSION = "v1.0.0"
+SCHEMA_ID = "https://pulseplate.app/schemas/philosophy-alignment-rule.v1.json"
+SCHEMA_TITLE = "PhilosophyAlignmentRule"
+JSON_SCHEMA_DRAFT = "https://json-schema.org/draft/2020-12/schema"
+RULE_TYPES = ("privacy", "harm", "misinfo", "wellness_scope", "copyright", "safety_other")
+SEVERITIES = ("block", "warn", "note")
+SOURCE_TYPES = ("repo", "policy_doc", "legal", "spec")
+REQUIRED_RULE_KEYS = (
+    "rule_id",
+    "rule_text",
+    "rule_type",
+    "severity",
+    "provenance",
+    "assertion_hints",
+    "created_by",
+    "created_at",
+    "schema_version",
+    "schema_hash",
+)
+OPTIONAL_RULE_KEYS = ("notes", "tags")
+RULE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]*$")
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+DATE_TIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$")
+
+
+def canonical_json_bytes(payload: object) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def schema_hash(schema: object) -> str:
+    return hashlib.sha256(canonical_json_bytes(schema)).hexdigest()
+
+
+def _load_json_no_duplicate_keys(
+    text: str,
+    *,
+    invalid_prefix: str,
+    duplicate_prefix: str,
+) -> tuple[object | None, list[str]]:
+    def _hook(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        seen: set[str] = set()
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in seen:
+                raise ValueError(f"{duplicate_prefix}: {key}")
+            seen.add(key)
+            result[key] = value
+        return result
+
+    try:
+        return json.loads(text, object_pairs_hook=_hook), []
+    except json.JSONDecodeError as exc:
+        return None, [f"{invalid_prefix}: {exc.msg}"]
+    except ValueError as exc:
+        return None, [str(exc)]
+
+
+def _as_object(value: object, *, label: str) -> tuple[dict[str, object], list[str]]:
+    if not isinstance(value, dict):
+        return {}, [f"{label} must be an object"]
+    return value, []
+
+
+def _string_list(value: object, *, label: str) -> list[str]:
+    if not isinstance(value, list):
+        return [f"{label} must be an array"]
+    errors: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            errors.append(f"{label}[{index}] must be a string")
+            continue
+        if item in seen:
+            errors.append(f"{label} contains duplicate item: {item}")
+        seen.add(item)
+    return errors
+
+
+def _validate_enum_property(
+    properties: dict[str, object],
+    *,
+    key: str,
+    expected: tuple[str, ...],
+) -> list[str]:
+    prop, errors = _as_object(properties.get(key), label=f"alignment schema property {key}")
+    if errors:
+        return errors
+    enum = prop.get("enum")
+    if enum != list(expected):
+        return [f"alignment schema enum mismatch for {key}"]
+    return []
+
+
+def _object_property(
+    properties: dict[str, object], key: str
+) -> tuple[dict[str, object], list[str]]:
+    return _as_object(properties.get(key), label=f"alignment schema property {key}")
+
+
+def _validate_string_property(
+    properties: dict[str, object],
+    *,
+    key: str,
+    min_length: int | None = None,
+    pattern: str | None = None,
+    const: str | None = None,
+    format_name: str | None = None,
+) -> list[str]:
+    prop, errors = _object_property(properties, key)
+    if errors:
+        return errors
+    if prop.get("type") != "string":
+        errors.append(f"alignment schema property {key} type must be string")
+    if min_length is not None and prop.get("minLength") != min_length:
+        errors.append(f"alignment schema property {key} minLength mismatch")
+    if pattern is not None and prop.get("pattern") != pattern:
+        errors.append(f"alignment schema property {key} pattern mismatch")
+    if const is not None and prop.get("const") != const:
+        errors.append(f"alignment schema property {key} const mismatch")
+    if format_name is not None and prop.get("format") != format_name:
+        errors.append(f"alignment schema property {key} format mismatch")
+    return errors
+
+
+def _validate_string_array_property(
+    properties: dict[str, object],
+    *,
+    key: str,
+    unique_items: bool,
+) -> list[str]:
+    prop, errors = _object_property(properties, key)
+    if errors:
+        return errors
+    if prop.get("type") != "array":
+        errors.append(f"alignment schema property {key} type must be array")
+    if prop.get("uniqueItems") is not unique_items:
+        errors.append(f"alignment schema property {key} uniqueItems mismatch")
+    items, item_errors = _as_object(
+        prop.get("items"),
+        label=f"alignment schema property {key}.items",
+    )
+    errors.extend(item_errors)
+    if not item_errors and items.get("type") != "string":
+        errors.append(f"alignment schema property {key}.items type must be string")
+    return errors
+
+
+def _is_date_time(value: str) -> bool:
+    if not DATE_TIME_RE.fullmatch(value):
+        return False
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
+
+
+def validate_alignment_rule_schema(schema_text: str) -> list[str]:
+    schema, parse_errors = _load_json_no_duplicate_keys(
+        schema_text,
+        invalid_prefix="alignment rule schema invalid JSON",
+        duplicate_prefix="alignment rule schema duplicate key",
+    )
+    if parse_errors:
+        return parse_errors
+    schema_obj, errors = _as_object(schema, label="alignment rule schema")
+    if errors:
+        return errors
+
+    if schema_obj.get("$schema") != JSON_SCHEMA_DRAFT:
+        errors.append("alignment rule schema $schema mismatch")
+    if schema_obj.get("$id") != SCHEMA_ID:
+        errors.append("alignment rule schema $id mismatch")
+    if schema_obj.get("title") != SCHEMA_TITLE:
+        errors.append("alignment rule schema title mismatch")
+    if schema_obj.get("type") != "object":
+        errors.append("alignment rule schema root type must be object")
+    if schema_obj.get("additionalProperties") is not False:
+        errors.append("alignment rule schema must set additionalProperties false")
+
+    required = schema_obj.get("required")
+    if required != list(REQUIRED_RULE_KEYS):
+        errors.append("alignment rule schema required keys mismatch")
+
+    properties, property_errors = _as_object(
+        schema_obj.get("properties"),
+        label="alignment rule schema properties",
+    )
+    errors.extend(property_errors)
+    if property_errors:
+        return errors
+
+    allowed_keys = set(REQUIRED_RULE_KEYS) | set(OPTIONAL_RULE_KEYS)
+    if set(properties) != allowed_keys:
+        errors.append("alignment rule schema properties keys mismatch")
+
+    errors.extend(_validate_string_property(properties, key="rule_id", pattern=RULE_ID_RE.pattern))
+    errors.extend(_validate_string_property(properties, key="rule_text", min_length=1))
+    errors.extend(_validate_string_property(properties, key="created_by", min_length=1))
+    errors.extend(
+        _validate_string_property(
+            properties,
+            key="created_at",
+            format_name="date-time",
+            pattern=DATE_TIME_RE.pattern,
+        )
+    )
+    errors.extend(_validate_string_property(properties, key="schema_version", const=SCHEMA_VERSION))
+    errors.extend(
+        _validate_string_property(properties, key="schema_hash", pattern=SHA256_RE.pattern)
+    )
+    errors.extend(_validate_string_property(properties, key="notes"))
+    errors.extend(_validate_string_array_property(properties, key="tags", unique_items=True))
+    errors.extend(_validate_enum_property(properties, key="rule_type", expected=RULE_TYPES))
+    errors.extend(_validate_enum_property(properties, key="severity", expected=SEVERITIES))
+
+    provenance, provenance_errors = _as_object(
+        properties.get("provenance"),
+        label="alignment schema property provenance",
+    )
+    errors.extend(provenance_errors)
+    if not provenance_errors:
+        if provenance.get("additionalProperties") is not False:
+            errors.append("alignment provenance schema must set additionalProperties false")
+        if provenance.get("required") != ["source_id", "source_type", "version", "anchor_hash"]:
+            errors.append("alignment provenance schema required keys mismatch")
+        provenance_props, provenance_prop_errors = _as_object(
+            provenance.get("properties"),
+            label="alignment provenance schema properties",
+        )
+        errors.extend(provenance_prop_errors)
+        if not provenance_prop_errors:
+            if set(provenance_props) != {"source_id", "source_type", "version", "anchor_hash"}:
+                errors.append("alignment provenance schema properties keys mismatch")
+            errors.extend(
+                _validate_string_property(provenance_props, key="source_id", min_length=1)
+            )
+            errors.extend(_validate_string_property(provenance_props, key="version", min_length=1))
+            errors.extend(
+                _validate_string_property(provenance_props, key="anchor_hash", min_length=8)
+            )
+            errors.extend(
+                _validate_enum_property(provenance_props, key="source_type", expected=SOURCE_TYPES)
+            )
+
+    assertion_hints, hints_errors = _as_object(
+        properties.get("assertion_hints"),
+        label="alignment schema property assertion_hints",
+    )
+    errors.extend(hints_errors)
+    if not hints_errors:
+        if assertion_hints.get("additionalProperties") is not False:
+            errors.append("alignment assertion_hints schema must set additionalProperties false")
+        hint_props, hint_prop_errors = _as_object(
+            assertion_hints.get("properties"),
+            label="alignment assertion_hints schema properties",
+        )
+        errors.extend(hint_prop_errors)
+        if not hint_prop_errors:
+            if set(hint_props) != {"boolean_checks", "regexes"}:
+                errors.append("alignment assertion_hints schema properties keys mismatch")
+            errors.extend(
+                _validate_string_array_property(
+                    hint_props,
+                    key="boolean_checks",
+                    unique_items=True,
+                )
+            )
+            errors.extend(
+                _validate_string_array_property(
+                    hint_props,
+                    key="regexes",
+                    unique_items=True,
+                )
+            )
+
+    return errors
+
+
+def validate_alignment_rule(
+    *,
+    rule_text: str,
+    schema: object,
+    expected_schema_hash: str,
+    label: str,
+) -> tuple[str | None, list[str]]:
+    rule, parse_errors = _load_json_no_duplicate_keys(
+        rule_text,
+        invalid_prefix=f"{label}: invalid JSON",
+        duplicate_prefix=f"{label}: duplicate key",
+    )
+    if parse_errors:
+        return None, parse_errors
+    rule_obj, errors = _as_object(rule, label=f"{label}: alignment rule")
+    if errors:
+        return None, errors
+
+    allowed_keys = set(REQUIRED_RULE_KEYS) | set(OPTIONAL_RULE_KEYS)
+    for key in REQUIRED_RULE_KEYS:
+        if key not in rule_obj:
+            errors.append(f"{label}: missing required key {key}")
+    for key in sorted(set(rule_obj) - allowed_keys):
+        errors.append(f"{label}: unknown key {key}")
+
+    rule_id = rule_obj.get("rule_id")
+    if not isinstance(rule_id, str) or not RULE_ID_RE.fullmatch(rule_id):
+        errors.append(f"{label}: rule_id must match {RULE_ID_RE.pattern}")
+
+    for key in ("rule_text", "created_by"):
+        value = rule_obj.get(key)
+        if not isinstance(value, str) or not value:
+            errors.append(f"{label}: {key} must be a non-empty string")
+    created_at = rule_obj.get("created_at")
+    if not isinstance(created_at, str) or not created_at:
+        errors.append(f"{label}: created_at must be a non-empty string")
+    elif not _is_date_time(created_at):
+        errors.append(f"{label}: created_at must be a valid date-time")
+
+    if rule_obj.get("schema_version") != SCHEMA_VERSION:
+        errors.append(
+            f"{label}: schema_version mismatch: expected {SCHEMA_VERSION}, "
+            f"got {rule_obj.get('schema_version')!r}"
+        )
+    if rule_obj.get("schema_hash") != expected_schema_hash:
+        errors.append(f"{label}: schema_hash mismatch")
+
+    if rule_obj.get("rule_type") not in RULE_TYPES:
+        errors.append(f"{label}: invalid rule_type {rule_obj.get('rule_type')!r}")
+    if rule_obj.get("severity") not in SEVERITIES:
+        errors.append(f"{label}: invalid severity {rule_obj.get('severity')!r}")
+
+    provenance, provenance_errors = _as_object(
+        rule_obj.get("provenance"),
+        label=f"{label}: provenance",
+    )
+    errors.extend(provenance_errors)
+    if not provenance_errors:
+        provenance_allowed = {"source_id", "source_type", "version", "anchor_hash"}
+        for key in sorted(set(provenance) - provenance_allowed):
+            errors.append(f"{label}: provenance unknown key {key}")
+        for key in ("source_id", "version", "anchor_hash"):
+            value = provenance.get(key)
+            if not isinstance(value, str) or not value:
+                errors.append(f"{label}: provenance.{key} must be a non-empty string")
+        if provenance.get("source_type") not in SOURCE_TYPES:
+            errors.append(f"{label}: invalid provenance.source_type")
+        anchor_hash = provenance.get("anchor_hash")
+        if isinstance(anchor_hash, str) and len(anchor_hash) < 8:
+            errors.append(f"{label}: provenance.anchor_hash must be at least 8 characters")
+
+    assertion_hints, hints_errors = _as_object(
+        rule_obj.get("assertion_hints"),
+        label=f"{label}: assertion_hints",
+    )
+    errors.extend(hints_errors)
+    if not hints_errors:
+        for key in sorted(set(assertion_hints) - {"boolean_checks", "regexes"}):
+            errors.append(f"{label}: assertion_hints unknown key {key}")
+        if "boolean_checks" in assertion_hints:
+            errors.extend(
+                _string_list(
+                    assertion_hints["boolean_checks"],
+                    label=f"{label}: assertion_hints.boolean_checks",
+                )
+            )
+        if "regexes" in assertion_hints:
+            regex_values = assertion_hints["regexes"]
+            regex_errors = _string_list(
+                regex_values,
+                label=f"{label}: assertion_hints.regexes",
+            )
+            errors.extend(regex_errors)
+            if not regex_errors and isinstance(regex_values, list):
+                for pattern in [item for item in regex_values if isinstance(item, str)]:
+                    try:
+                        re.compile(pattern)
+                    except re.error as exc:
+                        errors.append(f"{label}: invalid regex {pattern!r}: {exc}")
+
+    if "tags" in rule_obj:
+        errors.extend(_string_list(rule_obj["tags"], label=f"{label}: tags"))
+    if "notes" in rule_obj and not isinstance(rule_obj["notes"], str):
+        errors.append(f"{label}: notes must be a string")
+
+    if not isinstance(schema, dict):
+        errors.append(f"{label}: companion schema must be an object")
+
+    return rule_id if isinstance(rule_id, str) else None, errors
+
+
+def validate_alignment_rules(
+    *,
+    schema_text: str,
+    rule_texts: dict[str, str],
+) -> list[str]:
+    schema, parse_errors = _load_json_no_duplicate_keys(
+        schema_text,
+        invalid_prefix="alignment rule schema invalid JSON",
+        duplicate_prefix="alignment rule schema duplicate key",
+    )
+    if parse_errors:
+        return parse_errors
+
+    errors = validate_alignment_rule_schema(schema_text)
+    if errors:
+        return errors
+
+    expected_hash = schema_hash(schema)
+    seen_ids: dict[str, str] = {}
+    for label, rule_text in sorted(rule_texts.items()):
+        rule_id, rule_errors = validate_alignment_rule(
+            rule_text=rule_text,
+            schema=schema,
+            expected_schema_hash=expected_hash,
+            label=label,
+        )
+        errors.extend(rule_errors)
+        if rule_id:
+            previous = seen_ids.get(rule_id)
+            if previous:
+                errors.append(f"{label}: duplicate rule_id {rule_id} also used by {previous}")
+            else:
+                seen_ids[rule_id] = label
+
+    return errors
+
+
+def _read_rule_files(paths: list[Path]) -> dict[str, str]:
+    return {str(path): path.read_text(encoding="utf-8") for path in paths}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate Philosophy alignment-rule records.")
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    parser.add_argument("--rule", action="append", type=Path, default=[])
+    args = parser.parse_args(argv)
+
+    schema_text = args.schema.read_text(encoding="utf-8")
+    errors = validate_alignment_rules(
+        schema_text=schema_text,
+        rule_texts=_read_rule_files(args.rule),
+    )
+    if errors:
+        print("ERROR: philosophy alignment-rule validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    schema_obj, _ = _load_json_no_duplicate_keys(
+        schema_text,
+        invalid_prefix="alignment rule schema invalid JSON",
+        duplicate_prefix="alignment rule schema duplicate key",
+    )
+    print(f"philosophy alignment-rule schema passed: {args.schema}")
+    print(f"schema_hash={schema_hash(schema_obj)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_philosophy_alignment_rules.py
+++ b/scripts/ci/check_philosophy_alignment_rules.py
@@ -73,7 +73,7 @@ def _load_json_no_duplicate_keys(
     try:
         return json.loads(text, object_pairs_hook=_hook), []
     except json.JSONDecodeError as exc:
-        return None, [f"{invalid_prefix}: {exc.msg}"]
+        return None, [f"{invalid_prefix}: {exc}"]
     except ValueError as exc:
         return None, [str(exc)]
 
@@ -303,7 +303,6 @@ def validate_alignment_rule_schema(schema_text: str) -> list[str]:
 def validate_alignment_rule(
     *,
     rule_text: str,
-    schema: object,
     expected_schema_hash: str,
     label: str,
 ) -> tuple[str | None, list[str]]:
@@ -405,9 +404,6 @@ def validate_alignment_rule(
     if "notes" in rule_obj and not isinstance(rule_obj["notes"], str):
         errors.append(f"{label}: notes must be a string")
 
-    if not isinstance(schema, dict):
-        errors.append(f"{label}: companion schema must be an object")
-
     return rule_id if isinstance(rule_id, str) else None, errors
 
 
@@ -433,7 +429,6 @@ def validate_alignment_rules(
     for label, rule_text in sorted(rule_texts.items()):
         rule_id, rule_errors = validate_alignment_rule(
             rule_text=rule_text,
-            schema=schema,
             expected_schema_hash=expected_hash,
             label=label,
         )

--- a/scripts/ci/check_philosophy_alignment_rules.py
+++ b/scripts/ci/check_philosophy_alignment_rules.py
@@ -39,6 +39,20 @@ OPTIONAL_RULE_KEYS = ("notes", "tags")
 RULE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]*$")
 SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 DATE_TIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$")
+ROOT_SCHEMA_KEYS = {
+    "$id",
+    "$schema",
+    "additionalProperties",
+    "properties",
+    "required",
+    "title",
+    "type",
+}
+OBJECT_SCHEMA_KEYS = {"additionalProperties", "properties", "required", "type"}
+OPTIONAL_OBJECT_SCHEMA_KEYS = {"additionalProperties", "properties", "type"}
+ENUM_SCHEMA_KEYS = {"enum", "type"}
+ARRAY_SCHEMA_KEYS = {"items", "type", "uniqueItems"}
+ITEM_SCHEMA_KEYS = {"type"}
 
 
 def canonical_json_bytes(payload: object) -> bytes:
@@ -108,10 +122,25 @@ def _validate_enum_property(
     prop, errors = _as_object(properties.get(key), label=f"alignment schema property {key}")
     if errors:
         return errors
+    errors.extend(
+        _reject_unknown_schema_keys(prop, ENUM_SCHEMA_KEYS, f"alignment schema property {key}")
+    )
+    if prop.get("type") != "string":
+        errors.append(f"alignment schema property {key} type must be string")
     enum = prop.get("enum")
     if enum != list(expected):
-        return [f"alignment schema enum mismatch for {key}"]
-    return []
+        errors.append(f"alignment schema enum mismatch for {key}")
+    return errors
+
+
+def _reject_unknown_schema_keys(
+    schema_part: dict[str, object],
+    allowed_keys: set[str],
+    label: str,
+) -> list[str]:
+    return [
+        f"{label} unknown schema keyword {key}" for key in sorted(set(schema_part) - allowed_keys)
+    ]
 
 
 def _object_property(
@@ -132,6 +161,18 @@ def _validate_string_property(
     prop, errors = _object_property(properties, key)
     if errors:
         return errors
+    allowed_keys = {"type"}
+    if min_length is not None:
+        allowed_keys.add("minLength")
+    if pattern is not None:
+        allowed_keys.add("pattern")
+    if const is not None:
+        allowed_keys.add("const")
+    if format_name is not None:
+        allowed_keys.add("format")
+    errors.extend(
+        _reject_unknown_schema_keys(prop, allowed_keys, f"alignment schema property {key}")
+    )
     if prop.get("type") != "string":
         errors.append(f"alignment schema property {key} type must be string")
     if min_length is not None and prop.get("minLength") != min_length:
@@ -154,6 +195,9 @@ def _validate_string_array_property(
     prop, errors = _object_property(properties, key)
     if errors:
         return errors
+    errors.extend(
+        _reject_unknown_schema_keys(prop, ARRAY_SCHEMA_KEYS, f"alignment schema property {key}")
+    )
     if prop.get("type") != "array":
         errors.append(f"alignment schema property {key} type must be array")
     if prop.get("uniqueItems") is not unique_items:
@@ -163,8 +207,16 @@ def _validate_string_array_property(
         label=f"alignment schema property {key}.items",
     )
     errors.extend(item_errors)
-    if not item_errors and items.get("type") != "string":
-        errors.append(f"alignment schema property {key}.items type must be string")
+    if not item_errors:
+        errors.extend(
+            _reject_unknown_schema_keys(
+                items,
+                ITEM_SCHEMA_KEYS,
+                f"alignment schema property {key}.items",
+            )
+        )
+        if items.get("type") != "string":
+            errors.append(f"alignment schema property {key}.items type must be string")
     return errors
 
 
@@ -200,6 +252,9 @@ def validate_alignment_rule_schema(schema_text: str) -> list[str]:
         errors.append("alignment rule schema root type must be object")
     if schema_obj.get("additionalProperties") is not False:
         errors.append("alignment rule schema must set additionalProperties false")
+    errors.extend(
+        _reject_unknown_schema_keys(schema_obj, ROOT_SCHEMA_KEYS, "alignment rule schema")
+    )
 
     required = schema_obj.get("required")
     if required != list(REQUIRED_RULE_KEYS):
@@ -217,7 +272,14 @@ def validate_alignment_rule_schema(schema_text: str) -> list[str]:
     if set(properties) != allowed_keys:
         errors.append("alignment rule schema properties keys mismatch")
 
-    errors.extend(_validate_string_property(properties, key="rule_id", pattern=RULE_ID_RE.pattern))
+    errors.extend(
+        _validate_string_property(
+            properties,
+            key="rule_id",
+            min_length=1,
+            pattern=RULE_ID_RE.pattern,
+        )
+    )
     errors.extend(_validate_string_property(properties, key="rule_text", min_length=1))
     errors.extend(_validate_string_property(properties, key="created_by", min_length=1))
     errors.extend(
@@ -243,6 +305,15 @@ def validate_alignment_rule_schema(schema_text: str) -> list[str]:
     )
     errors.extend(provenance_errors)
     if not provenance_errors:
+        errors.extend(
+            _reject_unknown_schema_keys(
+                provenance,
+                OBJECT_SCHEMA_KEYS,
+                "alignment provenance schema",
+            )
+        )
+        if provenance.get("type") != "object":
+            errors.append("alignment provenance schema type must be object")
         if provenance.get("additionalProperties") is not False:
             errors.append("alignment provenance schema must set additionalProperties false")
         if provenance.get("required") != ["source_id", "source_type", "version", "anchor_hash"]:
@@ -272,8 +343,19 @@ def validate_alignment_rule_schema(schema_text: str) -> list[str]:
     )
     errors.extend(hints_errors)
     if not hints_errors:
+        errors.extend(
+            _reject_unknown_schema_keys(
+                assertion_hints,
+                OPTIONAL_OBJECT_SCHEMA_KEYS,
+                "alignment assertion_hints schema",
+            )
+        )
+        if assertion_hints.get("type") != "object":
+            errors.append("alignment assertion_hints schema type must be object")
         if assertion_hints.get("additionalProperties") is not False:
             errors.append("alignment assertion_hints schema must set additionalProperties false")
+        if "required" in assertion_hints:
+            errors.append("alignment assertion_hints schema required keys mismatch")
         hint_props, hint_prop_errors = _as_object(
             assertion_hints.get("properties"),
             label="alignment assertion_hints schema properties",

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -256,6 +256,10 @@ def test_docs_phase1_gates_include_schema_only_contract_changes() -> None:
         in docs_phase1_section
     )
     assert (
+        "':(glob)docs/orchestration/contracts/philosophy_alignment_rules/**/*.json'"
+        in docs_phase1_section
+    )
+    assert (
         "'tests/fixtures/orchestration/philosophy_admission_claim_oracle.json'"
         in docs_phase1_section
     )

--- a/tests/test_docs_phase1_gates.py
+++ b/tests/test_docs_phase1_gates.py
@@ -422,3 +422,17 @@ def test_phase1_guard_validates_philosophy_admission_dry_run_schema_only_edits(
     )
 
     assert any("dry-run schema const missing for gate_status" in error for error in errors)
+
+
+def test_phase1_guard_validates_philosophy_alignment_rule_schema_edits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        gates,
+        "_load_philosophy_alignment_rule_validator",
+        lambda: lambda **_kwargs: ["alignment validator called"],
+    )
+
+    errors = gates.check_docs_phase1_guards(markdown_files=[gates.PHILOSOPHY_ALIGNMENT_RULE_SCHEMA])
+
+    assert any("alignment validator called" in error for error in errors)

--- a/tests/test_docs_phase1_gates.py
+++ b/tests/test_docs_phase1_gates.py
@@ -456,7 +456,11 @@ def test_phase1_guard_validates_philosophy_alignment_rule_record_edits(
         return ["record validator called"]
 
     monkeypatch.setattr(gates, "REPO_ROOT", tmp_path)
-    monkeypatch.setattr(gates, "_load_philosophy_alignment_rule_validator", lambda: _fake_validator)
+    monkeypatch.setattr(
+        gates,
+        "_load_philosophy_alignment_rule_validator",
+        lambda: _fake_validator,
+    )
 
     errors = gates.check_docs_phase1_guards(markdown_files=[record_relpath])
 
@@ -464,3 +468,37 @@ def test_phase1_guard_validates_philosophy_alignment_rule_record_edits(
     assert calls
     assert calls[0]["schema_text"] == "{}"
     assert calls[0]["rule_texts"] == {record_relpath: '{"rule_id": "sample"}'}
+
+
+def test_phase1_guard_collects_nested_philosophy_alignment_rule_records(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema_path = tmp_path / gates.PHILOSOPHY_ALIGNMENT_RULE_SCHEMA
+    schema_path.parent.mkdir(parents=True, exist_ok=True)
+    schema_path.write_text("{}", encoding="utf-8")
+    root_record_relpath = f"{gates.PHILOSOPHY_ALIGNMENT_RULE_RECORD_PREFIX}sample.json"
+    nested_record_relpath = f"{gates.PHILOSOPHY_ALIGNMENT_RULE_RECORD_PREFIX}wellness/scope.json"
+    root_record_path = tmp_path / root_record_relpath
+    nested_record_path = tmp_path / nested_record_relpath
+    root_record_path.parent.mkdir(parents=True, exist_ok=True)
+    nested_record_path.parent.mkdir(parents=True, exist_ok=True)
+    root_record_path.write_text('{"rule_id": "sample"}', encoding="utf-8")
+    nested_record_path.write_text('{"rule_id": "scope"}', encoding="utf-8")
+    calls: list[dict[str, object]] = []
+
+    def _fake_validator(**kwargs: object) -> list[str]:
+        calls.append(kwargs)
+        return ["record validator called"]
+
+    monkeypatch.setattr(gates, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(gates, "_load_philosophy_alignment_rule_validator", lambda: _fake_validator)
+
+    errors = gates.check_docs_phase1_guards(markdown_files=[nested_record_relpath])
+
+    assert any("record validator called" in error for error in errors)
+    assert calls
+    assert calls[0]["rule_texts"] == {
+        root_record_relpath: '{"rule_id": "sample"}',
+        nested_record_relpath: '{"rule_id": "scope"}',
+    }

--- a/tests/test_docs_phase1_gates.py
+++ b/tests/test_docs_phase1_gates.py
@@ -436,3 +436,31 @@ def test_phase1_guard_validates_philosophy_alignment_rule_schema_edits(
     errors = gates.check_docs_phase1_guards(markdown_files=[gates.PHILOSOPHY_ALIGNMENT_RULE_SCHEMA])
 
     assert any("alignment validator called" in error for error in errors)
+
+
+def test_phase1_guard_validates_philosophy_alignment_rule_record_edits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schema_path = tmp_path / gates.PHILOSOPHY_ALIGNMENT_RULE_SCHEMA
+    schema_path.parent.mkdir(parents=True, exist_ok=True)
+    schema_path.write_text("{}", encoding="utf-8")
+    record_relpath = f"{gates.PHILOSOPHY_ALIGNMENT_RULE_RECORD_PREFIX}sample.json"
+    record_path = tmp_path / record_relpath
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    record_path.write_text('{"rule_id": "sample"}', encoding="utf-8")
+    calls: list[dict[str, object]] = []
+
+    def _fake_validator(**kwargs: object) -> list[str]:
+        calls.append(kwargs)
+        return ["record validator called"]
+
+    monkeypatch.setattr(gates, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(gates, "_load_philosophy_alignment_rule_validator", lambda: _fake_validator)
+
+    errors = gates.check_docs_phase1_guards(markdown_files=[record_relpath])
+
+    assert any("record validator called" in error for error in errors)
+    assert calls
+    assert calls[0]["schema_text"] == "{}"
+    assert calls[0]["rule_texts"] == {record_relpath: '{"rule_id": "sample"}'}

--- a/tests/test_philosophy_alignment_rules.py
+++ b/tests/test_philosophy_alignment_rules.py
@@ -168,6 +168,23 @@ def test_alignment_rule_schema_rejects_provenance_required_drift() -> None:
     assert "alignment provenance schema required keys mismatch" in errors
 
 
+def test_alignment_rule_schema_rejects_nested_object_type_drift() -> None:
+    schema = _schema()
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    provenance = properties["provenance"]
+    assertion_hints = properties["assertion_hints"]
+    assert isinstance(provenance, dict)
+    assert isinstance(assertion_hints, dict)
+    del provenance["type"]
+    del assertion_hints["type"]
+
+    errors = validate_alignment_rule_schema(json.dumps(schema, sort_keys=True))
+
+    assert "alignment provenance schema type must be object" in errors
+    assert "alignment assertion_hints schema type must be object" in errors
+
+
 def test_alignment_rule_schema_rejects_identity_drift() -> None:
     schema = _schema()
     schema["$id"] = "https://example.invalid/wrong.json"
@@ -246,6 +263,41 @@ def test_alignment_rule_schema_rejects_tags_unique_items_drift() -> None:
     errors = validate_alignment_rule_schema(json.dumps(schema, sort_keys=True))
 
     assert "alignment schema property tags uniqueItems mismatch" in errors
+
+
+def test_alignment_rule_schema_rejects_unknown_root_keyword() -> None:
+    schema = _schema()
+    schema["not"] = {}
+
+    errors = validate_alignment_rule_schema(json.dumps(schema, sort_keys=True))
+
+    assert "alignment rule schema unknown schema keyword not" in errors
+
+
+def test_alignment_rule_schema_rejects_unknown_property_keyword() -> None:
+    schema = _schema()
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    schema_hash_property = properties["schema_hash"]
+    assert isinstance(schema_hash_property, dict)
+    schema_hash_property["not"] = {"type": "string"}
+
+    errors = validate_alignment_rule_schema(json.dumps(schema, sort_keys=True))
+
+    assert "alignment schema property schema_hash unknown schema keyword not" in errors
+
+
+def test_alignment_rule_schema_rejects_assertion_hints_required_drift() -> None:
+    schema = _schema()
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    assertion_hints = properties["assertion_hints"]
+    assert isinstance(assertion_hints, dict)
+    assertion_hints["required"] = ["boolean_checks", "regexes"]
+
+    errors = validate_alignment_rule_schema(json.dumps(schema, sort_keys=True))
+
+    assert "alignment assertion_hints schema required keys mismatch" in errors
 
 
 def test_alignment_rule_cli_prints_schema_hash(capsys: CaptureFixture[str]) -> None:

--- a/tests/test_philosophy_alignment_rules.py
+++ b/tests/test_philosophy_alignment_rules.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pytest import CaptureFixture
+
+from scripts.ci.check_philosophy_alignment_rules import (
+    main as alignment_rules_main,
+    schema_hash,
+    validate_alignment_rule_schema,
+    validate_alignment_rules,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = (
+    REPO_ROOT / "docs" / "orchestration" / "contracts" / "PHILOSOPHY_ALIGNMENT_RULE.schema.json"
+)
+
+
+def _schema_text() -> str:
+    return SCHEMA.read_text(encoding="utf-8")
+
+
+def _schema() -> dict[str, object]:
+    schema = json.loads(_schema_text())
+    assert isinstance(schema, dict)
+    return schema
+
+
+def _rule(**overrides: object) -> dict[str, object]:
+    rule: dict[str, object] = {
+        "rule_id": "wellness_scope.no_medical_claims",
+        "rule_text": "PulsePlate must not present wellness planning as diagnosis or treatment.",
+        "rule_type": "wellness_scope",
+        "severity": "block",
+        "provenance": {
+            "source_id": "AGENTS.md",
+            "source_type": "repo",
+            "version": "commit-4d0a54c0",
+            "anchor_hash": "wellness-only-boundary-v1",
+        },
+        "assertion_hints": {
+            "boolean_checks": ["semantic_cache_gate_closed"],
+            "regexes": ["(?i)diagnosis|treatment"],
+        },
+        "created_by": "agent-coordinator",
+        "created_at": "2026-05-21T00:00:00Z",
+        "schema_version": "v1.0.0",
+        "schema_hash": schema_hash(_schema()),
+        "tags": ["philosophy", "semantic-cache", "wellness"],
+    }
+    rule.update(overrides)
+    return rule
+
+
+def _validate(rule: dict[str, object]) -> list[str]:
+    return validate_alignment_rules(
+        schema_text=_schema_text(),
+        rule_texts={"rule.json": json.dumps(rule, sort_keys=True)},
+    )
+
+
+def test_alignment_rule_schema_is_current() -> None:
+    assert validate_alignment_rule_schema(_schema_text()) == []
+
+
+def test_valid_alignment_rule_passes() -> None:
+    assert _validate(_rule()) == []
+
+
+def test_alignment_rule_rejects_schema_hash_drift() -> None:
+    errors = _validate(_rule(schema_hash="0" * 64))
+
+    assert "rule.json: schema_hash mismatch" in errors
+
+
+def test_alignment_rule_rejects_invalid_regex() -> None:
+    rule = _rule(assertion_hints={"regexes": ["["]})
+
+    errors = _validate(rule)
+
+    assert any("invalid regex '['" in error for error in errors)
+
+
+def test_alignment_rule_rejects_invalid_created_at() -> None:
+    errors = _validate(_rule(created_at="not-a-date"))
+
+    assert "rule.json: created_at must be a valid date-time" in errors
+
+
+def test_alignment_rule_rejects_date_only_created_at() -> None:
+    errors = _validate(_rule(created_at="2026-05-21"))
+
+    assert "rule.json: created_at must be a valid date-time" in errors
+
+
+def test_alignment_rule_rejects_space_separated_created_at() -> None:
+    errors = _validate(_rule(created_at="2026-05-21 00:00:00"))
+
+    assert "rule.json: created_at must be a valid date-time" in errors
+
+
+def test_alignment_rule_rejects_timestamp_without_timezone() -> None:
+    errors = _validate(_rule(created_at="2026-05-21T00:00:00"))
+
+    assert "rule.json: created_at must be a valid date-time" in errors
+
+
+def test_alignment_rule_rejects_duplicate_rule_ids() -> None:
+    rule_text = json.dumps(_rule(), sort_keys=True)
+
+    errors = validate_alignment_rules(
+        schema_text=_schema_text(),
+        rule_texts={"a.json": rule_text, "b.json": rule_text},
+    )
+
+    assert (
+        "b.json: duplicate rule_id wellness_scope.no_medical_claims also used by a.json" in errors
+    )
+
+
+def test_alignment_rule_rejects_unknown_provenance_key() -> None:
+    provenance = {
+        "source_id": "AGENTS.md",
+        "source_type": "repo",
+        "version": "commit-4d0a54c0",
+        "anchor_hash": "wellness-only-boundary-v1",
+        "extra": "not allowed",
+    }
+
+    errors = _validate(_rule(provenance=provenance))
+
+    assert "rule.json: provenance unknown key extra" in errors
+
+
+def test_alignment_rule_rejects_non_string_notes() -> None:
+    errors = _validate(_rule(notes=123))
+
+    assert "rule.json: notes must be a string" in errors
+
+
+def test_alignment_rule_schema_rejects_provenance_required_drift() -> None:
+    schema = _schema()
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    provenance = properties["provenance"]
+    assert isinstance(provenance, dict)
+    provenance["required"] = ["source_id"]
+
+    errors = validate_alignment_rule_schema(json.dumps(schema, sort_keys=True))
+
+    assert "alignment provenance schema required keys mismatch" in errors
+
+
+def test_alignment_rule_schema_rejects_identity_drift() -> None:
+    schema = _schema()
+    schema["$id"] = "https://example.invalid/wrong.json"
+    schema["title"] = "WrongSchema"
+
+    errors = validate_alignment_rule_schema(json.dumps(schema, sort_keys=True))
+
+    assert "alignment rule schema $id mismatch" in errors
+    assert "alignment rule schema title mismatch" in errors
+
+
+def test_alignment_rule_schema_rejects_created_at_format_drift() -> None:
+    schema = _schema()
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    created_at = properties["created_at"]
+    assert isinstance(created_at, dict)
+    del created_at["format"]
+
+    errors = validate_alignment_rule_schema(json.dumps(schema, sort_keys=True))
+
+    assert "alignment schema property created_at format mismatch" in errors
+
+
+def test_alignment_rule_schema_rejects_created_at_pattern_drift() -> None:
+    schema = _schema()
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    created_at = properties["created_at"]
+    assert isinstance(created_at, dict)
+    del created_at["pattern"]
+
+    errors = validate_alignment_rule_schema(json.dumps(schema, sort_keys=True))
+
+    assert "alignment schema property created_at pattern mismatch" in errors
+
+
+def test_alignment_rule_schema_rejects_rule_id_pattern_drift() -> None:
+    schema = _schema()
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    rule_id = properties["rule_id"]
+    assert isinstance(rule_id, dict)
+    del rule_id["pattern"]
+
+    errors = validate_alignment_rule_schema(json.dumps(schema, sort_keys=True))
+
+    assert "alignment schema property rule_id pattern mismatch" in errors
+
+
+def test_alignment_rule_schema_rejects_regex_item_type_drift() -> None:
+    schema = _schema()
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    assertion_hints = properties["assertion_hints"]
+    assert isinstance(assertion_hints, dict)
+    hint_props = assertion_hints["properties"]
+    assert isinstance(hint_props, dict)
+    regexes = hint_props["regexes"]
+    assert isinstance(regexes, dict)
+    regexes["items"] = {"type": "number"}
+
+    errors = validate_alignment_rule_schema(json.dumps(schema, sort_keys=True))
+
+    assert "alignment schema property regexes.items type must be string" in errors
+
+
+def test_alignment_rule_schema_rejects_tags_unique_items_drift() -> None:
+    schema = _schema()
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    tags = properties["tags"]
+    assert isinstance(tags, dict)
+    del tags["uniqueItems"]
+
+    errors = validate_alignment_rule_schema(json.dumps(schema, sort_keys=True))
+
+    assert "alignment schema property tags uniqueItems mismatch" in errors
+
+
+def test_alignment_rule_cli_prints_schema_hash(capsys: CaptureFixture[str]) -> None:
+    exit_code = alignment_rules_main(["--schema", str(SCHEMA)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "philosophy alignment-rule schema passed:" in captured.out
+    assert f"schema_hash={schema_hash(_schema())}" in captured.out

--- a/tests/test_philosophy_alignment_rules.py
+++ b/tests/test_philosophy_alignment_rules.py
@@ -83,6 +83,21 @@ def test_alignment_rule_rejects_invalid_regex() -> None:
     assert any("invalid regex '['" in error for error in errors)
 
 
+def test_alignment_rule_invalid_json_reports_location() -> None:
+    errors = validate_alignment_rules(
+        schema_text=_schema_text(),
+        rule_texts={"rule.json": "{\n"},
+    )
+
+    assert any(
+        error.startswith(
+            "rule.json: invalid JSON: Expecting property name enclosed in double quotes"
+        )
+        and "line 2 column 1" in error
+        for error in errors
+    )
+
+
 def test_alignment_rule_rejects_invalid_created_at() -> None:
     errors = _validate(_rule(created_at="not-a-date"))
 


### PR DESCRIPTION
## Summary
- Add a repo-native Philosophy alignment-rule JSON schema for future semantic-cache admission rule records.
- Add deterministic validation for schema hash, schema version, rule IDs, provenance, assertion hints, regex compilation, and schema drift.
- Keep this slice governance/test-only: no runtime semantic-cache activation, no provider/client wiring, no DB/cache column, no release-manifest mutation.

## Scope
- Schema: `docs/orchestration/contracts/PHILOSOPHY_ALIGNMENT_RULE.schema.json`
- Validator: `scripts/ci/check_philosophy_alignment_rules.py`
- Tests/docs Phase1 routing: `tests/test_philosophy_alignment_rules.py`, `tests/test_docs_phase1_gates.py`, `scripts/ci/check_docs_phase1_gates.py`
- Ledger and review governance: `docs/roadmap/BACKLOG_LEDGER.md`, `docs/review/PR_1789_FIXED_MAPPING.md`

## Split Justification
- This is a narrow governance/test-only slice, but the deterministic schema fixture, validator, drift tests, ledger entry, and review mapping cross the 800-LoC guard. Splitting would leave the schema without its CI validator or tests, so the PR stays one auditable contract slice with no runtime/cache/provider/client activation.

## Validation
- `python3 scripts/orchestration/check_preflight.py` -> PASS
- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS
- `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open` -> PASS, packet `artifacts/orchestration/task_packets/d2e36e91b405.json`
- `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review` -> PASS, packet `artifacts/orchestration/task_packets/0cd5f8098592.json`
- `.venv/bin/python scripts/ci/check_philosophy_alignment_rules.py` -> PASS, `schema_hash=31d165ca54e37c0255c8103c52d9fbe29c70084398d665b1ada5f98532453f50`
- `.venv/bin/python -m pytest -q tests/test_philosophy_alignment_rules.py tests/test_docs_phase1_gates.py -k "alignment or philosophy"` -> PASS, 35 tests
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/orchestration/contracts/PHILOSOPHY_ALIGNMENT_RULE.schema.json docs/roadmap/BACKLOG_LEDGER.md` -> PASS
- `python3 scripts/ci/check_semantic_cache_gate.py` -> PASS, semantic-cache gates remain closed
- `make validate-changed` -> PASS, 47 tests
- `pre-commit run --all-files` -> PASS
- pre-push hooks -> PASS, including mypy, pip-audit, backend pre-push tests, full-repo Bandit, and docker build test

## Lane Start Provenance
- Packet: `artifacts/orchestration/task_packets/d2e36e91b405.json`
- Packet: `artifacts/orchestration/task_packets/0cd5f8098592.json`
- Starter: `scripts/orchestration/start_pr_lane.sh`

## Experiment Runner Evidence
- Artifact: `artifacts/orchestration/experiments/results/exp-cb87fc8b19cc.json`
- Status: accepted; `runner_mode=oracle_only_governance_reviewer`, `mutated_paths=[]`, `shared_tree_untouched=true`, `promotion_ready=false`, `coauthor_required=false`.
- Diagnostic rejected artifact: `artifacts/orchestration/experiments/results/exp-3f10cc3d8c92.json` failed only because the isolated checkout lacked FastAPI for the pytest oracle; it did not shape the commit decision.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- Pre-open role review completed in order: `agent-coordinator -> architecture-specialist -> philosophy-agent -> security-auditor -> qa-engineer-agent -> bug-hunter`.
- Post-open bootstrap completed with packet `artifacts/orchestration/task_packets/0cd5f8098592.json`.
- Sourcery review actionables were fixed and mapped in `docs/review/PR_1789_FIXED_MAPPING.md` before readiness checks.

### Fixed in Commit Mapping
- [x] Fixed in commit mapping completed
- canonical artifact: `docs/review/PR_1789_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Current-head CI terminal success confirmed after the mapping artifact commit.
- [ ] CodeRabbit / Sourcery / Cubic / Codex review actionables checked and mapped.
- [ ] Strict review-thread disposition passes with auth.
- [ ] Strict merge-readiness guard passes with auth.
- [ ] Mandatory wait-window after latest bot/review activity completed.

## Deferred / Follow-ups
- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-philosophy-epic-v2-alignment-rule-trust-schema`
- Future release-manifest slice: add `alignment_schema_hash` only after the release evidence contract explicitly accepts the field.
- Future runtime semantic-cache slice: add cache-row `rule_id` linkage only after the global semantic-cache gate opens with DB/cache migration, replay safety, rollback, and verification-bundle admission coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Philosophy Alignment Rules JSON schema, a deterministic validator/CLI mode, and a CI gate to validate schema edits.

* **Tests**
  * Added comprehensive tests covering the schema, rule validation, CLI schema mode, invalid inputs (regex, timestamps, duplicates) and schema-drift scenarios.

* **Documentation**
  * Updated backlog status and added a review document recording the fix, validation evidence, and follow-ups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1789?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->