### PR TITLE
fix(ci): fail closed for required Experiment Runner evidence artifacts

### DIFF
--- a/docs/review/PR_1800_FIXED_MAPPING.md
+++ b/docs/review/PR_1800_FIXED_MAPPING.md
@@ -1,0 +1,59 @@
+# PR 1800 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: NOT-A-BUG
+Evidence: PR comment is rate-limit/no-review notification, not actionable code feedback.
+Reason: CodeRabbit did not start a review and selected no code action items.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1800#issuecomment-4526045756
+
+Disposition: NOT-A-BUG
+Evidence: Sourcery review body says weekly rate limit reached and contains no actionable code feedback.
+Reason: Sourcery did not provide code findings for this PR.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1800#pullrequestreview-3330114568
+
+Disposition: NOT-A-BUG
+Evidence: Codecov reports all modified and coverable lines are covered by tests.
+Reason: Coverage report is informational/pass signal, not an actionable review comment.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1800#issuecomment-4526085730
+
+## Agent Execution Log
+- agent-coordinator: scope locked #1800 as first after #1799, security/governance PR only; requested `--pr-phase post_open` was unsupported by current tooling and rerun as `post_open_review`.
+- architecture-specialist: Phase2 gate remains the centralized enforcement point; `check_merge_ready.py` forwards required mode to Phase2 without duplicating validator logic.
+- security-auditor: fake/missing/unreadable/unparsable/invalid/rejected Experiment Runner artifacts fail closed in required mode; advisory/default behavior remains non-blocking.
+- qa-engineer-agent: regression tests cover structured required-mode failures, valid accepted artifact evidence, CLI non-zero required mode, and advisory/default mode preservation.
+- bug-hunter: probed fake prefix paths, malformed JSON, missing result metadata, rejected artifacts, unrelated advisories, advisory/default behavior, and CLI exit codes.
+
+## Premortem Risk Fix Matrix
+| Risk ID | Failure mode | Fix | Regression test | Evidence command | Disposition |
+| --- | --- | --- | --- | --- | --- |
+| PM-1800-001 | Fake artifact path satisfies required Experiment Runner Evidence. | Required mode validates local artifact availability and promotes missing artifact to hard error. | `test_experiment_runner_evidence_required_mode_rejects_nonexistent_artifact`; CLI fake path test. | `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py -k "experiment_runner or evidence or artifact"` | FIXED |
+| PM-1800-002 | Malformed artifact JSON satisfies required evidence. | Required mode reads/parses artifact JSON and errors on `json.JSONDecodeError`. | `test_experiment_runner_evidence_required_mode_rejects_invalid_json`. | `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py -k "experiment_runner or evidence or artifact"` | FIXED |
+| PM-1800-003 | Advisory mode behavior is accidentally made blocking. | Structured artifact validation runs only when `experiment_runner_evidence_mode == required`; advisory co-author diagnostics remain warnings. | `test_phase2_cli_advisory_mode_allows_unavailable_experiment_runner_artifact`. | `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py -k "experiment_runner or evidence or artifact"` | FIXED |
+| PM-1800-004 | Default mode flips to required and blocks unrelated PRs. | Default CLI/env normalization remains `advisory`. | `test_phase2_cli_default_mode_allows_unavailable_experiment_runner_artifact`. | `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py -k "experiment_runner or evidence or artifact"` | FIXED |
+| PM-1800-005 | Error wording is too broad and catches unrelated warnings. | Legacy warning promotion helper remains prefix-scoped to Experiment Runner artifact availability/metadata warnings; structured required validation handles real enforcement. | `test_required_mode_does_not_promote_unrelated_advisory`. | `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py -k "experiment_runner or evidence or artifact"` | FIXED |
+| PM-1800-006 | Merge wrapper required mode does not inherit fail-closed behavior. | `check_merge_ready.py` forwards `--experiment-runner-evidence-mode required` into the centralized Phase2 gate; no duplicate wrapper logic needed. | `tests/test_orchestration_merge_ready.py` required-mode forwarding tests. | `.venv/bin/python -m pytest -q tests/test_orchestration_merge_ready.py -k "experiment_runner or evidence"` | NOT-A-BUG |
+
+## Bounded Check Evidence
+- `python3 scripts/orchestration/check_preflight.py` — PASS: All required SoT files present; PASS: working tree clean.
+- `python3 scripts/orchestration/check_agent_consistency.py` — OK: agent docs and files are consistent.
+- `.venv/bin/python scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review` — packet `artifacts/orchestration/task_packets/54f6ae81e75e.json`.
+- `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py -k "experiment_runner or evidence or artifact"` — 43 passed.
+- `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py` — 98 passed.
+- `.venv/bin/python -m pytest -q tests/test_orchestration_merge_ready.py -k "experiment_runner or evidence"` — 3 passed.
+- `.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null scripts/ci/check_pr_body_phase2_gates.py tests/test_pr_body_phase2_gates.py` — failed before checking with duplicate module-name mapping: `Source file found twice under different module names: "check_pr_body_phase2_gates" and "scripts.ci.check_pr_body_phase2_gates"`.
+- `.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null --explicit-package-bases scripts/ci/check_pr_body_phase2_gates.py tests/test_pr_body_phase2_gates.py` — Success: no issues found in 2 source files.
+- `make validate-changed` — PASS: `tests/test_pr_body_phase2_gates.py` passed.
+- `pre-commit run --all-files` — PASS: all hooks passed.
+
+## Experiment Runner Evidence
+- Artifact: artifacts/orchestration/experiments/results/pr-1800-evidence-gate-oracle.json
+- Status: rejected, environment-only after repo `.venv` bounded gates passed.
+- Raw rejection: `ModuleNotFoundError: No module named 'fastapi'` while isolated checkout loaded `conftest.py` for `python3 -m pytest -q tests/test_pr_body_phase2_gates.py -k 'experiment_runner or evidence or artifact'`.
+- Disposition: NOT-A-BUG; the isolated Experiment Runner checkout did not install repo dependencies, while repo `.venv` gates passed for the same Phase2 evidence tests.
+
+## Deferred / Follow-ups
+- None.

--- a/docs/review/PR_1800_FIXED_MAPPING.md
+++ b/docs/review/PR_1800_FIXED_MAPPING.md
@@ -21,6 +21,7 @@ Reason: Coverage report is informational/pass signal, not an actionable review c
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1800#issuecomment-4526085730
 
 ## Agent Execution Log
+- Commit: 329b2d2ab
 - agent-coordinator: scope locked #1800 as first after #1799, security/governance PR only; requested `--pr-phase post_open` was unsupported by current tooling and rerun as `post_open_review`.
 - architecture-specialist: Phase2 gate remains the centralized enforcement point; `check_merge_ready.py` forwards required mode to Phase2 without duplicating validator logic.
 - security-auditor: fake/missing/unreadable/unparsable/invalid/rejected Experiment Runner artifacts fail closed in required mode; advisory/default behavior remains non-blocking.
@@ -36,6 +37,8 @@ Reason: Coverage report is informational/pass signal, not an actionable review c
 | PM-1800-004 | Default mode flips to required and blocks unrelated PRs. | Default CLI/env normalization remains `advisory`. | `test_phase2_cli_default_mode_allows_unavailable_experiment_runner_artifact`. | `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py -k "experiment_runner or evidence or artifact"` | FIXED |
 | PM-1800-005 | Error wording is too broad and catches unrelated warnings. | Legacy warning promotion helper remains prefix-scoped to Experiment Runner artifact availability/metadata warnings; structured required validation handles real enforcement. | `test_required_mode_does_not_promote_unrelated_advisory`. | `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py -k "experiment_runner or evidence or artifact"` | FIXED |
 | PM-1800-006 | Merge wrapper required mode does not inherit fail-closed behavior. | `check_merge_ready.py` forwards `--experiment-runner-evidence-mode required` into the centralized Phase2 gate; no duplicate wrapper logic needed. | `tests/test_orchestration_merge_ready.py` required-mode forwarding tests. | `.venv/bin/python -m pytest -q tests/test_orchestration_merge_ready.py -k "experiment_runner or evidence"` | NOT-A-BUG |
+
+Commit: 329b2d2ab
 
 ## Bounded Check Evidence
 - `python3 scripts/orchestration/check_preflight.py` — PASS: All required SoT files present; PASS: working tree clean.

--- a/docs/review/PR_1800_FIXED_MAPPING.md
+++ b/docs/review/PR_1800_FIXED_MAPPING.md
@@ -6,8 +6,8 @@
 
 ## Fixed in Commit Mapping
 Disposition: NOT-A-BUG
-Evidence: PR comment is rate-limit/no-review notification, not actionable code feedback.
-Reason: CodeRabbit did not start a review and selected no code action items.
+Evidence: PR comment says "No actionable comments were generated in the recent review"; docstring coverage note is advisory/pre-merge warning, not a repo-required merge gate.
+Reason: CodeRabbit provided no actionable code comments for PR #1800.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1800#issuecomment-4526045756
 
 Disposition: NOT-A-BUG

--- a/docs/review/PR_1800_FIXED_MAPPING.md
+++ b/docs/review/PR_1800_FIXED_MAPPING.md
@@ -20,6 +20,11 @@ Evidence: Codecov reports all modified and coverable lines are covered by tests.
 Reason: Coverage report is informational/pass signal, not an actionable review comment.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1800#issuecomment-4526085730
 
+Disposition: NOT-A-BUG
+Evidence: Codex connector comment reports account usage limits for code reviews and contains no code finding for PR #1800.
+Reason: External review-quota notice is not actionable PR code feedback.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1800#issuecomment-4526412721
+
 ## Agent Execution Log
 - Commit: 329b2d2ab
 - agent-coordinator: scope locked #1800 as first after #1799, security/governance PR only; requested `--pr-phase post_open` was unsupported by current tooling and rerun as `post_open_review`.

--- a/docs/review/PR_1800_FIXED_MAPPING.md
+++ b/docs/review/PR_1800_FIXED_MAPPING.md
@@ -54,9 +54,9 @@ Commit: 329b2d2ab
 
 ## Experiment Runner Evidence
 - Artifact: artifacts/orchestration/experiments/results/pr-1800-evidence-gate-oracle.json
-- Status: rejected, environment-only after repo `.venv` bounded gates passed.
-- Raw rejection: `ModuleNotFoundError: No module named 'fastapi'` while isolated checkout loaded `conftest.py` for `python3 -m pytest -q tests/test_pr_body_phase2_gates.py -k 'experiment_runner or evidence or artifact'`.
-- Disposition: NOT-A-BUG; the isolated Experiment Runner checkout did not install repo dependencies, while repo `.venv` gates passed for the same Phase2 evidence tests.
+- Status: accepted.
+- Oracle evidence: 3 dependency-light Python oracles passed, covering required mode missing/malformed/invalid artifact failures, valid accepted artifact pass, rejected artifact failure, and advisory/default non-blocking CLI behavior.
+- Attribution: `coauthor_required=true`; commit `329b2d2ab` includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
 
 ## Deferred / Follow-ups
 - None.

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -19,7 +19,10 @@ from scripts.orchestration.review_mapping_artifact import (
     validate_mapping_artifact_text,
 )
 from scripts.orchestration.check_experiment_runner_identity import EXPECTED_CO_AUTHOR_TRAILER
-from scripts.orchestration.experiment_contract import validate_contribution_attribution
+from scripts.orchestration.experiment_contract import (
+    validate_contribution_attribution,
+    validate_experiment_result,
+)
 
 # Phase2 contract: headings and checkbox labels (single source for parser and docs).
 # Changing template wording requires updating these constants and re-running tests.
@@ -420,11 +423,80 @@ def _experiment_runner_artifact_paths(text: str) -> list[str]:
     return list(dict.fromkeys(paths))
 
 
+def _required_experiment_runner_artifact_errors(
+    artifact_paths: list[str],
+    *,
+    repo_root: Path,
+) -> list[str]:
+    """Return fail-closed required-mode errors for unverifiable runner artifacts."""
+
+    errors: list[str] = []
+    resolved_repo_root = repo_root.resolve()
+    for artifact_path in artifact_paths:
+        absolute_path = repo_root / artifact_path
+        try:
+            resolved_path = absolute_path.resolve(strict=True)
+            resolved_path.relative_to(resolved_repo_root)
+        except (OSError, RuntimeError, ValueError):
+            errors.append(
+                "Required: Experiment Runner artifact "
+                f"`{artifact_path}` is referenced but unavailable locally."
+            )
+            continue
+        if not resolved_path.is_file():
+            errors.append(
+                "Required: Experiment Runner artifact "
+                f"`{artifact_path}` is referenced but unavailable locally."
+            )
+            continue
+        try:
+            payload = json.loads(resolved_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            errors.append(
+                "Required: Experiment Runner artifact "
+                f"`{artifact_path}` is referenced but cannot be read."
+            )
+            continue
+        except json.JSONDecodeError:
+            errors.append(
+                "Required: Experiment Runner artifact "
+                f"`{artifact_path}` is referenced but cannot be parsed as JSON."
+            )
+            continue
+        if not isinstance(payload, dict):
+            errors.append(
+                "Required: Experiment Runner artifact "
+                f"`{artifact_path}` must be a JSON object result artifact."
+            )
+            continue
+        try:
+            result = validate_experiment_result(payload)
+        except ValueError as exc:
+            errors.append(
+                "Required: Experiment Runner artifact "
+                f"`{artifact_path}` has invalid result metadata: {exc}"
+            )
+            continue
+        if result["status"] != "accepted":
+            errors.append(
+                "Required: Experiment Runner artifact "
+                f"`{artifact_path}` is not accepted evidence: status={result['status']}."
+            )
+            continue
+        if not result["oracle_results"]:
+            errors.append(
+                "Required: Experiment Runner artifact "
+                f"`{artifact_path}` is not accepted evidence: oracle_results is empty."
+            )
+    return errors
+
+
 def check_experiment_runner_evidence(
     text: str,
     *,
     mode: ExperimentRunnerEvidenceMode = ExperimentRunnerEvidenceMode.ADVISORY,
     missing_section_is_warning: bool = False,
+    repo_root: Path = REPO_ROOT,
 ) -> tuple[list[str], list[str]]:
     """Validate Experiment Runner evidence.
 
@@ -454,16 +526,20 @@ def check_experiment_runner_evidence(
         )
 
     if artifact_matches:
+        artifact_paths = [match.group("path") for match in artifact_matches]
         invalid_paths = [
-            match.group("path")
-            for match in artifact_matches
-            if not _valid_experiment_runner_artifact_path(match.group("path"))
+            path for path in artifact_paths if not _valid_experiment_runner_artifact_path(path)
         ]
         if invalid_paths:
             errors.append(
                 "Experiment Runner artifact path must stay under "
                 f"`{EXPERIMENT_RUNNER_ARTIFACT_PREFIX}` and end with `.json`: "
                 + ", ".join(invalid_paths)
+            )
+        if mode is ExperimentRunnerEvidenceMode.REQUIRED:
+            required_paths = [path for path in artifact_paths if path not in invalid_paths]
+            errors.extend(
+                _required_experiment_runner_artifact_errors(required_paths, repo_root=repo_root)
             )
 
     if na_matches:
@@ -627,8 +703,6 @@ def check_experiment_runner_coauthor_advisory(
     return warnings
 
 
-
-
 def _required_experiment_runner_artifact_warning_to_error(warning: str) -> str | None:
     """Promote artifact-unverifiable advisories to required-mode hard errors."""
 
@@ -637,6 +711,7 @@ def _required_experiment_runner_artifact_warning_to_error(warning: str) -> str |
     if " unavailable locally" in warning or " invalid co-author metadata" in warning:
         return warning.replace("Advisory:", "Required:", 1)
     return None
+
 
 def _select_body_validation_mode(*, artifact_checked: bool) -> BodyValidationMode:
     """Choose body validation mode from the canonical artifact/body contract."""

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -627,6 +627,17 @@ def check_experiment_runner_coauthor_advisory(
     return warnings
 
 
+
+
+def _required_experiment_runner_artifact_warning_to_error(warning: str) -> str | None:
+    """Promote artifact-unverifiable advisories to required-mode hard errors."""
+
+    if not warning.startswith("Advisory: Experiment Runner artifact `"):
+        return None
+    if " unavailable locally" in warning or " invalid co-author metadata" in warning:
+        return warning.replace("Advisory:", "Required:", 1)
+    return None
+
 def _select_body_validation_mode(*, artifact_checked: bool) -> BodyValidationMode:
     """Choose body validation mode from the canonical artifact/body contract."""
     if artifact_checked:
@@ -851,6 +862,20 @@ def main() -> int:
                 )
             )
         advisory_warnings = list(dict.fromkeys(advisory_warnings))
+        if args.experiment_runner_evidence_mode is ExperimentRunnerEvidenceMode.REQUIRED:
+            promoted_artifact_errors = [
+                promoted
+                for warning in advisory_warnings
+                if (promoted := _required_experiment_runner_artifact_warning_to_error(warning))
+                is not None
+            ]
+            if promoted_artifact_errors:
+                artifact_errors.extend(promoted_artifact_errors)
+                advisory_warnings = [
+                    warning
+                    for warning in advisory_warnings
+                    if _required_experiment_runner_artifact_warning_to_error(warning) is None
+                ]
     if not lane_start_seen:
         advisory_warnings.extend(dict.fromkeys(lane_start_warning_candidates))
     advisory_warnings = list(dict.fromkeys(advisory_warnings))

--- a/tests/test_pr_body_phase2_gates.py
+++ b/tests/test_pr_body_phase2_gates.py
@@ -1554,3 +1554,39 @@ Starter: scripts/orchestration/start_pr_lane.sh
     assert result.returncode == 1
     assert "PR body validation failed" in result.stdout
     assert "canonical mapping artifact validation failed" not in result.stdout
+def test_required_mode_promotes_unavailable_experiment_artifact_to_error() -> None:
+    warning = (
+        "Advisory: Experiment Runner artifact "
+        "`artifacts/orchestration/experiments/results/missing.json` is referenced "
+        "but unavailable locally, so coauthor_required cannot be verified against "
+        "branch commits."
+    )
+
+    promoted = gates._required_experiment_runner_artifact_warning_to_error(warning)
+
+    assert promoted is not None
+    assert promoted.startswith("Required: Experiment Runner artifact")
+
+
+def test_phase2_cli_required_mode_fails_unavailable_experiment_runner_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    body = VALID_BODY_WITH_MAPPING.replace(
+        "artifacts/orchestration/experiments/results/exp-719.json",
+        "artifacts/orchestration/experiments/results/does-not-exist.json",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_pr_body_phase2_gates.py",
+            "--body",
+            body,
+            "--experiment-runner-evidence-mode",
+            "required",
+        ],
+    )
+
+    assert gates.main() == 1
+
+

--- a/tests/test_pr_body_phase2_gates.py
+++ b/tests/test_pr_body_phase2_gates.py
@@ -50,6 +50,48 @@ Starter: scripts/orchestration/start_pr_lane.sh
 """
 
 
+def _valid_experiment_result_payload(*, status: str = "accepted") -> dict[str, object]:
+    return {
+        "schema_version": "1.0",
+        "experiment_id": "exp-1800",
+        "runner_mode": "oracle_only_governance_reviewer",
+        "candidate_patch": "oracle_only_governance_reviewer",
+        "status": status,
+        "failure_class": None if status == "accepted" else "policy_violation",
+        "mutated_paths": [],
+        "oracle_results": [
+            {
+                "command": ".venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py",
+                "returncode": 0,
+                "timed_out": False,
+                "truncated": False,
+                "stdout": "passed",
+                "stderr": "",
+                "cwd": ".",
+            }
+        ],
+        "budget_observations": {"wall_clock_seconds": 1},
+        "shared_tree_untouched": True,
+        "promotion_ready": False,
+        "contribution_kind": "none",
+        "coauthor_required": False,
+        "coauthor_reason": "",
+    }
+
+
+def _write_experiment_result(
+    repo_root: Path,
+    relative_path: str,
+    payload: dict[str, object] | None = None,
+) -> None:
+    artifact = repo_root / relative_path
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text(
+        json.dumps(payload or _valid_experiment_result_payload()),
+        encoding="utf-8",
+    )
+
+
 def test_phase2_guard_accepts_valid_mapping() -> None:
     errors = gates.check_pr_body_phase2_gates(body=VALID_BODY_WITH_MAPPING)
     assert errors == []
@@ -189,12 +231,105 @@ def test_experiment_runner_evidence_required_mode_fails_missing_block() -> None:
     assert any("Required: missing `## Experiment Runner Evidence`" in error for error in errors)
 
 
-def test_experiment_runner_evidence_required_mode_accepts_valid_artifact_path() -> None:
+def test_experiment_runner_evidence_required_mode_rejects_valid_but_missing_artifact_path() -> None:
     errors, warnings = gates.check_experiment_runner_evidence(
         """## Experiment Runner Evidence
 Artifact: artifacts/orchestration/experiments/results/exp-required.json
 """,
         mode=gates.ExperimentRunnerEvidenceMode.REQUIRED,
+    )
+
+    assert warnings == []
+    assert any("unavailable locally" in error for error in errors)
+
+
+def test_experiment_runner_evidence_required_mode_rejects_nonexistent_artifact(
+    tmp_path: Path,
+) -> None:
+    errors, warnings = gates.check_experiment_runner_evidence(
+        """## Experiment Runner Evidence
+Artifact: artifacts/orchestration/experiments/results/missing.json
+""",
+        mode=gates.ExperimentRunnerEvidenceMode.REQUIRED,
+        repo_root=tmp_path,
+    )
+
+    assert warnings == []
+    assert any("unavailable locally" in error for error in errors)
+
+
+def test_experiment_runner_evidence_required_mode_rejects_invalid_json(
+    tmp_path: Path,
+) -> None:
+    relative_path = "artifacts/orchestration/experiments/results/malformed.json"
+    artifact = tmp_path / relative_path
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("{", encoding="utf-8")
+
+    errors, warnings = gates.check_experiment_runner_evidence(
+        f"""## Experiment Runner Evidence
+Artifact: {relative_path}
+""",
+        mode=gates.ExperimentRunnerEvidenceMode.REQUIRED,
+        repo_root=tmp_path,
+    )
+
+    assert warnings == []
+    assert any("cannot be parsed as JSON" in error for error in errors)
+
+
+def test_experiment_runner_evidence_required_mode_rejects_missing_metadata(
+    tmp_path: Path,
+) -> None:
+    relative_path = "artifacts/orchestration/experiments/results/missing-metadata.json"
+    _write_experiment_result(tmp_path, relative_path, {"schema_version": "1.0"})
+
+    errors, warnings = gates.check_experiment_runner_evidence(
+        f"""## Experiment Runner Evidence
+Artifact: {relative_path}
+""",
+        mode=gates.ExperimentRunnerEvidenceMode.REQUIRED,
+        repo_root=tmp_path,
+    )
+
+    assert warnings == []
+    assert any("invalid result metadata" in error for error in errors)
+
+
+def test_experiment_runner_evidence_required_mode_rejects_rejected_artifact(
+    tmp_path: Path,
+) -> None:
+    relative_path = "artifacts/orchestration/experiments/results/rejected.json"
+    _write_experiment_result(
+        tmp_path,
+        relative_path,
+        _valid_experiment_result_payload(status="rejected"),
+    )
+
+    errors, warnings = gates.check_experiment_runner_evidence(
+        f"""## Experiment Runner Evidence
+Artifact: {relative_path}
+""",
+        mode=gates.ExperimentRunnerEvidenceMode.REQUIRED,
+        repo_root=tmp_path,
+    )
+
+    assert warnings == []
+    assert any("not accepted evidence" in error for error in errors)
+
+
+def test_experiment_runner_evidence_required_mode_accepts_valid_local_artifact(
+    tmp_path: Path,
+) -> None:
+    relative_path = "artifacts/orchestration/experiments/results/accepted.json"
+    _write_experiment_result(tmp_path, relative_path)
+
+    errors, warnings = gates.check_experiment_runner_evidence(
+        f"""## Experiment Runner Evidence
+Artifact: {relative_path}
+""",
+        mode=gates.ExperimentRunnerEvidenceMode.REQUIRED,
+        repo_root=tmp_path,
     )
 
     assert errors == []
@@ -1554,6 +1689,8 @@ Starter: scripts/orchestration/start_pr_lane.sh
     assert result.returncode == 1
     assert "PR body validation failed" in result.stdout
     assert "canonical mapping artifact validation failed" not in result.stdout
+
+
 def test_required_mode_promotes_unavailable_experiment_artifact_to_error() -> None:
     warning = (
         "Advisory: Experiment Runner artifact "
@@ -1568,25 +1705,93 @@ def test_required_mode_promotes_unavailable_experiment_artifact_to_error() -> No
     assert promoted.startswith("Required: Experiment Runner artifact")
 
 
-def test_phase2_cli_required_mode_fails_unavailable_experiment_runner_artifact(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_required_mode_does_not_promote_unrelated_advisory() -> None:
+    warning = "Advisory: unrelated governance note should remain advisory."
+
+    promoted = gates._required_experiment_runner_artifact_warning_to_error(warning)
+
+    assert promoted is None
+
+
+def test_phase2_cli_required_mode_fails_unavailable_experiment_runner_artifact() -> None:
     body = VALID_BODY_WITH_MAPPING.replace(
         "artifacts/orchestration/experiments/results/exp-719.json",
         "artifacts/orchestration/experiments/results/does-not-exist.json",
     )
-    monkeypatch.setattr(
-        sys,
-        "argv",
+
+    result = subprocess.run(
         [
-            "check_pr_body_phase2_gates.py",
+            sys.executable,
+            str(Path(gates.__file__)),
             "--body",
             body,
             "--experiment-runner-evidence-mode",
             "required",
+            "--commit-range",
+            "HEAD..HEAD",
         ],
+        cwd=gates.REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
     )
 
-    assert gates.main() == 1
+    assert result.returncode == 1
+    assert "unavailable locally" in result.stdout
 
 
+def test_phase2_cli_advisory_mode_allows_unavailable_experiment_runner_artifact() -> None:
+    body = VALID_BODY_WITH_MAPPING.replace(
+        "artifacts/orchestration/experiments/results/exp-719.json",
+        "artifacts/orchestration/experiments/results/does-not-exist.json",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(Path(gates.__file__)),
+            "--body",
+            body,
+            "--experiment-runner-evidence-mode",
+            "advisory",
+            "--commit-range",
+            "HEAD..HEAD",
+        ],
+        cwd=gates.REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0
+    assert "WARNING:" in result.stdout
+    assert "unavailable locally" in result.stdout
+
+
+def test_phase2_cli_default_mode_allows_unavailable_experiment_runner_artifact() -> None:
+    body = VALID_BODY_WITH_MAPPING.replace(
+        "artifacts/orchestration/experiments/results/exp-719.json",
+        "artifacts/orchestration/experiments/results/does-not-exist.json",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(Path(gates.__file__)),
+            "--body",
+            body,
+            "--commit-range",
+            "HEAD..HEAD",
+        ],
+        cwd=gates.REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0
+    assert "WARNING:" in result.stdout
+    assert "unavailable locally" in result.stdout


### PR DESCRIPTION
## Summary
Hardens the Phase2 PR body gate so required Experiment Runner Evidence fails closed when an artifact path is fake, missing, unreadable, malformed, invalid, or not accepted evidence.

## Goal
Make `--experiment-runner-evidence-mode required` reject unverifiable Experiment Runner artifact evidence while keeping advisory/default mode non-blocking.

## Business reason
Experiment Runner Evidence is now part of PulsePlate merge governance. A fake artifact path must not satisfy required evidence mode, otherwise future AI/runtime/security/design PRs can claim oracle validation without auditable evidence.

## Scope
- `scripts/ci/check_pr_body_phase2_gates.py`
- `tests/test_pr_body_phase2_gates.py`
- `docs/review/PR_1800_FIXED_MAPPING.md`

## Out of scope
- Runtime app code
- Backend routes
- Frontend
- iOS
- Design contracts/validators
- Dependencies
- CI workflow YAML
- OpenAPI/generated mirrors
- Kimi/native transport code
- Task bootstrap transport logic
- PR #1801/#1802 files

## Root cause
Required Experiment Runner Evidence mode treated some artifact availability and parseability failures as advisories. A PR could therefore claim required Experiment Runner evidence with a syntactically valid but nonexistent or invalid artifact path. Required mode must fail closed on unverifiable evidence.

## Source of truth
- `AGENTS.md`
- `RUNBOOK_AGENT.md`
- `scripts/ci/check_pr_body_phase2_gates.py`
- `tests/test_pr_body_phase2_gates.py`
- `scripts/orchestration/check_merge_ready.py`
- `scripts/orchestration/experiment_runner.py`
- `docs/review/PR_1800_FIXED_MAPPING.md`

## Agent Execution Log
- `agent-coordinator`: scope locked #1800 as first after #1799 and security/governance-only. Bootstrap packet: `artifacts/orchestration/task_packets/54f6ae81e75e.json`.
- `architecture-specialist`: Phase2 gate remains the centralized enforcement point; merge wrapper forwards required mode into Phase2.
- `security-auditor`: fake/missing/unreadable/unparsable/invalid/rejected artifacts fail closed in required mode; advisory/default behavior preserved.
- `qa-engineer-agent`: regression matrix covers required/advisory/default modes plus CLI behavior.
- `bug-hunter`: probed fake path, malformed JSON, missing metadata, rejected artifact, unrelated advisory, and CLI exit code.

## Skill Execution Log
- `pulseplate-workflow`: used for coordinator-first startup and PR-lane policy.
- `pulseplate-premortem-risk-review`: applied to the actual PR diff and risk matrix below.
- `pulseplate-pr-review`: applied to the scoped PR review and fixed-mapping governance.
- `pulseplate-gates`: applied through bounded local gates and pre-commit.

## Experiment Runner Evidence
Artifact: artifacts/orchestration/experiments/results/pr-1800-evidence-gate-oracle.json

Status: accepted.

Oracle evidence: 3 dependency-light Python oracles passed, covering required mode missing/malformed/invalid artifact failures, valid accepted artifact pass, rejected artifact failure, and advisory/default non-blocking CLI behavior.

Attribution: `coauthor_required=true`; commit `329b2d2ab` includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.

## Lane Start Provenance
Packet: artifacts/orchestration/task_packets/54f6ae81e75e.json
Starter: scripts/orchestration/start_pr_lane.sh

Note: the requested `--pr-phase post_open` is not accepted by current tooling; valid current equivalent `post_open_review` was used.

## Premortem
It is 48 hours from now. This CI/security PR made governance worse because fake Experiment Runner artifacts still satisfied required mode, advisory mode was accidentally made blocking, or merge-wrapper paths diverged from Phase2 behavior. The revised implementation validates local artifact existence, parseability, result schema, accepted status, and oracle presence only in required mode, with tests for false positives and default/advisory preservation.

## Premortem Risk Fix Matrix
| Risk ID | Failure mode | Fix | Regression test | Evidence command | Disposition |
| --- | --- | --- | --- | --- | --- |
| PM-1800-001 | Fake artifact path satisfies required Experiment Runner Evidence. | Required mode validates local artifact availability and promotes missing artifact to hard error. | `test_experiment_runner_evidence_required_mode_rejects_nonexistent_artifact`; CLI fake path test. | `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py -k "experiment_runner or evidence or artifact"` | FIXED |
| PM-1800-002 | Malformed artifact JSON satisfies required evidence. | Required mode reads/parses artifact JSON and errors on `json.JSONDecodeError`. | `test_experiment_runner_evidence_required_mode_rejects_invalid_json`. | `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py -k "experiment_runner or evidence or artifact"` | FIXED |
| PM-1800-003 | Advisory mode behavior is accidentally made blocking. | Structured artifact validation runs only when `experiment_runner_evidence_mode == required`; advisory co-author diagnostics remain warnings. | `test_phase2_cli_advisory_mode_allows_unavailable_experiment_runner_artifact`. | `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py -k "experiment_runner or evidence or artifact"` | FIXED |
| PM-1800-004 | Default mode flips to required and blocks unrelated PRs. | Default CLI/env normalization remains `advisory`. | `test_phase2_cli_default_mode_allows_unavailable_experiment_runner_artifact`. | `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py -k "experiment_runner or evidence or artifact"` | FIXED |
| PM-1800-005 | Error wording is too broad and catches unrelated warnings. | Legacy warning promotion helper remains prefix-scoped to Experiment Runner artifact availability/metadata warnings; structured required validation handles real enforcement. | `test_required_mode_does_not_promote_unrelated_advisory`. | `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py -k "experiment_runner or evidence or artifact"` | FIXED |
| PM-1800-006 | Merge wrapper required mode does not inherit the fail-closed behavior. | `check_merge_ready.py` forwards `--experiment-runner-evidence-mode required` into the centralized Phase2 gate; no duplicate wrapper logic needed. | `tests/test_orchestration_merge_ready.py` required-mode forwarding tests. | `.venv/bin/python -m pytest -q tests/test_orchestration_merge_ready.py -k "experiment_runner or evidence"` | NOT-A-BUG |

## Security Review
- No runtime code touched.
- No design code touched.
- No dependency changes.
- No CI workflow YAML changes.
- Advisory mode preserved.
- Required mode fails closed.
- Fake artifact path cannot satisfy required evidence.

## Bug Hunter Pass
- Fake path with correct prefix: covered by required-mode helper and CLI tests.
- Valid path but invalid JSON: covered.
- Valid JSON but missing required metadata: covered.
- Unrelated advisory text: not promoted.
- Advisory mode behavior: covered.
- Required mode behavior: covered.
- Default mode behavior: covered.
- CLI exit code: required mode returns non-zero for fake artifact; advisory/default return zero with warnings.

## Tests / bounded checks
- `python3 scripts/orchestration/check_preflight.py` — PASS.
- `python3 scripts/orchestration/check_agent_consistency.py` — PASS.
- `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py -k "experiment_runner or evidence or artifact"` — PASS, 43 passed.
- `.venv/bin/python -m pytest -q tests/test_pr_body_phase2_gates.py` — PASS, 98 passed.
- `.venv/bin/python -m pytest -q tests/test_orchestration_merge_ready.py -k "experiment_runner or evidence"` — PASS, 3 passed.
- `.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null scripts/ci/check_pr_body_phase2_gates.py tests/test_pr_body_phase2_gates.py` — FAIL before type-checking due repo module-name duplication: `Source file found twice under different module names: "check_pr_body_phase2_gates" and "scripts.ci.check_pr_body_phase2_gates"`.
- `.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null --explicit-package-bases scripts/ci/check_pr_body_phase2_gates.py tests/test_pr_body_phase2_gates.py` — PASS.
- `make validate-changed` — PASS.
- `pre-commit run --all-files` — PASS.

## Deferred / Follow-ups
None.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Canonical artifact: docs/review/PR_1800_FIXED_MAPPING.md

## Merge Readiness
Not claimed. Required current-head CI, review-thread disposition guard, strict merge-readiness wrapper, bot-actionable pass, and wait-window must still complete after push.

## Rollback
Rollback is revert-only: revert #1800 to restore previous Phase2 required-evidence behavior.

Risk of rollback: required Experiment Runner Evidence can again be bypassed by fake/missing artifact paths.

## DoD
- [x] Required mode fails on fake/missing artifact paths.
- [x] Required mode fails on malformed JSON artifacts.
- [x] Required mode fails on missing/invalid result metadata.
- [x] Required mode fails on rejected/non-accepted artifacts.
- [x] Required mode accepts valid accepted artifact evidence.
- [x] Advisory mode remains non-blocking.
- [x] Default mode remains advisory.
- [x] CLI tests prove required-mode non-zero behavior.
- [x] No runtime/design/dependency/workflow scope drift.
- [x] Premortem Risk Fix Matrix complete.
- [x] Experiment Runner oracle evidence recorded and accepted.
- [x] Bounded checks passed in repo `.venv`, except exact direct mypy command blocked by repo module-name mapping and covered by package-aware equivalent.

## Commit breakdown
- `4ea3f5047488e4b42718e16046378ee23c97a099` initial fail-closed helper/tests.
- `329b2d2ab` structured required-mode artifact validation, expanded tests, fixed mapping.
- `c56ae2a38` fixed-mapping SHA update.
- `0b92e6475` accepted Experiment Runner evidence mapping update.

## Pre-push checklist
- [x] `check_preflight`
- [x] `check_agent_consistency`
- [x] focused Phase2 tests
- [x] full Phase2 tests
- [x] merge-wrapper focused tests
- [x] package-aware focused mypy
- [x] `make validate-changed`
- [x] `pre-commit run --all-files`

## Post-merge checklist
- Sync local `main` with `origin/main`.
- Confirm main current-head health before starting #1801/#1802/design PRs.
- Clean merged branch/worktree if applicable.

## AGENTS.md updates
No AGENTS.md update required; no workflow/invariant change outside existing Phase2/Experiment Runner governance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive resolution note capturing discussion outcomes, evidence links, tooling phase executions, a premortem risk/fix matrix, experiment-runner evidence summary, and a “Deferred / Follow-ups: none” statement.

* **Bug Fixes**
  * Stricter fail-closed validation for experiment-runner artifacts and promotion of certain advisory warnings to hard errors when required mode is active.

* **Tests**
  * Expanded test coverage and CLI checks for artifact validation across required, advisory, and default modes, including missing, malformed, rejected, and accepted-evidence scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->