### PR TITLE
fix(orchestration): require requested subagent execution and repo-python oracle context

### DIFF
--- a/docs/orchestration/AUTOMATION_READINESS_MATRIX.md
+++ b/docs/orchestration/AUTOMATION_READINESS_MATRIX.md
@@ -251,7 +251,7 @@ Operator path today (repo companion, **not** a guarantee of raw-session auto-sta
 
 1. `scripts/orchestration/start_pr_lane.sh --goal "<goal>" --task-class "<class>" --branch "codex/<slug>" --worktree "worktrees/<slug>" --path "<scope>"` from a clean checkout synced with `origin/main` — creates the isolated PR worktree, runs analyze preflight, invokes `task_bootstrap.py`, and prints the plugin/runtime checklist, packet summary, and `Paste into Codex now` block.
 2. (Optional) `scripts/orchestration/local_session_bootstrap.sh` from repo root — preflight analyze + printed `task_bootstrap` recipe + Codex-ready next-step block. It does not execute `task_bootstrap.py` or create the authoritative packet. For flag-specific option handling, use the script's `--help` output.
-3. For Kimi Code CLI sessions, the same `start_pr_lane.sh` and `local_session_bootstrap.sh` entrypoints apply. The generated packet carries `transport: "kimi-native-subagents"` when the runtime signals Kimi support. Agent instructions are loaded from `.cursor/agents/*.md` and skills from `.agents/skills/` regardless of transport.
+3. For Kimi Code CLI sessions, the same `start_pr_lane.sh` and `local_session_bootstrap.sh` entrypoints apply. The generated packet carries `transport: "kimi-native-subagents"` only when the operator explicitly selects that native bridge transport. Agent instructions are loaded from `.cursor/agents/*.md` and skills from `.agents/skills/` regardless of transport.
 4. `python3 scripts/orchestration/task_bootstrap.py ...` — deterministic packet + routing metadata once invoked.
 
 In:

--- a/docs/orchestration/KIMI_NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md
+++ b/docs/orchestration/KIMI_NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md
@@ -80,6 +80,12 @@ Each role binding includes:
 Reviewer bindings always receive `native_agent_type: "explorer"` and
 `execution_mode: "review_read_only"` regardless of the base role.
 
+Advisory bindings that are explicitly requested role agents remain required
+role passes. They use `execution_mode: "advisory_review"`,
+`spawn_with_native_subagent: true`, and `required_role_pass: true`; advisory
+means analysis/review contribution type, not permission for the runtime to skip
+the agent.
+
 ---
 
 ## 4. Dispatch rules
@@ -93,6 +99,7 @@ When the runtime is Kimi Code CLI:
 4. Load the instruction path listed in the bridge entry (from `.cursor/agents/`).
 5. Load `required_context` and `recommended_skills` from the same task packet.
 6. In updates, describe the work using the repo-agent slug.
+7. Execute required advisory role passes when `required_role_pass: true`.
 
 ---
 

--- a/docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md
+++ b/docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md
@@ -67,9 +67,9 @@ Each role binding includes:
 - `transport_rationale`
 - `dispatch_contract`
 
-Advisory collaborators are visible in the packet for transparency, but they are
-**not runnable native subagents** unless a later contract explicitly promotes
-them.
+Advisory collaborators are visible in the packet for transparency and are
+required role passes when explicitly requested. Advisory describes the
+contribution profile, not permission to skip execution.
 
 This makes the adapter explicit and testable without changing the canonical
 repo-agent routing contract.
@@ -84,9 +84,10 @@ When a runtime supports native subagents:
 2. Use `primary_agent` / `secondary_agents` / `reviewer` as the canonical role
    identities.
 3. Read `native_subagent_bridge` only to choose the host runtime transport type.
-4. Spawn only `primary`, executable `secondary`, and `reviewer` bindings.
-5. Keep `advisory` bindings non-runnable unless a future promoted contract says
-   otherwise.
+4. Spawn `primary`, executable `secondary`, `reviewer`, and any `advisory`
+   binding whose dispatch contract sets `required_role_pass: true`.
+5. Treat advisory role passes as read-only / analysis-first unless their
+   explicit profile grants broader authority.
 6. Load the instruction path listed in the bridge entry.
 7. Load `required_context` and `recommended_skills` from the same task packet.
 8. In updates, describe the work using the repo-agent slug.

--- a/docs/review/PR_1802_FIXED_MAPPING.md
+++ b/docs/review/PR_1802_FIXED_MAPPING.md
@@ -11,7 +11,7 @@
 
 ## Lane Start Provenance
 
-- Task packet: `artifacts/orchestration/task_packets/b5504bcb1893.json`
+- Packet: `artifacts/orchestration/task_packets/b5504bcb1893.json`
 - Preflight: `python3 scripts/orchestration/check_preflight.py` passed.
 - Agent consistency: `python3 scripts/orchestration/check_agent_consistency.py` passed.
 - Dispatch bridge: `python3 scripts/orchestration/qoder_dispatch_bridge.py --packet artifacts/orchestration/task_packets/b5504bcb1893.json --pretty`
@@ -52,20 +52,20 @@
 ## Fixed in Commit Mapping
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#pullrequestreview-4343659344 -> 983c675555
-  - Disposition: FIXED
-  - Commit: 983c675555
-  - Evidence: `tests/test_task_bootstrap.py` annotates `test_main_passes_native_bridge_transport_flag` fixtures with `pytest.MonkeyPatch` and `pytest.CaptureFixture[str]`.
-  - Reason: CodeRabbit requested complete type hints for the test fixtures.
+Disposition: FIXED
+Commit: 983c675555
+Evidence: `tests/test_task_bootstrap.py` annotates `test_main_passes_native_bridge_transport_flag` fixtures with `pytest.MonkeyPatch` and `pytest.CaptureFixture[str]`.
+Reason: CodeRabbit requested complete type hints for the test fixtures.
 
-- CodeRabbit PR walkthrough comment: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#issuecomment-4526058312
-  - Disposition: NOT-A-BUG
-  - Evidence: The prior transport-only summary is superseded by this expanded mapping and the upgraded PR body.
-  - Reason: The comment is an aggregate walkthrough, not a separate actionable code finding.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#issuecomment-4526058312
+Disposition: NOT-A-BUG
+Evidence: The prior transport-only summary is superseded by this expanded mapping and the upgraded PR body.
+Reason: The comment is an aggregate walkthrough, not a separate actionable code finding.
 
-- Codecov report: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#issuecomment-4526073390
-  - Disposition: NOT-A-BUG
-  - Evidence: Codecov reported all modified coverable lines covered on the original diff; expanded local tests cover the new scope.
-  - Reason: No actionable failure was reported.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#issuecomment-4526073390
+Disposition: NOT-A-BUG
+Evidence: Codecov reported all modified coverable lines covered on the original diff; expanded local tests cover the new scope.
+Reason: No actionable failure was reported.
 
 ## Role-Agent Findings
 
@@ -108,7 +108,7 @@
 
 ## Experiment Runner Evidence
 
-- Accepted artifact: `artifacts/orchestration/experiments/results/pr1802-oracle-result-v3.json`
+- Artifact: `artifacts/orchestration/experiments/results/pr1802-oracle-result-v3.json`
 - Packet: `artifacts/orchestration/experiments/pr1802-oracle-packet-v3.json`
 - Mode: `oracle_only_governance_reviewer`
 - Result: `accepted`

--- a/docs/review/PR_1802_FIXED_MAPPING.md
+++ b/docs/review/PR_1802_FIXED_MAPPING.md
@@ -83,8 +83,12 @@
   - Evidence: `scripts/orchestration/qoder_dispatch_bridge.py` preserves requested role order and keeps `qa-engineer-agent -> bug-hunter` as mandatory post-open order.
 - Finding: Experiment Runner bare `python` oracle commands could resolve through host Python.
   - Disposition: FIXED
-  - Commit: 983c675555
+  - Commit: 983c675555, 6aa57c5a37
   - Evidence: `scripts/orchestration/experiment_runner.py` selects repo-approved Python from absolute executable `VENV_PYTHON`, absolute executable `DEV_PYTHON`, or repo `.venv/bin/python`, then prepends its parent directory to sandbox `PATH`.
+- Finding: Pre-push mypy hook flagged changed-file type issues not caught by the earlier explicit-package-bases command.
+  - Disposition: FIXED
+  - Commit: 6aa57c5a37
+  - Evidence: `scripts/orchestration/qoder_dispatch_bridge.py` imports optional PyYAML through `importlib.import_module`; `scripts/orchestration/experiment_runner.py` normalizes `REPO_ROOT` through `Path(...)` before resolving repo `.venv`.
 
 ## Premortem Risk Fix Matrix
 
@@ -133,6 +137,10 @@
 - First `pre-commit run --all-files` reformatted Python files with `black`.
 - Second `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python pre-commit run --all-files` -> PASS.
 - `pulseplate-pr-review` dry-run on current rebased diff -> one advisory large-diff-risk note, dispositioned as NOT-A-BUG for split rationale because all changed files are in the coherent orchestration scope and bounded gates passed.
+- Initial pre-push attempt failed in `mypy (type-check, changed files)`:
+  - `scripts/orchestration/qoder_dispatch_bridge.py:225: error: Library stubs not installed for "yaml" [import-untyped]`
+  - `scripts/orchestration/experiment_runner.py:291: error: Returning Any from function declared to return "Path | None" [no-any-return]`
+- `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python pre-commit run mypy --hook-stage pre-push --files scripts/orchestration/qoder_dispatch_bridge.py scripts/orchestration/experiment_runner.py` -> PASS.
 
 ## Scope Guard
 

--- a/docs/review/PR_1802_FIXED_MAPPING.md
+++ b/docs/review/PR_1802_FIXED_MAPPING.md
@@ -1,0 +1,167 @@
+# PR 1802 Fixed in Commit Mapping
+
+## PR
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Lane Start Provenance
+
+- Task packet: `artifacts/orchestration/task_packets/b5504bcb1893.json`
+- Preflight: `python3 scripts/orchestration/check_preflight.py` passed.
+- Agent consistency: `python3 scripts/orchestration/check_agent_consistency.py` passed.
+- Dispatch bridge: `python3 scripts/orchestration/qoder_dispatch_bridge.py --packet artifacts/orchestration/task_packets/b5504bcb1893.json --pretty`
+- Required role order: `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> pulseplate-premortem-risk-review -> pulseplate-pr-review -> pulseplate-gates`
+
+## Agent Execution Log
+
+- `agent-coordinator`
+  - Disposition: FIXED
+  - Evidence: Coordinator locked the expanded #1802 scope and required role order before implementation.
+- `architecture-specialist`
+  - Disposition: FIXED
+  - Evidence: `scripts/orchestration/task_bootstrap.py`, `scripts/orchestration/native_subagent_bridge.py`, and `scripts/orchestration/experiment_runner.py` were updated to preserve transport selection, required role execution, and repo-Python oracle context.
+- `security-auditor`
+  - Disposition: FIXED
+  - Evidence: `ORACLE_BINARY_ALLOWLIST` remains enforced; Python oracle resolution prepends a repo-approved Python directory instead of substituting arbitrary absolute commands.
+- `qa-engineer-agent`
+  - Disposition: FIXED
+  - Evidence: Focused transport, advisory-role, qoder-dispatch, and oracle-env tests passed under repo `.venv`.
+- `bug-hunter`
+  - Disposition: FIXED
+  - Evidence: Requested-role dispatch order and advisory required role passes are covered by `tests/test_qoder_dispatch_bridge.py`.
+
+## Skill Execution Log
+
+- `pulseplate-premortem-risk-review`
+  - Disposition: FIXED
+  - Evidence: Premortem was run against the actual diff. Blocking findings were addressed by this mapping, PR body expansion, accepted Experiment Runner evidence, and bounded gate reruns.
+- `pulseplate-pr-review`
+  - Disposition: FIXED
+  - Evidence: `python3 scripts/orchestration/pr_review_context.py --pr 1802 --repo Katsiarynakavaleuskaya/PulsePlate --base origin/main --head HEAD --repo-root . --output /tmp/pulseplate_pr1802_review_context_current.json` plus `python3 scripts/orchestration/pr_review_report.py --context /tmp/pulseplate_pr1802_review_context_current.json --format markdown --packet-id b5504bcb1893 --packet-path artifacts/orchestration/task_packets/b5504bcb1893.json`.
+  - Finding: Advisory large-diff-risk note.
+  - Disposition reason: The expanded diff is a coherent orchestration-layer fix, bounded to task bootstrap, native bridge, qoder dispatch, Experiment Runner, protocol docs, and tests. FastAPI/Starlette, #1800, #1801, runtime app code, dependency files, OpenAPI, and CI workflow YAML remain out of scope. Targeted deterministic gates passed.
+- `pulseplate-gates`
+  - Disposition: FIXED
+  - Evidence: Bounded local gates passed with repo `.venv` after the host-Python failure was reproduced and rerun correctly.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#pullrequestreview-4343659344 -> 983c675555
+  - Disposition: FIXED
+  - Commit: 983c675555
+  - Evidence: `tests/test_task_bootstrap.py` annotates `test_main_passes_native_bridge_transport_flag` fixtures with `pytest.MonkeyPatch` and `pytest.CaptureFixture[str]`.
+  - Reason: CodeRabbit requested complete type hints for the test fixtures.
+
+- CodeRabbit PR walkthrough comment: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#issuecomment-4526058312
+  - Disposition: NOT-A-BUG
+  - Evidence: The prior transport-only summary is superseded by this expanded mapping and the upgraded PR body.
+  - Reason: The comment is an aggregate walkthrough, not a separate actionable code finding.
+
+- Codecov report: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#issuecomment-4526073390
+  - Disposition: NOT-A-BUG
+  - Evidence: Codecov reported all modified coverable lines covered on the original diff; expanded local tests cover the new scope.
+  - Reason: No actionable failure was reported.
+
+## Role-Agent Findings
+
+- Finding: Requested agents classified as advisory could be emitted as no-spawn and skipped.
+  - Disposition: FIXED
+  - Commit: 983c675555
+  - Evidence: `scripts/orchestration/native_subagent_bridge.py` emits `execution_mode: advisory_review`, `spawn_with_native_subagent: True`, `advisory_only: False`, and `required_role_pass: True`.
+- Finding: Requested reviewers displaced by post-open QA routing could be absent from executable bridge output.
+  - Disposition: FIXED
+  - Commit: 983c675555
+  - Evidence: `scripts/orchestration/task_bootstrap.py` appends missing known requested role passes after secondary partitioning.
+- Finding: Dispatch bridge did not preserve the coordinator-required requested role order.
+  - Disposition: FIXED
+  - Commit: 983c675555
+  - Evidence: `scripts/orchestration/qoder_dispatch_bridge.py` preserves requested role order and keeps `qa-engineer-agent -> bug-hunter` as mandatory post-open order.
+- Finding: Experiment Runner bare `python` oracle commands could resolve through host Python.
+  - Disposition: FIXED
+  - Commit: 983c675555
+  - Evidence: `scripts/orchestration/experiment_runner.py` selects repo-approved Python from absolute executable `VENV_PYTHON`, absolute executable `DEV_PYTHON`, or repo `.venv/bin/python`, then prepends its parent directory to sandbox `PATH`.
+
+## Premortem Risk Fix Matrix
+
+| Risk ID | Failure mode | Fix | Regression test | Evidence command | Disposition |
+| --- | --- | --- | --- | --- | --- |
+| PM-1802-001 | Kimi transport becomes default. | Default remains `codex-native-subagents`. | Default CLI/build packet emits Codex transport. | `.venv/bin/python -m pytest -q tests/test_task_bootstrap.py -k "native_bridge_transport"` | FIXED |
+| PM-1802-002 | Explicit Kimi transport flag is ignored. | CLI flag propagates into packet builder/native bridge. | Explicit Kimi transport observed in packet. | `.venv/bin/python -m pytest -q tests/test_task_bootstrap.py -k "native_bridge_transport"` | FIXED |
+| PM-1802-003 | Invalid transport label accepted. | Argparse choices and builder validation restrict allowed transports. | Invalid label fails. | `.venv/bin/python -m pytest -q tests/test_task_bootstrap.py -k "native_bridge_transport"` | FIXED |
+| PM-1802-004 | Requested subagents are marked `advisory_no_spawn` and skipped. | Known requested advisory/domain-mismatch agents become required advisory-review role passes. | Advisory requested agent has spawn and required role flags. | `.venv/bin/python -m pytest -q tests/test_native_subagent_bridge.py` | FIXED |
+| PM-1802-005 | Unknown agents accidentally become executable. | Unknown agents remain rejected and absent from executable bridge output. | Unknown requested agent remains rejected. | `.venv/bin/python -m pytest -q tests/test_task_bootstrap.py -k "requested_agent"` | FIXED |
+| PM-1802-006 | All advisory agents become write-capable. | Advisory-review role passes keep write capability disabled. | Review/advisory roles remain non-write. | `.venv/bin/python -m pytest -q tests/test_native_subagent_bridge.py` | FIXED |
+| PM-1802-007 | Experiment Runner oracle uses host Python and misses repo dependencies. | Repo Python bin dir is prepended via `VENV_PYTHON`, `DEV_PYTHON`, or repo `.venv`. | Bare python oracle resolves to controlled repo Python. | `.venv/bin/python -m pytest -q tests/test_experiment_runner.py -k "python or oracle or sandbox or env"` | FIXED |
+| PM-1802-008 | Missing repo Python silently falls back to host Python. | Python oracle commands fail closed when no repo Python is available. | Missing repo Python plus python oracle raises infra failure. | `.venv/bin/python -m pytest -q tests/test_experiment_runner.py -k "python or oracle or sandbox or env"` | FIXED |
+| PM-1802-009 | Sandbox allowlist bypassed by absolute Python substitution. | Sandbox binary remains bare `python` or `python3`; allowlist still gates execution. | Non-allowlisted binary remains rejected. | `.venv/bin/python -m pytest -q tests/test_experiment_runner.py -k "sandbox or oracle"` | FIXED |
+| PM-1802-010 | Env mutation leaks across runner runs. | Temporary sandbox env restores previous env. | PATH/VENV_PYTHON/DEV_PYTHON restoration covered. | `.venv/bin/python -m pytest -q tests/test_experiment_runner.py -k "env"` | FIXED |
+| PM-1802-011 | #1802 scope drifts into #1800/#1801/FastAPI/runtime/dependency/CI workflow work. | Changed files are limited to orchestration scripts, tests, protocol docs, and this mapping. | Changed-file scope guard by review. | `git diff --name-only origin/main...HEAD` | FIXED |
+
+## Experiment Runner Evidence
+
+- Accepted artifact: `artifacts/orchestration/experiments/results/pr1802-oracle-result-v3.json`
+- Packet: `artifacts/orchestration/experiments/pr1802-oracle-packet-v3.json`
+- Mode: `oracle_only_governance_reviewer`
+- Result: `accepted`
+- Co-author required: `true`
+- Trailer used in fix commit: `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+- Diagnostic rejected artifact: `artifacts/orchestration/experiments/results/pr1802-oracle-result-v2.json`
+  - Failure class: `guard_failure`
+  - Raw failure class observed: isolated checkout oracle hit `ModuleNotFoundError: No module named 'fastapi'`.
+  - Disposition: NOT-A-BUG for the implementation; this reproduced the repo-Python context problem class and was superseded by accepted source-contract oracle evidence.
+
+## Bounded Local Checks
+
+- `python3 scripts/orchestration/check_preflight.py` -> PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS.
+- `.venv/bin/python -m pytest -q tests/test_task_bootstrap.py -k "native_bridge_transport or advisory or requested_agent or pr_phase or displaced_requested_reviewer"` -> 20 passed.
+- `.venv/bin/python -m pytest -q tests/test_native_subagent_bridge.py` -> 8 passed.
+- `.venv/bin/python -m pytest -q tests/test_experiment_runner.py -k "python or oracle or sandbox or env"` -> 41 passed.
+- `.venv/bin/python -m pytest -q tests/test_qoder_dispatch_bridge.py -k "advisory or requested_role_order or no_spawn or coordinator_first or mandatory_post_open"` -> 10 passed.
+- `.venv/bin/python -m pytest -q tests/test_task_bootstrap.py tests/test_native_subagent_bridge.py tests/test_experiment_runner.py tests/test_experiment_runner_identity_policy.py tests/test_qoder_dispatch_bridge.py` -> PASS.
+- Exact mypy command without package-base normalization failed with duplicate module mapping:
+  - `scripts/orchestration/native_subagent_bridge.py: error: Source file found twice under different module names: "native_subagent_bridge" and "scripts.orchestration.native_subagent_bridge"`
+- `.venv/bin/python -m mypy --explicit-package-bases --no-incremental --cache-dir=/dev/null scripts/orchestration/task_bootstrap.py scripts/orchestration/native_subagent_bridge.py scripts/orchestration/experiment_runner.py scripts/orchestration/qoder_dispatch_bridge.py tests/test_task_bootstrap.py tests/test_native_subagent_bridge.py tests/test_experiment_runner.py tests/test_qoder_dispatch_bridge.py` -> PASS.
+- Initial `make validate-changed` in this worktree failed through host Python:
+  - `ModuleNotFoundError: No module named 'fastapi'`
+- `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed` -> PASS.
+- First `pre-commit run --all-files` reformatted Python files with `black`.
+- Second `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python pre-commit run --all-files` -> PASS.
+- `pulseplate-pr-review` dry-run on current rebased diff -> one advisory large-diff-risk note, dispositioned as NOT-A-BUG for split rationale because all changed files are in the coherent orchestration scope and bounded gates passed.
+
+## Scope Guard
+
+Changed files are limited to:
+
+- `scripts/orchestration/task_bootstrap.py`
+- `scripts/orchestration/native_subagent_bridge.py`
+- `scripts/orchestration/experiment_runner.py`
+- `scripts/orchestration/qoder_dispatch_bridge.py`
+- `tests/test_task_bootstrap.py`
+- `tests/test_native_subagent_bridge.py`
+- `tests/test_experiment_runner.py`
+- `tests/test_qoder_dispatch_bridge.py`
+- `docs/orchestration/KIMI_NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md`
+- `docs/orchestration/NATIVE_SUBAGENT_BRIDGE_PROTOCOL.md`
+- `docs/orchestration/AUTOMATION_READINESS_MATRIX.md`
+- `docs/review/PR_1802_FIXED_MAPPING.md`
+
+Out of scope and untouched: FastAPI/Starlette fix, #1800 Phase2 evidence semantics, #1801 design validator logic, runtime app code, dependency files, OpenAPI, and CI workflow YAML.
+
+## Merge Readiness
+
+- [ ] Current-head CI is terminal and passing.
+- [ ] No unresolved review threads remain.
+- [ ] No actionable bot comments remain after current-head review.
+- [ ] PR body Phase2 gates pass.
+- [ ] Review-thread disposition guard passes with auth.
+- [ ] Strict merge-readiness wrapper passes with auth.
+- [ ] Mandatory wait-window completed.
+- [ ] Operator confirms FastAPI fix is not required inside #1802.
+
+This PR must not be called merge-ready until every item above is satisfied.

--- a/docs/review/PR_1802_FIXED_MAPPING.md
+++ b/docs/review/PR_1802_FIXED_MAPPING.md
@@ -79,6 +79,23 @@ Disposition: NOT-A-BUG
 Evidence: Both actionable CodeRabbit review comments are mapped as FIXED in `discussion_r3294159463` and `discussion_r3294159464`.
 Reason: Aggregate review record; no separate code finding beyond the mapped discussion threads.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3294764638 -> 6b3201ef2
+Disposition: FIXED
+Commit: 6b3201ef2
+Evidence: `scripts/orchestration/experiment_runner.py` now preserves the selected repo `.venv/bin` path for Python oracle PATH prefixes instead of resolving symlinked venv interpreters to host Python directories; `tests/test_experiment_runner.py` covers symlinked `.venv/bin/python`.
+Reason: CodeRabbit found that resolving symlinked venv interpreters could defeat the repo Python boundary.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3294764640 -> 6b3201ef2
+Disposition: FIXED
+Commit: 6b3201ef2
+Evidence: `scripts/orchestration/qoder_dispatch_bridge.py` preserves duplicate requested role passes when the slug is spawnable; `tests/test_qoder_dispatch_bridge.py` covers duplicate requested `agent-coordinator` passes.
+Reason: CodeRabbit found requested-agent ordering still deduped intentional repeated passes.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#pullrequestreview-4352937393
+Disposition: NOT-A-BUG
+Evidence: Both actionable CodeRabbit review comments are mapped as FIXED in `discussion_r3294764638` and `discussion_r3294764640`.
+Reason: Aggregate review record; no separate code finding beyond the mapped discussion threads.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#issuecomment-4526058312
 Disposition: NOT-A-BUG
 Evidence: The prior transport-only summary is superseded by this expanded mapping and the upgraded PR body.

--- a/docs/review/PR_1802_FIXED_MAPPING.md
+++ b/docs/review/PR_1802_FIXED_MAPPING.md
@@ -51,9 +51,9 @@
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3293225158 -> b2d265e8a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3293225158 -> c2d9255ea
 Disposition: FIXED
-Commit: b2d265e8a
+Commit: c2d9255ea
 Evidence: `tests/test_task_bootstrap.py` annotates `test_main_passes_native_bridge_transport_flag` fixtures with `pytest.MonkeyPatch` and `pytest.CaptureFixture[str]`.
 Reason: CodeRabbit requested complete type hints for the test fixtures.
 
@@ -62,15 +62,15 @@ Disposition: NOT-A-BUG
 Evidence: The sole actionable CodeRabbit review comment is mapped as FIXED in `discussion_r3293225158`.
 Reason: Aggregate review record; no separate code finding beyond the mapped discussion thread.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3294159463 -> 603b3d1b6
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3294159463 -> 72309fbed
 Disposition: FIXED
-Commit: 603b3d1b6
+Commit: 72309fbed
 Evidence: `scripts/orchestration/qoder_dispatch_bridge.py` preserves duplicate mandatory post-open role passes while still ordering `qa-engineer-agent` before `bug-hunter`; `tests/test_qoder_dispatch_bridge.py` asserts duplicate bug-hunter preservation.
 Reason: CodeRabbit found that `_enforce_mandatory_post_open_order` collapsed duplicate mandatory passes.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3294159464 -> 603b3d1b6
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3294159464 -> 72309fbed
 Disposition: FIXED
-Commit: 603b3d1b6
+Commit: 72309fbed
 Evidence: `tests/test_qoder_dispatch_bridge.py` now uses `require_feature(f"agent_definition:{slug}")` for the flagged optional agent-definition skip path.
 Reason: CodeRabbit requested repo-standard optional-feature skip reasons.
 
@@ -93,23 +93,23 @@ Reason: No actionable failure was reported.
 
 - Finding: Requested agents classified as advisory could be emitted as no-spawn and skipped.
   - Disposition: FIXED
-  - Commit: b2d265e8a
+  - Commit: c2d9255ea
   - Evidence: `scripts/orchestration/native_subagent_bridge.py` emits `execution_mode: advisory_review`, `spawn_with_native_subagent: True`, `advisory_only: False`, and `required_role_pass: True`.
 - Finding: Requested reviewers displaced by post-open QA routing could be absent from executable bridge output.
   - Disposition: FIXED
-  - Commit: b2d265e8a
+  - Commit: c2d9255ea
   - Evidence: `scripts/orchestration/task_bootstrap.py` appends missing known requested role passes after secondary partitioning.
 - Finding: Dispatch bridge did not preserve the coordinator-required requested role order.
   - Disposition: FIXED
-  - Commit: b2d265e8a
+  - Commit: c2d9255ea
   - Evidence: `scripts/orchestration/qoder_dispatch_bridge.py` preserves requested role order and keeps `qa-engineer-agent -> bug-hunter` as mandatory post-open order.
 - Finding: Experiment Runner bare `python` oracle commands could resolve through host Python.
   - Disposition: FIXED
-  - Commit: b2d265e8a, d4fe3aaff
+  - Commit: c2d9255ea, f5038d083
   - Evidence: `scripts/orchestration/experiment_runner.py` selects repo-approved Python from absolute executable `VENV_PYTHON`, absolute executable `DEV_PYTHON`, or repo `.venv/bin/python`, then prepends its parent directory to sandbox `PATH`.
 - Finding: Pre-push mypy hook flagged changed-file type issues not caught by the earlier explicit-package-bases command.
   - Disposition: FIXED
-  - Commit: d4fe3aaff
+  - Commit: f5038d083
   - Evidence: `scripts/orchestration/qoder_dispatch_bridge.py` imports optional PyYAML through `importlib.import_module`; `scripts/orchestration/experiment_runner.py` normalizes `REPO_ROOT` through `Path(...)` before resolving repo `.venv`.
 
 ## Premortem Risk Fix Matrix

--- a/docs/review/PR_1802_FIXED_MAPPING.md
+++ b/docs/review/PR_1802_FIXED_MAPPING.md
@@ -51,9 +51,9 @@
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3293225158 -> c2d9255ea
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3293225158 -> ce9c404b4
 Disposition: FIXED
-Commit: c2d9255ea
+Commit: ce9c404b4
 Evidence: `tests/test_task_bootstrap.py` annotates `test_main_passes_native_bridge_transport_flag` fixtures with `pytest.MonkeyPatch` and `pytest.CaptureFixture[str]`.
 Reason: CodeRabbit requested complete type hints for the test fixtures.
 
@@ -62,15 +62,15 @@ Disposition: NOT-A-BUG
 Evidence: The sole actionable CodeRabbit review comment is mapped as FIXED in `discussion_r3293225158`.
 Reason: Aggregate review record; no separate code finding beyond the mapped discussion thread.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3294159463 -> 72309fbed
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3294159463 -> 8b5cb5e47
 Disposition: FIXED
-Commit: 72309fbed
+Commit: 8b5cb5e47
 Evidence: `scripts/orchestration/qoder_dispatch_bridge.py` preserves duplicate mandatory post-open role passes while still ordering `qa-engineer-agent` before `bug-hunter`; `tests/test_qoder_dispatch_bridge.py` asserts duplicate bug-hunter preservation.
 Reason: CodeRabbit found that `_enforce_mandatory_post_open_order` collapsed duplicate mandatory passes.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3294159464 -> 72309fbed
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3294159464 -> 8b5cb5e47
 Disposition: FIXED
-Commit: 72309fbed
+Commit: 8b5cb5e47
 Evidence: `tests/test_qoder_dispatch_bridge.py` now uses `require_feature(f"agent_definition:{slug}")` for the flagged optional agent-definition skip path.
 Reason: CodeRabbit requested repo-standard optional-feature skip reasons.
 
@@ -93,23 +93,23 @@ Reason: No actionable failure was reported.
 
 - Finding: Requested agents classified as advisory could be emitted as no-spawn and skipped.
   - Disposition: FIXED
-  - Commit: c2d9255ea
+  - Commit: ce9c404b4
   - Evidence: `scripts/orchestration/native_subagent_bridge.py` emits `execution_mode: advisory_review`, `spawn_with_native_subagent: True`, `advisory_only: False`, and `required_role_pass: True`.
 - Finding: Requested reviewers displaced by post-open QA routing could be absent from executable bridge output.
   - Disposition: FIXED
-  - Commit: c2d9255ea
+  - Commit: ce9c404b4
   - Evidence: `scripts/orchestration/task_bootstrap.py` appends missing known requested role passes after secondary partitioning.
 - Finding: Dispatch bridge did not preserve the coordinator-required requested role order.
   - Disposition: FIXED
-  - Commit: c2d9255ea
+  - Commit: ce9c404b4
   - Evidence: `scripts/orchestration/qoder_dispatch_bridge.py` preserves requested role order and keeps `qa-engineer-agent -> bug-hunter` as mandatory post-open order.
 - Finding: Experiment Runner bare `python` oracle commands could resolve through host Python.
   - Disposition: FIXED
-  - Commit: c2d9255ea, f5038d083
+  - Commit: ce9c404b4, 5dc11038f
   - Evidence: `scripts/orchestration/experiment_runner.py` selects repo-approved Python from absolute executable `VENV_PYTHON`, absolute executable `DEV_PYTHON`, or repo `.venv/bin/python`, then prepends its parent directory to sandbox `PATH`.
 - Finding: Pre-push mypy hook flagged changed-file type issues not caught by the earlier explicit-package-bases command.
   - Disposition: FIXED
-  - Commit: f5038d083
+  - Commit: 5dc11038f
   - Evidence: `scripts/orchestration/qoder_dispatch_bridge.py` imports optional PyYAML through `importlib.import_module`; `scripts/orchestration/experiment_runner.py` normalizes `REPO_ROOT` through `Path(...)` before resolving repo `.venv`.
 
 ## Premortem Risk Fix Matrix

--- a/docs/review/PR_1802_FIXED_MAPPING.md
+++ b/docs/review/PR_1802_FIXED_MAPPING.md
@@ -51,9 +51,9 @@
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3293225158 -> 983c675555
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3293225158 -> b2d265e8a
 Disposition: FIXED
-Commit: 983c675555
+Commit: b2d265e8a
 Evidence: `tests/test_task_bootstrap.py` annotates `test_main_passes_native_bridge_transport_flag` fixtures with `pytest.MonkeyPatch` and `pytest.CaptureFixture[str]`.
 Reason: CodeRabbit requested complete type hints for the test fixtures.
 
@@ -76,23 +76,23 @@ Reason: No actionable failure was reported.
 
 - Finding: Requested agents classified as advisory could be emitted as no-spawn and skipped.
   - Disposition: FIXED
-  - Commit: 983c675555
+  - Commit: b2d265e8a
   - Evidence: `scripts/orchestration/native_subagent_bridge.py` emits `execution_mode: advisory_review`, `spawn_with_native_subagent: True`, `advisory_only: False`, and `required_role_pass: True`.
 - Finding: Requested reviewers displaced by post-open QA routing could be absent from executable bridge output.
   - Disposition: FIXED
-  - Commit: 983c675555
+  - Commit: b2d265e8a
   - Evidence: `scripts/orchestration/task_bootstrap.py` appends missing known requested role passes after secondary partitioning.
 - Finding: Dispatch bridge did not preserve the coordinator-required requested role order.
   - Disposition: FIXED
-  - Commit: 983c675555
+  - Commit: b2d265e8a
   - Evidence: `scripts/orchestration/qoder_dispatch_bridge.py` preserves requested role order and keeps `qa-engineer-agent -> bug-hunter` as mandatory post-open order.
 - Finding: Experiment Runner bare `python` oracle commands could resolve through host Python.
   - Disposition: FIXED
-  - Commit: 983c675555, 6aa57c5a37
+  - Commit: b2d265e8a, d4fe3aaff
   - Evidence: `scripts/orchestration/experiment_runner.py` selects repo-approved Python from absolute executable `VENV_PYTHON`, absolute executable `DEV_PYTHON`, or repo `.venv/bin/python`, then prepends its parent directory to sandbox `PATH`.
 - Finding: Pre-push mypy hook flagged changed-file type issues not caught by the earlier explicit-package-bases command.
   - Disposition: FIXED
-  - Commit: 6aa57c5a37
+  - Commit: d4fe3aaff
   - Evidence: `scripts/orchestration/qoder_dispatch_bridge.py` imports optional PyYAML through `importlib.import_module`; `scripts/orchestration/experiment_runner.py` normalizes `REPO_ROOT` through `Path(...)` before resolving repo `.venv`.
 
 ## Premortem Risk Fix Matrix

--- a/docs/review/PR_1802_FIXED_MAPPING.md
+++ b/docs/review/PR_1802_FIXED_MAPPING.md
@@ -62,6 +62,23 @@ Disposition: NOT-A-BUG
 Evidence: The sole actionable CodeRabbit review comment is mapped as FIXED in `discussion_r3293225158`.
 Reason: Aggregate review record; no separate code finding beyond the mapped discussion thread.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3294159463 -> 603b3d1b6
+Disposition: FIXED
+Commit: 603b3d1b6
+Evidence: `scripts/orchestration/qoder_dispatch_bridge.py` preserves duplicate mandatory post-open role passes while still ordering `qa-engineer-agent` before `bug-hunter`; `tests/test_qoder_dispatch_bridge.py` asserts duplicate bug-hunter preservation.
+Reason: CodeRabbit found that `_enforce_mandatory_post_open_order` collapsed duplicate mandatory passes.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3294159464 -> 603b3d1b6
+Disposition: FIXED
+Commit: 603b3d1b6
+Evidence: `tests/test_qoder_dispatch_bridge.py` now uses `require_feature(f"agent_definition:{slug}")` for the flagged optional agent-definition skip path.
+Reason: CodeRabbit requested repo-standard optional-feature skip reasons.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#pullrequestreview-4352052891
+Disposition: NOT-A-BUG
+Evidence: Both actionable CodeRabbit review comments are mapped as FIXED in `discussion_r3294159463` and `discussion_r3294159464`.
+Reason: Aggregate review record; no separate code finding beyond the mapped discussion threads.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#issuecomment-4526058312
 Disposition: NOT-A-BUG
 Evidence: The prior transport-only summary is superseded by this expanded mapping and the upgraded PR body.

--- a/docs/review/PR_1802_FIXED_MAPPING.md
+++ b/docs/review/PR_1802_FIXED_MAPPING.md
@@ -51,11 +51,16 @@
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#pullrequestreview-4343659344 -> 983c675555
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#discussion_r3293225158 -> 983c675555
 Disposition: FIXED
 Commit: 983c675555
 Evidence: `tests/test_task_bootstrap.py` annotates `test_main_passes_native_bridge_transport_flag` fixtures with `pytest.MonkeyPatch` and `pytest.CaptureFixture[str]`.
 Reason: CodeRabbit requested complete type hints for the test fixtures.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#pullrequestreview-4351193876
+Disposition: NOT-A-BUG
+Evidence: The sole actionable CodeRabbit review comment is mapped as FIXED in `discussion_r3293225158`.
+Reason: Aggregate review record; no separate code finding beyond the mapped discussion thread.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1802#issuecomment-4526058312
 Disposition: NOT-A-BUG

--- a/scripts/orchestration/experiment_runner.py
+++ b/scripts/orchestration/experiment_runner.py
@@ -272,10 +272,9 @@ def _repo_python_from_env(env_name: str) -> Path | None:
     candidate = Path(raw_value).expanduser()
     if not candidate.is_absolute():
         raise InfraFlakeError(f"{env_name} must be an absolute executable path.")
-    resolved = candidate.resolve()
-    if not resolved.is_file() or not os.access(resolved, os.X_OK):
-        raise InfraFlakeError(f"{env_name} is set but is not executable: {resolved}")
-    return resolved
+    if not candidate.is_file() or not os.access(candidate, os.X_OK):
+        raise InfraFlakeError(f"{env_name} is set but is not executable: {candidate}")
+    return candidate
 
 
 def _select_repo_python() -> Path | None:
@@ -288,7 +287,7 @@ def _select_repo_python() -> Path | None:
 
     repo_python = Path(REPO_ROOT) / ".venv" / "bin" / "python"
     if repo_python.is_file() and os.access(repo_python, os.X_OK):
-        return repo_python.resolve()
+        return repo_python
     return None
 
 
@@ -309,7 +308,7 @@ def _python_oracle_path_prefix(requests: list[SandboxRequest]) -> str | None:
             f"VENV_PYTHON, DEV_PYTHON, or repo .venv/bin/python was found for: {binaries}"
         )
 
-    python_bin_dir = selected_python.parent.resolve()
+    python_bin_dir = selected_python.parent
     for binary in python_binaries:
         resolved_binary = shutil.which(binary, path=str(python_bin_dir))
         if resolved_binary is None:
@@ -317,7 +316,7 @@ def _python_oracle_path_prefix(requests: list[SandboxRequest]) -> str | None:
                 f"Python oracle binary {binary!r} was not found in repo-approved "
                 f"Python bin dir: {python_bin_dir}"
             )
-        if Path(resolved_binary).resolve().parent != python_bin_dir:
+        if Path(resolved_binary).parent != python_bin_dir:
             raise InfraFlakeError(
                 f"Python oracle binary {binary!r} did not resolve through "
                 f"repo-approved Python bin dir: {python_bin_dir}"

--- a/scripts/orchestration/experiment_runner.py
+++ b/scripts/orchestration/experiment_runner.py
@@ -52,6 +52,7 @@ OOM_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\boom\b", re.IGNORECASE),
     re.compile(r"\bcannot allocate memory\b", re.IGNORECASE),
 )
+PYTHON_ORACLE_BINARIES = {"python", "python3"}
 
 
 class ExperimentRunnerError(RuntimeError):
@@ -262,6 +263,68 @@ def _absolute_path_env(raw_path: str | None) -> str:
     return os.pathsep.join(absolute_entries)
 
 
+def _repo_python_from_env(env_name: str) -> Path | None:
+    """Return a validated repo-approved Python executable from an env override."""
+
+    raw_value = os.environ.get(env_name)
+    if raw_value is None or raw_value.strip() == "":
+        return None
+    candidate = Path(raw_value).expanduser()
+    if not candidate.is_absolute():
+        raise InfraFlakeError(f"{env_name} must be an absolute executable path.")
+    resolved = candidate.resolve()
+    if not resolved.is_file() or not os.access(resolved, os.X_OK):
+        raise InfraFlakeError(f"{env_name} is set but is not executable: {resolved}")
+    return resolved
+
+
+def _select_repo_python() -> Path | None:
+    """Select the repo-approved Python interpreter for Python oracle commands."""
+
+    for env_name in ("VENV_PYTHON", "DEV_PYTHON"):
+        selected = _repo_python_from_env(env_name)
+        if selected is not None:
+            return selected
+
+    repo_python = REPO_ROOT / ".venv" / "bin" / "python"
+    if repo_python.is_file() and os.access(repo_python, os.X_OK):
+        return repo_python.resolve()
+    return None
+
+
+def _python_oracle_path_prefix(requests: list[SandboxRequest]) -> str | None:
+    """Return PATH prefix required for Python oracles, or fail closed."""
+
+    python_binaries = sorted(
+        {request.binary for request in requests if request.binary in PYTHON_ORACLE_BINARIES}
+    )
+    if not python_binaries:
+        return None
+
+    selected_python = _select_repo_python()
+    if selected_python is None:
+        binaries = ", ".join(python_binaries)
+        raise InfraFlakeError(
+            "Python oracle command requires repo-approved Python, but no executable "
+            f"VENV_PYTHON, DEV_PYTHON, or repo .venv/bin/python was found for: {binaries}"
+        )
+
+    python_bin_dir = selected_python.parent.resolve()
+    for binary in python_binaries:
+        resolved_binary = shutil.which(binary, path=str(python_bin_dir))
+        if resolved_binary is None:
+            raise InfraFlakeError(
+                f"Python oracle binary {binary!r} was not found in repo-approved "
+                f"Python bin dir: {python_bin_dir}"
+            )
+        if Path(resolved_binary).resolve().parent != python_bin_dir:
+            raise InfraFlakeError(
+                f"Python oracle binary {binary!r} did not resolve through "
+                f"repo-approved Python bin dir: {python_bin_dir}"
+            )
+    return str(python_bin_dir)
+
+
 def _shared_tree_status(root: Path) -> str:
     """Capture tracked/untracked status to prove the shared tree stayed untouched."""
 
@@ -327,16 +390,20 @@ def _temporary_sandbox_env(
     sandbox_root: Path,
     allowed_binaries: tuple[str, ...],
     timeout_seconds: int,
+    path_prefix: str | None = None,
 ) -> Iterator[None]:
     """Temporarily configure sandbox env without leaking state across runs."""
 
+    normalized_path = _absolute_path_env(os.environ.get("PATH") or os.defpath)
+    if path_prefix:
+        normalized_path = os.pathsep.join([path_prefix, normalized_path])
     overrides = {
         sandbox.SANDBOX_ENABLED_ENV: "true",
         sandbox.SANDBOX_ROOT_ENV: str(sandbox_root),
         sandbox.SANDBOX_TIMEOUT_ENV: str(timeout_seconds),
         sandbox.SANDBOX_ALLOWED_BINARIES_ENV: ",".join(allowed_binaries),
         cp.EXECUTION_MODE_ENV: cp.EXECUTION_MODE_AUTO_SAFE,
-        "PATH": _absolute_path_env(os.environ.get("PATH") or os.defpath),
+        "PATH": normalized_path,
     }
     previous = {key: os.environ.get(key) for key in overrides}
     try:
@@ -417,6 +484,7 @@ def _run_oracles(
     failure_class: str | None = None
     requests = [_command_to_request(oracle["command"]) for oracle in packet["immutable_oracles"]]
     allowed_binaries = tuple(sorted({request.binary for request in requests}))
+    path_prefix = _python_oracle_path_prefix(requests)
     total_wall_clock_seconds = int(packet["budgets"]["wall_clock_seconds"])
     started_at = time.monotonic()
 
@@ -442,6 +510,7 @@ def _run_oracles(
             sandbox_root=checkout_root,
             allowed_binaries=allowed_binaries,
             timeout_seconds=timeout_seconds,
+            path_prefix=path_prefix,
         ):
             try:
                 result = sandbox.run_local_sandbox(

--- a/scripts/orchestration/experiment_runner.py
+++ b/scripts/orchestration/experiment_runner.py
@@ -286,7 +286,7 @@ def _select_repo_python() -> Path | None:
         if selected is not None:
             return selected
 
-    repo_python = REPO_ROOT / ".venv" / "bin" / "python"
+    repo_python = Path(REPO_ROOT) / ".venv" / "bin" / "python"
     if repo_python.is_file() and os.access(repo_python, os.X_OK):
         return repo_python.resolve()
     return None

--- a/scripts/orchestration/native_subagent_bridge.py
+++ b/scripts/orchestration/native_subagent_bridge.py
@@ -20,6 +20,10 @@ AGENTS_DIR = REPO_ROOT / ".cursor" / "agents"
 BRIDGE_PROTOCOL_VERSION = "1.0"
 BRIDGE_TRANSPORT = "codex-native-subagents"
 KIMI_BRIDGE_TRANSPORT = "kimi-native-subagents"
+BRIDGE_TRANSPORTS: tuple[str, ...] = (
+    BRIDGE_TRANSPORT,
+    KIMI_BRIDGE_TRANSPORT,
+)
 
 
 @dataclass(frozen=True)
@@ -180,6 +184,12 @@ def build_native_subagent_bridge(
     profiles.
     """
 
+    if transport not in BRIDGE_TRANSPORTS:
+        supported = ", ".join(BRIDGE_TRANSPORTS)
+        raise ValueError(
+            f"Unsupported native subagent bridge transport: {transport}. Supported: {supported}"
+        )
+
     validate_native_subagent_bridge_profiles()
     normalized_advisory_agents = advisory_agents or []
     advisory_bindings: list[dict[str, Any]] = []
@@ -191,11 +201,14 @@ def build_native_subagent_bridge(
         advisory_bindings.append(
             {
                 **advisory_binding,
-                "execution_mode": "advisory_no_spawn",
+                "native_agent_type": "explorer",
+                "execution_mode": "advisory_review",
                 "dispatch_contract": {
                     **advisory_binding["dispatch_contract"],
-                    "spawn_with_native_subagent": False,
-                    "advisory_only": True,
+                    "spawn_with_native_subagent": True,
+                    "advisory_only": False,
+                    "required_role_pass": True,
+                    "write_capability": "disabled_for_advisory_review",
                 },
             }
         )

--- a/scripts/orchestration/qoder_dispatch_bridge.py
+++ b/scripts/orchestration/qoder_dispatch_bridge.py
@@ -738,7 +738,8 @@ def _enforce_mandatory_post_open_order(role_slugs: List[str]) -> List[str]:
     """Keep the canonical post-open QA -> bug-hunter pass last when present."""
 
     ordered = [slug for slug in role_slugs if slug not in MANDATORY_POST_OPEN_ORDER]
-    ordered.extend(slug for slug in MANDATORY_POST_OPEN_ORDER if slug in role_slugs)
+    for slug in MANDATORY_POST_OPEN_ORDER:
+        ordered.extend([slug] * role_slugs.count(slug))
     return ordered
 
 

--- a/scripts/orchestration/qoder_dispatch_bridge.py
+++ b/scripts/orchestration/qoder_dispatch_bridge.py
@@ -439,7 +439,7 @@ def _parse_json_packet_roles(payload: Dict[str, Any]) -> List[str]:
         requested_ordered: List[str] = []
         for value in requested_agents:
             slug = str(value).strip()
-            if slug in spawnable_roles and slug not in requested_ordered:
+            if slug in spawnable_roles:
                 requested_ordered.append(slug)
         if requested_ordered:
             ordered = requested_ordered

--- a/scripts/orchestration/qoder_dispatch_bridge.py
+++ b/scripts/orchestration/qoder_dispatch_bridge.py
@@ -222,7 +222,7 @@ def _parse_frontmatter(text: str) -> Tuple[Dict[str, Any], str]:
 
     # Try yaml first
     try:
-        import yaml  # type: ignore[import-untyped]
+        import yaml
 
         meta = yaml.safe_load(raw_fm)
         if isinstance(meta, dict):
@@ -426,9 +426,23 @@ def _parse_json_packet_roles(payload: Dict[str, Any]) -> List[str]:
     if isinstance(secondary_items, list):
         for item in secondary_items:
             add_slug(item)
+    advisory_items = bridge.get("advisory")
+    if isinstance(advisory_items, list):
+        for item in advisory_items:
+            add_slug(item, default_when_unspecified=False)
     add_slug(bridge.get("reviewer"))
     if not ordered:
         return []
+    requested_agents = payload.get("requested_agents")
+    if isinstance(requested_agents, list):
+        spawnable_roles = set(ordered)
+        requested_ordered: List[str] = []
+        for value in requested_agents:
+            slug = str(value).strip()
+            if slug in spawnable_roles and slug not in requested_ordered:
+                requested_ordered.append(slug)
+        if requested_ordered:
+            ordered = requested_ordered
     if ordered[0] != "agent-coordinator":
         return ["agent-coordinator", *ordered]
     return ordered
@@ -717,6 +731,16 @@ def _recommend_skills(slug: str) -> List[str]:
 # Manifest builder
 # ---------------------------------------------------------------------------
 
+MANDATORY_POST_OPEN_ORDER: tuple[str, ...] = ("qa-engineer-agent", "bug-hunter")
+
+
+def _enforce_mandatory_post_open_order(role_slugs: List[str]) -> List[str]:
+    """Keep the canonical post-open QA -> bug-hunter pass last when present."""
+
+    ordered = [slug for slug in role_slugs if slug not in MANDATORY_POST_OPEN_ORDER]
+    ordered.extend(slug for slug in MANDATORY_POST_OPEN_ORDER if slug in role_slugs)
+    return ordered
+
 
 def build_dispatch_manifest(
     *,
@@ -735,6 +759,7 @@ def build_dispatch_manifest(
     dispatch_sequence: List[Dict[str, Any]] = []
     missing_agents: List[str] = []
     loaded_agents: List[Tuple[str, Dict[str, Any]]] = []
+    role_slugs = _enforce_mandatory_post_open_order(role_slugs)
 
     for slug in role_slugs:
         agent_def = _load_agent_definition(slug)
@@ -806,7 +831,7 @@ def build_dispatch_manifest(
         "mode": mode,
         "dispatch_sequence": dispatch_sequence,
         "parallelizable_groups": parallel_groups,
-        "mandatory_post_open": ["qa-engineer-agent", "bug-hunter"],
+        "mandatory_post_open": list(MANDATORY_POST_OPEN_ORDER),
         "missing_agents": missing_agents,
     }
 

--- a/scripts/orchestration/qoder_dispatch_bridge.py
+++ b/scripts/orchestration/qoder_dispatch_bridge.py
@@ -25,6 +25,7 @@ import json
 import re
 import sys
 from datetime import datetime, timezone
+from importlib import import_module
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -220,11 +221,10 @@ def _parse_frontmatter(text: str) -> Tuple[Dict[str, Any], str]:
     raw_fm = text[3:end_idx].strip()
     body = text[end_idx + 3 :].strip()
 
-    # Try yaml first
+    # Try PyYAML first without creating a hard typed dependency.
     try:
-        import yaml
-
-        meta = yaml.safe_load(raw_fm)
+        yaml_module = import_module("yaml")
+        meta = yaml_module.safe_load(raw_fm)
         if isinstance(meta, dict):
             return meta, body
     except Exception:

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -63,7 +63,7 @@ from scripts.orchestration.design_lane_contract import (
 )
 from scripts.orchestration.native_subagent_bridge import (
     BRIDGE_TRANSPORT,
-    KIMI_BRIDGE_TRANSPORT,
+    BRIDGE_TRANSPORTS,
     build_native_subagent_bridge,
 )
 from scripts.orchestration.route_with_telemetry import TELEMETRY_PATH, route
@@ -102,10 +102,7 @@ PR_PHASES: tuple[str, ...] = (
     PR_PHASE_POST_OPEN_REVIEW,
     PR_PHASE_MERGE_READY,
 )
-NATIVE_BRIDGE_TRANSPORTS: tuple[str, ...] = (
-    BRIDGE_TRANSPORT,
-    KIMI_BRIDGE_TRANSPORT,
-)
+NATIVE_BRIDGE_TRANSPORTS: tuple[str, ...] = (*BRIDGE_TRANSPORTS,)
 POST_OPEN_REVIEW_LANE: tuple[str, ...] = ("qa-engineer-agent", "bug-hunter")
 PR_REVIEW_ARTIFACT_TEMPLATE = "docs/review/PR_<N>_FIXED_MAPPING.md"
 MERGE_READINESS_ENTRYPOINT = "scripts/orchestration/check_merge_ready.py"
@@ -463,12 +460,12 @@ def _partition_native_secondaries(
     requested_agent_disposition: list[dict[str, str]],
     forced_executable_agents: set[str] | None = None,
 ) -> tuple[list[str], list[str]]:
-    """Split executable secondaries from advisory-only collaborators.
+    """Split secondaries from required advisory role-pass collaborators.
 
-    RU: advisory specialists stay in the task packet but must not be promoted to
-    runnable native subagents.
-    EN: advisory specialists remain in the task packet but must not be promoted
-    into runnable native subagents.
+    RU: advisory describes contribution type, not permission to skip a requested
+    role pass.
+    EN: advisory describes contribution type, not permission to skip a requested
+    role pass.
     """
 
     advisory_statuses = {
@@ -525,6 +522,33 @@ def _promote_forced_secondary_dispositions(
             )
         disposition["status"] = REQUESTED_AGENT_STATUS_HONORED_SECONDARY
         disposition["reason"] = reason
+
+
+def _append_missing_requested_role_passes(
+    *,
+    requested_agent_disposition: list[dict[str, str]],
+    primary_agent: str,
+    secondary_agents: list[str],
+    reviewer: str,
+) -> list[str]:
+    """Ensure every known requested role is present in the executable plan."""
+
+    ordered_secondary_agents = list(secondary_agents)
+    planned_agents = {primary_agent, reviewer, *ordered_secondary_agents}
+    for disposition in requested_agent_disposition:
+        agent_slug = disposition["agent"]
+        if disposition["status"] == REQUESTED_AGENT_STATUS_REJECTED_UNKNOWN:
+            continue
+        if agent_slug in planned_agents:
+            continue
+        ordered_secondary_agents.append(agent_slug)
+        planned_agents.add(agent_slug)
+        if disposition["status"] == REQUESTED_AGENT_STATUS_HONORED_REVIEWER:
+            disposition["status"] = REQUESTED_AGENT_STATUS_HONORED_SECONDARY
+            disposition["reason"] = (
+                "Requested reviewer remains a required role pass after PR lifecycle synthesis."
+            )
+    return ordered_secondary_agents
 
 
 def _apply_requested_agent_overrides(
@@ -713,6 +737,12 @@ def build_task_packet(
     normalized_paths = repo_relative_paths(
         [path.strip() for path in candidate_paths if path.strip()]
     )
+    if native_bridge_transport not in NATIVE_BRIDGE_TRANSPORTS:
+        supported = ", ".join(NATIVE_BRIDGE_TRANSPORTS)
+        raise ValueError(
+            "Unsupported native_bridge_transport: "
+            f"{native_bridge_transport}. Supported: {supported}"
+        )
     normalized_requested_agents = normalize_requested_agents(requested_agents)
     normalized_pr_phase = _normalize_pr_phase(pr_phase)
     design_lane_mode, design_lane_contract, design_lane_enabled = _build_design_lane_contract(
@@ -792,6 +822,12 @@ def build_task_packet(
         reviewer=lifecycle_reviewer,
     )
     requested_agent_resolution["reviewer"] = lifecycle_reviewer
+    requested_agent_resolution["secondary_agents"] = _append_missing_requested_role_passes(
+        requested_agent_disposition=requested_agent_resolution["requested_agent_disposition"],
+        primary_agent=requested_agent_resolution["primary_agent"],
+        secondary_agents=requested_agent_resolution["secondary_agents"],
+        reviewer=requested_agent_resolution["reviewer"],
+    )
     skill_routing = route_skills(
         goal=goal,
         task_class=task_class,

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -61,7 +61,11 @@ from scripts.orchestration.design_lane_contract import (
     normalize_design_enum,
     normalize_optional_text,
 )
-from scripts.orchestration.native_subagent_bridge import build_native_subagent_bridge
+from scripts.orchestration.native_subagent_bridge import (
+    BRIDGE_TRANSPORT,
+    KIMI_BRIDGE_TRANSPORT,
+    build_native_subagent_bridge,
+)
 from scripts.orchestration.route_with_telemetry import TELEMETRY_PATH, route
 from scripts.orchestration.routing_graph_loader import (
     BootstrapLaneActivation,
@@ -97,6 +101,10 @@ PR_PHASES: tuple[str, ...] = (
     PR_PHASE_PRE_OPEN,
     PR_PHASE_POST_OPEN_REVIEW,
     PR_PHASE_MERGE_READY,
+)
+NATIVE_BRIDGE_TRANSPORTS: tuple[str, ...] = (
+    BRIDGE_TRANSPORT,
+    KIMI_BRIDGE_TRANSPORT,
 )
 POST_OPEN_REVIEW_LANE: tuple[str, ...] = ("qa-engineer-agent", "bug-hunter")
 PR_REVIEW_ARTIFACT_TEMPLATE = "docs/review/PR_<N>_FIXED_MAPPING.md"
@@ -697,6 +705,7 @@ def build_task_packet(
     design_blockers: list[str] | tuple[str, ...] = (),
     code_native_design_brief_path: str | None = None,
     explicit_creation_mode: bool = False,
+    native_bridge_transport: str = BRIDGE_TRANSPORT,
     telemetry_path: Path = TELEMETRY_PATH,
 ) -> dict[str, Any]:
     """Build a deterministic task packet for orchestration tooling."""
@@ -826,6 +835,7 @@ def build_task_packet(
         secondary_agents=executable_secondaries,
         reviewer=requested_agent_resolution["reviewer"],
         advisory_agents=advisory_agents,
+        transport=native_bridge_transport,
     )
     judgment_activation = _validated_judgment_activation(
         require_bootstrap_lane_activation(
@@ -986,6 +996,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--telemetry", default=str(TELEMETRY_PATH))
     parser.add_argument(
+        "--native-bridge-transport",
+        default=BRIDGE_TRANSPORT,
+        choices=NATIVE_BRIDGE_TRANSPORTS,
+        help="Native subagent bridge transport label for runtime-specific packets.",
+    )
+    parser.add_argument(
         "--design-source",
         choices=DESIGN_SOURCES,
         default=None,
@@ -1046,6 +1062,7 @@ def main(argv: list[str] | None = None) -> int:
         design_blockers=args.design_blocker,
         code_native_design_brief_path=args.code_native_design_brief_path,
         explicit_creation_mode=args.explicit_creation_mode,
+        native_bridge_transport=args.native_bridge_transport,
         telemetry_path=Path(args.telemetry),
     )
     try:

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import shlex
 import shutil
 import subprocess
 import sys
@@ -13,7 +14,7 @@ from typing import Any, cast
 
 import pytest
 
-from app.security.execution_sandbox import SandboxResult
+from app.security.execution_sandbox import SandboxRequest, SandboxResult
 import scripts.orchestration.context_pack as context_pack
 import scripts.orchestration.experiment_contract as experiment_contract
 import scripts.orchestration.experiment_runner as experiment_runner
@@ -77,6 +78,14 @@ def _init_repo(tmp_path: Path) -> Path:
         "def test_oracle() -> None:\n" "    assert True\n",
         encoding="utf-8",
     )
+    (repo / ".venv" / "bin").mkdir(parents=True)
+    for python_name in ("python", "python3"):
+        python_path = repo / ".venv" / "bin" / python_name
+        python_path.write_text(
+            f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n',
+            encoding="utf-8",
+        )
+        python_path.chmod(0o755)
 
     _git(tmp_path, "init", "--quiet", str(repo))
     _git(repo, "config", "user.email", "pulseplate@pm.me")
@@ -102,7 +111,7 @@ def _base_packet(
     oracle_command: str,
     experiment_id: str = "exp-test",
     runner_mode: str = "candidate_patch",
-) -> dict[str, object]:
+) -> dict[str, Any]:
     return {
         "schema_version": "1.0",
         "experiment_id": experiment_id,
@@ -144,7 +153,7 @@ def _configure_runner_repo(
     return result_dir
 
 
-def _validate_packet(packet: dict[str, object]) -> dict[str, object]:
+def _validate_packet(packet: dict[str, Any]) -> dict[str, Any]:
     validated = experiment_contract.validate_experiment_packet(packet)
     assert validated["experiment_id"]
     return validated
@@ -371,6 +380,146 @@ def test_absolute_path_env_uses_default_path_when_unset(
         timeout_seconds=1,
     ):
         assert os.environ["PATH"] == experiment_runner._absolute_path_env(os.defpath)
+
+
+def _write_executable(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _fake_python_bin(tmp_path: Path, name: str) -> Path:
+    bin_dir = tmp_path / name
+    bin_dir.mkdir()
+    python = bin_dir / "python"
+    python3 = bin_dir / "python3"
+    _write_executable(python)
+    _write_executable(python3)
+    return python
+
+
+def test_python_oracle_path_prefix_prefers_venv_python(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    venv_python = _fake_python_bin(tmp_path, "venv-bin")
+    dev_python = _fake_python_bin(tmp_path, "dev-bin")
+    monkeypatch.setenv("VENV_PYTHON", str(venv_python))
+    monkeypatch.setenv("DEV_PYTHON", str(dev_python))
+
+    prefix = experiment_runner._python_oracle_path_prefix(
+        [SandboxRequest(binary="python", args=("-c", "pass"), cwd=".")]
+    )
+
+    assert prefix == str(venv_python.parent)
+
+
+def test_python_oracle_path_prefix_uses_dev_python_without_venv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dev_python = _fake_python_bin(tmp_path, "dev-bin")
+    monkeypatch.delenv("VENV_PYTHON", raising=False)
+    monkeypatch.setenv("DEV_PYTHON", str(dev_python))
+
+    prefix = experiment_runner._python_oracle_path_prefix(
+        [SandboxRequest(binary="python3", args=("-c", "pass"), cwd=".")]
+    )
+
+    assert prefix == str(dev_python.parent)
+
+
+def test_python_oracle_path_prefix_uses_repo_venv_python(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_python = tmp_path / ".venv" / "bin" / "python"
+    repo_python.parent.mkdir(parents=True)
+    _write_executable(repo_python)
+    _write_executable(repo_python.parent / "python3")
+    monkeypatch.delenv("VENV_PYTHON", raising=False)
+    monkeypatch.delenv("DEV_PYTHON", raising=False)
+    monkeypatch.setattr(experiment_runner, "REPO_ROOT", tmp_path)
+
+    prefix = experiment_runner._python_oracle_path_prefix(
+        [SandboxRequest(binary="python", args=("-c", "pass"), cwd=".")]
+    )
+
+    assert prefix == str(repo_python.parent)
+
+
+def test_python_oracle_path_prefix_rejects_relative_venv_python(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VENV_PYTHON", ".venv/bin/python")
+
+    with pytest.raises(experiment_runner.InfraFlakeError, match="absolute executable path"):
+        experiment_runner._python_oracle_path_prefix(
+            [SandboxRequest(binary="python", args=("-c", "pass"), cwd=".")]
+        )
+
+
+def test_python_oracle_path_prefix_rejects_non_executable_venv_python(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    python = tmp_path / "python"
+    python.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    monkeypatch.setenv("VENV_PYTHON", str(python))
+
+    with pytest.raises(experiment_runner.InfraFlakeError, match="not executable"):
+        experiment_runner._python_oracle_path_prefix(
+            [SandboxRequest(binary="python", args=("-c", "pass"), cwd=".")]
+        )
+
+
+def test_python_oracle_path_prefix_fails_closed_without_repo_python(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VENV_PYTHON", raising=False)
+    monkeypatch.delenv("DEV_PYTHON", raising=False)
+    monkeypatch.setattr(experiment_runner, "REPO_ROOT", tmp_path)
+
+    with pytest.raises(experiment_runner.InfraFlakeError, match="repo-approved Python"):
+        experiment_runner._python_oracle_path_prefix(
+            [SandboxRequest(binary="python3", args=("-c", "pass"), cwd=".")]
+        )
+
+
+def test_non_python_oracle_path_prefix_does_not_validate_python_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VENV_PYTHON", ".venv/bin/python")
+
+    assert (
+        experiment_runner._python_oracle_path_prefix(
+            [SandboxRequest(binary="git", args=("--version",), cwd=".")]
+        )
+        is None
+    )
+
+
+def test_temporary_sandbox_env_prepends_python_path_and_restores_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_path = "/usr/bin"
+    python_bin = tmp_path / "repo-python-bin"
+    python_bin.mkdir()
+    monkeypatch.setenv("PATH", original_path)
+    monkeypatch.setenv("VENV_PYTHON", "keep-me")
+
+    with experiment_runner._temporary_sandbox_env(
+        sandbox_root=Path.cwd(),
+        allowed_binaries=("python",),
+        timeout_seconds=1,
+        path_prefix=str(python_bin),
+    ):
+        assert os.environ["PATH"].split(os.pathsep)[0] == str(python_bin)
+        assert os.environ["VENV_PYTHON"] == "keep-me"
+
+    assert os.environ["PATH"] == original_path
+    assert os.environ["VENV_PYTHON"] == "keep-me"
 
 
 def test_validate_packet_rejects_wrong_schema_version() -> None:

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -413,6 +413,29 @@ def test_python_oracle_path_prefix_prefers_venv_python(
     assert prefix == str(venv_python.parent)
 
 
+def test_python_oracle_path_prefix_preserves_symlinked_venv_bin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_bin = tmp_path / "real-bin"
+    real_bin.mkdir()
+    real_python3 = real_bin / "python3"
+    _write_executable(real_python3)
+    venv_bin = tmp_path / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    (venv_bin / "python3").symlink_to(real_python3)
+    venv_python = venv_bin / "python"
+    venv_python.symlink_to("python3")
+    monkeypatch.setenv("VENV_PYTHON", str(venv_python))
+    monkeypatch.delenv("DEV_PYTHON", raising=False)
+
+    prefix = experiment_runner._python_oracle_path_prefix(
+        [SandboxRequest(binary="python3", args=("-c", "pass"), cwd=".")]
+    )
+
+    assert prefix == str(venv_bin)
+
+
 def test_python_oracle_path_prefix_uses_dev_python_without_venv(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_native_subagent_bridge.py
+++ b/tests/test_native_subagent_bridge.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from scripts.orchestration.agent_consistency_loader import load_inventory_agents
 from scripts.orchestration.native_subagent_bridge import (
     BRIDGE_PROTOCOL_VERSION,
@@ -62,8 +64,8 @@ def test_build_native_subagent_bridge_shapes_primary_secondary_and_reviewer() ->
     assert bridge["reviewer"]["execution_mode"] == "review_read_only"
 
 
-def test_build_native_subagent_bridge_keeps_advisory_collaborators_non_runnable() -> None:
-    """Advisory specialists must stay visible but not spawnable."""
+def test_build_native_subagent_bridge_requires_advisory_role_passes() -> None:
+    """Advisory specialists must stay visible and required to run."""
 
     bridge = build_native_subagent_bridge(
         primary_agent="ai-innovation-specialist",
@@ -75,8 +77,27 @@ def test_build_native_subagent_bridge_keeps_advisory_collaborators_non_runnable(
     assert [binding["repo_agent_slug"] for binding in bridge["secondary"]] == ["rag-systems-agent"]
     assert [binding["repo_agent_slug"] for binding in bridge["advisory"]] == ["ml-engineer-agent"]
     assert bridge["advisory"][0]["role"] == "advisory"
-    assert bridge["advisory"][0]["execution_mode"] == "advisory_no_spawn"
-    assert bridge["advisory"][0]["dispatch_contract"]["spawn_with_native_subagent"] is False
+    assert bridge["advisory"][0]["native_agent_type"] == "explorer"
+    assert bridge["advisory"][0]["execution_mode"] == "advisory_review"
+    assert bridge["advisory"][0]["dispatch_contract"]["spawn_with_native_subagent"] is True
+    assert bridge["advisory"][0]["dispatch_contract"]["advisory_only"] is False
+    assert bridge["advisory"][0]["dispatch_contract"]["required_role_pass"] is True
+    assert (
+        bridge["advisory"][0]["dispatch_contract"]["write_capability"]
+        == "disabled_for_advisory_review"
+    )
+
+
+def test_build_native_subagent_bridge_rejects_unknown_transport() -> None:
+    """Direct bridge builders must reject unsupported transport labels."""
+
+    with pytest.raises(ValueError, match="Unsupported native subagent bridge transport"):
+        build_native_subagent_bridge(
+            primary_agent="agent-coordinator",
+            secondary_agents=["bug-hunter"],
+            reviewer="architecture-specialist",
+            transport="unknown-native-subagents",
+        )
 
 
 def test_build_kimi_native_subagent_bridge_uses_kimi_transport() -> None:

--- a/tests/test_qoder_dispatch_bridge.py
+++ b/tests/test_qoder_dispatch_bridge.py
@@ -43,6 +43,12 @@ REQUIRED_ENTRY_KEYS = {
 }
 
 
+def require_feature(feature_key: str) -> None:
+    """Skip with the repo-standard optional-feature reason prefix."""
+
+    pytest.skip(f"feature_disabled:{feature_key}")
+
+
 # ---------------------------------------------------------------------------
 # 1. test_manifest_generation_from_packet
 # ---------------------------------------------------------------------------
@@ -1058,7 +1064,7 @@ def test_mandatory_post_open_bug_hunter_depends_on_qa() -> None:
     slugs = ["qa-engineer-agent", "bug-hunter"]
     for s in slugs:
         if not (agents_dir / f"{s}.md").is_file():
-            pytest.skip(f"Agent definition not found: {s}")
+            require_feature(f"agent_definition:{s}")
 
     manifest = qoder_dispatch_bridge.build_dispatch_manifest(
         role_slugs=slugs,
@@ -1076,10 +1082,16 @@ def test_mandatory_post_open_bug_hunter_depends_on_qa() -> None:
 def test_mandatory_post_open_pass_is_ordered_last() -> None:
     """Generated manifests must not run bug-hunter before QA in post-open lanes."""
     agents_dir = REPO_ROOT / ".cursor" / "agents"
-    slugs = ["agent-coordinator", "bug-hunter", "security-auditor", "qa-engineer-agent"]
+    slugs = [
+        "agent-coordinator",
+        "bug-hunter",
+        "security-auditor",
+        "qa-engineer-agent",
+        "bug-hunter",
+    ]
     for slug in slugs:
         if not (agents_dir / f"{slug}.md").is_file():
-            pytest.skip(f"Agent definition not found: {slug}")
+            require_feature(f"agent_definition:{slug}")
 
     manifest = qoder_dispatch_bridge.build_dispatch_manifest(
         role_slugs=slugs,
@@ -1091,6 +1103,7 @@ def test_mandatory_post_open_pass_is_ordered_last() -> None:
         "agent-coordinator",
         "security-auditor",
         "qa-engineer-agent",
+        "bug-hunter",
         "bug-hunter",
     ]
 

--- a/tests/test_qoder_dispatch_bridge.py
+++ b/tests/test_qoder_dispatch_bridge.py
@@ -331,6 +331,33 @@ def test_parse_task_bootstrap_json_packet_preserves_requested_role_order(
     ]
 
 
+def test_parse_task_bootstrap_json_packet_preserves_duplicate_requested_roles(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repeated requested agents represent intentional repeated role passes."""
+    monkeypatch.setattr(qoder_dispatch_bridge, "REPO_ROOT", tmp_path)
+    packet = {
+        "requested_agents": [
+            "agent-coordinator",
+            "security-auditor",
+            "agent-coordinator",
+        ],
+        "native_subagent_bridge": {
+            "primary": {"repo_agent_slug": "agent-coordinator"},
+            "secondary": [{"repo_agent_slug": "security-auditor"}],
+            "advisory": [],
+        },
+    }
+    packet_path = tmp_path / "packet.json"
+    packet_path.write_text(json.dumps(packet), encoding="utf-8")
+
+    assert qoder_dispatch_bridge._parse_packet_roles(packet_path) == [
+        "agent-coordinator",
+        "security-auditor",
+        "agent-coordinator",
+    ]
+
+
 def test_parse_task_bootstrap_json_packet_empty_bridge_returns_no_roles(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_qoder_dispatch_bridge.py
+++ b/tests/test_qoder_dispatch_bridge.py
@@ -255,6 +255,76 @@ def test_parse_task_bootstrap_json_packet_skips_no_spawn_secondary(
     ]
 
 
+def test_parse_task_bootstrap_json_packet_includes_required_advisory_role_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Required advisory bindings are executable role passes, not skipped metadata."""
+    monkeypatch.setattr(qoder_dispatch_bridge, "REPO_ROOT", tmp_path)
+    packet = {
+        "native_subagent_bridge": {
+            "primary": {"repo_agent_slug": "agent-coordinator"},
+            "reviewer": {"repo_agent_slug": "architecture-specialist"},
+            "secondary": [{"repo_agent_slug": "qa-engineer-agent"}],
+            "advisory": [
+                {
+                    "repo_agent_slug": "ml-engineer-agent",
+                    "dispatch_contract": {
+                        "advisory_only": False,
+                        "spawn_with_native_subagent": True,
+                        "required_role_pass": True,
+                    },
+                }
+            ],
+        }
+    }
+    packet_path = tmp_path / "packet.json"
+    packet_path.write_text(json.dumps(packet), encoding="utf-8")
+
+    assert qoder_dispatch_bridge._parse_packet_roles(packet_path) == [
+        "agent-coordinator",
+        "qa-engineer-agent",
+        "ml-engineer-agent",
+        "architecture-specialist",
+    ]
+
+
+def test_parse_task_bootstrap_json_packet_preserves_requested_role_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit requested agents define the role order when they are spawnable."""
+    monkeypatch.setattr(qoder_dispatch_bridge, "REPO_ROOT", tmp_path)
+    packet = {
+        "requested_agents": [
+            "agent-coordinator",
+            "architecture-specialist",
+            "security-auditor",
+            "qa-engineer-agent",
+            "bug-hunter",
+        ],
+        "native_subagent_bridge": {
+            "primary": {"repo_agent_slug": "agent-coordinator"},
+            "secondary": [
+                {"repo_agent_slug": "bug-hunter"},
+                {"repo_agent_slug": "cursor-specialist-agent"},
+                {"repo_agent_slug": "security-auditor"},
+                {"repo_agent_slug": "architecture-specialist"},
+            ],
+            "reviewer": {"repo_agent_slug": "qa-engineer-agent"},
+            "advisory": [],
+        },
+    }
+    packet_path = tmp_path / "packet.json"
+    packet_path.write_text(json.dumps(packet), encoding="utf-8")
+
+    assert qoder_dispatch_bridge._parse_packet_roles(packet_path) == [
+        "agent-coordinator",
+        "architecture-specialist",
+        "security-auditor",
+        "qa-engineer-agent",
+        "bug-hunter",
+    ]
+
+
 def test_parse_task_bootstrap_json_packet_empty_bridge_returns_no_roles(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -384,10 +454,10 @@ def test_parse_task_bootstrap_json_packet_malformed_dispatch_contract_returns_no
     assert qoder_dispatch_bridge._parse_packet_roles(packet_path) == []
 
 
-def test_parse_task_bootstrap_json_packet_never_runs_advisory_roles(
+def test_parse_task_bootstrap_json_packet_runs_spawnable_advisory_roles(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Advisory bridge entries are context-only even if hand-edited as spawnable."""
+    """Advisory bridge entries are required role passes when spawnable."""
     monkeypatch.setattr(qoder_dispatch_bridge, "REPO_ROOT", tmp_path)
     packet = {
         "native_subagent_bridge": {
@@ -410,6 +480,7 @@ def test_parse_task_bootstrap_json_packet_never_runs_advisory_roles(
 
     assert qoder_dispatch_bridge._parse_packet_roles(packet_path) == [
         "agent-coordinator",
+        "qa-engineer-agent",
         "architecture-specialist",
     ]
 
@@ -1000,6 +1071,28 @@ def test_mandatory_post_open_bug_hunter_depends_on_qa() -> None:
     assert by_slug["qa-engineer-agent"]["depends_on_previous"] is False
     assert by_slug["bug-hunter"]["qoder_subagent_type"] == "Verify"
     assert by_slug["bug-hunter"]["depends_on_previous"] is True
+
+
+def test_mandatory_post_open_pass_is_ordered_last() -> None:
+    """Generated manifests must not run bug-hunter before QA in post-open lanes."""
+    agents_dir = REPO_ROOT / ".cursor" / "agents"
+    slugs = ["agent-coordinator", "bug-hunter", "security-auditor", "qa-engineer-agent"]
+    for slug in slugs:
+        if not (agents_dir / f"{slug}.md").is_file():
+            pytest.skip(f"Agent definition not found: {slug}")
+
+    manifest = qoder_dispatch_bridge.build_dispatch_manifest(
+        role_slugs=slugs,
+        mode="analysis",
+        packet_source="test",
+    )
+
+    assert [entry["role_slug"] for entry in manifest["dispatch_sequence"]] == [
+        "agent-coordinator",
+        "security-auditor",
+        "qa-engineer-agent",
+        "bug-hunter",
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -484,7 +484,7 @@ def test_task_bootstrap_deduplicates_reviewer_from_secondary_in_post_open_lane()
 
 
 def test_task_bootstrap_keeps_non_routable_requested_agent_advisory_in_post_open_lane() -> None:
-    """Lifecycle reconciliation must not upgrade advisory-only agents to executable roles."""
+    """Lifecycle reconciliation must keep advisory agents as required role passes."""
 
     packet = build_task_packet(
         goal="Prepare ML post-open review packet with advisory collaborator",
@@ -495,9 +495,11 @@ def test_task_bootstrap_keeps_non_routable_requested_agent_advisory_in_post_open
     )
 
     assert "ml-engineer-agent" in packet["secondary_agents"]
-    assert [
-        binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["advisory"]
-    ] == ["ml-engineer-agent"]
+    advisory_bindings = packet["native_subagent_bridge"]["advisory"]
+    assert [binding["repo_agent_slug"] for binding in advisory_bindings] == ["ml-engineer-agent"]
+    assert advisory_bindings[0]["execution_mode"] == "advisory_review"
+    assert advisory_bindings[0]["dispatch_contract"]["spawn_with_native_subagent"] is True
+    assert advisory_bindings[0]["dispatch_contract"]["required_role_pass"] is True
     assert packet["requested_agent_disposition"] == [
         {
             "agent": "ml-engineer-agent",
@@ -533,7 +535,7 @@ def test_task_bootstrap_keeps_unknown_requested_agent_rejected_in_post_open_lane
 
 
 def test_task_bootstrap_keeps_domain_mismatch_requested_agent_advisory_in_post_open_lane() -> None:
-    """Post-open synthesis must preserve domain-mismatched requests as advisory only."""
+    """Post-open synthesis must preserve domain-mismatched requests as required advisory."""
 
     packet = build_task_packet(
         goal="Prepare post-open review packet with frontend collaborator request",
@@ -544,9 +546,11 @@ def test_task_bootstrap_keeps_domain_mismatch_requested_agent_advisory_in_post_o
     )
 
     assert "frontend-engineer" in packet["secondary_agents"]
-    assert [
-        binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["advisory"]
-    ] == ["frontend-engineer"]
+    advisory_bindings = packet["native_subagent_bridge"]["advisory"]
+    assert [binding["repo_agent_slug"] for binding in advisory_bindings] == ["frontend-engineer"]
+    assert advisory_bindings[0]["execution_mode"] == "advisory_review"
+    assert advisory_bindings[0]["dispatch_contract"]["spawn_with_native_subagent"] is True
+    assert advisory_bindings[0]["dispatch_contract"]["required_role_pass"] is True
     assert packet["requested_agent_disposition"] == [
         {
             "agent": "frontend-engineer",
@@ -815,7 +819,7 @@ def test_task_bootstrap_promotes_requested_routable_agent() -> None:
 
 
 def test_task_bootstrap_keeps_non_routable_requested_agent_as_advisory() -> None:
-    """Non-routable specialists should be preserved as advisory collaborators."""
+    """Non-routable specialists should be preserved as required advisory passes."""
 
     packet = build_task_packet(
         goal="Design AI reliability experiment packet",
@@ -830,9 +834,11 @@ def test_task_bootstrap_keeps_non_routable_requested_agent_as_advisory() -> None
     assert {
         binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["secondary"]
     } == {"rag-systems-agent", "security-auditor"}
-    assert [
-        binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["advisory"]
-    ] == ["ml-engineer-agent"]
+    advisory_bindings = packet["native_subagent_bridge"]["advisory"]
+    assert [binding["repo_agent_slug"] for binding in advisory_bindings] == ["ml-engineer-agent"]
+    assert advisory_bindings[0]["execution_mode"] == "advisory_review"
+    assert advisory_bindings[0]["dispatch_contract"]["advisory_only"] is False
+    assert advisory_bindings[0]["dispatch_contract"]["required_role_pass"] is True
     assert packet["requested_agent_disposition"] == [
         {
             "agent": "ml-engineer-agent",
@@ -867,7 +873,7 @@ def test_task_bootstrap_rejects_unknown_requested_agent_with_explicit_rationale(
 
 
 def test_task_bootstrap_keeps_domain_mismatch_requested_agent_as_advisory() -> None:
-    """Routable-but-mismatched requested agents should remain advisory with explicit rationale."""
+    """Routable-but-mismatched requested agents stay required advisory passes."""
 
     packet = build_task_packet(
         goal="Implement backend entitlement routing",
@@ -888,9 +894,11 @@ def test_task_bootstrap_keeps_domain_mismatch_requested_agent_as_advisory() -> N
     assert {
         binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["secondary"]
     } == {"architecture-specialist"}
-    assert [
-        binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["advisory"]
-    ] == ["frontend-engineer"]
+    advisory_bindings = packet["native_subagent_bridge"]["advisory"]
+    assert [binding["repo_agent_slug"] for binding in advisory_bindings] == ["frontend-engineer"]
+    assert advisory_bindings[0]["execution_mode"] == "advisory_review"
+    assert advisory_bindings[0]["dispatch_contract"]["spawn_with_native_subagent"] is True
+    assert advisory_bindings[0]["dispatch_contract"]["required_role_pass"] is True
 
 
 def test_task_bootstrap_requested_agents_change_packet_id() -> None:
@@ -1024,6 +1032,39 @@ def test_task_bootstrap_preserves_coordinator_primary_for_requested_orchestratio
             "reason": (
                 "Coordinator-owned lane keeps `agent-coordinator` as primary; "
                 "requested reviewer stays honored in reviewer."
+            ),
+        },
+    ]
+
+
+def test_task_bootstrap_keeps_displaced_requested_reviewer_required_post_open() -> None:
+    """Post-open QA synthesis must not drop a requested reviewer role pass."""
+
+    packet = build_task_packet(
+        goal="Update privileged orchestration workflow",
+        task_class="Orchestration",
+        candidate_paths=["scripts/orchestration/task_bootstrap.py"],
+        requested_agents=["agent-coordinator", "architecture-specialist"],
+        pr_phase="post_open_review",
+    )
+
+    assert packet["primary_agent"] == "agent-coordinator"
+    assert packet["reviewer"] == "qa-engineer-agent"
+    assert "architecture-specialist" in packet["secondary_agents"]
+    assert "architecture-specialist" in {
+        binding["repo_agent_slug"] for binding in packet["native_subagent_bridge"]["secondary"]
+    }
+    assert packet["requested_agent_disposition"] == [
+        {
+            "agent": "agent-coordinator",
+            "status": "honored_primary",
+            "reason": "Requested agent already matches the routed primary.",
+        },
+        {
+            "agent": "architecture-specialist",
+            "status": "honored_secondary",
+            "reason": (
+                "Requested reviewer remains a required role pass after PR lifecycle synthesis."
             ),
         },
     ]
@@ -1683,7 +1724,10 @@ def test_main_passes_pr_phase_flag(monkeypatch, capsys) -> None:
     assert json.loads(captured.out)["task_packet_id"] == "pr-phase-packet"
 
 
-def test_main_passes_native_bridge_transport_flag(monkeypatch, capsys) -> None:
+def test_main_passes_native_bridge_transport_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """CLI should propagate --native-bridge-transport into the packet builder."""
 
     observed: dict[str, object] = {}
@@ -1755,6 +1799,43 @@ def test_main_passes_native_bridge_transport_flag(monkeypatch, capsys) -> None:
     assert exit_code == 0
     assert observed["native_bridge_transport"] == "kimi-native-subagents"
     assert json.loads(captured.out)["task_packet_id"] == "bridge-transport-packet"
+
+
+def test_build_task_packet_defaults_native_bridge_transport_to_codex() -> None:
+    """Direct packet builder calls should preserve Codex as the default transport."""
+
+    packet = build_task_packet(
+        goal="Harden orchestration bootstrap",
+        task_class="Orchestration",
+        candidate_paths=["scripts/orchestration/task_bootstrap.py"],
+    )
+
+    assert packet["native_subagent_bridge"]["transport"] == "codex-native-subagents"
+
+
+def test_build_task_packet_passes_explicit_kimi_native_bridge_transport() -> None:
+    """Direct packet builder calls should propagate explicit Kimi transport."""
+
+    packet = build_task_packet(
+        goal="Harden orchestration bootstrap",
+        task_class="Orchestration",
+        candidate_paths=["scripts/orchestration/task_bootstrap.py"],
+        native_bridge_transport="kimi-native-subagents",
+    )
+
+    assert packet["native_subagent_bridge"]["transport"] == "kimi-native-subagents"
+
+
+def test_build_task_packet_rejects_unknown_native_bridge_transport() -> None:
+    """Direct packet builder calls must reject unsupported transport labels."""
+
+    with pytest.raises(ValueError, match="Unsupported native_bridge_transport"):
+        build_task_packet(
+            goal="Harden orchestration bootstrap",
+            task_class="Orchestration",
+            candidate_paths=["scripts/orchestration/task_bootstrap.py"],
+            native_bridge_transport="unknown-native-subagents",
+        )
 
 
 def test_main_passes_design_lane_flags(
@@ -1932,7 +2013,7 @@ def test_build_task_packet_rejects_unknown_requested_agent() -> None:
 
 
 def test_build_task_packet_non_routable_requested_agent_stays_advisory() -> None:
-    """Non-routable specialists outside domain slots stay advisory with disposition."""
+    """Non-routable specialists outside domain slots stay required advisory passes."""
 
     packet = build_task_packet(
         goal="Harden task bootstrap",
@@ -1948,6 +2029,10 @@ def test_build_task_packet_non_routable_requested_agent_stays_advisory() -> None
     assert "ml-engineer-agent" not in secondary_slugs
     advisory_slugs = {b["repo_agent_slug"] for b in packet["native_subagent_bridge"]["advisory"]}
     assert "ml-engineer-agent" in advisory_slugs
+    advisory_binding = packet["native_subagent_bridge"]["advisory"][0]
+    assert advisory_binding["execution_mode"] == "advisory_review"
+    assert advisory_binding["dispatch_contract"]["spawn_with_native_subagent"] is True
+    assert advisory_binding["dispatch_contract"]["required_role_pass"] is True
 
 
 def test_build_task_packet_promotes_requested_agent_in_domain_slot_set() -> None:
@@ -1967,7 +2052,7 @@ def test_build_task_packet_promotes_requested_agent_in_domain_slot_set() -> None
 
 
 def test_build_task_packet_routable_agent_domain_mismatch_stays_advisory() -> None:
-    """Routable agent outside routed domain slots becomes advisory_domain_mismatch."""
+    """Routable agent outside routed domain slots becomes a required advisory pass."""
 
     packet = build_task_packet(
         goal="Docs routing only",
@@ -1979,6 +2064,11 @@ def test_build_task_packet_routable_agent_domain_mismatch_stays_advisory() -> No
     assert dm["backend-engineer"]["status"] == REQUESTED_AGENT_STATUS_ADVISORY_DOMAIN_MISMATCH
     assert "slot" in dm["backend-engineer"]["reason"].lower()
     assert packet["primary_agent"] == "agent-coordinator"
+    advisory_binding = packet["native_subagent_bridge"]["advisory"][0]
+    assert advisory_binding["repo_agent_slug"] == "backend-engineer"
+    assert advisory_binding["execution_mode"] == "advisory_review"
+    assert advisory_binding["dispatch_contract"]["spawn_with_native_subagent"] is True
+    assert advisory_binding["dispatch_contract"]["required_role_pass"] is True
 
 
 def test_build_task_packet_graph_slot_precedes_non_routable_specialist_list() -> None:

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -1683,6 +1683,80 @@ def test_main_passes_pr_phase_flag(monkeypatch, capsys) -> None:
     assert json.loads(captured.out)["task_packet_id"] == "pr-phase-packet"
 
 
+def test_main_passes_native_bridge_transport_flag(monkeypatch, capsys) -> None:
+    """CLI should propagate --native-bridge-transport into the packet builder."""
+
+    observed: dict[str, object] = {}
+
+    def _fake_build_task_packet(**kwargs: object) -> dict[str, object]:
+        observed.update(kwargs)
+        return {
+            "schema_version": "2.0",
+            "task_packet_id": "bridge-transport-packet",
+            "goal": "Use kimi native transport",
+            "task_class": "Orchestration",
+            "domain": "orchestration",
+            "cluster": "ops",
+            "candidate_paths": ["scripts/orchestration/task_bootstrap.py"],
+            "primary_agent": "agent-coordinator",
+            "secondary_agents": ["bug-hunter"],
+            "reviewer": "qa-engineer-agent",
+            "requested_agents": [],
+            "requested_agent_disposition": [],
+            "required_context": ["AGENTS.md"],
+            "recommended_skills": ["pulseplate-workflow"],
+            "skill_routing": {
+                "policy_version": "2026-03-27",
+                "selection_mode": "deterministic-weighted",
+                "requested_agents": [],
+                "task_classification": {
+                    "label": "implementation",
+                    "score": 0,
+                    "reasons": ["fallback:default-implementation"],
+                },
+                "required": [
+                    {
+                        "skill": "pulseplate-workflow",
+                        "rationale": "Mandatory entry skill for all PulsePlate tasks.",
+                        "reasons": ["always-on"],
+                    }
+                ],
+                "recommended": [],
+                "conditional": [],
+                "blocked": [],
+            },
+            "native_subagent_bridge": {
+                "protocol_version": "1.0",
+                "transport": "kimi-native-subagents",
+                "primary": {"native_agent_type": "default"},
+                "secondary": [{"native_agent_type": "worker"}],
+                "reviewer": {"native_agent_type": "explorer"},
+            },
+            "routing_rationale": {"source": "canonical_only"},
+        }
+
+    monkeypatch.setattr(
+        "scripts.orchestration.task_bootstrap.build_task_packet",
+        _fake_build_task_packet,
+    )
+
+    exit_code = main(
+        [
+            "--goal",
+            "Use Kimi bridge transport",
+            "--task-class",
+            "Orchestration",
+            "--native-bridge-transport",
+            "kimi-native-subagents",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert observed["native_bridge_transport"] == "kimi-native-subagents"
+    assert json.loads(captured.out)["task_packet_id"] == "bridge-transport-packet"
+
+
 def test_main_passes_design_lane_flags(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
## Summary
Expand #1802 from transport-only wiring into a coherent orchestration hardening PR covering native bridge transport selection, required execution for known requested role agents, and deterministic repo-Python context for Experiment Runner oracle subprocesses.

## Goal
Make orchestration packets explicit and executable: requested known role agents must run or be explicitly rejected, Kimi transport remains opt-in, and Experiment Runner Python oracles must not silently resolve through host Python.

## Business reason
PulsePlate governance depends on reliable coordinator-first execution, review evidence, and deterministic validation. Silent advisory no-spawn behavior and host-Python oracle fallback create false-green or false-red PR evidence.

## Scope
- Add and validate native bridge transport selection through task bootstrap.
- Replace requested advisory no-spawn behavior with required advisory-review role passes.
- Preserve unknown-agent rejection and non-write review/analysis semantics.
- Make qoder dispatch include spawnable advisory role passes in coordinator-requested order.
- Harden Experiment Runner Python oracle PATH resolution through repo-approved Python.
- Update orchestration protocol docs and PR fixed mapping.

## Out of scope
FastAPI/Starlette fix, #1800 Phase2 evidence semantics, #1801 design validator logic, runtime app code, frontend/iOS runtime, dependency files, OpenAPI, generated mirrors, and CI workflow YAML.

## Root cause
PulsePlate added native bridge transport metadata, but task bootstrap could not select non-default transports. Additionally, requested agents classified as advisory were emitted with no-spawn semantics, allowing required role-agent passes to be skipped. Separately, Experiment Runner oracle subprocesses could resolve bare `python` through host PATH inside isolated checkouts, causing dependency-loaded validations to fail with missing imports. Orchestration must preserve explicit transport labels, require requested role-agent execution, and make oracle Python resolution deterministic through repo-approved Python context.

## Source of truth
Read and followed: `AGENTS.md`, `docs/dev/AGENT_COMPATIBILITY_ONBOARDING.md`, `RUNBOOK_AGENT.md`, `scripts/AGENTS.md`, `tests/AGENTS.md`, task packet `artifacts/orchestration/task_packets/b5504bcb1893.json`, and `docs/review/PR_1802_FIXED_MAPPING.md`.

## Agent Execution Log
- `agent-coordinator`: locked expanded #1802 scope, risks, DoD, and role order before implementation.
- `architecture-specialist`: verified task_bootstrap/native bridge/Experiment Runner contract fixes.
- `security-auditor`: verified no sandbox allowlist bypass, no skipped known requested agents, and no widened write authority.
- `qa-engineer-agent`: verified focused transport, role-agent, dispatch, and oracle-env tests.
- `bug-hunter`: probed host-Python fallback, env leak, advisory skip, unknown-agent false-green, and dispatch-order risks.

## Skill Execution Log
- `pulseplate-premortem-risk-review`: run after the actual diff; blocking governance findings closed through mapping/body/evidence.
- `pulseplate-pr-review`: run against the rebased current diff; one advisory large-diff-risk note dispositioned by split rationale and bounded-gate evidence.
- `pulseplate-gates`: bounded local gates run with repo `.venv`; full `make verify` intentionally not run per plan.

## Experiment Runner Evidence
- Artifact: `artifacts/orchestration/experiments/results/pr1802-oracle-result-v3.json`
- Packet: `artifacts/orchestration/experiments/pr1802-oracle-packet-v3.json`
- Mode: `oracle_only_governance_reviewer`
- Result: `accepted`
- `coauthor_required=true`; commit includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
- Diagnostic artifact: `artifacts/orchestration/experiments/results/pr1802-oracle-result-v2.json` reproduced the dependency-missing class with `ModuleNotFoundError: No module named 'fastapi'` in isolated oracle context and was superseded by v3.

## Lane Start Provenance
- Preflight: `python3 scripts/orchestration/check_preflight.py` -> PASS.
- Agent consistency: `python3 scripts/orchestration/check_agent_consistency.py` -> PASS.
- Packet: `artifacts/orchestration/task_packets/b5504bcb1893.json`
- Dispatch: `python3 scripts/orchestration/qoder_dispatch_bridge.py --packet artifacts/orchestration/task_packets/b5504bcb1893.json --pretty`.
- Required role order: `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter`.

## Premortem
Premortem decision was `block until fixed` for governance closeout until mapping/body/evidence/gates were current. Fixes are recorded in `docs/review/PR_1802_FIXED_MAPPING.md`.

## Premortem Risk Fix Matrix
| Risk ID | Failure mode | Fix | Regression test | Evidence command | Disposition |
| --- | --- | --- | --- | --- | --- |
| PM-1802-001 | Kimi transport becomes default. | Default remains `codex-native-subagents`. | Default transport tests. | `pytest tests/test_task_bootstrap.py -k native_bridge_transport` | FIXED |
| PM-1802-002 | Explicit Kimi transport flag is ignored. | CLI flag propagates into packet/native bridge. | Kimi propagation test. | `pytest tests/test_task_bootstrap.py -k native_bridge_transport` | FIXED |
| PM-1802-003 | Invalid transport label accepted. | Argparse choices plus builder validation. | Invalid label fails. | `pytest tests/test_task_bootstrap.py -k native_bridge_transport` | FIXED |
| PM-1802-004 | Requested subagents are `advisory_no_spawn` and skipped. | Required `advisory_review` role pass. | Spawn/required flags asserted. | `pytest tests/test_native_subagent_bridge.py` | FIXED |
| PM-1802-005 | Unknown agents become executable. | Unknowns remain rejected. | Unknown-agent rejection tests. | `pytest tests/test_task_bootstrap.py -k requested_agent` | FIXED |
| PM-1802-006 | Advisory agents become write-capable. | Advisory-review keeps write disabled. | Non-write role tests. | `pytest tests/test_native_subagent_bridge.py` | FIXED |
| PM-1802-007 | Oracle uses host Python. | Repo Python bin dir prepended. | Bare python context tests. | `pytest tests/test_experiment_runner.py -k "python or oracle or sandbox or env"` | FIXED |
| PM-1802-008 | Missing repo Python silently falls back. | Fail closed for Python oracles. | Missing repo Python infra failure. | `pytest tests/test_experiment_runner.py -k "python or oracle or sandbox or env"` | FIXED |
| PM-1802-009 | Sandbox allowlist bypassed. | Keep bare binary and allowlist enforcement. | Non-allowlisted rejection. | `pytest tests/test_experiment_runner.py -k sandbox` | FIXED |
| PM-1802-010 | Env mutation leaks. | Temporary env restore. | PATH/env restoration test. | `pytest tests/test_experiment_runner.py -k env` | FIXED |
| PM-1802-011 | Scope drifts into adjacent PRs. | Changed-file scope guard. | Rebased diff limited to orchestration/test/docs mapping. | `git diff --name-only origin/main...HEAD` | FIXED |


## Split Justification
This PR intentionally stays as one orchestration-layer change because the three fixes share the same execution contract: task bootstrap selects the bridge transport, native/qoder dispatch must run known requested role agents even when advisory, and Experiment Runner must validate that orchestration behavior under deterministic repo-Python oracle context. Splitting these would leave false intermediate states where packets can be labeled but requested agents can still be skipped, or role execution can be fixed while oracle evidence still resolves through host Python. FastAPI/Starlette, #1800, #1801, runtime app code, dependencies, OpenAPI, and CI workflow YAML remain excluded.

## Security Review
Default remains Codex transport; Kimi transport is explicit opt-in. Known requested agents are not silently skipped; unknown agents remain rejected. Write capability is not broadened for analysis/review roles. Sandbox allowlist is preserved; repo Python resolution is deterministic by PATH prefix; no runtime app code, dependency changes, CI workflow YAML, FastAPI fix, #1800, or #1801 semantics are mixed in.

## Bug Hunter Pass
Covered host-Python fallback, env restoration, advisory no-spawn skip, unknown-agent execution, and requested-role dispatch ordering. The qoder dispatch bridge now preserves requested role order and keeps `qa-engineer-agent -> bug-hunter` post-open order.

## Tests / bounded checks
- `python3 scripts/orchestration/check_preflight.py` -> PASS.
- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS.
- `.venv/bin/python -m pytest -q tests/test_task_bootstrap.py -k "native_bridge_transport or advisory or requested_agent or pr_phase or displaced_requested_reviewer"` -> 20 passed.
- `.venv/bin/python -m pytest -q tests/test_native_subagent_bridge.py` -> 8 passed.
- `.venv/bin/python -m pytest -q tests/test_experiment_runner.py -k "python or oracle or sandbox or env"` -> 41 passed.
- `.venv/bin/python -m pytest -q tests/test_qoder_dispatch_bridge.py -k "advisory or requested_role_order or no_spawn or coordinator_first or mandatory_post_open"` -> 10 passed.
- `.venv/bin/python -m pytest -q tests/test_task_bootstrap.py tests/test_native_subagent_bridge.py tests/test_experiment_runner.py tests/test_experiment_runner_identity_policy.py tests/test_qoder_dispatch_bridge.py` -> PASS.
- `.venv/bin/python -m mypy --explicit-package-bases --no-incremental --cache-dir=/dev/null ...` -> PASS.
- Initial `make validate-changed` and commit hook reproduced host-Python `ModuleNotFoundError: No module named 'fastapi'`; rerun with `PATH`/`VENV_PYTHON` from repo `.venv` passed.
- `make validate-changed` with repo `.venv` -> PASS.
- `pre-commit run --all-files` with repo `.venv` -> PASS after `black` formatting rerun.
- Pre-push hook initially failed mypy on PyYAML stubs and `Path | None`; fixed in `5dc11038f`; retry passed.

## Deferred / Follow-ups
None added. `pulseplate-ledger` was not run because this PR did not create a deferral or backlog-tracked skip.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Canonical artifact: `docs/review/PR_1802_FIXED_MAPPING.md`.

## Merge Readiness
Not claimed. Remaining blockers: current-head CI must finish and pass, no unresolved review threads/actionable bot comments, PR body Phase2 gates, review-thread disposition guard with auth, strict merge-readiness wrapper with auth, mandatory wait-window, and operator confirmation that FastAPI fix is not required inside #1802.

## Rollback
Revert-only: remove native transport CLI propagation, restore previous advisory bridge behavior, and remove repo-Python oracle context changes. Rollback risk: Kimi packets cannot be explicitly labeled, requested role agents can again be skipped as no-spawn advisory, and Experiment Runner can again resolve `python` to host Python.

## DoD
- [x] Default transport remains Codex.
- [x] Kimi transport is explicit opt-in.
- [x] Known requested agents cannot be silently skipped as no-spawn advisory.
- [x] Unknown agents remain rejected.
- [x] Review/analysis agents are not made write-capable.
- [x] Bare Python oracle subprocesses resolve through repo-approved Python context or fail closed.
- [x] Sandbox allowlist remains enforced.
- [x] Env restoration is tested.
- [x] Premortem Risk Fix Matrix is complete.
- [x] Experiment Runner artifact recorded.
- [x] Bounded local checks pass in repo `.venv`.

## Commit breakdown
- `db46dcb60`: initial native bridge transport selector from original #1802 scope.
- `ce9c404b4`: required role execution, repo-Python oracle context, qoder dispatch, docs/tests.
- `2aaedaab2`: fixed mapping creation.
- `5dc11038f`: pre-push type-check fixes.
- `ac8562b8f`: fixed mapping update for pre-push type fix.
- `f0dd38823`: fixed mapping format for Phase2 body gates.
- `e830ae3b3`: exact CodeRabbit discussion mapping for strict review governance.
- `3fadce7d0`: fixed mapping SHA refresh after rebasing on #1809.
- `8b5cb5e47`: CodeRabbit fix for duplicate mandatory post-open roles and repo-standard qoder skip reason.
- `35ed94315`: post-rebase CodeRabbit mapping refresh before the #1810/#1811 rebase.
- `def942f1a`: fixed mapping SHA refresh after rebasing on #1810 and #1811.
- `26477c215`: fixed mapping SHA refresh after rebasing on #1812.
- `6b3201ef2`: CodeRabbit fix for symlinked repo `.venv/bin` preservation and duplicate requested role passes.
- `9619d22ce`: fixed mapping for latest CodeRabbit review comments.

## Pre-push checklist
- [x] Branch rebased on current `origin/main`.
- [x] Changed-file scope reviewed.
- [x] `make validate-changed` passed with repo `.venv`.
- [x] `pre-commit run --all-files` passed with repo `.venv`.
- [x] Pre-push hooks passed on final push.

## Post-merge checklist
- Sync local `main` with `origin/main`.
- Confirm main health before next PR.
- Remove the isolated worktree only after merge/sync proof.

## AGENTS.md updates
None. This PR updates orchestration behavior and protocol docs, not repository agent policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime selection for native subagent bridge transport via CLI.
  * Requested advisory roles can be appended as executable required review passes (advisory-review mode).

* **Bug Fixes**
  * Unknown transport labels are rejected with clear errors.
  * Python-oracle runner prefers repo-approved interpreter and prepares PATH for sandboxed runs.
  * Enforced mandatory post-open ordering for specified roles.

* **Tests**
  * Expanded coverage for transport propagation, advisory-role/run behavior, and Python-oracle env handling.

* **Documentation**
  * Clarified advisory-role semantics and transport rollout guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1802?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

