### PR TITLE
bump(dev): update types-pyyaml without unsafe pip pin

### DIFF
--- a/docs/review/PR_1814_FIXED_MAPPING.md
+++ b/docs/review/PR_1814_FIXED_MAPPING.md
@@ -1,0 +1,54 @@
+# PR 1814 Fixed in Commit Mapping
+
+## PR
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1814
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Experiment Runner Evidence
+
+Artifact: `artifacts/orchestration/experiments/results/pr1808-types-pyyaml-oracle-result-v2.json`
+Status: accepted
+Contribution: `oracle_review`
+Co-author required: true
+
+## Lane Start Provenance
+
+Packet: `artifacts/orchestration/task_packets/ff8682fe24f8.json`
+Queue packet: `artifacts/orchestration/task_packets/96e522edd8df.json`
+Starter: `scripts/orchestration/start_pr_lane.sh`
+
+## Validation
+
+- `python3 scripts/orchestration/check_preflight.py` -> PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS
+- `git rev-list --left-right --count HEAD...origin/main` -> `0 0` before lane edit
+- `pip download --isolated --index-url $PULSEPLATE_PYTHON_INDEX_URL --only-binary=:all: --no-deps types-pyyaml==6.0.12.20260518` -> PASS
+- `python3 scripts/ci/install_locked_python_requirements.py --python-executable /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python --requirements-file requirements.txt --dev-requirements-file requirements-dev.txt --constraints-file constraints.txt --requirements-profile runtime-dev --require-virtualenv --preflight-only` -> PASS
+- `python3 scripts/ci/install_locked_python_requirements.py --python-executable /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python --requirements-file requirements.txt --dev-requirements-file requirements-dev.txt --constraints-file constraints.txt --requirements-profile runtime-dev --require-virtualenv` -> PASS
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pip check` -> PASS
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pip install --dry-run -r requirements-dev.txt` -> PASS
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m mypy --version` -> PASS (`mypy 2.1.0`)
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -c "import yaml; import typing_extensions; print('dev typing smoke ok')"` -> PASS
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_dependency_security_guard.py::test_repo_managed_lock_surfaces_do_not_pin_pip` -> PASS
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py` -> PASS (`54 passed`)
+- `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH make validate-changed` -> PASS
+- `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH pre-commit run --all-files` -> PASS
+- Pre-push hooks -> PASS
+
+## Merge Readiness
+
+- [ ] Current-head CI completed for this PR.
+- [ ] Phase2 PR body gate passed for this PR.
+- [ ] Post-open `qa-engineer-agent -> security-auditor -> bug-hunter` pass completed.
+- [ ] Strict merge-readiness wrapper passed for this PR after latest bot/review activity.
+- [ ] No actionable bot comments remain.
+- [ ] Mandatory wait window elapsed after latest bot/review activity.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -240,7 +240,7 @@ tomli==2.3.0
     # via pip-audit
 tomli-w==1.2.0
     # via pip-audit
-types-pyyaml==6.0.12.20260510
+types-pyyaml==6.0.12.20260518
     # via -r requirements-dev.in
 typing-extensions==4.15.0
     # via


### PR DESCRIPTION
## Summary
Replace Dependabot #1808 with a human-owned, private-index-safe `types-pyyaml` patch update.

## Goal
Update `types-pyyaml` from `6.0.12.20260510` to `6.0.12.20260518` without accepting the Dependabot-generated unsafe `pip==26.1.1` lockfile drift.

## Business reason
Keep development typing dependencies current while preserving deterministic dependency governance, private-index installs, and emergency-wheel boundaries.

## Scope
- `requirements-dev.txt`: update only the `types-pyyaml` pin.

## Out of scope
- Dependabot #1808 unsafe `pip==26.1.1` addition.
- Emergency wheel manifest expansion.
- CI workflow edits.
- #1802 orchestration/repo-python work, owned by another agent.
- Any production, runtime, RAG/vector, or test dependency lane.

## Dependency surfaces
- Source: `requirements-dev.in` already allows `types-pyyaml~=6.0.12`.
- Lock: `requirements-dev.txt` now pins `types-pyyaml==6.0.12.20260518`.
- No `requirements.txt`, `requirements-lock.txt`, `constraints.txt`, CI, or emergency manifest changes.

## Private index evidence
- `pip download --isolated --index-url $PULSEPLATE_PYTHON_INDEX_URL --only-binary=:all: --no-deps types-pyyaml==6.0.12.20260518`: PASS.
- `install_locked_python_requirements.py --requirements-profile runtime-dev --require-virtualenv --preflight-only`: PASS.
- `install_locked_python_requirements.py --requirements-profile runtime-dev --require-virtualenv`: PASS.

## Emergency wheel manifest audit
`scripts/ci/emergency_python_wheels.json` still contains the older emergency fallback `types-pyyaml==6.0.12.20260408`. This lane does not expand emergency fallback policy because the private proxy serves the new pin.

## Source/lock parity
`requirements-dev.in` has `types-pyyaml~=6.0.12`; `requirements-dev.txt` pins `6.0.12.20260518`, which is within that source constraint. Diff audit shows only the compiled dev lock pin changed.

## Agent Execution Log
- `agent-coordinator`: scoped replacement lane and blocked Dependabot #1808 as-is.
- `security-auditor`: supply-chain review, private-index requirements, unsafe pip blocker.
- `architecture-specialist`: profile-surface and source/lock boundary review.
- `qa-engineer-agent`: bounded validation plan and guard-gap assessment.
- `bug-hunter`: false-green and stale-manifest risk review.
- `dev-operator`: operational caveats; full installer proof rerun locally after partial report.

## Skill Execution Log
- `pulseplate-premortem-risk-review`: applied to actual dependency diff and PM-DEPS matrix below.
- `pulseplate-pr-review`: diff-scoped pre-open self-review found no remaining blockers after removing `pip==` drift.
- `pulseplate-gates`: bounded gates run through repo `.venv`.
- `codex-security:security-scan`: diff-scoped supply-chain scan found the Dependabot unsafe-pip drift and validated this replacement removes it.

## Experiment Runner Evidence
- Initial task packet was schema `2.0`; Experiment Runner requires experiment packet schema `1.0`, so a dedicated oracle-only experiment packet was generated.
- First oracle run rejected under host `python3` due environment-only `ModuleNotFoundError: No module named 'fastapi'`.
- Rerun with repo `.venv` on `PATH` accepted.
Artifact: artifacts/orchestration/experiments/results/pr1808-types-pyyaml-oracle-result-v2.json
- `coauthor_required=true`; commit includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.

## Lane Start Provenance
Packet: artifacts/orchestration/task_packets/ff8682fe24f8.json
- Queue packet: `artifacts/orchestration/task_packets/96e522edd8df.json`.


## Premortem
It is 48 hours from now and this dependency lane made things worse: the likely failures are unsafe `pip` lock drift, private-index parity gaps, emergency fallback confusion, and local/CI Python mismatch. The replacement diff closes the unsafe pin path and requires private-index, `.venv`, and governance evidence before readiness.

## Premortem Risk Fix Matrix

| Risk ID | Failure mode | Fix | Regression test | Evidence command | Disposition |
| --- | --- | --- | --- | --- | --- |
| `PM-DEPS-001` | source constraints and compiled locks drift. | Keep `requirements-dev.in` unchanged and update only the in-range compiled pin. | Diff audit. | `git diff -- requirements-dev.in requirements-dev.txt` | FIXED |
| `PM-DEPS-002` | private Python index cannot serve the new pinned wheel. | Verify exact wheel via private proxy and installer profile. | Private-index download plus installer path. | `pip download --isolated --index-url $PULSEPLATE_PYTHON_INDEX_URL --only-binary=:all: --no-deps types-pyyaml==6.0.12.20260518` | FIXED |
| `PM-DEPS-003` | emergency wheel manifest becomes stale for newly pinned versions. | Audit manifest and avoid expansion because private proxy serves the pin. | Manifest audit. | `rg -n 'types-pyyaml' scripts/ci/emergency_python_wheels.json` | NOT-A-BUG |
| `PM-DEPS-004` | PR silently widens profile surface. | Use human replacement with `requirements-dev.txt` only. | Changed-file audit. | `git diff --name-only` | FIXED |
| `PM-DEPS-005` | local `.venv` and CI diverge. | Run Python gates through repo `.venv` and rerun Experiment Runner with `.venv` PATH. | `.venv` checks. | `.venv/bin/python -m pip check` | FIXED |
| `PM-DEPS-006` | dependency update breaks import/runtime smoke. | Run dev typing import smoke. | Import smoke. | `.venv/bin/python -c "import yaml; import typing_extensions; print('dev typing smoke ok')"` | FIXED |
| `PM-DEPS-007` | Dependabot PR conflicts after another dependency PR lands. | Replace stale Dependabot branch with current `origin/main` human branch. | Branch sync audit. | `git rev-list --left-right --count HEAD...origin/main` | FIXED |
| `PM-DEPS-008` | unsafe package pin appears unintentionally. | Reject Dependabot unsafe `pip==26.1.1`; keep replacement lock free of `pip==`. | Existing pip-pin guard. | `.venv/bin/python -m pytest -q tests/test_dependency_security_guard.py::test_repo_managed_lock_surfaces_do_not_pin_pip` | FIXED |
| `PM-DEPS-009` | full `make verify` deferred without sufficient bounded evidence. | Run private-index, installer, guard, changed-file, and pre-commit bundle; rely on current-head CI for heavy project signal. | Bounded gate bundle. | `pre-commit run --all-files` | FIXED |

## Security Review
Codex Security phases:
- Threat model: dev lockfile supply-chain surface; primary risk is unsafe package-manager pin drift or private-index bypass.
- Finding discovery: Dependabot #1808 introduces `pip==26.1.1` under unsafe packages.
- Validation: this branch removes the unsafe pin and preserves a one-line `types-pyyaml` lock update.
- Attack-path analysis: repo-managed `pip` pins could normalize package-manager drift and weaken emergency fallback governance.
- Final report: no reportable vulnerability remains in this replacement diff after private-index and guard evidence.

## Bug Hunter Pass
Pre-open bug-hunter review found false-green risks around stale Dependabot checks, host-Python Experiment Runner failure, emergency manifest confusion, and unsafe `pip`. The replacement diff and rerun evidence address those risks.

## Tests / bounded checks
- `python3 scripts/orchestration/check_preflight.py`: PASS.
- `python3 scripts/orchestration/check_agent_consistency.py`: PASS.
- `.venv/bin/python -m pip check`: PASS.
- `.venv/bin/python -m pip install --dry-run -r requirements-dev.txt`: PASS.
- `install_locked_python_requirements.py --requirements-profile runtime-dev --require-virtualenv`: PASS.
- `.venv/bin/python -m mypy --version`: PASS (`mypy 2.1.0`).
- `.venv/bin/python -c "import yaml; import typing_extensions; print('dev typing smoke ok')"`: PASS.
- `.venv/bin/python -m pytest -q tests/test_dependency_security_guard.py::test_repo_managed_lock_surfaces_do_not_pin_pip`: PASS.
- `.venv/bin/python -m pytest -q tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py`: PASS (`54 passed`).
- `make validate-changed`: PASS.
- `pre-commit run --all-files`: PASS.

## Deferred / Follow-ups
- None for this lane.
- #1802 remains owned by another agent and is not touched here.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Canonical artifact: `docs/review/PR_1814_FIXED_MAPPING.md`

## Merge Readiness
Not ready yet. Required before merge: current-head CI terminal/pass, post-open `qa-engineer-agent -> security-auditor -> bug-hunter`, external bot pass/no-actionables, no unresolved review threads, PR body gates, strict merge-readiness wrapper with auth, and wait-window.

## Rollback
Revert the single commit to restore `types-pyyaml==6.0.12.20260510` in `requirements-dev.txt`.

## DoD
- [x] Diff limited to `requirements-dev.txt`.
- [x] No repo-managed `pip==` lock pin.
- [x] Private proxy serves `types-pyyaml==6.0.12.20260518`.
- [x] Emergency manifest audited without expansion.
- [x] Bounded local gates pass.
- [ ] Current-head CI terminal and passing.
- [ ] Post-open role-agent pass complete.
- [ ] Review-thread and bot disposition pass complete.
- [ ] Strict merge-readiness wrapper passes.

## Commit breakdown
- `6be76fda`: `bump(dev): update types-pyyaml without unsafe pip pin`.

## Pre-push checklist
- [x] `pre-commit run --all-files`
- [x] Pre-push hooks
- [x] Private-index exact wheel proof
- [x] Installer profile proof

## Post-merge checklist
- Sync `main`.
- Confirm `git rev-list --left-right --count HEAD...origin/main` returns `0 0`.
- Verify current-head `main` CI health before processing #1803.

## AGENTS.md updates
None.

## Summary by Sourcery

Enhancements:
- Обновить закреплённую версию `types-pyyaml` в `requirements-dev.txt` в рамках существующего ограничения исходников, без изменений в зависимостях времени выполнения или конфигурации инструментов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Refresh the types-pyyaml pin in requirements-dev.txt within the existing source constraint, with no changes to runtime dependencies or tooling configuration.

</details>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation capturing PR review status and validation results.

* **Chores**
  * Updated development dependencies to latest versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->