### PR TITLE
fix(orchestration): preserve required roles when requested_agents reorder

### DIFF
--- a/.cursor/agents/agent-coordinator.md
+++ b/.cursor/agents/agent-coordinator.md
@@ -476,6 +476,11 @@ Coordinator enforces project quality gates; see `AGENTS.md` (policy) and `RUNBOO
 
 - `python scripts/orchestration/task_bootstrap.py --goal "..." --task-class "..." --path ...`
 - `python scripts/orchestration/check_preflight.py --mode analyze|execute|merge ...`
+- `python scripts/orchestration/qoder_dispatch_bridge.py --packet <packet> --pretty`
+  must be run after `task_bootstrap.py` emits a packet; packet creation does
+  not execute role agents. Use the emitted `dispatch_sequence` in order, and do
+  not skip an assigned role without an explicit coordinator packet/runbook
+  update.
 
 These commands are the executable implementation of coordinator-first behavior for task start, execution handoff, and merge prep.
 

--- a/.cursor/agents/cursor-specialist-agent.md
+++ b/.cursor/agents/cursor-specialist-agent.md
@@ -25,6 +25,9 @@ description: Cursor/Codex workflow specialist for PulsePlate. Owns coordinator b
 - Make coordinator-first behavior executable and low-friction.
 - Keep context loading and task packets deterministic.
 - Reduce orchestration drift between docs, scripts, and actual agent usage.
+- Ensure bootstrap prompts distinguish packet creation from role-agent
+  execution, and surface the required `qoder_dispatch_bridge.py --packet
+  <packet> --pretty` manifest step before implementation.
 
 ## When Invoked
 
@@ -38,4 +41,5 @@ description: Cursor/Codex workflow specialist for PulsePlate. Owns coordinator b
 - Workflow recommendation or patch scope
 - Task packet contract
 - Context-pack definition
+- Role-agent dispatch manifest guidance when bootstrap or prompt surfaces change
 - Operational caveats

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -479,6 +479,15 @@ Operational procedure lives in `RUNBOOK_AGENT.md` and `docs/orchestration/COORDI
 
 **Agent docs consistency:** Agent docs MUST stay consistent: routing ⊆ inventory ⊆ capability. Run `python scripts/orchestration/check_agent_consistency.py` (must PASS before merge readiness).
 
+**Durable agent lessons:** When a PR exposes a repeatable role-agent failure mode,
+architecture lesson, or workflow insight that changes how future agents should act,
+update the smallest authoritative instruction surface in the same PR when in scope:
+the relevant `.cursor/agents/*.md` role instruction, nearest scoped `AGENTS.md`,
+root `AGENTS.md`, or `docs/ENGINEERING_LESSONS.md`. Do not store transient PR
+notes, local memory summaries, or evidence-only research as instructions. If the
+lesson is real but out of scope, add a tracked follow-up in `docs/roadmap/BACKLOG_LEDGER.md`
+instead of silently dropping it.
+
 **Templates:**
 - Task Analysis: `docs/orchestration/task_analysis.template.md`
 - Work Review: `docs/orchestration/work_review.template.md`

--- a/docs/ENGINEERING_LESSONS.md
+++ b/docs/ENGINEERING_LESSONS.md
@@ -220,7 +220,39 @@ Also replace `os.environ` mutation in `setup_method()` with an autouse
 
 ---
 
-## 12) Merged AI/RAG ledger items need closeout, not duplicate implementation
+## 12) Bootstrap packets do not execute role agents
+
+### Problem
+
+`task_bootstrap.py` creates the coordinator packet and role metadata, but it does
+not launch the role agents. Treating packet creation as execution can leave
+requested reviewers, QA, bug-hunter, or security roles skipped while the PR looks
+formally bootstrapped.
+
+### Rule
+
+After every non-trivial bootstrap packet is created, generate the dispatch
+manifest and execute its `dispatch_sequence` in order:
+
+```bash
+python scripts/orchestration/qoder_dispatch_bridge.py --packet <packet> --pretty
+```
+
+Assigned role agents are mandatory lane steps unless the coordinator updates the
+packet/runbook with an explicit disposition. Do not replace this with skills,
+host preflight, Experiment Runner evidence, or PR-body prose.
+
+### Fix pattern
+
+- Packet schemas should expose a machine-readable role dispatch contract.
+- Startup prompts should say that packet creation does not execute roles.
+- Lane starter output should print the exact dispatch-manifest command.
+- Tests should cover requested role order, coordinator-first behavior, and the
+  required post-bootstrap dispatch guidance.
+
+---
+
+## 13) Merged AI/RAG ledger items need closeout, not duplicate implementation
 
 ### Problem
 
@@ -245,7 +277,7 @@ landed code.
 
 ---
 
-## 13) Feature-flag backend routing must have explicit priority + lock-safe lazy init
+## 14) Feature-flag backend routing must have explicit priority + lock-safe lazy init
 
 ### Problem
 
@@ -284,7 +316,7 @@ git grep -n '@patch("app.services.food_store' -- tests/
 
 If any matches remain, convert them to `monkeypatch.setattr()`.
 
-## 14) API schema types must match persisted row types (barcode hit contract)
+## 15) API schema types must match persisted row types (barcode hit contract)
 
 ### Problem
 Endpoint handlers that construct `FoodItem(**row)` can fail at runtime if DB columns store

--- a/docs/review/PR_1818_FIXED_MAPPING.md
+++ b/docs/review/PR_1818_FIXED_MAPPING.md
@@ -62,6 +62,20 @@ Evidence: `tests/test_qoder_dispatch_bridge.py:297` updates the requested-order 
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3294942615 -> 4b81482f4629e540a780e8e161c864b671425565
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3295019396
+Disposition: FIXED
+Commit: daa4cc30f72264be9c27fb447a90a32a011f6c57
+Evidence: `scripts/orchestration/qoder_dispatch_bridge.py:497` requires requested JSON order to explicitly keep `qa-engineer-agent` before `bug-hunter` before disabling mandatory tail normalization; `scripts/orchestration/qoder_dispatch_bridge.py:972` keeps tail enforcement enabled for partial requested orders; `tests/test_qoder_dispatch_bridge.py:399` covers partial requested order preserving the canonical QA -> bug tail.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3295019396 -> daa4cc30f72264be9c27fb447a90a32a011f6c57
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3295019397
+Disposition: FIXED
+Commit: daa4cc30f72264be9c27fb447a90a32a011f6c57
+Evidence: `scripts/orchestration/render_codex_start_prompt.py:111` applies the same mandatory tail normalization used by the dispatch manifest for JSON packets that do not explicitly request QA before bug; `tests/test_render_codex_start_prompt.py:150` verifies the prompt order matches the manifest order for partial requested packets.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3295019397 -> daa4cc30f72264be9c27fb447a90a32a011f6c57
+
 ## Post-Open Agent Findings
 
 | Role | Finding | Disposition | Evidence |
@@ -70,15 +84,17 @@ Evidence: `tests/test_qoder_dispatch_bridge.py:297` updates the requested-order 
 | architecture-specialist | Bootstrap packet creation must not be treated as role-agent execution; add a machine-readable role dispatch contract and prompt guidance. | FIXED | `scripts/orchestration/task_bootstrap.py:362`; `scripts/orchestration/render_codex_start_prompt.py:185`; `tests/test_task_bootstrap.py`; `tests/test_render_codex_start_prompt.py`. |
 | cursor-specialist-agent | `start_pr_lane.sh` printed next steps outside the subshell and did not print the exact dispatch-manifest command. | FIXED | `scripts/orchestration/start_pr_lane.sh:425`; `scripts/orchestration/start_pr_lane.sh:429`; `tests/test_start_pr_lane.py`. |
 | security-auditor | Avoid collapsing legitimate repeated coordinator packet slots; quote packet paths in copy-paste commands. | FIXED | `scripts/orchestration/qoder_dispatch_bridge.py:457`; `scripts/orchestration/render_codex_start_prompt.py:92`; `scripts/orchestration/start_pr_lane.sh:429`; focused pytest and `bash -n` passed. |
-| qa-engineer-agent | Final manifest could move QA/bug-hunter behind explicit requested order; engineering lesson numbering duplicated. | FIXED | `scripts/orchestration/qoder_dispatch_bridge.py:943` disables tail normalization when JSON packet has explicit requested order; `tests/test_qoder_dispatch_bridge.py:335`; `docs/ENGINEERING_LESSONS.md` numbering corrected. |
-| bug-hunter | Prompt role order and advisory labels could contradict the dispatch manifest; shell quoting needed unsafe-path coverage. | FIXED | `scripts/orchestration/render_codex_start_prompt.py:104`; `scripts/orchestration/render_codex_start_prompt.py:185`; `tests/test_render_codex_start_prompt.py:119`; `tests/test_render_codex_start_prompt.py:213`. |
+| qa-engineer-agent | Final manifest could move QA/bug-hunter behind explicit requested order; engineering lesson numbering duplicated. | FIXED | `scripts/orchestration/qoder_dispatch_bridge.py:972` disables tail normalization only when JSON `requested_agents` explicitly keeps QA before bug; `tests/test_qoder_dispatch_bridge.py:335`; `tests/test_qoder_dispatch_bridge.py:399`; `docs/ENGINEERING_LESSONS.md` numbering corrected. |
+| bug-hunter | Prompt role order and advisory labels could contradict the dispatch manifest; shell quoting needed unsafe-path coverage. | FIXED | `scripts/orchestration/render_codex_start_prompt.py:104`; `scripts/orchestration/render_codex_start_prompt.py:111`; `scripts/orchestration/render_codex_start_prompt.py:185`; `tests/test_render_codex_start_prompt.py:119`; `tests/test_render_codex_start_prompt.py:150`; `tests/test_render_codex_start_prompt.py:213`. |
+| Codex review 2026-05-24T17:11:24Z | Partial `requested_agents` disabled mandatory QA -> bug tail. | FIXED | Commit `daa4cc30f72264be9c27fb447a90a32a011f6c57`; `scripts/orchestration/qoder_dispatch_bridge.py:497`; `tests/test_qoder_dispatch_bridge.py:399`. |
+| Codex review 2026-05-24T17:11:24Z | Prompt role order could diverge from final manifest tail enforcement. | FIXED | Commit `daa4cc30f72264be9c27fb447a90a32a011f6c57`; `scripts/orchestration/render_codex_start_prompt.py:111`; `tests/test_render_codex_start_prompt.py:150`. |
 
 ## Premortem Risk Fix Matrix
 
 | Risk ID | Failure mode | Disposition | Evidence |
 | --- | --- | --- | --- |
 | PM-1818-001 | Agents stop after `task_bootstrap.py`, leaving requested role passes unrun. | FIXED | `role_agent_dispatch_contract` in `scripts/orchestration/task_bootstrap.py:362`; prompt/launcher dispatch guidance in `scripts/orchestration/render_codex_start_prompt.py:185` and `scripts/orchestration/start_pr_lane.sh:429`. |
-| PM-1818-002 | Requested-agent order is correct at parser level but false-green at final manifest level. | FIXED | `scripts/orchestration/qoder_dispatch_bridge.py:943`; `tests/test_qoder_dispatch_bridge.py:335`. |
+| PM-1818-002 | Requested-agent order is correct at parser level but false-green at final manifest level. | FIXED | `scripts/orchestration/qoder_dispatch_bridge.py:497`; `scripts/orchestration/qoder_dispatch_bridge.py:972`; `tests/test_qoder_dispatch_bridge.py:335`; `tests/test_qoder_dispatch_bridge.py:399`. |
 | PM-1818-003 | Role-agent lesson is lost after this PR and future agents repeat the same bootstrap mistake. | FIXED | `AGENTS.md`; `.cursor/agents/agent-coordinator.md`; `.cursor/agents/cursor-specialist-agent.md`; `docs/ENGINEERING_LESSONS.md`. |
 | PM-1818-004 | Packet paths with spaces or quotes generate unsafe copy-paste dispatch commands. | FIXED | `scripts/orchestration/render_codex_start_prompt.py:92`; `scripts/orchestration/start_pr_lane.sh:429`; `tests/test_render_codex_start_prompt.py:213`; `tests/test_start_pr_lane.py`. |
 | PM-1818-005 | Mapping/body are updated before code fixes, creating invalid review disposition evidence. | FIXED | Code/test commit `4b81482f4629e540a780e8e161c864b671425565` exists before this mapping artifact. |
@@ -117,6 +133,7 @@ Evidence: `tests/test_qoder_dispatch_bridge.py:297` updates the requested-order 
 - `make validate-changed` -> PASS
 - `pre-commit run --all-files` -> PASS after Black reformatted `tests/test_render_codex_start_prompt.py`; rerun passed.
 - Commit hooks -> PASS with `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH`.
+- Post-Codex-review focused gates -> PASS: `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH python -m pytest -q tests/test_qoder_dispatch_bridge.py tests/test_render_codex_start_prompt.py`; `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH flake8 scripts/orchestration/qoder_dispatch_bridge.py scripts/orchestration/render_codex_start_prompt.py tests/test_qoder_dispatch_bridge.py tests/test_render_codex_start_prompt.py`; `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH python -m mypy --explicit-package-bases scripts/orchestration/qoder_dispatch_bridge.py scripts/orchestration/render_codex_start_prompt.py`.
 - Full local `make verify`: deferred by operator-approved machine-heavy governance exception; use current-head CI parity before merge.
 
 ## Deferred / Follow-ups

--- a/docs/review/PR_1818_FIXED_MAPPING.md
+++ b/docs/review/PR_1818_FIXED_MAPPING.md
@@ -1,0 +1,135 @@
+# PR 1818 Fixed in Commit Mapping
+
+## Summary
+
+PR #1818 fixes requested-agent role ordering in the Qoder dispatch bridge and
+adds an explicit post-bootstrap role-agent dispatch contract so
+`task_bootstrap.py` packet creation cannot be mistaken for actual role-agent
+execution.
+
+## Scope
+
+- `scripts/orchestration/qoder_dispatch_bridge.py`
+- `scripts/orchestration/task_bootstrap.py`
+- `scripts/orchestration/render_codex_start_prompt.py`
+- `scripts/orchestration/start_pr_lane.sh`
+- `tests/test_qoder_dispatch_bridge.py`
+- `tests/test_task_bootstrap.py`
+- `tests/test_render_codex_start_prompt.py`
+- `tests/test_start_pr_lane.py`
+- `tests/test_local_session_bootstrap.py`
+- `.cursor/agents/agent-coordinator.md`
+- `.cursor/agents/cursor-specialist-agent.md`
+- `AGENTS.md`
+- `docs/ENGINEERING_LESSONS.md`
+- `docs/review/PR_1818_FIXED_MAPPING.md`
+
+## Lane Start Provenance
+
+- Preflight: `python3 scripts/orchestration/check_preflight.py` -> PASS
+- Scoped preflight: `python3 scripts/orchestration/check_preflight.py --path ...` -> PASS
+- Packet: `artifacts/orchestration/task_packets/00e986e4dde3.json`
+- Bootstrap command: `python3 scripts/orchestration/task_bootstrap.py --goal "Close PR #1818 merge-readiness blockers for requested_agents role-order preservation without widening orchestration scope" --task-class Orchestration --pr-phase post_open_review --path scripts/orchestration/qoder_dispatch_bridge.py --path tests/test_qoder_dispatch_bridge.py --path docs/review/PR_1818_FIXED_MAPPING.md --requested-agent agent-coordinator --requested-agent architecture-specialist --requested-agent security-auditor --requested-agent qa-engineer-agent --requested-agent bug-hunter`
+- Dispatch manifest command: `python3 scripts/orchestration/qoder_dispatch_bridge.py --packet artifacts/orchestration/task_packets/00e986e4dde3.json --pretty`
+- Dispatch order used: `agent-coordinator -> architecture-specialist -> security-auditor -> cursor-specialist-agent -> qa-engineer-agent -> bug-hunter`
+- Role-agent passes completed: `agent-coordinator`, `architecture-specialist`, `cursor-specialist-agent`, `security-auditor`, `qa-engineer-agent`, `bug-hunter`
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3294942611
+Disposition: FIXED
+Commit: 4b81482f4629e540a780e8e161c864b671425565
+Evidence: `scripts/orchestration/qoder_dispatch_bridge.py:436` caps requested role occurrences by available packet slots; `scripts/orchestration/qoder_dispatch_bridge.py:457` preserves one mandatory first coordinator without adding a synthetic duplicate when a coordinator slot already exists; `tests/test_qoder_dispatch_bridge.py:335` verifies final manifest order also preserves explicit requested order.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3294942611 -> 4b81482f4629e540a780e8e161c864b671425565
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3294942613
+Disposition: FIXED
+Commit: 4b81482f4629e540a780e8e161c864b671425565
+Evidence: `tests/test_qoder_dispatch_bridge.py` now has normal top-level spacing and `pre-commit run --all-files` passed after Black formatting.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3294942613 -> 4b81482f4629e540a780e8e161c864b671425565
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3294942615
+Disposition: FIXED
+Commit: 4b81482f4629e540a780e8e161c864b671425565
+Evidence: `tests/test_qoder_dispatch_bridge.py:297` updates the requested-order assertion to the append contract where required non-requested roles remain appended, and `tests/test_qoder_dispatch_bridge.py:335` covers final manifest preservation.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3294942615 -> 4b81482f4629e540a780e8e161c864b671425565
+
+## Post-Open Agent Findings
+
+| Role | Finding | Disposition | Evidence |
+| --- | --- | --- | --- |
+| agent-coordinator | PR must preserve coordinator-first startup and close the three Codex threads with code/test evidence before mapping. | FIXED | Commit `4b81482f4629e540a780e8e161c864b671425565`; this artifact maps all three threads. |
+| architecture-specialist | Bootstrap packet creation must not be treated as role-agent execution; add a machine-readable role dispatch contract and prompt guidance. | FIXED | `scripts/orchestration/task_bootstrap.py:362`; `scripts/orchestration/render_codex_start_prompt.py:185`; `tests/test_task_bootstrap.py`; `tests/test_render_codex_start_prompt.py`. |
+| cursor-specialist-agent | `start_pr_lane.sh` printed next steps outside the subshell and did not print the exact dispatch-manifest command. | FIXED | `scripts/orchestration/start_pr_lane.sh:425`; `scripts/orchestration/start_pr_lane.sh:429`; `tests/test_start_pr_lane.py`. |
+| security-auditor | Avoid collapsing legitimate repeated coordinator packet slots; quote packet paths in copy-paste commands. | FIXED | `scripts/orchestration/qoder_dispatch_bridge.py:457`; `scripts/orchestration/render_codex_start_prompt.py:92`; `scripts/orchestration/start_pr_lane.sh:429`; focused pytest and `bash -n` passed. |
+| qa-engineer-agent | Final manifest could move QA/bug-hunter behind explicit requested order; engineering lesson numbering duplicated. | FIXED | `scripts/orchestration/qoder_dispatch_bridge.py:943` disables tail normalization when JSON packet has explicit requested order; `tests/test_qoder_dispatch_bridge.py:335`; `docs/ENGINEERING_LESSONS.md` numbering corrected. |
+| bug-hunter | Prompt role order and advisory labels could contradict the dispatch manifest; shell quoting needed unsafe-path coverage. | FIXED | `scripts/orchestration/render_codex_start_prompt.py:104`; `scripts/orchestration/render_codex_start_prompt.py:185`; `tests/test_render_codex_start_prompt.py:119`; `tests/test_render_codex_start_prompt.py:213`. |
+
+## Premortem Risk Fix Matrix
+
+| Risk ID | Failure mode | Disposition | Evidence |
+| --- | --- | --- | --- |
+| PM-1818-001 | Agents stop after `task_bootstrap.py`, leaving requested role passes unrun. | FIXED | `role_agent_dispatch_contract` in `scripts/orchestration/task_bootstrap.py:362`; prompt/launcher dispatch guidance in `scripts/orchestration/render_codex_start_prompt.py:185` and `scripts/orchestration/start_pr_lane.sh:429`. |
+| PM-1818-002 | Requested-agent order is correct at parser level but false-green at final manifest level. | FIXED | `scripts/orchestration/qoder_dispatch_bridge.py:943`; `tests/test_qoder_dispatch_bridge.py:335`. |
+| PM-1818-003 | Role-agent lesson is lost after this PR and future agents repeat the same bootstrap mistake. | FIXED | `AGENTS.md`; `.cursor/agents/agent-coordinator.md`; `.cursor/agents/cursor-specialist-agent.md`; `docs/ENGINEERING_LESSONS.md`. |
+| PM-1818-004 | Packet paths with spaces or quotes generate unsafe copy-paste dispatch commands. | FIXED | `scripts/orchestration/render_codex_start_prompt.py:92`; `scripts/orchestration/start_pr_lane.sh:429`; `tests/test_render_codex_start_prompt.py:213`; `tests/test_start_pr_lane.py`. |
+| PM-1818-005 | Mapping/body are updated before code fixes, creating invalid review disposition evidence. | FIXED | Code/test commit `4b81482f4629e540a780e8e161c864b671425565` exists before this mapping artifact. |
+
+## Codex Security Diff Scan
+
+- Scope: changed orchestration Python, shell prompt, tests, agent instructions, and governance docs.
+- Threat model: no auth, billing, secrets, network, runtime product API, or data migration surface changed.
+- Finding discovery: no new subprocess execution of untrusted input; added shell rendering uses `shlex.quote` for prompt copy-paste and Bash `%q` for lane starter output.
+- Validation: `pre-commit run --all-files` passed, including Bandit on changed files and detect-secrets.
+- Attack path analysis: no reportable path from PR input to command execution, secret exposure, auth bypass, or fail-open merge-readiness weakening.
+- Disposition: NOT-A-BUG for security risk; no reportable security finding.
+
+## Experiment Runner Evidence
+
+- Packet: `artifacts/orchestration/experiments/pr1818-role-dispatch-oracle-full.json`
+- Artifact: `artifacts/orchestration/experiments/results/exp-7d9b0476fa50-v2.json`
+- Status: `accepted`
+- Runner mode: `oracle_only_governance_reviewer`
+- `mutated_paths`: `[]`
+- `shared_tree_untouched`: `true`
+- `contribution_kind`: `oracle_review`
+- `coauthor_required`: `true`
+- Co-author trailer present in commit `4b81482f4629e540a780e8e161c864b671425565`: `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+- Diagnostic rejected artifacts:
+  - `artifacts/orchestration/experiments/results/exp-f8042f7fd2c7.json`: rejected because the packet context omitted later doc/test surfaces.
+  - `artifacts/orchestration/experiments/results/exp-7d9b0476fa50.json`: rejected because `VENV_PYTHON` was not exported for oracle Python commands.
+
+## Local Validation
+
+- `python3 scripts/orchestration/check_preflight.py --path ...` -> PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS: `OK: agent docs and files are consistent.`
+- `pytest -q tests/test_qoder_dispatch_bridge.py tests/test_task_bootstrap.py tests/test_render_codex_start_prompt.py tests/test_start_pr_lane.py tests/test_local_session_bootstrap.py tests/test_native_subagent_bridge.py` -> PASS
+- `flake8 scripts/orchestration/qoder_dispatch_bridge.py scripts/orchestration/render_codex_start_prompt.py scripts/orchestration/task_bootstrap.py tests/test_qoder_dispatch_bridge.py tests/test_render_codex_start_prompt.py tests/test_start_pr_lane.py tests/test_local_session_bootstrap.py tests/test_task_bootstrap.py tests/test_native_subagent_bridge.py` -> PASS
+- `bash -n scripts/orchestration/start_pr_lane.sh scripts/orchestration/local_session_bootstrap.sh` -> PASS
+- `make validate-changed` -> PASS
+- `pre-commit run --all-files` -> PASS after Black reformatted `tests/test_render_codex_start_prompt.py`; rerun passed.
+- Commit hooks -> PASS with `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH`.
+- Full local `make verify`: deferred by operator-approved machine-heavy governance exception; use current-head CI parity before merge.
+
+## Deferred / Follow-ups
+
+- None.
+
+## Merge Readiness
+
+- [ ] PR body mirror refreshed from canonical mapping artifact.
+- [x] Local PR-scoped gates passed: preflight, agent consistency, focused pytest, `make validate-changed`, `pre-commit run --all-files`, PR review dry-run, premortem closure, and diff-scoped security scan.
+- [ ] Current-head CI passing with all required checks green and no pending jobs.
+- [ ] Review-thread disposition guard with auth passed after latest bot/human activity.
+- [ ] Strict merge-readiness wrapper with auth passed after latest bot/human activity.
+- [ ] CodeRabbit, Sourcery, Cubic, and Codex comments checked and dispositioned.
+- [ ] No actionable review threads remain unresolved.
+- [ ] Mandatory wait window elapsed after latest bot/review activity.

--- a/scripts/orchestration/qoder_dispatch_bridge.py
+++ b/scripts/orchestration/qoder_dispatch_bridge.py
@@ -435,14 +435,25 @@ def _parse_json_packet_roles(payload: Dict[str, Any]) -> List[str]:
         return []
     requested_agents = payload.get("requested_agents")
     if isinstance(requested_agents, list):
-        spawnable_roles = set(ordered)
+        available_counts: Dict[str, int] = {}
+        for slug in ordered:
+            available_counts[slug] = available_counts.get(slug, 0) + 1
+
         requested_ordered: List[str] = []
         for value in requested_agents:
             slug = str(value).strip()
-            if slug in spawnable_roles:
+            if available_counts.get(slug, 0) > 0:
                 requested_ordered.append(slug)
+                available_counts[slug] -= 1
+
         if requested_ordered:
-            ordered = requested_ordered
+            remaining_counts = dict(available_counts)
+            remaining_ordered: List[str] = []
+            for slug in ordered:
+                if remaining_counts.get(slug, 0) > 0:
+                    remaining_ordered.append(slug)
+                    remaining_counts[slug] -= 1
+            ordered = [*requested_ordered, *remaining_ordered]
     if ordered[0] != "agent-coordinator":
         return ["agent-coordinator", *ordered]
     return ordered

--- a/scripts/orchestration/qoder_dispatch_bridge.py
+++ b/scripts/orchestration/qoder_dispatch_bridge.py
@@ -494,6 +494,35 @@ def _json_packet_has_requested_order(packet_path: Path) -> bool:
     return any(str(agent).strip() for agent in requested_agents)
 
 
+def _json_payload_requested_order_preserves_mandatory_tail(payload: Dict[str, Any]) -> bool:
+    """Return whether requested_agents explicitly keeps QA before bug-hunter."""
+
+    requested_agents = payload.get("requested_agents")
+    if not isinstance(requested_agents, list):
+        return False
+    requested_order = [str(agent).strip() for agent in requested_agents if str(agent).strip()]
+    try:
+        qa_index = requested_order.index("qa-engineer-agent")
+        bug_index = requested_order.index("bug-hunter")
+    except ValueError:
+        return False
+    return qa_index < bug_index
+
+
+def _json_packet_requested_order_preserves_mandatory_tail(packet_path: Path) -> bool:
+    """Return whether a JSON packet can safely override mandatory tail normalization."""
+
+    try:
+        resolved_packet_path = packet_path.resolve(strict=True)
+        resolved_packet_path.relative_to(REPO_ROOT.resolve())
+    except (OSError, RuntimeError, ValueError):
+        return False
+    payload = _load_json_packet(resolved_packet_path)
+    if payload is None:
+        return False
+    return _json_payload_requested_order_preserves_mandatory_tail(payload)
+
+
 def _parse_packet_roles(packet_path: Path) -> List[str]:
     """Extract ordered role slugs from a governance packet.
 
@@ -940,7 +969,9 @@ def main(argv: Optional[List[str]] = None) -> int:
         packet_path = Path(args.packet)
         if not packet_path.is_absolute():
             packet_path = (REPO_ROOT / packet_path).resolve()
-        enforce_mandatory_post_open_tail = not _json_packet_has_requested_order(packet_path)
+        enforce_mandatory_post_open_tail = not (
+            _json_packet_requested_order_preserves_mandatory_tail(packet_path)
+        )
         role_slugs = _parse_packet_roles(packet_path)
         # Extract bracket-notation parallelizable groups from packet
         packet_lines = packet_path.read_text(encoding="utf-8").splitlines()

--- a/scripts/orchestration/qoder_dispatch_bridge.py
+++ b/scripts/orchestration/qoder_dispatch_bridge.py
@@ -454,9 +454,16 @@ def _parse_json_packet_roles(payload: Dict[str, Any]) -> List[str]:
                     remaining_ordered.append(slug)
                     remaining_counts[slug] -= 1
             ordered = [*requested_ordered, *remaining_ordered]
-    if ordered[0] != "agent-coordinator":
-        return ["agent-coordinator", *ordered]
-    return ordered
+    if ordered[0] == "agent-coordinator":
+        return ordered
+    if "agent-coordinator" in ordered:
+        coordinator_index = ordered.index("agent-coordinator")
+        return [
+            "agent-coordinator",
+            *ordered[:coordinator_index],
+            *ordered[coordinator_index + 1 :],
+        ]
+    return ["agent-coordinator", *ordered]
 
 
 def _load_json_packet(packet_path: Path) -> Optional[Dict[str, Any]]:
@@ -468,6 +475,23 @@ def _load_json_packet(packet_path: Path) -> Optional[Dict[str, Any]]:
     if not isinstance(payload, dict):
         return None
     return payload
+
+
+def _json_packet_has_requested_order(packet_path: Path) -> bool:
+    """Return whether a JSON packet carries an explicit requested role order."""
+
+    try:
+        resolved_packet_path = packet_path.resolve(strict=True)
+        resolved_packet_path.relative_to(REPO_ROOT.resolve())
+    except (OSError, RuntimeError, ValueError):
+        return False
+    payload = _load_json_packet(resolved_packet_path)
+    if payload is None:
+        return False
+    requested_agents = payload.get("requested_agents")
+    if not isinstance(requested_agents, list):
+        return False
+    return any(str(agent).strip() for agent in requested_agents)
 
 
 def _parse_packet_roles(packet_path: Path) -> List[str]:
@@ -761,6 +785,7 @@ def build_dispatch_manifest(
     packet_source: Optional[str] = None,
     bracket_groups: Optional[List[List[str]]] = None,
     chained_successors: Optional[set[str]] = None,
+    enforce_mandatory_post_open_tail: bool = True,
 ) -> Dict[str, Any]:
     """Build the full JSON dispatch manifest for the given role order."""
     context_map = _parse_context_map()
@@ -771,7 +796,8 @@ def build_dispatch_manifest(
     dispatch_sequence: List[Dict[str, Any]] = []
     missing_agents: List[str] = []
     loaded_agents: List[Tuple[str, Dict[str, Any]]] = []
-    role_slugs = _enforce_mandatory_post_open_order(role_slugs)
+    if enforce_mandatory_post_open_tail:
+        role_slugs = _enforce_mandatory_post_open_order(role_slugs)
 
     for slug in role_slugs:
         agent_def = _load_agent_definition(slug)
@@ -909,10 +935,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     packet_source: Optional[str] = None
     packet_bracket_groups: Optional[List[List[str]]] = None
     packet_chained_successors: Optional[set[str]] = None
+    enforce_mandatory_post_open_tail = True
     if args.packet:
         packet_path = Path(args.packet)
         if not packet_path.is_absolute():
             packet_path = (REPO_ROOT / packet_path).resolve()
+        enforce_mandatory_post_open_tail = not _json_packet_has_requested_order(packet_path)
         role_slugs = _parse_packet_roles(packet_path)
         # Extract bracket-notation parallelizable groups from packet
         packet_lines = packet_path.read_text(encoding="utf-8").splitlines()
@@ -942,6 +970,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         packet_source=packet_source,
         bracket_groups=packet_bracket_groups,
         chained_successors=packet_chained_successors,
+        enforce_mandatory_post_open_tail=enforce_mandatory_post_open_tail,
     )
     if manifest.get("missing_agents"):
         print(

--- a/scripts/orchestration/render_codex_start_prompt.py
+++ b/scripts/orchestration/render_codex_start_prompt.py
@@ -106,7 +106,7 @@ def _packet_role_order(packet: dict[str, Any]) -> list[str]:
     if isinstance(bridge, dict):
         from scripts.orchestration import qoder_dispatch_bridge
 
-        parsed_roles = qoder_dispatch_bridge._parse_json_packet_roles(packet)
+        parsed_roles: list[str] = qoder_dispatch_bridge._parse_json_packet_roles(packet)
         if parsed_roles:
             return parsed_roles
     role_order: list[str] = []

--- a/scripts/orchestration/render_codex_start_prompt.py
+++ b/scripts/orchestration/render_codex_start_prompt.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import sys
 from pathlib import Path
 from typing import Any, Iterable
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 DEFAULT_PR_REVIEW_CHECKLIST = (
     "agent-coordinator",
     "architecture-specialist",
@@ -32,6 +35,12 @@ EXPERIMENT_RUNNER_ENV_GUIDANCE = (
     "non-trivial lane cannot load or write the runner artifact because the "
     "environment misses FastAPI/runtime deps, artifact load/write failures are "
     "infra blockers, not `Not applicable`."
+)
+ROLE_DISPATCH_GUIDANCE = (
+    "Role-agent dispatch is a required post-bootstrap step: generate the "
+    "`qoder_dispatch_bridge.py --packet <packet> --pretty` manifest, then run "
+    "each `dispatch_sequence` role in order. Do not treat task_bootstrap.py "
+    "packet creation as role-agent execution."
 )
 
 
@@ -82,12 +91,24 @@ def _prompt_text(value: object, fallback: str = "") -> str:
     return text.replace("\\", "\\\\").replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t")
 
 
+def _shell_quote(value: object, fallback: str = "") -> str:
+    """Render user/packet data safely for copy-paste shell commands."""
+
+    return shlex.quote(str(value if value not in (None, "") else fallback))
+
+
 def _prompt_list(items: list[str], fallback: str) -> str:
     return ", ".join(_prompt_text(item) for item in items) if items else fallback
 
 
 def _packet_role_order(packet: dict[str, Any]) -> list[str]:
     bridge = packet.get("native_subagent_bridge")
+    if isinstance(bridge, dict):
+        from scripts.orchestration import qoder_dispatch_bridge
+
+        parsed_roles = qoder_dispatch_bridge._parse_json_packet_roles(packet)
+        if parsed_roles:
+            return parsed_roles
     role_order: list[str] = []
     if isinstance(bridge, dict):
         primary = bridge.get("primary")
@@ -111,13 +132,30 @@ def _packet_role_order(packet: dict[str, Any]) -> list[str]:
     return _unique(["agent-coordinator", *role_order])
 
 
-def _packet_advisory_roles(packet: dict[str, Any]) -> list[str]:
+def _advisory_binding_is_executable(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    slug = str(value.get("repo_agent_slug", "")).strip()
+    if not slug:
+        return False
+    dispatch_contract = value.get("dispatch_contract")
+    if not isinstance(dispatch_contract, dict):
+        return False
+    return not (
+        dispatch_contract.get("advisory_only")
+        or dispatch_contract.get("spawn_with_native_subagent") is False
+    )
+
+
+def _packet_advisory_roles(packet: dict[str, Any], *, executable: bool) -> list[str]:
     bridge = packet.get("native_subagent_bridge")
     advisory_roles: list[str] = []
     if isinstance(bridge, dict):
         for advisory in bridge.get("advisory") or []:
             if isinstance(advisory, dict):
-                advisory_roles.extend(_as_string_list([advisory.get("repo_agent_slug")]))
+                is_executable = _advisory_binding_is_executable(advisory)
+                if executable == is_executable:
+                    advisory_roles.extend(_as_string_list([advisory.get("repo_agent_slug")]))
     return _unique(advisory_roles)
 
 
@@ -146,8 +184,18 @@ def render_packet_prompt(
     pr_phase = str(packet.get("pr_phase") or "none")
     candidate_paths = _as_string_list(packet.get("candidate_paths"))
     role_order = _packet_role_order(packet)
-    advisory_roles = _packet_advisory_roles(packet)
+    executable_advisory_roles = _packet_advisory_roles(packet, executable=True)
+    closure_only_advisory_roles = _packet_advisory_roles(packet, executable=False)
     recommended_skills = _as_string_list(packet.get("recommended_skills"))
+    role_dispatch_contract = packet.get("role_agent_dispatch_contract")
+    if not isinstance(role_dispatch_contract, dict):
+        role_dispatch_contract = {}
+    packet_creation_executes_roles = str(
+        role_dispatch_contract.get("packet_creation_executes_roles", False)
+    ).lower()
+    role_agent_dispatch_required = str(
+        role_dispatch_contract.get("role_agent_dispatch_required", True)
+    ).lower()
 
     lines = _common_prompt_lines(
         mode_note=(
@@ -166,13 +214,17 @@ def render_packet_prompt(
             f"Path scope: {_prompt_list(candidate_paths, '<no explicit paths>')}",
             f"Role order: {_prompt_list(role_order, 'agent-coordinator')}",
             f"Default PR review checklist: {_prompt_list(list(DEFAULT_PR_REVIEW_CHECKLIST), 'agent-coordinator')}",
-            f"Advisory/no-spawn roles still require closure input: {_prompt_list(advisory_roles, '<none>')}",
+            f"Executable advisory role passes: {_prompt_list(executable_advisory_roles, '<none>')}",
+            f"Closure-only/no-spawn advisory roles still require disposition input: {_prompt_list(closure_only_advisory_roles, '<none>')}",
             f"Passive skills from packet: {_prompt_list(recommended_skills, '<none>')}",
             "",
             "Open the PR non-draft by default so GitHub, CodeRabbit, Cubic, Sourcery, and current-head checks can run; draft requires an explicit operator exception.",
             "Skills are passive/discovery-only; they do not replace agent-coordinator, task_bootstrap.py, review governance, or merge-readiness gates.",
             "Host/Codex preflight is not authoritative lane provenance. Repo custom orchestration remains: check_preflight.py -> task_bootstrap.py -> agent-coordinator.",
             "Experiment Runner joins after coordinator bootstrap as oracle-only evidence; it must not replace agent-coordinator or become the lane-start authority.",
+            f"Packet role dispatch contract: packet_creation_executes_roles={packet_creation_executes_roles}; role_agent_dispatch_required={role_agent_dispatch_required}.",
+            f"Next role-agent dispatch command: $VENV_PYTHON scripts/orchestration/qoder_dispatch_bridge.py --packet {_shell_quote(packet_path)} --pretty",
+            ROLE_DISPATCH_GUIDANCE,
             "Experiment Runner evidence: for every non-trivial PR, create oracle-only evidence by default and record `## Experiment Runner Evidence` as `Artifact: artifacts/orchestration/experiments/results/<id>.json`; use `Not applicable: <reason>` only when the runner result is genuinely unused or inapplicable.",
             "Lane start provenance: record `## Lane Start Provenance` with `Packet: artifacts/orchestration/task_packets/<id>.json` or a narrow documented cleanup/emergency `Exception: <reason>`; `Starter: scripts/orchestration/start_pr_lane.sh` is supplemental and cannot be used alone.",
             "Premortem closure rule: every premortem finding must be fixed in code/docs/tests or formally dispositioned as NOT-A-BUG/DEFERRED with evidence/backlog. No finding may be ignored as advisory.",
@@ -224,6 +276,8 @@ def render_recipe_prompt(
             "Open the PR non-draft by default so bot review and current-head checks run; draft requires an explicit operator exception.",
             "Skills are passive/discovery-only; they do not replace agent-coordinator, task_bootstrap.py, review governance, or merge-readiness gates.",
             "Host/Codex preflight is not authoritative lane provenance. Repo custom orchestration remains: check_preflight.py -> task_bootstrap.py -> agent-coordinator.",
+            "After task_bootstrap.py returns a packet, run `$VENV_PYTHON scripts/orchestration/qoder_dispatch_bridge.py --packet <packet> --pretty` and execute the manifest `dispatch_sequence` in order.",
+            ROLE_DISPATCH_GUIDANCE,
             "After coordinator bootstrap, create oracle-only Experiment Runner evidence by default for non-trivial PRs; the runner joins the lane and must not replace agent-coordinator.",
             "Record `## Experiment Runner Evidence` as `Artifact: artifacts/orchestration/experiments/results/<id>.json`; use `Not applicable: <reason>` only when the runner result is genuinely unused or inapplicable.",
             "Record `## Lane Start Provenance` with `Packet: artifacts/orchestration/task_packets/<id>.json` or a narrow documented cleanup/emergency `Exception: <reason>`; `Starter: scripts/orchestration/start_pr_lane.sh` is supplemental and cannot be used alone.",

--- a/scripts/orchestration/render_codex_start_prompt.py
+++ b/scripts/orchestration/render_codex_start_prompt.py
@@ -108,6 +108,12 @@ def _packet_role_order(packet: dict[str, Any]) -> list[str]:
 
         parsed_roles: list[str] = qoder_dispatch_bridge._parse_json_packet_roles(packet)
         if parsed_roles:
+            if not qoder_dispatch_bridge._json_payload_requested_order_preserves_mandatory_tail(
+                packet
+            ):
+                parsed_roles = qoder_dispatch_bridge._enforce_mandatory_post_open_order(
+                    parsed_roles
+                )
             return parsed_roles
     role_order: list[str] = []
     if isinstance(bridge, dict):

--- a/scripts/orchestration/start_pr_lane.sh
+++ b/scripts/orchestration/start_pr_lane.sh
@@ -421,11 +421,13 @@ PY
         --packet "${BOOTSTRAP_PACKET_PATH}" \
         --branch "${BRANCH}" \
         --worktree "${WORKTREE_REL}"
-)
 
-echo ""
-echo "Next steps:"
-echo "  1. cd ${WORKTREE_REL}"
-echo "  2. Follow the generated task packet before implementation."
-echo "  3. Create Experiment Runner oracle-only evidence after coordinator bootstrap when the lane is non-trivial."
-echo "  4. Open the PR non-draft after local validation and initial PR body/mapping are ready."
+    echo ""
+    echo "Next steps:"
+    echo "  1. cd ${WORKTREE_REL}"
+    echo "  2. Generate the role-agent dispatch manifest:"
+    printf "     %q scripts/orchestration/qoder_dispatch_bridge.py --packet %q --pretty\n" "${REPO_PYTHON}" "${BOOTSTRAP_PACKET_PATH}"
+    echo "  3. Run the dispatch_sequence roles in order before implementation."
+    echo "  4. Create Experiment Runner oracle-only evidence after coordinator bootstrap when the lane is non-trivial."
+    echo "  5. Open the PR non-draft after local validation and initial PR body/mapping are ready."
+)

--- a/scripts/orchestration/task_bootstrap.py
+++ b/scripts/orchestration/task_bootstrap.py
@@ -106,6 +106,7 @@ NATIVE_BRIDGE_TRANSPORTS: tuple[str, ...] = (*BRIDGE_TRANSPORTS,)
 POST_OPEN_REVIEW_LANE: tuple[str, ...] = ("qa-engineer-agent", "bug-hunter")
 PR_REVIEW_ARTIFACT_TEMPLATE = "docs/review/PR_<N>_FIXED_MAPPING.md"
 MERGE_READINESS_ENTRYPOINT = "scripts/orchestration/check_merge_ready.py"
+ROLE_DISPATCH_MANIFEST_ENTRYPOINT = "scripts/orchestration/qoder_dispatch_bridge.py"
 MESSAGE_ENVELOPE_PROTOCOL_VERSION = "1.0"
 MESSAGE_ENVELOPE_DERIVED_VIEW = "TASK_PACKET_V1"
 ENVELOPE_ONLY_RESULT_REQUIREMENT = "AGENT_RESULT_V1 envelope only (no preamble)"
@@ -355,6 +356,20 @@ def _build_pr_lifecycle_contract(pr_phase: str) -> dict[str, Any]:
         "merge_readiness_entrypoint": (
             MERGE_READINESS_ENTRYPOINT if pr_phase == PR_PHASE_MERGE_READY else ""
         ),
+    }
+
+
+def _build_role_agent_dispatch_contract() -> dict[str, Any]:
+    """Return deterministic metadata for the post-bootstrap role dispatch step."""
+
+    return {
+        "packet_creation_executes_roles": False,
+        "role_agent_dispatch_required": True,
+        "dispatch_manifest_entrypoint": ROLE_DISPATCH_MANIFEST_ENTRYPOINT,
+        "dispatch_manifest_command": (
+            f"{ROLE_DISPATCH_MANIFEST_ENTRYPOINT} --packet <packet> --pretty"
+        ),
+        "must_execute_dispatch_sequence_in_order": True,
     }
 
 
@@ -976,6 +991,7 @@ def build_task_packet(
             "pr_lifecycle_enabled": normalized_pr_phase != PR_PHASE_NONE,
             "design_lane_enabled": design_lane_enabled,
         },
+        "role_agent_dispatch_contract": _build_role_agent_dispatch_contract(),
         "pr_phase": normalized_pr_phase,
         "pr_lifecycle_contract": pr_lifecycle_contract,
         "design_lane_mode": design_lane_mode,
@@ -1115,6 +1131,9 @@ def main(argv: list[str] | None = None) -> int:
         output_ref = str(out_path.relative_to(REPO_ROOT))
     except ValueError:
         output_ref = str(out_path)
+    role_dispatch_contract = packet.get("role_agent_dispatch_contract")
+    if not isinstance(role_dispatch_contract, dict):
+        role_dispatch_contract = _build_role_agent_dispatch_contract()
     print(
         json.dumps(
             {
@@ -1130,6 +1149,15 @@ def main(argv: list[str] | None = None) -> int:
                 ],
                 "reviewer_native_agent_type": packet["native_subagent_bridge"]["reviewer"][
                     "native_agent_type"
+                ],
+                "packet_creation_executes_roles": role_dispatch_contract[
+                    "packet_creation_executes_roles"
+                ],
+                "role_agent_dispatch_required": role_dispatch_contract[
+                    "role_agent_dispatch_required"
+                ],
+                "dispatch_manifest_entrypoint": role_dispatch_contract[
+                    "dispatch_manifest_entrypoint"
                 ],
                 "output": output_ref,
             },

--- a/tests/test_local_session_bootstrap.py
+++ b/tests/test_local_session_bootstrap.py
@@ -87,6 +87,9 @@ def test_local_session_bootstrap_prints_exact_selected_bootstrap_command(
     assert "Path scope: scripts/orchestration/local_session_bootstrap.sh" in result.stdout
     assert "Requested role order seed: agent-coordinator, qa-engineer-agent" in result.stdout
     assert "Skills are passive/discovery-only" in result.stdout
+    assert "After task_bootstrap.py returns a packet, run `$VENV_PYTHON" in result.stdout
+    assert "qoder_dispatch_bridge.py --packet <packet> --pretty" in result.stdout
+    assert "execute the manifest `dispatch_sequence` in order" in result.stdout
     assert "Premortem closure rule: every premortem finding must be fixed" in result.stdout
     assert "No finding may be ignored as advisory." in result.stdout
     assert "VENV_PYTHON" in result.stdout

--- a/tests/test_qoder_dispatch_bridge.py
+++ b/tests/test_qoder_dispatch_bridge.py
@@ -145,7 +145,7 @@ def test_parse_task_bootstrap_json_packet_places_reviewer_tail(
 def test_parse_task_bootstrap_json_packet_preserves_repeated_roles(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """JSON packets may intentionally reuse a role in distinct positions."""
+    """JSON packets may intentionally reuse the same role in distinct positions."""
     monkeypatch.setattr(qoder_dispatch_bridge, "REPO_ROOT", tmp_path)
     packet = {
         "native_subagent_bridge": {
@@ -168,7 +168,7 @@ def test_parse_task_bootstrap_json_packet_preserves_repeated_roles(
 def test_parse_task_bootstrap_json_packet_preserves_adjacent_repeated_roles(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Adjacent duplicate JSON bindings still represent distinct packet slots."""
+    """Adjacent duplicate JSON bindings represent distinct packet slots."""
     monkeypatch.setattr(qoder_dispatch_bridge, "REPO_ROOT", tmp_path)
     packet = {
         "native_subagent_bridge": {
@@ -328,6 +328,71 @@ def test_parse_task_bootstrap_json_packet_preserves_requested_role_order(
         "security-auditor",
         "qa-engineer-agent",
         "bug-hunter",
+        "cursor-specialist-agent",
+    ]
+
+
+def test_manifest_preserves_requested_order_from_json_packet(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit requested order must survive final dispatch manifest generation."""
+    monkeypatch.setattr(qoder_dispatch_bridge, "REPO_ROOT", tmp_path)
+    required_slugs = [
+        "agent-coordinator",
+        "architecture-specialist",
+        "security-auditor",
+        "qa-engineer-agent",
+        "bug-hunter",
+        "cursor-specialist-agent",
+    ]
+    tmp_agents_dir = tmp_path / ".cursor" / "agents"
+    tmp_agents_dir.mkdir(parents=True)
+    for slug in required_slugs:
+        qoder_type = "Verify" if slug in {"qa-engineer-agent", "bug-hunter"} else "Research"
+        (tmp_agents_dir / f"{slug}.md").write_text(
+            f"---\nslug: {slug}\nqoder_type: {qoder_type}\n---\n# {slug}\n",
+            encoding="utf-8",
+        )
+    packet = {
+        "requested_agents": [
+            "agent-coordinator",
+            "architecture-specialist",
+            "security-auditor",
+            "qa-engineer-agent",
+            "bug-hunter",
+        ],
+        "native_subagent_bridge": {
+            "primary": {"repo_agent_slug": "agent-coordinator"},
+            "secondary": [
+                {"repo_agent_slug": "bug-hunter"},
+                {"repo_agent_slug": "cursor-specialist-agent"},
+                {"repo_agent_slug": "security-auditor"},
+                {"repo_agent_slug": "architecture-specialist"},
+            ],
+            "reviewer": {"repo_agent_slug": "qa-engineer-agent"},
+            "advisory": [],
+        },
+    }
+    packet_path = tmp_path / "packet.json"
+    packet_path.write_text(json.dumps(packet), encoding="utf-8")
+
+    roles = qoder_dispatch_bridge._parse_packet_roles(packet_path)
+    manifest = qoder_dispatch_bridge.build_dispatch_manifest(
+        role_slugs=roles,
+        mode="analysis",
+        packet_source="packet.json",
+        enforce_mandatory_post_open_tail=not qoder_dispatch_bridge._json_packet_has_requested_order(
+            packet_path
+        ),
+    )
+
+    assert [entry["role_slug"] for entry in manifest["dispatch_sequence"]] == [
+        "agent-coordinator",
+        "architecture-specialist",
+        "security-auditor",
+        "qa-engineer-agent",
+        "bug-hunter",
+        "cursor-specialist-agent",
     ]
 
 
@@ -357,8 +422,6 @@ def test_parse_task_bootstrap_json_packet_limits_duplicate_requested_roles_to_sp
     ]
 
 
-
-
 def test_parse_task_bootstrap_json_packet_requested_roles_keep_required_non_requested_roles(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -385,6 +448,7 @@ def test_parse_task_bootstrap_json_packet_requested_roles_keep_required_non_requ
         "security-auditor",
         "architecture-specialist",
     ]
+
 
 def test_parse_task_bootstrap_json_packet_empty_bridge_returns_no_roles(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_qoder_dispatch_bridge.py
+++ b/tests/test_qoder_dispatch_bridge.py
@@ -381,8 +381,8 @@ def test_manifest_preserves_requested_order_from_json_packet(
         role_slugs=roles,
         mode="analysis",
         packet_source="packet.json",
-        enforce_mandatory_post_open_tail=not qoder_dispatch_bridge._json_packet_has_requested_order(
-            packet_path
+        enforce_mandatory_post_open_tail=not (
+            qoder_dispatch_bridge._json_packet_requested_order_preserves_mandatory_tail(packet_path)
         ),
     )
 
@@ -393,6 +393,61 @@ def test_manifest_preserves_requested_order_from_json_packet(
         "qa-engineer-agent",
         "bug-hunter",
         "cursor-specialist-agent",
+    ]
+
+
+def test_manifest_enforces_mandatory_tail_for_partial_requested_order_from_json_packet(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Partial requested order must not disable the canonical QA -> bug tail."""
+    monkeypatch.setattr(qoder_dispatch_bridge, "REPO_ROOT", tmp_path)
+    required_slugs = [
+        "agent-coordinator",
+        "frontend-engineer",
+        "security-auditor",
+        "qa-engineer-agent",
+        "bug-hunter",
+    ]
+    tmp_agents_dir = tmp_path / ".cursor" / "agents"
+    tmp_agents_dir.mkdir(parents=True)
+    for slug in required_slugs:
+        qoder_type = "Verify" if slug in {"qa-engineer-agent", "bug-hunter"} else "Research"
+        (tmp_agents_dir / f"{slug}.md").write_text(
+            f"---\nslug: {slug}\nqoder_type: {qoder_type}\n---\n# {slug}\n",
+            encoding="utf-8",
+        )
+    packet = {
+        "requested_agents": ["frontend-engineer"],
+        "native_subagent_bridge": {
+            "primary": {"repo_agent_slug": "agent-coordinator"},
+            "secondary": [
+                {"repo_agent_slug": "bug-hunter"},
+                {"repo_agent_slug": "frontend-engineer"},
+                {"repo_agent_slug": "security-auditor"},
+            ],
+            "reviewer": {"repo_agent_slug": "qa-engineer-agent"},
+            "advisory": [],
+        },
+    }
+    packet_path = tmp_path / "packet.json"
+    packet_path.write_text(json.dumps(packet), encoding="utf-8")
+
+    roles = qoder_dispatch_bridge._parse_packet_roles(packet_path)
+    manifest = qoder_dispatch_bridge.build_dispatch_manifest(
+        role_slugs=roles,
+        mode="analysis",
+        packet_source="packet.json",
+        enforce_mandatory_post_open_tail=not (
+            qoder_dispatch_bridge._json_packet_requested_order_preserves_mandatory_tail(packet_path)
+        ),
+    )
+
+    assert [entry["role_slug"] for entry in manifest["dispatch_sequence"]] == [
+        "agent-coordinator",
+        "frontend-engineer",
+        "security-auditor",
+        "qa-engineer-agent",
+        "bug-hunter",
     ]
 
 

--- a/tests/test_qoder_dispatch_bridge.py
+++ b/tests/test_qoder_dispatch_bridge.py
@@ -331,10 +331,10 @@ def test_parse_task_bootstrap_json_packet_preserves_requested_role_order(
     ]
 
 
-def test_parse_task_bootstrap_json_packet_preserves_duplicate_requested_roles(
+def test_parse_task_bootstrap_json_packet_limits_duplicate_requested_roles_to_spawnable_slots(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Repeated requested agents represent intentional repeated role passes."""
+    """Requested duplicates must not synthesize extra passes beyond bridge slots."""
     monkeypatch.setattr(qoder_dispatch_bridge, "REPO_ROOT", tmp_path)
     packet = {
         "requested_agents": [
@@ -354,9 +354,37 @@ def test_parse_task_bootstrap_json_packet_preserves_duplicate_requested_roles(
     assert qoder_dispatch_bridge._parse_packet_roles(packet_path) == [
         "agent-coordinator",
         "security-auditor",
-        "agent-coordinator",
     ]
 
+
+
+
+def test_parse_task_bootstrap_json_packet_requested_roles_keep_required_non_requested_roles(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Requested role ordering must not drop required bridge roles."""
+    monkeypatch.setattr(qoder_dispatch_bridge, "REPO_ROOT", tmp_path)
+    packet = {
+        "requested_agents": ["frontend-engineer"],
+        "native_subagent_bridge": {
+            "primary": {"repo_agent_slug": "agent-coordinator"},
+            "secondary": [
+                {"repo_agent_slug": "frontend-engineer"},
+                {"repo_agent_slug": "security-auditor"},
+            ],
+            "reviewer": {"repo_agent_slug": "architecture-specialist"},
+            "advisory": [],
+        },
+    }
+    packet_path = tmp_path / "packet.json"
+    packet_path.write_text(json.dumps(packet), encoding="utf-8")
+
+    assert qoder_dispatch_bridge._parse_packet_roles(packet_path) == [
+        "agent-coordinator",
+        "frontend-engineer",
+        "security-auditor",
+        "architecture-specialist",
+    ]
 
 def test_parse_task_bootstrap_json_packet_empty_bridge_returns_no_roles(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_render_codex_start_prompt.py
+++ b/tests/test_render_codex_start_prompt.py
@@ -147,6 +147,29 @@ def test_packet_prompt_renders_manifest_dispatch_order_for_executable_advisory_r
     )
 
 
+def test_packet_prompt_enforces_mandatory_tail_for_partial_requested_order() -> None:
+    """Prompt order must match manifest tail enforcement for partial requests."""
+
+    packet = _packet()
+    packet["requested_agents"] = ["security-auditor"]
+    packet["native_subagent_bridge"] = {
+        "primary": {"repo_agent_slug": "agent-coordinator"},
+        "reviewer": {"repo_agent_slug": "qa-engineer-agent"},
+        "secondary": [
+            {"repo_agent_slug": "bug-hunter"},
+            {"repo_agent_slug": "security-auditor"},
+        ],
+        "advisory": [],
+    }
+
+    prompt = render_packet_prompt(packet, packet_path="packet.json")
+
+    assert (
+        "Role order: agent-coordinator, security-auditor, qa-engineer-agent, bug-hunter" in prompt
+    )
+    assert "Role order: agent-coordinator, security-auditor, bug-hunter" not in prompt
+
+
 def test_packet_prompt_contains_coordinator_stop_marker_and_closure_contract() -> None:
     """Packet mode should render the copy-paste guardrails Codex needs."""
 

--- a/tests/test_render_codex_start_prompt.py
+++ b/tests/test_render_codex_start_prompt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 from pathlib import Path
 
 import pytest
@@ -55,7 +56,10 @@ def test_packet_prompt_forces_agent_coordinator_first_when_packet_primary_differ
     prompt = render_packet_prompt(packet, packet_path="packet.json")
 
     assert "Start with agent-coordinator as the mandatory first role." in prompt
-    assert "Role order: agent-coordinator, backend-engineer, qa-engineer-agent" in prompt
+    assert (
+        "Role order: agent-coordinator, backend-engineer, security-auditor, qa-engineer-agent"
+        in prompt
+    )
 
 
 def test_packet_prompt_fallback_role_order_without_bridge() -> None:
@@ -108,7 +112,39 @@ def test_packet_prompt_tolerates_null_native_bridge_role_lists() -> None:
     prompt = render_packet_prompt(packet, packet_path="packet.json")
 
     assert "Role order: agent-coordinator, backend-engineer, qa-engineer-agent" in prompt
-    assert "Advisory/no-spawn roles still require closure input: <none>" in prompt
+    assert "Executable advisory role passes: <none>" in prompt
+    assert "Closure-only/no-spawn advisory roles still require disposition input: <none>" in prompt
+
+
+def test_packet_prompt_renders_manifest_dispatch_order_for_executable_advisory_roles() -> None:
+    """Prompt role order must match qoder dispatch bridge ordering semantics."""
+
+    packet = _packet()
+    packet["native_subagent_bridge"] = {
+        "primary": {"repo_agent_slug": "agent-coordinator"},
+        "reviewer": {"repo_agent_slug": "architecture-specialist"},
+        "secondary": [],
+        "advisory": [
+            {
+                "repo_agent_slug": "ml-engineer-agent",
+                "dispatch_contract": {
+                    "advisory_only": False,
+                    "spawn_with_native_subagent": True,
+                    "required_role_pass": True,
+                },
+            },
+            {"repo_agent_slug": "qa-engineer-agent"},
+        ],
+    }
+
+    prompt = render_packet_prompt(packet, packet_path="packet.json")
+
+    assert "Role order: agent-coordinator, ml-engineer-agent, architecture-specialist" in prompt
+    assert "Executable advisory role passes: ml-engineer-agent" in prompt
+    assert (
+        "Closure-only/no-spawn advisory roles still require disposition input: qa-engineer-agent"
+        in prompt
+    )
 
 
 def test_packet_prompt_contains_coordinator_stop_marker_and_closure_contract() -> None:
@@ -130,19 +166,28 @@ def test_packet_prompt_contains_coordinator_stop_marker_and_closure_contract() -
     assert "Branch: codex/fix-codex-coordinator-start-bridge" in prompt
     assert "Worktree: worktrees/fix-codex-coordinator-start-bridge" in prompt
     assert "scripts/orchestration/start_pr_lane.sh" in prompt
+    assert ("Role order: agent-coordinator, security-auditor, architecture-specialist") in prompt
+    assert "Executable advisory role passes: <none>" in prompt
     assert (
-        "Role order: agent-coordinator, architecture-specialist, security-auditor, "
-        "qa-engineer-agent, bug-hunter"
-    ) in prompt
-    assert (
-        "Advisory/no-spawn roles still require closure input: qa-engineer-agent, bug-hunter"
-        in prompt
+        "Closure-only/no-spawn advisory roles still require disposition input: "
+        "qa-engineer-agent, bug-hunter" in prompt
     )
     assert "Skills are passive/discovery-only" in prompt
     assert "Host/Codex preflight is not authoritative lane provenance" in prompt
     assert "check_preflight.py -> task_bootstrap.py -> agent-coordinator" in prompt
     assert "Experiment Runner joins after coordinator bootstrap" in prompt
     assert "must not replace agent-coordinator" in prompt
+    assert (
+        "Packet role dispatch contract: packet_creation_executes_roles=false; "
+        "role_agent_dispatch_required=true."
+    ) in prompt
+    assert (
+        "Next role-agent dispatch command: $VENV_PYTHON "
+        "scripts/orchestration/qoder_dispatch_bridge.py --packet "
+        "artifacts/orchestration/task_packets/demo.json --pretty"
+    ) in prompt
+    assert "Role-agent dispatch is a required post-bootstrap step" in prompt
+    assert "Do not treat task_bootstrap.py packet creation as role-agent execution." in prompt
     assert "for every non-trivial PR, create oracle-only evidence by default" in prompt
     assert "Artifact: artifacts/orchestration/experiments/results/<id>.json" in prompt
     assert "Not applicable: <reason>" in prompt
@@ -165,6 +210,19 @@ def test_packet_prompt_contains_coordinator_stop_marker_and_closure_contract() -
     assert "auto-start" not in prompt.lower()
 
 
+def test_packet_prompt_shell_quotes_dispatch_packet_path() -> None:
+    """The rendered dispatch command must be safe to copy for shell paths."""
+
+    packet_path = "artifacts/orchestration/task packets/demo's.json"
+
+    prompt = render_packet_prompt(_packet(), packet_path=packet_path)
+
+    assert (
+        "$VENV_PYTHON scripts/orchestration/qoder_dispatch_bridge.py --packet "
+        f"{shlex.quote(packet_path)} --pretty"
+    ) in prompt
+
+
 def test_recipe_prompt_says_authoritative_bootstrap_has_not_run() -> None:
     """The local helper prompt must not masquerade as task_bootstrap output."""
 
@@ -185,6 +243,11 @@ def test_recipe_prompt_says_authoritative_bootstrap_has_not_run() -> None:
     assert "Requested role order seed: agent-coordinator, qa-engineer-agent" in prompt
     assert "Next required repo command: run task_bootstrap.py" in prompt
     assert "Host/Codex preflight is not authoritative lane provenance" in prompt
+    assert "After task_bootstrap.py returns a packet, run `$VENV_PYTHON" in prompt
+    assert "qoder_dispatch_bridge.py --packet <packet> --pretty" in prompt
+    assert "execute the manifest `dispatch_sequence` in order" in prompt
+    assert "Role-agent dispatch is a required post-bootstrap step" in prompt
+    assert "Do not treat task_bootstrap.py packet creation as role-agent execution." in prompt
     assert "After coordinator bootstrap, create oracle-only Experiment Runner evidence" in prompt
     assert "runner joins the lane and must not replace agent-coordinator" in prompt
     assert "Artifact: artifacts/orchestration/experiments/results/<id>.json" in prompt

--- a/tests/test_start_pr_lane.py
+++ b/tests/test_start_pr_lane.py
@@ -151,6 +151,9 @@ def test_start_pr_lane_dry_run_prints_stable_commands_and_plugins() -> None:
     assert "Experiment Runner: joins after coordinator bootstrap as oracle-only evidence." in (
         result.stdout
     )
+    assert "qoder_dispatch_bridge.py --packet <packet> --pretty" in result.stdout
+    assert "execute the manifest `dispatch_sequence` in order" in result.stdout
+    assert "Role-agent dispatch is a required post-bootstrap step" in result.stdout
     assert "After coordinator bootstrap, create oracle-only Experiment Runner evidence" in (
         result.stdout
     )
@@ -171,7 +174,7 @@ def test_start_pr_lane_execute_path_prints_packet_prompt(tmp_path: Path) -> None
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    packet_path = tmp_path / "packet.json"
+    packet_path = tmp_path / "packet with space.json"
     packet_payload = {
         "goal": "Start governed PR lane",
         "task_class": "pr_governance",
@@ -259,7 +262,15 @@ esac
     assert result.returncode == 0, result.stderr
     assert "Authoritative bootstrap already ran" in result.stdout
     assert f"Task packet: {packet_path}" in result.stdout
-    assert "Role order: agent-coordinator, backend-engineer, qa-engineer-agent" in result.stdout
+    assert "packet_creation_executes_roles=false" in result.stdout
+    assert "role_agent_dispatch_required=true" in result.stdout
+    assert "qoder_dispatch_bridge.py --packet" in result.stdout
+    assert "packet\\ with\\ space.json" in result.stdout
+    assert "Run the dispatch_sequence roles in order before implementation." in result.stdout
+    assert (
+        "Role order: agent-coordinator, backend-engineer, security-auditor, qa-engineer-agent"
+        in result.stdout
+    )
     assert "Passive skills from packet: pulseplate-premortem-risk-review" in result.stdout
     assert "VENV_PYTHON" in result.stdout
     assert "$VENV_PYTHON -m pytest" in result.stdout

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -119,6 +119,15 @@ def test_task_bootstrap_adds_automation_metadata_defaults() -> None:
         "current_head_truth": "not-applicable",
         "merge_readiness_entrypoint": "",
     }
+    assert packet["role_agent_dispatch_contract"] == {
+        "packet_creation_executes_roles": False,
+        "role_agent_dispatch_required": True,
+        "dispatch_manifest_entrypoint": "scripts/orchestration/qoder_dispatch_bridge.py",
+        "dispatch_manifest_command": (
+            "scripts/orchestration/qoder_dispatch_bridge.py --packet <packet> --pretty"
+        ),
+        "must_execute_dispatch_sequence_in_order": True,
+    }
     assert packet["design_lane_mode"] == "disabled"
     assert packet["design_lane_contract"] == {
         "design_source": "",
@@ -1465,8 +1474,15 @@ def test_main_writes_relative_output_inside_repo(monkeypatch, capsys) -> None:
         assert written["decision_contract"]["claim_taxonomy"] == list(CLAIM_TYPES)
         assert written["result_adjudication"]["support_statuses"] == list(SUPPORT_STATUSES)
         assert written["result_adjudication"]["evidence_modes"] == list(EVIDENCE_MODES)
-        assert json.loads(captured.out)["output"] == relative_output.as_posix()
-        assert json.loads(captured.out)["primary_native_agent_type"] == "default"
+        stdout_payload = json.loads(captured.out)
+        assert stdout_payload["output"] == relative_output.as_posix()
+        assert stdout_payload["primary_native_agent_type"] == "default"
+        assert stdout_payload["packet_creation_executes_roles"] is False
+        assert stdout_payload["role_agent_dispatch_required"] is True
+        assert (
+            stdout_payload["dispatch_manifest_entrypoint"]
+            == "scripts/orchestration/qoder_dispatch_bridge.py"
+        )
     finally:
         if repo_output.exists():
             repo_output.unlink()


### PR DESCRIPTION
### Motivation
- Close PR #1818 merge-readiness blockers for requested-agent ordering and post-bootstrap role dispatch.
- Prevent a governance false-green where `task_bootstrap.py` creates a packet but role agents are not actually dispatched.

### Description
- Preserves explicit requested role order through both parser and final Qoder dispatch manifest while capping duplicates by available packet slots; partial requests still keep the mandatory `qa-engineer-agent -> bug-hunter` tail.
- Adds `role_agent_dispatch_contract` metadata to task packets: packet creation does not execute roles, and `qoder_dispatch_bridge.py --packet <packet> --pretty` is required before implementation.
- Updates startup prompts and `start_pr_lane.sh` to print the dispatch manifest command and execute `dispatch_sequence` instruction.
- Adds durable agent lessons in root/role instructions and `docs/ENGINEERING_LESSONS.md` so future agents update role instructions/insights when a repeatable workflow failure is found.

### Scope
- Orchestration bridge, bootstrap metadata, startup prompt/lane starter text, focused tests, role instructions, engineering lessons, and `docs/review/PR_1818_FIXED_MAPPING.md`.
- Out of scope: product runtime, OpenAPI, billing, auth, wellness copy, release, and FastAPI runtime behavior.

## Lane Start Provenance
- Preflight: `python3 scripts/orchestration/check_preflight.py` -> PASS.
- Packet: `artifacts/orchestration/task_packets/00e986e4dde3.json`
- Dispatch manifest: `python3 scripts/orchestration/qoder_dispatch_bridge.py --packet artifacts/orchestration/task_packets/00e986e4dde3.json --pretty`.
- Role order used: `agent-coordinator -> architecture-specialist -> security-auditor -> cursor-specialist-agent -> qa-engineer-agent -> bug-hunter`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3294942611 -> 4b81482f4629e540a780e8e161c864b671425565
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3294942613 -> 4b81482f4629e540a780e8e161c864b671425565
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3294942615 -> 4b81482f4629e540a780e8e161c864b671425565
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3295019396 -> daa4cc30f72264be9c27fb447a90a32a011f6c57
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1818#discussion_r3295019397 -> daa4cc30f72264be9c27fb447a90a32a011f6c57

## Experiment Runner Evidence
- Artifact: `artifacts/orchestration/experiments/results/exp-7d9b0476fa50-v2.json`
- Status: accepted; runner mode: `oracle_only_governance_reviewer`; `mutated_paths: []`; `shared_tree_untouched: true`.
- Contribution: oracle review shaped the final dispatch/mapping decision; code commit includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.

## Premortem Risk Fix Matrix
- PM-1818-001 packet creation mistaken for role execution -> FIXED by task packet dispatch contract and prompt/lane-starter command evidence.
- PM-1818-002 parser green but final manifest reorders requested roles -> FIXED by preserving explicit requested order only when JSON `requested_agents` explicitly keeps QA before bug, while partial requested orders retain the mandatory QA -> bug tail.
- PM-1818-003 durable role-agent lesson lost -> FIXED in root/role agent instructions and `docs/ENGINEERING_LESSONS.md`.
- PM-1818-004 unsafe copy-paste packet path -> FIXED by `shlex.quote`, Bash `%q`, and unsafe-path tests.
- PM-1818-005 mapping before code fix -> FIXED by code/test commit `4b81482f4629e540a780e8e161c864b671425565` before mapping commit.

## Validation
- `python3 scripts/orchestration/check_preflight.py --path ...` -> PASS.
- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS.
- `pytest -q tests/test_qoder_dispatch_bridge.py tests/test_task_bootstrap.py tests/test_render_codex_start_prompt.py tests/test_start_pr_lane.py tests/test_local_session_bootstrap.py tests/test_native_subagent_bridge.py` -> PASS.
- `flake8` on changed Python/test files -> PASS.
- `bash -n scripts/orchestration/start_pr_lane.sh scripts/orchestration/local_session_bootstrap.sh` -> PASS.
- `make validate-changed` -> PASS.
- `pre-commit run --all-files` -> PASS after Black reformatted `tests/test_render_codex_start_prompt.py`; rerun passed.
- Post-Codex-review focused gates -> PASS: `.venv` pytest for `tests/test_qoder_dispatch_bridge.py tests/test_render_codex_start_prompt.py`, flake8 on changed bridge/prompt/tests, and `.venv` mypy with `--explicit-package-bases` on changed orchestration modules.
- `pr_review_report.py` after mapping -> no deterministic findings.
- Codex Security diff-scoped scan -> no reportable findings; changed shell rendering is quoted and Bandit/detect-secrets passed.

## Merge Readiness
- [ ] Current-head CI is green with no required pending/failing jobs.
- [ ] Review-thread disposition guard with auth passes after this push.
- [ ] Strict merge-readiness wrapper passes after this push.
- [ ] CodeRabbit, Sourcery, Cubic, and Codex comments are checked and dispositioned.
- [ ] Mandatory wait window elapsed after latest bot/review activity.
- Full local `make verify` deferred under the operator-approved machine-heavy governance exception; PR-scoped local gates above are passing and current-head CI parity is required before merge.

## Risks / Rollback
- Risk: orchestration prompts could drift from manifest semantics. Mitigation: prompt tests now assert dispatch-order and advisory-role split.
- Rollback: revert commits `adada97c6`, `daa4cc30`, `65e38f6b`, `94beced8b`, and `4b81482f4` to restore prior PR state.

## Deferred / Follow-ups
- None.


