### PR TITLE
fix(orchestration): stabilize main role order and hook Python

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,6 +15,13 @@ fi
 # Enhanced pre-commit hook with comprehensive checks
 echo "🔍 Running pre-commit checks..."
 
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# shellcheck source=scripts/hooks/repo_python.sh
+source "$ROOT_DIR/scripts/hooks/repo_python.sh"
+REPO_PYTHON_BIN="$(resolve_repo_python "$ROOT_DIR")"
+export VENV_PYTHON="$REPO_PYTHON_BIN"
+export PATH="$(dirname "$REPO_PYTHON_BIN"):$PATH"
+
 # 1. Clean Python cache files
 echo "🧹 Cleaning cache files..."
 # Use Homebrew bash explicitly to support nameref (requires Bash 4.3+)
@@ -143,7 +150,7 @@ if [ -n "$PYTHON_CHANGES" ]; then
 
     # Auto-format with Black (project standard)
     echo "🎨 Auto-formatting Python code with Black..."
-    if command -v black > /dev/null 2>&1; then
+    if "$REPO_PYTHON_BIN" -m black --version > /dev/null 2>&1; then
         # Filter to only existing files
         EXISTING_PY_FILES=()
         while IFS= read -r f; do
@@ -151,10 +158,10 @@ if [ -n "$PYTHON_CHANGES" ]; then
         done <<< "$PYTHON_CHANGES"
         if [ ${#EXISTING_PY_FILES[@]} -gt 0 ]; then
             # Use --check with --diff to show what will be changed
-            if ! black --check --diff "${EXISTING_PY_FILES[@]}" 2>/dev/null; then
+            if ! "$REPO_PYTHON_BIN" -m black --check --diff "${EXISTING_PY_FILES[@]}" 2>/dev/null; then
                 echo "⚠️  Black would reformat the following files (diff shown above)"
                 # Apply formatting
-                if black "${EXISTING_PY_FILES[@]}"; then
+                if "$REPO_PYTHON_BIN" -m black "${EXISTING_PY_FILES[@]}"; then
                     echo "✅ Black formatting applied. Files re-staged."
                     git add "${EXISTING_PY_FILES[@]}"
                     echo "⚠️  Black reformatted files. Review changes and re-commit."
@@ -167,15 +174,15 @@ if [ -n "$PYTHON_CHANGES" ]; then
             fi
         fi
     else
-        echo "⚠️  Warning: Black not found, skipping auto-formatting"
-        echo "   Install with: pip install black"
+        echo "❌ Black not available through repo Python: $REPO_PYTHON_BIN"
+        exit 1
     fi
 
     # Check Python syntax
     while IFS= read -r file; do
         if [ -f "$file" ]; then
             echo "Checking syntax: $file"
-            if ! python -m py_compile "$file"; then
+            if ! "$REPO_PYTHON_BIN" -m py_compile "$file"; then
                 echo "❌ Python syntax error in $file"
                 exit 1
             fi
@@ -186,7 +193,7 @@ if [ -n "$PYTHON_CHANGES" ]; then
     echo "🧪 Running backend tests for changed files..."
     if [ "${SKIP_TESTS:-0}" = "1" ]; then
         echo "⏩ SKIP_TESTS=1 set, skipping backend tests"
-    elif command -v pytest > /dev/null 2>&1; then
+    elif "$REPO_PYTHON_BIN" -m pytest --version > /dev/null 2>&1; then
         # Extract test files that correspond to changed Python files
         declare -a TEST_FILES=()
         while IFS= read -r file; do
@@ -236,7 +243,7 @@ if [ -n "$PYTHON_CHANGES" ]; then
             # Deduplicate test files to avoid running the same test multiple times
             mapfile -t TEST_FILES < <(printf '%s\n' "${TEST_FILES[@]}" | sort -u)
             echo "Running tests: ${TEST_FILES[*]}"
-            if ! pytest -q "${TEST_FILES[@]}" --tb=short -x; then
+            if ! "$REPO_PYTHON_BIN" -m pytest -q "${TEST_FILES[@]}" --tb=short -x; then
                 echo "❌ Backend tests failed. Please fix failing tests before committing."
                 exit 1
             fi
@@ -245,13 +252,14 @@ if [ -n "$PYTHON_CHANGES" ]; then
             echo "ℹ️  No corresponding test files found for changed Python files"
         fi
     else
-        echo "⚠️  Warning: pytest not found, skipping backend tests"
+        echo "❌ pytest not available through repo Python: $REPO_PYTHON_BIN"
+        exit 1
     fi
 fi
 
 # 5. Run pre-commit framework hooks (MyPy, Bandit, etc.)
 echo "🔧 Running pre-commit framework checks..."
-if command -v pre-commit > /dev/null 2>&1; then
+if "$REPO_PYTHON_BIN" -m pre_commit --version > /dev/null 2>&1; then
     # Temporarily unset hooksPath to prevent recursion
     ORIGINAL_HOOKS_PATH=""
     ORIGINAL_HOOKS_PATH_SET=0
@@ -265,15 +273,16 @@ if command -v pre-commit > /dev/null 2>&1; then
     # Safely handle filenames with spaces by using array
     mapfile -t STAGED_FILES < <(git diff --cached --name-only --diff-filter=ACM)
     if [ ${#STAGED_FILES[@]} -gt 0 ]; then
-        if ! pre-commit run --files "${STAGED_FILES[@]}" 2>&1; then
+        if ! "$REPO_PYTHON_BIN" -m pre_commit run --files "${STAGED_FILES[@]}" 2>&1; then
             echo "❌ Pre-commit checks failed (see above)"
             echo "ℹ️  If only formatting was fixed, re-add files and commit again."
             exit 1
         fi
     fi
 else
-    echo "⚠️  Warning: pre-commit not installed"
-    echo "   Install with: pip install pre-commit && pre-commit install"
+    echo "❌ pre-commit not available through repo Python: $REPO_PYTHON_BIN"
+    echo "   Run make venv or set absolute VENV_PYTHON to the repo environment."
+    exit 1
 fi
 
 echo "✅ All pre-commit checks completed!"

--- a/.githooks/pre-commit-unified
+++ b/.githooks/pre-commit-unified
@@ -16,9 +16,16 @@ fi
 
 echo "🔍 Running unified pre-commit checks..."
 
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# shellcheck source=scripts/hooks/repo_python.sh
+source "$ROOT_DIR/scripts/hooks/repo_python.sh"
+REPO_PYTHON_BIN="$(resolve_repo_python "$ROOT_DIR")"
+export VENV_PYTHON="$REPO_PYTHON_BIN"
+export PATH="$(dirname "$REPO_PYTHON_BIN"):$PATH"
+
 # 1. Run pre-commit framework checks (Black, Bandit, etc.)
 echo "📋 Step 1/2: Pre-commit framework (Black, Bandit, yaml, etc.)"
-if command -v pre-commit > /dev/null 2>&1; then
+if "$REPO_PYTHON_BIN" -m pre_commit --version > /dev/null 2>&1; then
     # Temporarily unset hooksPath to allow pre-commit to run
     ORIGINAL_HOOKS_PATH=""
     ORIGINAL_HOOKS_PATH_SET=0
@@ -42,7 +49,7 @@ if command -v pre-commit > /dev/null 2>&1; then
     # Capture staged files and avoid GNU-only xargs -r for macOS compatibility
     mapfile -t STAGED_FILES < <(git diff --cached --name-only --diff-filter=ACM)
     if [ ${#STAGED_FILES[@]} -gt 0 ]; then
-        if ! pre-commit run --files "${STAGED_FILES[@]}"; then
+        if ! "$REPO_PYTHON_BIN" -m pre_commit run --files "${STAGED_FILES[@]}"; then
             echo "❌ Pre-commit checks failed (Black, Bandit, etc.)"
             echo "ℹ️  Fix the issues above, then re-stage and commit"
             exit 1
@@ -50,8 +57,9 @@ if command -v pre-commit > /dev/null 2>&1; then
     fi
     # Trap will handle restoration on exit
 else
-    echo "⚠️  Warning: pre-commit not installed"
-    echo "   Install with: pip install pre-commit"
+    echo "❌ pre-commit not available through repo Python: $REPO_PYTHON_BIN"
+    echo "   Run make venv or set absolute VENV_PYTHON to the repo environment."
+    exit 1
 fi
 
 # 2. Run custom checks from original .githooks/pre-commit
@@ -66,7 +74,7 @@ if [ -n "$PYTHON_CHANGES" ]; then
     echo "🐍 Checking Python syntax..."
     while IFS= read -r file; do
         if [ -f "$file" ]; then
-            if ! python -m py_compile "$file" 2>&1; then
+            if ! "$REPO_PYTHON_BIN" -m py_compile "$file" 2>&1; then
                 echo "❌ Python syntax error in $file"
                 exit 1
             fi
@@ -79,7 +87,7 @@ if [ -n "$PYTHON_CHANGES" ]; then
     echo "🧪 Running backend tests for changed files..."
     if [ "${SKIP_TESTS:-0}" = "1" ]; then
         echo "⏩ SKIP_TESTS=1 set, skipping backend tests"
-    elif command -v pytest > /dev/null 2>&1; then
+    elif "$REPO_PYTHON_BIN" -m pytest --version > /dev/null 2>&1; then
         # Extract test files that correspond to changed Python files
         declare -a TEST_FILES=()
         while IFS= read -r file; do
@@ -123,7 +131,7 @@ if [ -n "$PYTHON_CHANGES" ]; then
             mapfile -t TEST_FILES < <(printf '%s\n' "${TEST_FILES[@]}" | sort -u)
             echo "Running tests: ${TEST_FILES[*]}"
             # Fail fast on first error (-x flag)
-            if ! pytest -q --tb=short -x -- "${TEST_FILES[@]}"; then
+            if ! "$REPO_PYTHON_BIN" -m pytest -q --tb=short -x -- "${TEST_FILES[@]}"; then
                 echo "❌ Backend tests failed"
                 echo "ℹ️  Fix failing tests or commit with --no-verify to skip"
                 exit 1
@@ -133,7 +141,8 @@ if [ -n "$PYTHON_CHANGES" ]; then
             echo "ℹ️  No corresponding test files found"
         fi
     else
-        echo "⚠️  Warning: pytest not found, skipping tests"
+        echo "❌ pytest not available through repo Python: $REPO_PYTHON_BIN"
+        exit 1
     fi
 fi
 

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ unit-fast:
 SHELL := /bin/bash
 VENV_PYTHON ?= .venv/bin/python
 PIP ?= $(VENV_PYTHON) -m pip
+HOOK_REPO_PYTHON = . scripts/hooks/repo_python.sh; resolve_repo_python "$$PWD"
 
 # Container-aware Python: prefers .venv when present, falls back to system python3
 # inside containers.  Generic developer targets (test, lint, typecheck, coverage,
@@ -98,8 +99,8 @@ venv: ensure-python-proxy ## Create venv, install requirements & setup git hooks
 	@test -x $(VENV_PYTHON) || python3 -m venv .venv
 	PIP_REQUIRE_VIRTUALENV=1 $(VENV_PYTHON) scripts/ci/install_locked_python_requirements.py --python-executable $(VENV_PYTHON) --constraints-file constraints.txt --install-dev --require-virtualenv
 	@echo "$(YELLOW)🔧 Настройка автоматизации...$(NC)"
-	pre-commit install
-	pre-commit install --hook-type pre-push
+	$(VENV_PYTHON) -m pre_commit install
+	$(VENV_PYTHON) -m pre_commit install --hook-type pre-push
 	chmod +x scripts/*.sh
 	./scripts/setup_git_aliases.sh
 	@echo "$(GREEN)✅ Окружение готово!$(NC)"
@@ -113,8 +114,8 @@ venv-sync: ensure-python-proxy ## Refresh .venv from locked requirements without
 ## Setup automation only (git hooks & aliases)
 setup-automation: ## Setup pre-commit hooks and git aliases
 	@echo "$(YELLOW)🔧 Настройка автоматизации...$(NC)"
-	pre-commit install
-	pre-commit install --hook-type pre-push
+	@"$$($(HOOK_REPO_PYTHON))" -m pre_commit install
+	@"$$($(HOOK_REPO_PYTHON))" -m pre_commit install --hook-type pre-push
 	chmod +x scripts/*.sh
 	./scripts/setup_git_aliases.sh
 	@echo "$(GREEN)✅ Автоматизация настроена!$(NC)"
@@ -144,7 +145,7 @@ validate-min: ## Run the cheap deterministic local validation bundle
 ## Diff-based validation for changed Python files
 validate-changed: ## Run tests inferred from changed Python files
 	@echo "$(YELLOW)🧪 Running diff-based validation for changed Python files...$(NC)"
-	VENV_PYTHON="$(DEV_PYTHON)" BRANCH_DIFF_MODE=1 bash scripts/run-backend-tests-pre-commit.sh
+	VENV_PYTHON="$$($(HOOK_REPO_PYTHON))" BRANCH_DIFF_MODE=1 bash scripts/run-backend-tests-pre-commit.sh
 	@echo "$(GREEN)✅ Diff-based validation completed$(NC)"
 
 pr-start: ## Start a governed PR lane in an isolated worktree
@@ -362,7 +363,7 @@ security: ## Run security checks (bandit + pip-audit)
 ## Run all pre-commit hooks
 pre-commit: ## Run all pre-commit hooks
 	@echo "$(YELLOW)🔄 Запуск pre-commit хуков...$(NC)"
-	pre-commit run --all-files
+	"$$($(HOOK_REPO_PYTHON))" -m pre_commit run --all-files
 	@echo "$(GREEN)✅ Pre-commit завершен$(NC)"
 
 ## Quick check before commit
@@ -579,8 +580,8 @@ devcontainer-bootstrap: ensure-python-proxy ## Install deps + hooks inside dev c
 	@# Create .venv so existing VENV_PYTHON targets and activate scripts work
 	@python3 -m venv .venv --without-pip 2>/dev/null || true
 	@ln -sf "$$(command -v python3)" .venv/bin/python
-	pre-commit install
-	pre-commit install --hook-type pre-push
+	python3 -m pre_commit install
+	python3 -m pre_commit install --hook-type pre-push
 	chmod +x scripts/*.sh
 	./scripts/setup_git_aliases.sh
 	@echo "$(GREEN)Devcontainer bootstrap complete$(NC)"

--- a/docs/PRE_COMMIT_HOOKS.md
+++ b/docs/PRE_COMMIT_HOOKS.md
@@ -17,6 +17,13 @@ git config core.hooksPath .githooks
 .githooks/pre-commit
 ```
 
+Checked-in hooks resolve Python through `scripts/hooks/repo_python.sh`.
+The resolver prefers the current checkout `.venv`, then the shared root
+`.venv` when running from `worktrees/...`. Local hook execution fails closed
+when no repo/shared `.venv` exists; CI may fall back to system Python. Keep
+Python tools behind the resolved interpreter (`python -m ...`) so local commits
+do not drift into an ambient environment missing locked deps such as FastAPI.
+
 **Преимущества:**
 - 🎯 Все проверки в одном месте
 - 🚀 Работает автоматически
@@ -42,6 +49,13 @@ git config core.hooksPath .githooks
 # Run the hook directly for a quick check
 .githooks/pre-commit
 ```
+
+Checked-in hooks resolve Python through `scripts/hooks/repo_python.sh`.
+The resolver prefers the current checkout `.venv`, then the shared root
+`.venv` when running from `worktrees/...`. Local hook execution fails closed
+when no repo/shared `.venv` exists; CI may fall back to system Python. Keep
+Python tools behind the resolved interpreter (`python -m ...`) so local commits
+do not drift into an ambient environment missing locked deps such as FastAPI.
 
 **Advantages:**
 - 🎯 All checks in a single place

--- a/docs/review/PR_1824_FIXED_MAPPING.md
+++ b/docs/review/PR_1824_FIXED_MAPPING.md
@@ -9,6 +9,8 @@
 
 ## Lane Start Provenance
 
+- Packet: `artifacts/orchestration/task_packets/9498199b884d.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
 - Main failure run classified: `26372552018`
 - Experiment Runner oracle: `exp-0fc34adf981f`
 - Final requested role order: `agent-coordinator -> dev-operator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter`
@@ -16,12 +18,12 @@
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed after bot/human comments
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 
-No bot or human review threads have been resolved yet.
+- No actionable review comments
 
 ## Main Failure Evidence
 
@@ -48,7 +50,9 @@ No bot or human review threads have been resolved yet.
 
 ## Experiment Runner Evidence
 
-- Artifact: `artifacts/orchestration/experiments/results/exp-0fc34adf981f.json` (local, gitignored)
+Artifact: `artifacts/orchestration/experiments/results/exp-0fc34adf981f.json`
+
+- Artifact class: local, gitignored
 - Status: accepted
 - Contribution kind: `oracle_review`
 - Co-author trailer required and included in `008f7aa503d0d4002224b0ab36317a7cd4bf4a18`.

--- a/docs/review/PR_1824_FIXED_MAPPING.md
+++ b/docs/review/PR_1824_FIXED_MAPPING.md
@@ -38,6 +38,11 @@ Disposition: FIXED
 Commit: 8e788421892cd895301b37fa43c4d0af7fd60435
 Evidence: `tests/test_pre_commit_hook_python_resolver.py` quotes the resolver path with `shlex.quote(...)` before passing it to `bash -lc`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1824#pullrequestreview-4353462449 -> 8e788421892cd895301b37fa43c4d0af7fd60435
+Disposition: FIXED
+Commit: 8e788421892cd895301b37fa43c4d0af7fd60435
+Evidence: CodeRabbit's review-level actionable was the aggregate wrapper for `discussion_r3295372251` and `discussion_r3295372256`; both findings are fixed and mapped above.
+
 ## Main Failure Evidence
 
 - `main` run `26372552018` at `2b34747eed264efd60e56502d8094521d1c0828e` failed `test-main (3.11, 60)` with:

--- a/docs/review/PR_1824_FIXED_MAPPING.md
+++ b/docs/review/PR_1824_FIXED_MAPPING.md
@@ -5,7 +5,7 @@
 - PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1824
 - Branch: `codex/main-coverage-scripts-ci-omit`
 - Initial implementation commit: `008f7aa503d0d4002224b0ab36317a7cd4bf4a18`
-- Mapping artifact commit: `27e0d6734b9b3b9d2700ab3aaaa93c7ae4703d5e`
+- Mapping artifact commit: `96957c48572f44c3337ce08790df9a47c5e046af`
 
 ## Lane Start Provenance
 

--- a/docs/review/PR_1824_FIXED_MAPPING.md
+++ b/docs/review/PR_1824_FIXED_MAPPING.md
@@ -1,0 +1,85 @@
+# PR 1824 Fixed in Commit Mapping
+
+## PR
+
+- PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1824
+- Branch: `codex/main-coverage-scripts-ci-omit`
+- Initial implementation commit: `008f7aa503d0d4002224b0ab36317a7cd4bf4a18`
+- Mapping artifact commit: `27e0d6734b9b3b9d2700ab3aaaa93c7ae4703d5e`
+
+## Lane Start Provenance
+
+- Main failure run classified: `26372552018`
+- Experiment Runner oracle: `exp-0fc34adf981f`
+- Final requested role order: `agent-coordinator -> dev-operator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter`
+- Mandatory post-open role order: `qa-engineer-agent -> bug-hunter -> security-auditor`
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed after bot/human comments
+
+## Fixed in Commit Mapping
+
+No bot or human review threads have been resolved yet.
+
+## Main Failure Evidence
+
+- `main` run `26372552018` at `2b34747eed264efd60e56502d8094521d1c0828e` failed `test-main (3.11, 60)` with:
+  - `tests/test_qoder_dispatch_bridge.py::test_manifest_enforces_mandatory_tail_for_partial_requested_order_from_json_packet`
+  - `tests/test_render_codex_start_prompt.py::test_packet_prompt_enforces_mandatory_tail_for_partial_requested_order`
+- The same run failed `test-main (3.12, 90)` and `test-main (3.13, 90)` on the render role-order check.
+- Disposition: FIXED
+- Commit: `008f7aa503d0d4002224b0ab36317a7cd4bf4a18`
+- Evidence:
+  - `scripts/orchestration/qoder_dispatch_bridge.py` normalizes requested role order so `security-auditor` cannot remain before `bug-hunter` in the canonical post-open tail.
+  - `tests/test_qoder_dispatch_bridge.py` covers explicit invalid security-before-bug ordering.
+  - `tests/test_render_codex_start_prompt.py` covers packet prompt normalization to `qa-engineer-agent -> bug-hunter -> security-auditor`.
+
+## Hook / FastAPI Drift Evidence
+
+- Disposition: FIXED
+- Commit: `008f7aa503d0d4002224b0ab36317a7cd4bf4a18`
+- Evidence:
+  - `scripts/hooks/repo_python.sh` resolves current checkout `.venv`, shared root `.venv` from `worktrees/...`, and fails closed locally when neither exists.
+  - `.githooks/pre-commit`, `.githooks/pre-commit-unified`, `scripts/run-backend-tests-pre-commit.sh`, and `Makefile` run Python tools through the resolved interpreter.
+  - `tests/test_pre_commit_hook_python_resolver.py` covers shared worktree `.venv`, relative override rejection, local fail-closed behavior, commit-hook `GIT_*` env handling, hook entrypoints, and Makefile contracts.
+  - `docs/PRE_COMMIT_HOOKS.md` documents the resolver and FastAPI/import-drift rationale.
+
+## Experiment Runner Evidence
+
+- Artifact: `artifacts/orchestration/experiments/results/exp-0fc34adf981f.json` (local, gitignored)
+- Status: accepted
+- Contribution kind: `oracle_review`
+- Co-author trailer required and included in `008f7aa503d0d4002224b0ab36317a7cd4bf4a18`.
+- Oracle command:
+  - `python -m pytest -q tests/test_qoder_dispatch_bridge.py tests/test_render_codex_start_prompt.py tests/test_experiment_runner.py::test_python_oracle_path_prefix_uses_shared_worktree_root_venv tests/test_pre_commit_hook_python_resolver.py`
+
+## Local Validation
+
+- `python3 scripts/orchestration/check_preflight.py` PASS
+- `python scripts/orchestration/check_agent_consistency.py` PASS
+- Focused pytest through repo resolver PASS
+- `bash -n .githooks/pre-commit .githooks/pre-commit-unified scripts/run-backend-tests-pre-commit.sh scripts/hooks/repo_python.sh` PASS
+- `pre-commit run --all-files` PASS
+- `make validate-changed` PASS after commit
+- Commit hooks PASS
+- Pre-push hooks PASS, including mypy changed-files, pip-audit, backend pre-push pytest, full-repo Bandit, and docker build test
+
+## Advisory Agent Findings
+
+- QA post-change pass: no blocking findings; required reruns completed.
+- Bug-hunter finding: ambient Python / Makefile resolver false-green fixed in `008f7aa503d0d4002224b0ab36317a7cd4bf4a18`.
+- Security finding: local system Python fallback removed for hook execution; resolver now fails closed locally.
+- Security ordering concern: NOT-A-BUG for this PR because current canonical post-open tail and the operator plan require `qa-engineer-agent -> bug-hunter -> security-auditor`.
+
+## Merge Readiness
+
+- Current state: not merge-ready.
+- Required before merge:
+  - Current-head PR CI complete.
+  - Mandatory post-open role pass complete.
+  - Bot comments and review threads checked and dispositioned.
+  - PR body mirror updated from this artifact after review activity.
+  - `check_merge_ready.py --require-auth` passes.
+  - Mandatory wait-window after latest review or bot activity.

--- a/docs/review/PR_1824_FIXED_MAPPING.md
+++ b/docs/review/PR_1824_FIXED_MAPPING.md
@@ -23,7 +23,10 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1824#discussion_r3295362610 -> 94dccc287fe159efe4d6d28f55134d736dd13586
+Disposition: FIXED
+Commit: 94dccc287fe159efe4d6d28f55134d736dd13586
+Evidence: `scripts/run-backend-tests-pre-commit.sh` checks `SKIP_TESTS=1` before resolving repo Python or validating pytest availability; `tests/test_pre_commit_hook_python_resolver.py` covers the ordering contract.
 
 ## Main Failure Evidence
 

--- a/docs/review/PR_1824_FIXED_MAPPING.md
+++ b/docs/review/PR_1824_FIXED_MAPPING.md
@@ -28,6 +28,16 @@ Disposition: FIXED
 Commit: 94dccc287fe159efe4d6d28f55134d736dd13586
 Evidence: `scripts/run-backend-tests-pre-commit.sh` checks `SKIP_TESTS=1` before resolving repo Python or validating pytest availability; `tests/test_pre_commit_hook_python_resolver.py` covers the ordering contract.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1824#discussion_r3295372251 -> 8e788421892cd895301b37fa43c4d0af7fd60435
+Disposition: FIXED
+Commit: 8e788421892cd895301b37fa43c4d0af7fd60435
+Evidence: `scripts/hooks/repo_python.sh` now immediately fails when an explicit absolute `VENV_PYTHON` or `DEV_PYTHON` override is not executable; `tests/test_pre_commit_hook_python_resolver.py` covers the fail-closed override behavior.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1824#discussion_r3295372256 -> 8e788421892cd895301b37fa43c4d0af7fd60435
+Disposition: FIXED
+Commit: 8e788421892cd895301b37fa43c4d0af7fd60435
+Evidence: `tests/test_pre_commit_hook_python_resolver.py` quotes the resolver path with `shlex.quote(...)` before passing it to `bash -lc`.
+
 ## Main Failure Evidence
 
 - `main` run `26372552018` at `2b34747eed264efd60e56502d8094521d1c0828e` failed `test-main (3.11, 60)` with:

--- a/scripts/hooks/repo_python.sh
+++ b/scripts/hooks/repo_python.sh
@@ -18,7 +18,14 @@ resolve_repo_python() {
 
     if [[ -n "${raw_python_override}" ]]; then
         case "${raw_python_override}" in
-            /*) candidates+=("${raw_python_override}") ;;
+            /*)
+                if [[ -x "${raw_python_override}" ]]; then
+                    printf '%s\n' "${raw_python_override}"
+                    return 0
+                fi
+                echo "ERROR: VENV_PYTHON/DEV_PYTHON is set but is not executable: ${raw_python_override}" >&2
+                return 1
+                ;;
             *)
                 echo "ERROR: VENV_PYTHON/DEV_PYTHON must be an absolute executable path for hooks: ${raw_python_override}" >&2
                 return 1

--- a/scripts/hooks/repo_python.sh
+++ b/scripts/hooks/repo_python.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Resolve the Python interpreter that owns PulsePlate's locked developer deps.
+
+resolve_repo_python() {
+    local repo_root="${1:?repo root required}"
+    local candidate=""
+    local git_common_dir=""
+    local parent_dir=""
+    local shared_root=""
+    local raw_python_override="${VENV_PYTHON:-${DEV_PYTHON:-}}"
+    local git_binary=""
+    local candidates=()
+
+    if ! repo_root="$(cd "${repo_root}" 2>/dev/null && pwd -P)"; then
+        echo "ERROR: repo root is not a readable directory: ${1:?repo root required}" >&2
+        return 1
+    fi
+
+    if [[ -n "${raw_python_override}" ]]; then
+        case "${raw_python_override}" in
+            /*) candidates+=("${raw_python_override}") ;;
+            *)
+                echo "ERROR: VENV_PYTHON/DEV_PYTHON must be an absolute executable path for hooks: ${raw_python_override}" >&2
+                return 1
+                ;;
+        esac
+    fi
+
+    candidates+=(
+        "${repo_root}/.venv/bin/python"
+        "${repo_root}/.venv/Scripts/python.exe"
+    )
+
+    parent_dir="$(dirname "${repo_root}")"
+    git_binary="$(command -v git || true)"
+    if [[ "$(basename "${parent_dir}")" == "worktrees" ]] &&
+        [[ -n "${git_binary}" ]] &&
+        git_common_dir="$(
+            env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX -u GIT_COMMON_DIR \
+                "${git_binary}" -C "${repo_root}" rev-parse --path-format=absolute --git-common-dir 2>/dev/null
+        )"; then
+        shared_root="$(cd "$(dirname "${parent_dir}")" 2>/dev/null && pwd -P)"
+        git_common_dir="$(cd "${git_common_dir}" 2>/dev/null && pwd -P)"
+        case "${git_common_dir}" in
+            "${shared_root}/.git" | "${shared_root}/.git/"*)
+                candidates+=(
+                    "${shared_root}/.venv/bin/python"
+                    "${shared_root}/.venv/Scripts/python.exe"
+                )
+                ;;
+        esac
+    fi
+
+    for candidate in "${candidates[@]}"; do
+        if [[ -x "${candidate}" ]]; then
+            printf '%s\n' "${candidate}"
+            return 0
+        fi
+    done
+
+    if [[ "${CI:-}" == "true" ]] && command -v python3 >/dev/null 2>&1; then
+        command -v python3
+        return 0
+    fi
+    if [[ "${CI:-}" == "true" ]] && command -v python >/dev/null 2>&1; then
+        command -v python
+        return 0
+    fi
+
+    echo "ERROR: no repo/shared .venv Python found for local hook execution" >&2
+    return 1
+}

--- a/scripts/orchestration/experiment_runner.py
+++ b/scripts/orchestration/experiment_runner.py
@@ -285,9 +285,34 @@ def _select_repo_python() -> Path | None:
         if selected is not None:
             return selected
 
-    repo_python = Path(REPO_ROOT) / ".venv" / "bin" / "python"
-    if repo_python.is_file() and os.access(repo_python, os.X_OK):
-        return repo_python
+    candidates = [
+        Path(REPO_ROOT) / ".venv" / "bin" / "python",
+        Path(REPO_ROOT) / ".venv" / "Scripts" / "python.exe",
+    ]
+    parent_dir = Path(REPO_ROOT).resolve().parent
+    if parent_dir.name == "worktrees":
+        shared_root = parent_dir.parent
+        try:
+            git_common_dir = Path(
+                _run_git(
+                    ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+                    cwd=Path(REPO_ROOT),
+                ).stdout.strip()
+            ).resolve()
+            git_common_dir.relative_to(shared_root / ".git")
+        except (InfraFlakeError, OSError, ValueError):
+            pass
+        else:
+            candidates.extend(
+                [
+                    shared_root / ".venv" / "bin" / "python",
+                    shared_root / ".venv" / "Scripts" / "python.exe",
+                ]
+            )
+
+    for repo_python in candidates:
+        if repo_python.is_file() and os.access(repo_python, os.X_OK):
+            return repo_python
     return None
 
 

--- a/scripts/orchestration/qoder_dispatch_bridge.py
+++ b/scripts/orchestration/qoder_dispatch_bridge.py
@@ -500,7 +500,7 @@ def _json_packet_has_requested_order(packet_path: Path) -> bool:
 
 
 def _json_payload_requested_order_preserves_mandatory_tail(payload: Dict[str, Any]) -> bool:
-    """Return whether requested_agents explicitly keeps QA before bug-hunter."""
+    """Return whether requested_agents explicitly keeps the canonical post-open tail."""
 
     requested_agents = payload.get("requested_agents")
     if not isinstance(requested_agents, list):
@@ -511,7 +511,11 @@ def _json_payload_requested_order_preserves_mandatory_tail(payload: Dict[str, An
         bug_index = requested_order.index("bug-hunter")
     except ValueError:
         return False
-    return qa_index < bug_index
+    if qa_index >= bug_index:
+        return False
+    if "security-auditor" not in requested_order:
+        return True
+    return bug_index < requested_order.index("security-auditor")
 
 
 def _json_packet_requested_order_preserves_mandatory_tail(packet_path: Path) -> bool:

--- a/scripts/run-backend-tests-pre-commit.sh
+++ b/scripts/run-backend-tests-pre-commit.sh
@@ -18,6 +18,21 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+# Resolve Python through the repo/worktree-aware hook resolver before running
+# syntax or pytest checks. This prevents local hooks from falling back to an
+# ambient PATH interpreter that lacks locked deps such as FastAPI.
+# shellcheck source=scripts/hooks/repo_python.sh
+source "$ROOT_DIR/scripts/hooks/repo_python.sh"
+REPO_PYTHON_BIN="$(resolve_repo_python "$ROOT_DIR")"
+export VENV_PYTHON="$REPO_PYTHON_BIN"
+export PATH="$(dirname "$REPO_PYTHON_BIN"):$PATH"
+
+if ! "$REPO_PYTHON_BIN" -m pytest --version > /dev/null 2>&1; then
+    echo "❌ pytest not available through repo Python: $REPO_PYTHON_BIN" >&2
+    echo "   Run make venv or set absolute VENV_PYTHON to the repo environment." >&2
+    exit 1
+fi
+
 # Debug mode: set PREPUSH_DEBUG=1 to see detailed information
 DEBUG="${PREPUSH_DEBUG:-0}"
 log_debug() {
@@ -31,19 +46,8 @@ if [ "${SKIP_TESTS:-0}" = "1" ]; then
     exit 0
 fi
 
-VENV_PYTHON_BIN="${VENV_PYTHON:-$ROOT_DIR/.venv/bin/python}"
-declare -a PYTEST_COMMAND=()
-
-if [ -x "$VENV_PYTHON_BIN" ]; then
-    PYTEST_COMMAND=("$VENV_PYTHON_BIN" -m pytest)
-    log_debug "Using repo venv pytest via: ${PYTEST_COMMAND[*]}"
-elif command -v pytest > /dev/null 2>&1; then
-    PYTEST_COMMAND=("pytest")
-    log_debug "Using PATH pytest via: $(command -v pytest)"
-else
-    echo "⚠️  Warning: pytest not found, skipping backend tests"
-    exit 0
-fi
+declare -a PYTEST_COMMAND=("$REPO_PYTHON_BIN" -m pytest)
+log_debug "Using repo Python pytest via: ${PYTEST_COMMAND[*]}"
 
 # Get changed Python files
 # For pre-commit: check staged files

--- a/scripts/run-backend-tests-pre-commit.sh
+++ b/scripts/run-backend-tests-pre-commit.sh
@@ -18,6 +18,11 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+if [ "${SKIP_TESTS:-0}" = "1" ]; then
+    echo "⏩ SKIP_TESTS=1 set, skipping backend tests"
+    exit 0
+fi
+
 # Resolve Python through the repo/worktree-aware hook resolver before running
 # syntax or pytest checks. This prevents local hooks from falling back to an
 # ambient PATH interpreter that lacks locked deps such as FastAPI.
@@ -33,6 +38,8 @@ if ! "$REPO_PYTHON_BIN" -m pytest --version > /dev/null 2>&1; then
     exit 1
 fi
 
+declare -a PYTEST_COMMAND=("$REPO_PYTHON_BIN" -m pytest)
+
 # Debug mode: set PREPUSH_DEBUG=1 to see detailed information
 DEBUG="${PREPUSH_DEBUG:-0}"
 log_debug() {
@@ -41,12 +48,6 @@ log_debug() {
     fi
 }
 
-if [ "${SKIP_TESTS:-0}" = "1" ]; then
-    echo "⏩ SKIP_TESTS=1 set, skipping backend tests"
-    exit 0
-fi
-
-declare -a PYTEST_COMMAND=("$REPO_PYTHON_BIN" -m pytest)
 log_debug "Using repo Python pytest via: ${PYTEST_COMMAND[*]}"
 
 # Get changed Python files

--- a/tests/test_experiment_runner.py
+++ b/tests/test_experiment_runner.py
@@ -470,6 +470,43 @@ def test_python_oracle_path_prefix_uses_repo_venv_python(
     assert prefix == str(repo_python.parent)
 
 
+def test_python_oracle_path_prefix_uses_shared_worktree_root_venv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared_root = tmp_path / "repo"
+    worktree_root = shared_root / "worktrees" / "lane"
+    shared_python = shared_root / ".venv" / "bin" / "python"
+    worktree_root.mkdir(parents=True)
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    _write_executable(shared_python.parent / "python3")
+    monkeypatch.delenv("VENV_PYTHON", raising=False)
+    monkeypatch.delenv("DEV_PYTHON", raising=False)
+    monkeypatch.setattr(experiment_runner, "REPO_ROOT", worktree_root)
+
+    def fake_run_git(
+        args: list[str],
+        *,
+        cwd: Path,
+        check: bool = True,
+        input_text: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        assert args == ["rev-parse", "--path-format=absolute", "--git-common-dir"]
+        assert cwd == worktree_root
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=str(shared_root / ".git")
+        )
+
+    monkeypatch.setattr(experiment_runner, "_run_git", fake_run_git)
+
+    prefix = experiment_runner._python_oracle_path_prefix(
+        [SandboxRequest(binary="python3", args=("-c", "pass"), cwd=".")]
+    )
+
+    assert prefix == str(shared_python.parent)
+
+
 def test_python_oracle_path_prefix_rejects_relative_venv_python(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_food_source_preflight.py
+++ b/tests/test_food_source_preflight.py
@@ -5,14 +5,25 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from datetime import date
 from pathlib import Path
+from typing import Callable, cast
 
 import pytest
 
+from core.food_sources.source_catalog import SourceCatalog, SourceCatalogEntry, SourceCatalogError
+from core.food_sources.source_onboarding import (
+    IngestionPath,
+    OnboardingStatus,
+    SourceOnboarding,
+    SourceOnboardingEntry,
+    SourceOnboardingError,
+)
 from core.food_sources.source_preflight import (
     SourceManifestError,
     build_source_preflight_report,
     load_source_manifest,
+    parse_source_manifest,
     validate_manifest_source_contract,
 )
 
@@ -70,6 +81,108 @@ def _write_onboarding_variant(
     return path
 
 
+def _valid_manifest_payload() -> dict[str, object]:
+    return cast(
+        dict[str, object],
+        json.loads(_fixture("incoming_off_manifest.json").read_text(encoding="utf-8")),
+    )
+
+
+def _set_payload_value(payload: dict[str, object], key: str, value: object) -> None:
+    payload[key] = value
+
+
+def _set_nested_payload_value(
+    payload: dict[str, object],
+    section: str,
+    key: str,
+    value: object,
+) -> None:
+    nested = payload[section]
+    assert isinstance(nested, dict)
+    nested[key] = value
+
+
+def _valid_catalog_entry(
+    *,
+    source_url: str = "https://world.openfoodfacts.org/data",
+    active_update_source: bool = True,
+    manifest_required: bool = True,
+    preflight_required: bool = True,
+) -> SourceCatalogEntry:
+    return SourceCatalogEntry(
+        source="open_food_facts",
+        source_classification="current",
+        source_family="barcode_branded",
+        status="candidate",
+        source_url=source_url,
+        license_review="odbl_obligations",
+        active_update_source=active_update_source,
+        manifest_required=manifest_required,
+        preflight_required=preflight_required,
+        replacement_required=False,
+        replacement_for=None,
+        notes="Open Food Facts reviewed snapshot.",
+    )
+
+
+def _catalog_with_entry(entry: SourceCatalogEntry) -> SourceCatalog:
+    return SourceCatalog(
+        schema_version="food-source-catalog.v1",
+        generated_on=date(2026, 4, 24),
+        runtime_cutover=False,
+        digitalocean_postgres_load=False,
+        bulk_ingest=False,
+        sources=(entry,),
+    )
+
+
+def _valid_onboarding_entry(
+    *,
+    onboarding_status: OnboardingStatus = "eligible_preflight",
+    ingestion_path: IngestionPath = "manifest_preflight_only",
+) -> SourceOnboardingEntry:
+    return SourceOnboardingEntry(
+        source="open_food_facts",
+        source_classification="current",
+        source_family="barcode_branded",
+        onboarding_status=onboarding_status,
+        ingestion_path=ingestion_path,
+        cache_decision="allowed_reviewed_snapshot",
+        redistribution_decision="odbl_obligations_required",
+        display_decision="allowed_with_attribution",
+        attribution_required=True,
+        commercial_risk="medium",
+        provider_policy_ref="docs/legal/OPEN_FOOD_FACTS_ODBL_POLICY.md",
+        source_specific_policy_required=True,
+        notes="Eligible for file-only manifest preflight.",
+    )
+
+
+def _onboarding_with_entry(
+    entry: SourceOnboardingEntry,
+    *,
+    runtime_cutover: bool = False,
+    digitalocean_postgres_load: bool = False,
+    bulk_ingest: bool = False,
+    file_only: bool = True,
+    network_allowed: bool = False,
+    db_writes_allowed: bool = False,
+) -> SourceOnboarding:
+    return SourceOnboarding(
+        schema_version="food-source-onboarding.v1",
+        generated_on=date(2026, 4, 28),
+        catalog_ref="docs/architecture/FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json",
+        runtime_cutover=runtime_cutover,
+        digitalocean_postgres_load=digitalocean_postgres_load,
+        bulk_ingest=bulk_ingest,
+        file_only=file_only,
+        network_allowed=network_allowed,
+        db_writes_allowed=db_writes_allowed,
+        sources=(entry,),
+    )
+
+
 def test_load_source_manifest_accepts_current_source_classification() -> None:
     manifest = load_source_manifest(_fixture("current_off_manifest.json"))
 
@@ -105,6 +218,108 @@ def test_load_source_manifest_accepts_legacy_static_menustat() -> None:
     assert manifest.source_classification == "legacy_static"
     assert manifest.source_version == "2022"
     assert manifest.collision_policy.collision_resolution == "quarantine"
+
+
+def test_parse_source_manifest_accepts_skip_collision_resolution() -> None:
+    payload = _valid_manifest_payload()
+    collision_policy = payload["collision_policy"]
+    assert isinstance(collision_policy, dict)
+    collision_policy["collision_resolution"] = "skip"
+
+    manifest = parse_source_manifest(payload)
+
+    assert manifest.collision_policy.collision_resolution == "skip"
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_error"),
+    (
+        (["not-a-mapping"], "must be an object"),
+        ({1: "non-string-key"}, "all object keys must be strings"),
+    ),
+)
+def test_parse_source_manifest_rejects_non_object_payloads(
+    payload: object,
+    expected_error: str,
+) -> None:
+    with pytest.raises(SourceManifestError, match=expected_error):
+        parse_source_manifest(payload)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_error"),
+    (
+        (
+            lambda payload: _set_payload_value(payload, "source", " "),
+            "missing non-empty string 'source'",
+        ),
+        (
+            lambda payload: _set_payload_value(payload, "source_url", "ftp://example.test/data"),
+            "http",
+        ),
+        (
+            lambda payload: _set_payload_value(payload, "retrieved_on", "2026-02-31"),
+            "YYYY-MM-DD",
+        ),
+        (
+            lambda payload: _set_nested_payload_value(payload, "schema", "fields", "code"),
+            "list of strings",
+        ),
+        (
+            lambda payload: _set_nested_payload_value(
+                payload,
+                "schema",
+                "fields",
+                ["code", "code"],
+            ),
+            "duplicate",
+        ),
+        (
+            lambda payload: _set_nested_payload_value(payload, "schema", "fields", []),
+            "must not be empty",
+        ),
+        (
+            lambda payload: _set_nested_payload_value(
+                payload,
+                "artifact",
+                "checksum_sha256",
+                "not-a-sha",
+            ),
+            "64 hex chars",
+        ),
+        (
+            lambda payload: _set_nested_payload_value(payload, "artifact", "record_count", True),
+            "non-negative int",
+        ),
+        (
+            lambda payload: _set_nested_payload_value(
+                payload,
+                "collision_policy",
+                "collision_resolution",
+                "merge",
+            ),
+            "collision_resolution must be one of",
+        ),
+        (
+            lambda payload: _set_nested_payload_value(
+                payload,
+                "collision_policy",
+                "mapping_fields",
+                ["missing_schema_field"],
+            ),
+            "mapping_fields must reference schema fields",
+        ),
+    ),
+)
+def test_parse_source_manifest_rejects_malformed_fields(
+    mutation: Callable[[dict[str, object]], None],
+    expected_error: str,
+) -> None:
+    payload = _valid_manifest_payload()
+    mutation(payload)
+
+    with pytest.raises(SourceManifestError, match=expected_error):
+        parse_source_manifest(payload)
 
 
 @pytest.mark.parametrize("current_fixture,incoming_fixture", _USDA_MANIFEST_PAIRS)
@@ -217,6 +432,145 @@ def test_validate_manifest_source_contract_rejects_classification_mismatch(
     ]
 
 
+def test_validate_manifest_source_contract_surfaces_catalog_loader_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_source_manifest(_fixture("incoming_off_manifest.json"))
+
+    def raise_catalog_error(path: Path | str) -> SourceCatalog:
+        raise SourceCatalogError(f"broken catalog {path}")
+
+    monkeypatch.setattr(
+        "core.food_sources.source_catalog.load_source_catalog",
+        raise_catalog_error,
+    )
+
+    errors = validate_manifest_source_contract(
+        manifest,
+        catalog_path=_CATALOG,
+        onboarding_path=_ONBOARDING,
+    )
+
+    assert errors == [f"catalog: broken catalog {_CATALOG}"]
+
+
+def test_validate_manifest_source_contract_surfaces_onboarding_loader_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_source_manifest(_fixture("incoming_off_manifest.json"))
+
+    def load_catalog(path: Path | str) -> SourceCatalog:
+        return _catalog_with_entry(_valid_catalog_entry())
+
+    def raise_onboarding_error(
+        path: Path | str,
+        *,
+        catalog: SourceCatalog,
+        expected_catalog_ref: str,
+    ) -> SourceOnboarding:
+        assert catalog.sources[0].source == "open_food_facts"
+        assert expected_catalog_ref.endswith("FOOD_DATA_SOURCE_CATALOG_PR3_2026-04-24.json")
+        raise SourceOnboardingError(f"broken onboarding {path}")
+
+    monkeypatch.setattr("core.food_sources.source_catalog.load_source_catalog", load_catalog)
+    monkeypatch.setattr(
+        "core.food_sources.source_onboarding.load_source_onboarding",
+        raise_onboarding_error,
+    )
+
+    errors = validate_manifest_source_contract(
+        manifest,
+        catalog_path=_CATALOG,
+        onboarding_path=_ONBOARDING,
+    )
+
+    assert errors == [f"onboarding: broken onboarding {_ONBOARDING}"]
+
+
+def test_validate_manifest_source_contract_rejects_catalog_gate_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = load_source_manifest(_fixture("incoming_off_manifest.json"))
+    catalog_entry = _valid_catalog_entry(
+        source_url="https://example.test/off",
+        manifest_required=False,
+        preflight_required=False,
+        active_update_source=False,
+    )
+
+    monkeypatch.setattr(
+        "core.food_sources.source_catalog.load_source_catalog",
+        lambda path: _catalog_with_entry(catalog_entry),
+    )
+    monkeypatch.setattr(
+        "core.food_sources.source_onboarding.load_source_onboarding",
+        lambda path, *, catalog, expected_catalog_ref: _onboarding_with_entry(
+            _valid_onboarding_entry(),
+        ),
+    )
+
+    errors = validate_manifest_source_contract(
+        manifest,
+        catalog_path=_CATALOG,
+        onboarding_path=_ONBOARDING,
+    )
+
+    assert errors == [
+        "catalog: source_url mismatch for 'open_food_facts': "
+        "manifest='https://world.openfoodfacts.org/data' catalog='https://example.test/off'",
+        "catalog: 'open_food_facts' must require a manifest",
+        "catalog: 'open_food_facts' must require preflight",
+        "catalog: 'open_food_facts' must be an active update source",
+    ]
+
+
+def test_validate_manifest_source_contract_rejects_onboarding_gate_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest = load_source_manifest(_fixture("incoming_off_manifest.json"))
+    onboarding_entry = _valid_onboarding_entry(
+        onboarding_status="legacy_baseline_blocked",
+        ingestion_path="legacy_snapshot_review_only",
+    )
+
+    monkeypatch.setattr(
+        "core.food_sources.source_catalog.load_source_catalog",
+        lambda path: _catalog_with_entry(_valid_catalog_entry()),
+    )
+    monkeypatch.setattr(
+        "core.food_sources.source_onboarding.load_source_onboarding",
+        lambda path, *, catalog, expected_catalog_ref: _onboarding_with_entry(
+            onboarding_entry,
+            runtime_cutover=True,
+            digitalocean_postgres_load=True,
+            bulk_ingest=True,
+            file_only=False,
+            network_allowed=True,
+            db_writes_allowed=True,
+        ),
+    )
+
+    errors = validate_manifest_source_contract(
+        manifest,
+        catalog_path=tmp_path / "catalog-outside-repo.json",
+        onboarding_path=_ONBOARDING,
+    )
+
+    assert errors == [
+        "onboarding: 'open_food_facts' must be eligible_preflight, "
+        "got 'legacy_baseline_blocked'",
+        "onboarding: 'open_food_facts' must use manifest_preflight_only, "
+        "got 'legacy_snapshot_review_only'",
+        "onboarding: runtime_cutover must remain false",
+        "onboarding: digitalocean_postgres_load must remain false",
+        "onboarding: bulk_ingest must remain false",
+        "onboarding: file_only must remain true",
+        "onboarding: network_allowed must remain false",
+        "onboarding: db_writes_allowed must remain false",
+    ]
+
+
 def test_build_source_preflight_report_enforces_strict_source_contract(
     tmp_path: Path,
 ) -> None:
@@ -239,6 +593,35 @@ def test_build_source_preflight_report_enforces_strict_source_contract(
         "source_contract: catalog: unknown source 'usda_unknown'",
         "source_contract: onboarding: missing source 'usda_unknown'",
     ]
+
+
+def test_build_source_preflight_report_requires_catalog_and_onboarding_together() -> None:
+    report = build_source_preflight_report(
+        _fixture("current_off_manifest.json"),
+        _fixture("incoming_off_manifest.json"),
+        catalog_path=_CATALOG,
+    )
+
+    assert report["success"] is False
+    assert report["validation_errors"] == [
+        "source_contract: catalog_path and onboarding_path must be provided together"
+    ]
+
+
+def test_build_source_preflight_report_surfaces_unreadable_manifests(tmp_path: Path) -> None:
+    invalid_json = tmp_path / "invalid.json"
+    invalid_json.write_text("{not json", encoding="utf-8")
+    missing_manifest = tmp_path / "missing.json"
+
+    report = build_source_preflight_report(missing_manifest, invalid_json)
+
+    assert report["success"] is False
+    assert report["dry_run"] is True
+    assert report["runtime_cutover"] is False
+    errors = report["validation_errors"]
+    assert isinstance(errors, list)
+    assert str(missing_manifest) in str(errors[0])
+    assert str(invalid_json) in str(errors[1])
 
 
 def test_load_source_manifest_rejects_invalid_source_classification() -> None:

--- a/tests/test_makefile_dev_python_migration.py
+++ b/tests/test_makefile_dev_python_migration.py
@@ -249,6 +249,29 @@ def test_verify_env_uses_venv_python() -> None:
     assert "$(VENV_PYTHON)" in body, "verify-env must use VENV_PYTHON (it validates venv health)"
 
 
+def test_makefile_installs_pre_commit_through_repo_python() -> None:
+    """Hook installation must not capture whichever pre-commit is first on PATH."""
+    text = _makefile_text()
+
+    assert "$(VENV_PYTHON) -m pre_commit install" in text
+    assert "$(VENV_PYTHON) -m pre_commit install --hook-type pre-push" in text
+    assert '$$($(HOOK_REPO_PYTHON))" -m pre_commit install' in text
+    assert '$$($(HOOK_REPO_PYTHON))" -m pre_commit install --hook-type pre-push' in text
+    assert "\tpre-commit install" not in text
+
+
+def test_makefile_pre_commit_target_uses_dev_python() -> None:
+    """Manual pre-commit runs should use the same repo-aware Python path."""
+    text = _makefile_text()
+
+    pattern = re.compile(r"(?m)^pre-commit:.*\n(?P<body>(?:\t[^\n]*\n)+)")
+    match = pattern.search(text)
+    assert match, "pre-commit target must exist"
+    body = match.group("body")
+    assert '"$$($(HOOK_REPO_PYTHON))" -m pre_commit run --all-files' in body
+    assert "\tpre-commit run --all-files" not in body
+
+
 # ---------------------------------------------------------------------------
 # openapi target uses DEV_PYTHON
 # ---------------------------------------------------------------------------

--- a/tests/test_pre_commit_hook_python_resolver.py
+++ b/tests/test_pre_commit_hook_python_resolver.py
@@ -1,0 +1,173 @@
+"""Guards for repo/worktree-aware Python resolution in local hooks."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK_RESOLVER = REPO_ROOT / "scripts" / "hooks" / "repo_python.sh"
+HOOK_FILES = [
+    REPO_ROOT / ".githooks" / "pre-commit",
+    REPO_ROOT / ".githooks" / "pre-commit-unified",
+]
+
+
+def _write_executable(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    git_binary = shutil.which("git")
+    assert git_binary is not None, "git binary is required for hook resolver tests"
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    return subprocess.run(
+        [git_binary, *args],
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _clean_hook_env() -> dict[str, str]:
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    env.pop("VENV_PYTHON", None)
+    env.pop("DEV_PYTHON", None)
+    env.pop("CI", None)
+    return env
+
+
+def _bash(command: str, *, cwd: Path, env: dict[str, str] | None = None) -> str:
+    bash_binary = shutil.which("bash")
+    assert bash_binary is not None, "bash binary is required for hook resolver tests"
+    completed = subprocess.run(
+        [bash_binary, "-lc", command],
+        cwd=str(cwd),
+        env=env or _clean_hook_env(),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+def _bash_failure(
+    command: str, *, cwd: Path, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    bash_binary = shutil.which("bash")
+    assert bash_binary is not None, "bash binary is required for hook resolver tests"
+    return subprocess.run(
+        [bash_binary, "-lc", command],
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_hook_resolver_prefers_shared_root_venv_from_worktree(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(tmp_path, "init", "--quiet", str(repo))
+    _git(repo, "config", "user.email", "pulseplate@pm.me")
+    _git(repo, "config", "user.name", "PulsePlate Hook Resolver")
+    (repo / "README.md").write_text("hook resolver test\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "--quiet", "-m", "init")
+    shared_python = repo / ".venv" / "bin" / "python"
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    worktree = repo / "worktrees" / "lane"
+    _git(repo, "worktree", "add", "--quiet", str(worktree), "HEAD")
+
+    resolved = _bash(
+        f'source {HOOK_RESOLVER}; resolve_repo_python "$PWD"',
+        cwd=worktree,
+    )
+
+    assert resolved == str(shared_python)
+
+
+def test_hook_resolver_ignores_commit_hook_git_env_for_worktree_lookup(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(tmp_path, "init", "--quiet", str(repo))
+    _git(repo, "config", "user.email", "pulseplate@pm.me")
+    _git(repo, "config", "user.name", "PulsePlate Hook Resolver")
+    (repo / "README.md").write_text("hook resolver test\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "--quiet", "-m", "init")
+    shared_python = repo / ".venv" / "bin" / "python"
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    worktree = repo / "worktrees" / "lane"
+    _git(repo, "worktree", "add", "--quiet", str(worktree), "HEAD")
+    env = _clean_hook_env()
+    env["GIT_DIR"] = str(repo / ".git")
+    env["GIT_INDEX_FILE"] = str(repo / ".git" / "index")
+
+    resolved = _bash(
+        f'source {HOOK_RESOLVER}; resolve_repo_python "$PWD"',
+        cwd=worktree,
+        env=env,
+    )
+
+    assert resolved == str(shared_python)
+
+
+def test_hook_resolver_rejects_relative_python_override(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = _clean_hook_env()
+    env["VENV_PYTHON"] = ".venv/bin/python"
+
+    completed = _bash_failure(
+        f'source {HOOK_RESOLVER}; resolve_repo_python "$PWD"',
+        cwd=repo,
+        env=env,
+    )
+
+    assert completed.returncode == 1
+    assert "must be an absolute executable path" in completed.stderr
+
+
+def test_hook_resolver_fails_closed_without_repo_python(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = _clean_hook_env()
+
+    completed = _bash_failure(
+        f'source {HOOK_RESOLVER}; resolve_repo_python "$PWD"',
+        cwd=repo,
+        env=env,
+    )
+
+    assert completed.returncode == 1
+    assert "no repo/shared .venv Python found" in completed.stderr
+
+
+def test_hook_entrypoints_use_repo_python_for_python_tools() -> None:
+    for hook_file in HOOK_FILES:
+        text = hook_file.read_text(encoding="utf-8")
+        assert "scripts/hooks/repo_python.sh" in text
+        assert 'export VENV_PYTHON="$REPO_PYTHON_BIN"' in text
+        assert '"$REPO_PYTHON_BIN" -m py_compile' in text
+        assert '"$REPO_PYTHON_BIN" -m pytest' in text
+        assert '"$REPO_PYTHON_BIN" -m pre_commit' in text
+        assert "not available through repo Python" in text
+
+
+def test_makefile_hook_targets_use_shared_python_resolver() -> None:
+    makefile_text = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+
+    assert "HOOK_REPO_PYTHON = . scripts/hooks/repo_python.sh" in makefile_text
+    assert 'VENV_PYTHON="$$($(HOOK_REPO_PYTHON))"' in makefile_text
+    assert '"$$($(HOOK_REPO_PYTHON))" -m pre_commit run --all-files' in makefile_text

--- a/tests/test_pre_commit_hook_python_resolver.py
+++ b/tests/test_pre_commit_hook_python_resolver.py
@@ -165,6 +165,18 @@ def test_hook_entrypoints_use_repo_python_for_python_tools() -> None:
         assert "not available through repo Python" in text
 
 
+def test_backend_hook_honors_skip_tests_before_python_resolution() -> None:
+    hook_text = (REPO_ROOT / "scripts" / "run-backend-tests-pre-commit.sh").read_text(
+        encoding="utf-8"
+    )
+
+    skip_index = hook_text.index('if [ "${SKIP_TESTS:-0}" = "1" ]; then')
+    resolver_index = hook_text.index('source "$ROOT_DIR/scripts/hooks/repo_python.sh"')
+    pytest_index = hook_text.index('"$REPO_PYTHON_BIN" -m pytest --version')
+
+    assert skip_index < resolver_index < pytest_index
+
+
 def test_makefile_hook_targets_use_shared_python_resolver() -> None:
     makefile_text = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
 

--- a/tests/test_pre_commit_hook_python_resolver.py
+++ b/tests/test_pre_commit_hook_python_resolver.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 import shutil
+import shlex
 import subprocess
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -13,6 +14,7 @@ HOOK_FILES = [
     REPO_ROOT / ".githooks" / "pre-commit",
     REPO_ROOT / ".githooks" / "pre-commit-unified",
 ]
+RESOLVE_COMMAND = f'source {shlex.quote(str(HOOK_RESOLVER))}; resolve_repo_python "$PWD"'
 
 
 def _write_executable(path: Path) -> None:
@@ -87,7 +89,7 @@ def test_hook_resolver_prefers_shared_root_venv_from_worktree(tmp_path: Path) ->
     _git(repo, "worktree", "add", "--quiet", str(worktree), "HEAD")
 
     resolved = _bash(
-        f'source {HOOK_RESOLVER}; resolve_repo_python "$PWD"',
+        RESOLVE_COMMAND,
         cwd=worktree,
     )
 
@@ -115,7 +117,7 @@ def test_hook_resolver_ignores_commit_hook_git_env_for_worktree_lookup(
     env["GIT_INDEX_FILE"] = str(repo / ".git" / "index")
 
     resolved = _bash(
-        f'source {HOOK_RESOLVER}; resolve_repo_python "$PWD"',
+        RESOLVE_COMMAND,
         cwd=worktree,
         env=env,
     )
@@ -130,7 +132,7 @@ def test_hook_resolver_rejects_relative_python_override(tmp_path: Path) -> None:
     env["VENV_PYTHON"] = ".venv/bin/python"
 
     completed = _bash_failure(
-        f'source {HOOK_RESOLVER}; resolve_repo_python "$PWD"',
+        RESOLVE_COMMAND,
         cwd=repo,
         env=env,
     )
@@ -139,13 +141,38 @@ def test_hook_resolver_rejects_relative_python_override(tmp_path: Path) -> None:
     assert "must be an absolute executable path" in completed.stderr
 
 
+def test_hook_resolver_rejects_non_executable_absolute_python_override(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    shared_python = repo / ".venv" / "bin" / "python"
+    shared_python.parent.mkdir(parents=True)
+    _write_executable(shared_python)
+    bad_override = tmp_path / "not-python"
+    bad_override.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    bad_override.chmod(0o644)
+    env = _clean_hook_env()
+    env["VENV_PYTHON"] = str(bad_override)
+
+    completed = _bash_failure(
+        RESOLVE_COMMAND,
+        cwd=repo,
+        env=env,
+    )
+
+    assert completed.returncode == 1
+    assert "is set but is not executable" in completed.stderr
+    assert str(shared_python) not in completed.stdout
+
+
 def test_hook_resolver_fails_closed_without_repo_python(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     env = _clean_hook_env()
 
     completed = _bash_failure(
-        f'source {HOOK_RESOLVER}; resolve_repo_python "$PWD"',
+        RESOLVE_COMMAND,
         cwd=repo,
         env=env,
     )

--- a/tests/test_qoder_dispatch_bridge.py
+++ b/tests/test_qoder_dispatch_bridge.py
@@ -303,9 +303,9 @@ def test_parse_task_bootstrap_json_packet_preserves_requested_role_order(
         "requested_agents": [
             "agent-coordinator",
             "architecture-specialist",
-            "security-auditor",
             "qa-engineer-agent",
             "bug-hunter",
+            "security-auditor",
         ],
         "native_subagent_bridge": {
             "primary": {"repo_agent_slug": "agent-coordinator"},
@@ -325,9 +325,9 @@ def test_parse_task_bootstrap_json_packet_preserves_requested_role_order(
     assert qoder_dispatch_bridge._parse_packet_roles(packet_path) == [
         "agent-coordinator",
         "architecture-specialist",
-        "security-auditor",
         "qa-engineer-agent",
         "bug-hunter",
+        "security-auditor",
         "cursor-specialist-agent",
     ]
 
@@ -389,10 +389,67 @@ def test_manifest_preserves_requested_order_from_json_packet(
     assert [entry["role_slug"] for entry in manifest["dispatch_sequence"]] == [
         "agent-coordinator",
         "architecture-specialist",
+        "qa-engineer-agent",
+        "bug-hunter",
+        "security-auditor",
+        "cursor-specialist-agent",
+    ]
+
+
+def test_manifest_normalizes_requested_order_when_security_precedes_bug_hunter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit requests must still preserve the canonical QA -> bug -> security tail."""
+    monkeypatch.setattr(qoder_dispatch_bridge, "REPO_ROOT", tmp_path)
+    required_slugs = [
+        "agent-coordinator",
         "security-auditor",
         "qa-engineer-agent",
         "bug-hunter",
-        "cursor-specialist-agent",
+    ]
+    tmp_agents_dir = tmp_path / ".cursor" / "agents"
+    tmp_agents_dir.mkdir(parents=True)
+    for slug in required_slugs:
+        qoder_type = "Verify" if slug in {"qa-engineer-agent", "bug-hunter"} else "Research"
+        (tmp_agents_dir / f"{slug}.md").write_text(
+            f"---\nslug: {slug}\nqoder_type: {qoder_type}\n---\n# {slug}\n",
+            encoding="utf-8",
+        )
+    packet = {
+        "requested_agents": [
+            "agent-coordinator",
+            "qa-engineer-agent",
+            "security-auditor",
+            "bug-hunter",
+        ],
+        "native_subagent_bridge": {
+            "primary": {"repo_agent_slug": "agent-coordinator"},
+            "secondary": [
+                {"repo_agent_slug": "security-auditor"},
+                {"repo_agent_slug": "bug-hunter"},
+            ],
+            "reviewer": {"repo_agent_slug": "qa-engineer-agent"},
+            "advisory": [],
+        },
+    }
+    packet_path = tmp_path / "packet.json"
+    packet_path.write_text(json.dumps(packet), encoding="utf-8")
+
+    roles = qoder_dispatch_bridge._parse_packet_roles(packet_path)
+    manifest = qoder_dispatch_bridge.build_dispatch_manifest(
+        role_slugs=roles,
+        mode="analysis",
+        packet_source="packet.json",
+        enforce_mandatory_post_open_tail=not (
+            qoder_dispatch_bridge._json_packet_requested_order_preserves_mandatory_tail(packet_path)
+        ),
+    )
+
+    assert [entry["role_slug"] for entry in manifest["dispatch_sequence"]] == [
+        "agent-coordinator",
+        "qa-engineer-agent",
+        "bug-hunter",
+        "security-auditor",
     ]
 
 
@@ -445,9 +502,9 @@ def test_manifest_enforces_mandatory_tail_for_partial_requested_order_from_json_
     assert [entry["role_slug"] for entry in manifest["dispatch_sequence"]] == [
         "agent-coordinator",
         "frontend-engineer",
-        "security-auditor",
         "qa-engineer-agent",
         "bug-hunter",
+        "security-auditor",
     ]
 
 

--- a/tests/test_render_codex_start_prompt.py
+++ b/tests/test_render_codex_start_prompt.py
@@ -165,9 +165,37 @@ def test_packet_prompt_enforces_mandatory_tail_for_partial_requested_order() -> 
     prompt = render_packet_prompt(packet, packet_path="packet.json")
 
     assert (
-        "Role order: agent-coordinator, security-auditor, qa-engineer-agent, bug-hunter" in prompt
+        "Role order: agent-coordinator, qa-engineer-agent, bug-hunter, security-auditor" in prompt
     )
     assert "Role order: agent-coordinator, security-auditor, bug-hunter" not in prompt
+
+
+def test_packet_prompt_normalizes_requested_order_when_security_precedes_bug_hunter() -> None:
+    """Prompt order must not let explicit requests invert bug-hunter and security."""
+
+    packet = _packet()
+    packet["requested_agents"] = [
+        "agent-coordinator",
+        "qa-engineer-agent",
+        "security-auditor",
+        "bug-hunter",
+    ]
+    packet["native_subagent_bridge"] = {
+        "primary": {"repo_agent_slug": "agent-coordinator"},
+        "reviewer": {"repo_agent_slug": "qa-engineer-agent"},
+        "secondary": [
+            {"repo_agent_slug": "security-auditor"},
+            {"repo_agent_slug": "bug-hunter"},
+        ],
+        "advisory": [],
+    }
+
+    prompt = render_packet_prompt(packet, packet_path="packet.json")
+
+    assert (
+        "Role order: agent-coordinator, qa-engineer-agent, bug-hunter, security-auditor" in prompt
+    )
+    assert "Role order: agent-coordinator, qa-engineer-agent, security-auditor" not in prompt
 
 
 def test_packet_prompt_contains_coordinator_stop_marker_and_closure_contract() -> None:


### PR DESCRIPTION
## Goal
Stabilize the current red `main` orchestration checks and harden commit/pre-commit Python resolution so hooks run through the repo/worktree-approved `.venv` instead of ambient `PATH`.

## Business reason
`main` was failing current-head CI on role-order governance tests, and local commit hooks could drift into a Python without locked runtime deps such as FastAPI. That combination blocks safe PR sequencing and makes local/CI evidence unreliable.

## Scope
- Fix role-order normalization so partial requested orders cannot bypass the canonical post-open tail.
- Add a repo/worktree-aware hook Python resolver and route `.githooks`, backend pre-commit runner, and Makefile hook targets through it.
- Keep FastAPI in scope only as the dependency-drift symptom: Python tools now run via repo/shared `.venv`, not by adding runtime dependency changes.
- Add focused regression coverage for hook resolver fail-closed behavior, commit-hook `GIT_*` env handling, Makefile contracts, Experiment Runner shared-worktree Python selection, role-order normalization, and coverage buffer around touched CI shards.

## Out of scope
- Runtime app behavior, OpenAPI/client contracts, dependency pins, broad CI routing, product behavior, or medical/wellness copy.
- Claiming merge readiness before current-head PR CI, bot review disposition, fixed mapping, and strict merge-readiness gates complete.

## Main failure classification
Live `main` run `26372552018` at `2b34747eed264efd60e56502d8094521d1c0828e` was terminal red in:
- `test-main (3.11, 60)`: `tests/test_qoder_dispatch_bridge.py::test_manifest_enforces_mandatory_tail_for_partial_requested_order_from_json_packet` and `tests/test_render_codex_start_prompt.py::test_packet_prompt_enforces_mandatory_tail_for_partial_requested_order`.
- `test-main (3.12, 90)` and `test-main (3.13, 90)`: render role-order failure.

## Key decisions
- Split the current `main` stabilization into this PR because the observed red jobs are role-order governance fallout, not a runtime FastAPI defect.
- Include the hook/FastAPI drift hardening in the same narrow PR because it is tooling-only and was already blocking local commit evidence.
- Treat Experiment Runner startup friction as a fail-closed packet/context contract issue, then rerun with an oracle-only packet covering `.githooks`, `Makefile`, `docs/PRE_COMMIT_HOOKS.md`, `scripts`, and `tests`.

## Tests / validation
- `python3 scripts/orchestration/check_preflight.py` — PASS
- `python scripts/orchestration/check_agent_consistency.py` — PASS
- Focused pytest via repo resolver — PASS
- `bash -n .githooks/pre-commit .githooks/pre-commit-unified scripts/run-backend-tests-pre-commit.sh scripts/hooks/repo_python.sh` — PASS
- `SKIP_TESTS=1 bash scripts/run-backend-tests-pre-commit.sh` — PASS
- `VENV_PYTHON=<non-executable> bash -lc '. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD"'` — expected FAIL
- `pre-commit run --all-files` — PASS
- `make validate-changed` — PASS after commit
- Commit hooks — PASS
- Pre-push hooks — PASS: mypy changed-files, pip-audit, backend pytest pre-push, full bandit, docker build test
- Experiment Runner oracle `exp-0fc34adf981f` — accepted; oracle command returned 0; co-author trailer included

## Security notes
- Hook resolver fails closed locally when no repo/shared `.venv` exists.
- Relative `VENV_PYTHON` / `DEV_PYTHON` overrides are rejected.
- Non-executable absolute `VENV_PYTHON` / `DEV_PYTHON` overrides now fail immediately instead of falling back silently.
- Commit-hook `GIT_*` environment is ignored for worktree shared-root lookup.
- `SKIP_TESTS=1` keeps its explicit bypass semantics before Python/pytest lookup.
- No secrets, auth, billing, entitlements, CI workflow permissions, or production runtime surfaces changed.

## Risks / rollback
- Risk: hook resolver may expose machines that lack a repo/shared `.venv` sooner than before. This is intentional fail-closed behavior; rollback is reverting the hook resolver commit and reinstalling hooks.
- Risk: role-order normalization may reorder invalid explicit packets into the canonical post-open tail. This matches the governed mandatory tail and is covered by regression tests.

## Deferred / follow-ups
- Full `make verify` not run locally; this is a machine-heavy orchestration/tooling PR. Current-head PR CI and strict merge-readiness gates remain required before readiness claims.
- If Codex UI still shows `[features].codex_hooks is deprecated`, that is a host Codex config surface, not repo git-hook runtime. Local `/Users/katsiaryna_kavaleuskaya/.codex/config.toml` currently has `[features].hooks = true`.

## Split Justification
This PR is above the normal size threshold because it intentionally keeps one main-stabilization fix and one hook-hardening fix together: the role-order failure is current `main` fallout, while the hook resolver prevents the same lane from producing false local evidence through ambient Python/FastAPI drift. Splitting would leave either `main` red or local commit evidence unreliable during the same governed PR train. The large line count is mostly focused regression coverage, not product/runtime expansion.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
Canonical artifact: `docs/review/PR_1824_FIXED_MAPPING.md`.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1824#discussion_r3295362610 -> 94dccc287fe159efe4d6d28f55134d736dd13586
Disposition: FIXED
Commit: 94dccc287fe159efe4d6d28f55134d736dd13586
Evidence: `scripts/run-backend-tests-pre-commit.sh` checks `SKIP_TESTS=1` before resolving repo Python or validating pytest availability; `tests/test_pre_commit_hook_python_resolver.py` covers the ordering contract.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1824#discussion_r3295372251 -> 8e788421892cd895301b37fa43c4d0af7fd60435
Disposition: FIXED
Commit: 8e788421892cd895301b37fa43c4d0af7fd60435
Evidence: `scripts/hooks/repo_python.sh` now immediately fails when an explicit absolute `VENV_PYTHON` or `DEV_PYTHON` override is not executable; `tests/test_pre_commit_hook_python_resolver.py` covers the fail-closed override behavior.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1824#discussion_r3295372256 -> 8e788421892cd895301b37fa43c4d0af7fd60435
Disposition: FIXED
Commit: 8e788421892cd895301b37fa43c4d0af7fd60435
Evidence: `tests/test_pre_commit_hook_python_resolver.py` quotes the resolver path with `shlex.quote(...)` before passing it to `bash -lc`.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1824#pullrequestreview-4353462449 -> 8e788421892cd895301b37fa43c4d0af7fd60435
Disposition: FIXED
Commit: 8e788421892cd895301b37fa43c4d0af7fd60435
Evidence: CodeRabbit's review-level actionable was the aggregate wrapper for `discussion_r3295372251` and `discussion_r3295372256`; both findings are fixed and mapped above.

Initial mappings recorded in the artifact:
- Main role-order CI failure: FIXED in `008f7aa503d0d4002224b0ab36317a7cd4bf4a18`.
- Hook/FastAPI ambient Python drift: FIXED in `008f7aa503d0d4002224b0ab36317a7cd4bf4a18`.

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/exp-0fc34adf981f.json`

- Status: accepted
- Contribution kind: `oracle_review`
- Co-author trailer included in `008f7aa503d0d4002224b0ab36317a7cd4bf4a18`.

## Lane Start Provenance
Packet: `artifacts/orchestration/task_packets/9498199b884d.json`
Starter: `scripts/orchestration/start_pr_lane.sh`

- Main failure run classified: `26372552018`.
- Final requested role order: `agent-coordinator -> dev-operator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter`.
- Mandatory post-open role order: `qa-engineer-agent -> bug-hunter -> security-auditor`.

## Merge Readiness
Not merge-ready yet. Current-head PR CI, mandatory post-open agent pass, bot review disposition, wait-window, and `check_merge_ready.py --require-auth` are still pending.
