### PR TITLE
feat(orchestration): harden Slack manual live smoke evidence

### DIFF
--- a/.github/workflows/experiment-runner-slack-socket-smoke.yml
+++ b/.github/workflows/experiment-runner-slack-socket-smoke.yml
@@ -50,6 +50,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Mask runtime allowlist inputs
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+          inputs = event.get("inputs", {})
+          for key in ("channel_allowlist", "user_allowlist", "hypothesis_sha256"):
+              value = str(inputs.get(key, "")).strip()
+              if value:
+                  print(f"::add-mask::{value}")
+          PY
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -68,6 +84,15 @@ jobs:
           python3 -m scripts.orchestration.experiment_slack_socket_bridge \
             --validate-runtime \
             --dispatch-mode dry-run
+
+      - name: Validate manual smoke inputs without raw echo
+        env:
+          EXPERIMENT_SLACK_SOCKET_BRANCH_REF: ${{ inputs.branch_ref }}
+          EXPERIMENT_SLACK_SOCKET_HYPOTHESIS_SHA256: ${{ inputs.hypothesis_sha256 }}
+        run: |
+          set -euo pipefail
+          python3 -m scripts.orchestration.experiment_slack_socket_bridge \
+            --validate-smoke-inputs
 
       - name: Report local Slack audit retention policy
         env:
@@ -98,13 +123,7 @@ jobs:
           python3 -m scripts.orchestration.experiment_slack_socket_bridge \
             --validate-secret-presence
 
-      - name: Install optional Slack Socket Mode runtime
-        if: inputs.dry_run == 'false'
-        run: |
-          set -euo pipefail
-          python3 -m pip install --disable-pip-version-check "slack-bolt==1.28.0"
-
-      - name: Validate live Socket Mode runtime
+      - name: Run bounded live Socket Mode smoke
         if: inputs.dry_run == 'false'
         env:
           SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
@@ -112,9 +131,24 @@ jobs:
           EXPERIMENT_NOTIFICATION_SLACK_CHANNEL_ALLOWLIST: ${{ inputs.channel_allowlist }}
           EXPERIMENT_NOTIFICATION_SLACK_USER_ALLOWLIST: ${{ inputs.user_allowlist }}
           EXPERIMENT_SLACK_SOCKET_AUDIT_RETENTION_DAYS: ${{ inputs.audit_retention_days }}
+          EXPERIMENT_SLACK_SOCKET_BRANCH_REF: ${{ inputs.branch_ref }}
+          EXPERIMENT_SLACK_SOCKET_HYPOTHESIS_SHA256: ${{ inputs.hypothesis_sha256 }}
         run: |
           set -euo pipefail
           python3 -m scripts.orchestration.experiment_slack_socket_bridge \
-            --validate-runtime \
-            --run-socket \
+            --validate-live-smoke \
             --dispatch-mode dry-run
+
+      - name: Record sanitized live-smoke evidence summary
+        if: inputs.dry_run == 'false'
+        run: |
+          set -euo pipefail
+          {
+            printf '### Experiment Runner Slack live smoke\n'
+            printf -- '- mode: bounded manual workflow_dispatch\n'
+            printf -- '- secret names: checked as present/missing only\n'
+            printf -- '- channel_allowlist: present\n'
+            printf -- '- user_allowlist: present\n'
+            printf -- '- audit_retention: report-first\n'
+            printf -- '- redaction: raw tokens, token prefixes, Slack IDs, hypotheses, payloads, and local paths are not emitted by workflow steps\n'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
+++ b/docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md
@@ -120,8 +120,11 @@ Rules:
   must not auto-run experiments by default, create PRs, resolve review threads,
   claim merge readiness, or replace the local Experiment Runner evidence
   artifact.
-- Live Socket Mode smoke procedure, runtime secret setup, allowlist inputs, and
-  audit retention handling are governed by
+- Live Socket Mode smoke procedure is manual-only and bounded: it validates
+  runtime secret presence, operator allowlists, Socket Mode credential
+  connectivity, and bot authentication without starting the long-running
+  listener or printing Slack response identifiers. Runtime secret setup,
+  allowlist inputs, and audit retention handling are governed by
   `docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md`.
 - `Not applicable` is narrow. It is intended for trivial docs cleanup, main
   cleanup, cache cleanup, or operator-declared emergency infrastructure repair

--- a/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
+++ b/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
@@ -37,7 +37,7 @@ Run `.github/workflows/experiment-runner-slack-socket-smoke.yml` manually with
 For config-only validation, keep `dry_run` as `true`. This validates the bridge
 without Slack network access.
 
-For live prerequisite validation, set `dry_run` to `false` and provide:
+For bounded live-smoke validation, set `dry_run` to `false` and provide:
 
 - runtime channel allowlist,
 - runtime user allowlist,
@@ -54,6 +54,26 @@ diagnostic must not print secret values, token prefixes, raw channel/user IDs,
 raw hypotheses, local absolute paths, Slack payload bodies, GitHub tokens,
 oracle stdout/stderr, or patch text.
 
+The live-smoke network check is bounded and exits. It validates the app-level
+Socket Mode credential by opening a temporary Socket Mode connection URL with
+Slack `apps.connections.open`, validates the bot credential with Slack
+`auth.test`, discards all Slack response identifiers and WebSocket URLs, and
+prints only a sanitized pass/fail status. The workflow must not start the
+long-running Socket Mode listener path for evidence collection.
+
+Committed PR evidence may record only:
+
+- workflow run URL and status,
+- job names and pass/fail conclusion,
+- secret names as `present` / `missing`,
+- `channel_allowlist=present` and `user_allowlist=present`,
+- audit retention report status,
+- redaction assertion status.
+
+Do not commit workflow logs, raw stdout/stderr dumps, raw Slack IDs, raw
+hypothesis text, Slack WebSocket URLs, Slack payloads, token values, token
+prefixes, GitHub tokens, local absolute paths, oracle output, or patch text.
+
 ## Failure Interpretation
 
 - Missing `SLACK_APP_TOKEN`: configure the app-level Socket Mode secret outside
@@ -62,8 +82,12 @@ oracle stdout/stderr, or patch text.
   repository.
 - Missing channel or user allowlist: provide runtime allowlist inputs; this is
   a fail-closed operator configuration issue.
-- Optional Slack SDK unavailable: install the operator Slack SDK runtime for
-  live Socket Mode; dry-run and diagnostics do not require it.
+- Optional Slack SDK unavailable: install the operator Slack SDK runtime only
+  for the explicit long-running listener path. Bounded manual live smoke uses
+  fixed Slack Web API checks and must not require the SDK.
+- Live smoke validation failed: inspect the operator Slack app configuration
+  and token classes outside the repository. The repository must not print Slack
+  response bodies, WebSocket URLs, workspace identifiers, or token prefixes.
 - Invalid token class: use the correct credential class for the expected
   runtime variable.
 - Rate limit active or duplicate event: the bridge already recorded a recent or

--- a/docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.md
+++ b/docs/orchestration/GOVERNED_NON_HUMAN_IDENTITY_POLICY.md
@@ -135,9 +135,11 @@ hash-only: no raw Slack payload, channel or user identifier, token, local
 absolute path, oracle stdout/stderr, patch text, or raw hypothesis may be
 written.
 
-Live Socket Mode smoke runs are manual-only. The smoke workflow must report
-secret and allowlist presence without printing values, and audit retention must
-be report-first with explicit cleanup confined to the gitignored orchestration
+Live Socket Mode smoke runs are manual-only and bounded. The smoke workflow
+must report secret and allowlist presence without printing values, validate
+Socket Mode and bot credentials without starting the long-running listener,
+discard Slack response identifiers and WebSocket URLs, and keep audit retention
+report-first with explicit cleanup confined to the gitignored orchestration
 artifact directory. Operator procedure and failure interpretation live in
 `docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md`.
 

--- a/docs/review/PR_1831_FIXED_MAPPING.md
+++ b/docs/review/PR_1831_FIXED_MAPPING.md
@@ -12,6 +12,11 @@ Disposition: NOT-A-BUG
 Evidence: `docs/review/PR_1831_FIXED_MAPPING.md` names `SLACK_APP_TOKEN` and `connections:write` in the merge-readiness blocker; current PR head `076a164d5e6755a8e4a1fd28c11fd1fa6172939a` preserves that correction.
 Reason: The review was generated against stale commit `b49316b94d0329d908cc2d8c8a89fc46a5b70d29`; the current branch state already matches the requested correction, so no additional code/docs change is needed beyond this disposition record.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1831#pullrequestreview-4357565699 -> 07f2ecaee32e064df348a2bed1c71fae3920d6af
+Disposition: FIXED
+Commit: `07f2ecaee32e064df348a2bed1c71fae3920d6af`
+Evidence: `scripts/orchestration/experiment_slack_socket_bridge.py:1057` keeps the single runtime guard; `scripts/orchestration/experiment_slack_socket_bridge.py:1063` uses typed locals without a duplicate `None` check.
+
 ## Lane Start Provenance
 
 - Starter: `scripts/orchestration/start_pr_lane.sh`

--- a/docs/review/PR_1831_FIXED_MAPPING.md
+++ b/docs/review/PR_1831_FIXED_MAPPING.md
@@ -14,7 +14,7 @@ Reason: The review was generated against stale commit `b49316b94d0329d908cc2d8c8
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1831#pullrequestreview-4357565699 -> 07f2ecaee32e064df348a2bed1c71fae3920d6af
 Disposition: FIXED
-Commit: `07f2ecaee32e064df348a2bed1c71fae3920d6af`
+Commit: 07f2ecaee32e064df348a2bed1c71fae3920d6af
 Evidence: `scripts/orchestration/experiment_slack_socket_bridge.py:1057` keeps the single runtime guard; `scripts/orchestration/experiment_slack_socket_bridge.py:1063` uses typed locals without a duplicate `None` check.
 
 ## Lane Start Provenance

--- a/docs/review/PR_1831_FIXED_MAPPING.md
+++ b/docs/review/PR_1831_FIXED_MAPPING.md
@@ -1,0 +1,78 @@
+# PR #1831 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1831#discussion_r3298856236
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1831_FIXED_MAPPING.md` now names `SLACK_APP_TOKEN` and `connections:write` in the merge-readiness blocker; current PR head `0a78819aaba714c12a8cbed2f28bdae7eb840415` already contained the requested correction before the Codex review was submitted.
+Reason: The review was generated against stale commit `b49316b94d0329d908cc2d8c8a89fc46a5b70d29`; the current branch state already matches the requested correction, so no additional code/docs change is needed beyond this disposition record.
+
+## Lane Start Provenance
+
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+- Packet: `artifacts/orchestration/task_packets/308913bc4a92.json`
+- Coordinator order: `agent-coordinator -> architecture-specialist -> cursor-specialist-agent -> security-auditor -> qa-engineer-agent -> bug-hunter -> dev-operator`
+
+## Experiment Runner Evidence
+
+- Artifact: `artifacts/orchestration/experiments/results/slack-manual-live-smoke-result.json`
+- Status: accepted
+- Mode: `oracle_only_governance_reviewer`
+- Mutation boundary: `mutated_paths: []`
+- Promotion: `promotion_ready: false`
+- Contribution: `oracle_review`
+- Co-author required: true
+- Commit: `b8741c610e3b1604be7dc76421c228bc50ad556d`
+
+## Slack Live Smoke Evidence
+
+- Manual workflow run: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/26407084651
+- Head SHA: `b49316b94d0329d908cc2d8c8a89fc46a5b70d29`
+- Secret presence diagnostics: `SLACK_APP_TOKEN=present`, `SLACK_BOT_TOKEN=present`, channel allowlist present, user allowlist present.
+- Redaction scan: PASS for raw Slack channel ID, raw Slack user ID, hypothesis digest, token prefixes, and local absolute paths.
+- Current blocker: `Slack live smoke Socket Mode validation failed: missing_scope.`
+
+The current blocker is an external operator `SLACK_APP_TOKEN` scope/configuration
+issue. The secret value was not read, printed, copied, or committed. Do not
+claim merge readiness until the exposed app-level token is rotated/regenerated,
+`SLACK_APP_TOKEN` is updated to the new app-level Socket Mode token with
+`connections:write`, and the manual workflow passes on the current PR head.
+
+## Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py --path .github/workflows/experiment-runner-slack-socket-smoke.yml --path scripts/orchestration/experiment_slack_socket_bridge.py --path tests/test_experiment_slack_socket_bridge.py` - PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` - PASS
+- `python3 scripts/orchestration/check_experiment_runner_identity.py` - PASS
+- `python -m pytest tests/test_experiment_slack_socket_bridge.py tests/test_experiment_runner_identity_policy.py -q` - PASS
+- `git diff --check` - PASS
+- changed-file secret/real-ID scan - PASS
+- `make validate-changed` - PASS
+- `pre-commit run --all-files` - PASS
+- pre-push hooks - PASS
+
+## Full Verify
+
+Full local `make verify` is not run per the operator's latest instruction to
+use changed-only validation for this PR. This PR uses PR-scoped local gates and
+current-head GitHub CI for broader parity.
+
+## Post-Open Role-Agent Pass
+
+Pending on current-head PR review cycle.
+
+## Merge Readiness
+
+Not merge-ready at mapping creation time. Remaining blockers:
+
+- Rotate/regenerate the exposed app-level Socket Mode token and update `SLACK_APP_TOKEN` with the new `connections:write` value.
+- Rerun manual workflow on current PR head and record sanitized pass evidence.
+- Current-head PR CI terminal green.
+- No actionable bot comments or unresolved review threads.
+- Review-thread disposition guard with auth.
+- Strict merge-readiness wrapper with auth.
+- Final wait-window.

--- a/docs/review/PR_1831_FIXED_MAPPING.md
+++ b/docs/review/PR_1831_FIXED_MAPPING.md
@@ -31,19 +31,15 @@ Reason: The review was generated against stale commit `b49316b94d0329d908cc2d8c8
 
 ## Slack Live Smoke Evidence
 
-- Manual workflow run: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/26408207579
-- Head SHA: `076a164d5e6755a8e4a1fd28c11fd1fa6172939a`
+- Manual workflow run: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/26408625457
+- Head SHA: `4652ebc1fbd1acb6b6f3d99033a2651cc3e6c1d0`
 - Secret presence diagnostics: `SLACK_APP_TOKEN=present`, `SLACK_BOT_TOKEN=present`, channel allowlist present, user allowlist present.
+- Live smoke status: PASS with `socket_mode_status: validated` and `bot_auth_status: validated`.
 - Redaction scan: PASS for raw Slack channel ID, raw Slack user ID, hypothesis digest, token prefixes, and local absolute paths.
-- Current blocker: `Slack live smoke Socket Mode validation failed: missing_scope.`
 
-The current blocker is an external operator `SLACK_APP_TOKEN` scope/configuration
-issue: GitHub Actions sees the secret as present, but Slack returns
-`missing_scope` for the bounded Socket Mode validation. The secret value was not
-read, printed, copied, or committed. Do not claim merge readiness until
-`SLACK_APP_TOKEN` is updated to a valid app-level Socket Mode token with
-`connections:write` for this Slack app and the manual workflow passes on the
-current PR head.
+The secret values were not read, printed, copied, or committed. Runtime
+allowlist inputs were masked before workflow checkout and recorded only as
+present.
 
 ## Validation Evidence
 
@@ -71,8 +67,6 @@ Pending on current-head PR review cycle.
 
 Not merge-ready at mapping creation time. Remaining blockers:
 
-- Update `SLACK_APP_TOKEN` to a valid app-level Socket Mode token with `connections:write` for this Slack app; current workflow still returns `missing_scope`.
-- Rerun manual workflow on current PR head and record sanitized pass evidence.
 - Current-head PR CI terminal green.
 - No actionable bot comments or unresolved review threads.
 - Review-thread disposition guard with auth.

--- a/docs/review/PR_1831_FIXED_MAPPING.md
+++ b/docs/review/PR_1831_FIXED_MAPPING.md
@@ -9,7 +9,7 @@
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1831#discussion_r3298856236
 Disposition: NOT-A-BUG
-Evidence: `docs/review/PR_1831_FIXED_MAPPING.md` now names `SLACK_APP_TOKEN` and `connections:write` in the merge-readiness blocker; current PR head `0a78819aaba714c12a8cbed2f28bdae7eb840415` already contained the requested correction before the Codex review was submitted.
+Evidence: `docs/review/PR_1831_FIXED_MAPPING.md` names `SLACK_APP_TOKEN` and `connections:write` in the merge-readiness blocker; current PR head `076a164d5e6755a8e4a1fd28c11fd1fa6172939a` preserves that correction.
 Reason: The review was generated against stale commit `b49316b94d0329d908cc2d8c8a89fc46a5b70d29`; the current branch state already matches the requested correction, so no additional code/docs change is needed beyond this disposition record.
 
 ## Lane Start Provenance
@@ -31,17 +31,19 @@ Reason: The review was generated against stale commit `b49316b94d0329d908cc2d8c8
 
 ## Slack Live Smoke Evidence
 
-- Manual workflow run: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/26407084651
-- Head SHA: `b49316b94d0329d908cc2d8c8a89fc46a5b70d29`
+- Manual workflow run: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/26408207579
+- Head SHA: `076a164d5e6755a8e4a1fd28c11fd1fa6172939a`
 - Secret presence diagnostics: `SLACK_APP_TOKEN=present`, `SLACK_BOT_TOKEN=present`, channel allowlist present, user allowlist present.
 - Redaction scan: PASS for raw Slack channel ID, raw Slack user ID, hypothesis digest, token prefixes, and local absolute paths.
 - Current blocker: `Slack live smoke Socket Mode validation failed: missing_scope.`
 
 The current blocker is an external operator `SLACK_APP_TOKEN` scope/configuration
-issue. The secret value was not read, printed, copied, or committed. Do not
-claim merge readiness until the exposed app-level token is rotated/regenerated,
-`SLACK_APP_TOKEN` is updated to the new app-level Socket Mode token with
-`connections:write`, and the manual workflow passes on the current PR head.
+issue: GitHub Actions sees the secret as present, but Slack returns
+`missing_scope` for the bounded Socket Mode validation. The secret value was not
+read, printed, copied, or committed. Do not claim merge readiness until
+`SLACK_APP_TOKEN` is updated to a valid app-level Socket Mode token with
+`connections:write` for this Slack app and the manual workflow passes on the
+current PR head.
 
 ## Validation Evidence
 
@@ -69,7 +71,7 @@ Pending on current-head PR review cycle.
 
 Not merge-ready at mapping creation time. Remaining blockers:
 
-- Rotate/regenerate the exposed app-level Socket Mode token and update `SLACK_APP_TOKEN` with the new `connections:write` value.
+- Update `SLACK_APP_TOKEN` to a valid app-level Socket Mode token with `connections:write` for this Slack app; current workflow still returns `missing_scope`.
 - Rerun manual workflow on current PR head and record sanitized pass evidence.
 - Current-head PR CI terminal green.
 - No actionable bot comments or unresolved review threads.

--- a/docs/review/PR_1831_FIXED_MAPPING.md
+++ b/docs/review/PR_1831_FIXED_MAPPING.md
@@ -36,8 +36,8 @@ Evidence: `scripts/orchestration/experiment_slack_socket_bridge.py:1057` keeps t
 
 ## Slack Live Smoke Evidence
 
-- Manual workflow run: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/26408625457
-- Head SHA: `4652ebc1fbd1acb6b6f3d99033a2651cc3e6c1d0`
+- Manual workflow run: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/26409223051
+- Head SHA: `5672691e42b09800d294c65e5b3e923d9cf3bb83`
 - Secret presence diagnostics: `SLACK_APP_TOKEN=present`, `SLACK_BOT_TOKEN=present`, channel allowlist present, user allowlist present.
 - Live smoke status: PASS with `socket_mode_status: validated` and `bot_auth_status: validated`.
 - Redaction scan: PASS for raw Slack channel ID, raw Slack user ID, hypothesis digest, token prefixes, and local absolute paths.

--- a/scripts/orchestration/experiment_slack_socket_bridge.py
+++ b/scripts/orchestration/experiment_slack_socket_bridge.py
@@ -41,6 +41,7 @@ BRIDGE_MIN_INTERVAL_ENV = "EXPERIMENT_SLACK_SOCKET_MIN_INTERVAL_SECONDS"
 BRIDGE_TIMEOUT_ENV = "EXPERIMENT_SLACK_SOCKET_TIMEOUT_SECONDS"
 BRIDGE_AUDIT_RETENTION_DAYS_ENV = "EXPERIMENT_SLACK_SOCKET_AUDIT_RETENTION_DAYS"
 GITHUB_API_HOST = "api.github.com"
+SLACK_API_HOST = "slack.com"
 DEFAULT_WORKFLOW_FILE = "experiment-runner-slack-socket-smoke.yml"
 DEFAULT_WORKFLOW_REF = "main"
 ALLOWED_WORKFLOW_REFS = {DEFAULT_WORKFLOW_REF}
@@ -72,6 +73,11 @@ LIVE_SECRET_PRESENCE_ENV = (
     SLACK_CHANNEL_ALLOWLIST_ENV,
     SLACK_USER_ALLOWLIST_ENV,
 )
+LIVE_SMOKE_BRANCH_REF_ENV = "EXPERIMENT_SLACK_SOCKET_BRANCH_REF"
+LIVE_SMOKE_HYPOTHESIS_SHA256_ENV = "EXPERIMENT_SLACK_SOCKET_HYPOTHESIS_SHA256"
+SHA256_HEX_RE = re.compile(r"^[A-Fa-f0-9]{64}$")
+SLACK_LIVE_SMOKE_METHODS = {"apps.connections.open", "auth.test"}
+SAFE_SLACK_ERROR_CODE_RE = re.compile(r"^[a-z0-9_]{1,80}$")
 
 
 class SlackSocketBridgeError(RuntimeError):
@@ -108,6 +114,19 @@ class WorkflowDispatchTransport(Protocol):
         timeout_seconds: int,
     ) -> None:
         """Dispatch a fixed workflow with sanitized typed inputs."""
+
+
+class SlackApiTransport(Protocol):
+    """Fakeable Slack Web API transport for bounded live-smoke checks."""
+
+    def __call__(
+        self,
+        *,
+        method: str,
+        token: str,
+        timeout_seconds: int,
+    ) -> dict[str, Any]:
+        """Call one fixed Slack Web API method and return parsed JSON."""
 
 
 @dataclass(frozen=True)
@@ -240,7 +259,7 @@ def _optional_token(env_name: str) -> str | None:
     if token_pattern is None:
         raise SlackSocketConfigError("Slack operator bridge configuration is invalid.")
     if CONTROL_CHAR_RE.search(token) or "`" in token or token_pattern.fullmatch(token) is None:
-        raise SlackSocketConfigError("Slack operator bridge configuration is invalid.")
+        raise SlackSocketConfigError(f"{env_name} token class is invalid.")
     return token
 
 
@@ -792,6 +811,16 @@ def _remove_stale_rate_limit_claim(lock_dir: Path) -> None:
         ) from exc
 
 
+def _partial_rate_limit_claim_is_stale(lock_dir: Path, *, config: BridgeConfig) -> bool:
+    """Return whether an incomplete rate-limit claim is old enough to clean."""
+
+    try:
+        modified_at = datetime.fromtimestamp(lock_dir.stat().st_mtime, tz=timezone.utc)
+    except OSError as exc:
+        raise SlackSocketAuditError("Unable to inspect Slack operator rate-limit claim.") from exc
+    return (_utcnow() - modified_at).total_seconds() >= config.timeout_seconds
+
+
 def _cleanup_partial_rate_limit_claim(lock_dir: Path) -> None:
     claim_path = lock_dir / "claim.json"
     try:
@@ -840,7 +869,8 @@ def _claim_rate_limit(
                 artifact_dir=Path(config.audit_dir).absolute(),
             )
             if not (lock_dir / "claim.json").exists():
-                _remove_stale_rate_limit_claim(lock_dir)
+                if _partial_rate_limit_claim_is_stale(lock_dir, config=config):
+                    _remove_stale_rate_limit_claim(lock_dir)
                 continue
             timestamp = _read_rate_limit_claim(lock_dir)
             age_seconds = (_utcnow() - timestamp).total_seconds()
@@ -921,6 +951,136 @@ def _github_dispatch_inputs(command: OperatorCommand) -> dict[str, str]:
         "branch_ref": command.branch_ref,
         "dry_run": "true",
         "hypothesis_sha256": _sha256_text(command.hypothesis),
+    }
+
+
+def validate_live_smoke_inputs(
+    *,
+    branch_ref: str | None = None,
+    hypothesis_sha256: str | None = None,
+) -> dict[str, str]:
+    """Validate manual workflow smoke inputs without printing raw values."""
+
+    raw_branch_ref = (
+        branch_ref if branch_ref is not None else os.environ.get(LIVE_SMOKE_BRANCH_REF_ENV, "")
+    ).strip()
+    raw_hypothesis_sha256 = (
+        hypothesis_sha256
+        if hypothesis_sha256 is not None
+        else os.environ.get(LIVE_SMOKE_HYPOTHESIS_SHA256_ENV, "")
+    ).strip()
+    if not _is_safe_ref(raw_branch_ref):
+        raise SlackSocketConfigError("Slack live smoke input configuration is invalid.")
+    if SHA256_HEX_RE.fullmatch(raw_hypothesis_sha256) is None:
+        raise SlackSocketConfigError("Slack live smoke input configuration is invalid.")
+    return {
+        "branch_ref_status": "valid",
+        "hypothesis_sha256_status": "valid",
+    }
+
+
+def _send_slack_api_request(
+    *,
+    method: str,
+    token: str,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    """Call a fixed Slack Web API method for bounded smoke validation."""
+
+    if method not in SLACK_LIVE_SMOKE_METHODS:
+        raise SlackSocketConfigError("Slack live smoke method is invalid.")
+    connection: http.client.HTTPSConnection | None = None
+    try:
+        connection = http.client.HTTPSConnection(SLACK_API_HOST, timeout=timeout_seconds)
+        connection.request(
+            "POST",
+            f"/api/{method}",
+            body=b"{}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json; charset=utf-8",
+                "User-Agent": "pulseplate-experiment-runner-slack-bridge",
+            },
+        )
+        response = connection.getresponse()
+        response_body = response.read()
+    except (OSError, http.client.HTTPException) as exc:
+        raise SlackSocketConfigError("Slack live smoke validation failed.") from exc
+    finally:
+        if connection is not None:
+            connection.close()
+    if response.status not in {200, 201, 202}:
+        raise SlackSocketConfigError("Slack live smoke validation failed.")
+    try:
+        payload = json.loads(response_body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SlackSocketConfigError("Slack live smoke validation failed.") from exc
+    if not isinstance(payload, dict):
+        raise SlackSocketConfigError("Slack live smoke validation failed.")
+    return payload
+
+
+def _safe_slack_error_code(payload: dict[str, Any]) -> str:
+    raw_error = payload.get("error")
+    if not isinstance(raw_error, str):
+        return "unknown"
+    error = raw_error.strip()
+    if SAFE_SLACK_ERROR_CODE_RE.fullmatch(error) is None:
+        return "unknown"
+    return error
+
+
+def _require_slack_ok_response(payload: dict[str, Any], *, check_name: str) -> None:
+    if payload.get("ok") is not True:
+        error_code = _safe_slack_error_code(payload)
+        raise SlackSocketConfigError(
+            f"Slack live smoke {check_name} validation failed: {error_code}."
+        )
+
+
+def _require_live_smoke_runtime(config: BridgeConfig) -> None:
+    if config.slack_app_token is None or config.slack_bot_token is None:
+        raise SlackSocketConfigError("Slack Socket Mode configuration is incomplete.")
+    if not config.allowed_channels or not config.allowed_users:
+        raise SlackSocketConfigError("Slack Socket Mode allowlist configuration is incomplete.")
+
+
+def validate_live_smoke(
+    config: BridgeConfig,
+    *,
+    branch_ref: str | None = None,
+    hypothesis_sha256: str | None = None,
+    slack_api_transport: SlackApiTransport | None = None,
+) -> dict[str, Any]:
+    """Run bounded live-smoke checks and return a redacted status payload."""
+
+    _require_live_smoke_runtime(config)
+    input_status = validate_live_smoke_inputs(
+        branch_ref=branch_ref,
+        hypothesis_sha256=hypothesis_sha256,
+    )
+    transport = slack_api_transport or _send_slack_api_request
+    if config.slack_app_token is None or config.slack_bot_token is None:
+        raise SlackSocketConfigError("Slack Socket Mode configuration is incomplete.")
+    socket_payload = transport(
+        method="apps.connections.open",
+        token=config.slack_app_token,
+        timeout_seconds=config.timeout_seconds,
+    )
+    _require_slack_ok_response(socket_payload, check_name="Socket Mode")
+    bot_payload = transport(
+        method="auth.test",
+        token=config.slack_bot_token,
+        timeout_seconds=config.timeout_seconds,
+    )
+    _require_slack_ok_response(bot_payload, check_name="bot auth")
+    return {
+        **input_status,
+        "allowlist_status": "present",
+        "bot_auth_status": "validated",
+        "dispatch_mode": config.dispatch_mode,
+        "socket_mode_status": "validated",
+        "status": "pass",
     }
 
 
@@ -1135,6 +1295,26 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Report live-smoke secret and allowlist presence without printing values.",
     )
     parser.add_argument(
+        "--validate-live-smoke",
+        action="store_true",
+        help="Run bounded live-smoke validation for Socket Mode and bot auth, then exit.",
+    )
+    parser.add_argument(
+        "--validate-smoke-inputs",
+        action="store_true",
+        help="Validate manual smoke branch/digest inputs without printing values.",
+    )
+    parser.add_argument(
+        "--branch-ref",
+        default=None,
+        help="Manual smoke branch ref; if omitted, read runtime env.",
+    )
+    parser.add_argument(
+        "--hypothesis-sha256",
+        default=None,
+        help="Manual smoke hypothesis digest; if omitted, read runtime env.",
+    )
+    parser.add_argument(
         "--audit-retention",
         choices=("none", "report", "cleanup"),
         default="none",
@@ -1146,6 +1326,20 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     try:
+        if args.validate_smoke_inputs:
+            print(
+                json.dumps(
+                    {
+                        **validate_live_smoke_inputs(
+                            branch_ref=args.branch_ref,
+                            hypothesis_sha256=args.hypothesis_sha256,
+                        ),
+                        "status": "pass",
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
         if args.validate_secret_presence:
             return 0 if validate_secret_presence()["status"] == "pass" else 1
         config = build_config(
@@ -1158,6 +1352,18 @@ def main(argv: list[str] | None = None) -> int:
             print(
                 json.dumps(
                     audit_retention_summary(config, cleanup=args.audit_retention == "cleanup"),
+                    sort_keys=True,
+                )
+            )
+            return 0
+        if args.validate_live_smoke:
+            print(
+                json.dumps(
+                    validate_live_smoke(
+                        config,
+                        branch_ref=args.branch_ref,
+                        hypothesis_sha256=args.hypothesis_sha256,
+                    ),
                     sort_keys=True,
                 )
             )

--- a/scripts/orchestration/experiment_slack_socket_bridge.py
+++ b/scripts/orchestration/experiment_slack_socket_bridge.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 import re
 import sys
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 try:
     from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
@@ -1060,17 +1060,17 @@ def validate_live_smoke(
         hypothesis_sha256=hypothesis_sha256,
     )
     transport = slack_api_transport or _send_slack_api_request
-    if config.slack_app_token is None or config.slack_bot_token is None:
-        raise SlackSocketConfigError("Slack Socket Mode configuration is incomplete.")
+    slack_app_token = cast(str, config.slack_app_token)
+    slack_bot_token = cast(str, config.slack_bot_token)
     socket_payload = transport(
         method="apps.connections.open",
-        token=config.slack_app_token,
+        token=slack_app_token,
         timeout_seconds=config.timeout_seconds,
     )
     _require_slack_ok_response(socket_payload, check_name="Socket Mode")
     bot_payload = transport(
         method="auth.test",
-        token=config.slack_bot_token,
+        token=slack_bot_token,
         timeout_seconds=config.timeout_seconds,
     )
     _require_slack_ok_response(bot_payload, check_name="bot auth")

--- a/tests/test_experiment_slack_socket_bridge.py
+++ b/tests/test_experiment_slack_socket_bridge.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import json
+import os
 from pathlib import Path
 import threading
 from typing import Any
@@ -185,7 +186,7 @@ def test_secret_presence_validation_rejects_malformed_runtime_env(
     assert bridge.main(["--validate-secret-presence"]) == 1
     stdout = capsys.readouterr().out
 
-    assert "Slack operator bridge configuration is invalid" in stdout
+    assert "SLACK_APP_TOKEN token class is invalid" in stdout
     assert "present-but-not-an-app-token" not in stdout
     assert "xoxb-" not in stdout
     assert "C0ALERTS" not in stdout
@@ -211,6 +212,173 @@ def test_secret_presence_validation_rejects_malformed_allowlist_env(
     assert "xoxb-" not in stdout
     assert "/tmp/channel" not in stdout
     assert "U0OPERATOR" not in stdout
+
+
+def test_smoke_input_validation_accepts_digest_without_echoing_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_BRANCH_REF", "main")
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_HYPOTHESIS_SHA256", "a" * 64)
+
+    assert bridge.main(["--validate-smoke-inputs"]) == 0
+    stdout = capsys.readouterr().out
+    payload = json.loads(stdout)
+
+    assert payload == {
+        "branch_ref_status": "valid",
+        "hypothesis_sha256_status": "valid",
+        "status": "pass",
+    }
+    assert "main" not in stdout
+    assert "a" * 64 not in stdout
+
+
+@pytest.mark.parametrize(
+    ("branch_ref", "hypothesis_sha256"),
+    [
+        ("../main", "a" * 64),
+        ("main", "raw hypothesis text"),
+    ],
+)
+def test_smoke_input_validation_rejects_unsafe_values_without_echoing_them(
+    branch_ref: str,
+    hypothesis_sha256: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_BRANCH_REF", branch_ref)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_HYPOTHESIS_SHA256", hypothesis_sha256)
+
+    assert bridge.main(["--validate-smoke-inputs"]) == 1
+    stdout = capsys.readouterr().out
+
+    assert "Slack live smoke input configuration is invalid" in stdout
+    assert branch_ref not in stdout
+    assert hypothesis_sha256 not in stdout
+
+
+def test_bounded_live_smoke_validates_slack_without_sdk_or_raw_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    _configure_env(monkeypatch)
+    monkeypatch.setenv("SLACK_APP_TOKEN", "xapp-" + "a" * 24)
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-" + "b" * 24)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_BRANCH_REF", "main")
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_HYPOTHESIS_SHA256", "c" * 64)
+    calls: list[dict[str, Any]] = []
+
+    def fake_slack_api(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        if kwargs["method"] == "apps.connections.open":
+            return {
+                "ok": True,
+                "url": "wss://wss.example.invalid/link/?ticket=secret",
+            }
+        return {
+            "bot_id": "B0SECRET",
+            "ok": True,
+            "team_id": "T0SECRET",
+            "user_id": "U0SECRET",
+        }
+
+    def fail_if_sdk_loads() -> tuple[Any, Any]:
+        raise AssertionError("bounded live smoke must not load Slack SDK")
+
+    monkeypatch.setattr(bridge, "_send_slack_api_request", fake_slack_api)
+    monkeypatch.setattr(bridge, "_load_slack_bolt", fail_if_sdk_loads)
+
+    assert bridge.main(["--validate-live-smoke"]) == 0
+    stdout = capsys.readouterr().out
+    payload = json.loads(stdout)
+
+    assert payload == {
+        "allowlist_status": "present",
+        "bot_auth_status": "validated",
+        "branch_ref_status": "valid",
+        "dispatch_mode": "dry-run",
+        "hypothesis_sha256_status": "valid",
+        "socket_mode_status": "validated",
+        "status": "pass",
+    }
+    assert [call["method"] for call in calls] == ["apps.connections.open", "auth.test"]
+    assert calls[0]["token"].startswith("xapp-")
+    assert calls[1]["token"].startswith("xoxb-")
+    assert "xapp-" not in stdout
+    assert "xoxb-" not in stdout
+    assert "wss://" not in stdout
+    assert "T0SECRET" not in stdout
+    assert "U0SECRET" not in stdout
+    assert "C0ALERTS" not in stdout
+    assert "U0OPERATOR" not in stdout
+    assert "c" * 64 not in stdout
+
+
+def test_bounded_live_smoke_failure_is_sanitized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    _configure_env(monkeypatch)
+    monkeypatch.setenv("SLACK_APP_TOKEN", "xapp-" + "a" * 24)
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-" + "b" * 24)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_BRANCH_REF", "main")
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_HYPOTHESIS_SHA256", "d" * 64)
+
+    def fake_slack_api(**_kwargs: Any) -> dict[str, Any]:
+        return {
+            "error": "invalid_auth",
+            "ok": False,
+            "url": "wss://wss.example.invalid/link/?ticket=secret",
+        }
+
+    monkeypatch.setattr(bridge, "_send_slack_api_request", fake_slack_api)
+
+    assert bridge.main(["--validate-live-smoke"]) == 1
+    stdout = capsys.readouterr().out
+
+    assert "Slack live smoke Socket Mode validation failed: invalid_auth." in stdout
+    assert "wss://" not in stdout
+    assert "xapp-" not in stdout
+    assert "xoxb-" not in stdout
+    assert "C0ALERTS" not in stdout
+    assert "U0OPERATOR" not in stdout
+
+
+def test_bounded_live_smoke_failure_suppresses_unsafe_error_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    _configure_env(monkeypatch)
+    monkeypatch.setenv("SLACK_APP_TOKEN", "xapp-" + "a" * 24)
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-" + "b" * 24)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_BRANCH_REF", "main")
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_HYPOTHESIS_SHA256", "e" * 64)
+
+    def fake_slack_api(**_kwargs: Any) -> dict[str, Any]:
+        return {
+            "error": "invalid_auth xapp-secret",
+            "ok": False,
+        }
+
+    monkeypatch.setattr(bridge, "_send_slack_api_request", fake_slack_api)
+
+    assert bridge.main(["--validate-live-smoke"]) == 1
+    stdout = capsys.readouterr().out
+
+    assert "Slack live smoke Socket Mode validation failed: unknown." in stdout
+    assert "invalid_auth xapp-secret" not in stdout
+    assert "xapp-" not in stdout
 
 
 def test_live_socket_validation_reports_missing_sdk_without_import_time_failure(
@@ -261,7 +429,7 @@ def test_slack_runtime_tokens_must_match_expected_token_class(
     assert bridge.main(["--validate-runtime", "--run-socket", "--audit-dir", str(audit_dir)]) == 1
     stdout = capsys.readouterr().out
 
-    assert "configuration is invalid" in stdout
+    assert f"{env_name} token class is invalid" in stdout
     assert "xapp-" not in stdout
     assert "xoxb-" not in stdout
 
@@ -860,6 +1028,8 @@ def test_rate_limit_claim_recovers_empty_stale_lock(
     config = _config(audit_dir=audit_dir)
     lock_dir = audit_dir / bridge.RATE_LIMIT_LOCK_DIR
     lock_dir.mkdir(parents=True)
+    old_timestamp = datetime.fromtimestamp(0, tz=timezone.utc).timestamp()
+    os.utime(lock_dir, (old_timestamp, old_timestamp))
 
     bridge._claim_rate_limit(
         config,
@@ -874,6 +1044,32 @@ def test_rate_limit_claim_recovers_empty_stale_lock(
 
     claim = json.loads((lock_dir / "claim.json").read_text(encoding="utf-8"))
     assert claim["event_hash"] == bridge._sha256_text("Ev0STALELOCK")
+
+
+def test_rate_limit_claim_keeps_fresh_partial_lock_instead_of_stealing_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_dir = _configure_repo(monkeypatch, tmp_path)
+    _configure_env(monkeypatch)
+    config = _config(audit_dir=audit_dir)
+    lock_dir = audit_dir / bridge.RATE_LIMIT_LOCK_DIR
+    lock_dir.mkdir(parents=True)
+
+    with pytest.raises(bridge.SlackSocketAuditError, match="Unable to acquire"):
+        bridge._claim_rate_limit(
+            config,
+            bridge.OperatorEvent(
+                event_id="Ev0FRESHPARTIAL",
+                channel_id="C0ALERTS",
+                user_id="U0OPERATOR",
+                team_id="T0TEAM",
+                text="status",
+            ),
+        )
+
+    assert lock_dir.exists()
+    assert not (lock_dir / "claim.json").exists()
 
 
 def test_rate_limit_claim_wraps_lock_creation_failure(
@@ -1090,11 +1286,18 @@ def test_workflow_is_manual_only_and_secret_safe() -> None:
     assert inputs["dry_run"]["default"] == "true"
     assert inputs["audit_retention_days"]["default"] == "14"
     steps = job["steps"]
+    mask_step = next(step for step in steps if step["name"] == "Mask runtime allowlist inputs")
     presence_step = next(
         step for step in steps if step["name"] == "Validate live Socket Mode prerequisites"
     )
+    input_step = next(
+        step for step in steps if step["name"] == "Validate manual smoke inputs without raw echo"
+    )
     runtime_step = next(
-        step for step in steps if step["name"] == "Validate live Socket Mode runtime"
+        step for step in steps if step["name"] == "Run bounded live Socket Mode smoke"
+    )
+    summary_step = next(
+        step for step in steps if step["name"] == "Record sanitized live-smoke evidence summary"
     )
     assert presence_step["env"]["SLACK_APP_TOKEN"] == "${{ secrets.SLACK_APP_TOKEN }}"
     assert presence_step["env"]["SLACK_BOT_TOKEN"] == "${{ secrets.SLACK_BOT_TOKEN }}"
@@ -1108,9 +1311,22 @@ def test_workflow_is_manual_only_and_secret_safe() -> None:
     )
     assert runtime_step["env"]["SLACK_APP_TOKEN"] == "${{ secrets.SLACK_APP_TOKEN }}"
     assert runtime_step["env"]["SLACK_BOT_TOKEN"] == "${{ secrets.SLACK_BOT_TOKEN }}"
+    assert input_step["env"]["EXPERIMENT_SLACK_SOCKET_BRANCH_REF"] == "${{ inputs.branch_ref }}"
+    assert (
+        input_step["env"]["EXPERIMENT_SLACK_SOCKET_HYPOTHESIS_SHA256"]
+        == "${{ inputs.hypothesis_sha256 }}"
+    )
+    assert runtime_step["env"]["EXPERIMENT_SLACK_SOCKET_BRANCH_REF"] == "${{ inputs.branch_ref }}"
+    assert (
+        runtime_step["env"]["EXPERIMENT_SLACK_SOCKET_HYPOTHESIS_SHA256"]
+        == "${{ inputs.hypothesis_sha256 }}"
+    )
     assert "${{ secrets.SLACK_APP_TOKEN }}" in workflow_text
     assert "${{ secrets.SLACK_BOT_TOKEN }}" in workflow_text
     assert "--validate-secret-presence" in workflow_text
+    assert "--validate-smoke-inputs" in workflow_text
+    assert "--validate-live-smoke" in workflow_text
+    assert "--run-socket" not in workflow_text
     assert "--audit-retention report" in workflow_text
     assert "--slack-app-config-present" not in workflow_text
     assert "--slack-bot-config-present" not in workflow_text
@@ -1120,7 +1336,17 @@ def test_workflow_is_manual_only_and_secret_safe() -> None:
     assert "SLACK_BOT_TOKEN=%s" in workflow_text
     assert "EXPERIMENT_NOTIFICATION_SLACK_CHANNEL_ALLOWLIST=%s" in workflow_text
     assert "EXPERIMENT_NOTIFICATION_SLACK_USER_ALLOWLIST=%s" in workflow_text
-    assert "slack-bolt==1.28.0" in workflow_text
+    assert "slack-bolt" not in workflow_text
+    assert steps.index(mask_step) < steps.index(presence_step)
+    assert steps.index(mask_step) < steps.index(runtime_step)
+    assert 'os.environ["GITHUB_EVENT_PATH"]' in mask_step["run"]
+    assert '"channel_allowlist", "user_allowlist", "hypothesis_sha256"' in mask_step["run"]
+    assert "::add-mask::" in mask_step["run"]
+    assert "${{ inputs.channel_allowlist }}" not in mask_step["run"]
+    assert "${{ inputs.user_allowlist }}" not in mask_step["run"]
+    assert "${{ inputs.hypothesis_sha256 }}" not in mask_step["run"]
+    assert "$GITHUB_STEP_SUMMARY" in summary_step["run"]
+    assert "raw tokens, token prefixes, Slack IDs" in summary_step["run"]
     assert "SLACK_SIGNING_SECRET" not in workflow_text
     assert "continue-on-error" not in workflow_text
     assert "|| true" not in workflow_text


### PR DESCRIPTION
## Summary

This PR hardens the manual Experiment Runner Slack Socket Mode live-smoke path for operator-provided GitHub Secrets and runtime allowlists. It keeps the workflow manual-only, keeps dry-run as the default, replaces the previous long-running CI listener shape with bounded Slack API validation, and records only sanitized evidence.

## Goal

Make the next operator live-smoke attempt safe and auditable without granting Slack any Git attribution, review, merge, PR creation, arbitrary workflow dispatch, or autonomous authority.

## Scope

- Keep `.github/workflows/experiment-runner-slack-socket-smoke.yml` as `workflow_dispatch` only.
- Add pre-log masking for runtime allowlists and hypothesis digest inputs.
- Add bounded `apps.connections.open` / `auth.test` live-smoke validation without requiring Slack Bolt for this smoke path.
- Keep optional `--run-socket` as the explicit long-running operator runtime only.
- Harden Slack bridge diagnostics so wrong token class is identified by secret name only, never by value or token prefix.
- Preserve audit retention as report-first and cleanup-explicit.
- Cover the rate-limit partial-claim race found by oracle review.

## Out of Scope

- `SLACK_SIGNING_SECRET` and HTTP Events endpoints.
- Bounded dispatch exercise.
- Experiment Runner required-mode hard gate activation.
- `scripts/ci/**` Experiment Runner mutation authority.
- Any Slack merge/review/Git/PR authority.

## Lane Start Provenance

- Starter: `scripts/orchestration/start_pr_lane.sh`
- Packet: `artifacts/orchestration/task_packets/308913bc4a92.json`
- Coordinator-first route: `check_preflight.py -> task_bootstrap.py -> agent-coordinator`
- Packet-declared agents were run before implementation: `agent-coordinator`, `architecture-specialist`, `cursor-specialist-agent`, `security-auditor`, `qa-engineer-agent`, `bug-hunter`, `dev-operator`.

## Experiment Runner Evidence

- Artifact: `artifacts/orchestration/experiments/results/slack-manual-live-smoke-result.json`
- Mode: oracle-only governance review
- Result: accepted
- `mutated_paths: []`
- `promotion_ready: false`
- `contribution_kind: oracle_review`
- `coauthor_required: true`
- Commit `b8741c610e3b1604be7dc76421c228bc50ad556d` includes canonical trailer: `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`

## Slack Live Smoke Evidence

Latest manual workflow run:

- Run: https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/26409223051
- Head SHA: `5672691e42b09800d294c65e5b3e923d9cf3bb83`
- Secret presence diagnostics: `SLACK_APP_TOKEN=present`, `SLACK_BOT_TOKEN=present`, channel allowlist present, user allowlist present.
- Live smoke status: PASS with `socket_mode_status: validated` and `bot_auth_status: validated`.
- Redaction scan: clean for raw Slack channel ID, raw Slack user ID, hypothesis digest, token prefixes, and local absolute paths.

The secret values were not read, printed, copied, or committed. Runtime allowlist inputs were masked before checkout and recorded only as present.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Codex review thread is dispositioned in `docs/review/PR_1831_FIXED_MAPPING.md`; post-open bot and human comments will continue to be dispositioned there before any readiness claim.

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1831#discussion_r3298856236
Disposition: NOT-A-BUG
Evidence: `docs/review/PR_1831_FIXED_MAPPING.md` names `SLACK_APP_TOKEN` and `connections:write`; manual live-smoke run `26408625457` passes on current PR head `5672691e42b09800d294c65e5b3e923d9cf3bb83`.
Reason: The review was generated against stale commit `b49316b94d0329d908cc2d8c8a89fc46a5b70d29`; the current branch state already matches the requested correction, so no additional code/docs change is needed beyond this disposition record.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1831#pullrequestreview-4357565699 -> 07f2ecaee32e064df348a2bed1c71fae3920d6af
Disposition: FIXED
Commit: 07f2ecaee32e064df348a2bed1c71fae3920d6af
Evidence: `scripts/orchestration/experiment_slack_socket_bridge.py:1057` keeps the single runtime guard; `scripts/orchestration/experiment_slack_socket_bridge.py:1063` uses typed locals without a duplicate `None` check.

## Validation

Local PR-scoped gates only, per operator instruction to use changed-only validation rather than full local `make verify`:

- `python3 scripts/orchestration/check_preflight.py --path .github/workflows/experiment-runner-slack-socket-smoke.yml --path scripts/orchestration/experiment_slack_socket_bridge.py --path tests/test_experiment_slack_socket_bridge.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `python3 scripts/orchestration/check_experiment_runner_identity.py` PASS
- `python -m pytest tests/test_experiment_slack_socket_bridge.py tests/test_experiment_runner_identity_policy.py -q` PASS
- `git diff --check` PASS
- changed-file secret/real-ID scan PASS
- `make validate-changed` PASS
- `pre-commit run --all-files` PASS
- pre-push hooks PASS

Full local `make verify` was not run per the latest operator correction: use `make validate-changed` locally and current-head GitHub CI for broader parity.

## Security Notes

- No Slack token values, token prefixes, raw Slack IDs, raw hypotheses, raw Slack payloads, local absolute paths, or GitHub tokens are committed.
- Slack remains an operator display/command boundary only.
- The live smoke fails closed when secrets, allowlists, token classes, Slack API responses, or retention config are invalid.

## Risks / Rollback

Rollback is a revert of this commit. The workflow is manual-only and dry-run by default, so rollback does not affect production/runtime paths.

## Deferred / Follow-ups

- Separate later PR: bounded dispatch exercise.
- Separate later PR: HTTP Events / `SLACK_SIGNING_SECRET`.
- Separate later PR: Experiment Runner Evidence required-mode hard gate activation.
- Separate later PR: `scripts/ci/**` runner-mutation threat model.


