### PR TITLE
Define Experiment Runner Slack manifest dispatch contract

### DIFF
--- a/.github/workflows/experiment-runner-dispatch.yml
+++ b/.github/workflows/experiment-runner-dispatch.yml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Experiment Runner Dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_ref:
+        description: "Operator target branch reference; validated as typed input only"
+        required: true
+        type: string
+        default: "main"
+      hypothesis_sha256:
+        description: "SHA256 of the operator hypothesis; never pass raw Slack text"
+        required: true
+        type: string
+        default: "0000000000000000000000000000000000000000000000000000000000000000"
+      dry_run:
+        description: "Keep true until the bounded live dispatch exercise PR enables execution"
+        required: true
+        type: choice
+        default: "true"
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  experiment-runner-dispatch-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Validate typed dispatch inputs without raw echo
+        env:
+          EXPERIMENT_SLACK_SOCKET_BRANCH_REF: ${{ inputs.branch_ref }}
+          EXPERIMENT_SLACK_SOCKET_HYPOTHESIS_SHA256: ${{ inputs.hypothesis_sha256 }}
+        run: |
+          set -euo pipefail
+          python3 -m scripts.orchestration.experiment_slack_socket_bridge \
+            --validate-dispatch-inputs
+
+      - name: Fail closed until bounded live dispatch is promoted
+        if: inputs.dry_run == 'false'
+        run: |
+          set -euo pipefail
+          printf 'Experiment Runner live dispatch is deferred to a later governed PR.\n'
+          exit 1
+
+      - name: Record sanitized dispatch contract summary
+        if: inputs.dry_run == 'true'
+        run: |
+          set -euo pipefail
+          {
+            printf '### Experiment Runner dispatch contract\n'
+            printf -- '- mode: manual workflow_dispatch only\n'
+            printf -- '- dry_run: true\n'
+            printf -- '- branch_ref: validated without raw echo\n'
+            printf -- '- hypothesis_sha256: validated without raw echo\n'
+            printf -- '- authority: no PR creation, review disposition, merge readiness, or arbitrary workflow dispatch\n'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/orchestration/EXPERIMENT_RUNNER_SLACK_APP_MANIFEST.yml
+++ b/docs/orchestration/EXPERIMENT_RUNNER_SLACK_APP_MANIFEST.yml
@@ -1,0 +1,25 @@
+_metadata:
+  major_version: 1
+display_information:
+  name: Experiment Runner
+  description: Governed PulsePlate operator bridge for bounded experiment requests.
+  background_color: "#2E1A47"
+features:
+  bot_user:
+    display_name: experiment-runner
+    always_online: false
+  slash_commands:
+    - command: /run-experiment
+      description: Request a bounded Experiment Runner dispatch from an allowlisted operator.
+      usage_hint: "<branch> <hypothesis>"
+      should_escape: false
+oauth_config:
+  scopes:
+    bot:
+      - commands
+      - chat:write
+settings:
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false
+  is_hosted: false

--- a/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
+++ b/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
@@ -29,6 +29,23 @@ time:
 Use the approved `#experiment-runner` channel ID only as a runtime input. The
 repository must not hardcode it as a default.
 
+## Slack App Manifest
+
+The secret-free operator setup manifest lives at
+`docs/orchestration/EXPERIMENT_RUNNER_SLACK_APP_MANIFEST.yml`.
+
+The manifest documents the repo-approved Socket Mode shape only: Experiment
+Runner app identity, Slack-safe bot display `experiment-runner`,
+`/run-experiment`, bot scopes `commands` and `chat:write`,
+`socket_mode_enabled: true`, `org_deploy_enabled: false`, and `is_hosted:
+false`.
+
+The manifest must not contain token values, token prefixes, webhook URLs,
+request URLs, real workspace/team/channel/user IDs, or repository defaults for
+operator allowlists. App-level Socket Mode token creation and the
+`connections:write` scope remain external operator setup, stored only in the
+runtime secret store.
+
 ## Manual Live Smoke
 
 Run `.github/workflows/experiment-runner-slack-socket-smoke.yml` manually with
@@ -107,8 +124,11 @@ rejected before deletion.
 ## Authority Boundary
 
 The Slack operator bridge may validate configuration, report status, and in
-explicit execute mode dispatch only the fixed smoke workflow with typed,
-sanitized inputs. It must not:
+explicit execute mode dispatch only the fixed
+`.github/workflows/experiment-runner-dispatch.yml` workflow with typed,
+sanitized inputs. The dispatch workflow is manual-only, defaults to `dry_run:
+true`, and fails closed for `dry_run: false` until a later bounded dispatch
+exercise PR promotes live execution. It must not:
 
 - create or update pull requests,
 - resolve review threads,
@@ -117,3 +137,7 @@ sanitized inputs. It must not:
 - run arbitrary workflows,
 - execute shell commands from Slack text,
 - auto-run experiments by default.
+
+The earlier `.github/workflows/experiment-runner-slack-socket-smoke.yml`
+workflow remains the separate manual live-smoke validation path for runtime
+Slack secrets and allowlists.

--- a/docs/review/PR_1836_FIXED_MAPPING.md
+++ b/docs/review/PR_1836_FIXED_MAPPING.md
@@ -1,0 +1,120 @@
+# PR #1836 Fixed in Commit Mapping
+
+## PR
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1836
+
+## Summary
+
+PR #1836 adds the next narrow Experiment Runner Slack slice: a secret-free
+Slack app manifest plus a fixed manual-only bounded dispatch workflow contract.
+It does not execute a real Slack command, enable live dispatch, add HTTP Events
+or `SLACK_SIGNING_SECRET`, flip Experiment Runner required mode, or grant
+`scripts/ci/**` mutation authority.
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/b1efd0790b29.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+- Branch: `codex/experiment-runner-slack-manifest-dispatch-contract`
+- Coordinator authority: `check_preflight.py -> task_bootstrap.py -> agent-coordinator`
+- Packet role order completed/dispositioned:
+  `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> dev-operator`
+- Packet secondary/advisory disposition: `cursor-specialist-agent` completed.
+
+## Agent Run Notes
+
+The initial QA/bug role prompt allowed role-purity drift. Coordinator corrected
+the lane before readiness: role agents were redirected to read the task packet
+and return review output only. Implementation stayed inside the
+coordinator-owned lane.
+
+## Experiment Runner Evidence
+
+- Artifact: `artifacts/orchestration/experiments/results/exp-75526d20af83.json`
+- Status: `accepted`
+- Runner mode: `oracle_only_governance_reviewer`
+- `mutated_paths`: `[]`
+- `promotion_ready`: `false`
+- `contribution_kind`: `commit_decision`
+- `coauthor_required`: `true`
+- Co-author trailer present in commit
+  `01447b93f32870216dd1f9eade5121dadf93d46c`.
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed after latest bot/review activity
+- [ ] Fixed in commit mapping completed after latest bot/review activity
+
+No GitHub review threads are open at mapping creation time.
+
+## Bot And Review Comments
+
+- Sourcery review capacity notice
+  Disposition: NOT-A-BUG
+  Evidence: Sourcery reported weekly diff-character rate limit / availability,
+  not a code finding. This PR uses compensating local coordinator,
+  architecture, security, QA, bug-hunter, dev-operator, Experiment Runner,
+  focused tests, pre-commit, and current-head CI evidence before readiness.
+
+- Cubic generated a neutral PR summary check.
+  Disposition: NOT-A-BUG
+  Evidence: No action requested at mapping creation time.
+
+- CodeRabbit status is SUCCESS at mapping creation time.
+  Disposition: NOT-A-BUG
+  Evidence: No CodeRabbit actionable review thread is present at mapping
+  creation time.
+
+## Fixed in Commit Mapping
+
+No actionable review thread has been resolved yet. Add every future resolved
+actionable thread here with disposition-specific proof before merge readiness.
+
+## Role-Agent Findings
+
+| Role | Finding | Disposition | Evidence |
+| --- | --- | --- | --- |
+| agent-coordinator | Scope must stay to 5 files and Experiment Runner must remain oracle-only evidence, not startup authority. | FIXED | Current diff is the 5-file packet surface; `exp-75526d20af83` is recorded as oracle-only evidence. |
+| architecture-specialist | Keep Slack manifest secret-free and fixed dispatch workflow manual-only/read-only. | FIXED | `docs/orchestration/EXPERIMENT_RUNNER_SLACK_APP_MANIFEST.yml`; `.github/workflows/experiment-runner-dispatch.yml`; tests. |
+| security-auditor | Do not commit Slack IDs, token values, token prefixes, webhook URLs, request URLs, or authority expansion. | FIXED | Manifest/workflow tests reject these surfaces; detect-secrets, Bandit, and pre-push hooks passed. |
+| qa-engineer-agent | Cover manifest/workflow/bridge contract deterministically and do not mix live smoke. | FIXED | `tests/test_experiment_slack_socket_bridge.py` covers manifest, workflow contract, arbitrary workflow rejection, and dispatch alias. |
+| bug-hunter | Authorized dispatch must remain fixed-workflow only and dry-run default must not be bypassed. | FIXED | Bridge default/allowlist tests and workflow fail-closed test. |
+| dev-operator | Branch must be synced with `origin/main` before PR open and use PR-scoped gates only. | FIXED | Branch rebased to `origin/main` (`0 0`) before push; PR-scoped gates listed below. |
+| cursor-specialist-agent | Keep coordinator-first startup and do not let docs make Experiment Runner the lane start authority. | FIXED | PR body and runbook preserve coordinator-first startup; Experiment Runner section is evidence-only. |
+
+## Bounded Check Evidence
+
+| Command | Result |
+| --- | --- |
+| `python3 scripts/orchestration/check_preflight.py --path <changed paths>` | PASS |
+| `python3 scripts/orchestration/check_agent_consistency.py` | PASS |
+| `python3 -m pytest -q tests/test_experiment_slack_socket_bridge.py tests/test_experiment_runner_identity_policy.py` | PASS |
+| `python3 scripts/orchestration/check_experiment_runner_identity.py` | PASS |
+| `make validate-changed` | PASS |
+| `pre-commit run --all-files` | PASS |
+| pre-push hooks | PASS: mypy, pip-audit, backend tests, full Bandit, docker build test |
+
+Full local `make verify` is deferred by operator instruction for this
+governance/tooling lane. This PR uses PR-scoped local gates plus current-head
+GitHub CI before readiness.
+
+## Deferred / Follow-ups
+
+- Manual Bounded Dispatch Exercise: one allowlisted Slack operator command into
+  the fixed workflow, sanitized evidence only.
+- HTTP Events / `SLACK_SIGNING_SECRET`: separate only if introducing HTTP
+  endpoint/interactivity.
+- Experiment Runner Evidence Required-Mode Activation: separate hard-gate
+  rollout PR.
+- `scripts/ci/**` runner mutation threat model: separate authority-widening PR.
+
+## Merge Readiness
+
+Not merge-ready at mapping creation time. Remaining blockers:
+
+- Current-head CI terminal green after the mapping commit.
+- Phase2 PR body gate passes against the mirrored body.
+- No actionable bot comments or unresolved review threads remain.
+- Strict merge-readiness wrapper passes with auth.
+- Mandatory final review/wait window after latest bot/review activity.

--- a/docs/review/PR_1836_FIXED_MAPPING.md
+++ b/docs/review/PR_1836_FIXED_MAPPING.md
@@ -78,7 +78,10 @@ No GitHub review threads are open at this mapping update.
 | architecture-specialist | Keep Slack manifest secret-free and fixed dispatch workflow manual-only/read-only. | FIXED | `docs/orchestration/EXPERIMENT_RUNNER_SLACK_APP_MANIFEST.yml`; `.github/workflows/experiment-runner-dispatch.yml`; tests. |
 | security-auditor | Do not commit Slack IDs, token values, token prefixes, webhook URLs, request URLs, or authority expansion. | FIXED | Manifest/workflow tests reject these surfaces; detect-secrets, Bandit, and pre-push hooks passed. |
 | qa-engineer-agent | Cover manifest/workflow/bridge contract deterministically and do not mix live smoke. | FIXED | `tests/test_experiment_slack_socket_bridge.py` covers manifest, workflow contract, arbitrary workflow rejection, and dispatch alias. |
+| qa-engineer-agent post-open | No actionable QA findings after PR open; review threads query returned empty and Phase2 body gate passed. | FIXED | Post-open QA PASS; focused pytest, `git diff --check origin/main...HEAD`, and `check_agent_consistency.py` passed. |
 | bug-hunter | Authorized dispatch must remain fixed-workflow only and dry-run default must not be bypassed. | FIXED | Bridge default/allowlist tests and workflow fail-closed test. |
+| bug-hunter post-open | No behavioral regression found for arbitrary dispatch, dry-run fail-closed, branch/digest validation, or redaction. | FIXED | Post-open bug-hunter PASS; focused pytest and sanitized scan evidence. |
+| security-auditor post-open | No actionable security finding for workflow permissions, pinned actions, manifest secret hygiene, auth boundary, or authority expansion. | FIXED | Post-open security-auditor PASS; current-head `security-scan` PASS and `CodeQL` PASS. |
 | dev-operator | Branch must be synced with `origin/main` before PR open and use PR-scoped gates only. | FIXED | Branch rebased to `origin/main` (`0 0`) before push; PR-scoped gates listed below. |
 | cursor-specialist-agent | Keep coordinator-first startup and do not let docs make Experiment Runner the lane start authority. | FIXED | PR body and runbook preserve coordinator-first startup; Experiment Runner section is evidence-only. |
 
@@ -93,6 +96,7 @@ No GitHub review threads are open at this mapping update.
 | `make validate-changed` | PASS |
 | `pre-commit run --all-files` | PASS |
 | pre-push hooks | PASS: mypy, pip-audit, backend tests, full Bandit, docker build test |
+| Current-head GitHub checks after latest push | PASS/SKIP terminal for visible checks: actionlint, build, CodeQL, security-scan, validate-pr, CodeRabbit, Cubic, Sourcery, Trivy |
 
 Full local `make verify` is deferred by operator instruction for this
 governance/tooling lane. This PR uses PR-scoped local gates plus current-head

--- a/docs/review/PR_1836_FIXED_MAPPING.md
+++ b/docs/review/PR_1836_FIXED_MAPPING.md
@@ -43,10 +43,10 @@ coordinator-owned lane.
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed after latest bot/review activity
-- [ ] Fixed in commit mapping completed after latest bot/review activity
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
-No GitHub review threads are open at mapping creation time.
+No GitHub review threads are open at this mapping update.
 
 ## Bot And Review Comments
 
@@ -68,8 +68,7 @@ No GitHub review threads are open at mapping creation time.
 
 ## Fixed in Commit Mapping
 
-No actionable review thread has been resolved yet. Add every future resolved
-actionable thread here with disposition-specific proof before merge readiness.
+- No actionable review comments
 
 ## Role-Agent Findings
 

--- a/scripts/orchestration/experiment_slack_socket_bridge.py
+++ b/scripts/orchestration/experiment_slack_socket_bridge.py
@@ -42,7 +42,7 @@ BRIDGE_TIMEOUT_ENV = "EXPERIMENT_SLACK_SOCKET_TIMEOUT_SECONDS"
 BRIDGE_AUDIT_RETENTION_DAYS_ENV = "EXPERIMENT_SLACK_SOCKET_AUDIT_RETENTION_DAYS"
 GITHUB_API_HOST = "api.github.com"
 SLACK_API_HOST = "slack.com"
-DEFAULT_WORKFLOW_FILE = "experiment-runner-slack-socket-smoke.yml"
+DEFAULT_WORKFLOW_FILE = "experiment-runner-dispatch.yml"
 DEFAULT_WORKFLOW_REF = "main"
 ALLOWED_WORKFLOW_REFS = {DEFAULT_WORKFLOW_REF}
 SAFE_SLACK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{1,79}$")
@@ -1303,6 +1303,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--validate-smoke-inputs",
         action="store_true",
         help="Validate manual smoke branch/digest inputs without printing values.",
+    )
+    parser.add_argument(
+        "--validate-dispatch-inputs",
+        action="store_true",
+        dest="validate_smoke_inputs",
+        help="Alias for validating bounded dispatch branch/digest inputs.",
     )
     parser.add_argument(
         "--branch-ref",

--- a/tests/test_experiment_slack_socket_bridge.py
+++ b/tests/test_experiment_slack_socket_bridge.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
+import re
 import threading
 from typing import Any
 
@@ -16,15 +17,21 @@ import scripts.orchestration.context_pack as context_pack
 from scripts.orchestration import experiment_slack_socket_bridge as bridge
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "experiment-runner-slack-socket-smoke.yml"
+SMOKE_WORKFLOW_PATH = (
+    REPO_ROOT / ".github" / "workflows" / "experiment-runner-slack-socket-smoke.yml"
+)
+DISPATCH_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "experiment-runner-dispatch.yml"
+SLACK_MANIFEST_PATH = (
+    REPO_ROOT / "docs" / "orchestration" / "EXPERIMENT_RUNNER_SLACK_APP_MANIFEST.yml"
+)
 
 
 def _workflow_on(workflow: dict[str, Any]) -> dict[str, Any]:
     return workflow.get("on") or workflow[True]
 
 
-def _load_workflow() -> dict[str, Any]:
-    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+def _load_workflow(path: Path = SMOKE_WORKFLOW_PATH) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
 
 
 def _configure_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
@@ -234,6 +241,28 @@ def test_smoke_input_validation_accepts_digest_without_echoing_values(
     }
     assert "main" not in stdout
     assert "a" * 64 not in stdout
+
+
+def test_dispatch_input_validation_alias_accepts_digest_without_echoing_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_BRANCH_REF", "main")
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_HYPOTHESIS_SHA256", "b" * 64)
+
+    assert bridge.main(["--validate-dispatch-inputs"]) == 0
+    stdout = capsys.readouterr().out
+    payload = json.loads(stdout)
+
+    assert payload == {
+        "branch_ref_status": "valid",
+        "hypothesis_sha256_status": "valid",
+        "status": "pass",
+    }
+    assert "main" not in stdout
+    assert "b" * 64 not in stdout
 
 
 @pytest.mark.parametrize(
@@ -544,6 +573,22 @@ def test_config_rejects_non_main_workflow_ref(
         )
 
 
+def test_config_rejects_arbitrary_workflow_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_dir = _configure_repo(monkeypatch, tmp_path)
+    _configure_env(monkeypatch)
+
+    with pytest.raises(bridge.SlackSocketConfigError):
+        bridge.build_config(
+            dispatch_mode="dry-run",
+            audit_dir=str(audit_dir),
+            repo="Katsiarynakavaleuskaya/PulsePlate",
+            workflow_file="experiment-runner-slack-socket-smoke.yml",
+        )
+
+
 def test_config_rejects_parent_traversal_audit_dir_escape(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -663,17 +708,19 @@ def test_execute_mode_dispatches_only_fixed_workflow_with_typed_inputs(
     assert decision.status == "dispatched"
     assert len(calls) == 1
     assert calls[0]["repo"] == "Katsiarynakavaleuskaya/PulsePlate"
-    assert calls[0]["workflow_file"] == "experiment-runner-slack-socket-smoke.yml"
+    assert calls[0]["workflow_file"] == "experiment-runner-dispatch.yml"
     assert calls[0]["ref"] == "main"
     assert calls[0]["inputs"] == {
         "branch_ref": "release/smoke",
         "dry_run": "true",
         "hypothesis_sha256": bridge._sha256_text("Validate bounded Slack operator bridge"),
     }
+    assert bridge.DEFAULT_WORKFLOW_FILE == "experiment-runner-dispatch.yml"
+    assert bridge.ALLOWED_WORKFLOWS == {"experiment-runner-dispatch.yml"}
 
 
 def test_dispatch_inputs_match_manual_workflow_contract() -> None:
-    workflow = _load_workflow()
+    workflow = _load_workflow(DISPATCH_WORKFLOW_PATH)
     triggers = _workflow_on(workflow)
     workflow_inputs = set(triggers["workflow_dispatch"]["inputs"])
     command = bridge.OperatorCommand(
@@ -1310,9 +1357,94 @@ def test_audit_retention_rejects_symlinked_artifact_ancestor(
     assert not (outside / "slack_socket_bridge").exists()
 
 
-def test_workflow_is_manual_only_and_secret_safe() -> None:
+def test_slack_app_manifest_is_socket_mode_and_secret_free() -> None:
+    manifest_text = SLACK_MANIFEST_PATH.read_text(encoding="utf-8")
+    manifest = yaml.safe_load(manifest_text)
+
+    assert manifest["display_information"]["name"] == "Experiment Runner"
+    assert manifest["settings"]["socket_mode_enabled"] is True
+    assert manifest["settings"]["is_hosted"] is False
+    assert manifest["settings"]["org_deploy_enabled"] is False
+    assert manifest["features"]["bot_user"]["display_name"] == "experiment-runner"
+    slash_commands = manifest["features"]["slash_commands"]
+    assert slash_commands == [
+        {
+            "command": "/run-experiment",
+            "description": (
+                "Request a bounded Experiment Runner dispatch from an allowlisted operator."
+            ),
+            "usage_hint": "<branch> <hypothesis>",
+            "should_escape": False,
+        }
+    ]
+    assert manifest["oauth_config"]["scopes"]["bot"] == ["commands", "chat:write"]
+    assert "url" not in slash_commands[0]
+    assert "request_url" not in manifest_text
+    assert "hooks.slack.com" not in manifest_text
+    assert "xapp-" not in manifest_text
+    assert "xox" not in manifest_text
+    assert "SLACK_APP_TOKEN" not in manifest_text
+    assert "SLACK_BOT_TOKEN" not in manifest_text
+    assert "/Users/" not in manifest_text
+    assert "/tmp/" not in manifest_text
+    assert re.search(r"\b[ACDGTUW][A-Z0-9]{8,}\b", manifest_text) is None
+
+
+def test_dispatch_workflow_is_manual_only_fixed_contract() -> None:
+    workflow = _load_workflow(DISPATCH_WORKFLOW_PATH)
+    workflow_text = DISPATCH_WORKFLOW_PATH.read_text(encoding="utf-8")
+    triggers = _workflow_on(workflow)
+
+    assert set(triggers) == {"workflow_dispatch"}
+    assert "pull_request" not in triggers
+    assert "pull_request_target" not in workflow_text
+    assert "push" not in triggers
+    assert "schedule" not in triggers
+    assert workflow["permissions"] == {"contents": "read"}
+    job = workflow["jobs"]["experiment-runner-dispatch-contract"]
+    assert job["timeout-minutes"] == 10
+    inputs = triggers["workflow_dispatch"]["inputs"]
+    assert set(inputs) == {"branch_ref", "hypothesis_sha256", "dry_run"}
+    assert inputs["dry_run"]["default"] == "true"
+    assert inputs["dry_run"]["options"] == ["true", "false"]
+    steps = job["steps"]
+    input_step = next(
+        step for step in steps if step["name"] == "Validate typed dispatch inputs without raw echo"
+    )
+    fail_closed_step = next(
+        step
+        for step in steps
+        if step["name"] == "Fail closed until bounded live dispatch is promoted"
+    )
+    summary_step = next(
+        step for step in steps if step["name"] == "Record sanitized dispatch contract summary"
+    )
+    assert input_step["env"]["EXPERIMENT_SLACK_SOCKET_BRANCH_REF"] == "${{ inputs.branch_ref }}"
+    assert (
+        input_step["env"]["EXPERIMENT_SLACK_SOCKET_HYPOTHESIS_SHA256"]
+        == "${{ inputs.hypothesis_sha256 }}"
+    )
+    assert "--validate-dispatch-inputs" in input_step["run"]
+    assert "--validate-smoke-inputs" not in workflow_text
+    assert fail_closed_step["if"] == "inputs.dry_run == 'false'"
+    assert "exit 1" in fail_closed_step["run"]
+    assert summary_step["if"] == "inputs.dry_run == 'true'"
+    assert "$GITHUB_STEP_SUMMARY" in summary_step["run"]
+    assert "SLACK_APP_TOKEN" not in workflow_text
+    assert "SLACK_BOT_TOKEN" not in workflow_text
+    assert "SLACK_SIGNING_SECRET" not in workflow_text
+    assert "pull-requests:" not in workflow_text
+    assert "issues:" not in workflow_text
+    assert "id-token:" not in workflow_text
+    assert "continue-on-error" not in workflow_text
+    assert "|| true" not in workflow_text
+    assert "gh pr" not in workflow_text
+    assert "gh workflow run" not in workflow_text
+
+
+def test_smoke_workflow_is_manual_only_and_secret_safe() -> None:
     workflow = _load_workflow()
-    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    workflow_text = SMOKE_WORKFLOW_PATH.read_text(encoding="utf-8")
     triggers = _workflow_on(workflow)
 
     assert set(triggers) == {"workflow_dispatch"}


### PR DESCRIPTION
## Summary
Adds the next narrow Experiment Runner Slack slice: a secret-free Slack app manifest and a fixed manual-only bounded dispatch workflow contract. The Slack bridge execute target is narrowed to `experiment-runner-dispatch.yml`; dry-run remains the default, and `dry_run=false` fails closed until a later bounded dispatch exercise PR.

## Lane Start Provenance
Packet: `artifacts/orchestration/task_packets/b1efd0790b29.json`
Starter: `scripts/orchestration/start_pr_lane.sh`
Coordinator: `agent-coordinator` remained the lane-start authority after `check_preflight.py` and `task_bootstrap.py`.
Fixed mapping artifact: `docs/review/PR_1836_FIXED_MAPPING.md`

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/exp-75526d20af83.json`
Mode: oracle-only governance reviewer
Contribution: commit decision
Co-author required: true
Commit trailers: `01447b93f32870216dd1f9eade5121dadf93d46c`, `6d9f00706979251e6a4a5d21f290c8c499fa5d92`

## Scope
- Add `docs/orchestration/EXPERIMENT_RUNNER_SLACK_APP_MANIFEST.yml` without real workspace IDs, channel/user IDs, request URLs, webhook URLs, token names, token prefixes, or secret values.
- Add `.github/workflows/experiment-runner-dispatch.yml` as `workflow_dispatch` only, `contents: read`, typed inputs only, and `dry_run: true` by default.
- Keep live execution fail-closed in this PR.
- Update the Slack bridge default workflow allowlist to the fixed dispatch workflow only.
- Extend Slack bridge tests for manifest, workflow contract, arbitrary workflow rejection, and dispatch input validation alias.
- Add `docs/review/PR_1836_FIXED_MAPPING.md` as canonical PR governance artifact.

## Out Of Scope
- No real Slack command execution or live bounded dispatch exercise.
- No HTTP Events endpoint or `SLACK_SIGNING_SECRET`.
- No required-mode Experiment Runner hard-gate activation.
- No `scripts/ci/**` runner mutation authority.
- No PR creation, review disposition, merge readiness, Git attribution, or autonomous workflow authority via Slack.

## Agent Flow
Pre-open packet order was executed/reviewed as: `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> dev-operator`, plus packet secondary `cursor-specialist-agent` disposition.

Coordinator correction: an early QA/bug role-purity drift was corrected. Role agents were redirected to read the packet/bootstrap and return role output only; implementation remained integrated through the coordinator-owned lane.

Post-open compensating pass completed: `qa-engineer-agent -> bug-hunter -> security-auditor`, with premortem and Codex Security-style security review evidence recorded in `docs/review/PR_1836_FIXED_MAPPING.md`.

## Premortem Risk Review
- Likely failure: the fixed workflow could be misread as enabling live dispatch. Containment: `dry_run` defaults to true and `dry_run=false` fails closed in this PR.
- High-impact failure: real Slack IDs, token names, token prefixes, request URLs, or webhook URLs could enter repo docs/tests. Containment: manifest/workflow tests and pre-commit/detect-secrets ran clean.
- Hidden assumption: future live bounded dispatch remains hash-only and runtime-allowlisted. Disposition: deferred to the separate Manual Bounded Dispatch Exercise PR.

## Validation
- `python3 scripts/orchestration/check_preflight.py --path .github/workflows/experiment-runner-dispatch.yml --path docs/orchestration/EXPERIMENT_RUNNER_SLACK_APP_MANIFEST.yml --path docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md --path scripts/orchestration/experiment_slack_socket_bridge.py --path tests/test_experiment_slack_socket_bridge.py`
- `python3 scripts/orchestration/check_preflight.py --path docs/review/PR_1836_FIXED_MAPPING.md --path <implementation paths>`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `python3 -m pytest -q tests/test_experiment_slack_socket_bridge.py tests/test_experiment_runner_identity_policy.py`
- `python3 scripts/orchestration/check_experiment_runner_identity.py`
- `make validate-changed`
- `pre-commit run --all-files`
- `python3 scripts/ci/check_pr_body_phase2_gates.py --body <current PR body> --pr-number 1836 --commit-range origin/main..HEAD`
- `GH_TOKEN=$(gh auth token) GITHUB_TOKEN=$(gh auth token) python3 scripts/orchestration/check_merge_ready.py --pr-number 1836 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`
- pre-push hooks: mypy, pip-audit, backend tests, full Bandit, docker build test
- current-head GitHub CI/check snapshot at `8181694143e53b21c5e326ae76e4ee68dd7acf15`: PASS/SKIP terminal, including `test-pr (3.13)`, CodeQL, security-scan, diff-coverage, CodeRabbit, PR Body Phase2 gates, and Merge readiness gate.

No full local `make verify` per operator-approved PR-scoped validation policy for this governance/tooling lane.

## Security Notes
- Manifest is sanitized setup guidance only.
- App-level `connections:write` token remains external operator setup and is not committed.
- GitHub secrets and real Slack IDs remain runtime-only.
- Audit and dispatch paths stay hash-only and redacted.
- Slack remains operator command/display infrastructure only.
- Sourcery posted a weekly rate-limit/capacity notice, not a code-actionable finding; mapping records it as NOT-A-BUG with compensating local/CI review evidence.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

No GitHub review threads are open at the final readiness pass. Post-open QA, bug-hunter, security-auditor, premortem, CodeRabbit/Codex Security-style review, current-head CI, and strict merge-readiness completed.

### Fixed in Commit Mapping
- No actionable review comments

Canonical artifact: `docs/review/PR_1836_FIXED_MAPPING.md`. Sourcery capacity notice, Cubic neutral summary, and CodeRabbit SUCCESS are documented in the mapping artifact.

## Merge Readiness
Strict merge-readiness wrapper passed after the final current-head check snapshot. Required/current-head checks are terminal, review threads are empty, and Phase2 body/mapping gates pass.

## Deferred / Follow-ups
- Manual Bounded Dispatch Exercise: one allowlisted Slack operator command into the fixed workflow, sanitized evidence only.
- HTTP Events / `SLACK_SIGNING_SECRET`: separate only if introducing HTTP endpoint/interactivity.
- Experiment Runner Evidence Required-Mode Activation: separate hard-gate rollout PR.
- `scripts/ci/**` runner mutation threat model: separate authority-widening PR.
