### PR TITLE
feat(frontend): add guided planning save and progress flow

### DIFF
--- a/docs/review/PR_1844_FIXED_MAPPING.md
+++ b/docs/review/PR_1844_FIXED_MAPPING.md
@@ -1,0 +1,29 @@
+# PR 1844 Fixed Mapping
+
+## Discussion Thread Pass
+
+- No review threads existed at PR open.
+
+## Fixed in Commit Mapping
+
+- No external review threads have been resolved yet.
+- Pre-open role-agent findings were fixed before PR open in commit `9f867f383`:
+  - `frontend-engineer`: CTA copy and auth-loading state corrected.
+  - `creative-designer`: screen-local mark copy and duplicate `/plate` CTA corrected.
+  - `architecture-specialist`: component-local mark semantics and observability option id corrected.
+  - `qa-engineer-agent`: authenticated and secondary continuation event coverage added.
+  - `bug-hunter`: mark reset, prompt-view dedupe, and same-selection no-op behavior fixed.
+
+## Merge Readiness
+
+- Not claimed.
+- Requires current-head CI, required checks, bot/review disposition, wait window, and strict merge wrapper.
+
+## Experiment Runner Evidence
+
+- Artifact: `artifacts/orchestration/experiments/results/frontend-guided-planning-save-progress-flow-oracle-portable-result.json` (local-only, not committed)
+- Status: accepted
+
+## Deferred / Follow-ups
+
+- None.

--- a/docs/review/PR_1844_FIXED_MAPPING.md
+++ b/docs/review/PR_1844_FIXED_MAPPING.md
@@ -2,17 +2,17 @@
 
 ## Discussion Thread Pass
 
-- No review threads existed at PR open.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- No line-level review threads existed at PR open.
+- Sourcery posted high-level actionable review feedback after PR open; fixed in commit `134c5979d`.
 
 ## Fixed in Commit Mapping
 
-- No external review threads have been resolved yet.
-- Pre-open role-agent findings were fixed before PR open in commit `9f867f383`:
-  - `frontend-engineer`: CTA copy and auth-loading state corrected.
-  - `creative-designer`: screen-local mark copy and duplicate `/plate` CTA corrected.
-  - `architecture-specialist`: component-local mark semantics and observability option id corrected.
-  - `qa-engineer-agent`: authenticated and secondary continuation event coverage added.
-  - `bug-hunter`: mark reset, prompt-view dedupe, and same-selection no-op behavior fixed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1844#pullrequestreview-3153735664 -> 134c5979d
+Disposition: FIXED
+Commit: 134c5979d
+Evidence: frontend/src/pages/Home.tsx:1, frontend/src/pages/Home.tsx:9, frontend/src/pages/Home.tsx:169, frontend/src/pages/Home.tsx:242, frontend/src/pages/__tests__/Home.test.tsx:66
 
 ## Merge Readiness
 
@@ -21,8 +21,8 @@
 
 ## Experiment Runner Evidence
 
-- Artifact: `artifacts/orchestration/experiments/results/frontend-guided-planning-save-progress-flow-oracle-portable-result.json` (local-only, not committed)
-- Status: accepted
+- Artifact: `artifacts/orchestration/experiments/results/frontend-guided-planning-save-progress-flow-oracle-portable-result.json`
+- Status: accepted; local-only and not committed
 
 ## Deferred / Follow-ups
 

--- a/docs/review/PR_1844_FIXED_MAPPING.md
+++ b/docs/review/PR_1844_FIXED_MAPPING.md
@@ -9,10 +9,16 @@
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1844#pullrequestreview-3153735664 -> 134c5979d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1844#pullrequestreview-4372887451 -> 134c5979d
 Disposition: FIXED
 Commit: 134c5979d
 Evidence: frontend/src/pages/Home.tsx:1, frontend/src/pages/Home.tsx:9, frontend/src/pages/Home.tsx:169, frontend/src/pages/Home.tsx:242, frontend/src/pages/__tests__/Home.test.tsx:66
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1844#pullrequestreview-4372920151 -> a2370eef4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1844#discussion_r3311245033 -> a2370eef4
+Disposition: FIXED
+Commit: a2370eef4
+Evidence: frontend/src/pages/Home.tsx:195
 
 ## Merge Readiness
 

--- a/frontend/src/lib/mvpObservability.ts
+++ b/frontend/src/lib/mvpObservability.ts
@@ -5,7 +5,12 @@ export type GuidedPlanningEventName =
   | 'planning_preview_seen'
   | 'tier_value_viewed'
   | 'primary_planning_cta_clicked'
-  | 'wellness_boundary_viewed';
+  | 'wellness_boundary_viewed'
+  | 'planning_save_prompt_viewed'
+  | 'planning_auth_prompt_viewed'
+  | 'planning_progress_state_viewed'
+  | 'planning_save_clicked'
+  | 'planning_continue_clicked';
 
 export type GuidedPlanningSurface = 'app';
 
@@ -15,6 +20,7 @@ export interface GuidedPlanningEventPayload {
   routePath: '/app' | '/setup' | '/plate' | '/progress' | '/pro';
   optionId?: string;
   tierLabel?: 'FREE' | 'PRO' | 'VIP';
+  authState?: 'authenticated' | 'unauthenticated' | 'unknown';
 }
 
 export interface GuidedPlanningEvent {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, CardContent, Hero, StatsCard, buttonClasses } from '../components/ui';
 import { useAuth } from '../lib/auth';
-import { trackGuidedPlanningEvent } from '../lib/mvpObservability';
+import { trackGuidedPlanningEvent, type GuidedPlanningEventPayload } from '../lib/mvpObservability';
 
 type PlanningIntentId = 'consistent' | 'balanced' | 'decision_fatigue' | 'shopping';
 type PlanningTimeId = 'quick' | 'standard' | 'batch' | 'flexible';
-type PlanningAuthState = 'authenticated' | 'unauthenticated' | 'unknown';
+type PlanningAuthState = NonNullable<GuidedPlanningEventPayload['authState']>;
 
 interface PlanningIntent {
   id: PlanningIntentId;
@@ -166,6 +166,7 @@ export default function Home(): JSX.Element {
   const [selectedIntent, setSelectedIntent] = useState<PlanningIntentId>('consistent');
   const [selectedTime, setSelectedTime] = useState<PlanningTimeId>('standard');
   const [isPreviewSaved, setIsPreviewSaved] = useState(false);
+  const unauthenticatedPromptViewedRef = useRef(false);
   const preview = previewByIntent[selectedIntent];
   const authState: PlanningAuthState = isLoading ? 'unknown' : isAuthenticated ? 'authenticated' : 'unauthenticated';
   const isKnownAuthenticated = authState === 'authenticated';
@@ -240,7 +241,8 @@ export default function Home(): JSX.Element {
   }, [authState, isPreviewSaved]);
 
   useEffect(() => {
-    if (authState === 'unauthenticated') {
+    if (authState === 'unauthenticated' && !unauthenticatedPromptViewedRef.current) {
+      unauthenticatedPromptViewedRef.current = true;
       trackGuidedPlanningEvent('planning_save_prompt_viewed', {
         surface: 'app',
         componentId: 'planning-save-auth-prompt',

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, CardContent, Hero, StatsCard, buttonClasses } from '../components/ui';
+import { useAuth } from '../lib/auth';
 import { trackGuidedPlanningEvent } from '../lib/mvpObservability';
 
 type PlanningIntentId = 'consistent' | 'balanced' | 'decision_fatigue' | 'shopping';
 type PlanningTimeId = 'quick' | 'standard' | 'batch' | 'flexible';
+type PlanningAuthState = 'authenticated' | 'unauthenticated' | 'unknown';
 
 interface PlanningIntent {
   id: PlanningIntentId;
@@ -160,9 +162,36 @@ function ValueRailCard({ title, detail, badge }: { title: string; detail: string
 }
 
 export default function Home(): JSX.Element {
+  const { isAuthenticated, isLoading } = useAuth();
   const [selectedIntent, setSelectedIntent] = useState<PlanningIntentId>('consistent');
   const [selectedTime, setSelectedTime] = useState<PlanningTimeId>('standard');
+  const [isPreviewSaved, setIsPreviewSaved] = useState(false);
   const preview = previewByIntent[selectedIntent];
+  const authState: PlanningAuthState = isLoading ? 'unknown' : isAuthenticated ? 'authenticated' : 'unauthenticated';
+  const isKnownAuthenticated = authState === 'authenticated';
+  const progressMessage = isPreviewSaved
+    ? 'Preview marked here. Continue when you are ready to turn this direction into weekly planning.'
+    : 'Planning progress starts with your selected intent and practical cooking window.';
+  const progressAuthMessage = isKnownAuthenticated
+    ? 'Your signed-in session can continue this planning direction into protected PulsePlate flows.'
+    : authState === 'unknown'
+      ? 'Checking your session before PulsePlate routes this preview into protected planning flows.'
+      : 'Sign in to continue this planning direction through protected flows. This preview mark stays on this screen only.';
+  const savePromptLabel = isKnownAuthenticated
+    ? 'Continue marked direction'
+    : authState === 'unknown'
+      ? 'Checking session'
+      : 'Save preview';
+  const savePromptCopy = isKnownAuthenticated
+    ? 'Your planning direction is ready. PulsePlate can mark this preview on this screen before you continue.'
+    : authState === 'unknown'
+      ? 'PulsePlate is checking whether this preview can continue through a signed-in planning session.'
+      : 'Without sign-in, PulsePlate can only mark this preview on this screen.';
+  const saveButtonLabel = isPreviewSaved
+    ? 'Preview marked here'
+    : isKnownAuthenticated
+      ? 'Mark preview ready here'
+      : 'Mark preview here';
   const copyCorpus = [
     ...planningIntents.map((intent) => `${intent.label} ${intent.helper}`),
     ...planningTimes.map((time) => `${time.label} ${time.helper}`),
@@ -171,6 +200,7 @@ export default function Home(): JSX.Element {
     ...preview.shoppingDirection,
     preview.nextAction,
     timeNotes[selectedTime],
+    progressMessage,
   ].join(' ');
 
   useEffect(() => {
@@ -199,11 +229,41 @@ export default function Home(): JSX.Element {
     });
   }, []);
 
+  useEffect(() => {
+    trackGuidedPlanningEvent('planning_progress_state_viewed', {
+      surface: 'app',
+      componentId: 'planning-progress-state',
+      routePath: '/app',
+      optionId: isPreviewSaved ? 'screen_preview_marked' : 'preview_ready',
+      authState,
+    });
+  }, [authState, isPreviewSaved]);
+
+  useEffect(() => {
+    if (authState === 'unauthenticated') {
+      trackGuidedPlanningEvent('planning_save_prompt_viewed', {
+        surface: 'app',
+        componentId: 'planning-save-auth-prompt',
+        routePath: '/app',
+        authState,
+      });
+      trackGuidedPlanningEvent('planning_auth_prompt_viewed', {
+        surface: 'app',
+        componentId: 'planning-save-auth-prompt',
+        routePath: '/app',
+        authState,
+      });
+    }
+  }, [authState]);
+
   if (forbiddenMedicalClaimPattern.test(copyCorpus)) {
     throw new Error('Guided Planning Preview contains forbidden medical claim copy.');
   }
 
   function selectIntent(intentId: PlanningIntentId): void {
+    if (intentId !== selectedIntent) {
+      setIsPreviewSaved(false);
+    }
     setSelectedIntent(intentId);
     trackGuidedPlanningEvent('planning_intent_selected', {
       surface: 'app',
@@ -214,6 +274,9 @@ export default function Home(): JSX.Element {
   }
 
   function selectTime(timeId: PlanningTimeId): void {
+    if (timeId !== selectedTime) {
+      setIsPreviewSaved(false);
+    }
     setSelectedTime(timeId);
     trackGuidedPlanningEvent('planning_time_selected', {
       surface: 'app',
@@ -228,6 +291,27 @@ export default function Home(): JSX.Element {
       surface: 'app',
       componentId: 'primary-planning-cta',
       routePath: '/setup',
+    });
+  }
+
+  function savePlanningPreview(): void {
+    setIsPreviewSaved(true);
+    trackGuidedPlanningEvent('planning_save_clicked', {
+      surface: 'app',
+      componentId: 'planning-save-cta',
+      routePath: '/app',
+      optionId: selectedIntent,
+      authState,
+    });
+  }
+
+  function trackContinuePlanning(routePath: '/plate' | '/progress' | '/pro'): void {
+    trackGuidedPlanningEvent('planning_continue_clicked', {
+      surface: 'app',
+      componentId: 'planning-continue-cta',
+      routePath,
+      optionId: selectedTime,
+      authState,
     });
   }
 
@@ -417,9 +501,49 @@ export default function Home(): JSX.Element {
                 <div className="rounded-2xl border border-white/12 bg-[var(--pp-navy)]/40 p-4">
                   <h3 className="text-sm font-semibold text-white">Next action</h3>
                   <p className="mt-2 text-sm leading-6 text-white/70">{preview.nextAction}</p>
+                  <div
+                    className="mt-4 rounded-2xl border border-white/12 bg-white/[0.07] p-4"
+                    data-testid="planning-progress-state"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/46">
+                      Planning progress
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-white/72">{progressMessage}</p>
+                    <p className="mt-2 text-xs font-semibold text-white/58">
+                      {progressAuthMessage}
+                    </p>
+                  </div>
+                  <div
+                    className="mt-4 rounded-2xl border border-white/12 bg-white/[0.06] p-4"
+                    data-testid="planning-save-auth-prompt"
+                  >
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/46">
+                      {savePromptLabel}
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-white/68">
+                      {savePromptCopy}
+                    </p>
+                    <div className="mt-4 flex flex-wrap gap-3">
+                      <button
+                        type="button"
+                        data-testid="planning-save-cta"
+                        onClick={savePlanningPreview}
+                        className={buttonClasses({
+                          variant: 'secondary',
+                          className: 'rounded-2xl border-white/14 bg-white/[0.08] text-white hover:bg-white/[0.12]',
+                        })}
+                      >
+                        {saveButtonLabel}
+                      </button>
+                    </div>
+                  </div>
                   <div className="mt-4 flex flex-wrap gap-3">
                     <Link
                       to="/plate"
+                      data-testid="planning-continue-cta"
+                      onClick={() => trackContinuePlanning('/plate')}
                       className={buttonClasses({
                         variant: 'secondary',
                         className: 'rounded-2xl border-white/14 bg-white/[0.08] text-white hover:bg-white/[0.12]',
@@ -429,6 +553,7 @@ export default function Home(): JSX.Element {
                     </Link>
                     <Link
                       to="/progress"
+                      onClick={() => trackContinuePlanning('/progress')}
                       className={buttonClasses({
                         variant: 'ghost',
                         className: 'rounded-2xl text-white hover:bg-white/[0.1]',
@@ -438,6 +563,7 @@ export default function Home(): JSX.Element {
                     </Link>
                     <Link
                       to="/pro"
+                      onClick={() => trackContinuePlanning('/pro')}
                       className={buttonClasses({
                         variant: 'ghost',
                         className: 'rounded-2xl text-white hover:bg-white/[0.1]',

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -202,6 +202,10 @@ export default function Home(): JSX.Element {
     preview.nextAction,
     timeNotes[selectedTime],
     progressMessage,
+    progressAuthMessage,
+    savePromptLabel,
+    savePromptCopy,
+    saveButtonLabel,
   ].join(' ');
 
   useEffect(() => {

--- a/frontend/src/pages/__tests__/Home.test.tsx
+++ b/frontend/src/pages/__tests__/Home.test.tsx
@@ -63,6 +63,26 @@ function renderHomeRoutes(): ReturnType<typeof render> {
   );
 }
 
+function rerenderHomeWithAuthState(
+  renderedHome: ReturnType<typeof render>,
+  authState: { isAuthenticated: boolean; isLoading: boolean }
+): void {
+  vi.mocked(useAuth).mockReturnValue({
+    apiKey: null,
+    isAuthenticated: authState.isAuthenticated,
+    isLoading: authState.isLoading,
+    setApiKey: vi.fn(),
+    clearApiKey: vi.fn(),
+    showAuthPrompt: false,
+    setShowAuthPrompt: vi.fn(),
+  });
+  renderedHome.rerender(
+    <MemoryRouter>
+      <Home />
+    </MemoryRouter>
+  );
+}
+
 describe('Home Guided Planning Preview', () => {
   const guidedPlanningEvents: GuidedPlanningEvent[] = [];
 
@@ -366,6 +386,38 @@ describe('Home Guided Planning Preview', () => {
       (event) => event.name === 'planning_save_prompt_viewed' || event.name === 'planning_auth_prompt_viewed'
     );
     expect(promptViewsAfterSelection).toHaveLength(2);
+  });
+
+  it('emits unauthenticated prompt viewed events once per page view across auth transitions', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      apiKey: null,
+      isAuthenticated: false,
+      isLoading: true,
+      setApiKey: vi.fn(),
+      clearApiKey: vi.fn(),
+      showAuthPrompt: false,
+      setShowAuthPrompt: vi.fn(),
+    });
+    const renderedHome = render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    );
+
+    expect(
+      guidedPlanningEvents.filter(
+        (event) => event.name === 'planning_save_prompt_viewed' || event.name === 'planning_auth_prompt_viewed'
+      )
+    ).toHaveLength(0);
+
+    rerenderHomeWithAuthState(renderedHome, { isAuthenticated: false, isLoading: false });
+    rerenderHomeWithAuthState(renderedHome, { isAuthenticated: false, isLoading: true });
+    rerenderHomeWithAuthState(renderedHome, { isAuthenticated: false, isLoading: false });
+
+    const promptViewsAfterAuthTransitions = guidedPlanningEvents.filter(
+      (event) => event.name === 'planning_save_prompt_viewed' || event.name === 'planning_auth_prompt_viewed'
+    );
+    expect(promptViewsAfterAuthTransitions).toHaveLength(2);
   });
 
   it('uses neutral save copy while auth state is loading', () => {

--- a/frontend/src/pages/__tests__/Home.test.tsx
+++ b/frontend/src/pages/__tests__/Home.test.tsx
@@ -122,6 +122,10 @@ describe('Home Guided Planning Preview', () => {
     expect(screen.getByTestId('tier-value-rail')).toBeInTheDocument();
     expect(screen.getByTestId('wellness-boundary-note')).toBeInTheDocument();
     expect(screen.getByTestId('primary-planning-cta')).toBeInTheDocument();
+    expect(screen.getByTestId('planning-save-cta')).toBeInTheDocument();
+    expect(screen.getByTestId('planning-continue-cta')).toBeInTheDocument();
+    expect(screen.getByTestId('planning-progress-state')).toBeInTheDocument();
+    expect(screen.getByTestId('planning-save-auth-prompt')).toBeInTheDocument();
   });
 
   it('emits safe frontend-only MVP view evidence on render', () => {
@@ -138,6 +142,9 @@ describe('Home Guided Planning Preview', () => {
       'tier_value_viewed',
       'tier_value_viewed',
       'wellness_boundary_viewed',
+      'planning_progress_state_viewed',
+      'planning_save_prompt_viewed',
+      'planning_auth_prompt_viewed',
     ]);
     expect(guidedPlanningEvents).toEqual(
       expect.arrayContaining([
@@ -152,6 +159,25 @@ describe('Home Guided Planning Preview', () => {
         {
           name: 'wellness_boundary_viewed',
           payload: { surface: 'app', componentId: 'wellness-boundary-note', routePath: '/app' },
+        },
+        {
+          name: 'planning_progress_state_viewed',
+          payload: {
+            surface: 'app',
+            componentId: 'planning-progress-state',
+            routePath: '/app',
+            optionId: 'preview_ready',
+            authState: 'unauthenticated',
+          },
+        },
+        {
+          name: 'planning_auth_prompt_viewed',
+          payload: {
+            surface: 'app',
+            componentId: 'planning-save-auth-prompt',
+            routePath: '/app',
+            authState: 'unauthenticated',
+          },
         },
       ])
     );
@@ -172,6 +198,8 @@ describe('Home Guided Planning Preview', () => {
 
     await user.click(screen.getByRole('button', { name: /Shopping-list planning/i }));
     await user.click(screen.getByRole('button', { name: /Batch prep/i }));
+    await user.click(screen.getByTestId('planning-save-cta'));
+    await user.click(screen.getByTestId('planning-continue-cta'));
     await user.click(screen.getByTestId('primary-planning-cta'));
 
     const payloadKeys = guidedPlanningEvents.flatMap((event) => Object.keys(event.payload));
@@ -225,6 +253,200 @@ describe('Home Guided Planning Preview', () => {
     );
   });
 
+  it('shows an honest unauthenticated session-local save and continuation state', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('planning-save-auth-prompt')).toHaveTextContent(
+      'Without sign-in, PulsePlate can only mark this preview on this screen.'
+    );
+    expect(screen.getByTestId('planning-progress-state')).toHaveTextContent(
+      'Planning progress starts with your selected intent and practical cooking window.'
+    );
+    expect(screen.getByTestId('planning-progress-state')).toHaveAttribute('role', 'status');
+    expect(screen.getByTestId('planning-save-cta')).toHaveAccessibleName('Mark preview here');
+    expect(screen.getByTestId('planning-continue-cta')).toHaveAttribute('href', '/plate');
+
+    await user.click(screen.getByTestId('planning-save-cta'));
+
+    expect(screen.getByTestId('planning-save-cta')).toHaveAccessibleName('Preview marked here');
+    expect(screen.getByTestId('planning-progress-state')).toHaveTextContent(
+      'Preview marked here. Continue when you are ready to turn this direction into weekly planning.'
+    );
+    expect(guidedPlanningEvents).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'planning_save_clicked',
+          payload: {
+            surface: 'app',
+            componentId: 'planning-save-cta',
+            routePath: '/app',
+            optionId: 'consistent',
+            authState: 'unauthenticated',
+          },
+        },
+        {
+          name: 'planning_progress_state_viewed',
+          payload: {
+            surface: 'app',
+            componentId: 'planning-progress-state',
+            routePath: '/app',
+            optionId: 'screen_preview_marked',
+            authState: 'unauthenticated',
+          },
+        },
+      ])
+    );
+  });
+
+  it('clears the screen-local preview mark when selections change', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByTestId('planning-save-cta'));
+    expect(screen.getByTestId('planning-save-cta')).toHaveAccessibleName('Preview marked here');
+
+    await user.click(screen.getByRole('button', { name: /Shopping-list planning/i }));
+
+    expect(screen.getByTestId('planning-save-cta')).toHaveAccessibleName('Mark preview here');
+    expect(screen.getByTestId('planning-progress-state')).toHaveTextContent(
+      'Planning progress starts with your selected intent and practical cooking window.'
+    );
+
+    await user.click(screen.getByTestId('planning-save-cta'));
+    expect(screen.getByTestId('planning-save-cta')).toHaveAccessibleName('Preview marked here');
+
+    await user.click(screen.getByRole('button', { name: /Batch prep/i }));
+
+    expect(screen.getByTestId('planning-save-cta')).toHaveAccessibleName('Mark preview here');
+  });
+
+  it('keeps the screen-local preview mark when the selected option is clicked again', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByTestId('planning-save-cta'));
+    expect(screen.getByTestId('planning-save-cta')).toHaveAccessibleName('Preview marked here');
+
+    await user.click(screen.getByRole('button', { name: /More consistent meals/i }));
+    await user.click(screen.getByRole('button', { name: /Standard meal window/i }));
+
+    expect(screen.getByTestId('planning-save-cta')).toHaveAccessibleName('Preview marked here');
+  });
+
+  it('does not re-emit prompt viewed events when only planning selections change', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    );
+
+    const initialPromptViews = guidedPlanningEvents.filter(
+      (event) => event.name === 'planning_save_prompt_viewed' || event.name === 'planning_auth_prompt_viewed'
+    );
+    expect(initialPromptViews).toHaveLength(2);
+
+    await user.click(screen.getByRole('button', { name: /Shopping-list planning/i }));
+    await user.click(screen.getByRole('button', { name: /Batch prep/i }));
+
+    const promptViewsAfterSelection = guidedPlanningEvents.filter(
+      (event) => event.name === 'planning_save_prompt_viewed' || event.name === 'planning_auth_prompt_viewed'
+    );
+    expect(promptViewsAfterSelection).toHaveLength(2);
+  });
+
+  it('uses neutral save copy while auth state is loading', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      apiKey: null,
+      isAuthenticated: false,
+      isLoading: true,
+      setApiKey: vi.fn(),
+      clearApiKey: vi.fn(),
+      showAuthPrompt: false,
+      setShowAuthPrompt: vi.fn(),
+    });
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('planning-progress-state')).toHaveTextContent(
+      'Checking your session before PulsePlate routes this preview into protected planning flows.'
+    );
+    expect(screen.getByTestId('planning-save-auth-prompt')).toHaveTextContent('Checking session');
+    expect(screen.queryByText(/Without sign-in/i)).not.toBeInTheDocument();
+    expect(guidedPlanningEvents).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'planning_progress_state_viewed',
+          payload: {
+            surface: 'app',
+            componentId: 'planning-progress-state',
+            routePath: '/app',
+            optionId: 'preview_ready',
+            authState: 'unknown',
+          },
+        },
+      ])
+    );
+  });
+
+  it('shows authenticated save-ready copy without claiming backend persistence', async () => {
+    const user = userEvent.setup();
+    vi.mocked(useAuth).mockReturnValue({
+      apiKey: null,
+      isAuthenticated: true,
+      isLoading: false,
+      setApiKey: vi.fn(),
+      clearApiKey: vi.fn(),
+      showAuthPrompt: false,
+      setShowAuthPrompt: vi.fn(),
+    });
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('planning-save-auth-prompt')).toHaveTextContent('Your planning direction is ready');
+    expect(screen.getByTestId('planning-save-auth-prompt')).toHaveTextContent('on this screen');
+    expect(screen.getByTestId('planning-save-cta')).toHaveAccessibleName('Mark preview ready here');
+
+    await user.click(screen.getByTestId('planning-save-cta'));
+
+    expect(screen.queryByText(/saved to your account/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('planning-save-auth-prompt')).not.toHaveTextContent(/saved weekly plan/i);
+    expect(screen.queryByText(/for the current session/i)).not.toBeInTheDocument();
+    expect(guidedPlanningEvents).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'planning_save_clicked',
+          payload: {
+            surface: 'app',
+            componentId: 'planning-save-cta',
+            routePath: '/app',
+            optionId: 'consistent',
+            authState: 'authenticated',
+          },
+        },
+      ])
+    );
+  });
+
   it('shows the FREE PRO VIP value ladder honestly', () => {
     render(
       <MemoryRouter>
@@ -261,6 +483,7 @@ describe('Home Guided Planning Preview', () => {
 
     expect(screen.getByTestId('primary-planning-cta')).toHaveAttribute('href', '/setup');
     expect(screen.getByRole('link', { name: 'Continue planning' })).toHaveAttribute('href', '/setup');
+    expect(screen.getByTestId('planning-continue-cta')).toHaveAttribute('href', '/plate');
     expect(screen.getByRole('link', { name: 'Learn why this is wellness-only' })).toHaveAttribute(
       'href',
       '#wellness-boundary'
@@ -315,6 +538,29 @@ describe('Home Guided Planning Preview', () => {
     expect(screen.getByTestId('enter-key-probe')).toHaveTextContent('/progress');
   });
 
+  it('emits continue evidence before protected route redirects', async () => {
+    const user = userEvent.setup();
+
+    renderHomeRoutes();
+    await user.click(screen.getByTestId('planning-continue-cta'));
+
+    expect(screen.getByTestId('enter-key-probe')).toHaveTextContent('/plate');
+    expect(guidedPlanningEvents).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'planning_continue_clicked',
+          payload: {
+            surface: 'app',
+            componentId: 'planning-continue-cta',
+            routePath: '/plate',
+            optionId: 'standard',
+            authState: 'unauthenticated',
+          },
+        },
+      ])
+    );
+  });
+
   it('opens protected planning CTAs when secure session exists', async () => {
     vi.mocked(useAuth).mockReturnValue({
       apiKey: null,
@@ -335,6 +581,68 @@ describe('Home Guided Planning Preview', () => {
     renderHomeRoutes();
     await user.click(screen.getByRole('link', { name: /Use progress check-ins/i }));
     expect(screen.getByTestId('progress-route')).toBeInTheDocument();
+  });
+
+  it('emits authenticated continuation evidence for protected and upgrade routes', async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      apiKey: null,
+      isAuthenticated: true,
+      isLoading: false,
+      setApiKey: vi.fn(),
+      clearApiKey: vi.fn(),
+      showAuthPrompt: false,
+      setShowAuthPrompt: vi.fn(),
+    });
+    const user = userEvent.setup();
+
+    const plateRender = renderHomeRoutes();
+    await user.click(screen.getByTestId('planning-continue-cta'));
+    expect(screen.getByTestId('plate-route')).toBeInTheDocument();
+    plateRender.unmount();
+
+    const progressRender = renderHomeRoutes();
+    await user.click(screen.getByRole('link', { name: /Use progress check-ins/i }));
+    expect(screen.getByTestId('progress-route')).toBeInTheDocument();
+    progressRender.unmount();
+
+    renderHomeRoutes();
+    await user.click(screen.getByRole('link', { name: /Unlock weekly planning/i }));
+    expect(screen.getByTestId('pro-route')).toBeInTheDocument();
+
+    expect(guidedPlanningEvents).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'planning_continue_clicked',
+          payload: {
+            surface: 'app',
+            componentId: 'planning-continue-cta',
+            routePath: '/plate',
+            optionId: 'standard',
+            authState: 'authenticated',
+          },
+        },
+        {
+          name: 'planning_continue_clicked',
+          payload: {
+            surface: 'app',
+            componentId: 'planning-continue-cta',
+            routePath: '/progress',
+            optionId: 'standard',
+            authState: 'authenticated',
+          },
+        },
+        {
+          name: 'planning_continue_clicked',
+          payload: {
+            surface: 'app',
+            componentId: 'planning-continue-cta',
+            routePath: '/pro',
+            optionId: 'standard',
+            authState: 'authenticated',
+          },
+        },
+      ])
+    );
   });
 
   it('keeps the page token-backed and tabbar-compatible', () => {


### PR DESCRIPTION
## Summary
Adds a frontend-only continuation loop to the existing `/app` Guided Planning Preview: users can mark the current preview on screen, see lightweight progress state, and continue through existing protected planning routes.

## Goal
Extend the Guided Planning Preview MVP slice with auth-aware save/continue/progress behavior without backend/API/payment/AI scope creep.

## Business reason
PR #1842 made the MVP planning preview visible and understandable. PR #1843 added observability and accessibility evidence hooks. This PR gives the MVP a small user-value loop so users understand their planning selections matter and have a safe reason to continue.

## Carryover from #1842/#1843
Builds on #1842 and #1843 and does not replace the MVP flow. Existing anchors, tier rail, wellness boundary, selector behavior, and local observability sink are preserved.

## MVP save/progress flow
- Adds screen-local preview mark behavior.
- Adds visible `planning-progress-state` status copy.
- Keeps the primary `/setup` CTA and existing `/plate`, `/progress`, `/pro` continuation paths.
- Does not claim backend/account persistence.

## Auth and continuation behavior
- Auth state is read from the existing frontend auth seam.
- Loading auth state shows neutral “checking session” copy.
- Unauthenticated state is explicit that the mark stays on this screen only.
- Authenticated state allows protected route continuation through existing route guards.

## Observability evidence
- Reuses the #1843 local/test event sink.
- Adds safe local event names for mark/progress/continue/auth prompt interactions.
- Payloads remain categorical and local: surface, component id, route path, option id, auth state.
- No external analytics vendor is added.
- No cookies/localStorage tracking is added.
- No sensitive health data is captured in events.

## Accessibility evidence
- Save control is a native button with accessible state-changing text.
- Continuation controls are existing route links with visible names.
- Progress state uses visible text plus `role="status"` / `aria-live="polite"`.
- Selector `aria-pressed` behavior remains intact.
- Targeted axe coverage remains in `Home.test.tsx`.

## Scope
In scope: frontend-only `/app` Guided Planning Preview continuation UI, safe local observability events, focused Home tests, thin-client guard coverage.

## Out of scope
No backend/API/OpenAPI changes, no billing/authz runtime changes, no checkout/payment side effects, no LLM/RAG/AI provider runtime, no Slack bridge, no iOS implementation, no token source changes, no generated token mirrors, no Figma/Kimi/Canva writes, no external analytics.

## Source of truth
- Root `AGENTS.md`
- `RUNBOOK_AGENT.md`
- `frontend/AGENTS.md`
- `docs/orchestration/workflow.md`
- Existing `/app` Guided Planning Preview implementation
- Existing local MVP observability helper

## Design/token/runtime boundary
Uses existing token-backed classes and UI primitives only. No token source values or generated mirrors changed. Figma/Kimi/Canva remain reference-only.

## Wellness safety
The existing boundary remains visible: “Wellness planning support only. Not medical advice.” Tests continue to assert forbidden medical claim copy is absent.

## Privacy / tracking posture
No external analytics SDK, cookies, localStorage tracking, API key, session token, email, user name, weight, height, BMI, health condition, free text, nutrition target, device fingerprint, or payment state is emitted.

## Implementation decisions
Mode B was used: no backend/client save seam was introduced or consumed. The PR implements an honest screen-local mark and continuation shell only.

## Orchestration source-of-truth note
`task_bootstrap.py` generated the packet but did not execute agents. `qoder_dispatch_bridge.py` is adapter-only; repo policy and the lane prompt controlled role execution.

## Agent Execution Log
- `agent-coordinator`: PASS, reviewed actual frontend-only diff and confirmed scope remains Guided Planning Preview save/continue/progress only; packet creation did not execute agents, so this entry records the explicit coordinator role pass.
- `frontend-engineer`: PASS after rerun; prior CTA copy and auth-loading findings were fixed.
- `creative-designer`: PASS after rerun; prior persistence-copy and duplicated `/plate` CTA findings were fixed.
- `accessibility-specialist`: PASS; reviewed accessible names, keyboard semantics, focus/status behavior, non-color-only state, selected-state preservation, and test coverage.
- `architecture-specialist`: PASS after reruns; component-local state is now screen-local and no backend/OpenAPI/payment/AI/token/generated boundary findings remain.
- `security-auditor`: PASS; no sensitive event payloads, token/API-key leakage, external analytics/storage, backend writes, direct fetches, authz bypass, payment/AI scope, or unsafe event naming found.
- `qa-engineer-agent`: PASS after rerun; authenticated/secondary continuation event coverage was added.
- `bug-hunter`: PASS after reruns; stale mark, duplicate prompt-view, and same-selection no-op findings were fixed.

## Skill Execution Log
- `pulseplate-workflow`: loaded and followed for lane start/governance.
- `pulseplate-design-launch-system`: loaded for design/token boundary posture.
- `pulseplate-pr-review`: loaded for PR self-review structure.
- `pulseplate-premortem-risk-review`: loaded for risk framing.
- `pulseplate-gates`: loaded for validation gate discipline.
- `pulseplate-guards`: loaded for frontend thin-client/guard posture.
- `pulseplate-ledger`: loaded; no deferred backend persistence item was added because this PR intentionally avoids claiming persistence and no immediate deferred scope is required.

## Lane Start Provenance
- Operator override accepted pending `main` CI at start. The run later completed successfully for #1843’s merge head.
- Packet: `artifacts/orchestration/task_packets/1e1924bdc3bb.json`
- Branch started from `origin/main` at `44cc88a492796155d5c13a01035c6ec3ae89ef88`.

## Premortem
Most likely failure was fake persistence copy. Fixed by using screen-local “marked here/on this screen” language and tests. Most dangerous failure was accidental backend/API/payment/AI scope creep; not present in the diff.

## Security Review
Frontend-only local event sink remains the only observability path. No sensitive identifiers or health values are emitted.

## Bug Hunter Pass
Bug-hunter findings were fixed: mark state resets on actual selection changes, remains on same-selection no-op, and prompt-view events no longer duplicate on selector changes.

## pulseplate-pr-review Pass
Pre-open self-review was performed through role passes and focused gates. It verifies product loop strengthening without backend/API/payment/AI scope creep; it does not replace external review or merge-readiness gates.

## Tests
See bounded checks below.

## Tests / bounded checks
- `npm test -- --run src/pages/__tests__/Home.test.tsx`: PASS, 21 tests
- `npm test -- --run src/pages/__tests__/Home.test.tsx src/api/__tests__/thin-client-guards.test.ts src/config/__tests__/routes.design-preview.test.ts`: PASS, 29 tests
- `npm run build`: PASS with existing Vite chunk-size/dynamic-import warnings
- `.venv/bin/python scripts/design/design_token_runtime_parity_boundary.py validate docs/orchestration/contracts/design_token_runtime_parity_boundary.v1.json`: PASS
- `.venv/bin/python scripts/design/design_token_runtime_parity_boundary.py summarize docs/orchestration/contracts/design_token_runtime_parity_boundary.v1.json`: PASS
- `.venv/bin/python -m pytest -q tests/test_design_token_runtime_parity_boundary.py tests/test_design_automation_next_lane_docs.py`: PASS
- `.venv/bin/python scripts/orchestration/check_preflight.py`: PASS
- `.venv/bin/python scripts/orchestration/check_agent_consistency.py`: PASS
- `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/PulsePlate-frontend-guided-planning-save-progress-flow/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/PulsePlate-frontend-guided-planning-save-progress-flow/.venv/bin/python make validate-changed`: PASS
- `PATH=/Users/katsiaryna_kavaleuskaya/Developer/PulsePlate-frontend-guided-planning-save-progress-flow/.venv/bin:$PATH pre-commit run --all-files`: PASS

Note: initial `make validate-changed` with relative `.venv/bin/python` failed because hooks require absolute executable paths; rerun with absolute paths passed.

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/frontend-guided-planning-save-progress-flow-oracle-portable-result.json`
Status: accepted
Notes: Initial oracle packet using `cd frontend && npm run build` was rejected by the runner allowlist; a second packet with `make validate-changed` was rejected in isolated checkout because no repo/shared `.venv` existed there. The accepted portable oracle used deterministic Python design-boundary commands; actual frontend build and `make validate-changed` passed locally as listed above.

## Deferred / Follow-ups
None. True backend/account persisted planning save remains out of scope and was not promised by this PR.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
Sourcery posted actionable high-level feedback after PR open; fixed in `134c5979d` and mapped in `docs/review/PR_1844_FIXED_MAPPING.md`. Cubic found an uncovered copy-guard issue; fixed in `a2370eef4` and mapped in `docs/review/PR_1844_FIXED_MAPPING.md`.

## Fixed in Commit Mapping
### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1844_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1844#pullrequestreview-4372887451 -> 134c5979d
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1844#pullrequestreview-4372920151 -> a2370eef4
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1844#discussion_r3311245033 -> a2370eef4

## Merge Readiness
Not claimed. Requires current-head CI, required checks, bot/review disposition, mapping artifact, wait window, and strict merge wrapper.

## Rollback
Revert the frontend commit. This removes only the screen-local mark/progress UI and local event names; no backend state or external analytics exists to roll back.

## DoD
- Guided Planning Preview remains intact.
- Observability/a11y evidence from #1843 remains intact.
- User can mark and continue from preview through honest screen-local behavior.
- Wellness boundary remains visible.
- FREE/PRO/VIP tier ladder remains visible.
- No backend/API/payment/LLM runtime scope added.
- Focused frontend tests/build and design checks passed locally.

## Commit breakdown
- `9f867f383 feat(frontend): add guided planning save progress flow`
- `b2420108b docs(review): add PR 1844 fixed mapping`
- `134c5979d fix(frontend): address guided planning review feedback`
- `6f638c65a docs(review): map PR 1844 review feedback`
- `a2370eef4 fix(frontend): cover planning continuation copy guard`
- `25c785110 docs(review): map PR 1844 cubic feedback`

## Pre-push checklist
- `pre-commit run --all-files`: PASS
- Push hooks: PASS
- No `artifacts/`, `.venv`, `node_modules`, coverage files, or local caches staged.

## Post-merge checklist
After merge, sync main, verify merged PR state, remove local/remote feature branch and worktree, and do not start the Slack / Experiment Runner operator bridge until this product loop is merged.

## AGENTS.md / guard / flaky-test updates
No AGENTS, guard policy, or flaky-test updates required.

## Split Justification
Not required; changed file count is 3.

## Summary by Sourcery

Расширить Guided Planning Preview на /app с помощью фронтенд‑только цикла «сохранить и продолжить», который отражает состояние аутентификации, обновляет прогресс‑сообщения на экране и генерирует локальные события наблюдаемости без добавления бэкенд‑персистентности.

New Features:
- Добавить локальные для экрана элементы управления предварительной отметкой/сохранением и сообщения о прогрессе в Guided Planning Preview, управляемые текущим намерением планирования/временем и состоянием аутентификации.
- Включить отдельный CTA «продолжить» из предпросмотра в существующие маршруты планирования (/plate, /progress, /pro), сохраняя при этом основной CTA /setup без изменений.

Enhancements:
- Дополнить локальную схему наблюдаемости новыми событиями guided planning для подсказок сохранения, подсказок аутентификации, состояния прогресса, кликов по сохранению и кликов по продолжению, включая контекст состояния аутентификации.
- Улучшить доступность предпросмотра планирования, используя сообщения о прогрессе с role="status", доступные подписи к кнопкам/ссылкам и текст, учитывающий состояние аутентификации, который не подразумевает персистентность аккаунта.

Tests:
- Расширить тесты для страницы Home, чтобы охватить неаутентифицированные, загружающиеся и аутентифицированные потоки сохранения/продолжения, поведение генерации событий, правила сброса локальных для экрана отметок и отслеживание продолжения для защищённых маршрутов планирования.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the Guided Planning Preview on /app with a frontend-only save and continue loop that reflects auth state, updates on-screen progress messaging, and emits local observability events without adding backend persistence.

New Features:
- Add screen-local preview mark/save controls and progress messaging to the Guided Planning Preview, driven by current planning intent/time and auth state.
- Enable a dedicated continue CTA from the preview into existing planning routes (/plate, /progress, /pro) while keeping the primary /setup CTA intact.

Enhancements:
- Augment the local observability schema with new guided planning events for save prompts, auth prompts, progress state, save clicks, and continuation clicks, including auth state context.
- Improve accessibility of the planning preview by using role="status" progress messaging, accessible button/link labels, and auth-aware copy that avoids implying account persistence.

Tests:
- Expand Home page tests to cover unauthenticated, loading, and authenticated save/continue flows, event emission behavior, screen-local mark reset rules, and continuation tracking for protected planning routes.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a frontend-only save and progress loop to the `/app` Guided Planning Preview. Users can mark the preview on screen, see auth-aware progress, and continue to `/plate`, `/progress`, or `/pro` without backend persistence.

- **New Features**
  - Screen-local preview mark with auth-aware progress and save prompts for unauthenticated, loading, and authenticated states.
  - Continue via `/plate`, `/progress`, `/pro`; `/setup` CTA unchanged; telemetry adds `planning_*` events with `authState` in the local sink.
  - A11y: progress uses role="status" with aria-live; clear, accessible button/link names.

- **Bug Fixes**
  - Prompt-view events emit once per page view, including across auth transitions.
  - Preview mark clears on real selection changes and persists on same-selection no-ops.
  - Guarded continuation copy to avoid implying account persistence; added `docs/review/PR_1844_FIXED_MAPPING.md` mapping.

<sup>Written for commit 25c7851108aff7f0af683dee37a33c2fa223db58. Summary will update on new commits. <a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1844?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



