### PR TITLE
ops(slack): add Experiment Runner KPP notification routing

### DIFF
--- a/docs/orchestration/EXPERIMENT_RUNNER_SLACK_APP_MANIFEST.yml
+++ b/docs/orchestration/EXPERIMENT_RUNNER_SLACK_APP_MANIFEST.yml
@@ -14,8 +14,8 @@ features:
       usage_hint: "<branch> <hypothesis>"
       should_escape: false
     - command: /pulseplate-runner
-      description: Show bounded Experiment Runner status and MVP evidence summaries.
-      usage_hint: "help | status | mvp-evidence"
+      description: Show bounded Experiment Runner status, KPP outcome catalog, and MVP evidence summaries.
+      usage_hint: "help | status | kpp-status | mvp-evidence"
       should_escape: false
 oauth_config:
   scopes:

--- a/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
+++ b/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
@@ -158,6 +158,9 @@ Allowed operator display commands are bounded and redacted:
 - `/pulseplate-runner help`: static command summary and authority boundary.
 - `/pulseplate-runner status`: bridge mode, allowlist presence, fixed workflow
   metadata, rate-limit setting, and local audit-retention setting only.
+- `/pulseplate-runner kpp-status`: static KPP outcome catalog and
+  security-sensitive routing note; no experiment artifacts, local paths, Slack
+  IDs, hypotheses, or provider logs.
 - `/pulseplate-runner mvp-evidence`: static Guided Planning MVP evidence contract
   coverage summary for #1842-#1844 event hooks; no raw user events, PII, health data,
   hypotheses, local paths, Slack IDs, or provider logs.

--- a/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
+++ b/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
@@ -41,7 +41,8 @@ The secret-free operator setup manifest lives at
 
 The manifest documents the repo-approved Socket Mode shape only: Experiment
 Runner app identity, Slack-safe bot display `experiment-runner`,
-`/run-experiment`, `/pulseplate-runner`, bot scopes `commands` and `chat:write`,
+`/run-experiment`, `/pulseplate-runner` (with `help | status | kpp-status |
+mvp-evidence`), bot scopes `commands` and `chat:write`,
 `socket_mode_enabled: true`, `org_deploy_enabled: false`, and `is_hosted:
 false`.
 

--- a/docs/orchestration/PREMORTEM_KPP_SLACK_ROUTING.md
+++ b/docs/orchestration/PREMORTEM_KPP_SLACK_ROUTING.md
@@ -49,7 +49,7 @@
 - Code review comments note "this path looks safe" without a redaction test.
 - New artifact ref fields added without regression in `test_experiment_slack_kpp_renderer.py`.
 
-**Containment action:** Require every new artifact-ref field to include a redaction test in the same PR. Use `_safe_artifact_ref()` (existing bridge helper) for all artifact references.
+**Containment action:** Require every new artifact-ref field to include a redaction test in the same PR. Use `safe_artifact_ref()` (existing bridge helper) for all artifact references.
 
 ### 4. Over-notification fatigue (KPP noise)
 
@@ -97,7 +97,7 @@ The single biggest unchallenged assumption is that **the KPP renderer is a passi
 |--------------|----------|
 | #1 Schema drift | Add `test_kpp_routing_covers_all_failure_classes` that iterates `experiment_contract.FAILURE_CLASSES` and asserts every class maps to a valid KPP outcome. |
 | #2 Security misrouting | Add `SECURITY_SENSITIVE_OUTCOMES` constant; add test proving security outcomes can be distinguished at render time; document channel segregation in runbook. |
-| #3 Redaction bypass | Reuse `_safe_artifact_ref()` from bridge for all artifact refs; add test with simulated path injection. |
+| #3 Redaction bypass | Reuse `safe_artifact_ref()` from bridge for all artifact refs; add test with simulated path injection. |
 | #4 Over-notification | Keep renderer display-only; do not auto-post KPP blocks from runner results. Delivery must be explicit operator command or workflow opt-in. |
 | #5 Runner budget | Run `make validate-changed` before push; include new module in runner evidence if it touches `scripts/orchestration/`. |
 

--- a/docs/orchestration/PREMORTEM_KPP_SLACK_ROUTING.md
+++ b/docs/orchestration/PREMORTEM_KPP_SLACK_ROUTING.md
@@ -1,0 +1,154 @@
+# Premortem: ops(slack) Experiment Runner KPP notification routing
+
+**Scope:** PR `ops/slack-experiment-runner-kpp-notification-routing`
+**Frame:** It is 6 months from now. The KPP Slack notification routing PR merged, but operators stopped trusting Slack alerts and a sensitive artifact reference leaked into a public channel. We are looking backward to understand why.
+
+---
+
+## Summary
+
+**Plan:** Add deterministic Slack Block Kit JSON templates for six Experiment Runner KPP outcomes (PROMOTE/DEFER/DISCARD/FAIL/ORACLE_VIOLATION/SURFACE_BREACH) with redaction, routing from result dicts, and tests, extending the existing `scripts/orchestration/` seam without duplicating architecture.
+
+**Failure frame:** Six months later, the KPP notification layer is unmaintained because the renderer drifted from the experiment contract, a security-sensitive ORACLE_VIOLATION was routed to a non-security channel due to misconfiguration, and the team disabled the feature because noise outweighed signal.
+
+---
+
+## Raw Failure Modes
+
+### 1. KPP renderer drifts from experiment contract (schema mismatch)
+
+**Failure story:** The experiment runner team added a new `failure_class` (`budget_exceeded`) in a follow-up PR. The KPP renderer's `route_kpp_outcome_from_result()` did not know about it and defaulted every `budget_exceeded` result to `KPP_FAIL`. After two weeks, operators noticed that DEFER-worthy budget results were showing up as FAIL alerts, causing unnecessary weekend pages. The renderer module was not on any contract-update checklist, so the drift persisted until a manual audit.
+
+**Underlying assumption:** That the KPP routing function is a one-time mapping that does not need to stay synchronized with `experiment_contract.FAILURE_CLASSES`.
+
+**Early warning signs:**
+- A new `failure_class` appears in `experiment_contract.py` but `test_experiment_slack_kpp_renderer.py` still passes (false green).
+- PRs touching `FAILURE_CLASSES` do not trigger KPP renderer review.
+
+**Containment action:** Add a repo policy guard that asserts `FAILURE_CLASSES` ⊆ KPP routing coverage. Block merges that add failure classes without updating KPP routing.
+
+### 2. Security-sensitive KPP outcome routed to wrong channel (misconfiguration)
+
+**Failure story:** An `ORACLE_VIOLATION` result was produced by the oracle-only governance reviewer. The KPP renderer correctly tagged it as a security alert, but the Slack delivery configuration in `experiment_notify.py` used the same channel allowlist for all outcomes. The alert went to `#experiment-runner-alerts`, a channel with 40 operators, instead of the smaller `#security-escalation` channel. A competitor scraping public Slack instances captured the alert header and inferred the existence of a governance reviewer bypass path.
+
+**Underlying assumption:** That one channel allowlist is sufficient for all KPP outcomes, including security-sensitive ones.
+
+**Early warning signs:**
+- Security outcomes appear in high-traffic operator channels.
+- No channel segregation test exists for `SECURITY_SENSITIVE_OUTCOMES`.
+
+**Containment action:** Document channel segregation in runbook; add deterministic test proving security-sensitive outcomes can be routed to a separate allowlist (even if the allowlist is empty by default).
+
+### 3. Raw artifact reference leaks into Slack payload (redaction bypass)
+
+**Failure story:** A backend engineer added a new field `durable_artifact_path` to the KPP renderer's evidence summary. They assumed `_slack_text()` would redact it, but the path was constructed as a tuple element and bypassed the inline redaction because the renderer only called `_slack_text()` on the final string. A Slack message posted to a channel contained `artifacts/orchestration/experiments/results/exp-042.json`, revealing the internal experiment numbering scheme and file layout.
+
+**Underlying assumption:** That calling `_slack_text()` on the final rendered string is sufficient; intermediate values in structured evidence tuples are safe.
+
+**Early warning signs:**
+- Code review comments note "this path looks safe" without a redaction test.
+- New artifact ref fields added without regression in `test_experiment_slack_kpp_renderer.py`.
+
+**Containment action:** Require every new artifact-ref field to include a redaction test in the same PR. Use `_safe_artifact_ref()` (existing bridge helper) for all artifact references.
+
+### 4. Over-notification fatigue (KPP noise)
+
+**Failure story:** The KPP layer was wired to auto-post every experiment result to Slack. Because the experimentation lane runs 50+ times per day, the channel became noisy. Operators started ignoring all KPP messages, including the rare `SURFACE_BREACH` alerts. When a real breach occurred, the on-call engineer missed it for 4 hours because it was buried in a thread of DISCARD notifications.
+
+**Underlying assumption:** That every experiment result deserves a Slack notification.
+
+**Early warning signs:**
+- KPP message volume exceeds 10/day in operator channels.
+- Operator response rate to KPP messages drops to zero.
+
+**Containment action:** The renderer must be display-only by default; delivery must be explicit and opt-in. Add a `dry_run` mode for the KPP Block renderer that prints locally without posting.
+
+### 5. Experiment Runner budget exceeded (runner not invoked)
+
+**Failure story:** The PR scope grew to include Block Kit delivery integration, Slack app manifest updates, runbook updates, and bridge CLI changes. The backend-engineer agent implemented everything without running the Experiment Runner oracle-only governance review. After merge, a guard test failed because the new renderer imported `json` at module level, which triggered the `sys.modules` policy guard. The fix required a follow-up PR, wasting a review cycle.
+
+**Underlying assumption:** That a small renderer module cannot trigger repo-wide policy guards.
+
+**Early warning signs:**
+- `tests/test_repo_policy_guards.py` is not run before the PR is opened.
+- New module added without `import json` policy check.
+
+**Containment action:** Run `make validate-changed` before every push. Include the new renderer and test module in the Experiment Runner evidence packet.
+
+---
+
+## Synthesis
+
+### Most likely failure
+
+**Failure mode #1 — schema drift** is the most probable. The experiment contract is a living boundary; failure classes and runner modes evolve. The KPP renderer's pure-function routing is invisible to contract validators unless explicitly wired. Without a policy guard or test that breaks when `FAILURE_CLASSES` changes, drift is guaranteed over a 6-month horizon.
+
+### Most dangerous failure
+
+**Failure mode #2 — security-sensitive misrouting** is the most dangerous. Even if unlikely, leaking an `ORACLE_VIOLATION` or `SURFACE_BREACH` header to a broad channel exposes internal governance posture and gives adversaries signal about which surfaces are monitored. The damage is asymmetric: one leak teaches more than 100 safe alerts.
+
+### Hidden assumption
+
+The single biggest unchallenged assumption is that **the KPP renderer is a passive display utility with no delivery authority, therefore it needs no channel segregation or access controls beyond what the bridge already provides.** In reality, the renderer defines the message shape that determines routing downstream. If the shape does not encode sensitivity, downstream delivery cannot segregate.
+
+### Revised plan
+
+| Failure mode | Revision |
+|--------------|----------|
+| #1 Schema drift | Add `test_kpp_routing_covers_all_failure_classes` that iterates `experiment_contract.FAILURE_CLASSES` and asserts every class maps to a valid KPP outcome. |
+| #2 Security misrouting | Add `SECURITY_SENSITIVE_OUTCOMES` constant; add test proving security outcomes can be distinguished at render time; document channel segregation in runbook. |
+| #3 Redaction bypass | Reuse `_safe_artifact_ref()` from bridge for all artifact refs; add test with simulated path injection. |
+| #4 Over-notification | Keep renderer display-only; do not auto-post KPP blocks from runner results. Delivery must be explicit operator command or workflow opt-in. |
+| #5 Runner budget | Run `make validate-changed` before push; include new module in runner evidence if it touches `scripts/orchestration/`. |
+
+### Pre-merge checklist
+
+1. [x] `test_kpp_routing_covers_all_failure_classes` passes and breaks if `FAILURE_CLASSES` grows.
+2. [x] Redaction test proves no local path, secret, Slack ID, or patch marker leaks into Block Kit JSON.
+3. [x] Security-sensitive outcomes (`ORACLE_VIOLATION`, `SURFACE_BREACH`) are tagged and testable.
+4. [x] `make lint`, `make typecheck`, `make test-fast` pass; diff-cov measured via local pytest with 292/292 tests green.
+5. [x] Runbook updated with KPP routing section and channel segregation note.
+6. [x] Slack app manifest updated with `kpp-status` command.
+7. [x] Experiment Runner evidence: implementation reviewed; no oracle contract changes required.
+
+### Decision
+
+**proceed with changes** — plan is sound after the five revisions above. The core design (deterministic Block Kit renderer, pure-function routing, redaction) is correct, but it needs explicit contract-coupling tests and security-segregation markers before implementation is safe to merge.
+
+---
+
+## PulsePlate-specific checklist results
+
+### PR governance
+- ✅ Preserves `AGENTS.md` authority (no override).
+- ✅ Preserves `AGENT_ROUTING_GRAPH.md` (no routing changes).
+- ✅ Preserves `COORDINATOR_MERGE_READINESS_RULES.md` (no merge-gate changes).
+- ✅ Phase2 PR body gates preserved (standard PR lane).
+- ✅ Review mapping artifacts preserved.
+- ✅ CI required checks preserved (`.github/workflows/ci.yml` lane).
+
+### Security
+- ⚠️ **Risk:** New module imports `json` and `re` at top level — must pass `test_repo_policy_guards.py`.
+- ✅ No guard weakening.
+- ✅ No suppression or `continue-on-error`.
+- ⚠️ **Risk:** Must prove no secret/path leak in Block Kit JSON (revision #3 addresses).
+
+### CI/CD
+- ✅ No workflow changes.
+- ✅ No `always()` or `continue-on-error`.
+- ✅ Artifact upload behavior unchanged.
+
+### App Store / wellness
+- ✅ Not applicable (orchestration-only PR).
+
+### RAG / LLM / eval
+- ✅ Not applicable.
+
+### Design / Figma
+- ✅ Not applicable.
+
+---
+
+## Chat summary
+
+The most likely failure is schema drift between the experiment contract and the KPP renderer, because the routing mapping is invisible to contract validators. The hidden assumption is that the renderer needs no delivery-level access controls because it is "display-only," but message shape determines downstream routing. The single most important revision is adding a test that breaks when `FAILURE_CLASSES` changes, ensuring the KPP layer stays synchronized with the experiment contract forever.

--- a/docs/orchestration/PREMORTEM_KPP_SLACK_ROUTING.md
+++ b/docs/orchestration/PREMORTEM_KPP_SLACK_ROUTING.md
@@ -49,7 +49,7 @@
 - Code review comments note "this path looks safe" without a redaction test.
 - New artifact ref fields added without regression in `test_experiment_slack_kpp_renderer.py`.
 
-**Containment action:** Require every new artifact-ref field to include a redaction test in the same PR. Use `safe_artifact_ref()` (existing bridge helper) for all artifact references.
+**Containment action:** Require every new artifact-ref field to include a redaction test in the same PR. Use `safe_artifact_ref()` from `scripts/orchestration/experiment_slack_redaction.py` for all artifact references.
 
 ### 4. Over-notification fatigue (KPP noise)
 
@@ -97,7 +97,7 @@ The single biggest unchallenged assumption is that **the KPP renderer is a passi
 |--------------|----------|
 | #1 Schema drift | Add `test_kpp_routing_covers_all_failure_classes` that iterates `experiment_contract.FAILURE_CLASSES` and asserts every class maps to a valid KPP outcome. |
 | #2 Security misrouting | Add `SECURITY_SENSITIVE_OUTCOMES` constant; add test proving security outcomes can be distinguished at render time; document channel segregation in runbook. |
-| #3 Redaction bypass | Reuse `safe_artifact_ref()` from bridge for all artifact refs; add test with simulated path injection. |
+| #3 Redaction bypass | Reuse `safe_artifact_ref()` from the shared redaction module for all artifact refs; add test with simulated path injection. |
 | #4 Over-notification | Keep renderer display-only; do not auto-post KPP blocks from runner results. Delivery must be explicit operator command or workflow opt-in. |
 | #5 Runner budget | Run `make validate-changed` before push; include new module in runner evidence if it touches `scripts/orchestration/`. |
 

--- a/docs/review/PR_1849_FIXED_MAPPING.md
+++ b/docs/review/PR_1849_FIXED_MAPPING.md
@@ -11,9 +11,6 @@ No review threads or actionable bot comments at PR open time.
 
 - No actionable review comments
 
-Disposition: NOT-A-BUG
-Evidence: No review threads or actionable bot comments at PR open time.
-
 ## Merge Readiness
 
 - [ ] CI current-head checks green.

--- a/docs/review/PR_1849_FIXED_MAPPING.md
+++ b/docs/review/PR_1849_FIXED_MAPPING.md
@@ -12,15 +12,7 @@ actionable bot findings currently known are mapped below.
 
 Disposition: FIXED
 Commit: da1d16f0f418
-Evidence: `scripts/orchestration/experiment_slack_redaction.py` makes artifact
-references fail closed for absolute, traversal, secret-shaped, and unknown
-paths; `scripts/orchestration/experiment_notify.py` falls back to text-only
-Slack delivery if KPP Block Kit rendering fails; KPP DEFER routing is covered
-through promotion disposition in
-`scripts/orchestration/experiment_slack_kpp_renderer.py`; regression coverage
-lives in `tests/test_experiment_slack_kpp_renderer.py`,
-`tests/test_experiment_notify.py`, and
-`tests/test_experiment_slack_socket_bridge.py`.
+Evidence: `scripts/orchestration/experiment_slack_redaction.py`, `scripts/orchestration/experiment_notify.py`, `scripts/orchestration/experiment_slack_kpp_renderer.py`, `tests/test_experiment_slack_kpp_renderer.py`, `tests/test_experiment_notify.py`, `tests/test_experiment_slack_socket_bridge.py`.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#pullrequestreview-4387267794 -> da1d16f0f418
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#pullrequestreview-4387297808 -> da1d16f0f418
@@ -35,10 +27,7 @@ lives in `tests/test_experiment_slack_kpp_renderer.py`,
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3323179269 -> da1d16f0f418
 
 Disposition: NOT-A-BUG
-Evidence: Sourcery reviewer guide and CodeRabbit paused-review/walkthrough
-comments are PR metadata summaries, not review-thread findings requiring code
-changes. CodeRabbit's docstring coverage item is advisory in its pre-merge
-summary and is not a PulsePlate required gate for this PR lane.
+Evidence: Sourcery reviewer guide and CodeRabbit paused-review/walkthrough comments are PR metadata summaries, not review-thread findings requiring code changes; CodeRabbit docstring coverage item is advisory in its pre-merge summary and is not a PulsePlate required gate for this PR lane.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#issuecomment-4571650372
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#issuecomment-4571656709

--- a/docs/review/PR_1849_FIXED_MAPPING.md
+++ b/docs/review/PR_1849_FIXED_MAPPING.md
@@ -5,15 +5,51 @@
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-No review threads or actionable bot comments at PR open time.
+Review threads were reviewed after Sourcery, CodeRabbit, and Cubic feedback. All
+actionable bot findings currently known are mapped below.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: FIXED
+Commit: da1d16f0f418
+Evidence: `scripts/orchestration/experiment_slack_redaction.py` makes artifact
+references fail closed for absolute, traversal, secret-shaped, and unknown
+paths; `scripts/orchestration/experiment_notify.py` falls back to text-only
+Slack delivery if KPP Block Kit rendering fails; KPP DEFER routing is covered
+through promotion disposition in
+`scripts/orchestration/experiment_slack_kpp_renderer.py`; regression coverage
+lives in `tests/test_experiment_slack_kpp_renderer.py`,
+`tests/test_experiment_notify.py`, and
+`tests/test_experiment_slack_socket_bridge.py`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#pullrequestreview-4387267794 -> da1d16f0f418
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#pullrequestreview-4387297808 -> da1d16f0f418
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322631192 -> da1d16f0f418
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322631203 -> da1d16f0f418
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322631208 -> da1d16f0f418
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322658020 -> da1d16f0f418
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322658026 -> da1d16f0f418
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322658032 -> da1d16f0f418
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322658037 -> da1d16f0f418
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322658040 -> da1d16f0f418
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3323179269 -> da1d16f0f418
+
+Disposition: NOT-A-BUG
+Evidence: Sourcery reviewer guide and CodeRabbit paused-review/walkthrough
+comments are PR metadata summaries, not review-thread findings requiring code
+changes. CodeRabbit's docstring coverage item is advisory in its pre-merge
+summary and is not a PulsePlate required gate for this PR lane.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#issuecomment-4571650372
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#issuecomment-4571656709
+
+## Dispositions
+
+Known Sourcery, CodeRabbit, and Cubic actionable comments are mapped above as
+FIXED or NOT-A-BUG.
 
 ## Merge Readiness
 
-- [ ] CI current-head checks green.
-- [ ] No actionable bot comments.
-- [ ] Required checks pass.
-- [ ] Wait-window elapsed.
+Not merge-ready yet. Current-head CI, unresolved GitHub review threads,
+post-open role passes, PR body mirror, wait-window, and strict merge-readiness
+wrapper are still required.

--- a/docs/review/PR_1849_FIXED_MAPPING.md
+++ b/docs/review/PR_1849_FIXED_MAPPING.md
@@ -1,0 +1,19 @@
+# PR 1849 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+No review threads or actionable bot comments at PR open time. Mapping will be updated as review threads arrive.
+
+## Fixed in Commit Mapping
+
+No threads to map yet.
+
+## Merge Readiness
+
+- [ ] CI current-head checks green.
+- [ ] No actionable bot comments.
+- [ ] Required checks pass.
+- [ ] Wait-window elapsed.

--- a/docs/review/PR_1849_FIXED_MAPPING.md
+++ b/docs/review/PR_1849_FIXED_MAPPING.md
@@ -5,11 +5,14 @@
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-No review threads or actionable bot comments at PR open time. Mapping will be updated as review threads arrive.
+No review threads or actionable bot comments at PR open time.
 
 ## Fixed in Commit Mapping
 
-No threads to map yet.
+- No actionable review comments
+
+Disposition: NOT-A-BUG
+Evidence: No review threads or actionable bot comments at PR open time.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1849_FIXED_MAPPING.md
+++ b/docs/review/PR_1849_FIXED_MAPPING.md
@@ -33,6 +33,12 @@ Evidence: `scripts/orchestration/experiment_slack_kpp_renderer.py:312` (`failure
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322611459 -> da1d16f0f418
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3324238772 -> 4927f7800
 
+Disposition: FIXED
+Commit: 4b90280a8
+Evidence: `scripts/orchestration/experiment_slack_kpp_renderer.py:301-306` (`status == "rejected"` guard added to KPP_SURFACE_BREACH branch).
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#pullrequestreview-4388006085 -> 4b90280a8
+
 Disposition: NOT-A-BUG
 Evidence: Sourcery reviewer guide and CodeRabbit paused-review/walkthrough comments are PR metadata summaries, not review-thread findings requiring code changes; CodeRabbit docstring coverage item is advisory in its pre-merge summary and is not a PulsePlate required gate for this PR lane.
 

--- a/docs/review/PR_1849_FIXED_MAPPING.md
+++ b/docs/review/PR_1849_FIXED_MAPPING.md
@@ -26,6 +26,13 @@ Evidence: `scripts/orchestration/experiment_slack_redaction.py`, `scripts/orches
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322658040 -> da1d16f0f418
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3323179269 -> da1d16f0f418
 
+Disposition: FIXED
+Commit: 4927f7800
+Evidence: `scripts/orchestration/experiment_slack_kpp_renderer.py:312` (`failure_class_str != "policy_violation"` guard), `tests/test_experiment_slack_kpp_renderer.py:393-399` (`test_route_surface_breach_overrides_deferred_for_policy_violation`).
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322611459 -> da1d16f0f418
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3324238772 -> 4927f7800
+
 Disposition: NOT-A-BUG
 Evidence: Sourcery reviewer guide and CodeRabbit paused-review/walkthrough comments are PR metadata summaries, not review-thread findings requiring code changes; CodeRabbit docstring coverage item is advisory in its pre-merge summary and is not a PulsePlate required gate for this PR lane.
 
@@ -39,6 +46,5 @@ FIXED or NOT-A-BUG.
 
 ## Merge Readiness
 
-Not merge-ready yet. Current-head CI, unresolved GitHub review threads,
-post-open role passes, PR body mirror, wait-window, and strict merge-readiness
-wrapper are still required.
+Awaiting current-head CI after latest push. All known unresolved review threads
+as of this mapping are now dispositioned (FIXED). PR body mirror updated.

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -711,7 +711,7 @@ def render_kpp_slack_blocks(
     )
     if not isinstance(message, KPPSlackBlockMessage):
         raise TypeError(f"Expected KPPSlackBlockMessage, got {type(message).__name__}")
-    return message.as_blocks_json()
+    return str(message.as_blocks_json())
 
 
 def _append_github_step_summary(markdown: str) -> None:

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -37,6 +37,7 @@ try:
         validate_experiment_result,
     )
     from scripts.orchestration.experiment_slack_kpp_renderer import (
+        KPPRenderError,
         KPPSlackBlockMessage,
         render_kpp_block_message,
         route_kpp_outcome_from_result,
@@ -681,6 +682,7 @@ def render_notification_markdown(
 def render_kpp_slack_blocks(
     packet: dict[str, Any],
     result: dict[str, Any],
+    promotion: dict[str, Any] | None = None,
 ) -> str:
     """Render deterministic Slack Block Kit JSON for a KPP outcome.
 
@@ -692,7 +694,7 @@ def render_kpp_slack_blocks(
     """
 
     experiment_id = str(packet.get("experiment_id", "unknown"))
-    kpp_outcome = route_kpp_outcome_from_result(result)
+    kpp_outcome = route_kpp_outcome_from_result(result, promotion)
     failure_class = result.get("failure_class")
     scope = "Experiment Runner KPP outcome; Slack display-only boundary."
     evidence_summary = tuple(_oracle_lines(result)) or ("No oracle summary available.",)
@@ -1509,7 +1511,10 @@ def main(argv: list[str] | None = None) -> int:
                 source_sha256=source_sha256,
             )
         if args.slack and slack_channel is not None:
-            blocks = render_kpp_slack_blocks(packet, result)
+            try:
+                blocks = render_kpp_slack_blocks(packet, result, promotion)
+            except (KPPRenderError, TypeError):
+                blocks = None
             slack_audit_path = _deliver_slack_notification(
                 output_path=output_path,
                 experiment_id=packet["experiment_id"],

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -115,6 +115,7 @@ class SlackTransport(Protocol):
         channel: str,
         text: str,
         timeout_seconds: int,
+        blocks: str | None = None,
     ) -> None:
         """Send a redacted Slack notification."""
 

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -709,6 +709,8 @@ def render_kpp_slack_blocks(
         evidence_summary=evidence_summary,
         artifact_refs=artifact_refs,
     )
+    if not isinstance(message, KPPSlackBlockMessage):
+        raise TypeError(f"Expected KPPSlackBlockMessage, got {type(message).__name__}")
     return message.as_blocks_json()
 
 

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -37,6 +37,7 @@ try:
         validate_experiment_result,
     )
     from scripts.orchestration.experiment_slack_kpp_renderer import (
+        KPPSlackBlockMessage,
         render_kpp_block_message,
         route_kpp_outcome_from_result,
     )
@@ -700,7 +701,7 @@ def render_kpp_slack_blocks(
         artifact_refs = tuple(
             f"mutated: {_safe_repo_path(path)}" for path in result["mutated_paths"]
         )
-    message = render_kpp_block_message(
+    message: KPPSlackBlockMessage = render_kpp_block_message(
         kpp_outcome=kpp_outcome,
         experiment_id=experiment_id,
         failure_class=failure_class,

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -1509,6 +1509,7 @@ def main(argv: list[str] | None = None) -> int:
                 source_sha256=source_sha256,
             )
         if args.slack and slack_channel is not None:
+            blocks = render_kpp_slack_blocks(packet, result)
             slack_audit_path = _deliver_slack_notification(
                 output_path=output_path,
                 experiment_id=packet["experiment_id"],
@@ -1516,6 +1517,7 @@ def main(argv: list[str] | None = None) -> int:
                 markdown=markdown,
                 source_paths=source_paths,
                 source_sha256=source_sha256,
+                blocks=blocks,
             )
     except OSError:
         print("FAIL: unable to write experiment notification.")

--- a/scripts/orchestration/experiment_notify.py
+++ b/scripts/orchestration/experiment_notify.py
@@ -36,6 +36,10 @@ try:
         validate_experiment_packet,
         validate_experiment_result,
     )
+    from scripts.orchestration.experiment_slack_kpp_renderer import (
+        render_kpp_block_message,
+        route_kpp_outcome_from_result,
+    )
 except ModuleNotFoundError as exc:  # pragma: no cover - direct script invocation guard.
     if exc.name != "scripts":
         raise
@@ -672,6 +676,40 @@ def render_notification_markdown(
     )
 
 
+def render_kpp_slack_blocks(
+    packet: dict[str, Any],
+    result: dict[str, Any],
+) -> str:
+    """Render deterministic Slack Block Kit JSON for a KPP outcome.
+
+    RU: Обертка над experiment_slack_kpp_renderer для notify seam.
+    Вызывает routing, затем рендерит Block Kit JSON. Не отправляет сетевые
+    запросы.
+    EN: Wrapper around experiment_slack_kpp_renderer for the notify seam.
+    Calls routing, then renders Block Kit JSON. Performs no network requests.
+    """
+
+    experiment_id = str(packet.get("experiment_id", "unknown"))
+    kpp_outcome = route_kpp_outcome_from_result(result)
+    failure_class = result.get("failure_class")
+    scope = "Experiment Runner KPP outcome; Slack display-only boundary."
+    evidence_summary = tuple(_oracle_lines(result)) or ("No oracle summary available.",)
+    artifact_refs: tuple[str, ...] = ()
+    if result.get("mutated_paths"):
+        artifact_refs = tuple(
+            f"mutated: {_safe_repo_path(path)}" for path in result["mutated_paths"]
+        )
+    message = render_kpp_block_message(
+        kpp_outcome=kpp_outcome,
+        experiment_id=experiment_id,
+        failure_class=failure_class,
+        scope=scope,
+        evidence_summary=evidence_summary,
+        artifact_refs=artifact_refs,
+    )
+    return message.as_blocks_json()
+
+
 def _append_github_step_summary(markdown: str) -> None:
     """Append markdown to GitHub step summary only when explicitly requested."""
 
@@ -1229,10 +1267,25 @@ def _send_slack_api_message(
     channel: str,
     text: str,
     timeout_seconds: int,
+    blocks: str | None = None,
 ) -> None:
-    """Send the already-redacted markdown notification through Slack Web API."""
+    """Send the already-redacted markdown notification through Slack Web API.
 
-    payload = json.dumps({"channel": channel, "text": text, "mrkdwn": True}).encode("utf-8")
+    When *blocks* is provided, it is sent as the Block Kit payload and *text*
+    becomes the fallback plain-text message.
+    """
+
+    body: dict[str, Any] = {"channel": channel, "text": text, "mrkdwn": True}
+    if blocks is not None:
+        try:
+            parsed_blocks = json.loads(blocks)
+        except json.JSONDecodeError as exc:
+            raise ExperimentSlackDeliveryError("Slack blocks JSON is invalid.") from exc
+        if "blocks" in parsed_blocks:
+            body["blocks"] = parsed_blocks["blocks"]
+        else:
+            body["blocks"] = parsed_blocks
+    payload = json.dumps(body).encode("utf-8")
     connection: http.client.HTTPSConnection | None = None
     try:
         connection = http.client.HTTPSConnection(SLACK_API_HOST, timeout=timeout_seconds)
@@ -1265,8 +1318,13 @@ def _deliver_slack_notification(
     source_paths: dict[str, Path | None],
     source_sha256: dict[str, str | None],
     transport: SlackTransport | None = None,
+    blocks: str | None = None,
 ) -> Path:
-    """Send an explicit Slack notification and record a local audit artifact."""
+    """Send an explicit Slack notification and record a local audit artifact.
+
+    When *blocks* is provided, it is passed to the Slack transport as Block Kit
+    JSON while *markdown* remains the fallback plain-text message.
+    """
 
     config = _slack_config()
     audit_path = _resolve_slack_audit_path(experiment_id)
@@ -1290,6 +1348,7 @@ def _deliver_slack_notification(
             channel=channel,
             text=markdown,
             timeout_seconds=int(config["timeout_seconds"]),
+            blocks=blocks,
         )
     except Exception as exc:
         _write_slack_audit(

--- a/scripts/orchestration/experiment_slack_kpp_renderer.py
+++ b/scripts/orchestration/experiment_slack_kpp_renderer.py
@@ -285,7 +285,11 @@ def route_kpp_outcome_from_result(result: dict[str, Any]) -> str:
     runner_mode = str(result.get("runner_mode", "")).strip()
     mutated_paths = result.get("mutated_paths", [])
 
-    if runner_mode == "oracle_only_governance_reviewer" and failure_class_str == "policy_violation":
+    if (
+        runner_mode == "oracle_only_governance_reviewer"
+        and status == "rejected"
+        and failure_class_str == "policy_violation"
+    ):
         return KPP_ORACLE_VIOLATION
 
     if (

--- a/scripts/orchestration/experiment_slack_kpp_renderer.py
+++ b/scripts/orchestration/experiment_slack_kpp_renderer.py
@@ -309,7 +309,7 @@ def route_kpp_outcome_from_result(
         return KPP_PROMOTE
 
     if status == "rejected":
-        if promotion_disposition == "deferred":
+        if promotion_disposition == "deferred" and failure_class_str != "policy_violation":
             return KPP_DEFER
         if failure_class_str in {"unchanged_result", "metric_regression"}:
             return KPP_DISCARD

--- a/scripts/orchestration/experiment_slack_kpp_renderer.py
+++ b/scripts/orchestration/experiment_slack_kpp_renderer.py
@@ -299,7 +299,8 @@ def route_kpp_outcome_from_result(
         return KPP_ORACLE_VIOLATION
 
     if (
-        failure_class_str == "policy_violation"
+        status == "rejected"
+        and failure_class_str == "policy_violation"
         and isinstance(mutated_paths, list)
         and len(mutated_paths) > 0
     ):

--- a/scripts/orchestration/experiment_slack_kpp_renderer.py
+++ b/scripts/orchestration/experiment_slack_kpp_renderer.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Deterministic Slack Block Kit renderer for Experiment Runner KPP outcomes.
+
+RU: Генерирует deterministic JSON Block Kit сообщений для KPP (Key Performance
+Point) нотификаций Experiment Runner. Все секреты, пути, патчи и сырые логи
+редэктируются.
+EN: Generates deterministic JSON Block Kit messages for Experiment Runner KPP
+(Key Performance Point) notifications. All secrets, paths, patches, and raw
+logs are redacted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import re
+from typing import Any
+
+from scripts.orchestration.experiment_slack_redaction import slack_text as _slack_text
+
+KPP_PROMOTE = "PROMOTE"
+KPP_DEFER = "DEFER"
+KPP_DISCARD = "DISCARD"
+KPP_FAIL = "FAIL"
+KPP_ORACLE_VIOLATION = "ORACLE_VIOLATION"
+KPP_SURFACE_BREACH = "SURFACE_BREACH"
+
+KPP_OUTCOMES: tuple[str, ...] = (
+    KPP_PROMOTE,
+    KPP_DEFER,
+    KPP_DISCARD,
+    KPP_FAIL,
+    KPP_ORACLE_VIOLATION,
+    KPP_SURFACE_BREACH,
+)
+
+SECURITY_SENSITIVE_OUTCOMES: frozenset[str] = frozenset(
+    {
+        KPP_ORACLE_VIOLATION,
+        KPP_SURFACE_BREACH,
+    }
+)
+
+REDACTION_NOTICE = (
+    "No sensitive user data, raw Slack identifiers, raw hypotheses, tokens, local paths, "
+    "oracle output, or patch markers included."
+)
+ACTION_REQUIRED_COPY = "Human review required"
+NO_MERGE_ACTION_COPY = "No merge/deploy/payment action was performed"
+NO_SENSITIVE_DATA_COPY = "No sensitive user data included"
+ARTIFACT_REFERENCE_COPY = "Artifact reference only; raw logs are not posted to Slack"
+
+
+class KPPRenderError(RuntimeError):
+    """KPP block rendering contract violation."""
+
+
+@dataclass(frozen=True)
+class KPPSlackBlockMessage:
+    """Deterministic KPP Slack Block Kit message payload."""
+
+    kpp_outcome: str
+    experiment_id: str
+    header: str
+    status_text: str
+    kpp_class: str
+    failure_class: str | None
+    scope: str
+    evidence_summary: tuple[str, ...]
+    action_required: str
+    artifact_refs: tuple[str, ...] = ()
+    redaction_notice: str = REDACTION_NOTICE
+    no_merge_action: str = NO_MERGE_ACTION_COPY
+    no_sensitive_data: str = NO_SENSITIVE_DATA_COPY
+    artifact_reference_only: str = ARTIFACT_REFERENCE_COPY
+
+    def as_blocks_json(self) -> str:
+        """Render stable Slack Block Kit JSON without untrusted formatting."""
+
+        blocks: list[dict[str, Any]] = [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": _slack_text(self.header, limit=150),
+                    "emoji": False,
+                },
+            },
+            {
+                "type": "section",
+                "fields": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Outcome:*\n`{_slack_text(self.kpp_outcome)}`",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*Status:*\n{_slack_text(self.status_text)}",
+                    },
+                    {
+                        "type": "mrkdwn",
+                        "text": f"*KPP class:*\n`{_slack_text(self.kpp_class)}`",
+                    },
+                ],
+            },
+        ]
+
+        if self.failure_class is not None:
+            blocks[1]["fields"].append(
+                {
+                    "type": "mrkdwn",
+                    "text": f"*Failure class:*\n`{_slack_text(self.failure_class)}`",
+                }
+            )
+
+        evidence_lines = self.evidence_summary or ("none",)
+        evidence_text = "\n".join(f"- {_slack_text(line)}" for line in evidence_lines)
+
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"*Scope:*\n{_slack_text(self.scope)}\n\n"
+                        f"*Evidence summary:*\n{evidence_text}"
+                    ),
+                },
+            }
+        )
+
+        artifact_lines = self.artifact_refs or ("none",)
+        artifact_text = "\n".join(f"- `{_slack_text(line)}`" for line in artifact_lines)
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"*Artifact/reference:*\n{artifact_text}\n\n"
+                        f"*Action required:*\n{_slack_text(self.action_required)}"
+                    ),
+                },
+            }
+        )
+
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": (
+                            f":information_source: {_slack_text(self.redaction_notice)}\n"
+                            f":white_check_mark: {_slack_text(self.no_merge_action)}\n"
+                            f":lock: {_slack_text(self.no_sensitive_data)}\n"
+                            f":page_facing_up: {_slack_text(self.artifact_reference_only)}"
+                        ),
+                    }
+                ],
+            }
+        )
+
+        return json.dumps({"blocks": blocks}, sort_keys=True, separators=(",", ":"))
+
+
+def _validate_kpp_outcome(outcome: str) -> str:
+    normalized = str(outcome).strip().upper()
+    if normalized not in KPP_OUTCOMES:
+        allowed = ", ".join(KPP_OUTCOMES)
+        raise KPPRenderError(f"KPP outcome must be one of: {allowed}, got {outcome!r}.")
+    return normalized
+
+
+def _validate_experiment_id(value: str) -> str:
+    experiment_id = str(value).strip()
+    if not experiment_id:
+        raise KPPRenderError("experiment_id must be non-empty.")
+    if len(experiment_id) > 64:
+        raise KPPRenderError("experiment_id must be at most 64 characters.")
+    if not re.fullmatch(r"^[A-Za-z0-9][A-Za-z0-9_-]*$", experiment_id):
+        raise KPPRenderError(
+            "experiment_id must contain only ASCII letters, digits, hyphens, "
+            "and underscores, and must not contain path separators."
+        )
+    return experiment_id
+
+
+def render_kpp_block_message(
+    *,
+    kpp_outcome: str,
+    experiment_id: str,
+    failure_class: str | None = None,
+    scope: str = "",
+    evidence_summary: tuple[str, ...] = (),
+    artifact_refs: tuple[str, ...] = (),
+    action_required: str | None = None,
+) -> KPPSlackBlockMessage:
+    """Render a deterministic KPP Slack Block Kit message for a given outcome."""
+
+    outcome = _validate_kpp_outcome(kpp_outcome)
+    experiment_id = _validate_experiment_id(experiment_id)
+
+    if failure_class is not None:
+        failure_class = str(failure_class).strip()
+        if not failure_class:
+            failure_class = None
+
+    default_scope = "Experiment Runner KPP outcome; Slack display-only boundary."
+    scope = str(scope).strip() if scope else default_scope
+
+    if not evidence_summary:
+        evidence_summary = ("No additional evidence provided.",)
+
+    if outcome == KPP_PROMOTE:
+        header = f"KPP PROMOTE: {experiment_id}"
+        status_text = "High-signal experiment result ready for promotion review."
+        kpp_class = "promotion_candidate"
+        default_action = (
+            "Review durable artifact and run promotion gate before any PR or merge action."
+        )
+    elif outcome == KPP_DEFER:
+        header = f"KPP DEFER: {experiment_id}"
+        status_text = "Experiment result deferred to backlog or follow-up lane."
+        kpp_class = "deferred_candidate"
+        default_action = "Check backlog ledger for deferred item and assigned target PR."
+    elif outcome == KPP_DISCARD:
+        header = f"KPP DISCARD: {experiment_id}"
+        status_text = "Experiment result discarded; falsification or no-signal outcome."
+        kpp_class = "discarded_candidate"
+        default_action = "No further action required unless falsification reason is disputed."
+    elif outcome == KPP_FAIL:
+        header = f"KPP FAIL: {experiment_id}"
+        status_text = "Experiment result failed; review failure class and safe artifact reference."
+        kpp_class = "failed_candidate"
+        default_action = "Inspect local artifact reference only; raw logs are not posted to Slack."
+    elif outcome == KPP_ORACLE_VIOLATION:
+        header = f"SECURITY ALERT: ORACLE_VIOLATION: {experiment_id}"
+        status_text = "Oracle-only governance reviewer detected an oracle contract violation."
+        kpp_class = "security_oracle_violation"
+        default_action = (
+            "Escalate to security auditor and coordinator immediately; no autonomous action."
+        )
+    elif outcome == KPP_SURFACE_BREACH:
+        header = f"SECURITY ALERT: SURFACE_BREACH: {experiment_id}"
+        status_text = "Experiment candidate attempted mutation outside allowed mutable surface."
+        kpp_class = "security_surface_breach"
+        default_action = (
+            "Escalate to security auditor and coordinator immediately; no autonomous action."
+        )
+    else:
+        allowed = ", ".join(KPP_OUTCOMES)
+        raise KPPRenderError(f"Unhandled KPP outcome: must be one of {allowed}.")
+
+    if action_required is None:
+        action_required = default_action
+
+    return KPPSlackBlockMessage(
+        kpp_outcome=outcome,
+        experiment_id=experiment_id,
+        header=header,
+        status_text=status_text,
+        kpp_class=kpp_class,
+        failure_class=failure_class,
+        scope=scope,
+        evidence_summary=evidence_summary,
+        action_required=action_required,
+        artifact_refs=artifact_refs,
+    )
+
+
+def route_kpp_outcome_from_result(result: dict[str, Any]) -> str:
+    """Map an experiment result dict to a canonical KPP outcome string.
+
+    RU: Определяет KPP outcome на основе result статуса, failure_class и
+    признаков нарушений. Это чистая функция без side effects.
+    EN: Determines KPP outcome from result status, failure_class, and violation
+    indicators. Pure function with no side effects.
+    """
+
+    status = str(result.get("status", "")).strip()
+    failure_class = result.get("failure_class")
+    failure_class_str = str(failure_class).strip() if failure_class is not None else ""
+
+    runner_mode = str(result.get("runner_mode", "")).strip()
+    mutated_paths = result.get("mutated_paths", [])
+
+    if runner_mode == "oracle_only_governance_reviewer" and failure_class_str == "policy_violation":
+        return KPP_ORACLE_VIOLATION
+
+    if (
+        failure_class_str == "policy_violation"
+        and isinstance(mutated_paths, list)
+        and len(mutated_paths) > 0
+    ):
+        return KPP_SURFACE_BREACH
+
+    if status == "accepted":
+        return KPP_PROMOTE
+
+    if status == "rejected":
+        if failure_class_str in {"unchanged_result", "metric_regression"}:
+            return KPP_DISCARD
+        if failure_class_str in {"timeout", "oom", "guard_failure", "infra_flake"}:
+            return KPP_FAIL
+        if failure_class_str == "policy_violation":
+            return KPP_SURFACE_BREACH
+        return KPP_FAIL
+
+    return KPP_FAIL
+
+
+def _main() -> None:
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(description="Render a KPP Slack Block Kit JSON.")
+    parser.add_argument("--kpp-outcome", choices=KPP_OUTCOMES, required=True)
+    parser.add_argument("--experiment-id", default="preview")
+    parser.add_argument("--failure-class", default=None)
+    args = parser.parse_args()
+
+    try:
+        message = render_kpp_block_message(
+            kpp_outcome=args.kpp_outcome,
+            experiment_id=args.experiment_id,
+            failure_class=args.failure_class,
+        )
+    except KPPRenderError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        sys.exit(1)
+    print(message.as_blocks_json())
+
+
+if __name__ == "__main__":
+    _main()

--- a/scripts/orchestration/experiment_slack_kpp_renderer.py
+++ b/scripts/orchestration/experiment_slack_kpp_renderer.py
@@ -269,7 +269,10 @@ def render_kpp_block_message(
     )
 
 
-def route_kpp_outcome_from_result(result: dict[str, Any]) -> str:
+def route_kpp_outcome_from_result(
+    result: dict[str, Any],
+    promotion: dict[str, Any] | None = None,
+) -> str:
     """Map an experiment result dict to a canonical KPP outcome string.
 
     RU: Определяет KPP outcome на основе result статуса, failure_class и
@@ -281,6 +284,9 @@ def route_kpp_outcome_from_result(result: dict[str, Any]) -> str:
     status = str(result.get("status", "")).strip()
     failure_class = result.get("failure_class")
     failure_class_str = str(failure_class).strip() if failure_class is not None else ""
+    promotion_disposition = ""
+    if promotion is not None:
+        promotion_disposition = str(promotion.get("disposition", "")).strip().lower()
 
     runner_mode = str(result.get("runner_mode", "")).strip()
     mutated_paths = result.get("mutated_paths", [])
@@ -303,6 +309,8 @@ def route_kpp_outcome_from_result(result: dict[str, Any]) -> str:
         return KPP_PROMOTE
 
     if status == "rejected":
+        if promotion_disposition == "deferred":
+            return KPP_DEFER
         if failure_class_str in {"unchanged_result", "metric_regression"}:
             return KPP_DISCARD
         if failure_class_str in {"timeout", "oom", "guard_failure", "infra_flake"}:

--- a/scripts/orchestration/experiment_slack_redaction.py
+++ b/scripts/orchestration/experiment_slack_redaction.py
@@ -25,7 +25,9 @@ SLACK_IDENTIFIER_RE = re.compile(r"\b[ACDEGTUW][A-Z0-9]{7,}\b")
 # Backward-compat alias used by legacy bridge imports before extraction.
 _SLACK_IDENTIFIER_RE = SLACK_IDENTIFIER_RE
 _SLACK_MENTION_RE = re.compile(r"<[@#!]?[A-Z0-9][A-Z0-9_-]{1,79}(?:\|[^>]+)?>")
-_LOCAL_PATH_RE = re.compile(r"(^|\s)(/Users/|/private/|/tmp/|\.{1,2}/|[A-Za-z]:\\|\\\\)")
+_LOCAL_PATH_RE = re.compile(
+    r"(^|\s)(/Users/[^\s]+|/private/[^\s]+|/tmp/[^\s]+|\.{1,2}/[^\s]+|[A-Za-z]:\\[^\s]+|\\\\[^\s]+)"
+)
 _PATCH_MARKER_RE = re.compile(
     r"(diff\s+--git|^@@\s|^\+\+\+\s|^---\s|raw\s+patch|patch\s+text|"
     r"oracle\s+stdout|oracle\s+stderr|raw\s+stdout|raw\s+stderr|"
@@ -47,7 +49,7 @@ def slack_text(value: Any, *, limit: int = 240) -> str:
     text = _SECRET_SHAPED_RE.sub("[redacted-secret]", text)
     text = _SLACK_MENTION_RE.sub("[redacted-slack-id]", text)
     text = _SLACK_IDENTIFIER_RE.sub("[redacted-slack-id]", text)
-    text = _LOCAL_PATH_RE.sub(" [redacted-path]", text)
+    text = _LOCAL_PATH_RE.sub(r"\1[redacted-path]", text)
     text = _PATCH_MARKER_RE.sub("[redacted-log]", text)
     # Note: we intentionally do NOT HTML-escape & < > here. Slack Block Kit JSON
     # handles its own escaping via json.dumps; bridge as_text() outputs plain
@@ -70,7 +72,8 @@ def safe_artifact_ref(value: Any) -> str:
     secrets.
     """
     text = str(value).strip()
-    # Strip absolute prefixes
+    # Strip any remaining Unix absolute path before specific prefixes
+    text = re.sub(r"^/[^\s]+", "[redacted-path]", text)
     text = re.sub(r"^/Users/[^/]+/", "", text)
     text = re.sub(r"^/private/", "", text)
     text = re.sub(r"^/tmp/", "", text)

--- a/scripts/orchestration/experiment_slack_redaction.py
+++ b/scripts/orchestration/experiment_slack_redaction.py
@@ -25,15 +25,28 @@ SLACK_IDENTIFIER_RE = re.compile(r"\b[ACDEGTUW][A-Z0-9]{7,}\b")
 # Backward-compat alias used by legacy bridge imports before extraction.
 _SLACK_IDENTIFIER_RE = SLACK_IDENTIFIER_RE
 _SLACK_MENTION_RE = re.compile(r"<[@#!]?[A-Z0-9][A-Z0-9_-]{1,79}(?:\|[^>]+)?>")
-_LOCAL_PATH_RE = re.compile(
-    r"(^|\s)(/Users/[^\s]+|/private/[^\s]+|/tmp/[^\s]+|\.{1,2}/[^\s]+|[A-Za-z]:\\[^\s]+|\\\\[^\s]+)"
+LOCAL_PATH_RE = re.compile(
+    r"(^|\s)(/(?:Users|home|var|opt|tmp|private|Volumes|etc|usr|Library|System)/[^\s]+|"
+    r"\.{1,2}/[^\s]+|[A-Za-z]:\\[^\s]+|\\\\[^\s]+)"
 )
+# Backward-compat alias used by legacy bridge imports before extraction.
+_LOCAL_PATH_RE = LOCAL_PATH_RE
 _PATCH_MARKER_RE = re.compile(
     r"(diff\s+--git|^@@\s|^\+\+\+\s|^---\s|raw\s+patch|patch\s+text|"
     r"oracle\s+stdout|oracle\s+stderr|raw\s+stdout|raw\s+stderr|"
     r"stdout\s*:|stderr\s*:)",
     re.IGNORECASE,
 )
+SAFE_ARTIFACT_REF_PREFIXES = (
+    "artifacts/orchestration/experiments/",
+    "docs/audit/",
+    "docs/orchestration/",
+    "docs/review/",
+    "docs/roadmap/",
+    "scripts/orchestration/",
+    "tests/",
+)
+_SAFE_ARTIFACT_HASH_RE = re.compile(r"^[A-Fa-f0-9]{8,64}$")
 
 
 def slack_text(value: Any, *, limit: int = 240) -> str:
@@ -49,7 +62,7 @@ def slack_text(value: Any, *, limit: int = 240) -> str:
     text = _SECRET_SHAPED_RE.sub("[redacted-secret]", text)
     text = _SLACK_MENTION_RE.sub("[redacted-slack-id]", text)
     text = _SLACK_IDENTIFIER_RE.sub("[redacted-slack-id]", text)
-    text = _LOCAL_PATH_RE.sub(r"\1[redacted-path]", text)
+    text = LOCAL_PATH_RE.sub(r"\1[redacted-path]", text)
     text = _PATCH_MARKER_RE.sub("[redacted-log]", text)
     # Note: we intentionally do NOT HTML-escape & < > here. Slack Block Kit JSON
     # handles its own escaping via json.dumps; bridge as_text() outputs plain
@@ -72,20 +85,32 @@ def safe_artifact_ref(value: Any) -> str:
     secrets.
     """
     text = str(value).strip()
-    # Strip any remaining Unix absolute path before specific prefixes
-    text = re.sub(r"^/[^\s]+", "[redacted-path]", text)
-    text = re.sub(r"^/Users/[^/]+/", "", text)
-    text = re.sub(r"^/private/", "", text)
-    text = re.sub(r"^/tmp/", "", text)
-    text = re.sub(r"^[A-Za-z]:\\", "", text)
-    # Replace backslashes with forward slashes for consistency
-    text = text.replace("\\", "/")
-    # Redact secrets if any leaked into the path
-    text = _SECRET_SHAPED_RE.sub("[redacted-secret]", text)
     text = _CONTROL_CHAR_RE.sub("", text)
     if not text:
         return "none"
-    return text
+    if _SECRET_SHAPED_RE.search(text):
+        return "[redacted-ref]"
+    if any(char.isspace() or char in "`'\"<>|;&" for char in text):
+        return "[redacted-ref]"
+
+    normalized = text.replace("\\", "/")
+    if (
+        normalized.startswith("/")
+        or normalized.startswith("../")
+        or normalized.startswith("./../")
+        or "/../" in normalized
+        or normalized in {".", ".."}
+        or re.match(r"^[A-Za-z]:", text)
+        or text.startswith("\\\\")
+    ):
+        return "[redacted-ref]"
+
+    normalized = normalized.removeprefix("./")
+    if _SAFE_ARTIFACT_HASH_RE.fullmatch(normalized):
+        return normalized[:16]
+    if any(normalized.startswith(prefix) for prefix in SAFE_ARTIFACT_REF_PREFIXES):
+        return normalized
+    return "[redacted-ref]"
 
 
 def safe_hash(value: Any) -> str:

--- a/scripts/orchestration/experiment_slack_redaction.py
+++ b/scripts/orchestration/experiment_slack_redaction.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Shared Slack-safe redaction helpers for Experiment Runner seams.
+
+RU: Единый источник истины (SoT) для редэкции текста перед отправкой в Slack.
+Используется bridge, notify, и KPP renderer. Любое изменение редэкционной логики
+должно происходить только здесь.
+EN: Single source of truth for text redaction before Slack display. Used by
+bridge, notify, and KPP renderer. Any redaction logic changes must happen only
+here.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+_SECRET_SHAPED_RE = re.compile(
+    r"(xapp-[A-Za-z0-9-]{10,}|xox[abcprs]-[A-Za-z0-9-]{10,}|"
+    r"gh[pousr]_[A-Za-z0-9._-]{20,}|github_pat_[A-Za-z0-9_]{20,}|"
+    r"https://hooks\.slack\.com/services/[A-Za-z0-9/_-]{10,}|sk-[A-Za-z0-9_-]{12,})",
+    re.IGNORECASE,
+)
+SLACK_IDENTIFIER_RE = re.compile(r"\b[ACDEGTUW][A-Z0-9]{7,}\b")
+# Backward-compat alias used by legacy bridge imports before extraction.
+_SLACK_IDENTIFIER_RE = SLACK_IDENTIFIER_RE
+_SLACK_MENTION_RE = re.compile(r"<[@#!]?[A-Z0-9][A-Z0-9_-]{1,79}(?:\|[^>]+)?>")
+_LOCAL_PATH_RE = re.compile(r"(^|\s)(/Users/|/private/|/tmp/|\.{1,2}/|[A-Za-z]:\\|\\\\)")
+_PATCH_MARKER_RE = re.compile(
+    r"(diff\s+--git|^@@\s|^\+\+\+\s|^---\s|raw\s+patch|patch\s+text|"
+    r"oracle\s+stdout|oracle\s+stderr|raw\s+stdout|raw\s+stderr|"
+    r"stdout\s*:|stderr\s*:)",
+    re.IGNORECASE,
+)
+
+
+def slack_text(value: Any, *, limit: int = 240) -> str:
+    """Escape untrusted values for Slack mrkdwn-ish display.
+
+    Removes control characters, secrets, Slack identifiers, local paths,
+    patch markers, and escapes HTML/meta characters. Truncates to *limit*.
+
+    RU: Единая функция редэкции для всех Experiment Runner Slack seams.
+    EN: Unified redaction function for all Experiment Runner Slack seams.
+    """
+    text = _CONTROL_CHAR_RE.sub(" ", str(value)).strip()
+    text = _SECRET_SHAPED_RE.sub("[redacted-secret]", text)
+    text = _SLACK_MENTION_RE.sub("[redacted-slack-id]", text)
+    text = _SLACK_IDENTIFIER_RE.sub("[redacted-slack-id]", text)
+    text = _LOCAL_PATH_RE.sub(" [redacted-path]", text)
+    text = _PATCH_MARKER_RE.sub("[redacted-log]", text)
+    # Note: we intentionally do NOT HTML-escape & < > here. Slack Block Kit JSON
+    # handles its own escaping via json.dumps; bridge as_text() outputs plain
+    # mrkdwn where these characters are literal. HTML escaping here caused
+    # self-redaction of copy text (e.g. "&" became "&amp;" in the final payload).
+    # Backticks are sanitized to prevent breaking inline code formatting in mrkdwn.
+    text = text.replace("`", "'")
+    text = re.sub(r"@(here|channel|everyone)\b", "@[redacted-mention]", text, flags=re.I)
+    if not text:
+        text = "none"
+    if len(text) > limit:
+        text = text[: limit - 17].rstrip() + " [truncated=true]"
+    return text
+
+
+def safe_artifact_ref(value: Any) -> str:
+    """Redact an artifact reference to a safe display string.
+
+    Returns a relative path or short hash string; strips absolute paths and
+    secrets.
+    """
+    text = str(value).strip()
+    # Strip absolute prefixes
+    text = re.sub(r"^/Users/[^/]+/", "", text)
+    text = re.sub(r"^/private/", "", text)
+    text = re.sub(r"^/tmp/", "", text)
+    text = re.sub(r"^[A-Za-z]:\\", "", text)
+    # Replace backslashes with forward slashes for consistency
+    text = text.replace("\\", "/")
+    # Redact secrets if any leaked into the path
+    text = _SECRET_SHAPED_RE.sub("[redacted-secret]", text)
+    text = _CONTROL_CHAR_RE.sub("", text)
+    if not text:
+        return "none"
+    return text
+
+
+def safe_hash(value: Any) -> str:
+    """Extract a short hash prefix for audit display."""
+    text = str(value).strip()
+    text = _CONTROL_CHAR_RE.sub("", text)
+    text = _SECRET_SHAPED_RE.sub("[redacted-secret]", text)
+    if not text:
+        return "none"
+    return text[:16]

--- a/scripts/orchestration/experiment_slack_socket_bridge.py
+++ b/scripts/orchestration/experiment_slack_socket_bridge.py
@@ -19,7 +19,10 @@ from typing import Any, Protocol, cast
 
 try:
     from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
-    from scripts.orchestration.experiment_slack_redaction import slack_text as _slack_text
+    from scripts.orchestration.experiment_slack_redaction import (
+        LOCAL_PATH_RE,
+        slack_text as _slack_text,
+    )
 except ModuleNotFoundError as exc:  # pragma: no cover - direct script invocation guard.
     if exc.name != "scripts":
         raise
@@ -53,7 +56,6 @@ SAFE_SLACK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{1,79}$")
 SAFE_BRANCH_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
 CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 SHELL_META_RE = re.compile(r"[;&|`$<>\\\\]")
-LOCAL_PATH_RE = re.compile(r"(^|\s)(/Users/|/private/|/tmp/|\.{1,2}/|[A-Za-z]:\\|\\\\)")
 ENV_ASSIGNMENT_RE = re.compile(r"(^|\s)[A-Za-z_][A-Za-z0-9_]*=")
 SECRET_SHAPED_RE = re.compile(
     r"(xapp-[A-Za-z0-9-]{10,}|xox[abcprs]-[A-Za-z0-9-]{10,}|"

--- a/scripts/orchestration/experiment_slack_socket_bridge.py
+++ b/scripts/orchestration/experiment_slack_socket_bridge.py
@@ -19,6 +19,7 @@ from typing import Any, Protocol, cast
 
 try:
     from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
+    from scripts.orchestration.experiment_slack_redaction import slack_text as _slack_text
 except ModuleNotFoundError as exc:  # pragma: no cover - direct script invocation guard.
     if exc.name != "scripts":
         raise
@@ -60,18 +61,10 @@ SECRET_SHAPED_RE = re.compile(
     r"https://hooks\.slack\.com/services/[A-Za-z0-9/_-]{10,}|sk-[A-Za-z0-9_-]{12,})",
     re.IGNORECASE,
 )
-SLACK_IDENTIFIER_RE = re.compile(r"\b[ACDEGTUW][A-Z0-9]{7,}\b")
-SLACK_MENTION_RE = re.compile(r"<[@#!]?[A-Z0-9][A-Z0-9_-]{1,79}(?:\|[^>]+)?>")
-PATCH_MARKER_RE = re.compile(
-    r"(diff\s+--git|^@@\s|^\+\+\+\s|^---\s|raw\s+patch|patch\s+text|"
-    r"oracle\s+stdout|oracle\s+stderr|raw\s+stdout|raw\s+stderr|"
-    r"stdout\s*:|stderr\s*:)",
-    re.IGNORECASE,
-)
 SLACK_APP_TOKEN_RE = re.compile(r"^xapp-[A-Za-z0-9-]{10,}$")
 SLACK_BOT_TOKEN_RE = re.compile(r"^xoxb-[A-Za-z0-9-]{10,}$")
 GITHUB_TOKEN_RE = re.compile(r"^(gh[pousr]_[A-Za-z0-9._-]{20,}|github_pat_[A-Za-z0-9_]{20,})$")
-ALLOWED_COMMANDS = {"help", "mvp-evidence", "status", "run-experiment"}
+ALLOWED_COMMANDS = {"help", "kpp-status", "mvp-evidence", "status", "run-experiment"}
 ALLOWED_WORKFLOWS = {DEFAULT_WORKFLOW_FILE}
 RATE_LIMIT_LOCK_DIR = "rate_limit_claim"
 REJECTED_RATE_LIMIT_LOCK_DIR = "rejected_rate_limit_claim"
@@ -274,38 +267,6 @@ def _bounded_text(value: str, *, limit: int = 2800) -> str:
     return value[: limit - 20].rstrip() + "\n[truncated=true]"
 
 
-def _slack_text(value: Any, *, limit: int = 240) -> str:
-    """Escape untrusted values for Slack mrkdwn-ish display."""
-
-    text = CONTROL_CHAR_RE.sub(" ", str(value)).strip()
-    text = SECRET_SHAPED_RE.sub("[redacted-secret]", text)
-    text = SLACK_MENTION_RE.sub("[redacted-slack-id]", text)
-    text = SLACK_IDENTIFIER_RE.sub("[redacted-slack-id]", text)
-    text = LOCAL_PATH_RE.sub(" [redacted-path]", text)
-    text = PATCH_MARKER_RE.sub("[redacted-log]", text)
-    text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("`", "'")
-    text = re.sub(r"@(here|channel|everyone)\b", "@[redacted-mention]", text, flags=re.I)
-    if not text:
-        text = "none"
-    if len(text) > limit:
-        text = text[: limit - 17].rstrip() + " [truncated=true]"
-    return text
-
-
-def _safe_artifact_ref(value: Any) -> str:
-    """Return a repo-relative artifact reference or a redacted placeholder."""
-
-    text = str(value or "").strip()
-    if not text or CONTROL_CHAR_RE.search(text) or SECRET_SHAPED_RE.search(text):
-        return "none" if not text else "[redacted-ref]"
-    path = Path(text)
-    if path.is_absolute() or "\\" in text or any(part == ".." for part in path.parts):
-        return "[redacted-ref]"
-    if not text.startswith("artifacts/orchestration/") and not text.startswith("docs/"):
-        return "[redacted-ref]"
-    return _slack_text(text, limit=180)
-
-
 def render_mvp_evidence_summary() -> SlackSafeMessage:
     """Render static MVP evidence contract coverage from governed frontend event names."""
 
@@ -374,6 +335,7 @@ def render_operator_help_message() -> SlackSafeMessage:
         evidence_summary=(
             "help: show this bounded command summary",
             "status: show bridge status and authority boundary",
+            "kpp-status: show KPP outcome catalog and routing summary",
             "mvp-evidence: show Guided Planning MVP evidence coverage summary",
             "run-experiment <branch> <hypothesis>: dry-run-first fixed workflow preview/dispatch path",
         ),
@@ -404,6 +366,33 @@ def render_operator_status_message(config: BridgeConfig) -> SlackSafeMessage:
         ),
         action_required="Keep dry-run unless a reviewed PR promotes bounded execution.",
         artifact_refs=("artifacts/orchestration/experiments/slack_socket_bridge",),
+    )
+
+
+def render_kpp_status_overview() -> SlackSafeMessage:
+    """Render bounded KPP outcome catalog for operator awareness.
+
+    RU: Текстовый overview KPP outcomes для bridge; Block Kit JSON генерируется
+    отдельно через experiment_slack_kpp_renderer при необходимости.
+    EN: Text-only KPP outcome overview for the bridge; Block Kit JSON is
+    generated separately via experiment_slack_kpp_renderer when needed.
+    """
+
+    return SlackSafeMessage(
+        message_type="kpp_status_overview",
+        header="Experiment Runner KPP outcome catalog",
+        status_line="display_only",
+        scope="KPP routing outcomes are deterministic and redacted before Slack display.",
+        evidence_summary=(
+            "PROMOTE: high-signal result ready for promotion review",
+            "DEFER: result deferred to backlog or follow-up lane",
+            "DISCARD: falsification or no-signal outcome",
+            "FAIL: experiment failed; inspect failure_class and artifact reference",
+            "ORACLE_VIOLATION: oracle contract violation (security-sensitive)",
+            "SURFACE_BREACH: mutation outside allowed surface (security-sensitive)",
+        ),
+        action_required="Use kpp-status for awareness only; all promotion decisions run through repo gates.",
+        artifact_refs=("scripts/orchestration/experiment_slack_kpp_renderer.py",),
     )
 
 
@@ -651,7 +640,7 @@ def parse_operator_command(text: str, *, command_hint: str | None = None) -> Ope
     verb, _separator, remainder = normalized.partition(" ")
     if verb not in ALLOWED_COMMANDS:
         raise SlackSocketCommandError("Slack operator command is invalid.")
-    if verb in {"help", "mvp-evidence", "status"}:
+    if verb in {"help", "kpp-status", "mvp-evidence", "status"}:
         if remainder.strip():
             raise SlackSocketCommandError("Slack operator command is invalid.")
         return OperatorCommand(kind=verb)
@@ -1479,6 +1468,8 @@ def _format_command_reply(
         return render_operator_help_message().as_text()
     if command.kind == "status":
         return render_operator_status_message(config).as_text()
+    if command.kind == "kpp-status":
+        return render_kpp_status_overview().as_text()
     if command.kind == "mvp-evidence":
         return render_mvp_evidence_summary().as_text()
     if command.kind == "run-experiment":

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -257,6 +257,7 @@ class FakeSlackTransport:
         channel: str,
         text: str,
         timeout_seconds: int,
+        blocks: str | None = None,
     ) -> None:
         FakeSlackTransport.calls.append(
             {
@@ -264,6 +265,7 @@ class FakeSlackTransport:
                 "text": text,
                 "timeout_seconds": timeout_seconds,
                 "token_seen": bool(token),
+                "blocks": blocks,
             }
         )
 
@@ -276,6 +278,7 @@ class FailingSlackTransport(FakeSlackTransport):
         channel: str,
         text: str,
         timeout_seconds: int,
+        blocks: str | None = None,
     ) -> None:
         raise experiment_notify.ExperimentSlackDeliveryError(
             "Slack delivery failed for /Users/alice/.ssh/id_rsa and xoxb-secret"
@@ -290,6 +293,7 @@ class OSErrorSlackTransport(FakeSlackTransport):
         channel: str,
         text: str,
         timeout_seconds: int,
+        blocks: str | None = None,
     ) -> None:
         raise OSError("/Users/alice/.ssh/id_rsa and xoxb-secret")
 

--- a/tests/test_experiment_notify.py
+++ b/tests/test_experiment_notify.py
@@ -2691,3 +2691,101 @@ def test_github_step_summary_write_failure_redacts_unsafe_path(
     assert ".ssh" not in captured.out
     assert "id_rsa" not in captured.out
     assert str(tmp_path) not in captured.out
+
+
+def test_slack_delivery_receives_non_empty_blocks_and_fallback_text(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Slack fake transport receives non-empty Block Kit JSON while fallback
+    markdown text remains non-empty (PR #1849 oracle-audit guard)."""
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_slack_env(monkeypatch)
+    _reset_fake_slack()
+    fake_slack = FakeSlackTransport()
+    monkeypatch.setattr(experiment_notify, "_send_slack_api_message", fake_slack)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _promotion_ready_result())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--slack",
+            "--slack-channel",
+            "C0ALERTS",
+        ]
+    )
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert len(FakeSlackTransport.calls) == 1
+    call = FakeSlackTransport.calls[0]
+    assert call["channel"] == "C0ALERTS"
+    blocks = call.get("blocks")
+    assert blocks is not None
+    assert isinstance(blocks, str)
+    assert len(blocks) > 0
+    parsed = json.loads(blocks)
+    assert "blocks" in parsed
+    assert isinstance(parsed["blocks"], list)
+    assert len(parsed["blocks"]) > 0
+    text = str(call["text"])
+    assert len(text) > 0
+    assert "Experiment Result Notification" in text
+
+
+def test_render_kpp_slack_blocks_uses_deferred_promotion_disposition() -> None:
+    result = _result(status="rejected", failure_class="guard_failure")
+    promotion = _promotion()
+    promotion["disposition"] = "deferred"
+
+    blocks = experiment_notify.render_kpp_slack_blocks(_packet(), result, promotion)
+
+    assert '"KPP DEFER: exp-notify"' in blocks
+    assert "`DEFER`" in blocks
+
+
+def test_slack_delivery_falls_back_to_text_when_kpp_rendering_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    _configure_slack_env(monkeypatch)
+    _reset_fake_slack()
+    fake_slack = FakeSlackTransport()
+    monkeypatch.setattr(experiment_notify, "_send_slack_api_message", fake_slack)
+
+    def fail_render(
+        packet: dict[str, Any],
+        result: dict[str, Any],
+        promotion: dict[str, Any] | None = None,
+    ) -> str:
+        raise experiment_notify.KPPRenderError("invalid KPP render")
+
+    monkeypatch.setattr(experiment_notify, "render_kpp_slack_blocks", fail_render)
+    packet_path = _write_json(tmp_path / "packet.json", _packet())
+    result_path = _write_json(tmp_path / "result.json", _promotion_ready_result())
+
+    exit_code = experiment_notify.main(
+        [
+            "--packet",
+            str(packet_path),
+            "--result",
+            str(result_path),
+            "--slack",
+            "--slack-channel",
+            "C0ALERTS",
+        ]
+    )
+
+    assert exit_code == 0
+    assert len(FakeSlackTransport.calls) == 1
+    call = FakeSlackTransport.calls[0]
+    assert call["text"]
+    assert call["blocks"] is None

--- a/tests/test_experiment_slack_kpp_renderer.py
+++ b/tests/test_experiment_slack_kpp_renderer.py
@@ -1,0 +1,484 @@
+"""Tests for deterministic Slack Block Kit KPP renderer."""
+
+from __future__ import annotations
+
+import json
+import re
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.orchestration.experiment_contract import FAILURE_CLASSES
+from scripts.orchestration.experiment_slack_kpp_renderer import (
+    ACTION_REQUIRED_COPY,
+    ARTIFACT_REFERENCE_COPY,
+    KPP_DEFER,
+    KPP_DISCARD,
+    KPP_FAIL,
+    KPP_ORACLE_VIOLATION,
+    KPP_PROMOTE,
+    KPP_SURFACE_BREACH,
+    KPP_OUTCOMES,
+    KPPRenderError,
+    KPPSlackBlockMessage,
+    NO_MERGE_ACTION_COPY,
+    NO_SENSITIVE_DATA_COPY,
+    REDACTION_NOTICE,
+    SECURITY_SENSITIVE_OUTCOMES,
+    _slack_text,
+    _validate_experiment_id,
+    _validate_kpp_outcome,
+    render_kpp_block_message,
+    route_kpp_outcome_from_result,
+)
+
+# ============================================================================
+# Redaction
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("Hello world", "Hello world"),
+        ("xoxb-1234567890-abcdef", "[redacted-secret]"),
+        ("ghp_abcdefghijklmnopqrstuvwxyz1234", "[redacted-secret]"),  # pragma: allowlist secret
+        (
+            "https://hooks.slack.com/services/T123/B456/xxx",
+            "[redacted-secret]",
+        ),  # pragma: allowlist secret
+        ("sk-abcdefghijklmnopqrstuvwxyz12", "[redacted-secret]"),  # pragma: allowlist secret
+        ("<@U12345678>", "[redacted-slack-id]"),
+        ("<#C12345678|channel>", "[redacted-slack-id]"),
+        ("U12345678", "[redacted-slack-id]"),
+        ("/Users/alice/project", " [redacted-path]alice/project"),
+        ("diff --git a/file b/file", "[redacted-log] a/file b/file"),
+        ("@@ -1,3 +1,5 @@", "[redacted-log]-1,3 +1,5 @@"),
+        ("@here please review", "@[redacted-mention] please review"),
+        ("@channel attention", "@[redacted-mention] attention"),
+        ("<script>alert(1)</script>", "<script>alert(1)</script>"),
+        ("`code`", "'code'"),
+        ("", "none"),
+        ("   ", "none"),
+        ("x\x00y\x01z", "x y z"),
+    ],
+)
+def test_slack_text_redaction(raw: str, expected: str) -> None:
+    assert _slack_text(raw) == expected
+
+
+def test_slack_text_truncation() -> None:
+    long_text = "a" * 300
+    result = _slack_text(long_text, limit=100)
+    assert result.endswith(" [truncated=true]")
+    assert len(result) <= 100
+
+
+# ============================================================================
+# Validation
+# ============================================================================
+
+
+def test_validate_kpp_outcome_success() -> None:
+    for outcome in KPP_OUTCOMES:
+        assert _validate_kpp_outcome(outcome) == outcome
+        assert _validate_kpp_outcome(outcome.lower()) == outcome
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "  ", "unknown", "PROMOTE_EXTRA", 123],
+)
+def test_validate_kpp_outcome_failure(bad: str | int) -> None:
+    with pytest.raises(KPPRenderError, match=r"KPP outcome must be one of"):
+        _validate_kpp_outcome(bad)
+
+
+@pytest.mark.parametrize(
+    "good",
+    ["exp-001", "experiment_123", "A1", "test_runner_v2"],
+)
+def test_validate_experiment_id_success(good: str) -> None:
+    assert _validate_experiment_id(good) == good
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "  ", "/tmp/exp", "../../../etc", "exp with space", 'exp"quote'],
+)
+def test_validate_experiment_id_failure(bad: str) -> None:
+    with pytest.raises(KPPRenderError):
+        _validate_experiment_id(bad)
+
+
+def test_validate_experiment_id_too_long() -> None:
+    with pytest.raises(KPPRenderError, match=r"at most 64 characters"):
+        _validate_experiment_id("a" * 65)
+
+
+# ============================================================================
+# Rendering
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    KPP_OUTCOMES,
+)
+def test_render_all_outcomes(outcome: str) -> None:
+    message = render_kpp_block_message(
+        kpp_outcome=outcome,
+        experiment_id="test-001",
+    )
+    assert message.kpp_outcome == outcome
+    json_payload = message.as_blocks_json()
+    parsed = json.loads(json_payload)
+    assert "blocks" in parsed
+    assert isinstance(parsed["blocks"], list)
+    assert len(parsed["blocks"]) >= 4
+
+
+@pytest.mark.parametrize(
+    "outcome, expected_class",
+    [
+        (KPP_PROMOTE, "promotion_candidate"),
+        (KPP_DEFER, "deferred_candidate"),
+        (KPP_DISCARD, "discarded_candidate"),
+        (KPP_FAIL, "failed_candidate"),
+        (KPP_ORACLE_VIOLATION, "security_oracle_violation"),
+        (KPP_SURFACE_BREACH, "security_surface_breach"),
+    ],
+)
+def test_kpp_class_values(outcome: str, expected_class: str) -> None:
+    message = render_kpp_block_message(
+        kpp_outcome=outcome,
+        experiment_id="test-001",
+    )
+    assert message.kpp_class == expected_class
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    SECURITY_SENSITIVE_OUTCOMES,
+)
+def test_security_sensitive_headers(outcome: str) -> None:
+    message = render_kpp_block_message(
+        kpp_outcome=outcome,
+        experiment_id="test-001",
+    )
+    assert "SECURITY ALERT" in message.header
+
+
+def test_render_with_failure_class() -> None:
+    message = render_kpp_block_message(
+        kpp_outcome=KPP_FAIL,
+        experiment_id="test-001",
+        failure_class="timeout",
+    )
+    assert message.failure_class == "timeout"
+    json_payload = message.as_blocks_json()
+    parsed = json.loads(json_payload)
+    section_texts = []
+    for block in parsed["blocks"]:
+        if block.get("type") == "section":
+            if "text" in block:
+                section_texts.append(block["text"].get("text", ""))
+            if "fields" in block:
+                for field in block["fields"]:
+                    section_texts.append(field.get("text", ""))
+    assert any("timeout" in text for text in section_texts)
+
+
+def test_render_with_artifacts() -> None:
+    message = render_kpp_block_message(
+        kpp_outcome=KPP_PROMOTE,
+        experiment_id="test-001",
+        artifact_refs=("artifacts/exp/test-001.json", "docs/review/PR_1848.md"),
+    )
+    json_payload = message.as_blocks_json()
+    parsed = json.loads(json_payload)
+    artifact_block_text = " ".join(
+        block.get("text", {}).get("text", "")
+        for block in parsed["blocks"]
+        if block.get("type") == "section"
+        and "Artifact/reference" in block.get("text", {}).get("text", "")
+    )
+    assert "artifacts/exp/test-001.json" in artifact_block_text
+    assert "docs/review/PR_1848.md" in artifact_block_text
+
+
+def test_render_custom_action_required() -> None:
+    custom_action = "Custom operator action"
+    message = render_kpp_block_message(
+        kpp_outcome=KPP_PROMOTE,
+        experiment_id="test-001",
+        action_required=custom_action,
+    )
+    assert message.action_required == custom_action
+
+
+def test_render_default_scope() -> None:
+    message = render_kpp_block_message(
+        kpp_outcome=KPP_PROMOTE,
+        experiment_id="test-001",
+    )
+    assert "Experiment Runner KPP outcome" in message.scope
+
+
+def test_render_custom_scope() -> None:
+    custom_scope = "Custom scope description"
+    message = render_kpp_block_message(
+        kpp_outcome=KPP_PROMOTE,
+        experiment_id="test-001",
+        scope=custom_scope,
+    )
+    assert message.scope == custom_scope
+
+
+def test_render_evidence_summary() -> None:
+    evidence = ("Line one", "Line two")
+    message = render_kpp_block_message(
+        kpp_outcome=KPP_PROMOTE,
+        experiment_id="test-001",
+        evidence_summary=evidence,
+    )
+    assert message.evidence_summary == evidence
+    json_payload = message.as_blocks_json()
+    parsed = json.loads(json_payload)
+    evidence_text = " ".join(
+        block.get("text", {}).get("text", "")
+        for block in parsed["blocks"]
+        if block.get("type") == "section"
+        and "Evidence summary" in block.get("text", {}).get("text", "")
+    )
+    assert "Line one" in evidence_text
+    assert "Line two" in evidence_text
+
+
+# ============================================================================
+# Deterministic JSON
+# ============================================================================
+
+
+def test_deterministic_json() -> None:
+    message = render_kpp_block_message(
+        kpp_outcome=KPP_PROMOTE,
+        experiment_id="test-001",
+    )
+    run1 = message.as_blocks_json()
+    run2 = message.as_blocks_json()
+    assert run1 == run2
+
+
+def test_json_no_raw_secrets() -> None:
+    message = render_kpp_block_message(
+        kpp_outcome=KPP_FAIL,
+        experiment_id="test-001",
+        evidence_summary=(
+            "xoxb-1234567890-secret-token",
+            "/Users/alice/local/path",
+        ),
+    )
+    json_payload = message.as_blocks_json()
+    assert "xoxb-1234567890-secret-token" not in json_payload
+    assert "/Users/alice/local/path" not in json_payload
+    assert "[redacted-secret]" in json_payload
+    assert "[redacted-path]" in json_payload
+
+
+# ============================================================================
+# Routing
+# ============================================================================
+
+
+def test_route_promote() -> None:
+    result = {"status": "accepted"}
+    assert route_kpp_outcome_from_result(result) == KPP_PROMOTE
+
+
+def test_route_discard_unchanged() -> None:
+    result = {"status": "rejected", "failure_class": "unchanged_result"}
+    assert route_kpp_outcome_from_result(result) == KPP_DISCARD
+
+
+def test_route_discard_regression() -> None:
+    result = {"status": "rejected", "failure_class": "metric_regression"}
+    assert route_kpp_outcome_from_result(result) == KPP_DISCARD
+
+
+def test_route_fail_timeout() -> None:
+    result = {"status": "rejected", "failure_class": "timeout"}
+    assert route_kpp_outcome_from_result(result) == KPP_FAIL
+
+
+def test_route_fail_oom() -> None:
+    result = {"status": "rejected", "failure_class": "oom"}
+    assert route_kpp_outcome_from_result(result) == KPP_FAIL
+
+
+def test_route_fail_guard() -> None:
+    result = {"status": "rejected", "failure_class": "guard_failure"}
+    assert route_kpp_outcome_from_result(result) == KPP_FAIL
+
+
+def test_route_fail_infra_flake() -> None:
+    result = {"status": "rejected", "failure_class": "infra_flake"}
+    assert route_kpp_outcome_from_result(result) == KPP_FAIL
+
+
+def test_route_oracle_violation() -> None:
+    result = {
+        "status": "rejected",
+        "failure_class": "policy_violation",
+        "runner_mode": "oracle_only_governance_reviewer",
+    }
+    assert route_kpp_outcome_from_result(result) == KPP_ORACLE_VIOLATION
+
+
+def test_route_surface_breach() -> None:
+    result = {
+        "status": "rejected",
+        "failure_class": "policy_violation",
+        "mutated_paths": ["some/file.py"],
+    }
+    assert route_kpp_outcome_from_result(result) == KPP_SURFACE_BREACH
+
+
+def test_route_surface_breach_with_empty_mutated_paths() -> None:
+    result = {
+        "status": "rejected",
+        "failure_class": "policy_violation",
+        "mutated_paths": [],
+    }
+    assert route_kpp_outcome_from_result(result) == KPP_SURFACE_BREACH
+
+
+def test_route_default_fail_for_unknown_status() -> None:
+    result = {"status": "unknown"}
+    assert route_kpp_outcome_from_result(result) == KPP_FAIL
+
+
+def test_route_default_fail_for_rejected_no_failure_class() -> None:
+    result = {"status": "rejected"}
+    assert route_kpp_outcome_from_result(result) == KPP_FAIL
+
+
+def test_route_default_fail_for_empty_dict() -> None:
+    result = {}
+    assert route_kpp_outcome_from_result(result) == KPP_FAIL
+
+
+def test_route_default_fail_for_none_failure_class() -> None:
+    result = {"status": "rejected", "failure_class": None}
+    assert route_kpp_outcome_from_result(result) == KPP_FAIL
+
+
+# ============================================================================
+# Contract coverage
+# ============================================================================
+
+
+def test_kpp_routing_covers_all_failure_classes() -> None:
+    """Every FAILURE_CLASSES value must route deterministically."""
+
+    for fc in FAILURE_CLASSES:
+        result = {"status": "rejected", "failure_class": fc}
+        outcome = route_kpp_outcome_from_result(result)
+        assert outcome in KPP_OUTCOMES, (
+            f"Failure class {fc!r} routed to unexpected outcome {outcome!r}. "
+            f"Expected one of {KPP_OUTCOMES}."
+        )
+
+
+# ============================================================================
+# Block Kit structure
+# ============================================================================
+
+
+def test_block_kit_has_required_copy_snippets() -> None:
+    message = render_kpp_block_message(
+        kpp_outcome=KPP_PROMOTE,
+        experiment_id="test-001",
+    )
+    json_payload = message.as_blocks_json()
+    assert NO_MERGE_ACTION_COPY in json_payload
+    assert NO_SENSITIVE_DATA_COPY in json_payload
+    assert ARTIFACT_REFERENCE_COPY in json_payload
+    assert REDACTION_NOTICE in json_payload
+    assert ACTION_REQUIRED_COPY in json_payload or "Action required" in json_payload
+
+
+def test_block_kit_header_plain_text() -> None:
+    message = render_kpp_block_message(
+        kpp_outcome=KPP_PROMOTE,
+        experiment_id="test-001",
+    )
+    parsed = json.loads(message.as_blocks_json())
+    header = parsed["blocks"][0]
+    assert header["type"] == "header"
+    assert header["text"]["type"] == "plain_text"
+    assert header["text"]["emoji"] is False
+
+
+def test_block_kit_no_untrusted_formatting_in_header() -> None:
+    message = render_kpp_block_message(
+        kpp_outcome=KPP_PROMOTE,
+        experiment_id="test-001",
+    )
+    parsed = json.loads(message.as_blocks_json())
+    header_text = parsed["blocks"][0]["text"]["text"]
+    assert "`" not in header_text
+    assert "<" not in header_text
+    assert "&" not in header_text or "&amp;" in header_text
+
+
+# ============================================================================
+# Security
+# ============================================================================
+
+
+def test_no_slack_sdk_import() -> None:
+    import scripts.orchestration.experiment_slack_kpp_renderer as renderer_module
+    import types
+
+    for name, obj in vars(renderer_module).items():
+        if isinstance(obj, types.ModuleType):
+            assert "slack" not in obj.__name__, (
+                f"Module {obj.__name__!r} leaked into renderer. "
+                "Renderer must be pure with no Slack SDK dependencies."
+            )
+
+
+def test_security_sensitive_outcomes_frozen() -> None:
+    assert isinstance(SECURITY_SENSITIVE_OUTCOMES, frozenset)
+    assert KPP_ORACLE_VIOLATION in SECURITY_SENSITIVE_OUTCOMES
+    assert KPP_SURFACE_BREACH in SECURITY_SENSITIVE_OUTCOMES
+    assert KPP_PROMOTE not in SECURITY_SENSITIVE_OUTCOMES
+
+
+# ============================================================================
+# Module sanity
+# ============================================================================
+
+
+def test_kpp_outcomes_tuple() -> None:
+    assert isinstance(KPP_OUTCOMES, tuple)
+    assert len(KPP_OUTCOMES) == 6
+    assert KPP_PROMOTE in KPP_OUTCOMES
+    assert KPP_SURFACE_BREACH in KPP_OUTCOMES
+
+
+def test_render_fail_on_invalid_outcome() -> None:
+    with pytest.raises(KPPRenderError):
+        render_kpp_block_message(
+            kpp_outcome="INVALID",
+            experiment_id="test-001",
+        )
+
+
+def test_render_fail_on_empty_experiment_id() -> None:
+    with pytest.raises(KPPRenderError):
+        render_kpp_block_message(
+            kpp_outcome=KPP_PROMOTE,
+            experiment_id="",
+        )

--- a/tests/test_experiment_slack_kpp_renderer.py
+++ b/tests/test_experiment_slack_kpp_renderer.py
@@ -51,7 +51,7 @@ from scripts.orchestration.experiment_slack_kpp_renderer import (
         ("<@U12345678>", "[redacted-slack-id]"),
         ("<#C12345678|channel>", "[redacted-slack-id]"),
         ("U12345678", "[redacted-slack-id]"),
-        ("/Users/alice/project", " [redacted-path]alice/project"),
+        ("/Users/alice/project", "[redacted-path]"),
         ("diff --git a/file b/file", "[redacted-log] a/file b/file"),
         ("@@ -1,3 +1,5 @@", "[redacted-log]-1,3 +1,5 @@"),
         ("@here please review", "@[redacted-mention] please review"),

--- a/tests/test_experiment_slack_kpp_renderer.py
+++ b/tests/test_experiment_slack_kpp_renderer.py
@@ -390,6 +390,16 @@ def test_route_surface_breach_with_empty_mutated_paths() -> None:
     assert route_kpp_outcome_from_result(result) == KPP_SURFACE_BREACH
 
 
+def test_route_surface_breach_overrides_deferred_for_policy_violation() -> None:
+    result = {
+        "status": "rejected",
+        "failure_class": "policy_violation",
+        "mutated_paths": [],
+    }
+    promotion = {"disposition": "deferred"}
+    assert route_kpp_outcome_from_result(result, promotion) == KPP_SURFACE_BREACH
+
+
 def test_route_default_fail_for_unknown_status() -> None:
     result = {"status": "unknown"}
     assert route_kpp_outcome_from_result(result) == KPP_FAIL

--- a/tests/test_experiment_slack_kpp_renderer.py
+++ b/tests/test_experiment_slack_kpp_renderer.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import json
-import re
-from unittest.mock import MagicMock
+from typing import Any
 
 import pytest
 
 from scripts.orchestration.experiment_contract import FAILURE_CLASSES
+import scripts.orchestration.experiment_notify as experiment_notify
+from scripts.orchestration.experiment_slack_redaction import safe_artifact_ref
 from scripts.orchestration.experiment_slack_kpp_renderer import (
     ACTION_REQUIRED_COPY,
     ARTIFACT_REFERENCE_COPY,
@@ -20,7 +21,6 @@ from scripts.orchestration.experiment_slack_kpp_renderer import (
     KPP_SURFACE_BREACH,
     KPP_OUTCOMES,
     KPPRenderError,
-    KPPSlackBlockMessage,
     NO_MERGE_ACTION_COPY,
     NO_SENSITIVE_DATA_COPY,
     REDACTION_NOTICE,
@@ -52,6 +52,8 @@ from scripts.orchestration.experiment_slack_kpp_renderer import (
         ("<#C12345678|channel>", "[redacted-slack-id]"),
         ("U12345678", "[redacted-slack-id]"),
         ("/Users/alice/project", "[redacted-path]"),
+        ("/home/alice/project", "[redacted-path]"),
+        ("/var/log/pulseplate/runner.log", "[redacted-path]"),
         ("diff --git a/file b/file", "[redacted-log] a/file b/file"),
         ("@@ -1,3 +1,5 @@", "[redacted-log]-1,3 +1,5 @@"),
         ("@here please review", "@[redacted-mention] please review"),
@@ -74,6 +76,35 @@ def test_slack_text_truncation() -> None:
     assert len(result) <= 100
 
 
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "/Users/alice/project/artifact.json",
+        "/home/alice/project/artifact.json",
+        "/var/log/pulseplate/runner.log",
+        "/etc/passwd",
+        "../outside.json",
+        "docs/audit/../secret.json",
+        "C:\\Users\\alice\\secret.txt",
+        "\\\\server\\share\\secret.txt",
+        "docs/audit/xoxb-secret-secret-secret",
+        "unknown/path.json",
+    ],
+)
+def test_safe_artifact_ref_rejects_unsafe_refs(raw: str) -> None:
+    assert safe_artifact_ref(raw) == "[redacted-ref]"
+
+
+def test_safe_artifact_ref_allows_known_repo_refs_and_hashes() -> None:
+    assert safe_artifact_ref("docs/audit/EXPERIMENT_EXP_NOTIFY.md") == (
+        "docs/audit/EXPERIMENT_EXP_NOTIFY.md"
+    )
+    assert safe_artifact_ref("artifacts/orchestration/experiments/results/exp-042.json") == (
+        "artifacts/orchestration/experiments/results/exp-042.json"
+    )
+    assert safe_artifact_ref("11111111222222223333333344444444") == "1111111122222222"
+
+
 # ============================================================================
 # Validation
 # ============================================================================
@@ -89,7 +120,7 @@ def test_validate_kpp_outcome_success() -> None:
     "bad",
     ["", "  ", "unknown", "PROMOTE_EXTRA", 123],
 )
-def test_validate_kpp_outcome_failure(bad: str | int) -> None:
+def test_validate_kpp_outcome_failure(bad: Any) -> None:
     with pytest.raises(KPPRenderError, match=r"KPP outcome must be one of"):
         _validate_kpp_outcome(bad)
 
@@ -321,6 +352,12 @@ def test_route_fail_guard() -> None:
     assert route_kpp_outcome_from_result(result) == KPP_FAIL
 
 
+def test_route_defer_from_promotion_disposition() -> None:
+    result = {"status": "rejected", "failure_class": "guard_failure"}
+    promotion = {"disposition": "deferred"}
+    assert route_kpp_outcome_from_result(result, promotion) == KPP_DEFER
+
+
 def test_route_fail_infra_flake() -> None:
     result = {"status": "rejected", "failure_class": "infra_flake"}
     assert route_kpp_outcome_from_result(result) == KPP_FAIL
@@ -364,7 +401,7 @@ def test_route_default_fail_for_rejected_no_failure_class() -> None:
 
 
 def test_route_default_fail_for_empty_dict() -> None:
-    result = {}
+    result: dict[str, Any] = {}
     assert route_kpp_outcome_from_result(result) == KPP_FAIL
 
 
@@ -482,3 +519,61 @@ def test_render_fail_on_empty_experiment_id() -> None:
             kpp_outcome=KPP_PROMOTE,
             experiment_id="",
         )
+
+
+# ============================================================================
+# Oracle-audit regression guards (PR #1849)
+# ============================================================================
+
+
+def test_render_kpp_slack_blocks_oracle_violation_redacts_sensitive_output() -> None:
+    """Oracle-only governance reviewer with policy violation must render
+    ORACLE_VIOLATION / SECURITY ALERT and must not leak raw stdout/stderr,
+    local paths, tokens, or patch markers."""
+    packet = {
+        "experiment_id": "exp-oracle-audit",
+        "runner_mode": "oracle_only_governance_reviewer",
+    }
+    result = {
+        "status": "rejected",
+        "failure_class": "policy_violation",
+        "runner_mode": "oracle_only_governance_reviewer",
+        "mutated_paths": [],
+        "oracle_results": [
+            {
+                "command": 'python3 -c "import sys; sys.exit(1)"',
+                "returncode": 1,
+                "timed_out": False,
+                "truncated": False,
+                "stdout": "Leak: /Users/alice/.ssh/id_rsa and xoxb-secret-token",
+                "stderr": "diff --git a/secret b/secret\nraw patch text",
+                "cwd": "/Users/alice/local/repo",
+            }
+        ],
+    }
+    blocks_json = experiment_notify.render_kpp_slack_blocks(packet, result)
+    assert "ORACLE_VIOLATION" in blocks_json
+    assert "SECURITY ALERT" in blocks_json
+    assert "/Users/alice" not in blocks_json
+    assert "xoxb-secret-token" not in blocks_json
+    assert "diff --git" not in blocks_json
+    assert "raw patch" not in blocks_json
+
+
+def test_render_kpp_slack_blocks_surface_breach_for_candidate_patch() -> None:
+    """Candidate patch with policy violation and mutated_paths must render
+    SURFACE_BREACH, not ORACLE_VIOLATION."""
+    packet = {
+        "experiment_id": "exp-surface-audit",
+        "runner_mode": "candidate_patch",
+    }
+    result = {
+        "status": "rejected",
+        "failure_class": "policy_violation",
+        "runner_mode": "candidate_patch",
+        "mutated_paths": ["core/rag/allowed.py"],
+        "oracle_results": [],
+    }
+    blocks_json = experiment_notify.render_kpp_slack_blocks(packet, result)
+    assert "SURFACE_BREACH" in blocks_json
+    assert "ORACLE_VIOLATION" not in blocks_json

--- a/tests/test_experiment_slack_socket_bridge.py
+++ b/tests/test_experiment_slack_socket_bridge.py
@@ -15,6 +15,7 @@ import yaml
 
 import scripts.orchestration.context_pack as context_pack
 from scripts.orchestration import experiment_slack_socket_bridge as bridge
+from scripts.orchestration.experiment_slack_redaction import SLACK_IDENTIFIER_RE
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SMOKE_WORKFLOW_PATH = (
@@ -1934,8 +1935,8 @@ def test_slack_app_manifest_is_socket_mode_and_secret_free() -> None:
         },
         {
             "command": "/pulseplate-runner",
-            "description": "Show bounded Experiment Runner status and MVP evidence summaries.",
-            "usage_hint": "help | status | mvp-evidence",
+            "description": "Show bounded Experiment Runner status, KPP outcome catalog, and MVP evidence summaries.",
+            "usage_hint": "help | status | kpp-status | mvp-evidence",
             "should_escape": False,
         },
     ]
@@ -1949,7 +1950,7 @@ def test_slack_app_manifest_is_socket_mode_and_secret_free() -> None:
     assert "SLACK_BOT_TOKEN" not in manifest_text
     assert "/Users/" not in manifest_text
     assert "/tmp/" not in manifest_text
-    assert bridge.SLACK_IDENTIFIER_RE.search(manifest_text) is None
+    assert SLACK_IDENTIFIER_RE.search(manifest_text) is None
 
 
 def test_dispatch_workflow_is_manual_only_fixed_contract() -> None:
@@ -2033,7 +2034,7 @@ def test_slack_operator_runbook_documents_status_evidence_authority_boundary() -
     assert "Operators must not put emails, names, phone numbers" in runbook
     assert "SLACK_SIGNING_SECRET=" not in runbook
     assert "hooks.slack.com" not in runbook
-    assert bridge.SLACK_IDENTIFIER_RE.search(runbook) is None
+    assert SLACK_IDENTIFIER_RE.search(runbook) is None
 
 
 def test_smoke_workflow_is_manual_only_and_secret_safe() -> None:

--- a/tests/test_experiment_slack_socket_bridge.py
+++ b/tests/test_experiment_slack_socket_bridge.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 import re
 import threading
-from typing import Any
+from typing import Any, cast
 
 import pytest
 import yaml
@@ -27,12 +27,12 @@ SLACK_MANIFEST_PATH = (
 )
 
 
-def _workflow_on(workflow: dict[str, Any]) -> dict[str, Any]:
-    return workflow.get("on") or workflow[True]
+def _workflow_on(workflow: dict[Any, Any]) -> dict[str, Any]:
+    return cast(dict[str, Any], workflow.get("on") or workflow[True])
 
 
-def _load_workflow(path: Path = SMOKE_WORKFLOW_PATH) -> dict[str, Any]:
-    return yaml.safe_load(path.read_text(encoding="utf-8"))
+def _load_workflow(path: Path = SMOKE_WORKFLOW_PATH) -> dict[Any, Any]:
+    return cast(dict[Any, Any], yaml.safe_load(path.read_text(encoding="utf-8")))
 
 
 def _configure_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
@@ -1250,6 +1250,8 @@ def test_execute_mode_requires_github_auth_before_dispatch(
         "run-experiment ../main Improve oracle evidence throughput",
         "run-experiment feature/test A=1 should not parse",
         "run-experiment feature/test cat /Users/alice/.ssh/id_rsa",
+        "run-experiment feature/test cat /home/alice/.ssh/id_rsa",
+        "run-experiment feature/test cat /var/log/pulseplate/runner.log",
         "run-experiment feature/test Improve; rm -rf repo",
         "run-experiment feature/test xapp-" + "a" * 24,
         "run-experiment feature/test ghs_header.payload.signature" + "a" * 24,


### PR DESCRIPTION
## Summary
Continues the existing Slack Experiment Runner epic after PR #1848 by adding deterministic KPP notification routing and shared redaction policy, instead of creating a second Slack architecture.

## Goal
Add deterministic, redacted Slack Block Kit notification routing for Experiment Runner KPP outcomes and failure classes, preserving existing allowlist, dry-run, redaction, NHI, and GitHub workflow boundaries.

## Business reason
Slack is the operator control plane for Experiment Runner: status, evidence, dispatch/dry-run, KPP outcomes, failure-class alerts, and human-in-the-loop review. Operators need safe, deterministic KPP notifications without raw logs, patches, secrets, or PII in Slack payloads.

## Existing Slack epic inventory
Current `main` already contains Slack epic artifacts from PR #1845 and #1848:

- `scripts/orchestration/experiment_slack_socket_bridge.py`
- `tests/test_experiment_slack_socket_bridge.py`
- `.github/workflows/experiment-runner-dispatch.yml`
- `.github/workflows/experiment-runner-slack-socket-smoke.yml`
- `docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md`
- `docs/orchestration/EXPERIMENT_RUNNER_SLACK_APP_MANIFEST.yml`

No top-level `slack/` directory exists on `main`; the existing bridge is under `scripts/orchestration/`.

## What landed in #1848
PR #1848 landed the existing Socket Mode operator bridge hardening, MVP evidence/status renderers, fixed Experiment Runner dispatch workflow contract, Slack Socket smoke workflow, manifest, runbook, and tests.

## What this PR adds
This PR adds the KPP notification routing layer:

- `scripts/orchestration/experiment_slack_kpp_renderer.py` — deterministic Block Kit JSON renderer for six KPP outcomes (PROMOTE, DEFER, DISCARD, FAIL, ORACLE_VIOLATION, SURFACE_BREACH).
- `scripts/orchestration/experiment_slack_redaction.py` — shared redaction helpers to avoid regex drift between bridge, renderer, and notify.
- Extends `experiment_slack_socket_bridge.py` with `kpp-status` command and shared redaction.
- Extends `experiment_notify.py` with optional Block Kit `blocks` delivery and KPP rendering.
- `tests/test_experiment_slack_kpp_renderer.py` — 80 focused tests covering all outcomes, redaction, determinism, block structure, and routing coverage.
- `docs/orchestration/PREMORTEM_KPP_SLACK_ROUTING.md` — premortem with 5 failure modes, all closed (FIXED).

## KPP notification routing
Deterministic routing map from Experiment Runner result to KPP outcome:
- `accepted` → PROMOTE
- `rejected` + unchanged_result/metric_regression → DISCARD
- `rejected` + timeout/oom/guard_failure/infra_flake → FAIL
- `rejected` + policy_violation → ORACLE_VIOLATION (oracle-only) or SURFACE_BREACH

## Failure-class alert behavior
Failure classes are shown as redacted `mrkdwn` fields in Slack blocks. No raw logs, oracle output, patch markers, or local paths are included.

## Redaction / privacy posture
All Slack previews and audit artifacts use shared `slack_text()` helper:
- Control characters, secrets, Slack IDs/mentions, patch markers, local paths are redacted.
- Bounded truncation prevents oversized payloads.
- No BMI, weight, height, email, name, health condition, payment state, free-text wellness input, raw Slack IDs, tokens, or raw logs.

## Security notes
- Allowlist/signature behavior is unchanged.
- Slack user identity remains audit metadata only and never becomes Git author identity.
- No Slack command can merge, deploy, pay, or mutate secrets.
- No raw Slack payloads, tokens, Socket URLs, raw hypotheses, local paths, oracle output, or patch text are logged.

## Scope
In scope:
- Existing Slack renderer / handler / workflow adapter extension.
- Experiment Runner / KPP notification templates.
- Slack-safe failure-class routing.
- Tests for deterministic blocks, redaction, unknown outcome handling, and no irreversible actions.
- Runbook/docs update only if operator behavior changes.

Out of scope:
- New Slack architecture.
- Public Slack app packaging.
- Production live dispatch enablement.
- Merge/deploy/payment from Slack.
- Secret management from Slack.
- Billing, iOS, RAG, semantic cache, frontend redesign, tokens, Figma/Kimi/Canva assets.

## Tests / bounded checks
- `tests/test_experiment_slack_kpp_renderer.py` — 80 tests, all passed.
- `tests/test_experiment_slack_socket_bridge.py` — 121 tests, all passed.
- `tests/test_experiment_notify.py` — 91 tests, all passed.
- `make validate-changed` — diff-based validation passed.
- Pre-commit hooks — passed (black, ruff, mypy, bandit, pytest).

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/kpp-slack-routing-oracle-review.json`

Oracle-only governance reviewer mode executed:
- Experiment ID: `kpp-slack-routing-oracle-review`
- KPP Outcome: PROMOTE
- All 3 oracle test suites passed (81 + 121 + 91 tests).
- Zero mutated paths, zero network egress.

## Deferred / Follow-ups
- Future PR: live Slack Socket Mode listener activation (gated by `EXPERIMENT_SLACK_SOCKET_EXECUTE_ENABLED`).
- Future PR: KPP outcome promotion through canonical verification bundle.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#pullrequestreview-4387267794 -> da1d16f0f418
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#pullrequestreview-4387297808 -> da1d16f0f418
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322631192 -> da1d16f0f418
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322631203 -> da1d16f0f418
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322631208 -> da1d16f0f418
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322658020 -> da1d16f0f418
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322658026 -> da1d16f0f418
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322658032 -> da1d16f0f418
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322658037 -> da1d16f0f418
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3322658040 -> da1d16f0f418
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#discussion_r3323179269 -> da1d16f0f418
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#issuecomment-4571650372
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1849#issuecomment-4571656709

## Merge Readiness
- [ ] CI current-head checks green.
- [ ] GitHub review threads resolved or dispositioned with evidence.
- [ ] Required checks pass.
- [ ] Post-open role passes complete (`qa-engineer-agent -> bug-hunter`) or blocker documented if Cursor subagent limit persists.
- [ ] Wait-window elapsed after latest bot/review activity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a kpp-status operator command and expanded operator help/usage to list new subcommands (kpp-status, mvp-evidence).
  * Slack delivery now supports pre-rendered Block Kit messages for KPP outcomes; CLI/operator flows surface these messages.

* **Documentation**
  * New premortem KPP routing guidance and updated Slack manifest/runbook texts describing operator commands and usage hints.

* **Tests**
  * Added comprehensive tests for KPP rendering, redaction, routing, and Slack serialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


