### PR TITLE
Feat/slack reviewed live dispatch approval gate

### DIFF
--- a/.github/workflows/experiment-runner-dispatch.yml
+++ b/.github/workflows/experiment-runner-dispatch.yml
@@ -22,6 +22,11 @@ on:
         options:
           - "true"
           - "false"
+      approval_ref:
+        description: "SHA256 approval digest for live dispatch; default 'none' for dry-run"
+        required: true
+        type: string
+        default: "none"
 
 permissions:
   contents: read
@@ -58,7 +63,7 @@ jobs:
           def _escape_workflow_command_value(value: str) -> str:
               return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
 
-          for key in ("branch_ref", "hypothesis_sha256"):
+          for key in ("branch_ref", "hypothesis_sha256", "approval_ref"):
               value = str(inputs.get(key, "")).strip()
               if value:
                   print(f"::add-mask::{_escape_workflow_command_value(value)}")
@@ -73,12 +78,14 @@ jobs:
           python3 -m scripts.orchestration.experiment_slack_socket_bridge \
             --validate-dispatch-inputs
 
-      - name: Fail closed until bounded live dispatch is promoted
+      - name: Validate live-dispatch approval reference
         if: inputs.dry_run == 'false'
+        env:
+          EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256: ${{ inputs.approval_ref }}
         run: |
           set -euo pipefail
-          printf 'Experiment Runner live dispatch is deferred to a later governed PR.\n'
-          exit 1
+          python3 -m scripts.orchestration.experiment_slack_socket_bridge \
+            --validate-live-approval
 
       - name: Record sanitized dispatch contract summary
         if: inputs.dry_run == 'true'
@@ -90,5 +97,6 @@ jobs:
             printf -- '- dry_run: true\n'
             printf -- '- branch_ref: validated without raw echo\n'
             printf -- '- hypothesis_sha256: validated without raw echo\n'
+            printf -- '- approval_ref: none (dry-run default)\n'
             printf -- '- authority: no PR creation, review disposition, merge readiness, or arbitrary workflow dispatch\n'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
+++ b/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
@@ -14,9 +14,16 @@ Configure these outside the repository, for example as GitHub Actions secrets:
   execute-mode dry-run dispatch preview only. Execute mode also requires
   `EXPERIMENT_SLACK_SOCKET_EXECUTE_ENABLED=reviewed-dry-run-dispatch` and must
   still send the fixed workflow with `dry_run: true`.
+- Optional `EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256`: SHA256 digest that
+  authorizes a single reviewed live dispatch for one specific
+  `branch_ref` + `hypothesis` pair. When absent, dispatch defaults to
+  `dry_run: true`. When present, the bridge computes
+  `SHA256(branch_ref + "\0" + hypothesis)` and allows `dry_run: false`
+  only on exact match.
 
-Do not commit token values, token prefixes, Slack webhook URLs, raw Slack
-payloads, or real workspace channel/user IDs as repository defaults.
+Do not commit token values, token prefixes, approval digests, Slack webhook
+URLs, raw Slack payloads, or real workspace channel/user IDs as repository
+defaults.
 
 ## Runtime Allowlists
 
@@ -124,6 +131,28 @@ prefixes, GitHub tokens, local absolute paths, oracle output, or patch text.
   runtime variable.
 - Rate limit active or duplicate event: the bridge already recorded a recent or
   duplicate operator event; wait or inspect the local hash-only audit artifact.
+
+## Live-Dispatch Approval Gate
+
+Live Experiment Runner dispatch (workflow input `dry_run: false`) is gated by a
+reviewed approval digest.
+
+1. A human reviewer generates the approval digest offline:
+   ```python
+   import hashlib
+   digest = hashlib.sha256((branch_ref + "\0" + hypothesis).encode("utf-8")).hexdigest()
+   ```
+2. The digest is supplied to the runtime environment as
+   `EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256`.
+3. The bridge computes the same digest from the Slack operator command and
+   allows `dry_run: false` only on exact match.
+4. A mismatch rejects the command with a clear error and writes an audit record.
+5. The digest is treated as a single-use secret: rotate it after each live
+dispatch or when leaked.
+
+Dry-run remains the default when the approval env is absent or does not match.
+Operators must not post raw approval digests, branch names, or hypotheses into
+Slack.
 
 ## Audit Retention
 

--- a/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
+++ b/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
@@ -154,6 +154,9 @@ Dry-run remains the default when the approval env is absent or does not match.
 Operators must not post raw approval digests, branch names, or hypotheses into
 Slack.
 
+See also: `docs/orchestration/PREMORTEM_SLACK_LIVE_DISPATCH_APPROVAL.md` for
+reviewed risk analysis and failure modes.
+
 ## Audit Retention
 
 Slack bridge audit artifacts live under

--- a/docs/orchestration/PREMORTEM_SLACK_LIVE_DISPATCH_APPROVAL.md
+++ b/docs/orchestration/PREMORTEM_SLACK_LIVE_DISPATCH_APPROVAL.md
@@ -68,15 +68,15 @@ The approval digest is treated as a long-lived shared secret between the reviewi
 
 ### Revised plan
 
-1. **Bridge:** Compute `SHA256(branch_ref + "\0" + hypothesis)` and compare with `EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256`. Reject with `SlackSocketDispatchError` on mismatch. Never log the env var or computed hash.
-2. **Workflow:** Add `approval_ref` input with default `"none"`. Validate SHA256 hex shape. Only allow `dry_run: false` when `approval_ref` matches the expected pattern and `inputs.dry_run == 'false'`. Mask `approval_ref` in `::add-mask::`.
-3. **Audit:** Add `approval_hash` field to every dispatch audit. Store `"none"` when dry-run, a truncated hash prefix when live-approved.
-4. **Tests:** Add parameterized unsafe-input tests for the live-dispatch path. Add explicit tests for approval mismatch, approval match, and missing approval env.
+1. **Bridge:** Compute `SHA256(branch_ref + "\0" + hypothesis)` and compare with `EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256`. Reject with `SlackSocketDispatchError` on mismatch. Never log the env var or computed hash. See runbook for operator digest generation instructions.
+2. **Workflow:** Add `approval_ref` input with default `"none"`. Validate SHA256 hex shape via bridge CLI `--validate-live-approval`. Only allow `dry_run: false` when `approval_ref` is valid and `inputs.dry_run == 'false'`. Mask `approval_ref` in `::add-mask::`.
+3. **Audit:** Add `approval_hash` field to run-experiment dispatch audits only. Store `"none"` when dry-run, a truncated hash prefix when live-approved.
+4. **Tests:** Add parameterized unsafe-input tests for the live-dispatch path. Add explicit tests for approval mismatch, approval match, missing approval env, case normalization, and sentinel `"none"`.
 5. **Runbook:** Document that approval digests are operator-managed secrets, single-use per dispatch is recommended, and leaked digests must be rotated immediately.
 
 ### Pre-merge checklist
 
-- [ ] `::add-mask::` covers `approval_ref` in both workflows.
+- [ ] `::add-mask::` covers `approval_ref` in the dispatch workflow.
 - [ ] No raw `EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256` appears in stdout, stderr, audit artifacts, or step summaries.
 - [ ] Tests prove `dry_run: false` is rejected without approval.
 - [ ] Tests prove `dry_run: false` is accepted with matching approval.

--- a/docs/orchestration/PREMORTEM_SLACK_LIVE_DISPATCH_APPROVAL.md
+++ b/docs/orchestration/PREMORTEM_SLACK_LIVE_DISPATCH_APPROVAL.md
@@ -1,0 +1,89 @@
+# Premortem: Slack Reviewed Live-Dispatch Approval Gate
+
+## Frame
+
+It is 6 months from now. The Slack live-dispatch approval gate failed. We are looking backward to understand why.
+
+## Raw Failure Modes
+
+### 1. Approval SHA256 env var leaked into CI logs or commit
+- **Story:** An operator set `EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256` in a workflow dispatch input for convenience. It was echoed in a step summary, captured in a public artifact, and scraped. An attacker reused the leaked approval digest to dispatch arbitrary live experiments.
+- **Assumption:** The approval digest is treated as a secret.
+- **Warning signs:** `::add-mask::` missing for approval ref in workflow; approval digest appears in GITHUB_STEP_SUMMARY or workflow artifact.
+- **Containment:** Workflow must mask approval_ref inputs; audit artifacts must store only a hash prefix or redacted marker.
+
+### 2. Workflow approval validation is too weak
+- **Story:** The `experiment-runner-dispatch.yml` workflow accepted `dry_run: false` because the `approval_ref` input was present but empty (`""`), and the check was truthy (`if: inputs.approval_ref != ''`) instead of validating SHA256 shape. Live dispatch ran without reviewed approval.
+- **Assumption:** A non-empty string means "approved."
+- **Warning signs:** Workflow `if` conditions use loose string checks; no explicit SHA256 hex regex validation.
+- **Containment:** Validate `approval_ref` with the same `SHA256_HEX_RE` pattern used by the bridge; fail closed on malformed refs.
+
+### 3. Bridge sends `dry_run: false` without approval by code path error
+- **Story:** A refactor of `_github_dispatch_inputs` introduced a default parameter or branch where `dry_run` was set to `"false"` when `approval_ref` was `None`. The existing tests only checked execute mode with `dry_run: true`, so the regression reached `main`.
+- **Assumption:** Existing tests cover all dispatch paths.
+- **Warning signs:** New code path added without corresponding negative test.
+- **Containment:** Every code path that sets `dry_run` must have an explicit test proving the value; code review must flag unguarded `"false"` literals.
+
+### 4. Approval replay / reuse across different branch/hypothesis pairs
+- **Story:** An operator approved one specific `branch_ref` + `hypothesis` pair. The approval SHA256 was reused for a different pair because the bridge only checked that *some* approval existed, not that it matched the current command.
+- **Assumption:** The bridge validates approval against the current command.
+- **Warning signs:** Approval check is a global boolean, not a per-command hash comparison.
+- **Containment:** Bridge must compute `SHA256(branch_ref + "\0" + hypothesis)` and compare with the env var; mismatch must reject with a clear error class.
+
+### 5. Race condition between approval env update and Slack command
+- **Story:** An operator updated the GitHub Actions environment secret with a new approval digest. Before the secret propagated, another operator issued a Slack command. The old approval was still active and matched an unintended command.
+- **Assumption:** Env updates are atomic and instantaneous.
+- **Warning signs:** Multiple workflow dispatches with the same approval digest but different branch/hypothesis pairs succeed.
+- **Containment:** Approval digest must include a nonce or timestamp, or be single-use via explicit claim/invalidation. Out of scope for this PR; document in runbook that approval env updates are operator-only and must be validated before dispatch.
+
+### 6. Audit artifact omits approval state, blocking post-incident investigation
+- **Story:** After an unauthorized live dispatch, the audit artifact only recorded `status: dispatched` without an `approval_hash` field. Security review could not determine whether approval was present or bypassed.
+- **Assumption:** The audit schema is comprehensive.
+- **Warning signs:** Audit JSON schema changes without test updates.
+- **Containment:** Audit payload must include `approval_hash` (or `"none"`) for every dispatch path; tests must assert its presence.
+
+### 7. Unsafe branch or hypothesis strings bypass validation in live path
+- **Story:** The live-dispatch path introduced a new code branch for computing dispatch inputs. This branch accidentally skipped `_is_safe_ref` or `_validate_hypothesis` because the inputs were derived from the approval hash rather than raw command text.
+- **Assumption:** Input validation is uniform across all paths.
+- **Warning signs:** Live-dispatch tests do not include the same unsafe-input parametrize cases as dry-run tests.
+- **Containment:** Live-dispatch tests must reuse the same unsafe branch/hypothesis parameterization; bridge must validate raw inputs before computing any hash.
+
+## Synthesis
+
+### Summary
+
+Add a reviewed live-dispatch approval gate to the Experiment Runner Slack bridge by introducing an env-var approval digest (`EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256`) that the bridge matches against `SHA256(branch_ref + "\0" + hypothesis)` before allowing `dry_run: false` in the workflow dispatch.
+
+### Most likely failure
+
+**Failure mode #3:** A code-path refactor accidentally sends `dry_run: false` without approval. The existing test suite is strong for dry-run paths but the new live-dispatch path is narrow and easy to regress.
+
+### Most dangerous failure
+
+**Failure mode #1:** Approval digest leaked into logs/artifacts. If leaked, it is a single-factor bypass for live dispatch. The workflow `::add-mask::` step must cover `approval_ref`, and the bridge must never print the raw env var.
+
+### Hidden assumption
+
+The approval digest is treated as a long-lived shared secret between the reviewing human and the runtime environment. This is acceptable for a first gate, but it assumes the secret store (GitHub Secrets or operator env) is the weakest link, not the bridge logic.
+
+### Revised plan
+
+1. **Bridge:** Compute `SHA256(branch_ref + "\0" + hypothesis)` and compare with `EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256`. Reject with `SlackSocketDispatchError` on mismatch. Never log the env var or computed hash.
+2. **Workflow:** Add `approval_ref` input with default `"none"`. Validate SHA256 hex shape. Only allow `dry_run: false` when `approval_ref` matches the expected pattern and `inputs.dry_run == 'false'`. Mask `approval_ref` in `::add-mask::`.
+3. **Audit:** Add `approval_hash` field to every dispatch audit. Store `"none"` when dry-run, a truncated hash prefix when live-approved.
+4. **Tests:** Add parameterized unsafe-input tests for the live-dispatch path. Add explicit tests for approval mismatch, approval match, and missing approval env.
+5. **Runbook:** Document that approval digests are operator-managed secrets, single-use per dispatch is recommended, and leaked digests must be rotated immediately.
+
+### Pre-merge checklist
+
+- [ ] `::add-mask::` covers `approval_ref` in both workflows.
+- [ ] No raw `EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256` appears in stdout, stderr, audit artifacts, or step summaries.
+- [ ] Tests prove `dry_run: false` is rejected without approval.
+- [ ] Tests prove `dry_run: false` is accepted with matching approval.
+- [ ] Audit schema tests include `approval_hash` field.
+- [ ] Unsafe branch/hypothesis inputs are rejected in live-dispatch path.
+- [ ] Runbook updated with approval-digest rotation instructions.
+
+### Decision
+
+`proceed with changes` — plan is sound after the revised plan items above are implemented.

--- a/docs/review/PR_1851_FIXED_MAPPING.md
+++ b/docs/review/PR_1851_FIXED_MAPPING.md
@@ -4,6 +4,11 @@
 
 All pre-open and post-open agent findings are dispositioned below.
 
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
 ### Agent findings
 
 | Finding | Role | Disposition | Evidence |
@@ -23,17 +28,22 @@ All pre-open and post-open agent findings are dispositioned below.
 | Premortem "both workflows" inaccuracy | cursor-specialist-agent | FIXED | Commit `d2194cbd5` — changed to "the dispatch workflow" |
 | Premortem duplicate explanations | cursor-specialist-agent | FIXED | Commit `d2194cbd5` — removed duplicate digest computation from revised plan; references runbook instead |
 | Premortem not linked from runbook | cursor-specialist-agent | FIXED | Commit `d2194cbd5` — added "See also" link to premortem from runbook Live-Dispatch Approval Gate section |
+| `SlackSocketConfigError` leak in `--validate-live-approval` CLI | sourcery-ai | FIXED | Commit `dae9fd3af` — wrapped `_live_approval_sha256()` in `try/except SlackSocketConfigError` in `main()` |
+| Duplicated `approval_hash` prefix logic | sourcery-ai | FIXED | Commit `dae9fd3af` — extracted `_approval_prefix(config, command)` helper used by `_audit_payload` and `process_operator_event` |
+| Missing `approval_ref` default assertion in contract test | sourcery-ai | FIXED | Commit `dae9fd3af` — added `monkeypatch.delenv(LIVE_APPROVAL_SHA256_ENV)` and `assert dispatch_inputs["approval_ref"] == "none"` |
+| Missing "## Discussion Thread Pass" section | coderabbitai | FIXED | Commit `dae9fd3af` — added required section with two checked checkboxes |
+| Prematurely checked merge-readiness checkboxes | coderabbitai | FIXED | Commit `dae9fd3af` — unchecked all merge-readiness items until final merge cycle |
 
 ### Merge readiness
 
-- [x] Pre-open agents: agent-coordinator, cursor-specialist-agent, security-auditor, architecture-specialist
-- [x] Post-open agents: qa-engineer-agent, bug-hunter
-- [x] `make validate-changed` passed
-- [x] `make test-fast` passed
-- [x] `pre-commit run --all-files` passed
-- [x] `python3 scripts/orchestration/check_preflight.py` passed
-- [x] `python3 scripts/orchestration/check_agent_consistency.py` passed
-- [x] PR review dry-run report generated (`/tmp/pulseplate_pr_review_context.json`)
+- [ ] Pre-open agents: agent-coordinator, cursor-specialist-agent, security-auditor, architecture-specialist
+- [ ] Post-open agents: qa-engineer-agent, bug-hunter
+- [ ] `make validate-changed` passed
+- [ ] `make test-fast` passed
+- [ ] `pre-commit run --all-files` passed
+- [ ] `python3 scripts/orchestration/check_preflight.py` passed
+- [ ] `python3 scripts/orchestration/check_agent_consistency.py` passed
+- [ ] PR review dry-run report generated (`/tmp/pulseplate_pr_review_context.json`)
 - [ ] Full `make verify` — operator-approved machine-heavy PR deferral (focused checks used)
 
 ### Experiment Runner evidence

--- a/docs/review/PR_1851_FIXED_MAPPING.md
+++ b/docs/review/PR_1851_FIXED_MAPPING.md
@@ -1,50 +1,76 @@
-# PR 1851 Fixed in Commit Mapping
-
-## Disposition summary
-
-All pre-open and post-open agent findings are dispositioned below.
+# PR 1851 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
 
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-### Agent findings
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: fb2736108
+Evidence: `scripts/orchestration/experiment_slack_socket_bridge.py`, `tests/test_experiment_slack_socket_bridge.py`, `.github/workflows/experiment-runner-dispatch.yml`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1851#pullrequestreview-4392957757 -> fb2736108
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1851#pullrequestreview-4392984719 -> fb2736108
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1851#discussion_r3327135789 -> fb2736108
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1851#discussion_r3327135793 -> fb2736108
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1851#pullrequestreview-4393133435 -> fb2736108
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1851#discussion_r3327198182 -> fb2736108
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1851#pullrequestreview-4393204478 -> fb2736108
+
+Disposition: FIXED
+Commit: c969c1978
+Evidence: `tests/test_experiment_slack_socket_bridge.py` — added live-dispatch approval path tests, audit schema assertions, reply formatting tests, `--validate-live-approval` CLI tests, live-dispatch integration tests, unsafe input rejection tests
+
+Disposition: FIXED
+Commit: d2194cbd5
+Evidence: `scripts/orchestration/experiment_slack_socket_bridge.py` — `approval_hash` gated on `command.kind == "run-experiment"`, `_live_approval_sha256` lowercase normalization, `"none"` sentinel handling; `docs/orchestration/PREMORTEM_SLACK_LIVE_DISPATCH_APPROVAL.md` — wording and cross-link fixes
+
+Disposition: NOT-A-BUG
+Reason: Approval digest leak risk is mitigated by prefix-only audit (16 chars), generic error messages, and `::add-mask::` in workflow. Workflow validation checks SHA256 hex shape as defense-in-depth; semantic binding (branch+hypothesis digest match) is enforced by the bridge before dispatch.
+Evidence: `scripts/orchestration/experiment_slack_socket_bridge.py`, `.github/workflows/experiment-runner-dispatch.yml:78-86`
+
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md`
+Evidence: Slack bridge crash-safety gap between GitHub dispatch transport return and final audit write. Orphaned dispatches require GitHub Actions UI monitoring. Target PR: future bounded reliability PR.
+
+## Agent Findings Summary
 
 | Finding | Role | Disposition | Evidence |
 |---------|------|-------------|----------|
-| Missing live-dispatch approval path tests | architecture-specialist | FIXED | Commit `c969c1978` — added `test_execute_mode_with_matching_live_approval_dispatches_dry_run_false`, `test_execute_mode_with_mismatched_live_approval_rejects_dispatch` |
-| Missing audit schema assertions | architecture-specialist | FIXED | Commit `c969c1978` — added `test_live_approval_audit_contains_truncated_hash_for_live_dispatch`, `test_dry_run_audit_contains_none_approval_hash` |
-| Missing reply formatting tests | architecture-specialist | FIXED | Commit `c969c1978` — added `test_live_dispatch_reply_shows_dry_run_false_and_approval_hash` |
-| Approval digest leak risk | security-auditor | NOT-A-BUG | `scripts/orchestration/experiment_slack_socket_bridge.py` — audit stores 16-char prefix only; Slack reply shows 16-char prefix; error message is generic; workflow masks via `::add-mask::` |
-| Workflow validation only checks format | security-auditor | NOT-A-BUG | `.github/workflows/experiment-runner-dispatch.yml:78-86` — semantic binding (branch+hypothesis digest match) is enforced by bridge in `_github_dispatch_inputs` before dispatch; workflow step validates SHA256 hex shape as defense-in-depth. Documented in runbook known limitations. |
-| Missing `--validate-live-approval` CLI tests | qa-engineer-agent | FIXED | Commit `c969c1978` — added `test_validate_live_approval_cli_passes_for_valid_digest` |
-| Missing live-dispatch integration tests | qa-engineer-agent | FIXED | Commit `c969c1978` — added approval match/mismatch/reply/audit tests |
-| Missing unsafe input tests for live path | qa-engineer-agent | FIXED | Commit `c969c1978` — added `test_live_dispatch_path_rejects_unsafe_inputs_via_existing_parser` |
-| `approval_hash` leaks into non-dispatch commands | bug-hunter | FIXED | Commit `d2194cbd5` — `_audit_payload` and `BridgeDecision` now gate `approval_hash` on `command.kind == "run-experiment"`; test `test_non_dispatch_command_does_not_carry_approval_hash` proves fix |
-| Case-sensitivity mismatch | bug-hunter | FIXED | Commit `d2194cbd5` — `_live_approval_sha256` normalizes to lowercase via `.lower()`; test `test_live_approval_sha256_normalizes_uppercase_to_lowercase` proves fix |
-| `"none"` sentinel crashes bridge | bug-hunter | FIXED | Commit `d2194cbd5` — `_live_approval_sha256` treats `"none"` / `"NONE"` as `None`; test `test_live_approval_sha256_returns_none_for_absent_and_none_sentinel` proves fix |
-| Crash-safety gap (dispatch vs audit write) | bug-hunter | DEFERRED | Backlog: `docs/roadmap/BACKLOG_LEDGER.md` — Slack bridge crash-safety gap between GitHub dispatch transport return and final audit write. Orphaned dispatches require GitHub Actions UI monitoring. Target PR: future bounded reliability PR. |
-| Premortem "both workflows" inaccuracy | cursor-specialist-agent | FIXED | Commit `d2194cbd5` — changed to "the dispatch workflow" |
-| Premortem duplicate explanations | cursor-specialist-agent | FIXED | Commit `d2194cbd5` — removed duplicate digest computation from revised plan; references runbook instead |
-| Premortem not linked from runbook | cursor-specialist-agent | FIXED | Commit `d2194cbd5` — added "See also" link to premortem from runbook Live-Dispatch Approval Gate section |
-| `SlackSocketConfigError` leak in `--validate-live-approval` CLI | sourcery-ai | FIXED | Commit `dae9fd3af` — wrapped `_live_approval_sha256()` in `try/except SlackSocketConfigError` in `main()` |
-| Duplicated `approval_hash` prefix logic | sourcery-ai | FIXED | Commit `dae9fd3af` — extracted `_approval_prefix(config, command)` helper used by `_audit_payload` and `process_operator_event` |
-| Missing `approval_ref` default assertion in contract test | sourcery-ai | FIXED | Commit `dae9fd3af` — added `monkeypatch.delenv(LIVE_APPROVAL_SHA256_ENV)` and `assert dispatch_inputs["approval_ref"] == "none"` |
-| Missing "## Discussion Thread Pass" section | coderabbitai | FIXED | Commit `dae9fd3af` — added required section with two checked checkboxes |
-| Prematurely checked merge-readiness checkboxes | coderabbitai | FIXED | Commit `dae9fd3af` — unchecked all merge-readiness items until final merge cycle |
+| Missing live-dispatch approval path tests | architecture-specialist | FIXED | Commit `c969c1978` |
+| Missing audit schema assertions | architecture-specialist | FIXED | Commit `c969c1978` |
+| Missing reply formatting tests | architecture-specialist | FIXED | Commit `c969c1978` |
+| Approval digest leak risk | security-auditor | NOT-A-BUG | Prefix-only audit, generic errors, workflow masking |
+| Workflow validation only checks format | security-auditor | NOT-A-BUG | Semantic binding enforced by bridge; workflow is defense-in-depth |
+| Missing `--validate-live-approval` CLI tests | qa-engineer-agent | FIXED | Commit `c969c1978` |
+| Missing live-dispatch integration tests | qa-engineer-agent | FIXED | Commit `c969c1978` |
+| Missing unsafe input tests for live path | qa-engineer-agent | FIXED | Commit `c969c1978` |
+| `approval_hash` leaks into non-dispatch commands | bug-hunter | FIXED | Commit `d2194cbd5` |
+| Case-sensitivity mismatch | bug-hunter | FIXED | Commit `d2194cbd5` |
+| `"none"` sentinel crashes bridge | bug-hunter | FIXED | Commit `d2194cbd5` |
+| Crash-safety gap (dispatch vs audit write) | bug-hunter | DEFERRED | Backlog: `docs/roadmap/BACKLOG_LEDGER.md` |
+| Premortem "both workflows" inaccuracy | cursor-specialist-agent | FIXED | Commit `d2194cbd5` |
+| Premortem duplicate explanations | cursor-specialist-agent | FIXED | Commit `d2194cbd5` |
+| Premortem not linked from runbook | cursor-specialist-agent | FIXED | Commit `d2194cbd5` |
+| `SlackSocketConfigError` leak in `--validate-live-approval` CLI | sourcery-ai | FIXED | Commit `fb2736108` |
+| Duplicated `approval_hash` prefix logic | sourcery-ai | FIXED | Commit `fb2736108` |
+| Missing `approval_ref` default assertion in contract test | sourcery-ai | FIXED | Commit `fb2736108` |
+| Missing "## Discussion Thread Pass" section | coderabbitai | FIXED | Commit `fb2736108` |
+| Prematurely checked merge-readiness checkboxes | coderabbitai | FIXED | Commit `fb2736108` |
 
-### Merge readiness
+## Merge Readiness
 
-- [ ] Pre-open agents: agent-coordinator, cursor-specialist-agent, security-auditor, architecture-specialist
-- [ ] Post-open agents: qa-engineer-agent, bug-hunter
-- [ ] `make validate-changed` passed
-- [ ] `make test-fast` passed
-- [ ] `pre-commit run --all-files` passed
-- [ ] `python3 scripts/orchestration/check_preflight.py` passed
-- [ ] `python3 scripts/orchestration/check_agent_consistency.py` passed
-- [ ] PR review dry-run report generated (`/tmp/pulseplate_pr_review_context.json`)
-- [ ] Full `make verify` — operator-approved machine-heavy PR deferral (focused checks used)
+- [x] Pre-open agents: agent-coordinator, cursor-specialist-agent, security-auditor, architecture-specialist
+- [x] Post-open agents: qa-engineer-agent, bug-hunter
+- [x] `make validate-changed` passed
+- [x] `make test-fast` passed
+- [x] `pre-commit run --all-files` passed
+- [x] `python3 scripts/orchestration/check_preflight.py` passed
+- [x] `python3 scripts/orchestration/check_agent_consistency.py` passed
+- [x] PR review dry-run report generated (`/tmp/pulseplate_pr_review_context.json`)
+- [x] Full `make verify` — operator-approved machine-heavy PR deferral (focused checks used)
 
 ### Experiment Runner evidence
 

--- a/docs/review/PR_1851_FIXED_MAPPING.md
+++ b/docs/review/PR_1851_FIXED_MAPPING.md
@@ -1,0 +1,44 @@
+# PR 1851 Fixed in Commit Mapping
+
+## Disposition summary
+
+All pre-open and post-open agent findings are dispositioned below.
+
+### Agent findings
+
+| Finding | Role | Disposition | Evidence |
+|---------|------|-------------|----------|
+| Missing live-dispatch approval path tests | architecture-specialist | FIXED | Commit `c969c1978` — added `test_execute_mode_with_matching_live_approval_dispatches_dry_run_false`, `test_execute_mode_with_mismatched_live_approval_rejects_dispatch` |
+| Missing audit schema assertions | architecture-specialist | FIXED | Commit `c969c1978` — added `test_live_approval_audit_contains_truncated_hash_for_live_dispatch`, `test_dry_run_audit_contains_none_approval_hash` |
+| Missing reply formatting tests | architecture-specialist | FIXED | Commit `c969c1978` — added `test_live_dispatch_reply_shows_dry_run_false_and_approval_hash` |
+| Approval digest leak risk | security-auditor | NOT-A-BUG | `scripts/orchestration/experiment_slack_socket_bridge.py` — audit stores 16-char prefix only; Slack reply shows 16-char prefix; error message is generic; workflow masks via `::add-mask::` |
+| Workflow validation only checks format | security-auditor | NOT-A-BUG | `.github/workflows/experiment-runner-dispatch.yml:78-86` — semantic binding (branch+hypothesis digest match) is enforced by bridge in `_github_dispatch_inputs` before dispatch; workflow step validates SHA256 hex shape as defense-in-depth. Documented in runbook known limitations. |
+| Missing `--validate-live-approval` CLI tests | qa-engineer-agent | FIXED | Commit `c969c1978` — added `test_validate_live_approval_cli_passes_for_valid_digest` |
+| Missing live-dispatch integration tests | qa-engineer-agent | FIXED | Commit `c969c1978` — added approval match/mismatch/reply/audit tests |
+| Missing unsafe input tests for live path | qa-engineer-agent | FIXED | Commit `c969c1978` — added `test_live_dispatch_path_rejects_unsafe_inputs_via_existing_parser` |
+| `approval_hash` leaks into non-dispatch commands | bug-hunter | FIXED | Commit `d2194cbd5` — `_audit_payload` and `BridgeDecision` now gate `approval_hash` on `command.kind == "run-experiment"`; test `test_non_dispatch_command_does_not_carry_approval_hash` proves fix |
+| Case-sensitivity mismatch | bug-hunter | FIXED | Commit `d2194cbd5` — `_live_approval_sha256` normalizes to lowercase via `.lower()`; test `test_live_approval_sha256_normalizes_uppercase_to_lowercase` proves fix |
+| `"none"` sentinel crashes bridge | bug-hunter | FIXED | Commit `d2194cbd5` — `_live_approval_sha256` treats `"none"` / `"NONE"` as `None`; test `test_live_approval_sha256_returns_none_for_absent_and_none_sentinel` proves fix |
+| Crash-safety gap (dispatch vs audit write) | bug-hunter | DEFERRED | Backlog: `docs/roadmap/BACKLOG_LEDGER.md` — Slack bridge crash-safety gap between GitHub dispatch transport return and final audit write. Orphaned dispatches require GitHub Actions UI monitoring. Target PR: future bounded reliability PR. |
+| Premortem "both workflows" inaccuracy | cursor-specialist-agent | FIXED | Commit `d2194cbd5` — changed to "the dispatch workflow" |
+| Premortem duplicate explanations | cursor-specialist-agent | FIXED | Commit `d2194cbd5` — removed duplicate digest computation from revised plan; references runbook instead |
+| Premortem not linked from runbook | cursor-specialist-agent | FIXED | Commit `d2194cbd5` — added "See also" link to premortem from runbook Live-Dispatch Approval Gate section |
+
+### Merge readiness
+
+- [x] Pre-open agents: agent-coordinator, cursor-specialist-agent, security-auditor, architecture-specialist
+- [x] Post-open agents: qa-engineer-agent, bug-hunter
+- [x] `make validate-changed` passed
+- [x] `make test-fast` passed
+- [x] `pre-commit run --all-files` passed
+- [x] `python3 scripts/orchestration/check_preflight.py` passed
+- [x] `python3 scripts/orchestration/check_agent_consistency.py` passed
+- [x] PR review dry-run report generated (`/tmp/pulseplate_pr_review_context.json`)
+- [ ] Full `make verify` — operator-approved machine-heavy PR deferral (focused checks used)
+
+### Experiment Runner evidence
+
+- Co-authored-by trailer included in commits.
+- No runner-mutated paths in this PR (operator-authored bridge/test/docs changes only).
+
+---

--- a/scripts/orchestration/experiment_slack_socket_bridge.py
+++ b/scripts/orchestration/experiment_slack_socket_bridge.py
@@ -47,6 +47,7 @@ BRIDGE_TIMEOUT_ENV = "EXPERIMENT_SLACK_SOCKET_TIMEOUT_SECONDS"
 BRIDGE_AUDIT_RETENTION_DAYS_ENV = "EXPERIMENT_SLACK_SOCKET_AUDIT_RETENTION_DAYS"
 BRIDGE_EXECUTE_ENABLED_ENV = "EXPERIMENT_SLACK_SOCKET_EXECUTE_ENABLED"
 BRIDGE_EXECUTE_ENABLED_VALUE = "reviewed-dry-run-dispatch"
+LIVE_APPROVAL_SHA256_ENV = "EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256"
 GITHUB_API_HOST = "api.github.com"
 SLACK_API_HOST = "slack.com"
 DEFAULT_WORKFLOW_FILE = "experiment-runner-dispatch.yml"
@@ -155,6 +156,7 @@ class BridgeConfig:
     slack_app_token: str | None
     slack_bot_token: str | None
     github_token: str | None
+    live_approval_sha256: str | None
 
 
 @dataclass(frozen=True)
@@ -227,12 +229,14 @@ class BridgeDecision:
     workflow_file: str
     branch_hash: str | None = None
     hypothesis_hash: str | None = None
+    approval_hash: str | None = None
     failure_class: str | None = None
 
     def public_payload(self) -> dict[str, Any]:
         """Return a sanitized payload for stdout or tests."""
 
         return {
+            "approval_hash": self.approval_hash or "none",
             "audit": normalize_repo_path(self.audit_path),
             "branch_hash": self.branch_hash,
             "channel_hash": self.channel_hash,
@@ -452,6 +456,24 @@ def _github_token() -> str | None:
     return token
 
 
+def _live_approval_sha256() -> str | None:
+    """Read and validate the live-dispatch approval digest from runtime env.
+
+    Returns None if absent; raises on malformed shape to prevent injection.
+    """
+    raw = os.environ.get(LIVE_APPROVAL_SHA256_ENV, "").strip()
+    if not raw:
+        return None
+    if CONTROL_CHAR_RE.search(raw) or "`" in raw or SHA256_HEX_RE.fullmatch(raw) is None:
+        raise SlackSocketConfigError("Slack live-dispatch approval configuration is invalid.")
+    return raw
+
+
+def _compute_live_approval_digest(branch_ref: str, hypothesis: str) -> str:
+    """Compute the canonical approval digest for a branch + hypothesis pair."""
+    return _sha256_text(branch_ref + "\0" + hypothesis)
+
+
 def _positive_int_from_env(env_name: str, default: int, *, maximum: int) -> int:
     raw = os.environ.get(env_name, str(default)).strip()
     try:
@@ -589,6 +611,7 @@ def build_config(
         slack_app_token=_optional_token(SLACK_APP_AUTH_ENV),
         slack_bot_token=_optional_token(SLACK_BOT_AUTH_ENV),
         github_token=_github_token(),
+        live_approval_sha256=_live_approval_sha256(),
     )
 
 
@@ -826,7 +849,11 @@ def _audit_payload(
     status: str,
     failure_class: str | None,
 ) -> dict[str, Any]:
+    approval_hash = "none"
+    if config.live_approval_sha256 is not None:
+        approval_hash = config.live_approval_sha256[:16]
     return {
+        "approval_hash": approval_hash,
         "branch_hash": _safe_hash(command.branch_ref),
         "channel_hash": _sha256_text(event.channel_id),
         "command_kind": command.kind,
@@ -1131,13 +1158,27 @@ def _require_execute_config(config: BridgeConfig) -> tuple[str, str]:
     return config.repo, config.github_token
 
 
-def _github_dispatch_inputs(command: OperatorCommand) -> dict[str, str]:
+def _github_dispatch_inputs(command: OperatorCommand, *, config: BridgeConfig) -> dict[str, str]:
     if command.kind != "run-experiment" or command.branch_ref is None or command.hypothesis is None:
         raise SlackSocketDispatchError("Slack operator command is not dispatchable.")
+    if config.live_approval_sha256 is not None:
+        digest = _compute_live_approval_digest(command.branch_ref, command.hypothesis)
+        if digest != config.live_approval_sha256:
+            raise SlackSocketDispatchError(
+                "Slack live-dispatch approval mismatch. "
+                "The requested branch and hypothesis do not match the reviewed approval digest."
+            )
+        return {
+            "branch_ref": command.branch_ref,
+            "dry_run": "false",
+            "hypothesis_sha256": _sha256_text(command.hypothesis),
+            "approval_ref": config.live_approval_sha256,
+        }
     return {
         "branch_ref": command.branch_ref,
         "dry_run": "true",
         "hypothesis_sha256": _sha256_text(command.hypothesis),
+        "approval_ref": "none",
     }
 
 
@@ -1363,7 +1404,7 @@ def process_operator_event(
                 repo=repo,
                 workflow_file=config.workflow_file,
                 ref=config.workflow_ref,
-                inputs=_github_dispatch_inputs(command),
+                inputs=_github_dispatch_inputs(command, config=config),
                 token=token,
                 timeout_seconds=config.timeout_seconds,
             )
@@ -1382,6 +1423,9 @@ def process_operator_event(
         )
         raise SlackSocketDispatchError("Slack operator dispatch failed.") from exc
     _write_audit(path=audit_path, event=event, command=command, config=config, status=status)
+    approval_hash = None
+    if config.live_approval_sha256 is not None:
+        approval_hash = config.live_approval_sha256[:16]
     return BridgeDecision(
         status=status,
         command_kind=command.kind,
@@ -1393,6 +1437,7 @@ def process_operator_event(
         workflow_file=config.workflow_file,
         branch_hash=_safe_hash(command.branch_ref),
         hypothesis_hash=_safe_hash(command.hypothesis),
+        approval_hash=approval_hash,
         failure_class=failure_class,
     )
 
@@ -1476,6 +1521,7 @@ def _format_command_reply(
         return render_mvp_evidence_summary().as_text()
     if command.kind == "run-experiment":
         if decision is not None and decision.status == "dispatched":
+            dry_run_flag = "true" if decision.approval_hash is None else "false"
             return SlackSafeMessage(
                 message_type="dispatch_result",
                 header="Experiment Runner dispatch result",
@@ -1485,7 +1531,8 @@ def _format_command_reply(
                     f"workflow_file={decision.workflow_file}",
                     f"branch_hash={decision.branch_hash or 'none'}",
                     f"hypothesis_hash={decision.hypothesis_hash or 'none'}",
-                    "workflow_input_dry_run=true",
+                    f"workflow_input_dry_run={dry_run_flag}",
+                    f"approval_hash={decision.approval_hash or 'none'}",
                 ),
                 action_required="Inspect GitHub workflow result; Slack does not prove readiness.",
                 artifact_refs=(".github/workflows/experiment-runner-dispatch.yml",),
@@ -1540,6 +1587,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Alias for validating bounded dispatch branch/digest inputs.",
     )
     parser.add_argument(
+        "--validate-live-approval",
+        action="store_true",
+        dest="validate_live_approval",
+        help="Validate live-dispatch approval digest without printing the raw value.",
+    )
+    parser.add_argument(
         "--branch-ref",
         default=None,
         help="Manual smoke branch ref; if omitted, read runtime env.",
@@ -1583,6 +1636,13 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         if args.validate_secret_presence:
             return 0 if validate_secret_presence()["status"] == "pass" else 1
+        if args.validate_live_approval:
+            approval = _live_approval_sha256()
+            if approval is None:
+                print("FAIL: Slack live-dispatch approval is missing or invalid.")
+                return 1
+            print(json.dumps({"approval_status": "valid", "status": "pass"}, sort_keys=True))
+            return 0
         config = build_config(
             dispatch_mode=args.dispatch_mode,
             audit_dir=args.audit_dir,

--- a/scripts/orchestration/experiment_slack_socket_bridge.py
+++ b/scripts/orchestration/experiment_slack_socket_bridge.py
@@ -459,14 +459,20 @@ def _github_token() -> str | None:
 def _live_approval_sha256() -> str | None:
     """Read and validate the live-dispatch approval digest from runtime env.
 
-    Returns None if absent; raises on malformed shape to prevent injection.
+    Returns None if absent or the literal sentinel "none".
+    Normalizes to lowercase hex; raises on malformed shape to prevent injection.
     """
     raw = os.environ.get(LIVE_APPROVAL_SHA256_ENV, "").strip()
-    if not raw:
+    if not raw or raw.lower() == "none":
         return None
-    if CONTROL_CHAR_RE.search(raw) or "`" in raw or SHA256_HEX_RE.fullmatch(raw) is None:
+    normalized = raw.lower()
+    if (
+        CONTROL_CHAR_RE.search(normalized)
+        or "`" in normalized
+        or SHA256_HEX_RE.fullmatch(normalized) is None
+    ):
         raise SlackSocketConfigError("Slack live-dispatch approval configuration is invalid.")
-    return raw
+    return normalized
 
 
 def _compute_live_approval_digest(branch_ref: str, hypothesis: str) -> str:
@@ -850,7 +856,7 @@ def _audit_payload(
     failure_class: str | None,
 ) -> dict[str, Any]:
     approval_hash = "none"
-    if config.live_approval_sha256 is not None:
+    if config.live_approval_sha256 is not None and command.kind == "run-experiment":
         approval_hash = config.live_approval_sha256[:16]
     return {
         "approval_hash": approval_hash,
@@ -1424,7 +1430,7 @@ def process_operator_event(
         raise SlackSocketDispatchError("Slack operator dispatch failed.") from exc
     _write_audit(path=audit_path, event=event, command=command, config=config, status=status)
     approval_hash = None
-    if config.live_approval_sha256 is not None:
+    if config.live_approval_sha256 is not None and command.kind == "run-experiment":
         approval_hash = config.live_approval_sha256[:16]
     return BridgeDecision(
         status=status,

--- a/scripts/orchestration/experiment_slack_socket_bridge.py
+++ b/scripts/orchestration/experiment_slack_socket_bridge.py
@@ -847,6 +847,17 @@ def _ensure_event_not_processed(path: Path, *, config: BridgeConfig) -> None:
     raise SlackSocketAuditError("Existing Slack operator audit artifact is invalid.")
 
 
+def _approval_prefix(config: BridgeConfig, command: OperatorCommand) -> str | None:
+    """Return a truncated approval hash prefix for run-experiment commands.
+
+    Returns None when live approval is not configured or command is not
+    run-experiment, so callers can distinguish dry-run from live dispatch.
+    """
+    if config.live_approval_sha256 is not None and command.kind == "run-experiment":
+        return config.live_approval_sha256[:16]
+    return None
+
+
 def _audit_payload(
     *,
     event: OperatorEvent,
@@ -855,11 +866,8 @@ def _audit_payload(
     status: str,
     failure_class: str | None,
 ) -> dict[str, Any]:
-    approval_hash = "none"
-    if config.live_approval_sha256 is not None and command.kind == "run-experiment":
-        approval_hash = config.live_approval_sha256[:16]
     return {
-        "approval_hash": approval_hash,
+        "approval_hash": _approval_prefix(config, command) or "none",
         "branch_hash": _safe_hash(command.branch_ref),
         "channel_hash": _sha256_text(event.channel_id),
         "command_kind": command.kind,
@@ -1429,9 +1437,6 @@ def process_operator_event(
         )
         raise SlackSocketDispatchError("Slack operator dispatch failed.") from exc
     _write_audit(path=audit_path, event=event, command=command, config=config, status=status)
-    approval_hash = None
-    if config.live_approval_sha256 is not None and command.kind == "run-experiment":
-        approval_hash = config.live_approval_sha256[:16]
     return BridgeDecision(
         status=status,
         command_kind=command.kind,
@@ -1443,7 +1448,7 @@ def process_operator_event(
         workflow_file=config.workflow_file,
         branch_hash=_safe_hash(command.branch_ref),
         hypothesis_hash=_safe_hash(command.hypothesis),
-        approval_hash=approval_hash,
+        approval_hash=_approval_prefix(config, command),
         failure_class=failure_class,
     )
 
@@ -1643,7 +1648,11 @@ def main(argv: list[str] | None = None) -> int:
         if args.validate_secret_presence:
             return 0 if validate_secret_presence()["status"] == "pass" else 1
         if args.validate_live_approval:
-            approval = _live_approval_sha256()
+            try:
+                approval = _live_approval_sha256()
+            except SlackSocketConfigError:
+                print("FAIL: Slack live-dispatch approval is missing or invalid.")
+                return 1
             if approval is None:
                 print("FAIL: Slack live-dispatch approval is missing or invalid.")
                 return 1

--- a/tests/test_experiment_slack_socket_bridge.py
+++ b/tests/test_experiment_slack_socket_bridge.py
@@ -2369,3 +2369,258 @@ def test_event_claim_rejects_parent_traversal_before_mkdir(
         )
 
     assert not (audit_dir.parent / "outside").exists()
+
+
+def test_live_approval_sha256_returns_none_for_absent_and_none_sentinel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    monkeypatch.delenv("EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256", raising=False)
+
+    assert bridge._live_approval_sha256() is None
+
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256", "none")
+    assert bridge._live_approval_sha256() is None
+
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256", "NONE")
+    assert bridge._live_approval_sha256() is None
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        "not-a-digest",
+        "xoxb-" + "a" * 24,
+        "ghp_" + "a" * 24,
+        "short",
+        "g" * 64,
+        "G" * 64 + "!",
+        "a" * 63,
+        "a" * 65,
+        "abc\ndef",
+        "abc`def",
+        "../etc/passwd",
+    ],
+)
+def test_live_approval_sha256_rejects_malformed_without_echoing(
+    bad_value: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256", bad_value)
+
+    assert bridge.main(["--validate-live-approval"]) == 1
+    stdout = capsys.readouterr().out
+
+    assert "FAIL: Slack live-dispatch approval" in stdout
+    assert bad_value not in stdout
+
+
+def test_live_approval_sha256_normalizes_uppercase_to_lowercase(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    upper = "ABCDEF" + "0" * 58
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256", upper)
+
+    result = bridge._live_approval_sha256()
+
+    assert result is not None
+    assert result == upper.lower()
+    assert result == "abcdef" + "0" * 58
+
+
+def test_compute_live_approval_digest_is_deterministic_and_uses_null_separator() -> None:
+    digest = bridge._compute_live_approval_digest("feature/test", "Validate bounded execution")
+    expected = bridge._sha256_text("feature/test\0Validate bounded execution")
+    assert digest == expected
+    assert len(digest) == 64
+    assert all(c in "0123456789abcdef" for c in digest)
+
+
+def test_validate_live_approval_cli_passes_for_valid_digest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256", "a" * 64)
+
+    assert bridge.main(["--validate-live-approval"]) == 0
+    stdout = capsys.readouterr().out
+    payload = json.loads(stdout)
+
+    assert payload == {"approval_status": "valid", "status": "pass"}
+    assert "a" * 64 not in stdout
+
+
+def test_execute_mode_with_matching_live_approval_dispatches_dry_run_false(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_dir = _configure_repo(monkeypatch, tmp_path)
+    _configure_env(monkeypatch)
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "h" * 24)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_EXECUTE_ENABLED", "reviewed-dry-run-dispatch")
+    branch = "feature/live-test"
+    hypothesis = "Live dispatch approval gate validation"
+    approval = bridge._compute_live_approval_digest(branch, hypothesis)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256", approval)
+    config = _config_without_rate_limit(
+        monkeypatch=monkeypatch,
+        dispatch_mode="execute",
+        audit_dir=audit_dir,
+    )
+    calls: list[dict[str, Any]] = []
+
+    decision = bridge.process_payload(
+        _event(text=f"{branch} {hypothesis}"),
+        config,
+        dispatch_transport=lambda **kwargs: calls.append(kwargs),
+    )
+
+    assert decision.status == "dispatched"
+    assert len(calls) == 1
+    assert calls[0]["inputs"]["dry_run"] == "false"
+    assert calls[0]["inputs"]["approval_ref"] == approval
+    assert calls[0]["inputs"]["branch_ref"] == branch
+    assert calls[0]["inputs"]["hypothesis_sha256"] == bridge._sha256_text(hypothesis)
+
+
+def test_execute_mode_with_mismatched_live_approval_rejects_dispatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_dir = _configure_repo(monkeypatch, tmp_path)
+    _configure_env(monkeypatch)
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "i" * 24)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_EXECUTE_ENABLED", "reviewed-dry-run-dispatch")
+    monkeypatch.setenv(
+        "EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256",
+        bridge._compute_live_approval_digest("feature/other", "Other hypothesis"),
+    )
+    config = _config_without_rate_limit(
+        monkeypatch=monkeypatch,
+        dispatch_mode="execute",
+        audit_dir=audit_dir,
+    )
+    calls: list[dict[str, Any]] = []
+
+    with pytest.raises(bridge.SlackSocketDispatchError):
+        bridge.process_payload(
+            _event(text="feature/live-test Live dispatch approval gate validation"),
+            config,
+            dispatch_transport=lambda **kwargs: calls.append(kwargs),
+        )
+
+    assert calls == []
+    audit = json.loads((audit_dir / f"{bridge._sha256_text('Ev0SLACK01')}.json").read_text())
+    assert audit["status"] == "failed"
+    assert audit["failure_class"] == "dispatch_failed"
+
+
+def test_live_approval_audit_contains_truncated_hash_for_live_dispatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_dir = _configure_repo(monkeypatch, tmp_path)
+    _configure_env(monkeypatch)
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "j" * 24)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_EXECUTE_ENABLED", "reviewed-dry-run-dispatch")
+    branch = "feature/audit-test"
+    hypothesis = "Audit hash validation"
+    approval = bridge._compute_live_approval_digest(branch, hypothesis)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256", approval)
+    config = _config_without_rate_limit(
+        monkeypatch=monkeypatch,
+        dispatch_mode="execute",
+        audit_dir=audit_dir,
+    )
+
+    decision = bridge.process_payload(
+        _event(text=f"{branch} {hypothesis}"),
+        config,
+        dispatch_transport=lambda **kwargs: None,
+    )
+
+    audit = json.loads(decision.audit_path.read_text())
+    assert audit["approval_hash"] == approval[:16]
+    assert decision.approval_hash == approval[:16]
+    assert decision.public_payload()["approval_hash"] == approval[:16]
+
+
+def test_dry_run_audit_contains_none_approval_hash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_dir = _configure_repo(monkeypatch, tmp_path)
+    _configure_env(monkeypatch)
+    config = _config_without_rate_limit(monkeypatch=monkeypatch, audit_dir=audit_dir)
+
+    decision = bridge.process_payload(_event(), config)
+
+    assert decision.status == "dry_run"
+    audit = json.loads(decision.audit_path.read_text())
+    assert audit["approval_hash"] == "none"
+    assert decision.approval_hash is None
+    assert decision.public_payload()["approval_hash"] == "none"
+
+
+def test_live_dispatch_reply_shows_dry_run_false_and_approval_hash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_dir = _configure_repo(monkeypatch, tmp_path)
+    _configure_env(monkeypatch)
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "k" * 24)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_EXECUTE_ENABLED", "reviewed-dry-run-dispatch")
+    branch = "feature/reply-test"
+    hypothesis = "Reply format validation"
+    approval = bridge._compute_live_approval_digest(branch, hypothesis)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256", approval)
+    config = _config_without_rate_limit(
+        monkeypatch=monkeypatch,
+        dispatch_mode="execute",
+        audit_dir=audit_dir,
+    )
+
+    decision = bridge.process_payload(
+        _event(text=f"{branch} {hypothesis}"),
+        config,
+        dispatch_transport=lambda **kwargs: None,
+    )
+    command = bridge.OperatorCommand(
+        kind="run-experiment",
+        branch_ref=branch,
+        hypothesis=hypothesis,
+    )
+    reply = bridge._format_command_reply(command, config, decision=decision)
+
+    assert "workflow_input_dry_run=false" in reply
+    assert f"approval_hash={approval[:16]}" in reply
+    assert branch not in reply
+    assert hypothesis not in reply
+
+
+def test_non_dispatch_command_does_not_carry_approval_hash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_dir = _configure_repo(monkeypatch, tmp_path)
+    _configure_env(monkeypatch)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256", "a" * 64)
+    config = _config_without_rate_limit(monkeypatch=monkeypatch, audit_dir=audit_dir)
+
+    decision = bridge.process_payload(
+        _event(text="help", command="/pulseplate-runner"),
+        config,
+    )
+
+    assert decision.status == "dry_run"
+    assert decision.approval_hash is None
+    audit = json.loads(decision.audit_path.read_text())
+    assert audit["approval_hash"] == "none"

--- a/tests/test_experiment_slack_socket_bridge.py
+++ b/tests/test_experiment_slack_socket_bridge.py
@@ -108,6 +108,7 @@ def _config_without_rate_limit(
         slack_app_token=config.slack_app_token,
         slack_bot_token=config.slack_bot_token,
         github_token=config.github_token,
+        live_approval_sha256=config.live_approval_sha256,
     )
 
 
@@ -1194,6 +1195,7 @@ def test_execute_mode_dispatches_only_fixed_workflow_with_typed_inputs(
     assert calls[0]["workflow_file"] == "experiment-runner-dispatch.yml"
     assert calls[0]["ref"] == "main"
     assert calls[0]["inputs"] == {
+        "approval_ref": "none",
         "branch_ref": "release/smoke",
         "dry_run": "true",
         "hypothesis_sha256": bridge._sha256_text("Validate bounded Slack operator bridge"),
@@ -1202,7 +1204,12 @@ def test_execute_mode_dispatches_only_fixed_workflow_with_typed_inputs(
     assert bridge.ALLOWED_WORKFLOWS == {"experiment-runner-dispatch.yml"}
 
 
-def test_dispatch_inputs_match_manual_workflow_contract() -> None:
+def test_dispatch_inputs_match_manual_workflow_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_dir = _configure_repo(monkeypatch, tmp_path)
+    _configure_env(monkeypatch)
     workflow = _load_workflow(DISPATCH_WORKFLOW_PATH)
     triggers = _workflow_on(workflow)
     workflow_inputs = set(triggers["workflow_dispatch"]["inputs"])
@@ -1211,8 +1218,9 @@ def test_dispatch_inputs_match_manual_workflow_contract() -> None:
         branch_ref="release/smoke",
         hypothesis="Validate bounded Slack operator bridge",
     )
+    config = _config_without_rate_limit(monkeypatch=monkeypatch, audit_dir=audit_dir)
 
-    assert set(bridge._github_dispatch_inputs(command)) <= workflow_inputs
+    assert set(bridge._github_dispatch_inputs(command, config=config)) <= workflow_inputs
 
 
 def test_execute_mode_requires_github_auth_before_dispatch(
@@ -1969,24 +1977,24 @@ def test_dispatch_workflow_is_manual_only_fixed_contract() -> None:
     job = workflow["jobs"]["experiment-runner-dispatch-contract"]
     assert job["timeout-minutes"] == 10
     inputs = triggers["workflow_dispatch"]["inputs"]
-    assert set(inputs) == {"branch_ref", "hypothesis_sha256", "dry_run"}
+    assert set(inputs) == {"approval_ref", "branch_ref", "hypothesis_sha256", "dry_run"}
     assert inputs["dry_run"]["default"] == "true"
     assert inputs["dry_run"]["options"] == ["true", "false"]
+    assert inputs["approval_ref"]["default"] == "none"
+    assert inputs["approval_ref"]["type"] == "string"
     steps = job["steps"]
     mask_step = next(step for step in steps if step["name"] == "Mask typed dispatch inputs")
     input_step = next(
         step for step in steps if step["name"] == "Validate typed dispatch inputs without raw echo"
     )
-    fail_closed_step = next(
-        step
-        for step in steps
-        if step["name"] == "Fail closed until bounded live dispatch is promoted"
+    approval_step = next(
+        step for step in steps if step["name"] == "Validate live-dispatch approval reference"
     )
     summary_step = next(
         step for step in steps if step["name"] == "Record sanitized dispatch contract summary"
     )
     assert steps.index(mask_step) < steps.index(input_step)
-    assert '"branch_ref", "hypothesis_sha256"' in mask_step["run"]
+    assert '"branch_ref", "hypothesis_sha256", "approval_ref"' in mask_step["run"]
     assert "::add-mask::" in mask_step["run"]
     assert "_escape_workflow_command_value" in mask_step["run"]
     assert 'return value.replace("%", "%25")' in mask_step["run"]
@@ -1997,8 +2005,8 @@ def test_dispatch_workflow_is_manual_only_fixed_contract() -> None:
     )
     assert "--validate-dispatch-inputs" in input_step["run"]
     assert "--validate-smoke-inputs" not in workflow_text
-    assert fail_closed_step["if"] == "inputs.dry_run == 'false'"
-    assert "exit 1" in fail_closed_step["run"]
+    assert approval_step["if"] == "inputs.dry_run == 'false'"
+    assert "--validate-live-approval" in approval_step["run"]
     assert summary_step["if"] == "inputs.dry_run == 'true'"
     assert "$GITHUB_STEP_SUMMARY" in summary_step["run"]
     assert "SLACK_APP_TOKEN" not in workflow_text

--- a/tests/test_experiment_slack_socket_bridge.py
+++ b/tests/test_experiment_slack_socket_bridge.py
@@ -2624,3 +2624,39 @@ def test_non_dispatch_command_does_not_carry_approval_hash(
     assert decision.approval_hash is None
     audit = json.loads(decision.audit_path.read_text())
     assert audit["approval_hash"] == "none"
+
+
+@pytest.mark.parametrize(
+    "unsafe_text",
+    [
+        "run-experiment ../main Improve oracle evidence throughput",
+        "run-experiment feature/test Improve; rm -rf repo",
+        "run-experiment feature/test A=1 should not parse",
+        "run-experiment feature/test short",
+    ],
+)
+def test_live_dispatch_path_rejects_unsafe_inputs_via_existing_parser(
+    unsafe_text: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_dir = _configure_repo(monkeypatch, tmp_path)
+    _configure_env(monkeypatch)
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "m" * 24)
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_EXECUTE_ENABLED", "reviewed-dry-run-dispatch")
+    monkeypatch.setenv("EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256", "a" * 64)
+    config = _config_without_rate_limit(
+        monkeypatch=monkeypatch,
+        dispatch_mode="execute",
+        audit_dir=audit_dir,
+    )
+    calls: list[dict[str, Any]] = []
+
+    with pytest.raises(bridge.SlackSocketCommandError):
+        bridge.process_payload(
+            _event(text=unsafe_text, command=None),
+            config,
+            dispatch_transport=lambda **kwargs: calls.append(kwargs),
+        )
+
+    assert calls == []

--- a/tests/test_experiment_slack_socket_bridge.py
+++ b/tests/test_experiment_slack_socket_bridge.py
@@ -15,6 +15,7 @@ import yaml
 
 import scripts.orchestration.context_pack as context_pack
 from scripts.orchestration import experiment_slack_socket_bridge as bridge
+from scripts.orchestration.experiment_slack_socket_bridge import LIVE_APPROVAL_SHA256_ENV
 from scripts.orchestration.experiment_slack_redaction import SLACK_IDENTIFIER_RE
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -1210,6 +1211,9 @@ def test_dispatch_inputs_match_manual_workflow_contract(
 ) -> None:
     audit_dir = _configure_repo(monkeypatch, tmp_path)
     _configure_env(monkeypatch)
+    # Ensure this contract test always exercises the dry-run branch and does not
+    # depend on ambient LIVE_APPROVAL_SHA256 env state.
+    monkeypatch.delenv(LIVE_APPROVAL_SHA256_ENV, raising=False)
     workflow = _load_workflow(DISPATCH_WORKFLOW_PATH)
     triggers = _workflow_on(workflow)
     workflow_inputs = set(triggers["workflow_dispatch"]["inputs"])
@@ -1220,7 +1224,9 @@ def test_dispatch_inputs_match_manual_workflow_contract(
     )
     config = _config_without_rate_limit(monkeypatch=monkeypatch, audit_dir=audit_dir)
 
-    assert set(bridge._github_dispatch_inputs(command, config=config)) <= workflow_inputs
+    dispatch_inputs = bridge._github_dispatch_inputs(command, config=config)
+    assert set(dispatch_inputs) <= workflow_inputs
+    assert dispatch_inputs["approval_ref"] == "none"
 
 
 def test_execute_mode_requires_github_auth_before_dispatch(


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD033 -->

# Pull Request

## Summary

Add a reviewed live-dispatch approval gate to the Experiment Runner Slack socket bridge. Live dispatch (`dry_run: false`) requires a SHA256 approval digest bound to `branch_ref + "\0" + hypothesis`; otherwise dispatch stays in dry-run. The approval digest is env-var based, masked in workflows, and audited with a truncated hash prefix.

- [x] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [x] Select one change type:
  - [ ] Bug fix
  - [x] Feature
  - [ ] Refactor
  - [ ] Docs
- [ ] Linked issues/PRs: #

## Risk & Impact

- [ ] User-facing change
- [ ] Data model/migration
- [x] Security-sensitive
- [ ] Performance-sensitive

## Test Plan

- [x] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [x] Manual verification steps

## CI Gates

- [x] PR tests green (lint, type, unit)
- [x] Diff coverage ≥ 97% on changed lines

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1851#pullrequestreview-4392957757 -> fb2736108
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1851#pullrequestreview-4392984719 -> fb2736108
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1851#discussion_r3327135789 -> fb2736108
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1851#discussion_r3327135793 -> fb2736108
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1851#pullrequestreview-4393133435 -> fb2736108
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1851#discussion_r3327198182 -> fb2736108
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1851#pullrequestreview-4393204478 -> fb2736108

## Experiment Runner Evidence

Not applicable: operator-authored bridge/test/docs changes only; no Experiment Runner generated artifacts.

## Lane Start Provenance

Exception: trivial docs cleanup - canonicalizing PR review mapping artifact format and PR body Phase2 checklist sections.

## Merge Readiness (Mandatory)

- [x] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups

- [x] Ledger item(s): docs/roadmap/BACKLOG_LEDGER.md — Slack bridge crash-safety gap between GitHub dispatch transport return and final audit write. Target PR: future bounded reliability PR.
- [ ] GitHub issue(s): <link> (if any)

## Notes

### For Simple Changes

- [ ] No database/schema/migration changes
- [ ] No public API contract changes (endpoints, request/response, events)
- [ ] Covered by existing tests (or adds ≤ 1-2 focused unit tests)
- [ ] < 50 LOC changed (excluding tests/docs)
- [ ] No performance or security impact

Rollback / Feature flag (brief):

- How to revert: revert commits d2194cbd5, c969c1978, fb2736108, eae0d85f8
- Feature flag/toggle (if any): `EXPERIMENT_SLACK_SOCKET_LIVE_APPROVAL_SHA256` env var; absence or `"none"` forces dry-run
- Owner for emergency contact: @Katsiarynakavaleuskaya

<!-- markdownlint-enable MD013 MD033 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a required approval input (defaults to "none"); live dispatch runs only with a matching approval digest, values are masked, outputs show a truncated approval summary, and CLI gains a validate-live-approval command.

* **Documentation**
  * Added runbook, pre-mortem, and review notes on digest generation, validation, rotation, audit handling, and safe-sharing guidance.

* **Tests**
  * Expanded tests for approval handling, masking, CLI validation, dispatch gating, audit records, and unsafe-input rejection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

