### PR TITLE
feat(evidence): back /pulseplate-runner mvp-evidence with durable sanitized ledger snapshot

### DIFF
--- a/docs/review/PREMORTEM_SLACK_MVP_EVIDENCE_LEDGER.md
+++ b/docs/review/PREMORTEM_SLACK_MVP_EVIDENCE_LEDGER.md
@@ -32,7 +32,7 @@ It is 6 months from now. The `/pulseplate-runner mvp-evidence` Slack command ret
 
 ### 5. Snapshot lacks schema version, breaking backward compatibility
 - **Story:** A follow-up PR added `latency_ms` to `MvpEvidenceSnapshot`. The bridge on an older branch could not read the new field and raised `TypeError` on deserialization. The Slack command failed on half the operator workstations.
-- **Assumption:** All consumers update atomously with producers.
+- **Assumption:** All consumers update atomically with producers.
 - **Warning signs:** Dataclass deserialization uses `**json.load(...)` without a schema version check.
 - **Containment:** Include a `snapshot_schema_version: str` field (e.g., `"v1"`) and fail closed on unknown versions.
 

--- a/docs/review/PREMORTEM_SLACK_MVP_EVIDENCE_LEDGER.md
+++ b/docs/review/PREMORTEM_SLACK_MVP_EVIDENCE_LEDGER.md
@@ -1,0 +1,92 @@
+# Premortem: Back /pulseplate-runner mvp-evidence with a durable sanitized ledger snapshot
+
+## Frame
+
+It is 6 months from now. The `/pulseplate-runner mvp-evidence` Slack command returned a snapshot that contained a raw `sessionId` value. A CI artifact tarball shipped the `artifacts/evidence/snapshots/` directory to a public analytics vendor. We are looking backward to understand why.
+
+## Raw Failure Modes
+
+### 1. Snapshot reader crashes before static fallback, breaking the Slack command
+- **Story:** A fresh clone or CI runner had no `artifacts/evidence/snapshots/` directory. `render_mvp_evidence_summary()` attempted to read the latest snapshot, raised `FileNotFoundError` or `json.JSONDecodeError`, and the exception propagated out of the renderer. The Slack bridge returned a generic error instead of the static MVP evidence summary. Operators lost visibility and assumed the bridge was down.
+- **Assumption:** The snapshot directory always exists and contains valid JSON.
+- **Warning signs:** `render_mvp_evidence_summary()` has no try/except around filesystem I/O; tests only mock a happy path.
+- **Containment:** Wrap snapshot reading in a bounded exception handler that always falls back to the static summary; log the failure class (not the path) for diagnostics.
+
+### 2. Incomplete sanitization leaks sensitive frontend fields into the snapshot
+- **Story:** A new frontend event payload included `analyticsDeviceId`, a field not present in `guidedPlanningObservabilitySensitiveFields`. The snapshot builder used the frontend denylist but not a general heuristic, so `analyticsDeviceId` was treated as safe and stored in `event_aggregates` keys. The leaked key was later correlated with user sessions.
+- **Assumption:** The two existing denylists (`frontend/src/lib/mvpObservability.ts` and `core/evidence/events.py`) are jointly exhaustive.
+- **Warning signs:** Snapshot tests only assert that known-bad fields are removed; no negative test for unknown fields.
+- **Containment:** Fail closed on unrecognized payload keys (drop the event or raise), or maintain an explicit allowlist of safe keys. Do not rely solely on a denylist for cross-domain data.
+
+### 3. `frozen` dataclass is not actually hashable due to a dict field
+- **Story:** `MvpEvidenceSnapshot` was declared with `@dataclass(frozen=True)`, but `event_aggregates` was typed as `dict[str, int]`. Python's `frozen=True` does not make unhashable fields hashable, so `__hash__` was silently set to `None`. A downstream bridge helper tried to deduplicate snapshots in a `set()` and lost entries, causing duplicate snapshot writes and unbounded disk growth.
+- **Assumption:** `frozen=True` implies hashable.
+- **Warning signs:** No test calls `hash(snapshot)` or stores snapshots in a `set`/`dict` key.
+- **Containment:** Use `tuple[tuple[str, int], ...]` or a custom frozen mapping type for `event_aggregates`; add a test that asserts `hash(snapshot)` succeeds and is deterministic.
+
+### 4. `artifacts/evidence/snapshots/` is accidentally committed or included in Docker context
+- **Story:** The directory was gitignored under a generic `artifacts/` rule, but a teammate added `artifacts/evidence/*.json` to a Docker `COPY` instruction for "debugging convenience." A snapshot containing route and auth-state buckets (while not PII alone) was shipped in a public image, violating the Evidence Graph Runtime rail-separation policy.
+- **Assumption:** `artifacts/` is universally treated as local-only and never copied.
+- **Warning signs:** Dockerfile gains new `COPY` lines without corresponding `.dockerignore` updates.
+- **Containment:** Explicitly add `artifacts/evidence/` to `.gitignore` and `.dockerignore`; add a repo policy guard that fails if any `artifacts/evidence/` path appears in `git ls-files` or Docker context.
+
+### 5. Snapshot lacks schema version, breaking backward compatibility
+- **Story:** A follow-up PR added `latency_ms` to `MvpEvidenceSnapshot`. The bridge on an older branch could not read the new field and raised `TypeError` on deserialization. The Slack command failed on half the operator workstations.
+- **Assumption:** All consumers update atomously with producers.
+- **Warning signs:** Dataclass deserialization uses `**json.load(...)` without a schema version check.
+- **Containment:** Include a `snapshot_schema_version: str` field (e.g., `"v1"`) and fail closed on unknown versions.
+
+### 6. `artifact_refs` field stores absolute or forbidden paths
+- **Story:** The snapshot builder included an absolute path like `/Users/dev/.ssh/config` in `artifact_refs` because a downstream helper passed `__file__` without normalization. The snapshot was stored and later referenced in a Slack message, leaking local filesystem structure.
+- **Assumption:** Callers always pass repo-relative, safe paths.
+- **Warning signs:** `artifact_refs` accepts `tuple[str, ...]` without validation.
+- **Containment:** Reuse `validate_source_artifact` from `core/evidence/events.py` (or equivalent logic) to reject absolute paths, traversal, and forbidden roots (`artifacts/agent_runs/`, `.venv/`, etc.).
+
+### 7. Snapshot storage path lacks symlink/traversal guards
+- **Story:** An attacker with local repo access symlinked `artifacts/evidence/snapshots/` to `/etc`. The bridge wrote a snapshot outside the repo, and a cleanup script later deleted an unintended file.
+- **Assumption:** The storage path is safe because it is under the repo root.
+- **Warning signs:** No `_reject_symlinked_output_components` equivalent for the snapshot directory.
+- **Containment:** Apply the same symlink-rejection and path-traversal guards used for `artifacts/orchestration/experiments/slack_socket_bridge/`.
+
+## Synthesis
+
+### Summary
+
+Add a durable, frozen, hash-safe `MvpEvidenceSnapshot` dataclass in `core/evidence/mvp_snapshot.py` that stores aggregate-only event counts, route/auth-state enum buckets, coverage flags, and validated artifact refs. Sanitize all inputs using a fail-closed union of the frontend and backend denylists. Store append-only JSON lines under `artifacts/evidence/snapshots/` (gitignored). Update the Slack bridge `render_mvp_evidence_summary()` to read the latest snapshot with graceful fallback to the existing static summary. No backend analytics, no DB, no network calls.
+
+### Most likely failure
+
+**Failure mode #1:** `render_mvp_evidence_summary()` crashes on a missing or corrupt snapshot directory before reaching the static fallback. The Slack `mvp-evidence` command becomes a hard error in CI and fresh clones, breaking operator visibility. The existing bridge tests are strong for static rendering but the new filesystem-dependent path is narrow and easy to regress.
+
+### Most dangerous failure
+
+**Failure mode #2:** Incomplete sanitization allows a sensitive field to leak into the snapshot. The snapshot lives in `artifacts/evidence/snapshots/` — while gitignored, it is a local file that can be tarballed, copied into Docker images, or accidentally committed. Because the Evidence Graph Runtime invariant demands strict rail separation, any leak of user-health or session identifiers from the frontend observability stream into a control-plane artifact is a policy violation with potential compliance implications.
+
+### Hidden assumption
+
+The plan assumes that "aggregate-only" (counts and enums) is a self-enforcing property. It is not. Once the snapshot infrastructure exists, the path of least resistance for a future developer who needs "just one more signal" is to add a raw payload field to `event_aggregates`. There is no runtime or type-level guard preventing raw payloads from being stored. The snapshot's `frozen` and `hash-safe` design is a good signal, but without an explicit schema allowlist or a redaction gate that audits every key, the aggregate-only constraint is a convention, not an invariant.
+
+### Revised plan
+
+1. **Dataclass design:** Use `@dataclass(frozen=True)` with only hashable field types. Represent `event_aggregates` as `tuple[tuple[str, int], ...]` (not `dict`). Add `snapshot_schema_version: str = "v1"` for forward compatibility. Add a test that proves `hash(snapshot)` succeeds and is deterministic.
+2. **Sanitization:** Build a unified denylist from `guidedPlanningObservabilitySensitiveFields` (camelCase) and `_FORBIDDEN_METADATA_KEY_FRAGMENTS` (snake_case), normalized to lowercase. Fail closed: if an event payload key is not in an explicit allowlist of safe aggregate keys (`surface`, `componentId`, `routePath`, `optionId`, `tierLabel`, `authState`), drop the event or raise. Do not rely on a denylist alone.
+3. **Artifact ref validation:** Reuse `validate_source_artifact` logic from `core/evidence/events.py` for every string in `artifact_refs`. Reject absolute paths, traversal, forbidden roots, and paths outside the repo.
+4. **Storage guards:** Apply `_reject_symlinked_output_components` equivalent to `artifacts/evidence/snapshots/` before any write. Reject symlinks in the path ancestry.
+5. **Bridge renderer:** Wrap snapshot file reading in a bounded `try/except` (catch `OSError`, `json.JSONDecodeError`, `ValueError`). On any failure, emit a `SlackSafeMessage` with `status_line="snapshot_unavailable"` and fall back to the static summary. Never expose the exception message or filesystem path in the Slack payload.
+6. **Git / Docker ignore:** Add `artifacts/evidence/` explicitly to `.gitignore` and `.dockerignore`. Add a repo policy guard (or extend an existing one) that fails if `artifacts/evidence/` paths appear in `git ls-files`.
+7. **Tests:** Add `tests/test_mvp_evidence_snapshot.py` covering: hashability, schema version mismatch, sanitization of every denied field, artifact ref validation, and symlink guard. Update `tests/test_experiment_slack_socket_bridge.py` to prove static fallback works when the snapshot dir is missing and when JSON is corrupted.
+
+### Pre-merge checklist
+
+- [ ] `MvpEvidenceSnapshot` is frozen and hashable (test calls `hash()` and asserts deterministic result).
+- [ ] Sanitization fails closed on unknown keys, not just denied keys (test with a never-before-seen key).
+- [ ] `render_mvp_evidence_summary()` never raises on missing/empty/corrupt snapshot dir (static fallback proven in test).
+- [ ] Snapshot storage path rejects symlinks and traversal (equivalent guards to bridge audit dir).
+- [ ] `artifacts/evidence/` is explicitly listed in `.gitignore` and `.dockerignore`.
+- [ ] `artifact_refs` validation rejects absolute paths, traversal, and forbidden roots.
+- [ ] No raw event payloads or unlisted metadata keys are stored in the snapshot (only counts, enums, and safe flags).
+- [ ] Snapshot schema version field is present and tested for unknown-version rejection.
+
+### Decision
+
+`proceed with changes` — the plan is directionally correct and scoped well, but it must implement the revised plan items above before opening the PR. Without them, the snapshot risks becoming an unguarded local file that violates Evidence Graph Runtime rail separation and breaks operator visibility in CI.

--- a/docs/review/PR_1852_FIXED_MAPPING.md
+++ b/docs/review/PR_1852_FIXED_MAPPING.md
@@ -31,6 +31,13 @@ Evidence: `scripts/orchestration/mvp_evidence_snapshot.py` — temp file cleanup
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328593729 -> cc7bf459d
 
+Disposition: FIXED
+Commit: TBD
+Evidence: `scripts/orchestration/mvp_evidence_snapshot.py` — added `eq=False` to `MvpEvidenceSnapshotLine` dataclass to avoid implicit `__hash__` generation failure due to unhashable `dict[str, int]` field; `tests/test_mvp_evidence_snapshot.py` — updated `test_read_latest_rejects_unknown_policy_version` to use a valid fingerprint computed via `_fingerprint_payload` so rejection is proven to come from policy_version validation, not fingerprint mismatch
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328571595 -> TBD
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#pullrequestreview-4395198767 -> TBD
+
 Disposition: NOT-A-BUG
 Reason: `routePath` and `authState` are frontend-controlled enum-like strings from the MVP observability contract. The snapshot is aggregate-only (event name counts) and values are preserved as opaque identifiers for operator diagnostics. Server-side enum enforcement would add coupling to frontend routing internals without security benefit for this aggregate-only, sanitized surface.
 Evidence: `scripts/orchestration/mvp_evidence_snapshot.py:ALLOWED_PAYLOAD_KEYS` defines the allowlist; payload values are never used for authorization or sensitive decisions; snapshot schema is explicitly aggregate-only with no PII.

--- a/docs/review/PR_1852_FIXED_MAPPING.md
+++ b/docs/review/PR_1852_FIXED_MAPPING.md
@@ -1,0 +1,72 @@
+# PR 1852 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: ec72bdf7c
+Evidence: `scripts/orchestration/mvp_evidence_snapshot.py` — added `policy_version` validation in `_read_latest_snapshot_line`, added `retention_days <= 0` guard in `cleanup_expired_snapshots`, wrapped `stat()` and `open()` in `try/except OSError` in `read_latest_snapshot_line`; `scripts/orchestration/experiment_slack_socket_bridge.py` — narrowed `except Exception` to `(ValueError, OSError, TypeError)` in `render_mvp_evidence_summary`; `docs/review/PREMORTEM_SLACK_MVP_EVIDENCE_LEDGER.md` — fixed typo `atomously` → `atomically`
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#pullrequestreview-4395156071 -> ec72bdf7c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328567935 -> ec72bdf7c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328567937 -> ec72bdf7c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328567939 -> ec72bdf7c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#pullrequestreview-4395159172 -> ec72bdf7c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328571594 -> ec72bdf7c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328571596 -> ec72bdf7c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328571598 -> ec72bdf7c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#pullrequestreview-4395162487 -> ec72bdf7c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328574636 -> ec72bdf7c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328574637 -> ec72bdf7c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#pullrequestreview-4395177150 -> ec72bdf7c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328591979 -> ec72bdf7c
+
+Disposition: FIXED
+Commit: TBD
+Evidence: `scripts/orchestration/mvp_evidence_snapshot.py` — temp file cleanup now matches `.tmp.{pid}` pattern via `".tmp" in entry.suffixes` instead of `entry.suffix == ".tmp"`; `tests/test_mvp_evidence_snapshot.py` — added `test_cleanup_removes_stale_temp_files_with_pid_suffix` and updated `test_render_mvp_evidence_summary_fallback_on_read_exception` to prove exception path was exercised with `nonlocal called` flag
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328593729 -> TBD
+
+Disposition: NOT-A-BUG
+Reason: `routePath` and `authState` are frontend-controlled enum-like strings from the MVP observability contract. The snapshot is aggregate-only (event name counts) and values are preserved as opaque identifiers for operator diagnostics. Server-side enum enforcement would add coupling to frontend routing internals without security benefit for this aggregate-only, sanitized surface.
+Evidence: `scripts/orchestration/mvp_evidence_snapshot.py:ALLOWED_PAYLOAD_KEYS` defines the allowlist; payload values are never used for authorization or sensitive decisions; snapshot schema is explicitly aggregate-only with no PII.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328574635
+
+## Agent Findings Summary
+
+| Finding | Role | Disposition | Evidence |
+|---------|------|-------------|----------|
+| Bare `Exception` in bridge snapshot read | sourcery-ai | FIXED | Commit `ec72bdf7c` |
+| Missing `retention_days` validation | sourcery-ai | FIXED | Commit `ec72bdf7c` |
+| Typo `atomously` → `atomically` | sourcery-ai | FIXED | Commit `ec72bdf7c` |
+| Typo `atomously` → `atomically` | coderabbitai | FIXED | Commit `ec72bdf7c` |
+| Filesystem race in `read_latest_snapshot_line` | coderabbitai | FIXED | Commit `ec72bdf7c` |
+| Unknown `policy_version` not rejected | coderabbitai | FIXED | Commit `ec72bdf7c` |
+| Test can't prove exception path exercised | coderabbitai | FIXED | Commit `TBD` |
+| Broad `except Exception` masks guard failures | cubic-dev-ai | FIXED | Commit `ec72bdf7c` |
+| `p.stat().st_mtime` OSError outside try block | cubic-dev-ai | FIXED | Commit `ec72bdf7c` |
+| Stale temp cleanup won't match `.tmp.{pid}` | cubic-dev-ai | FIXED | Commit `TBD` |
+| `routePath`/`authState` arbitrary strings | cubic-dev-ai | NOT-A-BUG | Aggregate-only, frontend-controlled contract |
+
+## Merge Readiness
+
+- [x] Pre-open agents: agent-coordinator, cursor-specialist-agent, security-auditor, architecture-specialist
+- [x] Post-open agents: qa-engineer-agent, bug-hunter
+- [x] `make validate-changed` passed
+- [x] `make test-fast` passed
+- [x] `pre-commit run --all-files` passed
+- [x] `python3 scripts/orchestration/check_preflight.py` passed
+- [x] `python3 scripts/orchestration/check_agent_consistency.py` passed
+- [x] PR review dry-run report generated (`/tmp/pulseplate_pr_review_context.json`)
+
+### Experiment Runner evidence
+
+- Co-authored-by trailer included in commits where runner materially contributed.
+- No runner-mutated paths in this PR (operator-authored snapshot/bridge/test/docs changes only).
+
+---

--- a/docs/review/PR_1852_FIXED_MAPPING.md
+++ b/docs/review/PR_1852_FIXED_MAPPING.md
@@ -69,4 +69,9 @@ Evidence: `scripts/orchestration/mvp_evidence_snapshot.py:ALLOWED_PAYLOAD_KEYS` 
 - Co-authored-by trailer included in commits where runner materially contributed.
 - No runner-mutated paths in this PR (operator-authored snapshot/bridge/test/docs changes only).
 
+### Review thread resolution
+
+- All 12 bot review threads resolved via GitHub API on 2026-05-30.
+- Dispositions recorded in artifact above (FIXED / NOT-A-BUG).
+
 ---

--- a/docs/review/PR_1852_FIXED_MAPPING.md
+++ b/docs/review/PR_1852_FIXED_MAPPING.md
@@ -32,11 +32,11 @@ Evidence: `scripts/orchestration/mvp_evidence_snapshot.py` — temp file cleanup
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328593729 -> cc7bf459d
 
 Disposition: FIXED
-Commit: TBD
+Commit: 52dfeab76
 Evidence: `scripts/orchestration/mvp_evidence_snapshot.py` — added `eq=False` to `MvpEvidenceSnapshotLine` dataclass to avoid implicit `__hash__` generation failure due to unhashable `dict[str, int]` field; `tests/test_mvp_evidence_snapshot.py` — updated `test_read_latest_rejects_unknown_policy_version` to use a valid fingerprint computed via `_fingerprint_payload` so rejection is proven to come from policy_version validation, not fingerprint mismatch
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328571595 -> TBD
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#pullrequestreview-4395198767 -> TBD
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328571595 -> 52dfeab76
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#pullrequestreview-4395198767 -> 52dfeab76
 
 Disposition: NOT-A-BUG
 Reason: `routePath` and `authState` are frontend-controlled enum-like strings from the MVP observability contract. The snapshot is aggregate-only (event name counts) and values are preserved as opaque identifiers for operator diagnostics. Server-side enum enforcement would add coupling to frontend routing internals without security benefit for this aggregate-only, sanitized surface.
@@ -58,6 +58,8 @@ Evidence: `scripts/orchestration/mvp_evidence_snapshot.py:ALLOWED_PAYLOAD_KEYS` 
 | Broad `except Exception` masks guard failures | cubic-dev-ai | FIXED | Commit `ec72bdf7c` |
 | `p.stat().st_mtime` OSError outside try block | cubic-dev-ai | FIXED | Commit `ec72bdf7c` |
 | Stale temp cleanup won't match `.tmp.{pid}` | cubic-dev-ai | FIXED | Commit `cc7bf459d` |
+| Dataclass hashability with dict field | coderabbitai | FIXED | Commit `52dfeab76` |
+| Test policy_version guarantee weakened by invalid fingerprint | coderabbitai | FIXED | Commit `52dfeab76` |
 | `routePath`/`authState` arbitrary strings | cubic-dev-ai | NOT-A-BUG | Aggregate-only, frontend-controlled contract |
 
 ## Merge Readiness

--- a/docs/review/PR_1852_FIXED_MAPPING.md
+++ b/docs/review/PR_1852_FIXED_MAPPING.md
@@ -26,10 +26,10 @@ Evidence: `scripts/orchestration/mvp_evidence_snapshot.py` — added `policy_ver
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328591979 -> ec72bdf7c
 
 Disposition: FIXED
-Commit: TBD
+Commit: cc7bf459d
 Evidence: `scripts/orchestration/mvp_evidence_snapshot.py` — temp file cleanup now matches `.tmp.{pid}` pattern via `".tmp" in entry.suffixes` instead of `entry.suffix == ".tmp"`; `tests/test_mvp_evidence_snapshot.py` — added `test_cleanup_removes_stale_temp_files_with_pid_suffix` and updated `test_render_mvp_evidence_summary_fallback_on_read_exception` to prove exception path was exercised with `nonlocal called` flag
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328593729 -> TBD
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1852#discussion_r3328593729 -> cc7bf459d
 
 Disposition: NOT-A-BUG
 Reason: `routePath` and `authState` are frontend-controlled enum-like strings from the MVP observability contract. The snapshot is aggregate-only (event name counts) and values are preserved as opaque identifiers for operator diagnostics. Server-side enum enforcement would add coupling to frontend routing internals without security benefit for this aggregate-only, sanitized surface.
@@ -47,10 +47,10 @@ Evidence: `scripts/orchestration/mvp_evidence_snapshot.py:ALLOWED_PAYLOAD_KEYS` 
 | Typo `atomously` → `atomically` | coderabbitai | FIXED | Commit `ec72bdf7c` |
 | Filesystem race in `read_latest_snapshot_line` | coderabbitai | FIXED | Commit `ec72bdf7c` |
 | Unknown `policy_version` not rejected | coderabbitai | FIXED | Commit `ec72bdf7c` |
-| Test can't prove exception path exercised | coderabbitai | FIXED | Commit `TBD` |
+| Test can't prove exception path exercised | coderabbitai | FIXED | Commit `cc7bf459d` |
 | Broad `except Exception` masks guard failures | cubic-dev-ai | FIXED | Commit `ec72bdf7c` |
 | `p.stat().st_mtime` OSError outside try block | cubic-dev-ai | FIXED | Commit `ec72bdf7c` |
-| Stale temp cleanup won't match `.tmp.{pid}` | cubic-dev-ai | FIXED | Commit `TBD` |
+| Stale temp cleanup won't match `.tmp.{pid}` | cubic-dev-ai | FIXED | Commit `cc7bf459d` |
 | `routePath`/`authState` arbitrary strings | cubic-dev-ai | NOT-A-BUG | Aggregate-only, frontend-controlled contract |
 
 ## Merge Readiness

--- a/scripts/orchestration/experiment_slack_socket_bridge.py
+++ b/scripts/orchestration/experiment_slack_socket_bridge.py
@@ -23,6 +23,10 @@ try:
         LOCAL_PATH_RE,
         slack_text as _slack_text,
     )
+    from scripts.orchestration.mvp_evidence_snapshot import (
+        ALLOWED_EVENT_NAMES as _MVP_ALLOWED_EVENT_NAMES,
+        read_latest_snapshot_line as _read_latest_snapshot_line,
+    )
 except ModuleNotFoundError as exc:  # pragma: no cover - direct script invocation guard.
     if exc.name != "scripts":
         raise
@@ -274,22 +278,45 @@ def _bounded_text(value: str, *, limit: int = 2800) -> str:
 
 
 def render_mvp_evidence_summary() -> SlackSafeMessage:
-    """Render static MVP evidence contract coverage from governed frontend event names."""
+    """Render MVP evidence summary from latest snapshot, falling back to static contract."""
 
-    events = (
-        "guided_planning_viewed",
-        "planning_intent_selected",
-        "planning_time_selected",
-        "planning_preview_seen",
-        "tier_value_viewed",
-        "primary_planning_cta_clicked",
-        "wellness_boundary_viewed",
-        "planning_save_prompt_viewed",
-        "planning_auth_prompt_viewed",
-        "planning_progress_state_viewed",
-        "planning_save_clicked",
-        "planning_continue_clicked",
-    )
+    try:
+        snapshot = _read_latest_snapshot_line()
+    except Exception:
+        snapshot = None
+
+    if snapshot is not None:
+        present_count = sum(1 for v in snapshot.event_aggregates.values() if v > 0)
+        route_str = ",".join(snapshot.route_buckets) if snapshot.route_buckets else "none"
+        auth_str = ",".join(snapshot.auth_state_buckets) if snapshot.auth_state_buckets else "none"
+        coverage_preview = "; ".join(
+            flag for flag in snapshot.coverage_flags if flag.endswith("=present")
+        )
+        if not coverage_preview:
+            coverage_preview = "no_events_observed"
+        return SlackSafeMessage(
+            message_type="mvp_evidence_summary",
+            header="MVP evidence snapshot summary",
+            status_line="snapshot_backed",
+            scope=(
+                "Dynamic Guided Planning Preview snapshot; aggregate-only; "
+                "no runtime analytics backend."
+            ),
+            evidence_summary=(
+                f"present_event_count={present_count}",
+                f"route_buckets={_slack_text(route_str)}",
+                f"auth_state_buckets={_slack_text(auth_str)}",
+                f"coverage_preview={_slack_text(coverage_preview)}",
+                f"policy_version={snapshot.policy_version}",
+            ),
+            action_required="Human review required for PR/merge decisions; Slack is display-only.",
+            artifact_refs=(
+                "frontend/src/lib/mvpObservability.ts",
+                "scripts/orchestration/mvp_evidence_snapshot.py",
+            ),
+        )
+
+    events = _MVP_ALLOWED_EVENT_NAMES
     return SlackSafeMessage(
         message_type="mvp_evidence_summary",
         header="MVP evidence contract summary",

--- a/scripts/orchestration/experiment_slack_socket_bridge.py
+++ b/scripts/orchestration/experiment_slack_socket_bridge.py
@@ -282,7 +282,7 @@ def render_mvp_evidence_summary() -> SlackSafeMessage:
 
     try:
         snapshot = _read_latest_snapshot_line()
-    except Exception:
+    except (ValueError, OSError, TypeError):
         snapshot = None
 
     if snapshot is not None:

--- a/scripts/orchestration/mvp_evidence_snapshot.py
+++ b/scripts/orchestration/mvp_evidence_snapshot.py
@@ -423,8 +423,8 @@ def cleanup_expired_snapshots(
     for entry in target_dir.iterdir():
         if not entry.is_file():
             continue
-        # Clean up stale temp files
-        if entry.suffix == ".tmp":
+        # Clean up stale temp files (pattern: *.tmp or *.tmp.{pid})
+        if ".tmp" in entry.suffixes:
             try:
                 mtime = entry.stat().st_mtime
             except OSError:

--- a/scripts/orchestration/mvp_evidence_snapshot.py
+++ b/scripts/orchestration/mvp_evidence_snapshot.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -97,8 +98,11 @@ _DENYLIST_KEY_FRAGMENTS: tuple[str, ...] = (
     "jwt",
 )
 
+_VALID_ROUTE_PATHS: frozenset[str] = frozenset({"/app", "/setup", "/plate", "/progress", "/pro"})
+_VALID_AUTH_STATES: frozenset[str] = frozenset({"authenticated", "unauthenticated", "unknown"})
+
 _SNAPSHOT_FILENAME_RE = re.compile(
-    r"^mvp_evidence_snapshot_(?P<produced_at>[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}\.[0-9]+\+[0-9]{2}-[0-9]{2})_(?P<idempotency_key>[a-f0-9]{24})\.json$"
+    r"^mvp_evidence_snapshot_(?P<produced_at>[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}(?:\.[0-9]+)?\+[0-9]{2}-[0-9]{2})_(?P<idempotency_key>[a-f0-9]{24})\.json$"
 )
 
 
@@ -158,7 +162,7 @@ def _fingerprint_payload(payload: Any) -> str:
 
 
 def _now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")
 
 
 def _sanitize_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -167,10 +171,12 @@ def _sanitize_payload(payload: dict[str, Any]) -> dict[str, Any]:
     for key, value in payload.items():
         if not isinstance(key, str):
             continue
+        # Allowlist first
+        if key not in ALLOWED_PAYLOAD_KEYS:
+            continue
+        # Denylist defense-in-depth
         lowered = key.lower()
         if any(fragment in lowered for fragment in _DENYLIST_KEY_FRAGMENTS):
-            continue
-        if key not in ALLOWED_PAYLOAD_KEYS:
             continue
         sanitized[key] = value
     return sanitized
@@ -203,10 +209,10 @@ def build_snapshot_line(
             event.get("payload", {}) if isinstance(event.get("payload"), dict) else {}
         )
         route_path = payload.get("routePath")
-        if isinstance(route_path, str):
+        if isinstance(route_path, str) and route_path in _VALID_ROUTE_PATHS:
             route_buckets.add(route_path)
         auth_state = payload.get("authState")
-        if isinstance(auth_state, str):
+        if isinstance(auth_state, str) and auth_state in _VALID_AUTH_STATES:
             auth_state_buckets.add(auth_state)
 
     coverage_flags = tuple(
@@ -287,11 +293,16 @@ def write_snapshot_line(
     target_dir.mkdir(parents=True, exist_ok=True)
     snapshot_file = target_dir / _snapshot_filename(line)
     record = _canonical_json_bytes(_snapshot_line_to_dict(line))
-    temp_file = snapshot_file.with_suffix(".tmp")
-    with open(temp_file, "wb") as f:
-        f.write(record)
-        f.flush()
-    temp_file.replace(snapshot_file)
+    temp_file = snapshot_file.with_suffix(f".tmp.{os.getpid()}")
+    try:
+        with open(temp_file, "wb") as f:
+            f.write(record)
+            f.flush()
+            os.fsync(f.fileno())
+        temp_file.replace(snapshot_file)
+    finally:
+        if temp_file.exists():
+            temp_file.unlink()
     return snapshot_file
 
 
@@ -330,6 +341,31 @@ def read_latest_snapshot_line(
     try:
         with open(latest, "r", encoding="utf-8") as f:
             data = json.load(f)
+        # Runtime type validation
+        if not (
+            isinstance(data.get("event_aggregates"), dict)
+            and isinstance(data.get("route_buckets"), list)
+            and isinstance(data.get("auth_state_buckets"), list)
+            and isinstance(data.get("coverage_flags"), list)
+            and all(isinstance(v, int) for v in data["event_aggregates"].values())
+            and all(isinstance(s, str) for s in data["route_buckets"])
+            and all(isinstance(s, str) for s in data["auth_state_buckets"])
+            and all(isinstance(s, str) for s in data["coverage_flags"])
+        ):
+            return None
+        # Fingerprint verification
+        recomputed_payload = {
+            "event_aggregates": dict(data["event_aggregates"]),
+            "route_buckets": sorted(data["route_buckets"]),
+            "auth_state_buckets": sorted(data["auth_state_buckets"]),
+            "coverage_flags": list(data["coverage_flags"]),
+            "policy_version": data["policy_version"],
+            "producer_name": data["producer_name"],
+            "producer_version": data["producer_version"],
+            "produced_at": data["produced_at"],
+        }
+        if data["fingerprint"] != _fingerprint_payload(recomputed_payload):
+            return None
         return MvpEvidenceSnapshotLine(
             idempotency_key=data["idempotency_key"],
             fingerprint=data["fingerprint"],
@@ -342,7 +378,7 @@ def read_latest_snapshot_line(
             auth_state_buckets=tuple(data["auth_state_buckets"]),
             coverage_flags=tuple(data["coverage_flags"]),
         )
-    except (json.JSONDecodeError, KeyError, TypeError):
+    except (json.JSONDecodeError, KeyError, TypeError, UnicodeDecodeError, OSError):
         return None
 
 
@@ -373,6 +409,20 @@ def cleanup_expired_snapshots(
     deleted_count = 0
     for entry in target_dir.iterdir():
         if not entry.is_file():
+            continue
+        # Clean up stale temp files
+        if entry.suffix == ".tmp":
+            try:
+                mtime = entry.stat().st_mtime
+            except OSError:
+                continue
+            if mtime < threshold:
+                expired_count += 1
+                try:
+                    entry.unlink()
+                    deleted_count += 1
+                except OSError:
+                    pass
             continue
         match = _SNAPSHOT_FILENAME_RE.match(entry.name)
         if not match:

--- a/scripts/orchestration/mvp_evidence_snapshot.py
+++ b/scripts/orchestration/mvp_evidence_snapshot.py
@@ -1,0 +1,397 @@
+"""Durable sanitized MVP evidence snapshot for Slack operator surface.
+
+RU: MVP evidence snapshot — aggregate-only, allowlist-first, no PII.
+EN: MVP evidence snapshot is aggregate-only, allowlist-first, with no PII.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+SnapshotPolicyVersion = Literal["2026-05-30-v1"]
+
+DEFAULT_SNAPSHOT_POLICY_VERSION: SnapshotPolicyVersion = "2026-05-30-v1"
+DEFAULT_RETENTION_DAYS = 30
+DEFAULT_PRODUCER_NAME = "mvp-evidence-snapshot"
+DEFAULT_PRODUCER_VERSION = "1.0.0"
+
+# Event name contract copied from frontend/src/lib/mvpObservability.ts.
+# Any drift must be caught by test_mvp_evidence_event_contract_matches_frontend_source.
+ALLOWED_EVENT_NAMES: tuple[str, ...] = (
+    "guided_planning_viewed",
+    "planning_intent_selected",
+    "planning_time_selected",
+    "planning_preview_seen",
+    "tier_value_viewed",
+    "primary_planning_cta_clicked",
+    "wellness_boundary_viewed",
+    "planning_save_prompt_viewed",
+    "planning_auth_prompt_viewed",
+    "planning_progress_state_viewed",
+    "planning_save_clicked",
+    "planning_continue_clicked",
+)
+
+# Allowlist of payload keys permitted in snapshot after sanitization.
+ALLOWED_PAYLOAD_KEYS: frozenset[str] = frozenset(
+    {
+        "surface",
+        "componentId",
+        "routePath",
+        "optionId",
+        "tierLabel",
+        "authState",
+    }
+)
+
+# Defense-in-depth denylist. Keys containing any fragment are dropped.
+_DENYLIST_KEY_FRAGMENTS: tuple[str, ...] = (
+    "api_key",
+    "apikey",
+    "access_token",
+    "health_payload",
+    "medical_record",
+    "password",
+    "prompt_text",
+    "raw_prompt",
+    "raw_response",
+    "refresh_token",
+    "response_text",
+    "secret",
+    "user_health",
+    "user_payload",
+    "email",
+    "name",
+    "weight",
+    "height",
+    "bmi",
+    "healthcondition",
+    "freetext",
+    "nutritiontargets",
+    "devicefingerprint",
+    "cookieid",
+    "trackingid",
+    "sessiontoken",
+    "sessionid",
+    "phone",
+    "address",
+    "dob",
+    "ssn",
+    "gender",
+    "diagnosis",
+    "medication",
+    "payment",
+    "card",
+    "ipaddress",
+    "latitude",
+    "longitude",
+    "photo",
+    "passwordhash",
+    "token",
+    "jwt",
+)
+
+_SNAPSHOT_FILENAME_RE = re.compile(
+    r"^mvp_evidence_snapshot_(?P<produced_at>[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}\.[0-9]+\+[0-9]{2}-[0-9]{2})_(?P<idempotency_key>[a-f0-9]{24})\.json$"
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).parent.parent.parent.resolve()
+
+
+def _snapshot_dir() -> Path:
+    return _repo_root() / "artifacts" / "orchestration" / "mvp_evidence_snapshots"
+
+
+def _reject_symlinked_path(candidate: Path, *, anchor: Path) -> None:
+    """Fail closed if candidate or any ancestor under anchor is a symlink."""
+    resolved_anchor = anchor.resolve()
+    # Check for symlinks before resolving
+    for part in [candidate, *candidate.parents]:
+        if part == resolved_anchor or part == anchor:
+            break
+        if part.is_symlink():
+            raise ValueError(f"Snapshot path must not traverse a symlink: {part}")
+    resolved_candidate = candidate.resolve()
+    try:
+        resolved_candidate.relative_to(resolved_anchor)
+    except ValueError as exc:
+        raise ValueError(f"Snapshot path must stay under {resolved_anchor}.") from exc
+
+
+@dataclass(frozen=True)
+class MvpEvidenceSnapshotLine:
+    """Single immutable snapshot line with idempotency and fingerprint."""
+
+    idempotency_key: str
+    fingerprint: str
+    produced_at: str
+    producer_name: str
+    producer_version: str
+    policy_version: SnapshotPolicyVersion
+    event_aggregates: dict[str, int]
+    route_buckets: tuple[str, ...]
+    auth_state_buckets: tuple[str, ...]
+    coverage_flags: tuple[str, ...]
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _fingerprint_payload(payload: Any) -> str:
+    digest = hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _sanitize_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Allowlist-first sanitization with denylist defense-in-depth."""
+    sanitized: dict[str, Any] = {}
+    for key, value in payload.items():
+        if not isinstance(key, str):
+            continue
+        lowered = key.lower()
+        if any(fragment in lowered for fragment in _DENYLIST_KEY_FRAGMENTS):
+            continue
+        if key not in ALLOWED_PAYLOAD_KEYS:
+            continue
+        sanitized[key] = value
+    return sanitized
+
+
+def build_snapshot_line(
+    events: list[dict[str, Any]],
+    expected_event_names: tuple[str, ...] = ALLOWED_EVENT_NAMES,
+    *,
+    producer_name: str = DEFAULT_PRODUCER_NAME,
+    producer_version: str = DEFAULT_PRODUCER_VERSION,
+    policy_version: SnapshotPolicyVersion = DEFAULT_SNAPSHOT_POLICY_VERSION,
+) -> MvpEvidenceSnapshotLine:
+    """Build a deterministic snapshot line from sanitized events.
+
+    Raises ValueError on invalid input.
+    """
+    event_aggregates: dict[str, int] = {name: 0 for name in expected_event_names}
+    route_buckets: set[str] = set()
+    auth_state_buckets: set[str] = set()
+
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        name = event.get("name")
+        if name not in expected_event_names:
+            continue
+        event_aggregates[name] = event_aggregates.get(name, 0) + 1
+        payload = _sanitize_payload(
+            event.get("payload", {}) if isinstance(event.get("payload"), dict) else {}
+        )
+        route_path = payload.get("routePath")
+        if isinstance(route_path, str):
+            route_buckets.add(route_path)
+        auth_state = payload.get("authState")
+        if isinstance(auth_state, str):
+            auth_state_buckets.add(auth_state)
+
+    coverage_flags = tuple(
+        f"{name}=present" if event_aggregates[name] > 0 else f"{name}=absent"
+        for name in expected_event_names
+    )
+
+    produced_at = _now_iso()
+    identity_payload = {
+        "event_aggregates": event_aggregates,
+        "route_buckets": sorted(route_buckets),
+        "auth_state_buckets": sorted(auth_state_buckets),
+        "coverage_flags": list(coverage_flags),
+        "policy_version": policy_version,
+        "producer_name": producer_name,
+        "producer_version": producer_version,
+        "produced_at": produced_at,
+    }
+    fingerprint = _fingerprint_payload(identity_payload)
+    idempotency_key = hashlib.sha256(
+        _canonical_json_bytes(
+            {
+                "producer_name": producer_name,
+                "producer_version": producer_version,
+                "produced_at": produced_at,
+            }
+        )
+    ).hexdigest()[:24]
+
+    return MvpEvidenceSnapshotLine(
+        idempotency_key=idempotency_key,
+        fingerprint=fingerprint,
+        produced_at=produced_at,
+        producer_name=producer_name,
+        producer_version=producer_version,
+        policy_version=policy_version,
+        event_aggregates=event_aggregates,
+        route_buckets=tuple(sorted(route_buckets)),
+        auth_state_buckets=tuple(sorted(auth_state_buckets)),
+        coverage_flags=coverage_flags,
+    )
+
+
+def _snapshot_line_to_dict(line: MvpEvidenceSnapshotLine) -> dict[str, Any]:
+    return {
+        "idempotency_key": line.idempotency_key,
+        "fingerprint": line.fingerprint,
+        "produced_at": line.produced_at,
+        "producer_name": line.producer_name,
+        "producer_version": line.producer_version,
+        "policy_version": line.policy_version,
+        "event_aggregates": line.event_aggregates,
+        "route_buckets": list(line.route_buckets),
+        "auth_state_buckets": list(line.auth_state_buckets),
+        "coverage_flags": list(line.coverage_flags),
+    }
+
+
+def _snapshot_filename(line: MvpEvidenceSnapshotLine) -> str:
+    safe_produced_at = line.produced_at.replace(":", "-")
+    return f"mvp_evidence_snapshot_{safe_produced_at}_{line.idempotency_key}.json"
+
+
+def write_snapshot_line(
+    line: MvpEvidenceSnapshotLine,
+    base_dir: Path | None = None,
+) -> Path:
+    """Atomic write of a single snapshot line as its own JSON file.
+
+    Returns the written file path.
+    Raises ValueError on path traversal or symlink injection.
+    """
+    raw_dir = base_dir or _snapshot_dir()
+    anchor = (_repo_root() / "artifacts" / "orchestration").resolve()
+    _reject_symlinked_path(raw_dir, anchor=anchor)
+    target_dir = raw_dir.resolve()
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_file = target_dir / _snapshot_filename(line)
+    record = _canonical_json_bytes(_snapshot_line_to_dict(line))
+    temp_file = snapshot_file.with_suffix(".tmp")
+    with open(temp_file, "wb") as f:
+        f.write(record)
+        f.flush()
+    temp_file.replace(snapshot_file)
+    return snapshot_file
+
+
+def read_latest_snapshot_line(
+    base_dir: Path | None = None,
+) -> MvpEvidenceSnapshotLine | None:
+    """Read the most recent snapshot line from the snapshot directory.
+
+    Returns None if no snapshots exist or the latest file is corrupt.
+    Raises ValueError on path traversal or symlink injection.
+    """
+    raw_dir = base_dir or _snapshot_dir()
+    anchor = (_repo_root() / "artifacts" / "orchestration").resolve()
+    _reject_symlinked_path(raw_dir, anchor=anchor)
+    target_dir = raw_dir.resolve()
+
+    if not target_dir.exists():
+        return None
+
+    snapshot_files: list[Path] = []
+    for entry in target_dir.iterdir():
+        if not entry.is_file():
+            continue
+        match = _SNAPSHOT_FILENAME_RE.match(entry.name)
+        if match:
+            snapshot_files.append(entry)
+
+    if not snapshot_files:
+        return None
+
+    # Sort by mtime descending; tie-break by filename for determinism.
+    snapshot_files.sort(key=lambda p: (p.stat().st_mtime, p.name), reverse=True)
+    latest = snapshot_files[0]
+    _reject_symlinked_path(latest, anchor=anchor)
+
+    try:
+        with open(latest, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return MvpEvidenceSnapshotLine(
+            idempotency_key=data["idempotency_key"],
+            fingerprint=data["fingerprint"],
+            produced_at=data["produced_at"],
+            producer_name=data["producer_name"],
+            producer_version=data["producer_version"],
+            policy_version=data["policy_version"],
+            event_aggregates=dict(data["event_aggregates"]),
+            route_buckets=tuple(data["route_buckets"]),
+            auth_state_buckets=tuple(data["auth_state_buckets"]),
+            coverage_flags=tuple(data["coverage_flags"]),
+        )
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return None
+
+
+def cleanup_expired_snapshots(
+    *,
+    retention_days: int = DEFAULT_RETENTION_DAYS,
+    base_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Delete snapshot files older than retention_days.
+
+    Returns a summary dict without exposing local paths.
+    """
+    raw_dir = base_dir or _snapshot_dir()
+    anchor = (_repo_root() / "artifacts" / "orchestration").resolve()
+    _reject_symlinked_path(raw_dir, anchor=anchor)
+    target_dir = raw_dir.resolve()
+
+    if not target_dir.exists():
+        return {
+            "deleted_count": 0,
+            "expired_count": 0,
+            "retention_days": retention_days,
+            "status": "pass",
+        }
+
+    threshold = datetime.now(timezone.utc).timestamp() - (retention_days * 86400)
+    expired_count = 0
+    deleted_count = 0
+    for entry in target_dir.iterdir():
+        if not entry.is_file():
+            continue
+        match = _SNAPSHOT_FILENAME_RE.match(entry.name)
+        if not match:
+            continue
+        try:
+            mtime = entry.stat().st_mtime
+        except OSError:
+            continue
+        if mtime < threshold:
+            expired_count += 1
+            try:
+                entry.unlink()
+                deleted_count += 1
+            except OSError:
+                pass
+
+    return {
+        "deleted_count": deleted_count,
+        "expired_count": expired_count,
+        "retention_days": retention_days,
+        "status": "pass",
+    }

--- a/scripts/orchestration/mvp_evidence_snapshot.py
+++ b/scripts/orchestration/mvp_evidence_snapshot.py
@@ -131,7 +131,7 @@ def _reject_symlinked_path(candidate: Path, *, anchor: Path) -> None:
         raise ValueError(f"Snapshot path must stay under {resolved_anchor}.") from exc
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class MvpEvidenceSnapshotLine:
     """Single immutable snapshot line with idempotency and fingerprint."""
 

--- a/scripts/orchestration/mvp_evidence_snapshot.py
+++ b/scripts/orchestration/mvp_evidence_snapshot.py
@@ -100,6 +100,7 @@ _DENYLIST_KEY_FRAGMENTS: tuple[str, ...] = (
 
 _VALID_ROUTE_PATHS: frozenset[str] = frozenset({"/app", "/setup", "/plate", "/progress", "/pro"})
 _VALID_AUTH_STATES: frozenset[str] = frozenset({"authenticated", "unauthenticated", "unknown"})
+_SUPPORTED_POLICY_VERSIONS: frozenset[SnapshotPolicyVersion] = frozenset({"2026-05-30-v1"})
 
 _SNAPSHOT_FILENAME_RE = re.compile(
     r"^mvp_evidence_snapshot_(?P<produced_at>[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}(?:\.[0-9]+)?\+[0-9]{2}-[0-9]{2})_(?P<idempotency_key>[a-f0-9]{24})\.json$"
@@ -333,14 +334,23 @@ def read_latest_snapshot_line(
     if not snapshot_files:
         return None
 
+    def _safe_mtime(p: Path) -> float:
+        try:
+            return p.stat().st_mtime
+        except OSError:
+            return 0.0
+
     # Sort by mtime descending; tie-break by filename for determinism.
-    snapshot_files.sort(key=lambda p: (p.stat().st_mtime, p.name), reverse=True)
+    snapshot_files.sort(key=lambda p: (_safe_mtime(p), p.name), reverse=True)
     latest = snapshot_files[0]
     _reject_symlinked_path(latest, anchor=anchor)
 
     try:
         with open(latest, "r", encoding="utf-8") as f:
             data = json.load(f)
+        # Policy version validation (fail closed on unknown versions)
+        if data.get("policy_version") not in _SUPPORTED_POLICY_VERSIONS:
+            return None
         # Runtime type validation
         if not (
             isinstance(data.get("event_aggregates"), dict)
@@ -389,8 +399,11 @@ def cleanup_expired_snapshots(
 ) -> dict[str, Any]:
     """Delete snapshot files older than retention_days.
 
+    Raises ValueError if retention_days is not positive.
     Returns a summary dict without exposing local paths.
     """
+    if retention_days <= 0:
+        raise ValueError("retention_days must be positive")
     raw_dir = base_dir or _snapshot_dir()
     anchor = (_repo_root() / "artifacts" / "orchestration").resolve()
     _reject_symlinked_path(raw_dir, anchor=anchor)

--- a/tests/test_experiment_slack_socket_bridge.py
+++ b/tests/test_experiment_slack_socket_bridge.py
@@ -336,24 +336,16 @@ def test_mvp_evidence_event_contract_matches_frontend_source() -> None:
         ";", 1
     )[0]
     frontend_events = set(re.findall(r"\| '([^']+)'", event_type_block))
-    bridge_source = (
-        REPO_ROOT / "scripts" / "orchestration" / "experiment_slack_socket_bridge.py"
-    ).read_text(encoding="utf-8")
-    bridge_events = set(
-        re.findall(
-            r'"([a-z]+(?:_[a-z]+)+)"',
-            bridge_source.split("def render_mvp_evidence_summary", 1)[1].split(
-                "return SlackSafeMessage", 1
-            )[0],
-        )
-    )
+    from scripts.orchestration.mvp_evidence_snapshot import ALLOWED_EVENT_NAMES
+
+    snapshot_events = set(ALLOWED_EVENT_NAMES)
 
     assert frontend_events
-    assert bridge_events
-    assert bridge_events == frontend_events
-    assert "email" not in bridge_events
-    assert "weight" not in bridge_events
-    assert "bmi" not in bridge_events
+    assert snapshot_events
+    assert snapshot_events == frontend_events
+    assert "email" not in snapshot_events
+    assert "weight" not in snapshot_events
+    assert "bmi" not in snapshot_events
 
 
 def test_dispatch_preview_hashes_branch_and_hypothesis_without_dispatching(

--- a/tests/test_mvp_evidence_snapshot.py
+++ b/tests/test_mvp_evidence_snapshot.py
@@ -1,0 +1,310 @@
+"""Tests for MVP evidence snapshot — sanitized, aggregate-only, allowlist-first."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+import pytest
+
+import scripts.orchestration.context_pack as context_pack
+from scripts.orchestration import experiment_slack_socket_bridge as bridge
+from scripts.orchestration import mvp_evidence_snapshot as snapshot
+from scripts.orchestration.mvp_evidence_snapshot import (
+    ALLOWED_EVENT_NAMES,
+    ALLOWED_PAYLOAD_KEYS,
+    MvpEvidenceSnapshotLine,
+    _DENYLIST_KEY_FRAGMENTS,
+    _repo_root,
+    _snapshot_dir,
+    build_snapshot_line,
+    cleanup_expired_snapshots,
+    read_latest_snapshot_line,
+    write_snapshot_line,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _configure_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    monkeypatch.setattr(context_pack, "REPO_ROOT", repo)
+    monkeypatch.setattr(bridge, "REPO_ROOT", repo)
+    monkeypatch.setattr(snapshot, "_repo_root", lambda: repo)
+    return repo
+
+
+def _sample_events() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "guided_planning_viewed",
+            "payload": {"surface": "app", "routePath": "/app", "authState": "authenticated"},
+        },
+        {
+            "name": "planning_save_clicked",
+            "payload": {
+                "surface": "app",
+                "routePath": "/app",
+                "authState": "authenticated",
+                "optionId": "save",
+            },
+        },
+        {
+            "name": "guided_planning_viewed",
+            "payload": {"surface": "app", "routePath": "/app", "authState": "unauthenticated"},
+        },
+    ]
+
+
+def test_build_snapshot_line_determinism(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(snapshot, "_now_iso", lambda: "2026-05-30T00:00:00.000000+00:00")
+    events = _sample_events()
+    line_a = build_snapshot_line(events, producer_name="test", producer_version="1.0.0")
+    line_b = build_snapshot_line(events, producer_name="test", producer_version="1.0.0")
+    assert line_a.fingerprint == line_b.fingerprint
+    assert line_a.idempotency_key == line_b.idempotency_key
+    assert line_a.event_aggregates == line_b.event_aggregates
+    assert line_a.route_buckets == line_b.route_buckets
+    assert line_a.auth_state_buckets == line_b.auth_state_buckets
+    assert line_a.coverage_flags == line_b.coverage_flags
+
+
+def test_build_snapshot_line_aggregates_counts() -> None:
+    events = _sample_events()
+    line = build_snapshot_line(events, producer_name="test", producer_version="1.0.0")
+    assert line.event_aggregates["guided_planning_viewed"] == 2
+    assert line.event_aggregates["planning_save_clicked"] == 1
+    assert line.event_aggregates["planning_continue_clicked"] == 0
+
+
+def test_build_snapshot_line_route_and_auth_buckets() -> None:
+    events = _sample_events()
+    line = build_snapshot_line(events, producer_name="test", producer_version="1.0.0")
+    assert line.route_buckets == ("/app",)
+    assert line.auth_state_buckets == ("authenticated", "unauthenticated")
+
+
+def test_sanitize_payload_allowlist_first() -> None:
+    raw = {
+        "surface": "app",
+        "routePath": "/app",
+        "authState": "authenticated",
+        "weight": 70,
+        "bmi": 22.5,
+        "freeText": "user comment",
+        "unknownField": "should be dropped",
+    }
+    sanitized = snapshot._sanitize_payload(raw)
+    assert sanitized == {
+        "surface": "app",
+        "routePath": "/app",
+        "authState": "authenticated",
+    }
+
+
+def test_sanitize_payload_denylist_defense_in_depth() -> None:
+    raw = {
+        "surface": "app",
+        "apiKey": "secret123",  # pragma: allowlist secret
+        "sessionToken": "tok",  # pragma: allowlist secret
+        "email": "a@b.com",
+        "passwordHash": "hash",  # pragma: allowlist secret
+        "jwt": "eyJ0",
+    }
+    sanitized = snapshot._sanitize_payload(raw)
+    assert "apiKey" not in sanitized
+    assert "sessionToken" not in sanitized
+    assert "email" not in sanitized
+    assert "passwordHash" not in sanitized
+    assert "jwt" not in sanitized
+    assert sanitized == {"surface": "app"}
+
+
+def test_build_snapshot_line_no_leak_of_sensitive_fields() -> None:
+    events = [
+        {
+            "name": "guided_planning_viewed",
+            "payload": {
+                "surface": "app",
+                "routePath": "/app",
+                "weight": 70,
+                "bmi": 22.5,
+                "freeText": "secret",
+            },
+        },
+    ]
+    line = build_snapshot_line(events, producer_name="test", producer_version="1.0.0")
+    assert "weight" not in line.event_aggregates
+    assert "bmi" not in line.event_aggregates
+    assert "freeText" not in line.event_aggregates
+    dict_form = snapshot._snapshot_line_to_dict(line)
+    # Ensure sensitive values do not appear in aggregate or bucket fields
+    assert dict_form["event_aggregates"] == {
+        "guided_planning_viewed": 1,
+        "planning_intent_selected": 0,
+        "planning_time_selected": 0,
+        "planning_preview_seen": 0,
+        "tier_value_viewed": 0,
+        "primary_planning_cta_clicked": 0,
+        "wellness_boundary_viewed": 0,
+        "planning_save_prompt_viewed": 0,
+        "planning_auth_prompt_viewed": 0,
+        "planning_progress_state_viewed": 0,
+        "planning_save_clicked": 0,
+        "planning_continue_clicked": 0,
+    }
+    assert dict_form["route_buckets"] == ["/app"]
+    assert dict_form["auth_state_buckets"] == []
+    # Ensure raw sensitive values do not leak into any field string representation
+    for bucket in dict_form["route_buckets"]:
+        assert "70" not in bucket and "22.5" not in bucket and "secret" not in bucket
+    for bucket in dict_form["auth_state_buckets"]:
+        assert "70" not in bucket and "22.5" not in bucket and "secret" not in bucket
+    for flag in dict_form["coverage_flags"]:
+        assert "70" not in flag and "22.5" not in flag and "secret" not in flag
+
+
+def test_write_and_read_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _configure_repo(monkeypatch, tmp_path)
+    events = _sample_events()
+    line = build_snapshot_line(events, producer_name="test", producer_version="1.0.0")
+    written = write_snapshot_line(line)
+    assert written.exists()
+    read = read_latest_snapshot_line()
+    assert read is not None
+    assert read.fingerprint == line.fingerprint
+    assert read.idempotency_key == line.idempotency_key
+    assert read.event_aggregates == line.event_aggregates
+
+
+def test_read_latest_returns_none_when_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    assert read_latest_snapshot_line() is None
+
+
+def test_read_latest_returns_none_on_corrupt_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _configure_repo(monkeypatch, tmp_path)
+    snap_dir = repo / "artifacts" / "orchestration" / "mvp_evidence_snapshots"
+    snap_dir.mkdir(parents=True)
+    corrupt = snap_dir / "mvp_evidence_snapshot_2026-05-30T00-00-00.000000+00-00_deadbeef.json"
+    corrupt.write_text("not json", encoding="utf-8")
+    assert read_latest_snapshot_line() is None
+
+
+def test_render_mvp_evidence_summary_with_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _configure_repo(monkeypatch, tmp_path)
+    events = _sample_events()
+    line = build_snapshot_line(events, producer_name="test", producer_version="1.0.0")
+    write_snapshot_line(line)
+    msg = bridge.render_mvp_evidence_summary()
+    assert msg.message_type == "mvp_evidence_summary"
+    assert msg.status_line == "snapshot_backed"
+    text = msg.as_text()
+    assert "present_event_count=2" in text
+    assert "route_buckets=/app" in text
+    assert "auth_state_buckets=authenticated,unauthenticated" in text
+    assert "coverage_preview=guided_planning_viewed=present; planning_save_clicked=present" in text
+
+
+def test_render_mvp_evidence_summary_fallback_without_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    msg = bridge.render_mvp_evidence_summary()
+    assert msg.message_type == "mvp_evidence_summary"
+    assert msg.status_line == "advisory_operator_summary"
+    text = msg.as_text()
+    assert "safe_event_count=12" in text
+    assert "route_path=/app" in text
+
+
+def test_cleanup_expired_snapshots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import os
+
+    repo = _configure_repo(monkeypatch, tmp_path)
+    snap_dir = repo / "artifacts" / "orchestration" / "mvp_evidence_snapshots"
+    snap_dir.mkdir(parents=True)
+    old_file = (
+        snap_dir
+        / "mvp_evidence_snapshot_2020-01-01T00-00-00.000000+00-00_000000000000000000000000.json"
+    )
+    old_file.write_text("{}", encoding="utf-8")
+    new_mtime = 1577836800.0  # 2020-01-01T00:00:00 UTC
+    os.utime(str(old_file), (new_mtime, new_mtime))
+
+    result = cleanup_expired_snapshots(retention_days=1)
+    assert result["status"] == "pass"
+    assert result["deleted_count"] == 1
+    assert result["expired_count"] == 1
+    assert not old_file.exists()
+
+
+def test_path_traversal_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _configure_repo(monkeypatch, tmp_path)
+    line = build_snapshot_line([], producer_name="test", producer_version="1.0.0")
+    with pytest.raises(ValueError, match="must stay under"):
+        write_snapshot_line(line, base_dir=tmp_path / "outside")
+
+
+def test_symlink_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _configure_repo(monkeypatch, tmp_path)
+    snap_dir = repo / "artifacts" / "orchestration" / "mvp_evidence_snapshots"
+    snap_dir.mkdir(parents=True)
+    symlink_dir = tmp_path / "symlink_attack"
+    symlink_dir.symlink_to(snap_dir)
+    line = build_snapshot_line([], producer_name="test", producer_version="1.0.0")
+    with pytest.raises(ValueError, match="symlink"):
+        write_snapshot_line(line, base_dir=symlink_dir)
+
+
+def test_cross_language_denylist_drift_guard() -> None:
+    frontend_source = (REPO_ROOT / "frontend" / "src" / "lib" / "mvpObservability.ts").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(
+        r"export const guidedPlanningObservabilitySensitiveFields = \[(.*?)\] as const;",
+        frontend_source,
+        re.DOTALL,
+    )
+    assert match is not None, "Frontend denylist not found"
+    frontend_fields = set(re.findall(r"'([^']+)'", match.group(1)))
+    assert frontend_fields, "Frontend denylist is empty"
+
+    python_denylist = set(_DENYLIST_KEY_FRAGMENTS)
+    # Frontend uses camelCase; Python denylist uses lowercase substring matching.
+    missing: set[str] = set()
+    for field in frontend_fields:
+        lowered = field.lower()
+        if not any(fragment in lowered for fragment in python_denylist):
+            missing.add(field)
+
+    assert not missing, (
+        f"Frontend sensitive fields missing in Python denylist: {sorted(missing)}. "
+        f"Add them to _DENYLIST_KEY_FRAGMENTS in mvp_evidence_snapshot.py."
+    )
+
+
+def test_allowed_payload_keys_subset_of_frontend_payload() -> None:
+    frontend_source = (REPO_ROOT / "frontend" / "src" / "lib" / "mvpObservability.ts").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(
+        r"export interface GuidedPlanningEventPayload \{(.*?)\}",
+        frontend_source,
+        re.DOTALL,
+    )
+    assert match is not None, "Frontend payload interface not found"
+    frontend_keys = set(re.findall(r"(\w+)\??:", match.group(1)))
+    assert frontend_keys, "Frontend payload keys not found"
+    # ALLOWED_PAYLOAD_KEYS must be a subset of frontend payload keys
+    extra = ALLOWED_PAYLOAD_KEYS - frontend_keys
+    assert not extra, f"ALLOWED_PAYLOAD_KEYS contains keys not in frontend payload: {sorted(extra)}"

--- a/tests/test_mvp_evidence_snapshot.py
+++ b/tests/test_mvp_evidence_snapshot.py
@@ -496,11 +496,26 @@ def test_read_latest_rejects_unknown_policy_version(
         snap_dir
         / "mvp_evidence_snapshot_2026-05-30T00-00-00.000000+00-00_000000000000000000000000.json"
     )
+    # Use a valid fingerprint so the rejection is proven to come from
+    # policy_version validation, not fingerprint mismatch.
+    from scripts.orchestration.mvp_evidence_snapshot import _fingerprint_payload
+
+    fake_payload = {
+        "event_aggregates": {},
+        "route_buckets": [],
+        "auth_state_buckets": [],
+        "coverage_flags": [],
+        "policy_version": "unknown-version",
+        "producer_name": "test",
+        "producer_version": "1.0.0",
+        "produced_at": "2026-05-30T00:00:00.000000+00:00",
+    }
+    valid_fingerprint = _fingerprint_payload(fake_payload)
     bad.write_text(
         json.dumps(
             {
                 "idempotency_key": "000000000000000000000000",
-                "fingerprint": "sha256:abcd",
+                "fingerprint": valid_fingerprint,
                 "produced_at": "2026-05-30T00:00:00.000000+00:00",
                 "producer_name": "test",
                 "producer_version": "1.0.0",

--- a/tests/test_mvp_evidence_snapshot.py
+++ b/tests/test_mvp_evidence_snapshot.py
@@ -193,7 +193,10 @@ def test_read_latest_returns_none_on_corrupt_file(
     repo = _configure_repo(monkeypatch, tmp_path)
     snap_dir = repo / "artifacts" / "orchestration" / "mvp_evidence_snapshots"
     snap_dir.mkdir(parents=True)
-    corrupt = snap_dir / "mvp_evidence_snapshot_2026-05-30T00-00-00.000000+00-00_deadbeef.json"
+    corrupt = (
+        snap_dir
+        / "mvp_evidence_snapshot_2026-05-30T00-00-00.000000+00-00_000000000000000000000000.json"
+    )
     corrupt.write_text("not json", encoding="utf-8")
     assert read_latest_snapshot_line() is None
 
@@ -308,3 +311,145 @@ def test_allowed_payload_keys_subset_of_frontend_payload() -> None:
     # ALLOWED_PAYLOAD_KEYS must be a subset of frontend payload keys
     extra = ALLOWED_PAYLOAD_KEYS - frontend_keys
     assert not extra, f"ALLOWED_PAYLOAD_KEYS contains keys not in frontend payload: {sorted(extra)}"
+
+
+def test_read_latest_rejects_symlinked_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _configure_repo(monkeypatch, tmp_path)
+    snap_dir = repo / "artifacts" / "orchestration" / "mvp_evidence_snapshots"
+    snap_dir.mkdir(parents=True)
+    real_file = (
+        snap_dir
+        / "mvp_evidence_snapshot_2026-05-30T00-00-00.000000+00-00_000000000000000000000000.json"
+    )
+    real_file.write_text("{}", encoding="utf-8")
+    symlink_file = (
+        snap_dir
+        / "mvp_evidence_snapshot_2026-05-30T00-00-00.000000+00-00_111111111111111111111111.json"
+    )
+    symlink_file.symlink_to(real_file)
+    with pytest.raises(ValueError, match="symlink"):
+        read_latest_snapshot_line()
+
+
+def test_read_latest_rejects_path_traversal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    with pytest.raises(ValueError, match="must stay under"):
+        read_latest_snapshot_line(base_dir=tmp_path / "outside")
+
+
+def test_cleanup_rejects_path_traversal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    with pytest.raises(ValueError, match="must stay under"):
+        cleanup_expired_snapshots(base_dir=tmp_path / "outside")
+
+
+def test_render_mvp_evidence_summary_fallback_on_read_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+
+    def _raise() -> None:
+        raise OSError("simulated read failure")
+
+    monkeypatch.setattr(bridge, "_read_latest_snapshot_line", _raise)
+    msg = bridge.render_mvp_evidence_summary()
+    assert msg.status_line == "advisory_operator_summary"
+    assert "safe_event_count=12" in msg.as_text()
+
+
+def test_cleanup_missing_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+    result = cleanup_expired_snapshots()
+    assert result == {
+        "deleted_count": 0,
+        "expired_count": 0,
+        "retention_days": 30,
+        "status": "pass",
+    }
+
+
+def test_render_mvp_evidence_summary_empty_buckets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _configure_repo(monkeypatch, tmp_path)
+    line = build_snapshot_line([], producer_name="test", producer_version="1.0.0")
+    write_snapshot_line(line)
+    msg = bridge.render_mvp_evidence_summary()
+    assert msg.status_line == "snapshot_backed"
+    text = msg.as_text()
+    assert "route_buckets=none" in text
+    assert "auth_state_buckets=none" in text
+
+
+def test_render_mvp_evidence_summary_no_events_observed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _configure_repo(monkeypatch, tmp_path)
+    line = build_snapshot_line([], producer_name="test", producer_version="1.0.0")
+    write_snapshot_line(line)
+    msg = bridge.render_mvp_evidence_summary()
+    assert msg.status_line == "snapshot_backed"
+    text = msg.as_text()
+    assert "coverage_preview=no_events_observed" in text
+
+
+def test_fingerprint_verification_on_read(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _configure_repo(monkeypatch, tmp_path)
+    events = _sample_events()
+    line = build_snapshot_line(events, producer_name="test", producer_version="1.0.0")
+    write_snapshot_line(line)
+    # Tamper with the file: change a count
+    latest = read_latest_snapshot_line()
+    assert latest is not None
+    snap_dir = repo / "artifacts" / "orchestration" / "mvp_evidence_snapshots"
+    files = list(snap_dir.iterdir())
+    assert files
+    with open(files[0], "r", encoding="utf-8") as f:
+        data = json.load(f)
+    data["event_aggregates"]["guided_planning_viewed"] = 999
+    with open(files[0], "w", encoding="utf-8") as f:
+        json.dump(data, f)
+    assert read_latest_snapshot_line() is None
+
+
+def test_zero_microsecond_filename_regex() -> None:
+    # Regex must match filenames without fractional seconds
+    filename = "mvp_evidence_snapshot_2026-05-30T00-00-00+00-00_000000000000000000000000.json"
+    match = snapshot._SNAPSHOT_FILENAME_RE.match(filename)
+    assert match is not None
+    assert match.group("idempotency_key") == "000000000000000000000000"
+
+
+def test_invalid_utf8_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _configure_repo(monkeypatch, tmp_path)
+    snap_dir = repo / "artifacts" / "orchestration" / "mvp_evidence_snapshots"
+    snap_dir.mkdir(parents=True)
+    bad = (
+        snap_dir
+        / "mvp_evidence_snapshot_2026-05-30T00-00-00.000000+00-00_000000000000000000000000.json"
+    )
+    bad.write_bytes(b"\xff\xfe not utf8")
+    assert read_latest_snapshot_line() is None
+
+
+def test_non_string_payload_values_ignored() -> None:
+    events = [
+        {
+            "name": "guided_planning_viewed",
+            "payload": {
+                "surface": "app",
+                "routePath": "/app",
+                "authState": "authenticated",
+                "optionId": 123,
+                "componentId": ["nested"],
+            },
+        },
+    ]
+    line = build_snapshot_line(events, producer_name="test", producer_version="1.0.0")
+    assert line.event_aggregates["guided_planning_viewed"] == 1
+    assert line.route_buckets == ("/app",)
+    assert line.auth_state_buckets == ("authenticated",)

--- a/tests/test_mvp_evidence_snapshot.py
+++ b/tests/test_mvp_evidence_snapshot.py
@@ -453,3 +453,40 @@ def test_non_string_payload_values_ignored() -> None:
     assert line.event_aggregates["guided_planning_viewed"] == 1
     assert line.route_buckets == ("/app",)
     assert line.auth_state_buckets == ("authenticated",)
+
+
+def test_cleanup_expired_snapshots_rejects_non_positive_retention() -> None:
+    with pytest.raises(ValueError, match="retention_days must be positive"):
+        cleanup_expired_snapshots(retention_days=0)
+    with pytest.raises(ValueError, match="retention_days must be positive"):
+        cleanup_expired_snapshots(retention_days=-1)
+
+
+def test_read_latest_rejects_unknown_policy_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _configure_repo(monkeypatch, tmp_path)
+    snap_dir = repo / "artifacts" / "orchestration" / "mvp_evidence_snapshots"
+    snap_dir.mkdir(parents=True)
+    bad = (
+        snap_dir
+        / "mvp_evidence_snapshot_2026-05-30T00-00-00.000000+00-00_000000000000000000000000.json"
+    )
+    bad.write_text(
+        json.dumps(
+            {
+                "idempotency_key": "000000000000000000000000",
+                "fingerprint": "sha256:abcd",
+                "produced_at": "2026-05-30T00:00:00.000000+00:00",
+                "producer_name": "test",
+                "producer_version": "1.0.0",
+                "policy_version": "unknown-version",
+                "event_aggregates": {},
+                "route_buckets": [],
+                "auth_state_buckets": [],
+                "coverage_flags": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert read_latest_snapshot_line() is None

--- a/tests/test_mvp_evidence_snapshot.py
+++ b/tests/test_mvp_evidence_snapshot.py
@@ -251,6 +251,26 @@ def test_cleanup_expired_snapshots(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     assert not old_file.exists()
 
 
+def test_cleanup_removes_stale_temp_files_with_pid_suffix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import os
+
+    repo = _configure_repo(monkeypatch, tmp_path)
+    snap_dir = repo / "artifacts" / "orchestration" / "mvp_evidence_snapshots"
+    snap_dir.mkdir(parents=True)
+    temp_file = snap_dir / "snapshot_2020-01-01T00-00-00.000000+00-00_abc123.tmp.12345"
+    temp_file.write_text("{}", encoding="utf-8")
+    old_mtime = 1577836800.0  # 2020-01-01T00:00:00 UTC
+    os.utime(str(temp_file), (old_mtime, old_mtime))
+
+    result = cleanup_expired_snapshots(retention_days=1)
+    assert result["status"] == "pass"
+    assert result["deleted_count"] == 1
+    assert result["expired_count"] == 1
+    assert not temp_file.exists()
+
+
 def test_path_traversal_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     repo = _configure_repo(monkeypatch, tmp_path)
     line = build_snapshot_line([], producer_name="test", producer_version="1.0.0")
@@ -351,12 +371,16 @@ def test_render_mvp_evidence_summary_fallback_on_read_exception(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _configure_repo(monkeypatch, tmp_path)
+    called = False
 
     def _raise() -> None:
+        nonlocal called
+        called = True
         raise OSError("simulated read failure")
 
     monkeypatch.setattr(bridge, "_read_latest_snapshot_line", _raise)
     msg = bridge.render_mvp_evidence_summary()
+    assert called is True
     assert msg.status_line == "advisory_operator_summary"
     assert "safe_event_count=12" in msg.as_text()
 


### PR DESCRIPTION
## Summary

Back the Slack `/pulseplate-runner mvp-evidence` command with a durable, sanitized, aggregate-only ledger snapshot while preserving static fallback for safe degradation.

- `scripts/orchestration/mvp_evidence_snapshot.py` — allowlist-first snapshot schema, reader/writer, retention cleanup, path-traversal/symlink guards, cross-language denylist drift guard.
- `scripts/orchestration/experiment_slack_socket_bridge.py` — `render_mvp_evidence_summary()` now reads the latest snapshot and falls back to the static contract summary when no snapshot exists.
- Tests cover determinism, sanitization fail-closed, no-leak, reader/writer roundtrip, Slack renderer contract, cleanup/retention, path traversal, symlink rejection, cross-language denylist parity, and temp-file cleanup.

## Risk & Impact

- [ ] User-facing change
- [ ] Data model/migration
- [x] Security-sensitive (PII/PHI sanitization)
- [ ] Performance-sensitive

## Test Plan

- [x] Unit tests updated/added
- [ ] Integration/slow tests (if applicable)
- [x] Manual verification steps

## CI Gates

- [x] PR tests green (lint, type, unit)
- [x] Diff coverage ≥ 97% on changed lines

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping

See `docs/review/PR_1852_FIXED_MAPPING.md` for full disposition evidence.

**FIXED (ec72bdf7c):**
- Sourcery: narrowed `except Exception` → `(ValueError, OSError, TypeError)` in bridge
- Sourcery: added `retention_days <= 0` guard in cleanup
- Sourcery/CodeRabbit: fixed typo `atomously` → `atomically` in premortem
- CodeRabbit: wrapped `stat()`/`open()` in `try/except OSError` in reader
- CodeRabbit: added `policy_version` validation in reader (fail-closed)
- Cubic: same broad-exception fix as Sourcery
- Cubic: same `stat()` OSError fix as CodeRabbit

**FIXED (cc7bf459d):**
- Cubic: temp file cleanup now matches `.tmp.{pid}` via `".tmp" in entry.suffixes`
- CodeRabbit: test now proves exception path exercised with `nonlocal called` flag

**NOT-A-BUG:**
- Cubic: `routePath`/`authState` values — aggregate-only snapshot, frontend-controlled enum-like strings, no security impact

## Premortem

See `docs/review/PREMORTEM_SLACK_MVP_EVIDENCE_LEDGER.md`.

## Summary by Sourcery

Поддержать Slack-команду `/pulseplate-runner mvp-evidence` с помощью долговечных, санитизированных снимков (snapshot) событий наблюдаемости фронтенд MVP, с безопасным откатом к существующей статической сводке.

Новые возможности:
- Ввести модуль snapshot’ов доказательств MVP, который формирует санитизированные, только-агрегированные snapshots событий и сохраняет их как долговечные JSON-артефакты для ознакомления оператора.
- Обновить рендерер доказательств MVP в Slack-bridge так, чтобы он использовал последний доступный snapshot и безопасно откатывался к статической сводке.

Тесты:
- Добавить всесторонний набор тестов для snapshot’ов доказательств MVP, охватывающий детерминизм, санитизацию, отсутствие утечек, roundtrip чтения/записи, контракт рендера, очистку/retention, защиту от path traversal и symlink, а также cross-language denylist parity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshot-backed Slack evidence reporting: deterministic, allowlist-first sanitized snapshots with fingerprinted records, atomic safe writes, retention cleanup, and advisory fallback when snapshots are unavailable.

* **Documentation**
  * Added a pre-mortem risk analysis and a PR review write-up covering failure modes, safeguards, rollout checklist, and go/no-go conditions.

* **Tests**
  * Expanded test suite for determinism, sanitization/no-leak guarantees, persistence/robustness, retention/cleanup, path-safety, and frontend/back-end contract checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katsiarynakavaleuskaya/PulsePlate/pull/1852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->