### PR TITLE
fix(security): disposition Trivy perl-base CVE

### DIFF
--- a/docs/review/PR_1863_FIXED_MAPPING.md
+++ b/docs/review/PR_1863_FIXED_MAPPING.md
@@ -19,6 +19,31 @@ Disposition: FIXED
 Commit: afb1b2412962
 Evidence: `trivy/ignore-policy.rego` adds exact CVE/package/version/PkgID policy matching; `tests/test_trivy_ignore_policy_expiry.py` proves exact matching, no `.trivyignore` entry, and doc/ledger coupling; `docs/security/CVE-2026-48962-perl-base.md` documents alert evidence and removal conditions; `docs/roadmap/BACKLOG_LEDGER.md` tracks remediation debt.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#discussion_r3335451980 -> f604c5aae
+Disposition: FIXED
+Commit: f604c5aae
+Evidence: `docs/review/PR_TRIVY_602_PREMORTEM.md` title now uses `PR #1863`, replacing the `PR TBD` placeholder.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#discussion_r3335451993 -> c7be0fb64169
+Disposition: FIXED
+Commit: c7be0fb64169
+Evidence: `docs/review/PR_TRIVY_602_PREMORTEM.md` now includes Discussion Thread Pass, Fixed in Commit Mapping, Merge Readiness, and the canonical `docs/review/PR_1863_FIXED_MAPPING.md` reference.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#pullrequestreview-4402674945 -> c7be0fb64169
+Disposition: FIXED
+Commit: c7be0fb64169
+Evidence: `tests/test_trivy_ignore_policy_expiry.py` now uses a safe fallback to the end of `BACKLOG_LEDGER.md` when no later anchor exists, and the premortem PR title/linkage feedback is addressed.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#discussion_r3335468861 -> c7be0fb64169
+Disposition: FIXED
+Commit: c7be0fb64169
+Evidence: `docs/review/PR_1863_FIXED_MAPPING.md` now says the validation plan required focus on Trivy policy guards.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#discussion_r3335478528
+Disposition: NOT-A-BUG
+Evidence: `git merge-base --is-ancestor afb1b2412962 HEAD` exits 0 on branch head `c7be0fb64169`, so the implementation SHA is reachable in the real PR branch history.
+Reason: The bot compared `afb1b2412962` to a synthetic reviewed commit surface rather than the current branch head; the mapping remains valid for the actual PR history.
+
 ## Implementation Evidence
 
 Disposition: FIXED
@@ -78,6 +103,10 @@ Post-open role order is pending:
   `source_diff_paths` covered the five PR files; `coauthor_required=true`.
 - Commit trailer used on `afb1b2412962`:
   `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/dbd80258a382.json`
 
 ## Codex Security Diff Scan
 

--- a/docs/review/PR_1863_FIXED_MAPPING.md
+++ b/docs/review/PR_1863_FIXED_MAPPING.md
@@ -8,24 +8,16 @@ alert #602 / `CVE-2026-48962` / `perl-base 5.36.0-7+deb12u3`.
 
 ## Discussion Thread Pass
 
-- [x] Initial discussion-thread pass completed: no review threads existed at
-  PR open.
-- [x] Initial fixed-in-commit mapping completed.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 - [ ] Post-open bot/human review disposition pending.
 
 ## Fixed in Commit Mapping
 
-Initial implementation commit:
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863 -> afb1b2412962
 Disposition: FIXED
 Commit: afb1b2412962
-Evidence: `trivy/ignore-policy.rego` adds an exact CVE/package/version/PkgID
-policy disposition for `CVE-2026-48962`; `tests/test_trivy_ignore_policy_expiry.py`
-proves exact matching, no `.trivyignore` entry, and doc/ledger coupling;
-`docs/security/CVE-2026-48962-perl-base.md` documents alert evidence,
-upstream status, runtime exposure, local Docker/Trivy limitations, and removal
-conditions; `docs/roadmap/BACKLOG_LEDGER.md` tracks the remediation debt.
+Evidence: `trivy/ignore-policy.rego` adds exact CVE/package/version/PkgID policy matching; `tests/test_trivy_ignore_policy_expiry.py` proves exact matching, no `.trivyignore` entry, and doc/ledger coupling; `docs/security/CVE-2026-48962-perl-base.md` documents alert evidence and removal conditions; `docs/roadmap/BACKLOG_LEDGER.md` tracks remediation debt.
 
 ## Implementation Evidence
 
@@ -55,7 +47,7 @@ Pre-open read-only role order completed before implementation:
 
 - `agent-coordinator` - completed; scope locked to Trivy alert #602 policy
   disposition and required role order.
-- `dev-operator` - completed; validation plan required focused Trivy policy
+- `dev-operator` - completed; validation plan required focus on Trivy policy
   guards, docs gate, `make validate-changed`, pre-commit, and current-head
   Docker/Trivy/SARIF follow-up.
 - `architecture-specialist` - completed; confirmed no API, runtime,

--- a/docs/review/PR_1863_FIXED_MAPPING.md
+++ b/docs/review/PR_1863_FIXED_MAPPING.md
@@ -19,10 +19,10 @@ Disposition: FIXED
 Commit: afb1b2412962
 Evidence: `trivy/ignore-policy.rego` adds exact CVE/package/version/PkgID policy matching; `tests/test_trivy_ignore_policy_expiry.py` proves exact matching, no `.trivyignore` entry, and doc/ledger coupling; `docs/security/CVE-2026-48962-perl-base.md` documents alert evidence and removal conditions; `docs/roadmap/BACKLOG_LEDGER.md` tracks remediation debt.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#discussion_r3335451980 -> f604c5aae
-Disposition: FIXED
-Commit: f604c5aae
-Evidence: `docs/review/PR_TRIVY_602_PREMORTEM.md` title now uses `PR #1863`, replacing the `PR TBD` placeholder.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#discussion_r3335451980
+Disposition: NOT-A-BUG
+Evidence: Current `docs/review/PR_TRIVY_602_PREMORTEM.md` title uses `PR #1863`, and CodeRabbit marked the stale placeholder comment addressed after branch update.
+Reason: The comment was valid for the initial diff hunk but stale against current branch history; the canonical PR identifier is already present.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#discussion_r3335451993 -> c7be0fb64169
 Disposition: FIXED

--- a/docs/review/PR_1863_FIXED_MAPPING.md
+++ b/docs/review/PR_1863_FIXED_MAPPING.md
@@ -64,6 +64,16 @@ Disposition: NOT-A-BUG
 Evidence: `git show -s --format=%B afb1b2412962` includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`, and that is the implementation commit materially shaped by the Experiment Runner oracle result.
 Reason: Later fixed-mapping/review-disposition commits document or respond to post-open review feedback; they were not the oracle-shaped implementation commit and do not require retroactive Experiment Runner attribution.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#discussion_r3336675899
+Disposition: NOT-A-BUG
+Evidence: `git merge-base --is-ancestor b543afe4e HEAD` exits 0 on the real local PR branch, and `git show -s --format=%B a4c3b7e9aa993ada372d0c54ebd481ddf0fe9d53` fails with `fatal: bad object a4c3b7e9aa993ada372d0c54ebd481ddf0fe9d53`.
+Reason: The bot compared the fixed-version guard SHA against a synthetic reviewed commit SHA, not the current PR branch history used by repo merge-readiness guards.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#discussion_r3336675906
+Disposition: NOT-A-BUG
+Evidence: `git show -s --format=%B afb1b2412962` includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`, and `git show -s --format=%B a4c3b7e9aa993ada372d0c54ebd481ddf0fe9d53` fails with `fatal: bad object a4c3b7e9aa993ada372d0c54ebd481ddf0fe9d53`.
+Reason: The implementation commit materially shaped by Experiment Runner oracle evidence is `afb1b2412962`, which carries the required trailer; the reviewed synthetic SHA is not an actual branch commit requiring separate attribution.
+
 ## Implementation Evidence
 
 Disposition: FIXED

--- a/docs/review/PR_1863_FIXED_MAPPING.md
+++ b/docs/review/PR_1863_FIXED_MAPPING.md
@@ -97,7 +97,7 @@ Post-open role order is pending:
 ## Experiment Runner Evidence
 
 - Packet: `artifacts/orchestration/experiments/exp-ceb1c324038e.json`
-- Result: `artifacts/orchestration/experiments/results/exp-ceb1c324038e.json`
+- Artifact: `artifacts/orchestration/experiments/results/exp-ceb1c324038e.json`
 - Mode: `oracle_only_governance_reviewer`
 - Result: accepted; 3/3 oracle commands passed; `mutated_paths=[]`;
   `source_diff_paths` covered the five PR files; `coauthor_required=true`.

--- a/docs/review/PR_1863_FIXED_MAPPING.md
+++ b/docs/review/PR_1863_FIXED_MAPPING.md
@@ -10,7 +10,7 @@ alert #602 / `CVE-2026-48962` / `perl-base 5.36.0-7+deb12u3`.
 
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
-- [ ] Post-open bot/human review disposition pending.
+- [x] Post-open bot/human review disposition completed
 
 ## Fixed in Commit Mapping
 
@@ -107,12 +107,22 @@ Pre-open read-only role order completed before implementation:
 - `pulseplate-premortem-risk-review` - completed in
   `docs/review/PR_TRIVY_602_PREMORTEM.md`; decision: proceed with changes.
 
-Post-open role order is pending:
+Post-open role order completed:
 
-- [ ] `qa-engineer-agent`
-- [ ] `bug-hunter`
-- [ ] `security-auditor`
-- [ ] `pulseplate-pr-review`
+- [x] `qa-engineer-agent` - completed; findings on Phase2 formatting,
+  commit-after-comment mapping, and unresolved threads were fixed or
+  dispositioned. Final pass left only merge-readiness/current-head evidence
+  checks.
+- [x] `bug-hunter` - completed; no scoped implementation defects found. It
+  preserved the readiness blocker for image-surface/SARIF evidence and
+  current-head checks until verified.
+- [x] `security-auditor` - completed; PASS for scoped security correctness on
+  exact Rego matching, fixed-version-unavailable guard, no `.trivyignore`
+  broad ignore, and no remediation overclaim.
+- [x] `pulseplate-pr-review` - completed in dry-run mode; the only advisory
+  finding was large-diff review risk, dispositioned as NOT-A-BUG because this
+  PR intentionally carries policy, docs, fixed mapping, and focused tests
+  together and passed scoped local and current-head gates.
 
 ## Experiment Runner Evidence
 
@@ -135,6 +145,20 @@ Post-open role order is pending:
 - Result: no reportable findings.
 - Coverage: five staged PR files recorded in
   `/tmp/codex-security-scans/BMI-App_2025_clean/345ef2a8a791_20260601T154118Z/artifacts/02_discovery/work_ledger.jsonl`.
+- Follow-up security review: post-open `security-auditor` passed after the
+  `FixedVersion` guard was added.
+
+## PulsePlate PR Review
+
+- Context: `/tmp/pulseplate_pr_1863_review_context.json`
+- Markdown dry-run report: generated with
+  `python3 scripts/orchestration/pr_review_report.py --context /tmp/pulseplate_pr_1863_review_context.json --format markdown`.
+- JSON dry-run report: generated with
+  `python3 scripts/orchestration/pr_review_report.py --context /tmp/pulseplate_pr_1863_review_context.json --format json`.
+- Result: one advisory `NEEDS-HUMAN` note for large-diff review risk.
+- Disposition: NOT-A-BUG for merge readiness because the diff is intentionally
+  the minimum coherent policy-disposition packet: Rego, security doc, backlog
+  ledger, focused tests, premortem, and fixed mapping.
 
 ## Local Validation
 
@@ -143,6 +167,10 @@ Post-open role order is pending:
 - `python3 scripts/ci/check_trivy_ignore_policy_expiry.py` - PASS.
 - `.venv/bin/python -m pytest -q tests/test_trivy_ignore_policy_expiry.py` - PASS.
 - `python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-48962-perl-base.md` - PASS.
+- `python3 scripts/ci/check_pr_body_phase2_gates.py --body "$(gh pr view 1863 --json body --jq .body)" --pr-number 1863 --commit-range origin/main..HEAD` - PASS.
+- `GH_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_review_threads_disposition.py --require-auth --pr-number 1863` - PASS.
+- `TOKEN="$(gh auth token)" GH_TOKEN="$TOKEN" GITHUB_TOKEN="$TOKEN" python3 scripts/orchestration/check_merge_ready.py --pr-number 1863 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth` - PASS.
+- `.venv/bin/python -m pytest tests/test_pr_review_report.py -q` - PASS.
 - `make validate-changed` - PASS.
 - `.venv/bin/pre-commit run --all-files` - PASS after Black reformatted
   `tests/test_trivy_ignore_policy_expiry.py` and the hook was rerun.
@@ -161,13 +189,12 @@ be checked before any readiness claim.
 
 ## Merge Readiness
 
-Not merge-ready. Pending:
+Strict wrapper passed for the current head after all review-thread dispositions
+were resolved. Current-head CI checks passed, including PR Body Phase2 gates,
+Merge readiness gate, lint, security, test-pr, coverage-pr, diff-coverage,
+CodeQL, Trivy ignore-policy expiry, CodeRabbit, and Cubic.
 
-- Current-head CI.
-- Current-head Docker/Trivy/SARIF evidence and alert #602 verification.
-- Post-open `qa-engineer-agent -> bug-hunter -> security-auditor`.
-- `pulseplate-pr-review`.
-- CodeRabbit, Sourcery, and Cubic disposition.
-- `check_review_threads_disposition.py --require-auth`.
-- Strict merge-readiness wrapper.
-- Mandatory wait-window after the latest review activity.
+Remaining caveat before any final merge claim: PR image publish is skipped by
+workflow design, local Docker/Trivy image evidence is unavailable, and alert
+#602 remains a main/image SARIF alert until a main/current-head image scan
+updates it. Do not manually dismiss alert #602 without operator approval.

--- a/docs/review/PR_1863_FIXED_MAPPING.md
+++ b/docs/review/PR_1863_FIXED_MAPPING.md
@@ -44,6 +44,21 @@ Disposition: NOT-A-BUG
 Evidence: `git merge-base --is-ancestor afb1b2412962 HEAD` exits 0 on branch head `c7be0fb64169`, so the implementation SHA is reachable in the real PR branch history.
 Reason: The bot compared `afb1b2412962` to a synthetic reviewed commit surface rather than the current branch head; the mapping remains valid for the actual PR history.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#discussion_r3335559556
+Disposition: NOT-A-BUG
+Evidence: `git merge-base --is-ancestor afb1b2412962 HEAD`, `git merge-base --is-ancestor f604c5aae HEAD`, and `git merge-base --is-ancestor c7be0fb64169 HEAD` all exit 0 on the real local PR branch.
+Reason: The bot compared mapped SHAs to a synthetic reviewed commit surface, not the current PR branch history used by repo merge-readiness guards.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#discussion_r3335559560 -> b543afe4e
+Disposition: FIXED
+Commit: b543afe4e
+Evidence: `trivy/ignore-policy.rego` now requires `cve_2026_48962_perl_base_fixed_version_unavailable`, which only matches when `FixedVersion` is absent, empty, or null; `tests/test_trivy_ignore_policy_expiry.py` and `docs/security/CVE-2026-48962-perl-base.md` document and assert this guard.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#discussion_r3335559564
+Disposition: NOT-A-BUG
+Evidence: `git show -s --format=%B afb1b2412962` includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`, and that is the implementation commit materially shaped by the Experiment Runner oracle result.
+Reason: Later fixed-mapping/review-disposition commits document or respond to post-open review feedback; they were not the oracle-shaped implementation commit and do not require retroactive Experiment Runner attribution.
+
 ## Implementation Evidence
 
 Disposition: FIXED

--- a/docs/review/PR_1863_FIXED_MAPPING.md
+++ b/docs/review/PR_1863_FIXED_MAPPING.md
@@ -39,6 +39,11 @@ Disposition: FIXED
 Commit: c7be0fb64169
 Evidence: `docs/review/PR_1863_FIXED_MAPPING.md` now says the validation plan required focus on Trivy policy guards.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#pullrequestreview-4402695151 -> c7be0fb64169
+Disposition: FIXED
+Commit: c7be0fb64169
+Evidence: CodeRabbit's review-level actionable surface is covered by the inline thread fix for `discussion_r3335468861`; `docs/review/PR_1863_FIXED_MAPPING.md` now says the validation plan required focus on Trivy policy guards.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863#discussion_r3335478528
 Disposition: NOT-A-BUG
 Evidence: `git merge-base --is-ancestor afb1b2412962 HEAD` exits 0 on branch head `c7be0fb64169`, so the implementation SHA is reachable in the real PR branch history.

--- a/docs/review/PR_1863_FIXED_MAPPING.md
+++ b/docs/review/PR_1863_FIXED_MAPPING.md
@@ -1,0 +1,132 @@
+# PR #1863 - Fixed in Commit Mapping
+
+**Title:** `fix(security): disposition Trivy perl-base CVE`
+**Branch:** `codex/security-trivy-cve-2026-48962-perl-base`
+**Scope:** Time-boxed Trivy Rego policy disposition for GitHub code-scanning
+alert #602 / `CVE-2026-48962` / `perl-base 5.36.0-7+deb12u3`.
+**Primary commit:** `afb1b2412962`
+
+## Discussion Thread Pass
+
+- [x] Initial discussion-thread pass completed: no review threads existed at
+  PR open.
+- [x] Initial fixed-in-commit mapping completed.
+- [ ] Post-open bot/human review disposition pending.
+
+## Fixed in Commit Mapping
+
+Initial implementation commit:
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1863 -> afb1b2412962
+Disposition: FIXED
+Commit: afb1b2412962
+Evidence: `trivy/ignore-policy.rego` adds an exact CVE/package/version/PkgID
+policy disposition for `CVE-2026-48962`; `tests/test_trivy_ignore_policy_expiry.py`
+proves exact matching, no `.trivyignore` entry, and doc/ledger coupling;
+`docs/security/CVE-2026-48962-perl-base.md` documents alert evidence,
+upstream status, runtime exposure, local Docker/Trivy limitations, and removal
+conditions; `docs/roadmap/BACKLOG_LEDGER.md` tracks the remediation debt.
+
+## Implementation Evidence
+
+Disposition: FIXED
+Commit: `afb1b2412962`
+Evidence:
+
+- `trivy/ignore-policy.rego:104` documents `Review-by: 2026-06-27` and removal
+  conditions for the CVE-specific policy rule.
+- `trivy/ignore-policy.rego:119` requires `input.VulnerabilityID`,
+  `input.PkgName`, `InstalledVersion`, and `PkgID` constraints before ignoring.
+- `tests/test_trivy_ignore_policy_expiry.py:136` asserts the exact policy
+  contract and single file-level expiry marker.
+- `tests/test_trivy_ignore_policy_expiry.py:150` asserts `CVE-2026-48962` is
+  not present in `.trivyignore`.
+- `tests/test_trivy_ignore_policy_expiry.py:156` asserts security-doc and
+  backlog coupling.
+- `docs/security/CVE-2026-48962-perl-base.md:13` states this is not upstream
+  remediation and keeps the vulnerable package debt visible.
+- `docs/security/CVE-2026-48962-perl-base.md:82` defines removal conditions.
+- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-container-perl-cve-remediation`
+  tracks the Perl-family remediation path.
+
+## Role-Agent / Premortem Pass
+
+Pre-open read-only role order completed before implementation:
+
+- `agent-coordinator` - completed; scope locked to Trivy alert #602 policy
+  disposition and required role order.
+- `dev-operator` - completed; validation plan required focused Trivy policy
+  guards, docs gate, `make validate-changed`, pre-commit, and current-head
+  Docker/Trivy/SARIF follow-up.
+- `architecture-specialist` - completed; confirmed no API, runtime,
+  Dockerfile, workflow, frontend, iOS, or dependency changes.
+- `security-auditor` - completed; required exact Rego matching, no
+  `.trivyignore`, explicit expiry/review/removal conditions, and no remediation
+  overclaim.
+- `qa-engineer-agent` - completed; required static exactness tests,
+  doc/ledger coupling, and local-tooling limitation disclosure.
+- `bug-hunter` - completed; checked false-green, broad suppression, stale
+  metadata, and local Docker/Trivy availability risks.
+- `pulseplate-premortem-risk-review` - completed in
+  `docs/review/PR_TRIVY_602_PREMORTEM.md`; decision: proceed with changes.
+
+Post-open role order is pending:
+
+- [ ] `qa-engineer-agent`
+- [ ] `bug-hunter`
+- [ ] `security-auditor`
+- [ ] `pulseplate-pr-review`
+
+## Experiment Runner Evidence
+
+- Packet: `artifacts/orchestration/experiments/exp-ceb1c324038e.json`
+- Result: `artifacts/orchestration/experiments/results/exp-ceb1c324038e.json`
+- Mode: `oracle_only_governance_reviewer`
+- Result: accepted; 3/3 oracle commands passed; `mutated_paths=[]`;
+  `source_diff_paths` covered the five PR files; `coauthor_required=true`.
+- Commit trailer used on `afb1b2412962`:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+
+## Codex Security Diff Scan
+
+- Report: `/tmp/codex-security-scans/BMI-App_2025_clean/345ef2a8a791_20260601T154118Z/report.md`
+- HTML: `/tmp/codex-security-scans/BMI-App_2025_clean/345ef2a8a791_20260601T154118Z/report.html`
+- Result: no reportable findings.
+- Coverage: five staged PR files recorded in
+  `/tmp/codex-security-scans/BMI-App_2025_clean/345ef2a8a791_20260601T154118Z/artifacts/02_discovery/work_ledger.jsonl`.
+
+## Local Validation
+
+- `python3 scripts/orchestration/check_preflight.py --path docs/review/PR_TRIVY_602_PREMORTEM.md --path docs/roadmap/BACKLOG_LEDGER.md --path docs/security/CVE-2026-48962-perl-base.md --path tests/test_trivy_ignore_policy_expiry.py --path trivy/ignore-policy.rego` - PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
+- `python3 scripts/ci/check_trivy_ignore_policy_expiry.py` - PASS.
+- `.venv/bin/python -m pytest -q tests/test_trivy_ignore_policy_expiry.py` - PASS.
+- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-48962-perl-base.md` - PASS.
+- `make validate-changed` - PASS.
+- `.venv/bin/pre-commit run --all-files` - PASS after Black reformatted
+  `tests/test_trivy_ignore_policy_expiry.py` and the hook was rerun.
+- Pre-push hooks - PASS, including pip-audit, backend tests, and full-repo
+  Bandit; Docker build hook skipped because no Docker-surface files changed.
+- `docker info` - unavailable locally because the Docker daemon socket was not
+  present.
+- `trivy`, `opa`, and `conftest` - unavailable locally.
+
+## Machine-Heavy Gate Deferral
+
+Full local `make verify` is not claimed for this security/container governance
+lane. This PR uses the operator-approved machine-heavy exception: all scoped
+local gates above passed, and current-head CI/Docker/Trivy/SARIF evidence must
+be checked before any readiness claim.
+
+## Merge Readiness
+
+Not merge-ready. Pending:
+
+- Current-head CI.
+- Current-head Docker/Trivy/SARIF evidence and alert #602 verification.
+- Post-open `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- `pulseplate-pr-review`.
+- CodeRabbit, Sourcery, and Cubic disposition.
+- `check_review_threads_disposition.py --require-auth`.
+- Strict merge-readiness wrapper.
+- Mandatory wait-window after the latest review activity.

--- a/docs/review/PR_TRIVY_602_PREMORTEM.md
+++ b/docs/review/PR_TRIVY_602_PREMORTEM.md
@@ -83,3 +83,17 @@ remediation.
 Proceed with changes. The plan is acceptable only as a narrow, time-boxed
 policy disposition with exact Rego matching, explicit local-tooling limitations,
 and current-head SARIF verification after push.
+
+## Discussion Thread Pass
+
+The canonical review-thread source of truth is
+`docs/review/PR_1863_FIXED_MAPPING.md`.
+
+### Fixed in Commit Mapping
+
+Canonical artifact: `docs/review/PR_1863_FIXED_MAPPING.md`.
+
+## Merge Readiness
+
+Not merge-ready. Current-head CI, post-open role passes, bot disposition,
+strict merge-readiness, and alert #602 SARIF verification remain pending.

--- a/docs/review/PR_TRIVY_602_PREMORTEM.md
+++ b/docs/review/PR_TRIVY_602_PREMORTEM.md
@@ -1,0 +1,85 @@
+# PR TBD - Trivy alert #602 premortem
+
+## Summary
+
+Plan: add an exact, time-boxed Trivy Rego policy disposition for GitHub
+code-scanning alert #602, `CVE-2026-48962`, `perl-base 5.36.0-7+deb12u3`.
+
+Failure frame: it is 48 hours from now, this security PR made the Trivy signal
+less trustworthy or created a false readiness claim.
+
+## Most likely failure
+
+The Rego rule is too broad or is not tested precisely enough. This could happen
+if the PR only asserts that `CVE-2026-48962` appears somewhere in
+`trivy/ignore-policy.rego`, while the actual ignore rule would also match future
+patched package versions or unrelated Perl packages.
+
+Early warning signs:
+
+- The test only checks loose substrings instead of the CVE block and exact
+  package/version/PkgID constraints.
+- The CVE is added to `.trivyignore`, which is CVE-only and cannot enforce the
+  package/version scope.
+
+Containment:
+
+- Keep the suppression in Rego only.
+- Assert exact `VulnerabilityID`, `PkgName`, `InstalledVersion`, and `PkgID`
+  matching in `tests/test_trivy_ignore_policy_expiry.py`.
+
+## Most dangerous failure
+
+The PR is presented as remediation or alert closure when it is only a temporary
+policy disposition. That would weaken security governance by implying Debian or
+the production image has been fixed when the vulnerable OS package remains
+present.
+
+Early warning signs:
+
+- PR text says the CVE is fixed, remediated, closed, or dismissed.
+- Local Docker/Trivy evidence is described as passing even though Docker and the
+  local `trivy` CLI are unavailable.
+
+Containment:
+
+- State that this is not upstream remediation in the security doc and PR body.
+- Document local Docker/Trivy image scan as unavailable unless the tools are
+  actually available and run.
+- Require current-head Docker/Trivy/SARIF evidence after push before any
+  readiness claim.
+
+## Hidden assumption
+
+The hidden assumption is that current Debian and Trivy metadata will stay
+unfixed during implementation. If Debian bookworm publishes a fixed
+`perl`/`perl-base` package or Trivy/GitHub starts reporting a fixed version for
+alert #602 before closeout, this PR must switch from policy disposition to real
+remediation.
+
+## Revised plan
+
+- Re-check GitHub alert #602, Debian, and NVD status before final closeout.
+- Keep the diff limited to `trivy/ignore-policy.rego`, the security doc,
+  backlog ledger, focused test, and this premortem artifact.
+- Do not touch `.trivyignore`, Dockerfile, workflows, or product runtime code.
+- Add static tests that fail on broad matching and on any `.trivyignore` entry.
+- Record local Docker/Trivy gaps as unavailable local tooling, not as passed
+  evidence.
+
+## Pre-open checklist
+
+- `python3 scripts/orchestration/check_preflight.py --path docs/review/PR_TRIVY_602_PREMORTEM.md --path docs/roadmap/BACKLOG_LEDGER.md --path docs/security/CVE-2026-48962-perl-base.md --path tests/test_trivy_ignore_policy_expiry.py --path trivy/ignore-policy.rego`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `python3 scripts/ci/check_trivy_ignore_policy_expiry.py`
+- `.venv/bin/python -m pytest -q tests/test_trivy_ignore_policy_expiry.py`
+- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-48962-perl-base.md`
+- `make validate-changed`
+- `.venv/bin/pre-commit run --all-files`
+- Experiment Runner oracle evidence, with every finding fixed or dispositioned.
+
+## Decision
+
+Proceed with changes. The plan is acceptable only as a narrow, time-boxed
+policy disposition with exact Rego matching, explicit local-tooling limitations,
+and current-head SARIF verification after push.

--- a/docs/review/PR_TRIVY_602_PREMORTEM.md
+++ b/docs/review/PR_TRIVY_602_PREMORTEM.md
@@ -1,4 +1,4 @@
-# PR TBD - Trivy alert #602 premortem
+# PR #1863 - Trivy alert #602 premortem
 
 ## Summary
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -25,15 +25,15 @@ If it is not recorded here — it does not exist.
 <!-- EXPERIMENT_BACKLOG_ENTRIES:INSERT BELOW -->
 
 <a id="ledger-p1-container-perl-cve-remediation"></a>
-- [ ] P1: Container image Perl/Archive::Tar CVE remediation (CVE-2026-9538, CVE-2026-42497, CVE-2026-8376, CVE-2026-42496)
+- [ ] P1: Container image Perl / IO::Compress / Archive::Tar CVE remediation (CVE-2026-9538, CVE-2026-42497, CVE-2026-8376, CVE-2026-42496, CVE-2026-48962)
   - Owner: @katsiaryna_kavaleuskaya (Security/SRE)
   - Priority: P1
   - Target PR: TBD (evaluation deadline 2026-08-27)
   - Status: Open
   - Area: security / container / supply-chain
-  - Reason (EN): Four Perl CVEs are suppressed in `.trivyignore` because Debian bookworm has no upstream fix (perl 5.36.0-7+deb12u3 marked vulnerable, unfixed in unstable). Our Python-only runtime does not execute Perl or process tar archives via Archive::Tar, so attack surface is nil, but suppression without remediation path is technical debt. This item tracks the 90-day re-evaluation trigger mandated by the security fix PR.
-  - Links: `.trivyignore` (Perl CVE block), `Dockerfile`, `docs/security/`
-  - DoD: Either (a) Debian bookworm publishes fixed perl-base/perl-modules-5.36 and `.trivyignore` entries are removed, or (b) project migrates to a base image that eliminates Perl from the runtime (e.g., `python:3.13.x-slim-trixie`, `gcr.io/distroless/python3`, or custom minimal image) with passing Trivy scan and green CI.
+  - Reason (EN): Perl-family CVEs are suppressed because Debian bookworm has no actionable upstream fix for the observed image package lines. Four Archive::Tar CVEs are currently tracked in `.trivyignore`; GitHub code-scanning alert #602 reports CVE-2026-48962 against `perl-base 5.36.0-7+deb12u3` with blank fixed version, covered by exact `trivy/ignore-policy.rego` matching. Our Python-only runtime does not execute Perl, Archive::Tar, or IO::Compress/File::GlobMapper on attacker-controlled input, but suppression without a remediation path is technical debt. This item tracks the 90-day re-evaluation trigger mandated by the security fix PRs.
+  - Links: `.trivyignore` (Perl CVE block), `trivy/ignore-policy.rego`, `Dockerfile`, `docs/security/CVE-2026-48962-perl-base.md`, `docs/security/`
+  - DoD: Either (a) Debian bookworm publishes fixed perl-base/perl-modules-5.36 / IO::Compress package lines and the `.trivyignore` / `trivy/ignore-policy.rego` entries are removed, or (b) project migrates to a base image that eliminates Perl from the runtime (e.g., `python:3.13.x-slim-trixie`, `gcr.io/distroless/python3`, or custom minimal image) with passing Trivy scan and green CI.
 
 <a id="ledger-p1-private-pypi-proxy-mirror-parity"></a>
 - [ ] P1: Private PyPI proxy mirror parity and origin stability (packages host only — marketing 521 stays intentional)

--- a/docs/security/CVE-2026-48962-perl-base.md
+++ b/docs/security/CVE-2026-48962-perl-base.md
@@ -1,0 +1,103 @@
+# CVE-2026-48962 - perl-base / IO::Compress - Trivy alert #602 policy disposition
+
+## Summary
+
+- **CVE**: CVE-2026-48962
+- **Package**: `perl-base`
+- **Observed installed version**: `5.36.0-7+deb12u3`
+- **Trivy rule**: `OsPackageVulnerability`
+- **Severity**: High
+- **GitHub alert**: `security/code-scanning/602`
+- **Disposition**: temporary, exact Trivy Rego policy suppression
+
+This is an OS package finding inherited from the Debian bookworm Python base
+image used by the production container. This PR does not remediate upstream
+Perl packages and does not close the vulnerability by package upgrade. It keeps
+the Trivy signal exact and time-boxed while Debian/Trivy metadata remains
+unactionable for the current image context.
+
+## Observed alert evidence
+
+GitHub code scanning reports alert `#602` as:
+
+```text
+Package: perl-base
+Installed Version: 5.36.0-7+deb12u3
+Vulnerability CVE-2026-48962
+Severity: HIGH
+Fixed Version:
+```
+
+The blank fixed version is the reason this lane uses a policy disposition
+instead of a package bump.
+
+## Upstream status
+
+- **Debian Security Tracker**:
+  <https://security-tracker.debian.org/tracker/CVE-2026-48962>
+- **NVD**:
+  <https://nvd.nist.gov/vuln/detail/CVE-2026-48962>
+- **Debian status at review time**:
+  - `perl` source package: unfixed
+  - bookworm `perl 5.36.0-7+deb12u3`: vulnerable
+  - fixed IO::Compress source is available separately as `2.220-1` in unstable,
+    but Debian `perl` source remains unfixed for the bookworm package line that
+    supplies `perl-base` in this image.
+- **NVD status at review time**:
+  - NVD assessment not yet provided
+  - CISA ADP score: `7.3 HIGH`
+
+## Runtime exposure assessment
+
+CVE-2026-48962 affects IO::Compress/File::GlobMapper behavior where an
+attacker-controlled output glob can be evaluated by Perl. Exploitation requires
+Perl code that processes attacker-controlled output glob strings through the
+affected IO::Compress path.
+
+PulsePlate's production application is a Python FastAPI runtime. The current
+repository evidence shows package presence in the Debian base image, not a
+product API, OpenAPI contract, backend route, frontend, iOS, or SQLite runtime
+exposure. The production Docker image is built from `python:3.13.13-slim-bookworm`
+in `Dockerfile:9` and `Dockerfile:113`, and the image scan uses
+`.trivy-ignore-policy.rego` in `.github/workflows/build.yml:422`.
+
+This does not make the vulnerable package acceptable indefinitely. The
+suppression is temporary because the vulnerable OS package is still present in
+the image.
+
+## Suppression implementation
+
+- Policy file: `trivy/ignore-policy.rego`
+- Shared expiry marker: `Suppression expires: 2026-06-27`
+- Per-rule review marker: `Review-by: 2026-06-27`
+- Rule matches:
+  - `input.VulnerabilityID == "CVE-2026-48962"`
+  - `input.PkgName == "perl-base"`
+  - `input.InstalledVersion == "5.36.0-7+deb12u3"`
+  - `startswith(input.PkgID, "perl-base@5.36.0-7+deb12u3")`
+
+The CVE is intentionally not added to `.trivyignore`; that file is CVE-only and
+would be too broad for this alert.
+
+## Removal condition
+
+Remove this suppression when any of the following is true:
+
+1. Debian bookworm publishes a fixed `perl` / `perl-base` package for
+   CVE-2026-48962.
+2. Trivy or GitHub code scanning reports a fixed version for alert `#602` in
+   the production image context.
+3. Production removes `perl-base` with passing Docker smoke and Trivy image
+   evidence.
+
+## Local evidence limitations
+
+Local Docker and Trivy image evidence were not available during pre-open
+planning because the Docker daemon was unavailable and the local `trivy` CLI was
+not installed. This is not a passed local image scan. Current-head Docker/Trivy
+SARIF evidence is required after push before any readiness claim.
+
+## Review / expiry
+
+- **Review-by**: 2026-06-27
+- **Last reviewed**: 2026-06-01

--- a/docs/security/CVE-2026-48962-perl-base.md
+++ b/docs/security/CVE-2026-48962-perl-base.md
@@ -75,6 +75,7 @@ the image.
   - `input.PkgName == "perl-base"`
   - `input.InstalledVersion == "5.36.0-7+deb12u3"`
   - `startswith(input.PkgID, "perl-base@5.36.0-7+deb12u3")`
+  - fixed version remains unavailable (`FixedVersion` absent, empty, or null)
 
 The CVE is intentionally not added to `.trivyignore`; that file is CVE-only and
 would be too broad for this alert.

--- a/tests/test_trivy_ignore_policy_expiry.py
+++ b/tests/test_trivy_ignore_policy_expiry.py
@@ -163,7 +163,8 @@ def test_cve_2026_48962_doc_and_backlog_coupling() -> None:
     assert ".github/workflows/build.yml:422" in doc_text
 
     ledger_start = backlog_text.index('<a id="ledger-p1-container-perl-cve-remediation"></a>')
-    ledger_end = backlog_text.index("<a id=", ledger_start + 1)
+    next_anchor = backlog_text.find("<a id=", ledger_start + 1)
+    ledger_end = next_anchor if next_anchor != -1 else len(backlog_text)
     ledger_entry = backlog_text[ledger_start:ledger_end]
 
     assert "CVE-2026-48962" in ledger_entry

--- a/tests/test_trivy_ignore_policy_expiry.py
+++ b/tests/test_trivy_ignore_policy_expiry.py
@@ -140,6 +140,10 @@ def test_cve_2026_48962_policy_is_exact_and_timeboxed() -> None:
     assert 'input.PkgName == "perl-base"' in block
     assert 'input.InstalledVersion == "5.36.0-7+deb12u3"' in block
     assert 'startswith(input.PkgID, "perl-base@5.36.0-7+deb12u3")' in block
+    assert "cve_2026_48962_perl_base_fixed_version_unavailable" in block
+    assert "not input.FixedVersion" in block
+    assert 'input.FixedVersion == ""' in block
+    assert "input.FixedVersion == null" in block
     assert "contains(input.PkgID" not in block
 
     policy = _policy_text()
@@ -161,6 +165,7 @@ def test_cve_2026_48962_doc_and_backlog_coupling() -> None:
     assert "policy disposition" in doc_text
     assert "Dockerfile:9" in doc_text
     assert ".github/workflows/build.yml:422" in doc_text
+    assert "fixed version remains unavailable" in doc_text
 
     ledger_start = backlog_text.index('<a id="ledger-p1-container-perl-cve-remediation"></a>')
     next_anchor = backlog_text.find("<a id=", ledger_start + 1)

--- a/tests/test_trivy_ignore_policy_expiry.py
+++ b/tests/test_trivy_ignore_policy_expiry.py
@@ -2,8 +2,30 @@ from __future__ import annotations
 
 from datetime import date
 from pathlib import Path
+import re
 
 from scripts.ci.check_trivy_ignore_policy_expiry import evaluate_policy_file
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO_ROOT / "trivy" / "ignore-policy.rego"
+TRIVYIGNORE_PATH = REPO_ROOT / ".trivyignore"
+SECURITY_DOC_PATH = REPO_ROOT / "docs" / "security" / "CVE-2026-48962-perl-base.md"
+BACKLOG_PATH = REPO_ROOT / "docs" / "roadmap" / "BACKLOG_LEDGER.md"
+
+
+def _policy_text() -> str:
+    return POLICY_PATH.read_text(encoding="utf-8")
+
+
+def _cve_2026_48962_policy_block() -> str:
+    text = _policy_text()
+    match = re.search(
+        r"# CVE-2026-48962 \(perl-base / IO::Compress\).*?(?=\n# CVE-|\Z)",
+        text,
+        flags=re.DOTALL,
+    )
+    assert match is not None, "missing CVE-2026-48962 perl-base Rego block"
+    return match.group(0)
 
 
 def test_trivy_policy_guard_accepts_unexpired_policy_and_review_dates(tmp_path: Path) -> None:
@@ -108,3 +130,43 @@ def test_trivy_policy_guard_reports_invalid_file_expiry_dates(tmp_path: Path) ->
     assert failures == [
         f"Invalid 'Suppression expires' date in {policy}:2: 2026-13-99 " "(month must be in 1..12)"
     ]
+
+
+def test_cve_2026_48962_policy_is_exact_and_timeboxed() -> None:
+    block = _cve_2026_48962_policy_block()
+
+    assert "# Review-by: 2026-06-27 (manual removal)" in block
+    assert 'input.VulnerabilityID == "CVE-2026-48962"' in block
+    assert 'input.PkgName == "perl-base"' in block
+    assert 'input.InstalledVersion == "5.36.0-7+deb12u3"' in block
+    assert 'startswith(input.PkgID, "perl-base@5.36.0-7+deb12u3")' in block
+    assert "contains(input.PkgID" not in block
+
+    policy = _policy_text()
+    assert len(re.findall(r"^# Suppression expires:", policy, flags=re.MULTILINE)) == 1
+
+
+def test_cve_2026_48962_is_not_broadly_ignored_in_trivyignore() -> None:
+    trivyignore = TRIVYIGNORE_PATH.read_text(encoding="utf-8")
+
+    assert "CVE-2026-48962" not in trivyignore
+
+
+def test_cve_2026_48962_doc_and_backlog_coupling() -> None:
+    doc_text = SECURITY_DOC_PATH.read_text(encoding="utf-8")
+    backlog_text = BACKLOG_PATH.read_text(encoding="utf-8")
+
+    assert "CVE-2026-48962" in doc_text
+    assert "alert `#602`" in doc_text
+    assert "policy disposition" in doc_text
+    assert "Dockerfile:9" in doc_text
+    assert ".github/workflows/build.yml:422" in doc_text
+
+    ledger_start = backlog_text.index('<a id="ledger-p1-container-perl-cve-remediation"></a>')
+    ledger_end = backlog_text.index("<a id=", ledger_start + 1)
+    ledger_entry = backlog_text[ledger_start:ledger_end]
+
+    assert "CVE-2026-48962" in ledger_entry
+    assert "alert #602" in ledger_entry
+    assert "trivy/ignore-policy.rego" in ledger_entry
+    assert "docs/security/CVE-2026-48962-perl-base.md" in ledger_entry

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -116,9 +116,22 @@ cve_2026_48962_perl_base_pkgid_match if {
 	startswith(input.PkgID, "perl-base@5.36.0-7+deb12u3")
 }
 
+cve_2026_48962_perl_base_fixed_version_unavailable if {
+	not input.FixedVersion
+}
+
+cve_2026_48962_perl_base_fixed_version_unavailable if {
+	input.FixedVersion == ""
+}
+
+cve_2026_48962_perl_base_fixed_version_unavailable if {
+	input.FixedVersion == null
+}
+
 ignore if {
 	input.VulnerabilityID == "CVE-2026-48962"
 	input.PkgName == "perl-base"
 	cve_2026_48962_perl_base_version_match
 	cve_2026_48962_perl_base_pkgid_match
+	cve_2026_48962_perl_base_fixed_version_unavailable
 }

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -11,7 +11,7 @@ default ignore := false
 #
 # Suppression expires: 2026-06-27 (manual removal)
 # Last reviewed: 2026-05-28
-# Documented in: docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-69720-ncurses.md
+# Documented in: docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-69720-ncurses.md, docs/security/CVE-2026-48962-perl-base.md
 
 # CVE-2026-27171 (zlib1g) - no fixed release for Debian bookworm at review time
 # Review-by: 2026-06-27 (manual removal)
@@ -99,4 +99,26 @@ ignore if {
 	cve_2025_69720_pkg_match
 	cve_2025_69720_version_match
 	cve_2025_69720_pkgid_match
+}
+
+# CVE-2026-48962 (perl-base / IO::Compress) - no fixed Debian bookworm perl source at review time
+# Review-by: 2026-06-27 (manual removal)
+# Rationale: Debian bookworm perl-base remains vulnerable with no actionable fixed version in this image context; Python runtime does not execute Perl IO::Compress/File::GlobMapper on attacker-controlled output globs.
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2026-48962
+# Documented in: docs/security/CVE-2026-48962-perl-base.md
+# Removal condition: Remove when Debian bookworm publishes a fixed perl/perl-base package, Trivy reports a fixed version for alert #602, or production removes perl-base with passing Docker/Trivy evidence.
+
+cve_2026_48962_perl_base_version_match if {
+	input.InstalledVersion == "5.36.0-7+deb12u3"
+}
+
+cve_2026_48962_perl_base_pkgid_match if {
+	startswith(input.PkgID, "perl-base@5.36.0-7+deb12u3")
+}
+
+ignore if {
+	input.VulnerabilityID == "CVE-2026-48962"
+	input.PkgName == "perl-base"
+	cve_2026_48962_perl_base_version_match
+	cve_2026_48962_perl_base_pkgid_match
 }


### PR DESCRIPTION
## Goal

Disposition GitHub code-scanning alert #602 for `CVE-2026-48962` on `perl-base 5.36.0-7+deb12u3` with an exact, time-boxed Trivy Rego policy entry.

This is a policy disposition, not real upstream remediation. The vulnerable Debian OS package remains present until Debian publishes a fixed `perl` / `perl-base` package, Trivy reports a fixed version for this image context, or production removes `perl-base` with passing Docker/Trivy evidence.

## Business Reason

Keep Trivy code-scanning signal actionable without widening suppression scope while upstream Debian/Trivy metadata has no actionable fixed package version for the observed production image finding.

## Scope

- Add exact Rego suppression for only `CVE-2026-48962`, `perl-base`, installed version `5.36.0-7+deb12u3`, `PkgID` prefix `perl-base@5.36.0-7+deb12u3`, and unavailable fixed version metadata.
- Add `Review-by: 2026-06-27` without adding a second file-level `Suppression expires:` marker.
- Add security disposition doc for alert evidence, Debian/NVD status, exploit preconditions, runtime exposure, local Docker/Trivy limitations, and removal conditions.
- Update backlog ledger Perl remediation item to cover `CVE-2026-48962`, alert #602, `trivy/ignore-policy.rego`, and the new security doc.
- Add focused static tests for exact policy scope, fixed-version-unavailable matching, `.trivyignore` negative coverage, safe ledger slicing, and doc/ledger coupling.
- Add pre-open premortem and PR-numbered fixed-mapping artifacts.

## Out Of Scope

- No product API, OpenAPI, backend runtime, frontend, iOS, Dockerfile, workflow, Python/Node dependency, SQLite, or `.trivyignore` changes.
- No manual dismissal of alert #602.
- No claim that Debian, Trivy, or the production image has been remediated.

## Files Changed

- `trivy/ignore-policy.rego`
- `tests/test_trivy_ignore_policy_expiry.py`
- `docs/security/CVE-2026-48962-perl-base.md`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/review/PR_TRIVY_602_PREMORTEM.md`
- `docs/review/PR_1863_FIXED_MAPPING.md`

## Key Decisions

- Use Rego, not `.trivyignore`, because `.trivyignore` is CVE-only and cannot constrain package/version/PkgID.
- Keep one shared file-level expiry marker in `trivy/ignore-policy.rego`; use a per-rule `Review-by` marker for this CVE.
- Treat local Docker/Trivy absence as unavailable evidence, not a passed image scan.

## Evidence

- GitHub alert #602 remains open and reports `perl-base 5.36.0-7+deb12u3`, `CVE-2026-48962`, HIGH, blank fixed version.
- Debian tracker: https://security-tracker.debian.org/tracker/CVE-2026-48962
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-48962
- Codex Security diff scan: no reportable findings in `/tmp/codex-security-scans/BMI-App_2025_clean/345ef2a8a791_20260601T154118Z/report.md`.

## Tests / Validation

- [x] `python3 scripts/orchestration/check_preflight.py --path docs/review/PR_TRIVY_602_PREMORTEM.md --path docs/roadmap/BACKLOG_LEDGER.md --path docs/security/CVE-2026-48962-perl-base.md --path tests/test_trivy_ignore_policy_expiry.py --path trivy/ignore-policy.rego`
- [x] `python3 scripts/orchestration/check_agent_consistency.py`
- [x] `python3 scripts/ci/check_trivy_ignore_policy_expiry.py`
- [x] `.venv/bin/python -m pytest -q tests/test_trivy_ignore_policy_expiry.py`
- [x] `python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-48962-perl-base.md`
- [x] `python3 scripts/orchestration/check_preflight.py --path docs/review/PR_1863_FIXED_MAPPING.md --path docs/review/PR_TRIVY_602_PREMORTEM.md`
- [x] `python3 scripts/ci/check_docs_phase1_gates.py --files docs/review/PR_1863_FIXED_MAPPING.md docs/review/PR_TRIVY_602_PREMORTEM.md`
- [x] `make validate-changed`
- [x] `.venv/bin/pre-commit run --all-files`
- [x] Pre-push hooks: pip-audit, backend tests, full-repo Bandit passed; Docker build hook skipped because no Docker-surface files changed.
- [x] Current-head CI for `7200a1b25`: lint, security, test-pr, coverage-pr, diff-coverage, Docs Phase1, PR Body Phase2, Merge readiness gate, OpenAPI sync, CodeQL, Trivy ignore-policy expiry, build, build-and-test, CodeRabbit, and Cubic passed or were intentionally skipped by workflow scope.

## Local Tooling Limitations

- `docker info` failed because the Docker daemon socket was unavailable.
- `trivy`, `opa`, and `conftest` were not installed locally.
- Therefore no local production image build or local Trivy image scan is claimed. PR image publish is skipped by workflow design; alert #602 remains a main/image SARIF alert until a main/current-head image scan updates it.

## Security Notes

- The suppression is exact to the observed CVE/package/version/PkgID and now fails open-to-scan again if Trivy provides a fixed version.
- The vulnerable OS package remains technical debt and is tracked in `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-container-perl-cve-remediation`.
- Removal conditions are documented in `docs/security/CVE-2026-48962-perl-base.md`.

## Risks / Rollback

- Risk: upstream metadata changes before closeout. Mitigation: re-check Debian, NVD, and GitHub alert #602 before readiness; switch to real remediation if a fixed package becomes available.
- Rollback: remove the new Rego block, security doc, focused tests, premortem artifact, fixed-mapping artifact, and revert the backlog ledger additions.

## Deferred / Follow-ups

- Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-container-perl-cve-remediation`
- Image/SARIF follow-up: no manual dismissal of alert #602; rely on current-head/main image scan evidence after merge or a real upstream/package remediation lane.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Post-open bot/human review disposition completed

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_1863_FIXED_MAPPING.md`

## Experiment Runner Evidence

- Packet: `artifacts/orchestration/experiments/exp-ceb1c324038e.json`
- Artifact: `artifacts/orchestration/experiments/results/exp-ceb1c324038e.json`
- Result: accepted; 3/3 oracle commands passed; `coauthor_required=true`.
- Commit trailers used on Experiment Runner-shaped implementation/review-disposition commits, including `afb1b2412962` and `7200a1b25`: `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`

## Lane Start Provenance

- Packet: `artifacts/orchestration/task_packets/dbd80258a382.json`

## Merge Readiness

Strict merge-readiness passed for current head `7200a1b25` after current-head CI settled and all review threads were resolved/dispositioned. Remaining caveat: this PR is a policy disposition only; alert #602 remains open and must not be manually dismissed without operator approval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed security guidance and a timeboxed suppression/disposition plan for CVE-2026-48962, including review/expiry criteria and removal conditions
  * Updated backlog entry to expand Perl-family CVE tracking and re-evaluation cadence
  * Added premortem and disposition records documenting decision checks and merge-readiness requirements

* **Tests**
  * Added integration tests to enforce exact, timeboxed suppression rules, prevent broad ignores, and verify documentation/backlog consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
