### PR TITLE
fix(ci): isolate main test shard temp dirs

### DIFF
--- a/docs/review/PR_1869_FIXED_MAPPING.md
+++ b/docs/review/PR_1869_FIXED_MAPPING.md
@@ -52,6 +52,11 @@ Disposition: NOT-A-BUG
 Evidence: The connector's reviewed commit `6009f79d84ef0a631e72fc92d502a5134f8c4f3c` is a synthetic review surface with parent `72fb232`, not the live PR branch head. The actual PR branch contains `9cc75668d65b6d0bb01b8c3fa662c47145828774`, `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd`, and the later mapping/review commits as normal branch ancestors, and this artifact intentionally keeps implementation-proof SHAs plus explicit current-head readiness caveats.
 Reason: The comment asks to rewrite fixed-proof commits to a synthetic reviewed/squash SHA, which would be worse evidence for the live PR branch and rollback path.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869#discussion_r3347054078
+Disposition: NOT-A-BUG
+Evidence: On current PR branch head `74defe42b7aabd1c4f10ff74fd226d83f90e95f6`, both `git merge-base --is-ancestor 9cc75668d65b6d0bb01b8c3fa662c47145828774 HEAD` and `git merge-base --is-ancestor f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd HEAD` returned exit code 0. The implementation commits are live branch ancestors and remain the correct rollback/provenance proof for this PR.
+Reason: The connector again evaluated a synthetic reviewed/squash commit surface rather than the live PR branch ancestry used by the local repository and GitHub PR head.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869 -> 9cc75668d65b6d0bb01b8c3fa662c47145828774
 Disposition: FIXED
 Commit: 9cc75668d65b6d0bb01b8c3fa662c47145828774

--- a/docs/review/PR_1869_FIXED_MAPPING.md
+++ b/docs/review/PR_1869_FIXED_MAPPING.md
@@ -6,25 +6,41 @@
 isolation. The PR changes only the main-suite shard runner and its focused
 tests; it does not change Experiment Runner product behavior, workflows,
 coverage policy, JUnit output, shard parallelism, or application runtime code.
-**Primary commit:** `9cc75668d65b6d0bb01b8c3fa662c47145828774`
+**Primary commits:** `d3a9fc53b6fb4f2d3cb4916b8fa3ed8b3e51426b`,
+`f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd`
 
 ## Discussion Thread Pass
 
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
-- [ ] Post-open bot/human review disposition completed
+- [x] Post-open bot/human review disposition completed
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869 -> 9cc75668d65b6d0bb01b8c3fa662c47145828774
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869#discussion_r3346781565 -> cf09dc6a9f1476cafc71482556e909e5c3964ae1
 Disposition: FIXED
-Commit: 9cc75668d65b6d0bb01b8c3fa662c47145828774
-Evidence: `scripts/ci/run_main_test_shards.py` now passes a deterministic external `--basetemp` to each child pytest shard, rejects repo-local configured temp roots, creates the basetemp parent before `pytest.main(...)`, and preserves existing coverage/JUnit behavior; `tests/test_main_test_shards.py` covers external unique basetemps, repo-local temp fallback, child pytest args, and parent creation.
+Commit: cf09dc6a9f1476cafc71482556e909e5c3964ae1
+Evidence: `docs/review/PR_1869_FIXED_MAPPING.md` replaces the PR-level-only fixed mapping with per-review-thread entries, including this CodeRabbit thread URL, disposition, post-comment commit SHA proof, and evidence text.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869#discussion_r3346782834 -> cf09dc6a9f1476cafc71482556e909e5c3964ae1
+Disposition: FIXED
+Commit: cf09dc6a9f1476cafc71482556e909e5c3964ae1
+Evidence: `docs/review/PR_1869_FIXED_MAPPING.md` now records the final branch commit `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd` for the bug-hunter final-path collision fix and keeps implementation evidence tied to branch commits rather than a synthetic reviewed commit surface.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869 -> d3a9fc53b6fb4f2d3cb4916b8fa3ed8b3e51426b
+Disposition: FIXED
+Commit: d3a9fc53b6fb4f2d3cb4916b8fa3ed8b3e51426b
+Evidence: Initial implementation passed a deterministic external `--basetemp` to each child pytest shard, rejected repo-local configured temp roots, created the basetemp parent before `pytest.main(...)`, and preserved existing coverage/JUnit behavior; focused tests covered external unique basetemps, repo-local temp fallback, child pytest args, and parent creation.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869 -> f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd
+Disposition: FIXED
+Commit: f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd
+Evidence: `scripts/ci/run_main_test_shards.py` now rechecks the final computed basetemp path after appending the PulsePlate shard container and falls back to `pulseplate-main-test-shards-external` if the primary final path would land inside the checkout; `tests/test_main_test_shards.py` adds a regression for a checkout named like the primary temp container.
 
 ## Implementation Evidence
 
 Disposition: FIXED
-Commit: `9cc75668d65b6d0bb01b8c3fa662c47145828774`
+Commit: `d3a9fc53b6fb4f2d3cb4916b8fa3ed8b3e51426b`
 Evidence:
 
 - `scripts/ci/run_main_test_shards.py` adds `external_temp_root(...)` to keep
@@ -38,6 +54,18 @@ Evidence:
 - Existing `TestShard.coverage_file`, `TestShard.junit_file`,
   `build_shard_env(...)`, coverage combine/report, and shard parallelism
   contracts are unchanged.
+
+Disposition: FIXED
+Commit: `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd`
+Evidence:
+
+- `scripts/ci/run_main_test_shards.py` rechecks final basetemp candidates after
+  appending the primary/fallback PulsePlate shard container.
+- `scripts/ci/run_main_test_shards.py` falls back to
+  `pulseplate-main-test-shards-external` when the primary final path would be
+  inside the checkout.
+- `tests/test_main_test_shards.py` covers the final-path collision case where
+  the repository root is itself named `pulseplate-main-test-shards`.
 
 ## Role-Agent / Premortem Pass
 
@@ -55,6 +83,20 @@ Pre-open role order completed from packet
   scope.
 - `security-auditor` - completed; first found and then verified the fix for
   repo-local temp-root risk. Final closure found no actionables.
+
+Post-open role order completed from packet
+`artifacts/orchestration/task_packets/318f23d86dd8.json`:
+
+- `qa-engineer-agent` - completed; found a PR-body file-list omission for the
+  mapping artifact. The live PR body now lists
+  `docs/review/PR_1869_FIXED_MAPPING.md`.
+- `bug-hunter` - completed; found the final-path collision edge case after
+  appending the PulsePlate temp container. Commit
+  `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd` fixed it and the bug-hunter
+  closure pass found no remaining actionables.
+- `security-auditor` - completed; found no additional code security
+  actionables. It required committing/pushing the bug-hunter fix and mapping
+  the CodeRabbit/Codex connector review threads before readiness.
 
 Premortem:
 
@@ -81,7 +123,23 @@ Premortem:
 - `mutated_paths=[]`
 - `shared_tree_untouched=true`
 - `coauthor_required=true`
-- Commit trailer used on `9cc75668d65b6d0bb01b8c3fa662c47145828774`:
+- Commit trailer used on `d3a9fc53b6fb4f2d3cb4916b8fa3ed8b3e51426b`:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+
+- Packet: `artifacts/orchestration/experiments/exp-aa444fd80390.json`
+- Artifact: `artifacts/orchestration/experiments/results/exp-aa444fd80390.json`
+- Mode: `oracle_only_governance_reviewer`
+- Result: accepted.
+- Oracle command:
+  `python3 -m pytest -q tests/test_main_test_shards.py tests/test_experiment_runner.py::test_main_writes_oracle_only_governance_reviewer_artifact`
+- Oracle return code: 0.
+- `source_diff_paths`:
+  - `scripts/ci/run_main_test_shards.py`
+  - `tests/test_main_test_shards.py`
+- `mutated_paths=[]`
+- `shared_tree_untouched=true`
+- `coauthor_required=true`
+- Commit trailer used on `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd`:
   `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
 
 ## Lane Start Provenance
@@ -92,13 +150,16 @@ Premortem:
 
 - `python3 scripts/orchestration/check_preflight.py --path scripts/ci/run_main_test_shards.py --path tests/test_main_test_shards.py` - PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
-- `. .venv/bin/activate && python -m pytest -q tests/test_main_test_shards.py tests/test_experiment_runner.py::test_main_writes_oracle_only_governance_reviewer_artifact` - PASS; 36 tests.
+- `. .venv/bin/activate && python -m pytest -q tests/test_main_test_shards.py tests/test_experiment_runner.py::test_main_writes_oracle_only_governance_reviewer_artifact` - PASS; 37 tests after the final-path collision regression.
 - `. .venv/bin/activate && python -m bandit -q scripts/ci/run_main_test_shards.py` - PASS.
 - `python3 scripts/orchestration/experiment_runner.py --packet artifacts/orchestration/experiments/exp-6c5981dd7108.json --contribution-kind oracle_review --coauthor-required ...` - PASS; result accepted.
 - `pre-commit run --all-files` - PASS.
 - `make validate-changed` after implementation commit - PASS; ran
   `tests/test_main_test_shards.py`.
-- Commit hooks for `9cc75668d65b6d0bb01b8c3fa662c47145828774` - PASS.
+- Commit hooks for `d3a9fc53b6fb4f2d3cb4916b8fa3ed8b3e51426b` - PASS.
+- Commit hooks for `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd` - PASS.
+- `make validate-changed` after `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd` - PASS; ran
+  `tests/test_main_test_shards.py`.
 - Pre-push hooks - PASS, including changed-file mypy, `pip-audit`, backend
   pre-push tests, full-repo Bandit, and docker build test.
 

--- a/docs/review/PR_1869_FIXED_MAPPING.md
+++ b/docs/review/PR_1869_FIXED_MAPPING.md
@@ -17,6 +17,16 @@ coverage policy, JUnit output, shard parallelism, or application runtime code.
 
 ## Fixed in Commit Mapping
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869#pullrequestreview-4416527538 -> 737469a05ba95320806fea291c78a4ea8253814d
+Disposition: FIXED
+Commit: 737469a05ba95320806fea291c78a4ea8253814d
+Evidence: CodeRabbit's review-level actionable summary for the initial mapping artifact review is covered by the per-thread mapping entry for `discussion_r3346781565`, which was added after the review timestamp and records thread URL, disposition, commit proof, and evidence.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869#pullrequestreview-4416643960 -> 3fa7e083049724984bb9d4d58625bb598e8e955c
+Disposition: FIXED
+Commit: 3fa7e083049724984bb9d4d58625bb598e8e955c
+Evidence: `tests/test_main_test_shards.py` now computes the external shard basetemp before `run_shard_child(...)`, keeps the child arg and parent-directory assertions inside the guarded block, and removes the external repo-key temp directory with `shutil.rmtree(..., ignore_errors=True)` in `finally`.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869#discussion_r3346781565 -> 737469a05ba95320806fea291c78a4ea8253814d
 Disposition: FIXED
 Commit: 737469a05ba95320806fea291c78a4ea8253814d

--- a/docs/review/PR_1869_FIXED_MAPPING.md
+++ b/docs/review/PR_1869_FIXED_MAPPING.md
@@ -1,0 +1,139 @@
+# PR #1869 - Fixed in Commit Mapping
+
+**Title:** `fix(ci): isolate main test shard temp dirs`
+**Branch:** `codex/main-ci-py313-shard-temp-isolation`
+**Scope:** CI/tooling hotfix for main `test-main (3.13, 90)` shard temp
+isolation. The PR changes only the main-suite shard runner and its focused
+tests; it does not change Experiment Runner product behavior, workflows,
+coverage policy, JUnit output, shard parallelism, or application runtime code.
+**Primary commit:** `9cc75668d65b6d0bb01b8c3fa662c47145828774`
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [ ] Post-open bot/human review disposition completed
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869 -> 9cc75668d65b6d0bb01b8c3fa662c47145828774
+Disposition: FIXED
+Commit: 9cc75668d65b6d0bb01b8c3fa662c47145828774
+Evidence: `scripts/ci/run_main_test_shards.py` now passes a deterministic external `--basetemp` to each child pytest shard, rejects repo-local configured temp roots, creates the basetemp parent before `pytest.main(...)`, and preserves existing coverage/JUnit behavior; `tests/test_main_test_shards.py` covers external unique basetemps, repo-local temp fallback, child pytest args, and parent creation.
+
+## Implementation Evidence
+
+Disposition: FIXED
+Commit: `9cc75668d65b6d0bb01b8c3fa662c47145828774`
+Evidence:
+
+- `scripts/ci/run_main_test_shards.py` adds `external_temp_root(...)` to keep
+  pytest basetemp roots outside the repository.
+- `scripts/ci/run_main_test_shards.py` adds `shard_basetemp_dir(...)`, keyed by
+  resolved repo-root hash, artifact label, and shard index.
+- `scripts/ci/run_main_test_shards.py` passes `--basetemp` into each child
+  pytest argument list and creates the basetemp parent before `pytest.main(...)`.
+- `tests/test_main_test_shards.py` proves basetemps are deterministic, unique
+  per shard, external to the repo, and still wired into child pytest args.
+- Existing `TestShard.coverage_file`, `TestShard.junit_file`,
+  `build_shard_env(...)`, coverage combine/report, and shard parallelism
+  contracts are unchanged.
+
+## Role-Agent / Premortem Pass
+
+Pre-open role order completed from packet
+`artifacts/orchestration/task_packets/d61404beb69c.json`:
+
+- `agent-coordinator` - completed; approved the narrow two-file CI/tooling
+  scope and required current-head PR CI evidence because the original failure
+  was GitHub-only.
+- `qa-engineer-agent` - completed; defined acceptance criteria for per-shard
+  external `--basetemp`, unchanged coverage/JUnit behavior, unchanged
+  parallelism, and focused regression tests.
+- `bug-hunter` - completed; identified the missing pytest temp isolation as the
+  likely defect and preserved Experiment Runner/product behavior as out of
+  scope.
+- `security-auditor` - completed; first found and then verified the fix for
+  repo-local temp-root risk. Final closure found no actionables.
+
+Premortem:
+
+- Frame: 48 hours from now this hotfix made things worse.
+- Decision: proceed with changes.
+- Finding closed as FIXED: environment-controlled temp roots could point inside
+  the checkout. `external_temp_root(...)` now rejects repo-local configured temp
+  roots and tests cover the fallback.
+- Residual risk: current-head PR CI remains required evidence for the original
+  GitHub-only py313 shard path.
+
+## Experiment Runner Evidence
+
+- Packet: `artifacts/orchestration/experiments/exp-6c5981dd7108.json`
+- Artifact: `artifacts/orchestration/experiments/results/exp-6c5981dd7108.json`
+- Mode: `oracle_only_governance_reviewer`
+- Result: accepted.
+- Oracle command:
+  `python3 -m pytest -q tests/test_main_test_shards.py tests/test_experiment_runner.py::test_main_writes_oracle_only_governance_reviewer_artifact`
+- Oracle return code: 0.
+- `source_diff_paths`:
+  - `scripts/ci/run_main_test_shards.py`
+  - `tests/test_main_test_shards.py`
+- `mutated_paths=[]`
+- `shared_tree_untouched=true`
+- `coauthor_required=true`
+- Commit trailer used on `9cc75668d65b6d0bb01b8c3fa662c47145828774`:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/d61404beb69c.json`
+
+## Local Validation
+
+- `python3 scripts/orchestration/check_preflight.py --path scripts/ci/run_main_test_shards.py --path tests/test_main_test_shards.py` - PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
+- `. .venv/bin/activate && python -m pytest -q tests/test_main_test_shards.py tests/test_experiment_runner.py::test_main_writes_oracle_only_governance_reviewer_artifact` - PASS; 36 tests.
+- `. .venv/bin/activate && python -m bandit -q scripts/ci/run_main_test_shards.py` - PASS.
+- `python3 scripts/orchestration/experiment_runner.py --packet artifacts/orchestration/experiments/exp-6c5981dd7108.json --contribution-kind oracle_review --coauthor-required ...` - PASS; result accepted.
+- `pre-commit run --all-files` - PASS.
+- `make validate-changed` after implementation commit - PASS; ran
+  `tests/test_main_test_shards.py`.
+- Commit hooks for `9cc75668d65b6d0bb01b8c3fa662c47145828774` - PASS.
+- Pre-push hooks - PASS, including changed-file mypy, `pip-audit`, backend
+  pre-push tests, full-repo Bandit, and docker build test.
+
+## Machine-Heavy Local Shard Note
+
+- Attempted:
+  `. .venv/bin/activate && python scripts/ci/run_main_test_shards.py --python-version 3.13 --shard-count 8 --max-parallel 4`
+- First attempt exposed and fixed a real parent-directory issue for the new
+  `--basetemp` path.
+- Final attempt got past basetemp setup and later failed in shard 8 on a
+  separate cross-shard repo-local `worktrees` race:
+  `tests/test_no_bmi_math_outside_core.py::test_no_whtr_formula_outside_core`
+  walked a `worktrees/dirty-origin-main-test-*` path while
+  `tests/test_start_pr_lane.py` ran in concurrent shard 7.
+- Confirming focused command passed:
+  `. .venv/bin/activate && python -m pytest -q tests/test_start_pr_lane.py tests/test_no_bmi_math_outside_core.py`
+  - PASS; 44 tests.
+- This PR does not claim to fix that separate cross-shard `worktrees` race.
+
+## Current CI Status
+
+Current-head PR CI has not completed yet. Do not claim green, ready, done, or
+mergeable until current-head checks, post-open role passes, external bot review
+disposition, and strict merge-readiness gates pass.
+
+## Codex Security Diff Scan
+
+Pending post-open.
+
+## PulsePlate PR Review
+
+Pending post-open.
+
+## Merge Readiness
+
+Not claimed. Green CI alone will not be sufficient; strict merge-readiness,
+review-thread disposition, fixed-mapping completion, and the mandatory wait
+window still apply.

--- a/docs/review/PR_1869_FIXED_MAPPING.md
+++ b/docs/review/PR_1869_FIXED_MAPPING.md
@@ -6,7 +6,7 @@
 isolation. The PR changes only the main-suite shard runner and its focused
 tests; it does not change Experiment Runner product behavior, workflows,
 coverage policy, JUnit output, shard parallelism, or application runtime code.
-**Primary commits:** `d3a9fc53b6fb4f2d3cb4916b8fa3ed8b3e51426b`,
+**Primary commits:** `9cc75668d65b6d0bb01b8c3fa662c47145828774`,
 `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd`
 
 ## Discussion Thread Pass
@@ -17,19 +17,19 @@ coverage policy, JUnit output, shard parallelism, or application runtime code.
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869#discussion_r3346781565 -> cf09dc6a9f1476cafc71482556e909e5c3964ae1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869#discussion_r3346781565 -> 737469a05ba95320806fea291c78a4ea8253814d
 Disposition: FIXED
-Commit: cf09dc6a9f1476cafc71482556e909e5c3964ae1
+Commit: 737469a05ba95320806fea291c78a4ea8253814d
 Evidence: `docs/review/PR_1869_FIXED_MAPPING.md` replaces the PR-level-only fixed mapping with per-review-thread entries, including this CodeRabbit thread URL, disposition, post-comment commit SHA proof, and evidence text.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869#discussion_r3346782834 -> cf09dc6a9f1476cafc71482556e909e5c3964ae1
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869#discussion_r3346782834 -> 737469a05ba95320806fea291c78a4ea8253814d
 Disposition: FIXED
-Commit: cf09dc6a9f1476cafc71482556e909e5c3964ae1
+Commit: 737469a05ba95320806fea291c78a4ea8253814d
 Evidence: `docs/review/PR_1869_FIXED_MAPPING.md` now records the final branch commit `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd` for the bug-hunter final-path collision fix and keeps implementation evidence tied to branch commits rather than a synthetic reviewed commit surface.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869 -> d3a9fc53b6fb4f2d3cb4916b8fa3ed8b3e51426b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869 -> 9cc75668d65b6d0bb01b8c3fa662c47145828774
 Disposition: FIXED
-Commit: d3a9fc53b6fb4f2d3cb4916b8fa3ed8b3e51426b
+Commit: 9cc75668d65b6d0bb01b8c3fa662c47145828774
 Evidence: Initial implementation passed a deterministic external `--basetemp` to each child pytest shard, rejected repo-local configured temp roots, created the basetemp parent before `pytest.main(...)`, and preserved existing coverage/JUnit behavior; focused tests covered external unique basetemps, repo-local temp fallback, child pytest args, and parent creation.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869 -> f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd
@@ -40,7 +40,7 @@ Evidence: `scripts/ci/run_main_test_shards.py` now rechecks the final computed b
 ## Implementation Evidence
 
 Disposition: FIXED
-Commit: `d3a9fc53b6fb4f2d3cb4916b8fa3ed8b3e51426b`
+Commit: `9cc75668d65b6d0bb01b8c3fa662c47145828774`
 Evidence:
 
 - `scripts/ci/run_main_test_shards.py` adds `external_temp_root(...)` to keep
@@ -123,7 +123,7 @@ Premortem:
 - `mutated_paths=[]`
 - `shared_tree_untouched=true`
 - `coauthor_required=true`
-- Commit trailer used on `d3a9fc53b6fb4f2d3cb4916b8fa3ed8b3e51426b`:
+- Commit trailer used on `9cc75668d65b6d0bb01b8c3fa662c47145828774`:
   `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
 
 - Packet: `artifacts/orchestration/experiments/exp-aa444fd80390.json`
@@ -156,7 +156,7 @@ Premortem:
 - `pre-commit run --all-files` - PASS.
 - `make validate-changed` after implementation commit - PASS; ran
   `tests/test_main_test_shards.py`.
-- Commit hooks for `d3a9fc53b6fb4f2d3cb4916b8fa3ed8b3e51426b` - PASS.
+- Commit hooks for `9cc75668d65b6d0bb01b8c3fa662c47145828774` - PASS.
 - Commit hooks for `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd` - PASS.
 - `make validate-changed` after `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd` - PASS; ran
   `tests/test_main_test_shards.py`.

--- a/docs/review/PR_1869_FIXED_MAPPING.md
+++ b/docs/review/PR_1869_FIXED_MAPPING.md
@@ -27,6 +27,11 @@ Disposition: FIXED
 Commit: 3fa7e083049724984bb9d4d58625bb598e8e955c
 Evidence: `tests/test_main_test_shards.py` now computes the external shard basetemp before `run_shard_child(...)`, keeps the child arg and parent-directory assertions inside the guarded block, and removes the external repo-key temp directory with `shutil.rmtree(..., ignore_errors=True)` in `finally`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869#pullrequestreview-4416747737
+Disposition: NOT-A-BUG
+Evidence: The repeated implementation commit SHAs are intentional: the `Fixed in Commit Mapping` block records PR-level fixed proof for the implementation commits, while `Implementation Evidence` records the technical file/test evidence for those same commits. This keeps the canonical artifact auditable for both review-thread disposition and implementation provenance without changing behavior or readiness claims.
+Reason: CodeRabbit classified this as a low-value/nitpick consolidation suggestion, and the current structure matches the repo's fixed-mapping proof requirements for this PR.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869#discussion_r3346781565 -> 737469a05ba95320806fea291c78a4ea8253814d
 Disposition: FIXED
 Commit: 737469a05ba95320806fea291c78a4ea8253814d
@@ -41,6 +46,11 @@ Evidence: `docs/review/PR_1869_FIXED_MAPPING.md` now records the final branch co
 Disposition: NOT-A-BUG
 Evidence: On current PR branch head `03d4903e98dd771d924881be185985a6e6cf7e82`, both `git merge-base --is-ancestor 9cc75668d65b6d0bb01b8c3fa662c47145828774 HEAD` and `git merge-base --is-ancestor f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd HEAD` returned exit code 0; the implementation commits are real branch ancestors, not stale out-of-branch proof, and the PR still does not claim readiness while current-head CI and strict merge-readiness remain pending.
 Reason: The connector comment evaluated a synthetic reviewed/squash commit surface rather than the live PR branch ancestry used by the local repository and GitHub PR head.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869#discussion_r3346970968
+Disposition: NOT-A-BUG
+Evidence: The connector's reviewed commit `6009f79d84ef0a631e72fc92d502a5134f8c4f3c` is a synthetic review surface with parent `72fb232`, not the live PR branch head. The actual PR branch contains `9cc75668d65b6d0bb01b8c3fa662c47145828774`, `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd`, and the later mapping/review commits as normal branch ancestors, and this artifact intentionally keeps implementation-proof SHAs plus explicit current-head readiness caveats.
+Reason: The comment asks to rewrite fixed-proof commits to a synthetic reviewed/squash SHA, which would be worse evidence for the live PR branch and rollback path.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869 -> 9cc75668d65b6d0bb01b8c3fa662c47145828774
 Disposition: FIXED

--- a/docs/review/PR_1869_FIXED_MAPPING.md
+++ b/docs/review/PR_1869_FIXED_MAPPING.md
@@ -27,6 +27,11 @@ Disposition: FIXED
 Commit: 737469a05ba95320806fea291c78a4ea8253814d
 Evidence: `docs/review/PR_1869_FIXED_MAPPING.md` now records the final branch commit `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd` for the bug-hunter final-path collision fix and keeps implementation evidence tied to branch commits rather than a synthetic reviewed commit surface.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869#discussion_r3346884051
+Disposition: NOT-A-BUG
+Evidence: On current PR branch head `03d4903e98dd771d924881be185985a6e6cf7e82`, both `git merge-base --is-ancestor 9cc75668d65b6d0bb01b8c3fa662c47145828774 HEAD` and `git merge-base --is-ancestor f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd HEAD` returned exit code 0; the implementation commits are real branch ancestors, not stale out-of-branch proof, and the PR still does not claim readiness while current-head CI and strict merge-readiness remain pending.
+Reason: The connector comment evaluated a synthetic reviewed/squash commit surface rather than the live PR branch ancestry used by the local repository and GitHub PR head.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1869 -> 9cc75668d65b6d0bb01b8c3fa662c47145828774
 Disposition: FIXED
 Commit: 9cc75668d65b6d0bb01b8c3fa662c47145828774
@@ -95,8 +100,10 @@ Post-open role order completed from packet
   `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd` fixed it and the bug-hunter
   closure pass found no remaining actionables.
 - `security-auditor` - completed; found no additional code security
-  actionables. It required committing/pushing the bug-hunter fix and mapping
-  the CodeRabbit/Codex connector review threads before readiness.
+  actionables. It required committing/pushing the bug-hunter fix, mapping the
+  CodeRabbit/Codex connector review threads, and dispositioning the follow-up
+  synthetic-SHA connector thread as NOT-A-BUG with branch-ancestry evidence
+  before any readiness claim.
 
 Premortem:
 
@@ -187,11 +194,42 @@ disposition, and strict merge-readiness gates pass.
 
 ## Codex Security Diff Scan
 
-Pending post-open.
+- Scan id: `03d4903e98dd_20260603T080909Z`
+- Markdown report:
+  `/tmp/codex-security-scans/BMI-App_2025_clean/03d4903e98dd_20260603T080909Z/report.md`
+- HTML report:
+  `/tmp/codex-security-scans/BMI-App_2025_clean/03d4903e98dd_20260603T080909Z/report.html`
+- Result: no reportable findings.
+- Coverage: 3/3 diff-scoped rows have completion receipts in
+  `artifacts/02_discovery/work_ledger.jsonl` inside the local scan bundle.
+- Discovery rows:
+  - `scripts/ci/run_main_test_shards.py` - `no_candidate`.
+  - `tests/test_main_test_shards.py` - `no_candidate`.
+  - `docs/review/PR_1869_FIXED_MAPPING.md` - `no_candidate`.
+- Validator:
+  `python3 .../codex-security/.../scripts/validate_report_format.py --report-md .../report.md`
+  - PASS.
+- Goal usage: scan goal completed with `tokensUsed=266685` and
+  `timeUsedSeconds=479`.
 
 ## PulsePlate PR Review
 
-Pending post-open.
+- Context:
+  `python3 scripts/orchestration/pr_review_context.py --pr 1869 --output /tmp/pulseplate_pr_review_context_1869.json`
+  - PASS.
+- Markdown dry-run report:
+  `/tmp/pulseplate_pr_review_1869.md`
+- JSON dry-run report:
+  `/tmp/pulseplate_pr_review_1869.json`
+- Finding: one advisory `note` from `bug-hunter` for diff size above the
+  deterministic review-risk threshold (`306` changed lines vs threshold `300`).
+- Disposition: NOT-A-BUG for this CI/tooling hotfix scope. The diff is limited
+  to one runner, its focused tests, and the canonical PR mapping artifact; the
+  PR body and this artifact document the split rationale, current-head CI
+  dependency, and machine-heavy local shard deferral.
+- Gate evidence:
+  `. .venv/bin/activate && python -m pytest tests/test_pr_review_report.py tests/test_pr_review_context.py -q`
+  - PASS; 13 tests.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1869_FIXED_MAPPING.md
+++ b/docs/review/PR_1869_FIXED_MAPPING.md
@@ -177,6 +177,8 @@ Premortem:
 - Commit hooks for `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd` - PASS.
 - `make validate-changed` after `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd` - PASS; ran
   `tests/test_main_test_shards.py`.
+- `. .venv/bin/activate && python -m pytest -q tests/test_main_test_shards.py`
+  after `3fa7e083049724984bb9d4d58625bb598e8e955c` - PASS; 36 tests.
 - Pre-push hooks - PASS, including changed-file mypy, `pip-audit`, backend
   pre-push tests, full-repo Bandit, and docker build test.
 
@@ -204,11 +206,11 @@ disposition, and strict merge-readiness gates pass.
 
 ## Codex Security Diff Scan
 
-- Scan id: `03d4903e98dd_20260603T080909Z`
+- Scan id: `12532ddc6b93_20260603T082628Z`
 - Markdown report:
-  `/tmp/codex-security-scans/BMI-App_2025_clean/03d4903e98dd_20260603T080909Z/report.md`
+  `/tmp/codex-security-scans/BMI-App_2025_clean/12532ddc6b93_20260603T082628Z/report.md`
 - HTML report:
-  `/tmp/codex-security-scans/BMI-App_2025_clean/03d4903e98dd_20260603T080909Z/report.html`
+  `/tmp/codex-security-scans/BMI-App_2025_clean/12532ddc6b93_20260603T082628Z/report.html`
 - Result: no reportable findings.
 - Coverage: 3/3 diff-scoped rows have completion receipts in
   `artifacts/02_discovery/work_ledger.jsonl` inside the local scan bundle.
@@ -219,20 +221,20 @@ disposition, and strict merge-readiness gates pass.
 - Validator:
   `python3 .../codex-security/.../scripts/validate_report_format.py --report-md .../report.md`
   - PASS.
-- Goal usage: scan goal completed with `tokensUsed=266685` and
-  `timeUsedSeconds=479`.
+- Goal usage: refreshed scan goal completed with `tokensUsed=7045` and
+  `timeUsedSeconds=79`.
 
 ## PulsePlate PR Review
 
 - Context:
-  `python3 scripts/orchestration/pr_review_context.py --pr 1869 --output /tmp/pulseplate_pr_review_context_1869.json`
+  `python3 scripts/orchestration/pr_review_context.py --pr 1869 --output /tmp/pulseplate_pr_review_context_1869_refresh.json`
   - PASS.
 - Markdown dry-run report:
-  `/tmp/pulseplate_pr_review_1869.md`
+  `/tmp/pulseplate_pr_review_1869_refresh.md`
 - JSON dry-run report:
-  `/tmp/pulseplate_pr_review_1869.json`
+  `/tmp/pulseplate_pr_review_1869_refresh.json`
 - Finding: one advisory `note` from `bug-hunter` for diff size above the
-  deterministic review-risk threshold (`306` changed lines vs threshold `300`).
+  deterministic review-risk threshold (`344` changed lines vs threshold `300`).
 - Disposition: NOT-A-BUG for this CI/tooling hotfix scope. The diff is limited
   to one runner, its focused tests, and the canonical PR mapping artifact; the
   PR body and this artifact document the split rationale, current-head CI

--- a/scripts/ci/run_main_test_shards.py
+++ b/scripts/ci/run_main_test_shards.py
@@ -24,6 +24,7 @@ DEFAULT_ARTIFACT_LABEL = "pymain"
 JUNIT_FAMILY = "legacy"
 SLOW_MARK_EXPRESSION = "not slow"
 PYTEST_BASETEMP_ROOT_NAME = "pulseplate-main-test-shards"
+PYTEST_BASETEMP_FALLBACK_ROOT_NAME = "pulseplate-main-test-shards-external"
 POSIX_TEMP_ROOT = Path(os.sep) / "tmp"
 WINDOWS_TEMP_ROOT = Path(os.environ.get("SystemRoot", r"C:\Windows")) / "Temp"
 
@@ -154,13 +155,14 @@ def external_temp_root(repo_root: Path) -> Path:
 def shard_basetemp_dir(repo_root: Path, shard: TestShard) -> Path:
     """Return a deterministic external pytest base temp directory for one shard."""
 
-    repo_key = hashlib.sha256(str(repo_root.resolve()).encode("utf-8")).hexdigest()[:12]
-    return (
-        external_temp_root(repo_root)
-        / PYTEST_BASETEMP_ROOT_NAME
-        / repo_key
-        / f"{shard.artifact_label}-shard-{shard.index}"
-    )
+    resolved_repo_root = repo_root.resolve()
+    repo_key = hashlib.sha256(str(resolved_repo_root).encode("utf-8")).hexdigest()[:12]
+    temp_root = external_temp_root(repo_root)
+    for root_name in (PYTEST_BASETEMP_ROOT_NAME, PYTEST_BASETEMP_FALLBACK_ROOT_NAME):
+        candidate = temp_root / root_name / repo_key / f"{shard.artifact_label}-shard-{shard.index}"
+        if not candidate.resolve().is_relative_to(resolved_repo_root):
+            return candidate
+    raise RuntimeError("unable to resolve pytest basetemp path outside repo")
 
 
 def build_pytest_args(shard: TestShard, repo_root: Path) -> list[str]:

--- a/scripts/ci/run_main_test_shards.py
+++ b/scripts/ci/run_main_test_shards.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 import argparse
 import concurrent.futures
+import hashlib
 import multiprocessing
 import os
 import signal
 import subprocess  # nosec B404: subprocess is required for bounded local shard isolation without shell (remove-by: 2026-07-31, ref: PR-1748)
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -21,6 +23,9 @@ DEFAULT_SHARD_TIMEOUT_SECONDS = 1800
 DEFAULT_ARTIFACT_LABEL = "pymain"
 JUNIT_FAMILY = "legacy"
 SLOW_MARK_EXPRESSION = "not slow"
+PYTEST_BASETEMP_ROOT_NAME = "pulseplate-main-test-shards"
+POSIX_TEMP_ROOT = Path(os.sep) / "tmp"
+WINDOWS_TEMP_ROOT = Path(os.environ.get("SystemRoot", r"C:\Windows")) / "Temp"
 
 
 @dataclass(frozen=True)
@@ -128,7 +133,37 @@ def partition_test_files(
     return shards
 
 
-def build_pytest_args(shard: TestShard) -> list[str]:
+def external_temp_root(repo_root: Path) -> Path:
+    """Return a temp root that is guaranteed to live outside the repo tree."""
+
+    resolved_repo_root = repo_root.resolve()
+    candidates = [Path(tempfile.gettempdir())]
+    if os.name == "posix":
+        candidates.append(POSIX_TEMP_ROOT)
+    elif os.name == "nt":
+        candidates.append(WINDOWS_TEMP_ROOT)
+
+    for candidate in candidates:
+        resolved_candidate = candidate.resolve()
+        if not resolved_candidate.is_relative_to(resolved_repo_root):
+            return resolved_candidate
+
+    raise RuntimeError("unable to resolve pytest basetemp root outside repo")
+
+
+def shard_basetemp_dir(repo_root: Path, shard: TestShard) -> Path:
+    """Return a deterministic external pytest base temp directory for one shard."""
+
+    repo_key = hashlib.sha256(str(repo_root.resolve()).encode("utf-8")).hexdigest()[:12]
+    return (
+        external_temp_root(repo_root)
+        / PYTEST_BASETEMP_ROOT_NAME
+        / repo_key
+        / f"{shard.artifact_label}-shard-{shard.index}"
+    )
+
+
+def build_pytest_args(shard: TestShard, repo_root: Path) -> list[str]:
     """Build one no-xdist pytest argv for a shard."""
 
     return [
@@ -142,6 +177,8 @@ def build_pytest_args(shard: TestShard) -> list[str]:
         "--durations-min=10.0",
         "-o",
         f"faulthandler_timeout={DEFAULT_FAULTHANDLER_TIMEOUT_SECONDS}",
+        "--basetemp",
+        str(shard_basetemp_dir(repo_root, shard)),
         "--cov=.",
         "--cov-report=",
         "--junitxml",
@@ -197,7 +234,8 @@ def run_shard_child(repo_root: Path, shard: TestShard, base_env: dict[str, str])
 
     import pytest
 
-    pytest_args = build_pytest_args(shard)
+    shard_basetemp_dir(repo_root, shard).parent.mkdir(parents=True, exist_ok=True)
+    pytest_args = build_pytest_args(shard, repo_root)
     env = build_shard_env(base_env, shard, repo_root)
     os.environ.pop("PYTEST_XDIST_WORKER", None)
     os.environ.update(env)

--- a/tests/test_main_test_shards.py
+++ b/tests/test_main_test_shards.py
@@ -187,6 +187,21 @@ def test_shard_basetemp_dir_avoids_repo_local_temp_root(
     assert not basetemp.resolve().is_relative_to(tmp_path.resolve())
 
 
+def test_shard_basetemp_dir_rechecks_final_path_collision(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / runner.PYTEST_BASETEMP_ROOT_NAME
+    repo_root.mkdir()
+    shard = runner.TestShard(index=1, artifact_label="py313")
+    monkeypatch.setattr(runner.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    basetemp = runner.shard_basetemp_dir(repo_root, shard)
+
+    assert runner.PYTEST_BASETEMP_FALLBACK_ROOT_NAME in basetemp.parts
+    assert not basetemp.resolve().is_relative_to(repo_root.resolve())
+
+
 def test_build_pytest_args_disables_xdist_and_emits_junit(tmp_path: Path) -> None:
     shard = runner.TestShard(
         index=2,

--- a/tests/test_main_test_shards.py
+++ b/tests/test_main_test_shards.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import tempfile
 from concurrent.futures import Future
 from pathlib import Path
 
@@ -152,7 +153,41 @@ def test_py312_compatibility_wrapper_executes_as_legacy_file(tmp_path: Path) -> 
     assert "tests/test_alpha.py" in result.stdout
 
 
-def test_build_pytest_args_disables_xdist_and_emits_junit() -> None:
+def test_shard_basetemp_dir_is_unique_deterministic_and_external(tmp_path: Path) -> None:
+    first = runner.TestShard(index=1, artifact_label="py313")
+    second = runner.TestShard(index=2, artifact_label="py313")
+
+    first_basetemp = runner.shard_basetemp_dir(tmp_path, first)
+    second_basetemp = runner.shard_basetemp_dir(tmp_path, second)
+
+    assert first_basetemp == runner.shard_basetemp_dir(tmp_path, first)
+    assert first_basetemp != second_basetemp
+    assert first_basetemp.name == "py313-shard-1"
+    assert second_basetemp.name == "py313-shard-2"
+    assert first_basetemp.parent.parent == (
+        Path(tempfile.gettempdir()).resolve() / runner.PYTEST_BASETEMP_ROOT_NAME
+    )
+    assert not first_basetemp.resolve().is_relative_to(tmp_path.resolve())
+    assert not second_basetemp.resolve().is_relative_to(tmp_path.resolve())
+
+
+def test_shard_basetemp_dir_avoids_repo_local_temp_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_local_temp = tmp_path / "tmp"
+    repo_local_temp.mkdir()
+    shard = runner.TestShard(index=1, artifact_label="py313")
+    monkeypatch.setattr(runner.tempfile, "gettempdir", lambda: str(repo_local_temp))
+
+    basetemp = runner.shard_basetemp_dir(tmp_path, shard)
+
+    fallback_root = runner.POSIX_TEMP_ROOT if os.name == "posix" else runner.WINDOWS_TEMP_ROOT
+    assert basetemp.parent.parent == fallback_root.resolve() / runner.PYTEST_BASETEMP_ROOT_NAME
+    assert not basetemp.resolve().is_relative_to(tmp_path.resolve())
+
+
+def test_build_pytest_args_disables_xdist_and_emits_junit(tmp_path: Path) -> None:
     shard = runner.TestShard(
         index=2,
         artifact_label="py313",
@@ -160,13 +195,17 @@ def test_build_pytest_args_disables_xdist_and_emits_junit() -> None:
         weight=10,
     )
 
-    pytest_args = runner.build_pytest_args(shard)
+    pytest_args = runner.build_pytest_args(shard, tmp_path)
 
     assert pytest_args[:2] == ["-c", "pyproject.toml"]
     assert "-p" in pytest_args
     assert "no:xdist" in pytest_args
     assert "-m" in pytest_args
     assert runner.SLOW_MARK_EXPRESSION in pytest_args
+    assert "--basetemp" in pytest_args
+    assert pytest_args[pytest_args.index("--basetemp") + 1] == str(
+        runner.shard_basetemp_dir(tmp_path, shard)
+    )
     assert f"junit_family={runner.JUNIT_FAMILY}" in pytest_args
     assert shard.junit_file in pytest_args
     assert "tests/test_alpha.py" in pytest_args
@@ -365,6 +404,10 @@ def test_run_shard_child_forces_exit_after_pytest_returns(
     assert captured["argv"] == ["pytest"]
     pytest_args = captured["pytest_args"]
     assert isinstance(pytest_args, list)
+    assert "--basetemp" in pytest_args
+    basetemp = runner.shard_basetemp_dir(tmp_path, shard)
+    assert pytest_args[pytest_args.index("--basetemp") + 1] == str(basetemp)
+    assert basetemp.parent.is_dir()
     assert "tests/test_alpha.py" in pytest_args
 
 

--- a/tests/test_main_test_shards.py
+++ b/tests/test_main_test_shards.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -408,22 +409,25 @@ def test_run_shard_child_forces_exit_after_pytest_returns(
     monkeypatch.setattr(pytest, "main", fake_pytest_main)
     monkeypatch.setattr(runner.os, "_exit", fake_exit)
 
+    basetemp = runner.shard_basetemp_dir(tmp_path, shard)
     try:
         with pytest.raises(SystemExit) as exc_info:
             runner.run_shard_child(tmp_path, shard, {})
+
+        assert exc_info.value.code == 7
+        assert captured["cwd"] == tmp_path
+        assert captured["argv"] == ["pytest"]
+        pytest_args = captured["pytest_args"]
+        assert isinstance(pytest_args, list)
+        assert "--basetemp" in pytest_args
+        assert pytest_args[pytest_args.index("--basetemp") + 1] == str(basetemp)
+        assert basetemp.parent.is_dir()
+        assert "tests/test_alpha.py" in pytest_args
     finally:
         os.chdir(original_cwd)
+        shutil.rmtree(basetemp.parent, ignore_errors=True)
 
-    assert exc_info.value.code == 7
-    assert captured["cwd"] == tmp_path
-    assert captured["argv"] == ["pytest"]
-    pytest_args = captured["pytest_args"]
-    assert isinstance(pytest_args, list)
-    assert "--basetemp" in pytest_args
-    basetemp = runner.shard_basetemp_dir(tmp_path, shard)
-    assert pytest_args[pytest_args.index("--basetemp") + 1] == str(basetemp)
-    assert basetemp.parent.is_dir()
-    assert "tests/test_alpha.py" in pytest_args
+    assert not basetemp.parent.exists()
 
 
 def test_remove_previous_outputs_deletes_stale_shard_files(tmp_path: Path) -> None:


### PR DESCRIPTION
## Goal
Fix the main-branch `test-main (3.13, 90)` shard failure pattern from CI run 26843418715 by isolating pytest temp roots per main-suite shard.

## Business reason
Main CI must be reliable before the next governed PR lane starts. This is a CI/tooling hotfix for a GitHub-only py313 parallel shard failure, not a product/runtime behavior change.

## Scope
- Add deterministic per-shard pytest `--basetemp` paths for `scripts/ci/run_main_test_shards.py`.
- Keep basetemp roots outside the repo, under system temp, keyed by repo hash + artifact label + shard index.
- Create the basetemp parent before invoking `pytest.main(...)`.
- Add focused regression tests in `tests/test_main_test_shards.py`.
- Clean the external repo-key basetemp directory created by the child-runner test.
- Add/update the canonical PR mapping artifact at `docs/review/PR_1869_FIXED_MAPPING.md`.

## Out of scope
- No Experiment Runner product behavior changes.
- No `.github/workflows/ci.yml` changes.
- No shard parallelism reduction.
- No coverage/JUnit behavior changes.
- No skipped tests, weakened assertions, xfail, or `continue-on-error`.

## Files changed
- `scripts/ci/run_main_test_shards.py`
- `tests/test_main_test_shards.py`
- `docs/review/PR_1869_FIXED_MAPPING.md`

## Key decisions
- `--basetemp` is passed directly to each child pytest process instead of changing global pytest config.
- Repo identity in temp paths uses a short SHA-256 hash of the resolved repo root, avoiding local path leakage.
- If an environment-controlled temp root points inside the checkout, the runner falls back to an external platform temp root; if no external root is available, it fails closed.
- The child-runner unit test removes its real external repo-key temp parent in `finally` after assertions.

## Tests / validation
- `python3 scripts/orchestration/check_preflight.py --path scripts/ci/run_main_test_shards.py --path tests/test_main_test_shards.py` PASS.
- `python3 scripts/orchestration/check_agent_consistency.py` PASS.
- `. .venv/bin/activate && python -m pytest -q tests/test_main_test_shards.py tests/test_experiment_runner.py::test_main_writes_oracle_only_governance_reviewer_artifact` PASS: 37 passed.
- `. .venv/bin/activate && python -m pytest -q tests/test_main_test_shards.py` PASS after CodeRabbit cleanup fix: 36 passed.
- `. .venv/bin/activate && python -m bandit -q scripts/ci/run_main_test_shards.py` PASS.
- `python3 scripts/orchestration/experiment_runner.py --packet artifacts/orchestration/experiments/exp-6c5981dd7108.json --contribution-kind oracle_review --coauthor-required ...` PASS: result `accepted`; oracle command returned 0; shared tree untouched.
- `python3 .../codex-security/.../scripts/validate_report_format.py --report-md /tmp/codex-security-scans/BMI-App_2025_clean/12532ddc6b93_20260603T082628Z/report.md` PASS.
- `. .venv/bin/activate && python -m pytest tests/test_pr_review_report.py tests/test_pr_review_context.py -q` PASS: 13 passed.
- `make validate-changed` PASS after latest code cleanup; selected and ran `tests/test_main_test_shards.py`.
- `pre-commit run --all-files` PASS after latest mapping/body evidence updates and before commit `65609c8cd`.
- Pre-push hooks PASS after latest push: changed-file hooks, `pip-audit`, backend pre-push tests, full-repo Bandit, docker build check where applicable.
- `python3 scripts/ci/check_pr_body_phase2_gates.py --body <current body> --pr-number 1869 --commit-range origin/main..HEAD --experiment-runner-evidence-mode required` PASS before latest push.

Machine-heavy local shard note:
- Attempted `. .venv/bin/activate && python scripts/ci/run_main_test_shards.py --python-version 3.13 --shard-count 8 --max-parallel 4`.
- First attempt exposed and fixed a real parent-directory issue for `--basetemp`.
- Final attempt got past the basetemp setup and later failed in shard 8 on a separate cross-shard repo-local `worktrees` race: `tests/test_no_bmi_math_outside_core.py::test_no_whtr_formula_outside_core` walked `worktrees/dirty-origin-main-test-test_start_pr_lane_allows_dirt0` while `tests/test_start_pr_lane.py` ran in concurrent shard 7.
- Confirming command `. .venv/bin/activate && python -m pytest -q tests/test_start_pr_lane.py tests/test_no_bmi_math_outside_core.py` PASS: 44 passed.
- This PR does not claim to fix that separate heavy-suite race; current-head PR CI remains required evidence for the original GitHub-only py313 shard path.

## Security notes
No shell surface was added. Pytest args remain list-based. Temp paths avoid raw repo paths and reject repo-local temp roots. Full pre-commit and full-repo pre-push Bandit passed.

Codex Security diff scan refreshed with no reportable findings:
- Scan id: `12532ddc6b93_20260603T082628Z`.
- Markdown report: `/tmp/codex-security-scans/BMI-App_2025_clean/12532ddc6b93_20260603T082628Z/report.md`.
- HTML report: `/tmp/codex-security-scans/BMI-App_2025_clean/12532ddc6b93_20260603T082628Z/report.html`.
- Coverage: 3/3 current diff-scoped rows had completion receipts; validation and attack-path phases were skipped because discovery emitted no candidates.

## Risks / rollback
Risk: deterministic basetemp paths could preserve stale temp contents across repeated same-shard runs. Pytest owns and recreates its basetemp for each run, and tests cover parent creation and external path selection. Rollback: revert implementation commits `9cc75668d`, `f74d0af80`, and test-cleanup commit `3fa7e0830` to restore prior shard runner/test behavior.

## Deferred / follow-ups
- Separate follow-up, if needed: investigate the unrelated cross-shard `worktrees` race between `tests/test_start_pr_lane.py` and repo-walking policy tests.

## AGENTS.md or agent-instruction updates
None.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Post-open bot/human review disposition completed

Resolved/dispositioned review threads and bot review-summary URLs are recorded in the canonical mapping artifact. CodeRabbit, Sourcery, and Cubic must be rechecked after the latest push; any new bot comments remain blocking until dispositioned.

### Fixed in Commit Mapping
Canonical mapping artifact: `docs/review/PR_1869_FIXED_MAPPING.md`. Initial implementation mapping is recorded for commit `9cc75668d65b6d0bb01b8c3fa662c47145828774`; final basetemp collision fix is recorded for commit `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd`; CodeRabbit cleanup is fixed in `3fa7e083049724984bb9d4d58625bb598e8e955c`; CodeRabbit/Codex connector thread dispositions and review-summary dispositions are recorded in `docs/review/PR_1869_FIXED_MAPPING.md`, including latest `discussion_r3347054078` as NOT-A-BUG.

## Lane Start Provenance
- Packet: `artifacts/orchestration/task_packets/d61404beb69c.json`

## Post-open Review
- `qa-engineer-agent` completed; PR body file-list omission fixed.
- `bug-hunter` completed; final basetemp path collision fixed in `f74d0af80e96b7ab1aa6b8d29640fd7668bb04bd`.
- `security-auditor` completed; code security review found no new actionables and required mapping follow-up connector/bot review threads.
- CodeRabbit cleanup review fixed in `3fa7e083049724984bb9d4d58625bb598e8e955c`.
- CodeRabbit low-value duplicate-doc nitpick dispositioned as NOT-A-BUG in the mapping artifact.
- Codex connector synthetic-SHA comments, including latest `discussion_r3347054078`, dispositioned as NOT-A-BUG with live branch ancestry evidence.
- Codex Security diff scan refreshed with no reportable findings.
- `pulseplate-pr-review` dry-run refreshed. It produced one advisory `note` for diff size (`344` changed lines vs threshold `300`), dispositioned as NOT-A-BUG because the scope is intentionally limited to one runner, its focused tests, and the canonical mapping artifact.

## Merge Readiness
Not claimed. The latest pushed commit is `65609c8cd`; current-head CI must complete on that SHA. Green CI alone is still not enough; strict merge-readiness, review-thread disposition, required checks, bot-actionable disposition, and the wait window still apply.

## Next best step
Watch current-head CI for `65609c8cd`, especially `test-main (3.13, 90)`, then rerun strict disposition and merge-readiness checks after the latest bot/review activity settles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated per-shard temp dirs in main CI pytest shards and hardened external path selection to avoid repo-local collisions. Updated `docs/review/PR_1869_FIXED_MAPPING.md` with post-open review summaries, the latest Codex connector disposition, and refreshed security scan evidence.

- **Bug Fixes**
  - Pass a per-shard `--basetemp` to each pytest run and pre-create the parent; keep temp roots outside the repo with deterministic paths; guard the final path and fall back to a safe external container if needed.
  - Add tests for basetemp determinism, uniqueness, external location, arg wiring, parent creation, repo-local fallback, and final-path collision; clean up basetemp parents after runs.

<sup>Written for commit 65609c8cd5ca9aa3e4364a3f8a8875d9efd66196. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shard test runs now use deterministic external per-shard temporary directories created before invocation and fall back to a safe external temp when a computed path would land inside the checkout.

* **Tests**
  * Added regression tests verifying deterministic, unique, external basetemp dirs, that --basetemp is passed, existence during runs, cleanup after, and handling of final-path collisions.

* **Documentation**
  * Added a detailed review artifact with fixed-in-commit mappings, validation checklist, CI status notes, and gate evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




