### PR TITLE
PR-3: Experiment Runner Operator Observability Report

### DIFF
--- a/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
+++ b/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
@@ -222,7 +222,9 @@ Malformed, missing, traversal, or symlinked result artifacts must degrade to a
 sanitized artifact status and must not print file contents, local paths, oracle
 output, patches, provider logs, or validator details. Local reports may be
 rendered as JSON, Markdown, or a deterministic escaped single-file HTML report
-under `artifacts/orchestration/experiments/`.
+under `artifacts/orchestration/experiments/`. Report payloads include source
+counts, malformed/missing artifact counts, and a redaction summary that keeps
+Slack, provider, patch, approval, health, and local-path data marked as absent.
 
 Generate the local operator observability report set from the repository root:
 

--- a/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
+++ b/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
@@ -208,12 +208,32 @@ dispatch mode, fixed workflow file/ref, hash-only branch and hypothesis
 identifiers, safe artifact references, failure class, co-author decision, human
 review outcome, retention policy, and explicit authority-boundary booleans that
 must remain false for PR creation, review-thread resolution, merge-readiness
-claims, and product runtime changes.
+claims, and product runtime changes. Observability reports may also project
+validated Experiment Runner result metadata from local result artifacts, but only
+the sanitized metadata allowlist: schema version, experiment id, runner mode,
+status, failure class, mutated-path count, shared-tree untouched,
+promotion-ready, contribution kind, and co-author-required state.
 
 The ledger and report must not store raw Slack text, Slack channel/user/team
 IDs, trigger IDs, raw branch refs, raw hypotheses, local absolute paths, health
 or wellness payloads, provider logs, token values or prefixes, approval
 digests, oracle stdout/stderr, workflow logs, or patch text.
+Malformed, missing, traversal, or symlinked result artifacts must degrade to a
+sanitized artifact status and must not print file contents, local paths, oracle
+output, patches, provider logs, or validator details. Local reports may be
+rendered as JSON, Markdown, or a deterministic escaped single-file HTML report
+under `artifacts/orchestration/experiments/`.
+
+Generate the local operator observability report set from the repository root:
+
+```bash
+python3 scripts/orchestration/experiment_operator_ledger.py --write-report-set
+```
+
+The command writes only gitignored local files under
+`artifacts/orchestration/experiments/operator_observability/`. Delete that
+directory when the local evidence is no longer needed; do not commit generated
+report files.
 
 `/pulseplate-runner status` may include a sanitized latest-ledger summary when a
 valid local ledger event exists. If no event exists, the status shows an absent
@@ -222,8 +242,8 @@ sanitized `invalid_local_artifact` class and does not print paths or contents.
 The bridge writes one local ledger record after Slack audit finalization for
 `dry_run`, `dispatched`, `failed`, and `rejected` outcomes. Duplicate Slack
 events are blocked by the existing audit idempotency check before a second
-ledger record can be created. No new Slack command is required for the PR-2
-closeout.
+ledger record can be created. No new Slack command or Slack authority is added
+by the local observability report set.
 
 ## Authority Boundary
 

--- a/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
+++ b/docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md
@@ -210,9 +210,12 @@ review outcome, retention policy, and explicit authority-boundary booleans that
 must remain false for PR creation, review-thread resolution, merge-readiness
 claims, and product runtime changes. Observability reports may also project
 validated Experiment Runner result metadata from local result artifacts, but only
-the sanitized metadata allowlist: schema version, experiment id, runner mode,
+when the file SHA-256 matches the ledger's `oracle_result_hash`. The sanitized
+metadata allowlist is schema version, experiment-id hash prefix, runner mode,
 status, failure class, mutated-path count, shared-tree untouched,
-promotion-ready, contribution kind, and co-author-required state.
+promotion-ready, contribution kind, and co-author-required state. Latest-event
+report summaries include dispatch mode, co-author decision/required state, and
+human review outcome as display-only operator evidence.
 
 The ledger and report must not store raw Slack text, Slack channel/user/team
 IDs, trigger IDs, raw branch refs, raw hypotheses, local absolute paths, health

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -142,11 +142,11 @@ Evidence: Dev-operator pass identified only hygiene/process requirements. Local 
 
 ## Experiment Runner Evidence
 
-Artifact: `artifacts/orchestration/experiments/results/exp-8975cbf08daa.json`
+Artifact: `artifacts/orchestration/experiments/results/exp-6560552e0103.json`
 
 Disposition: FIXED
 Commit: a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b
-Evidence: final oracle-only Experiment Runner result `artifacts/orchestration/experiments/results/exp-8975cbf08daa.json` returned `status=accepted`, `runner_mode=oracle_only_governance_reviewer`, `shared_tree_untouched=true`, and `coauthor_required=true` after the Cubic-identified malformed-artifact fail-closed fix. PR commits that materially use oracle evidence include `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+Evidence: final oracle-only Experiment Runner result `artifacts/orchestration/experiments/results/exp-6560552e0103.json` returned `status=accepted`, `runner_mode=oracle_only_governance_reviewer`, `shared_tree_untouched=true`, `contribution_kind=oracle_review`, and `coauthor_required=true` after the Codex-identified result-id redaction, latest-state projection, and artifact-hash verification fixes. PR commits that materially use oracle evidence include `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
 
 ## Post-Open Role-Agent Findings
 
@@ -190,7 +190,7 @@ Evidence: `pulseplate-pr-review` dry-run emitted one advisory `large-diff-risk` 
 - `git diff --check` - PASS.
 - `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed; PASS again on final head.
 - `PREPUSH_DEBUG=1 make validate-changed` - PASS on final head.
-- final oracle-only Experiment Runner evidence `artifacts/orchestration/experiments/results/exp-8975cbf08daa.json` - accepted.
+- final oracle-only Experiment Runner evidence `artifacts/orchestration/experiments/results/exp-6560552e0103.json` - accepted after the Codex-identified result-id redaction, latest-state projection, and artifact-hash verification fixes.
 - `git push -u origin codex/experiment-runner-operator-observability-report` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.
 - final `git push` to `9732d2243` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.
 

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -112,11 +112,11 @@ Evidence: Dev-operator pass identified only hygiene/process requirements. Local 
 
 ## Experiment Runner Evidence
 
-Artifact: `artifacts/orchestration/experiments/results/exp-7f0fdfc39c11.json`
+Artifact: `artifacts/orchestration/experiments/results/exp-346a93ac7a31.json`
 
 Disposition: FIXED
 Commit: a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b
-Evidence: oracle-only Experiment Runner result `artifacts/orchestration/experiments/results/exp-7f0fdfc39c11.json` returned `status=accepted`, `runner_mode=oracle_only_governance_reviewer`, `shared_tree_untouched=true`, and `coauthor_required=true`; the primary commit includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+Evidence: oracle-only Experiment Runner result `artifacts/orchestration/experiments/results/exp-7f0fdfc39c11.json` returned `status=accepted`, `runner_mode=oracle_only_governance_reviewer`, `shared_tree_untouched=true`, and `coauthor_required=true`; final post-open oracle-only result `artifacts/orchestration/experiments/results/exp-346a93ac7a31.json` returned `status=accepted`, `runner_mode=oracle_only_governance_reviewer`, `shared_tree_untouched=true`, and `coauthor_required=true`. PR commits that materially use oracle evidence include `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
 
 ## Post-Open Role-Agent Findings
 
@@ -148,6 +148,7 @@ Evidence: Post-open security-auditor pass reported no security findings after th
 - `git diff --check` - PASS.
 - `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed.
 - `PREPUSH_DEBUG=1 make validate-changed` - PASS.
+- final oracle-only Experiment Runner evidence `artifacts/orchestration/experiments/results/exp-346a93ac7a31.json` - accepted.
 - `git push -u origin codex/experiment-runner-operator-observability-report` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.
 
 ## Merge Readiness

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -44,6 +44,11 @@ Disposition: FIXED
 Commit: a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b
 Evidence: `scripts/orchestration/experiment_operator_ledger.py` adds sanitized JSON/Markdown/HTML operator observability report-set generation, safe Experiment Runner result metadata projection, path traversal and symlink rejection, malformed/missing artifact degradation, and deterministic aggregation; `tests/test_experiment_operator_ledger.py` covers strict schema, redaction probes, path safety, malformed artifacts, latest-status selection, deterministic ordering, idempotent report generation, HTML escaping, and source artifact non-mutation; `tests/test_experiment_slack_socket_bridge.py` and `docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md` preserve the unchanged Slack command/authority boundary.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#pullrequestreview-4422517035 -> 98ef819288ee8662a8b039402d2fac9c57b939b7
+Disposition: FIXED
+Commit: 98ef819288ee8662a8b039402d2fac9c57b939b7
+Evidence: Cubic identified that malformed result artifacts could still crash report generation when `validate_experiment_result(...)` raised non-`ValueError` validation exceptions. `scripts/orchestration/experiment_operator_ledger.py` now catches validator type/coercion errors as invalid local result metadata, and `tests/test_experiment_operator_ledger.py` covers a malformed `returncode` object that previously could raise `TypeError` but now degrades to sanitized `artifact_status=invalid`.
+
 ## Mapping Update Protocol
 
 Actionable GitHub review threads and top-level review comments must be recorded
@@ -155,6 +160,7 @@ Evidence: `pulseplate-pr-review` dry-run emitted one advisory `large-diff-risk` 
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
 - `python3 -m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after post-open QA and bug-hunter fixes.
+- repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Cubic-identified malformed-artifact fail-closed fix.
 - `git diff --check` - PASS.
 - `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed; PASS again on final head.
 - `PREPUSH_DEBUG=1 make validate-changed` - PASS on final head.

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -109,6 +109,16 @@ Disposition: FIXED
 Commit: 7dff01472d6a6fb045d612e3ce60c936e05b7e2a
 Evidence: CodeRabbit identified that the direct CLI subprocess test relied on `Path.cwd()` and relative artifact cleanup. `tests/test_experiment_operator_ledger.py` now anchors the subprocess script path, cwd, output file, and cleanup directory to `Path(__file__).resolve().parents[1]`, preventing test leakage when the caller's working directory changes.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3353259777 -> d9502e88e9114641d67c7135fb98f053c156fe77
+Disposition: FIXED
+Commit: d9502e88e9114641d67c7135fb98f053c156fe77
+Evidence: Codex identified that result-artifact hash read failures could raise `OperatorLedgerError` outside the sanitized invalid-artifact branch. `scripts/orchestration/experiment_operator_ledger.py` now catches `OperatorLedgerError` while projecting safe result metadata, and `tests/test_experiment_operator_ledger.py` proves a hash-read failure degrades to sanitized `artifact_status=invalid` without leaking the exception text.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#pullrequestreview-4424514406
+Disposition: NOT-A-BUG
+Evidence: `docs/review/PR_1874_FIXED_MAPPING.md` intentionally keeps exact per-fix local gate evidence lines so review governance can audit which rerun followed which fix.
+Reason: CodeRabbit marked the wording suggestion as a low-value nitpick. Consolidating the repeated gate lines would reduce traceability for this review-fix sequence without changing code, tests, docs contracts, or operator behavior.
+
 ## Mapping Update Protocol
 
 Actionable GitHub review threads and top-level review comments must be recorded
@@ -225,6 +235,7 @@ Evidence: final `pulseplate-pr-review` dry-run emitted one advisory `large-diff-
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the CodeQL stdout sink isolation fix in `7bca65ce`.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Cubic-identified quoted/backticked local-path stdout guard fix in `a4fc9c39`.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the CodeRabbit-identified direct CLI subprocess root anchoring fix in `7dff0147`.
+- repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Codex-identified result-artifact hash-read fail-closed fix in `d9502e88e`.
 - `git diff --check` - PASS.
 - `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed; PASS again on final head.
 - `PREPUSH_DEBUG=1 make validate-changed` - PASS on final head; PASS again after the CodeQL stdout sink isolation fix in `7bca65ce`.

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -177,7 +177,7 @@ Evidence: Codex Security diff scan covered 1/1 source-like diff row for `scripts
 ### pulseplate-pr-review
 
 Disposition: NOT-A-BUG
-Evidence: `pulseplate-pr-review` dry-run emitted one advisory `large-diff-risk` note because the PR has more than 800 changed lines. The note is closed as not-a-bug for this PR because the diff is a cohesive PR-3 operator observability slice, the PR body includes split justification, changed surfaces are limited to local operator observability, runbook, mapping, and focused tests, and targeted deterministic gates passed. Final local reports: `artifacts/orchestration/pr_review/PR_1874_PULSEPLATE_PR_REVIEW_FINAL.md` and `artifacts/orchestration/pr_review/PR_1874_PULSEPLATE_PR_REVIEW_FINAL.json`.
+Evidence: final `pulseplate-pr-review` dry-run emitted one advisory `large-diff-risk` note because the PR has more than 800 changed lines. The note is closed as not-a-bug for this PR because the diff is a cohesive PR-3 operator observability slice, the PR body includes split justification, changed surfaces are limited to local operator observability, runbook, mapping, and focused tests, and targeted deterministic gates passed.
 
 ## Local Gate Evidence
 

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -84,6 +84,11 @@ Disposition: FIXED
 Commit: 7bca65ce58e98ea435531233ed3e666e46a02180
 Evidence: The repeated GitHub Advanced Security CodeQL alert after the initial stdout guard still identified the shared stdout sink. `scripts/orchestration/experiment_operator_ledger.py` now structurally separates full report rendering from stdout output, and `tests/test_experiment_operator_ledger.py` verifies direct CLI summary invocation writes to a gitignored artifact output file with empty stdout.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3352162506 -> 7bca65ce58e98ea435531233ed3e666e46a02180
+Disposition: FIXED
+Commit: 7bca65ce58e98ea435531233ed3e666e46a02180
+Evidence: GitHub Advanced Security opened the CodeQL `Clear-text logging of sensitive information` review comment for the same operator observability CLI stdout sink. `scripts/orchestration/experiment_operator_ledger.py` now structurally separates full report rendering from stdout output, and `tests/test_experiment_operator_ledger.py` verifies direct CLI summary invocation writes to a gitignored artifact output file with empty stdout.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#pullrequestreview-4423139717 -> a4fc9c3943d822a69968e78f3cda75af5553bfdc
 Disposition: FIXED
 Commit: a4fc9c3943d822a69968e78f3cda75af5553bfdc

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -54,9 +54,9 @@ Disposition: FIXED
 Commit: 98ef819288ee8662a8b039402d2fac9c57b939b7
 Evidence: Cubic identified that malformed result artifacts could still crash report generation when `validate_experiment_result(...)` raised non-`ValueError` validation exceptions. `scripts/orchestration/experiment_operator_ledger.py` now catches validator type/coercion errors as invalid local result metadata, and `tests/test_experiment_operator_ledger.py` covers a malformed `returncode` object that previously could raise `TypeError` but now degrades to sanitized `artifact_status=invalid`.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3351603200 -> b557922c4cd4b243d82fcb5663b6293cc840c19b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3351603200 -> b557922c43609174096aa4ba62dd03eb4374059d
 Disposition: FIXED
-Commit: b557922c4cd4b243d82fcb5663b6293cc840c19b
+Commit: b557922c43609174096aa4ba62dd03eb4374059d
 Evidence: `scripts/orchestration/experiment_operator_ledger.py` now reports `experiment_id_hash` instead of raw Experiment Runner `experiment_id` in safe result metadata, and `tests/test_experiment_operator_ledger.py` covers a Slack-shaped `C0SECRETID` result id that is absent from JSON/Markdown/HTML output while only its hash prefix is rendered.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3351603207 -> 98ef819288ee8662a8b039402d2fac9c57b939b7
@@ -64,14 +64,14 @@ Disposition: FIXED
 Commit: 98ef819288ee8662a8b039402d2fac9c57b939b7
 Evidence: `scripts/orchestration/experiment_operator_ledger.py` catches validator `TypeError` and `OverflowError` as invalid local result metadata, and `tests/test_experiment_operator_ledger.py` reaches the validator path with a matching artifact hash before proving malformed `oracle_results[].returncode` degrades to sanitized `artifact_status=invalid`.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3351603215 -> b557922c4cd4b243d82fcb5663b6293cc840c19b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3351603215 -> b557922c43609174096aa4ba62dd03eb4374059d
 Disposition: FIXED
-Commit: b557922c4cd4b243d82fcb5663b6293cc840c19b
+Commit: b557922c43609174096aa4ba62dd03eb4374059d
 Evidence: `scripts/orchestration/experiment_operator_ledger.py` adds `dispatch_mode`, `coauthor_required`, `coauthor_decision`, and `human_review_outcome` to the sanitized `latest` report projection and JSON/Markdown/HTML renderers; `tests/test_experiment_operator_ledger.py` covers an approved execute dispatch latest event with required co-author attribution state.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3351823142 -> b557922c4cd4b243d82fcb5663b6293cc840c19b
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3351823142 -> b557922c43609174096aa4ba62dd03eb4374059d
 Disposition: FIXED
-Commit: b557922c4cd4b243d82fcb5663b6293cc840c19b
+Commit: b557922c43609174096aa4ba62dd03eb4374059d
 Evidence: `scripts/orchestration/experiment_operator_ledger.py` compares each result artifact file SHA-256 to the ledger `oracle_result_hash` before projecting metadata and fails closed to `artifact_status=invalid` on mismatch or missing hash; `tests/test_experiment_operator_ledger.py` adds a mismatched-hash regression and updates valid metadata fixtures to use the real artifact hash.
 
 ## Mapping Update Protocol

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -34,8 +34,8 @@ Starter: `scripts/orchestration/start_pr_lane.sh`
   are fixed or dispositioned.
 - [x] Post-open role-agent sequence completed:
   `qa-engineer-agent -> bug-hunter -> security-auditor`.
-- [ ] Codex Security diff scan / finding discovery completed.
-- [ ] `pulseplate-pr-review` completed.
+- [x] Codex Security diff scan / finding discovery completed.
+- [x] `pulseplate-pr-review` completed.
 
 ## Fixed in Commit Mapping
 
@@ -139,6 +139,16 @@ Evidence: oracle-only Experiment Runner result `artifacts/orchestration/experime
 Disposition: NOT-A-BUG
 Evidence: Post-open security-auditor pass reported no security findings after the QA and bug-hunter fixes. The pass confirmed safe result metadata allowlisting, result artifact traversal/symlink checks, report output confinement under `artifacts/orchestration/experiments`, reserved `events` rejection, false authority booleans, explicit redaction summary, and escaped HTML rendering.
 
+### Codex Security diff scan
+
+Disposition: NOT-A-BUG
+Evidence: Codex Security diff scan covered 1/1 source-like diff row for `scripts/orchestration/experiment_operator_ledger.py`, emitted no reportable candidates, wrote a completion receipt in `work_ledger.jsonl`, validated `report.md`, and rendered `report.html`. Local scan bundle id: `pr1874_9732d2243_20260603T204048Z`.
+
+### pulseplate-pr-review
+
+Disposition: NOT-A-BUG
+Evidence: `pulseplate-pr-review` dry-run emitted one advisory `large-diff-risk` note because the PR has more than 800 changed lines. The note is closed as not-a-bug for this PR because the diff is a cohesive PR-3 operator observability slice, the PR body includes split justification, changed surfaces are limited to local operator observability, runbook, mapping, and focused tests, and targeted deterministic gates passed. Local reports: `artifacts/orchestration/pr_review/PR_1874_PULSEPLATE_PR_REVIEW.md` and `artifacts/orchestration/pr_review/PR_1874_PULSEPLATE_PR_REVIEW.json`.
+
 ## Local Gate Evidence
 
 - `python3 scripts/orchestration/check_preflight.py` - PASS.
@@ -146,10 +156,11 @@ Evidence: Post-open security-auditor pass reported no security findings after th
 - `python3 -m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after post-open QA and bug-hunter fixes.
 - `git diff --check` - PASS.
-- `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed.
-- `PREPUSH_DEBUG=1 make validate-changed` - PASS.
+- `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed; PASS again on final head.
+- `PREPUSH_DEBUG=1 make validate-changed` - PASS on final head.
 - final oracle-only Experiment Runner evidence `artifacts/orchestration/experiments/results/exp-346a93ac7a31.json` - accepted.
 - `git push -u origin codex/experiment-runner-operator-observability-report` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.
+- final `git push` to `9732d2243` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -172,7 +172,7 @@ Evidence: Post-open security-auditor pass reported no security findings after th
 ### Codex Security diff scan
 
 Disposition: NOT-A-BUG
-Evidence: Codex Security diff scan covered 1/1 source-like diff row for `scripts/orchestration/experiment_operator_ledger.py`, emitted no reportable candidates, wrote a completion receipt in `work_ledger.jsonl`, validated `report.md`, and rendered `report.html` after the Cubic-identified malformed-artifact fail-closed fix. Local scan bundle id: `pr1874_75c9df2b2_20260603T205027Z`.
+Evidence: Codex Security diff scan covered 1/1 source-like diff row for `scripts/orchestration/experiment_operator_ledger.py`, emitted no reportable candidates, wrote a completion receipt in `work_ledger.jsonl`, validated `report.md`, and rendered `report.html` after the Codex-identified result-id redaction, latest-state projection, and artifact-hash verification fixes. Local scan bundle id: `pr1874_22676d28ed_20260603T213013Z`.
 
 ### pulseplate-pr-review
 

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -18,14 +18,21 @@ branch are not canonical proof targets. Actual PR disposition proof must be
 recorded in this artifact and checked by the repo's merge-readiness/disposition
 gates.
 
+## Lane Start Provenance
+
+Packet: `artifacts/orchestration/task_packets/53883fa25886.json`
+Starter: `scripts/orchestration/start_pr_lane.sh`
+
 ## Discussion Thread Pass
 
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 - [x] Initial post-open fixed-mapping artifact created after PR #1874 opened.
 - [x] PR body mirror includes Discussion Thread Pass, Fixed in Commit Mapping,
   and Merge Readiness sections.
 - [ ] Final discussion-thread pass completed after all human and bot comments
   are fixed or dispositioned.
-- [ ] Post-open role-agent sequence completed:
+- [x] Post-open role-agent sequence completed:
   `qa-engineer-agent -> bug-hunter -> security-auditor`.
 - [ ] Codex Security diff scan / finding discovery completed.
 - [ ] `pulseplate-pr-review` completed.
@@ -105,15 +112,39 @@ Evidence: Dev-operator pass identified only hygiene/process requirements. Local 
 
 ## Experiment Runner Evidence
 
+Artifact: `artifacts/orchestration/experiments/results/exp-7f0fdfc39c11.json`
+
 Disposition: FIXED
 Commit: a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b
 Evidence: oracle-only Experiment Runner result `artifacts/orchestration/experiments/results/exp-7f0fdfc39c11.json` returned `status=accepted`, `runner_mode=oracle_only_governance_reviewer`, `shared_tree_untouched=true`, and `coauthor_required=true`; the primary commit includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+
+## Post-Open Role-Agent Findings
+
+### qa-engineer-agent
+
+- Finding: empty-ledger report-set behavior lacked explicit regression coverage.
+  Disposition: FIXED
+  Commit: 6903691a14b329541d9c87f368bcbf5b5e5bd2d3
+  Evidence: `tests/test_experiment_operator_ledger.py` covers empty local ledger report-set output with `event_count=0`, `latest is None`, empty aggregate maps, empty result artifacts, `source_counts`, `malformed_artifact_counts`, `redaction_summary`, safe Markdown/HTML output, and no raw-leak/local-path content.
+
+### bug-hunter
+
+- Finding: `source_counts.result_artifact_refs` counted absent result-artifact projections as real artifact references.
+  Disposition: FIXED
+  Commit: 6903691a14b329541d9c87f368bcbf5b5e5bd2d3
+  Evidence: `scripts/orchestration/experiment_operator_ledger.py` now counts only non-absent result artifact refs; `tests/test_experiment_operator_ledger.py` covers `oracle_result_ref=none` producing `by_result_artifact_status={\"absent\": 1}` while `source_counts.result_artifact_refs=0`.
+
+### security-auditor
+
+Disposition: NOT-A-BUG
+Evidence: Post-open security-auditor pass reported no security findings after the QA and bug-hunter fixes. The pass confirmed safe result metadata allowlisting, result artifact traversal/symlink checks, report output confinement under `artifacts/orchestration/experiments`, reserved `events` rejection, false authority booleans, explicit redaction summary, and escaped HTML rendering.
 
 ## Local Gate Evidence
 
 - `python3 scripts/orchestration/check_preflight.py` - PASS.
 - `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
 - `python3 -m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS.
+- repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after post-open QA and bug-hunter fixes.
 - `git diff --check` - PASS.
 - `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed.
 - `PREPUSH_DEBUG=1 make validate-changed` - PASS.

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -119,6 +119,11 @@ Disposition: NOT-A-BUG
 Evidence: `docs/review/PR_1874_FIXED_MAPPING.md` intentionally keeps exact per-fix local gate evidence lines so review governance can audit which rerun followed which fix.
 Reason: CodeRabbit marked the wording suggestion as a low-value nitpick. Consolidating the repeated gate lines would reduce traceability for this review-fix sequence without changing code, tests, docs contracts, or operator behavior.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3353944709 -> 34a7bf36344f948bb33a7f18d8ee3609e11755c7
+Disposition: FIXED
+Commit: 34a7bf36344f948bb33a7f18d8ee3609e11755c7
+Evidence: Codex identified that unsafe `--report-dir` values could create report files before safe artifact-ref rejection. `scripts/orchestration/experiment_operator_ledger.py` now precomputes safe artifact refs for every report-set output before preflight and write operations, and `tests/test_experiment_operator_ledger.py` proves a Slack-ID-shaped report directory fails closed without creating that directory or leaking the identifier.
+
 ## Mapping Update Protocol
 
 Actionable GitHub review threads and top-level review comments must be recorded
@@ -236,6 +241,7 @@ Evidence: final `pulseplate-pr-review` dry-run emitted one advisory `large-diff-
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Cubic-identified quoted/backticked local-path stdout guard fix in `a4fc9c39`.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the CodeRabbit-identified direct CLI subprocess root anchoring fix in `7dff0147`.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Codex-identified result-artifact hash-read fail-closed fix in `d9502e88e`.
+- repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Codex-identified report-set output-ref prevalidation fix in `34a7bf36`.
 - `git diff --check` - PASS.
 - `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed; PASS again on final head.
 - `PREPUSH_DEBUG=1 make validate-changed` - PASS on final head; PASS again after the CodeQL stdout sink isolation fix in `7bca65ce`.

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -74,10 +74,15 @@ Disposition: FIXED
 Commit: b557922c43609174096aa4ba62dd03eb4374059d
 Evidence: `scripts/orchestration/experiment_operator_ledger.py` compares each result artifact file SHA-256 to the ledger `oracle_result_hash` before projecting metadata and fails closed to `artifact_status=invalid` on mismatch or missing hash; `tests/test_experiment_operator_ledger.py` adds a mismatched-hash regression and updates valid metadata fixtures to use the real artifact hash.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/runs/79401457146 -> 2d999e5b8087d03a1482f37af41c71c9d33af140
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/runs/79401457146 -> 7bca65ce58e98ea435531233ed3e666e46a02180
 Disposition: FIXED
-Commit: 2d999e5b8087d03a1482f37af41c71c9d33af140
-Evidence: GitHub Advanced Security CodeQL reported `Clear-text logging of sensitive information` on the operator observability CLI stdout sink. `scripts/orchestration/experiment_operator_ledger.py` now runs all CLI stdout payloads through a final fail-closed no-leak guard before writing to stdout, and `tests/test_experiment_operator_ledger.py` proves a rendered payload containing token-shaped text, a local path, and patch text returns only sanitized `FAIL: Experiment operator ledger output contains unsafe content.` without printing the unsafe content.
+Commit: 7bca65ce58e98ea435531233ed3e666e46a02180
+Evidence: GitHub Advanced Security CodeQL reported `Clear-text logging of sensitive information` on the operator observability CLI stdout sink. `scripts/orchestration/experiment_operator_ledger.py` now requires `--summary` reports to write through `--output`, keeps full report payloads out of the stdout branch, and reserves stdout for bounded acknowledgement payloads; `tests/test_experiment_operator_ledger.py` covers the no-stdout summary contract and proves an unsafe report-set acknowledgement returns only sanitized `FAIL: Experiment operator ledger output contains unsafe content.` without printing token-shaped text, local paths, or patch/log markers.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/runs/79403670201 -> 7bca65ce58e98ea435531233ed3e666e46a02180
+Disposition: FIXED
+Commit: 7bca65ce58e98ea435531233ed3e666e46a02180
+Evidence: The repeated GitHub Advanced Security CodeQL alert after the initial stdout guard still identified the shared stdout sink. `scripts/orchestration/experiment_operator_ledger.py` now structurally separates full report rendering from stdout output, and `tests/test_experiment_operator_ledger.py` verifies direct CLI summary invocation writes to a gitignored artifact output file with empty stdout.
 
 ## Mapping Update Protocol
 
@@ -192,10 +197,10 @@ Evidence: final `pulseplate-pr-review` dry-run emitted one advisory `large-diff-
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after post-open QA and bug-hunter fixes.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Cubic-identified malformed-artifact fail-closed fix.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Codex-identified result-id redaction, latest-state projection, and artifact-hash verification fixes in `b557922c4`.
-- repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the CodeQL stdout sink guard fix in `2d999e5b`.
+- repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the CodeQL stdout sink isolation fix in `7bca65ce`.
 - `git diff --check` - PASS.
 - `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed; PASS again on final head.
-- `PREPUSH_DEBUG=1 make validate-changed` - PASS on final head; PASS again after the CodeQL stdout sink guard fix in `2d999e5b`.
+- `PREPUSH_DEBUG=1 make validate-changed` - PASS on final head; PASS again after the CodeQL stdout sink isolation fix in `7bca65ce`.
 - final oracle-only Experiment Runner evidence `artifacts/orchestration/experiments/results/exp-6560552e0103.json` - accepted after the Codex-identified result-id redaction, latest-state projection, and artifact-hash verification fixes.
 - `git push -u origin codex/experiment-runner-operator-observability-report` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.
 - prior final `git push` to `208ff3bf2` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -74,6 +74,11 @@ Disposition: FIXED
 Commit: b557922c43609174096aa4ba62dd03eb4374059d
 Evidence: `scripts/orchestration/experiment_operator_ledger.py` compares each result artifact file SHA-256 to the ledger `oracle_result_hash` before projecting metadata and fails closed to `artifact_status=invalid` on mismatch or missing hash; `tests/test_experiment_operator_ledger.py` adds a mismatched-hash regression and updates valid metadata fixtures to use the real artifact hash.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/runs/79401457146 -> 2d999e5b8087d03a1482f37af41c71c9d33af140
+Disposition: FIXED
+Commit: 2d999e5b8087d03a1482f37af41c71c9d33af140
+Evidence: GitHub Advanced Security CodeQL reported `Clear-text logging of sensitive information` on the operator observability CLI stdout sink. `scripts/orchestration/experiment_operator_ledger.py` now runs all CLI stdout payloads through a final fail-closed no-leak guard before writing to stdout, and `tests/test_experiment_operator_ledger.py` proves a rendered payload containing token-shaped text, a local path, and patch text returns only sanitized `FAIL: Experiment operator ledger output contains unsafe content.` without printing the unsafe content.
+
 ## Mapping Update Protocol
 
 Actionable GitHub review threads and top-level review comments must be recorded
@@ -187,12 +192,13 @@ Evidence: final `pulseplate-pr-review` dry-run emitted one advisory `large-diff-
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after post-open QA and bug-hunter fixes.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Cubic-identified malformed-artifact fail-closed fix.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Codex-identified result-id redaction, latest-state projection, and artifact-hash verification fixes in `b557922c4`.
+- repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the CodeQL stdout sink guard fix in `2d999e5b`.
 - `git diff --check` - PASS.
 - `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed; PASS again on final head.
-- `PREPUSH_DEBUG=1 make validate-changed` - PASS on final head.
+- `PREPUSH_DEBUG=1 make validate-changed` - PASS on final head; PASS again after the CodeQL stdout sink guard fix in `2d999e5b`.
 - final oracle-only Experiment Runner evidence `artifacts/orchestration/experiments/results/exp-6560552e0103.json` - accepted after the Codex-identified result-id redaction, latest-state projection, and artifact-hash verification fixes.
 - `git push -u origin codex/experiment-runner-operator-observability-report` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.
-- final `git push` to `9732d2243` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.
+- prior final `git push` to `208ff3bf2` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.
 
 ## Merge Readiness
 

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -84,6 +84,16 @@ Disposition: FIXED
 Commit: 7bca65ce58e98ea435531233ed3e666e46a02180
 Evidence: The repeated GitHub Advanced Security CodeQL alert after the initial stdout guard still identified the shared stdout sink. `scripts/orchestration/experiment_operator_ledger.py` now structurally separates full report rendering from stdout output, and `tests/test_experiment_operator_ledger.py` verifies direct CLI summary invocation writes to a gitignored artifact output file with empty stdout.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#pullrequestreview-4423139717 -> a4fc9c3943d822a69968e78f3cda75af5553bfdc
+Disposition: FIXED
+Commit: a4fc9c3943d822a69968e78f3cda75af5553bfdc
+Evidence: Cubic identified that the stdout no-leak guard could miss local paths surrounded by quotes or backticks because the shared `LOCAL_PATH_RE` requires start-of-string or whitespace before the path. `scripts/orchestration/experiment_operator_ledger.py` now adds a CLI stdout local-path detector that matches absolute Unix, Windows drive, and UNC paths without requiring a leading whitespace boundary, and `tests/test_experiment_operator_ledger.py` proves a backticked `/Users/...` path in a report-set acknowledgement fails closed without printing the path.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3352193033 -> a4fc9c3943d822a69968e78f3cda75af5553bfdc
+Disposition: FIXED
+Commit: a4fc9c3943d822a69968e78f3cda75af5553bfdc
+Evidence: Cubic identified that the stdout no-leak guard could miss local paths surrounded by quotes or backticks because the shared `LOCAL_PATH_RE` requires start-of-string or whitespace before the path. `scripts/orchestration/experiment_operator_ledger.py` now adds a CLI stdout local-path detector that matches absolute Unix, Windows drive, and UNC paths without requiring a leading whitespace boundary, and `tests/test_experiment_operator_ledger.py` proves a backticked `/Users/...` path in a report-set acknowledgement fails closed without printing the path.
+
 ## Mapping Update Protocol
 
 Actionable GitHub review threads and top-level review comments must be recorded
@@ -198,9 +208,11 @@ Evidence: final `pulseplate-pr-review` dry-run emitted one advisory `large-diff-
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Cubic-identified malformed-artifact fail-closed fix.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Codex-identified result-id redaction, latest-state projection, and artifact-hash verification fixes in `b557922c4`.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the CodeQL stdout sink isolation fix in `7bca65ce`.
+- repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Cubic-identified quoted/backticked local-path stdout guard fix in `a4fc9c39`.
 - `git diff --check` - PASS.
 - `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed; PASS again on final head.
 - `PREPUSH_DEBUG=1 make validate-changed` - PASS on final head; PASS again after the CodeQL stdout sink isolation fix in `7bca65ce`.
+- `PREPUSH_DEBUG=1 make validate-changed` - PASS after the Cubic-identified quoted/backticked local-path stdout guard fix in `a4fc9c39`.
 - final oracle-only Experiment Runner evidence `artifacts/orchestration/experiments/results/exp-6560552e0103.json` - accepted after the Codex-identified result-id redaction, latest-state projection, and artifact-hash verification fixes.
 - `git push -u origin codex/experiment-runner-operator-observability-report` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.
 - prior final `git push` to `208ff3bf2` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -117,11 +117,11 @@ Evidence: Dev-operator pass identified only hygiene/process requirements. Local 
 
 ## Experiment Runner Evidence
 
-Artifact: `artifacts/orchestration/experiments/results/exp-346a93ac7a31.json`
+Artifact: `artifacts/orchestration/experiments/results/exp-8975cbf08daa.json`
 
 Disposition: FIXED
 Commit: a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b
-Evidence: oracle-only Experiment Runner result `artifacts/orchestration/experiments/results/exp-7f0fdfc39c11.json` returned `status=accepted`, `runner_mode=oracle_only_governance_reviewer`, `shared_tree_untouched=true`, and `coauthor_required=true`; final post-open oracle-only result `artifacts/orchestration/experiments/results/exp-346a93ac7a31.json` returned `status=accepted`, `runner_mode=oracle_only_governance_reviewer`, `shared_tree_untouched=true`, and `coauthor_required=true`. PR commits that materially use oracle evidence include `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+Evidence: final oracle-only Experiment Runner result `artifacts/orchestration/experiments/results/exp-8975cbf08daa.json` returned `status=accepted`, `runner_mode=oracle_only_governance_reviewer`, `shared_tree_untouched=true`, and `coauthor_required=true` after the Cubic-identified malformed-artifact fail-closed fix. PR commits that materially use oracle evidence include `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
 
 ## Post-Open Role-Agent Findings
 
@@ -147,12 +147,12 @@ Evidence: Post-open security-auditor pass reported no security findings after th
 ### Codex Security diff scan
 
 Disposition: NOT-A-BUG
-Evidence: Codex Security diff scan covered 1/1 source-like diff row for `scripts/orchestration/experiment_operator_ledger.py`, emitted no reportable candidates, wrote a completion receipt in `work_ledger.jsonl`, validated `report.md`, and rendered `report.html`. Local scan bundle id: `pr1874_9732d2243_20260603T204048Z`.
+Evidence: Codex Security diff scan covered 1/1 source-like diff row for `scripts/orchestration/experiment_operator_ledger.py`, emitted no reportable candidates, wrote a completion receipt in `work_ledger.jsonl`, validated `report.md`, and rendered `report.html` after the Cubic-identified malformed-artifact fail-closed fix. Local scan bundle id: `pr1874_75c9df2b2_20260603T205027Z`.
 
 ### pulseplate-pr-review
 
 Disposition: NOT-A-BUG
-Evidence: `pulseplate-pr-review` dry-run emitted one advisory `large-diff-risk` note because the PR has more than 800 changed lines. The note is closed as not-a-bug for this PR because the diff is a cohesive PR-3 operator observability slice, the PR body includes split justification, changed surfaces are limited to local operator observability, runbook, mapping, and focused tests, and targeted deterministic gates passed. Local reports: `artifacts/orchestration/pr_review/PR_1874_PULSEPLATE_PR_REVIEW.md` and `artifacts/orchestration/pr_review/PR_1874_PULSEPLATE_PR_REVIEW.json`.
+Evidence: `pulseplate-pr-review` dry-run emitted one advisory `large-diff-risk` note because the PR has more than 800 changed lines. The note is closed as not-a-bug for this PR because the diff is a cohesive PR-3 operator observability slice, the PR body includes split justification, changed surfaces are limited to local operator observability, runbook, mapping, and focused tests, and targeted deterministic gates passed. Final local reports: `artifacts/orchestration/pr_review/PR_1874_PULSEPLATE_PR_REVIEW_FINAL.md` and `artifacts/orchestration/pr_review/PR_1874_PULSEPLATE_PR_REVIEW_FINAL.json`.
 
 ## Local Gate Evidence
 
@@ -164,7 +164,7 @@ Evidence: `pulseplate-pr-review` dry-run emitted one advisory `large-diff-risk` 
 - `git diff --check` - PASS.
 - `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed; PASS again on final head.
 - `PREPUSH_DEBUG=1 make validate-changed` - PASS on final head.
-- final oracle-only Experiment Runner evidence `artifacts/orchestration/experiments/results/exp-346a93ac7a31.json` - accepted.
+- final oracle-only Experiment Runner evidence `artifacts/orchestration/experiments/results/exp-8975cbf08daa.json` - accepted.
 - `git push -u origin codex/experiment-runner-operator-observability-report` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.
 - final `git push` to `9732d2243` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.
 

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -109,9 +109,9 @@ Disposition: FIXED
 Commit: 7dff01472d6a6fb045d612e3ce60c936e05b7e2a
 Evidence: CodeRabbit identified that the direct CLI subprocess test relied on `Path.cwd()` and relative artifact cleanup. `tests/test_experiment_operator_ledger.py` now anchors the subprocess script path, cwd, output file, and cleanup directory to `Path(__file__).resolve().parents[1]`, preventing test leakage when the caller's working directory changes.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3353259777 -> d9502e88e9114641d67c7135fb98f053c156fe77
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3353259777 -> d9502e88ef8b254b079d8c7284e76fece26788b1
 Disposition: FIXED
-Commit: d9502e88e9114641d67c7135fb98f053c156fe77
+Commit: d9502e88ef8b254b079d8c7284e76fece26788b1
 Evidence: Codex identified that result-artifact hash read failures could raise `OperatorLedgerError` outside the sanitized invalid-artifact branch. `scripts/orchestration/experiment_operator_ledger.py` now catches `OperatorLedgerError` while projecting safe result metadata, and `tests/test_experiment_operator_ledger.py` proves a hash-read failure degrades to sanitized `artifact_status=invalid` without leaking the exception text.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#pullrequestreview-4424514406

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -49,6 +49,31 @@ Disposition: FIXED
 Commit: 98ef819288ee8662a8b039402d2fac9c57b939b7
 Evidence: Cubic identified that malformed result artifacts could still crash report generation when `validate_experiment_result(...)` raised non-`ValueError` validation exceptions. `scripts/orchestration/experiment_operator_ledger.py` now catches validator type/coercion errors as invalid local result metadata, and `tests/test_experiment_operator_ledger.py` covers a malformed `returncode` object that previously could raise `TypeError` but now degrades to sanitized `artifact_status=invalid`.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3351688844 -> 98ef819288ee8662a8b039402d2fac9c57b939b7
+Disposition: FIXED
+Commit: 98ef819288ee8662a8b039402d2fac9c57b939b7
+Evidence: Cubic identified that malformed result artifacts could still crash report generation when `validate_experiment_result(...)` raised non-`ValueError` validation exceptions. `scripts/orchestration/experiment_operator_ledger.py` now catches validator type/coercion errors as invalid local result metadata, and `tests/test_experiment_operator_ledger.py` covers a malformed `returncode` object that previously could raise `TypeError` but now degrades to sanitized `artifact_status=invalid`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3351603200 -> b557922c4cd4b243d82fcb5663b6293cc840c19b
+Disposition: FIXED
+Commit: b557922c4cd4b243d82fcb5663b6293cc840c19b
+Evidence: `scripts/orchestration/experiment_operator_ledger.py` now reports `experiment_id_hash` instead of raw Experiment Runner `experiment_id` in safe result metadata, and `tests/test_experiment_operator_ledger.py` covers a Slack-shaped `C0SECRETID` result id that is absent from JSON/Markdown/HTML output while only its hash prefix is rendered.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3351603207 -> 98ef819288ee8662a8b039402d2fac9c57b939b7
+Disposition: FIXED
+Commit: 98ef819288ee8662a8b039402d2fac9c57b939b7
+Evidence: `scripts/orchestration/experiment_operator_ledger.py` catches validator `TypeError` and `OverflowError` as invalid local result metadata, and `tests/test_experiment_operator_ledger.py` reaches the validator path with a matching artifact hash before proving malformed `oracle_results[].returncode` degrades to sanitized `artifact_status=invalid`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3351603215 -> b557922c4cd4b243d82fcb5663b6293cc840c19b
+Disposition: FIXED
+Commit: b557922c4cd4b243d82fcb5663b6293cc840c19b
+Evidence: `scripts/orchestration/experiment_operator_ledger.py` adds `dispatch_mode`, `coauthor_required`, `coauthor_decision`, and `human_review_outcome` to the sanitized `latest` report projection and JSON/Markdown/HTML renderers; `tests/test_experiment_operator_ledger.py` covers an approved execute dispatch latest event with required co-author attribution state.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3351823142 -> b557922c4cd4b243d82fcb5663b6293cc840c19b
+Disposition: FIXED
+Commit: b557922c4cd4b243d82fcb5663b6293cc840c19b
+Evidence: `scripts/orchestration/experiment_operator_ledger.py` compares each result artifact file SHA-256 to the ledger `oracle_result_hash` before projecting metadata and fails closed to `artifact_status=invalid` on mismatch or missing hash; `tests/test_experiment_operator_ledger.py` adds a mismatched-hash regression and updates valid metadata fixtures to use the real artifact hash.
+
 ## Mapping Update Protocol
 
 Actionable GitHub review threads and top-level review comments must be recorded
@@ -161,6 +186,7 @@ Evidence: `pulseplate-pr-review` dry-run emitted one advisory `large-diff-risk` 
 - `python3 -m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after post-open QA and bug-hunter fixes.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Cubic-identified malformed-artifact fail-closed fix.
+- repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Codex-identified result-id redaction, latest-state projection, and artifact-hash verification fixes in `b557922c4`.
 - `git diff --check` - PASS.
 - `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed; PASS again on final head.
 - `PREPUSH_DEBUG=1 make validate-changed` - PASS on final head.

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -99,6 +99,16 @@ Disposition: FIXED
 Commit: a4fc9c3943d822a69968e78f3cda75af5553bfdc
 Evidence: Cubic identified that the stdout no-leak guard could miss local paths surrounded by quotes or backticks because the shared `LOCAL_PATH_RE` requires start-of-string or whitespace before the path. `scripts/orchestration/experiment_operator_ledger.py` now adds a CLI stdout local-path detector that matches absolute Unix, Windows drive, and UNC paths without requiring a leading whitespace boundary, and `tests/test_experiment_operator_ledger.py` proves a backticked `/Users/...` path in a report-set acknowledgement fails closed without printing the path.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#pullrequestreview-4424400038 -> 7dff01472d6a6fb045d612e3ce60c936e05b7e2a
+Disposition: FIXED
+Commit: 7dff01472d6a6fb045d612e3ce60c936e05b7e2a
+Evidence: CodeRabbit identified that the direct CLI subprocess test relied on `Path.cwd()` and relative artifact cleanup. `tests/test_experiment_operator_ledger.py` now anchors the subprocess script path, cwd, output file, and cleanup directory to `Path(__file__).resolve().parents[1]`, preventing test leakage when the caller's working directory changes.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874#discussion_r3353256420 -> 7dff01472d6a6fb045d612e3ce60c936e05b7e2a
+Disposition: FIXED
+Commit: 7dff01472d6a6fb045d612e3ce60c936e05b7e2a
+Evidence: CodeRabbit identified that the direct CLI subprocess test relied on `Path.cwd()` and relative artifact cleanup. `tests/test_experiment_operator_ledger.py` now anchors the subprocess script path, cwd, output file, and cleanup directory to `Path(__file__).resolve().parents[1]`, preventing test leakage when the caller's working directory changes.
+
 ## Mapping Update Protocol
 
 Actionable GitHub review threads and top-level review comments must be recorded
@@ -214,10 +224,12 @@ Evidence: final `pulseplate-pr-review` dry-run emitted one advisory `large-diff-
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Codex-identified result-id redaction, latest-state projection, and artifact-hash verification fixes in `b557922c4`.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the CodeQL stdout sink isolation fix in `7bca65ce`.
 - repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Cubic-identified quoted/backticked local-path stdout guard fix in `a4fc9c39`.
+- repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the CodeRabbit-identified direct CLI subprocess root anchoring fix in `7dff0147`.
 - `git diff --check` - PASS.
 - `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed; PASS again on final head.
 - `PREPUSH_DEBUG=1 make validate-changed` - PASS on final head; PASS again after the CodeQL stdout sink isolation fix in `7bca65ce`.
 - `PREPUSH_DEBUG=1 make validate-changed` - PASS after the Cubic-identified quoted/backticked local-path stdout guard fix in `a4fc9c39`.
+- `PREPUSH_DEBUG=1 make validate-changed` - PASS after the CodeRabbit-identified direct CLI subprocess root anchoring fix in `7dff0147`.
 - final oracle-only Experiment Runner evidence `artifacts/orchestration/experiments/results/exp-6560552e0103.json` - accepted after the Codex-identified result-id redaction, latest-state projection, and artifact-hash verification fixes.
 - `git push -u origin codex/experiment-runner-operator-observability-report` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.
 - prior final `git push` to `208ff3bf2` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.

--- a/docs/review/PR_1874_FIXED_MAPPING.md
+++ b/docs/review/PR_1874_FIXED_MAPPING.md
@@ -1,0 +1,128 @@
+# PR #1874 - Fixed in Commit Mapping
+
+**Title:** `PR-3: Experiment Runner Operator Observability Report`
+**Branch:** `codex/experiment-runner-operator-observability-report`
+**Scope:** Add a local/dev-only sanitized Experiment Runner operator
+observability report set over the existing operator ledger and allowlisted
+Experiment Runner result metadata. This PR does not widen Slack command
+authority, PR/review/merge authority, product AI runtime, semantic cache, RAG,
+food data, CBT/coaching runtime, frontend MVP, iOS, backend API, OpenAPI, or
+database scope.
+**Primary commit:** `a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b`
+**Primary proof mode:** initial post-open governance artifact. No GitHub review
+thread is resolved by this initial artifact; actionable threads must be
+appended below with disposition proof before merge readiness.
+
+Synthetic or review-tool evaluated SHAs that are not present in the local PR
+branch are not canonical proof targets. Actual PR disposition proof must be
+recorded in this artifact and checked by the repo's merge-readiness/disposition
+gates.
+
+## Discussion Thread Pass
+
+- [x] Initial post-open fixed-mapping artifact created after PR #1874 opened.
+- [x] PR body mirror includes Discussion Thread Pass, Fixed in Commit Mapping,
+  and Merge Readiness sections.
+- [ ] Final discussion-thread pass completed after all human and bot comments
+  are fixed or dispositioned.
+- [ ] Post-open role-agent sequence completed:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- [ ] Codex Security diff scan / finding discovery completed.
+- [ ] `pulseplate-pr-review` completed.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1874 -> a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b
+Disposition: FIXED
+Commit: a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b
+Evidence: `scripts/orchestration/experiment_operator_ledger.py` adds sanitized JSON/Markdown/HTML operator observability report-set generation, safe Experiment Runner result metadata projection, path traversal and symlink rejection, malformed/missing artifact degradation, and deterministic aggregation; `tests/test_experiment_operator_ledger.py` covers strict schema, redaction probes, path safety, malformed artifacts, latest-status selection, deterministic ordering, idempotent report generation, HTML escaping, and source artifact non-mutation; `tests/test_experiment_slack_socket_bridge.py` and `docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md` preserve the unchanged Slack command/authority boundary.
+
+## Mapping Update Protocol
+
+Actionable GitHub review threads and top-level review comments must be recorded
+above before resolution.
+
+Future resolved actionable comments must be appended here with one of:
+
+- `Disposition: FIXED` plus branch-history commit SHA and evidence.
+- `Disposition: NOT-A-BUG` plus repo evidence and reason.
+- `Disposition: DEFERRED` plus backlog proof and PR-body follow-up note.
+
+## Pre-Open Role-Agent Findings
+
+### agent-coordinator
+
+Disposition: NOT-A-BUG
+Evidence: Coordinator scope locked this lane to local/dev-only operator observability over the existing ledger and safe result metadata, with Slack, RAG, semantic cache, product AI runtime, backend API, frontend MVP, food data, CBT/coaching runtime, PR/review authority, and merge authority explicitly out of scope.
+
+### architecture-specialist
+
+Disposition: NOT-A-BUG
+Evidence: Architecture pass confirmed the existing ledger script is the correct extension point and that the report remains a projection over local evidence rather than a second source of truth.
+
+### security-auditor
+
+Disposition: NOT-A-BUG
+Evidence: Security pass found no blocker after redaction/path-safety coverage was added; the implementation projects only allowlisted result metadata, rejects traversal and symlink result refs, excludes Slack IDs, raw text, raw refs, raw hypotheses, approval digests, local paths, provider logs, oracle stdout/stderr, patch text, token prefixes, and health data, and HTML-escapes dynamic report values.
+
+### qa-engineer-agent
+
+- Finding: missing-result artifacts and idempotent report/source non-mutation behavior needed explicit regression coverage.
+  Disposition: FIXED
+  Commit: a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b
+  Evidence: `tests/test_experiment_operator_ledger.py` covers missing result artifact status, deterministic/idempotent report-set writes, and source result artifact non-mutation.
+
+### bug-hunter
+
+- Finding: `--write-report-set --summary` accepted an ambiguous CLI combination and silently wrote the full report set.
+  Disposition: FIXED
+  Commit: a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b
+  Evidence: `scripts/orchestration/experiment_operator_ledger.py` rejects `--write-report-set` combined with `--summary`, `--record`, or `--output`; `tests/test_experiment_operator_ledger.py` covers the `--summary` conflict.
+
+### dev-operator
+
+Disposition: NOT-A-BUG
+Evidence: Dev-operator pass identified only hygiene/process requirements. Local gates were run after commit so `make validate-changed` saw the branch diff, and runtime artifacts/caches remain gitignored and uncommitted.
+
+### cursor-specialist-agent
+
+- Finding: the runbook retained stale PR-2 wording around local observability.
+  Disposition: FIXED
+  Commit: a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b
+  Evidence: `docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md` now states that no new Slack command or Slack authority is added by the local observability report set, and `tests/test_experiment_slack_socket_bridge.py` checks the updated runbook wording.
+
+## Premortem Findings
+
+- Failure mode: unsafe result artifact content leaks into operator reports.
+  Disposition: FIXED
+  Commit: a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b
+  Evidence: result metadata projection is allowlisted, raw oracle/provider/patch/log fields are excluded, and redaction/path-safety tests cover token-like probes, raw refs, raw hypotheses, local paths, Slack-shaped IDs, malformed artifacts, traversal, and symlink refs.
+
+- Failure mode: PR-3 accidentally widens Slack/operator authority or implies RAG/cache runtime.
+  Disposition: FIXED
+  Commit: a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b
+  Evidence: docs and tests preserve the unchanged Slack command surface, `/pulseplate-runner status` remains operator-status only, and the PR scope is local/dev-only report generation with semantic cache, RAG, and product AI runtime out of scope.
+
+## Experiment Runner Evidence
+
+Disposition: FIXED
+Commit: a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b
+Evidence: oracle-only Experiment Runner result `artifacts/orchestration/experiments/results/exp-7f0fdfc39c11.json` returned `status=accepted`, `runner_mode=oracle_only_governance_reviewer`, `shared_tree_untouched=true`, and `coauthor_required=true`; the primary commit includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+
+## Local Gate Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` - PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` - PASS.
+- `python3 -m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS.
+- `git diff --check` - PASS.
+- `pre-commit run --all-files` - PASS after Black hook rewrote files and rerun passed.
+- `PREPUSH_DEBUG=1 make validate-changed` - PASS.
+- `git push -u origin codex/experiment-runner-operator-observability-report` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.
+
+## Merge Readiness
+
+- [ ] Current-head CI checked after latest push.
+- [ ] No unresolved review threads.
+- [ ] No actionable bot comments remain unmapped.
+- [ ] Required checks pass with no pending jobs.
+- [ ] Wait-window completed after latest bot/review activity.

--- a/scripts/orchestration/experiment_operator_ledger.py
+++ b/scripts/orchestration/experiment_operator_ledger.py
@@ -8,6 +8,7 @@ from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import hashlib
+import html
 import json
 import os
 from pathlib import Path
@@ -21,6 +22,7 @@ if str(OPERATOR_LEDGER_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(OPERATOR_LEDGER_REPO_ROOT))
 
 from scripts.orchestration.context_pack import REPO_ROOT
+from scripts.orchestration.experiment_contract import validate_experiment_result
 from scripts.orchestration.experiment_slack_bridge_config import (
     _normalized_absolute_path,
     _reject_symlinked_output_components,
@@ -35,6 +37,10 @@ REDACTION_VERSION = "experiment-slack-redaction-v1"
 DEFAULT_RETENTION_DAYS = 30
 PROVIDER_TYPE = "experiment_runner_operator_plane"
 DEFAULT_LEDGER_DIR = REPO_ROOT / "artifacts" / "orchestration" / "experiments" / "operator_ledger"
+DEFAULT_OBSERVABILITY_REPORT_DIR = (
+    REPO_ROOT / "artifacts" / "orchestration" / "experiments" / "operator_observability"
+)
+EXPERIMENT_RESULTS_REPO_PREFIX = "artifacts/orchestration/experiments/results/"
 IDEMPOTENCY_KEY_ITERATIONS = 120_000
 IDEMPOTENCY_KEY_NAMESPACE = b"pulseplate-operator-ledger-idempotency-v1"
 IDEMPOTENCY_KEY_CHECK_ITERATIONS = 1_000
@@ -88,6 +94,30 @@ ALLOWED_COAUTHOR_DECISIONS = frozenset(
 )
 ALLOWED_REVIEW_OUTCOMES = frozenset(
     {"pending", "approved", "rejected", "deferred", "not_applicable"}
+)
+RESULT_METADATA_ABSENT = {
+    "artifact_status": "absent",
+    "artifact_ref": "none",
+}
+RESULT_METADATA_INVALID = {
+    "artifact_status": "invalid",
+    "artifact_ref": "none",
+}
+RESULT_METADATA_MISSING = {
+    "artifact_status": "missing",
+    "artifact_ref": "none",
+}
+SAFE_RESULT_METADATA_FIELDS = (
+    "schema_version",
+    "experiment_id",
+    "runner_mode",
+    "status",
+    "failure_class",
+    "mutated_paths_count",
+    "shared_tree_untouched",
+    "promotion_ready",
+    "contribution_kind",
+    "coauthor_required",
 )
 
 HASH_FIELDS = frozenset(
@@ -185,6 +215,13 @@ def default_ledger_dir(repo_root: Path | None = None) -> Path:
 
     effective_root = repo_root or REPO_ROOT
     return effective_root / "artifacts" / "orchestration" / "experiments" / "operator_ledger"
+
+
+def default_observability_report_dir(repo_root: Path | None = None) -> Path:
+    """Return the default local operator observability report directory."""
+
+    effective_root = repo_root or REPO_ROOT
+    return effective_root / "artifacts" / "orchestration" / "experiments" / "operator_observability"
 
 
 def _canonical_json_bytes(payload: Any) -> bytes:
@@ -885,6 +922,74 @@ def _hash_prefix(value: Any) -> str:
     return normalized[:16]
 
 
+def _result_metadata(artifact_status: str, artifact_ref: str, **values: Any) -> dict[str, Any]:
+    metadata = {"artifact_status": artifact_status, "artifact_ref": artifact_ref}
+    metadata.update(values)
+    return metadata
+
+
+def _validate_result_artifact_path(artifact_ref: str, *, repo_root: Path) -> Path:
+    if not artifact_ref.startswith(EXPERIMENT_RESULTS_REPO_PREFIX):
+        raise OperatorLedgerError("Experiment result artifact reference is invalid.")
+    artifact_root = _artifact_root(repo_root)
+    results_root = cast(
+        Path,
+        _normalized_absolute_path(repo_root / EXPERIMENT_RESULTS_REPO_PREFIX),
+    )
+    candidate = cast(Path, _normalized_absolute_path(repo_root / artifact_ref))
+    try:
+        candidate.relative_to(results_root)
+        candidate.relative_to(artifact_root)
+    except ValueError as exc:
+        raise OperatorLedgerError("Experiment result artifact reference is invalid.") from exc
+    try:
+        _reject_symlinked_output_components(
+            candidate,
+            artifact_dir=artifact_root,
+            repo_root=repo_root,
+        )
+    except SlackSocketAuditError as exc:
+        raise OperatorLedgerError("Experiment result artifact reference is invalid.") from exc
+    if candidate.exists() and (not candidate.is_file() or candidate.is_symlink()):
+        raise OperatorLedgerError("Experiment result artifact reference is invalid.")
+    return candidate
+
+
+def _safe_result_metadata_from_ref(artifact_ref: Any, *, repo_root: Path) -> dict[str, Any]:
+    try:
+        normalized_ref = _validate_artifact_ref(artifact_ref)
+    except OperatorLedgerError:
+        return dict(RESULT_METADATA_INVALID)
+    if normalized_ref == "none":
+        return dict(RESULT_METADATA_ABSENT)
+    try:
+        result_path = _validate_result_artifact_path(normalized_ref, repo_root=repo_root)
+    except OperatorLedgerError:
+        return _result_metadata("invalid", normalized_ref)
+    if not result_path.exists():
+        return _result_metadata("missing", normalized_ref)
+    try:
+        raw = json.loads(result_path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise ValueError("Experiment result must be a JSON object.")
+        result = validate_experiment_result(raw)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        return _result_metadata("invalid", normalized_ref)
+    metadata = {
+        "schema_version": result["schema_version"],
+        "experiment_id": result["experiment_id"],
+        "runner_mode": result["runner_mode"],
+        "status": result["status"],
+        "failure_class": result["failure_class"] or "none",
+        "mutated_paths_count": len(result["mutated_paths"]),
+        "shared_tree_untouched": result["shared_tree_untouched"],
+        "promotion_ready": result["promotion_ready"],
+        "contribution_kind": result["contribution_kind"],
+        "coauthor_required": result["coauthor_required"],
+    }
+    return _result_metadata("valid", normalized_ref, **metadata)
+
+
 def latest_operator_ledger_summary(
     *,
     ledger_dir: Path | None = None,
@@ -934,12 +1039,24 @@ def build_operator_observability_report(
 ) -> dict[str, Any]:
     """Build a redacted local observability report from operator ledger events."""
 
-    records = load_operator_ledger_events(ledger_dir=ledger_dir, repo_root=repo_root)
+    effective_root = repo_root or REPO_ROOT
+    records = load_operator_ledger_events(ledger_dir=ledger_dir, repo_root=effective_root)
     by_status = Counter(str(record.payload["status"]) for record in records)
     by_failure = Counter(str(record.payload["failure_class"]) for record in records)
     by_command = Counter(str(record.payload["command_kind"]) for record in records)
     by_dispatch_mode = Counter(str(record.payload["dispatch_mode"]) for record in records)
+    result_artifacts = [
+        _safe_result_metadata_from_ref(
+            record.payload["oracle_result_ref"],
+            repo_root=effective_root,
+        )
+        for record in records
+    ]
+    by_result_artifact_status = Counter(
+        str(metadata["artifact_status"]) for metadata in result_artifacts
+    )
     latest = records[-1].payload if records else None
+    latest_result_metadata = result_artifacts[-1] if result_artifacts else None
     return {
         "authority_boundary": {
             "claimed_merge_readiness": False,
@@ -950,6 +1067,7 @@ def build_operator_observability_report(
         "by_command_kind": dict(sorted(by_command.items())),
         "by_dispatch_mode": dict(sorted(by_dispatch_mode.items())),
         "by_failure_class": dict(sorted(by_failure.items())),
+        "by_result_artifact_status": dict(sorted(by_result_artifact_status.items())),
         "by_status": dict(sorted(by_status.items())),
         "event_count": len(records),
         "latest": (
@@ -959,6 +1077,7 @@ def build_operator_observability_report(
                 "failure_class": latest["failure_class"],
                 "hypothesis_hash": _hash_prefix(latest["hypothesis_hash"]),
                 "oracle_result_ref": latest["oracle_result_ref"],
+                "result_metadata": latest_result_metadata,
                 "status": latest["status"],
                 "workflow_file": latest["workflow_file"],
                 "workflow_ref": latest["workflow_ref"],
@@ -969,6 +1088,7 @@ def build_operator_observability_report(
         "policy_version": POLICY_VERSION,
         "redaction_version": REDACTION_VERSION,
         "report_scope": "local_operator_plane_only",
+        "result_artifacts": result_artifacts,
         "schema_version": SCHEMA_VERSION,
     }
 
@@ -999,6 +1119,14 @@ def render_operator_observability_markdown(report: dict[str, Any]) -> str:
             "oracle_result_ref",
         ):
             lines.append(f"- {key}: `{latest[key]}`")
+        result_metadata = latest.get("result_metadata") or {}
+        lines.extend(["", "## Latest Result Metadata"])
+        for key in (
+            "artifact_status",
+            *SAFE_RESULT_METADATA_FIELDS,
+        ):
+            if key in result_metadata:
+                lines.append(f"- {key}: `{result_metadata[key]}`")
     else:
         lines.append("- none")
     for section, key in (
@@ -1006,6 +1134,7 @@ def render_operator_observability_markdown(report: dict[str, Any]) -> str:
         ("Failure Class Counts", "by_failure_class"),
         ("Command Counts", "by_command_kind"),
         ("Dispatch Mode Counts", "by_dispatch_mode"),
+        ("Result Artifact Counts", "by_result_artifact_status"),
     ):
         lines.extend(["", f"## {section}"])
         counts = report[key]
@@ -1026,6 +1155,168 @@ def render_operator_observability_markdown(report: dict[str, Any]) -> str:
         ]
     )
     return "\n".join(lines)
+
+
+def _html_cell(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _render_html_table(rows: list[tuple[str, Any]]) -> str:
+    if not rows:
+        return "<p>none</p>"
+    rendered_rows = [
+        f'<tr><th scope="row">{_html_cell(name)}</th><td>{_html_cell(value)}</td></tr>'
+        for name, value in rows
+    ]
+    return "<table><tbody>" + "".join(rendered_rows) + "</tbody></table>"
+
+
+def render_operator_observability_html(report: dict[str, Any]) -> str:
+    """Render a deterministic escaped local-only HTML report."""
+
+    latest = report["latest"] or {}
+    latest_result = latest.get("result_metadata") if latest else None
+    sections: list[str] = [
+        "<!doctype html>",
+        '<html lang="en">',
+        "<head>",
+        '<meta charset="utf-8">',
+        "<title>Experiment Runner Operator Ledger Report</title>",
+        "</head>",
+        "<body>",
+        "<h1>Experiment Runner Operator Ledger Report</h1>",
+        "<p>Scope: local operator-plane evidence only.</p>",
+        (
+            "<p>Authority: display-only; not PR, review-thread, merge-readiness, "
+            "or product truth.</p>"
+        ),
+        _render_html_table(
+            [
+                ("policy_version", report["policy_version"]),
+                ("redaction_version", report["redaction_version"]),
+                ("event_count", report["event_count"]),
+            ]
+        ),
+        "<h2>Latest</h2>",
+    ]
+    if latest:
+        sections.append(
+            _render_html_table(
+                [
+                    (key, latest[key])
+                    for key in (
+                        "status",
+                        "failure_class",
+                        "command_kind",
+                        "workflow_file",
+                        "workflow_ref",
+                        "branch_hash",
+                        "hypothesis_hash",
+                        "oracle_result_ref",
+                    )
+                ]
+            )
+        )
+        sections.append("<h2>Latest Result Metadata</h2>")
+        if isinstance(latest_result, dict):
+            sections.append(
+                _render_html_table(
+                    [
+                        (key, latest_result[key])
+                        for key in (
+                            "artifact_status",
+                            *SAFE_RESULT_METADATA_FIELDS,
+                        )
+                        if key in latest_result
+                    ]
+                )
+            )
+        else:
+            sections.append("<p>none</p>")
+    else:
+        sections.append("<p>none</p>")
+    for title, key in (
+        ("Status Counts", "by_status"),
+        ("Failure Class Counts", "by_failure_class"),
+        ("Command Counts", "by_command_kind"),
+        ("Dispatch Mode Counts", "by_dispatch_mode"),
+        ("Result Artifact Counts", "by_result_artifact_status"),
+    ):
+        sections.append(f"<h2>{_html_cell(title)}</h2>")
+        sections.append(_render_html_table(sorted(report[key].items())))
+    sections.extend(
+        [
+            "<h2>Boundary</h2>",
+            _render_html_table(sorted(report["authority_boundary"].items())),
+            "</body>",
+            "</html>",
+            "",
+        ]
+    )
+    return "\n".join(sections)
+
+
+def _report_set_output_paths(
+    report_dir: Path | None,
+    *,
+    repo_root: Path,
+    ledger_dir: Path | None = None,
+) -> dict[str, Path]:
+    target_dir = report_dir or default_observability_report_dir(repo_root)
+    return {
+        "json": _validate_output_path(
+            target_dir / "operator_observability_report.json",
+            repo_root=repo_root,
+            ledger_dir=ledger_dir,
+        ),
+        "markdown": _validate_output_path(
+            target_dir / "operator_observability_report.md",
+            repo_root=repo_root,
+            ledger_dir=ledger_dir,
+        ),
+        "html": _validate_output_path(
+            target_dir / "operator_observability_report.html",
+            repo_root=repo_root,
+            ledger_dir=ledger_dir,
+        ),
+    }
+
+
+def write_operator_observability_report_set(
+    report: dict[str, Any],
+    *,
+    report_dir: Path | None = None,
+    ledger_dir: Path | None = None,
+    repo_root: Path | None = None,
+) -> dict[str, str]:
+    """Write JSON, Markdown, and HTML observability reports under local artifacts."""
+
+    effective_root = repo_root or REPO_ROOT
+    paths = _report_set_output_paths(
+        report_dir,
+        repo_root=effective_root,
+        ledger_dir=ledger_dir,
+    )
+    rendered = {
+        "json": json.dumps(report, indent=2, sort_keys=True) + "\n",
+        "markdown": render_operator_observability_markdown(report),
+        "html": render_operator_observability_html(report),
+    }
+    for path in paths.values():
+        try:
+            _preflight_output_write(path)
+        except OSError as exc:
+            raise OperatorLedgerError("Unable to write Experiment operator ledger output.") from exc
+    for kind, path in paths.items():
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(rendered[kind], encoding="utf-8")
+        except OSError as exc:
+            raise OperatorLedgerError("Unable to write Experiment operator ledger output.") from exc
+    return {
+        kind: _safe_artifact_ref_from_path(path, repo_root=effective_root)
+        for kind, path in paths.items()
+    }
 
 
 def _read_json_object(path: Path) -> dict[str, Any]:
@@ -1057,8 +1348,24 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Render a local observability report from the operator ledger.",
     )
     parser.add_argument(
+        "--write-report-set",
+        action="store_true",
+        help=(
+            "Write JSON, Markdown, and HTML reports under "
+            "artifacts/orchestration/experiments/operator_observability/."
+        ),
+    )
+    parser.add_argument(
+        "--report-dir",
+        default=None,
+        help=(
+            "Optional report-set directory under artifacts/orchestration/experiments. "
+            "Defaults to operator_observability/."
+        ),
+    )
+    parser.add_argument(
         "--format",
-        choices=("json", "markdown"),
+        choices=("html", "json", "markdown"),
         default="json",
         help="Summary output format.",
     )
@@ -1073,7 +1380,18 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     ledger_dir = Path(args.ledger_dir) if args.ledger_dir else None
+    report_dir = Path(args.report_dir) if args.report_dir else None
     try:
+        if args.write_report_set and args.record:
+            raise OperatorLedgerError("Experiment operator ledger report set cannot record events.")
+        if args.write_report_set and args.summary:
+            raise OperatorLedgerError(
+                "Experiment operator ledger report set cannot combine with summary."
+            )
+        if args.write_report_set and args.output:
+            raise OperatorLedgerError(
+                "Experiment operator ledger report set uses deterministic outputs."
+            )
         output_path = (
             _validate_output_path(
                 Path(args.output),
@@ -1102,13 +1420,30 @@ def main(argv: list[str] | None = None) -> int:
                 "status": "recorded",
             }
             rendered = json.dumps(payload, sort_keys=True) + "\n"
-        elif args.summary:
+        elif args.write_report_set:
             report = build_operator_observability_report(ledger_dir=ledger_dir)
             rendered = (
-                json.dumps(report, indent=2, sort_keys=True) + "\n"
-                if args.format == "json"
-                else render_operator_observability_markdown(report)
+                json.dumps(
+                    {
+                        "outputs": write_operator_observability_report_set(
+                            report,
+                            report_dir=report_dir,
+                            ledger_dir=ledger_dir,
+                        ),
+                        "status": "written",
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
             )
+        elif args.summary:
+            report = build_operator_observability_report(ledger_dir=ledger_dir)
+            if args.format == "json":
+                rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+            elif args.format == "html":
+                rendered = render_operator_observability_html(report)
+            else:
+                rendered = render_operator_observability_markdown(report)
         else:
             rendered = (
                 json.dumps(

--- a/scripts/orchestration/experiment_operator_ledger.py
+++ b/scripts/orchestration/experiment_operator_ledger.py
@@ -1491,6 +1491,10 @@ def main(argv: list[str] | None = None) -> int:
             if args.output
             else None
         )
+        if args.summary and output_path is None:
+            raise OperatorLedgerError(
+                "Experiment operator ledger summary output requires --output."
+            )
         if output_path:
             try:
                 _preflight_output_write(output_path)
@@ -1498,6 +1502,8 @@ def main(argv: list[str] | None = None) -> int:
                 raise OperatorLedgerError(
                     "Unable to write Experiment operator ledger output."
                 ) from exc
+        rendered: str | None = None
+        stdout_payload: str | None = None
         if args.record:
             if args.event_json is None:
                 raise OperatorLedgerError("Experiment operator ledger input is invalid.")
@@ -1509,10 +1515,10 @@ def main(argv: list[str] | None = None) -> int:
                 "idempotency_key": path.stem,
                 "status": "recorded",
             }
-            rendered = json.dumps(payload, sort_keys=True) + "\n"
+            stdout_payload = json.dumps(payload, sort_keys=True) + "\n"
         elif args.write_report_set:
             report = build_operator_observability_report(ledger_dir=ledger_dir)
-            rendered = (
+            stdout_payload = (
                 json.dumps(
                     {
                         "outputs": write_operator_observability_report_set(
@@ -1535,7 +1541,7 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 rendered = render_operator_observability_markdown(report)
         else:
-            rendered = (
+            stdout_payload = (
                 json.dumps(
                     {"policy_version": POLICY_VERSION, "status": "idle"},
                     sort_keys=True,
@@ -1543,6 +1549,10 @@ def main(argv: list[str] | None = None) -> int:
                 + "\n"
             )
         if output_path:
+            if rendered is None:
+                rendered = stdout_payload
+            if rendered is None:
+                raise OperatorLedgerError("Experiment operator ledger output is invalid.")
             try:
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 output_path.write_text(rendered, encoding="utf-8")
@@ -1551,7 +1561,9 @@ def main(argv: list[str] | None = None) -> int:
                     "Unable to write Experiment operator ledger output."
                 ) from exc
         else:
-            sys.stdout.write(_safe_cli_stdout_payload(rendered))
+            if stdout_payload is None:
+                raise OperatorLedgerError("Experiment operator ledger output is invalid.")
+            sys.stdout.write(_safe_cli_stdout_payload(stdout_payload))
     except OperatorLedgerError as exc:
         print(f"FAIL: {exc}")
         return 1

--- a/scripts/orchestration/experiment_operator_ledger.py
+++ b/scripts/orchestration/experiment_operator_ledger.py
@@ -1397,6 +1397,10 @@ def write_operator_observability_report_set(
         repo_root=effective_root,
         ledger_dir=ledger_dir,
     )
+    safe_refs = {
+        kind: _safe_artifact_ref_from_path(path, repo_root=effective_root)
+        for kind, path in paths.items()
+    }
     rendered = {
         "json": json.dumps(report, indent=2, sort_keys=True) + "\n",
         "markdown": render_operator_observability_markdown(report),
@@ -1413,10 +1417,7 @@ def write_operator_observability_report_set(
             path.write_text(rendered[kind], encoding="utf-8")
         except OSError as exc:
             raise OperatorLedgerError("Unable to write Experiment operator ledger output.") from exc
-    return {
-        kind: _safe_artifact_ref_from_path(path, repo_root=effective_root)
-        for kind, path in paths.items()
-    }
+    return safe_refs
 
 
 def _read_json_object(path: Path) -> dict[str, Any]:

--- a/scripts/orchestration/experiment_operator_ledger.py
+++ b/scripts/orchestration/experiment_operator_ledger.py
@@ -1023,6 +1023,7 @@ def _safe_result_metadata_from_ref(
         result = validate_experiment_result(raw)
     except (
         OSError,
+        OperatorLedgerError,
         UnicodeDecodeError,
         json.JSONDecodeError,
         ValueError,

--- a/scripts/orchestration/experiment_operator_ledger.py
+++ b/scripts/orchestration/experiment_operator_ledger.py
@@ -129,6 +129,14 @@ CLI_OUTPUT_PATCH_OR_LOG_RE = re.compile(
     r"stdout\s*:|stderr\s*:)",
     re.IGNORECASE | re.MULTILINE,
 )
+CLI_OUTPUT_LOCAL_PATH_RE = re.compile(
+    r"("
+    r"/(?:Users|home|var|opt|tmp|private|Volumes|etc|usr|Library|System)/"
+    r"[^\s\"'`<>]*"
+    r"|[A-Za-z]:\\[^\s\"'`<>]+"
+    r"|\\\\[^\s\"'`<>]+"
+    r")"
+)
 
 HASH_FIELDS = frozenset(
     {
@@ -363,6 +371,7 @@ def _safe_cli_stdout_payload(rendered: str) -> str:
         or GITHUB_APP_TOKEN_ARTIFACT_RE.search(rendered)
         or SLACK_IDENTIFIER_RE.search(rendered)
         or LOCAL_PATH_RE.search(rendered)
+        or CLI_OUTPUT_LOCAL_PATH_RE.search(rendered)
         or CLI_OUTPUT_PATCH_OR_LOG_RE.search(rendered)
     ):
         raise OperatorLedgerError("Experiment operator ledger output contains unsafe content.")

--- a/scripts/orchestration/experiment_operator_ledger.py
+++ b/scripts/orchestration/experiment_operator_ledger.py
@@ -109,7 +109,7 @@ RESULT_METADATA_MISSING = {
 }
 SAFE_RESULT_METADATA_FIELDS = (
     "schema_version",
-    "experiment_id",
+    "experiment_id_hash",
     "runner_mode",
     "status",
     "failure_class",
@@ -922,6 +922,10 @@ def _hash_prefix(value: Any) -> str:
     return normalized[:16]
 
 
+def _value_hash_prefix(value: Any) -> str:
+    return hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:16]
+
+
 def _result_metadata(artifact_status: str, artifact_ref: str, **values: Any) -> dict[str, Any]:
     metadata = {"artifact_status": artifact_status, "artifact_ref": artifact_ref}
     metadata.update(values)
@@ -955,9 +959,15 @@ def _validate_result_artifact_path(artifact_ref: str, *, repo_root: Path) -> Pat
     return candidate
 
 
-def _safe_result_metadata_from_ref(artifact_ref: Any, *, repo_root: Path) -> dict[str, Any]:
+def _safe_result_metadata_from_ref(
+    artifact_ref: Any,
+    *,
+    repo_root: Path,
+    expected_result_hash: Any = "none",
+) -> dict[str, Any]:
     try:
         normalized_ref = _validate_artifact_ref(artifact_ref)
+        normalized_expected_hash = _validate_hash(expected_result_hash)
     except OperatorLedgerError:
         return dict(RESULT_METADATA_INVALID)
     if normalized_ref == "none":
@@ -969,6 +979,11 @@ def _safe_result_metadata_from_ref(artifact_ref: Any, *, repo_root: Path) -> dic
     if not result_path.exists():
         return _result_metadata("missing", normalized_ref)
     try:
+        if (
+            normalized_expected_hash == "none"
+            or _sha256_file(result_path) != normalized_expected_hash
+        ):
+            return _result_metadata("invalid", normalized_ref)
         raw = json.loads(result_path.read_text(encoding="utf-8"))
         if not isinstance(raw, dict):
             raise ValueError("Experiment result must be a JSON object.")
@@ -984,7 +999,7 @@ def _safe_result_metadata_from_ref(artifact_ref: Any, *, repo_root: Path) -> dic
         return _result_metadata("invalid", normalized_ref)
     metadata = {
         "schema_version": result["schema_version"],
-        "experiment_id": result["experiment_id"],
+        "experiment_id_hash": _value_hash_prefix(result["experiment_id"]),
         "runner_mode": result["runner_mode"],
         "status": result["status"],
         "failure_class": result["failure_class"] or "none",
@@ -1056,6 +1071,7 @@ def build_operator_observability_report(
         _safe_result_metadata_from_ref(
             record.payload["oracle_result_ref"],
             repo_root=effective_root,
+            expected_result_hash=record.payload["oracle_result_hash"],
         )
         for record in records
     ]
@@ -1091,7 +1107,11 @@ def build_operator_observability_report(
             {
                 "branch_hash": _hash_prefix(latest["branch_hash"]),
                 "command_kind": latest["command_kind"],
+                "coauthor_decision": latest["coauthor_decision"],
+                "coauthor_required": latest["coauthor_required"],
+                "dispatch_mode": latest["dispatch_mode"],
                 "failure_class": latest["failure_class"],
+                "human_review_outcome": latest["human_review_outcome"],
                 "hypothesis_hash": _hash_prefix(latest["hypothesis_hash"]),
                 "oracle_result_ref": latest["oracle_result_ref"],
                 "result_metadata": latest_result_metadata,
@@ -1143,6 +1163,10 @@ def render_operator_observability_markdown(report: dict[str, Any]) -> str:
             "status",
             "failure_class",
             "command_kind",
+            "dispatch_mode",
+            "coauthor_decision",
+            "coauthor_required",
+            "human_review_outcome",
             "workflow_file",
             "workflow_ref",
             "branch_hash",
@@ -1242,6 +1266,10 @@ def render_operator_observability_html(report: dict[str, Any]) -> str:
                         "status",
                         "failure_class",
                         "command_kind",
+                        "dispatch_mode",
+                        "coauthor_decision",
+                        "coauthor_required",
+                        "human_review_outcome",
                         "workflow_file",
                         "workflow_ref",
                         "branch_hash",

--- a/scripts/orchestration/experiment_operator_ledger.py
+++ b/scripts/orchestration/experiment_operator_ledger.py
@@ -1055,6 +1055,16 @@ def build_operator_observability_report(
     by_result_artifact_status = Counter(
         str(metadata["artifact_status"]) for metadata in result_artifacts
     )
+    source_counts = {
+        "operator_ledger_events": len(records),
+        "result_artifact_refs": sum(
+            1 for metadata in result_artifacts if metadata.get("artifact_status") != "absent"
+        ),
+    }
+    malformed_artifact_counts = {
+        "invalid_result_artifacts": by_result_artifact_status.get("invalid", 0),
+        "missing_result_artifacts": by_result_artifact_status.get("missing", 0),
+    }
     latest = records[-1].payload if records else None
     latest_result_metadata = result_artifacts[-1] if result_artifacts else None
     return {
@@ -1085,11 +1095,25 @@ def build_operator_observability_report(
             if latest
             else None
         ),
+        "malformed_artifact_counts": malformed_artifact_counts,
         "policy_version": POLICY_VERSION,
         "redaction_version": REDACTION_VERSION,
+        "redaction_summary": {
+            "approval_digests_stored": False,
+            "health_data_stored": False,
+            "local_paths_stored": False,
+            "patch_text_stored": False,
+            "provider_logs_stored": False,
+            "raw_branch_refs_stored": False,
+            "raw_hypotheses_stored": False,
+            "raw_slack_text_stored": False,
+            "slack_ids_stored": False,
+            "token_prefixes_stored": False,
+        },
         "report_scope": "local_operator_plane_only",
         "result_artifacts": result_artifacts,
         "schema_version": SCHEMA_VERSION,
+        "source_counts": source_counts,
     }
 
 
@@ -1135,9 +1159,12 @@ def render_operator_observability_markdown(report: dict[str, Any]) -> str:
         ("Command Counts", "by_command_kind"),
         ("Dispatch Mode Counts", "by_dispatch_mode"),
         ("Result Artifact Counts", "by_result_artifact_status"),
+        ("Source Counts", "source_counts"),
+        ("Malformed Artifact Counts", "malformed_artifact_counts"),
+        ("Redaction Summary", "redaction_summary"),
     ):
         lines.extend(["", f"## {section}"])
-        counts = report[key]
+        counts = report.get(key, {})
         if counts:
             for name, count in counts.items():
                 lines.append(f"- `{name}`: `{count}`")
@@ -1241,9 +1268,13 @@ def render_operator_observability_html(report: dict[str, Any]) -> str:
         ("Command Counts", "by_command_kind"),
         ("Dispatch Mode Counts", "by_dispatch_mode"),
         ("Result Artifact Counts", "by_result_artifact_status"),
+        ("Source Counts", "source_counts"),
+        ("Malformed Artifact Counts", "malformed_artifact_counts"),
+        ("Redaction Summary", "redaction_summary"),
     ):
         sections.append(f"<h2>{_html_cell(title)}</h2>")
-        sections.append(_render_html_table(sorted(report[key].items())))
+        values = report.get(key, {})
+        sections.append(_render_html_table(sorted(values.items())))
     sections.extend(
         [
             "<h2>Boundary</h2>",

--- a/scripts/orchestration/experiment_operator_ledger.py
+++ b/scripts/orchestration/experiment_operator_ledger.py
@@ -29,7 +29,11 @@ from scripts.orchestration.experiment_slack_bridge_config import (
 )
 from scripts.orchestration.experiment_slack_bridge_constants import SECRET_SHAPED_RE, SHA256_HEX_RE
 from scripts.orchestration.experiment_slack_bridge_models import SlackSocketAuditError
-from scripts.orchestration.experiment_slack_redaction import SLACK_IDENTIFIER_RE, safe_artifact_ref
+from scripts.orchestration.experiment_slack_redaction import (
+    LOCAL_PATH_RE,
+    SLACK_IDENTIFIER_RE,
+    safe_artifact_ref,
+)
 
 SCHEMA_VERSION = "1.0"
 POLICY_VERSION = "operator-plane-2026-06-02-v1"
@@ -118,6 +122,12 @@ SAFE_RESULT_METADATA_FIELDS = (
     "promotion_ready",
     "contribution_kind",
     "coauthor_required",
+)
+CLI_OUTPUT_PATCH_OR_LOG_RE = re.compile(
+    r"(diff\s+--git|^@@\s|^\+\+\+\s|^---\s|raw\s+patch|patch\s+text|"
+    r"oracle\s+stdout|oracle\s+stderr|raw\s+stdout|raw\s+stderr|"
+    r"stdout\s*:|stderr\s*:)",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 HASH_FIELDS = frozenset(
@@ -343,6 +353,20 @@ def _validate_retention_days(value: Any) -> int:
     if value <= 0 or value > 366:
         raise OperatorLedgerError("Experiment operator ledger retention is invalid.")
     return value
+
+
+def _safe_cli_stdout_payload(rendered: str) -> str:
+    """Return a CLI stdout payload only after final no-leak enforcement."""
+
+    if (
+        SECRET_SHAPED_RE.search(rendered)
+        or GITHUB_APP_TOKEN_ARTIFACT_RE.search(rendered)
+        or SLACK_IDENTIFIER_RE.search(rendered)
+        or LOCAL_PATH_RE.search(rendered)
+        or CLI_OUTPUT_PATCH_OR_LOG_RE.search(rendered)
+    ):
+        raise OperatorLedgerError("Experiment operator ledger output contains unsafe content.")
+    return rendered
 
 
 def _idempotency_material(payload: dict[str, Any]) -> dict[str, Any]:
@@ -1527,7 +1551,7 @@ def main(argv: list[str] | None = None) -> int:
                     "Unable to write Experiment operator ledger output."
                 ) from exc
         else:
-            print(rendered, end="")
+            sys.stdout.write(_safe_cli_stdout_payload(rendered))
     except OperatorLedgerError as exc:
         print(f"FAIL: {exc}")
         return 1

--- a/scripts/orchestration/experiment_operator_ledger.py
+++ b/scripts/orchestration/experiment_operator_ledger.py
@@ -973,7 +973,14 @@ def _safe_result_metadata_from_ref(artifact_ref: Any, *, repo_root: Path) -> dic
         if not isinstance(raw, dict):
             raise ValueError("Experiment result must be a JSON object.")
         result = validate_experiment_result(raw)
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):
+    except (
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ValueError,
+        TypeError,
+        OverflowError,
+    ):
         return _result_metadata("invalid", normalized_ref)
     metadata = {
         "schema_version": result["schema_version"],

--- a/tests/test_experiment_operator_ledger.py
+++ b/tests/test_experiment_operator_ledger.py
@@ -607,6 +607,39 @@ def test_operator_ledger_result_metadata_fails_closed_for_malformed_artifact(
     _assert_no_raw_leak(rendered)
 
 
+def test_operator_ledger_result_metadata_fails_closed_for_hash_read_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result_path = _write_result(tmp_path, "operator-plane.json", _result())
+    ledger.write_operator_ledger_event(
+        _event(oracle_result_hash=hashlib.sha256(result_path.read_bytes()).hexdigest()),
+        repo_root=tmp_path,
+    )
+
+    def fail_hash(_: Path) -> str:
+        raise ledger.OperatorLedgerError("hash unavailable")
+
+    monkeypatch.setattr(ledger, "_sha256_file", fail_hash)
+
+    report = ledger.build_operator_observability_report(repo_root=tmp_path)
+    rendered = json.dumps(report, sort_keys=True) + ledger.render_operator_observability_html(
+        report
+    )
+
+    assert report["by_result_artifact_status"] == {"invalid": 1}
+    assert report["malformed_artifact_counts"] == {
+        "invalid_result_artifacts": 1,
+        "missing_result_artifacts": 0,
+    }
+    assert report["latest"]["result_metadata"] == {
+        "artifact_status": "invalid",
+        "artifact_ref": "artifacts/orchestration/experiments/results/operator-plane.json",
+    }
+    assert "hash unavailable" not in rendered
+    _assert_no_raw_leak(rendered)
+
+
 def test_operator_ledger_result_metadata_fails_closed_for_type_errors(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_experiment_operator_ledger.py
+++ b/tests/test_experiment_operator_ledger.py
@@ -530,6 +530,43 @@ def test_operator_ledger_result_metadata_fails_closed_for_malformed_artifact(
     _assert_no_raw_leak(rendered)
 
 
+def test_operator_ledger_result_metadata_fails_closed_for_type_errors(
+    tmp_path: Path,
+) -> None:
+    _write_result(
+        tmp_path,
+        "operator-plane.json",
+        _result(
+            oracle_results=[
+                {
+                    "command": "pytest tests/test_experiment_operator_ledger.py -q",
+                    "returncode": {"not": "an-int"},
+                    "stdout": "C0SECRET /Users/alice diff --git must not render",
+                    "stderr": "xoxb-secretsecretsecret must not render",
+                    "cwd": "/Users/alice/PulsePlate",
+                }
+            ]
+        ),
+    )
+    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+
+    report = ledger.build_operator_observability_report(repo_root=tmp_path)
+    rendered = json.dumps(report, sort_keys=True) + ledger.render_operator_observability_html(
+        report
+    )
+
+    assert report["by_result_artifact_status"] == {"invalid": 1}
+    assert report["malformed_artifact_counts"] == {
+        "invalid_result_artifacts": 1,
+        "missing_result_artifacts": 0,
+    }
+    assert report["latest"]["result_metadata"] == {
+        "artifact_status": "invalid",
+        "artifact_ref": "artifacts/orchestration/experiments/results/operator-plane.json",
+    }
+    _assert_no_raw_leak(rendered)
+
+
 def test_operator_ledger_result_metadata_fails_closed_for_symlinked_artifact(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_experiment_operator_ledger.py
+++ b/tests/test_experiment_operator_ledger.py
@@ -93,12 +93,28 @@ def _write_result(repo_root: Path, name: str, payload: dict[str, object]) -> Pat
     return path
 
 
+def _event_for_result(
+    repo_root: Path,
+    name: str = "operator-plane.json",
+    payload: dict[str, object] | None = None,
+    **overrides: object,
+) -> dict[str, object]:
+    result_path = _write_result(repo_root, name, payload or _result())
+    return _event(
+        oracle_result_ref=f"{ledger.EXPERIMENT_RESULTS_REPO_PREFIX}{name}",
+        oracle_result_hash=hashlib.sha256(result_path.read_bytes()).hexdigest(),
+        **overrides,
+    )
+
+
 def _assert_no_raw_leak(value: str) -> None:
     forbidden = (
         "C0SECRET",
+        "C0SECRETID",
         "U0DENIED",
         "T0SECRET",
         "Ev0SECRET",
+        "operator_report",
         "feature/operator-plane",
         "raw hypothesis",
         "/Users/",
@@ -451,8 +467,13 @@ def test_operator_ledger_report_and_status_summary_are_redacted(tmp_path: Path) 
 
 
 def test_operator_ledger_report_projects_only_safe_result_metadata(tmp_path: Path) -> None:
-    _write_result(tmp_path, "operator-plane.json", _result())
-    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+    ledger.write_operator_ledger_event(
+        _event_for_result(
+            tmp_path,
+            payload=_result(experiment_id="C0SECRETID"),
+        ),
+        repo_root=tmp_path,
+    )
 
     report = ledger.build_operator_observability_report(repo_root=tmp_path)
     markdown = ledger.render_operator_observability_markdown(report)
@@ -465,7 +486,7 @@ def test_operator_ledger_report_projects_only_safe_result_metadata(tmp_path: Pat
         "artifact_status": "valid",
         "artifact_ref": "artifacts/orchestration/experiments/results/operator-plane.json",
         "schema_version": "1.0",
-        "experiment_id": "operator_report",
+        "experiment_id_hash": _hash("C0SECRETID")[:16],
         "runner_mode": "candidate_patch",
         "status": "accepted",
         "failure_class": "none",
@@ -485,6 +506,58 @@ def test_operator_ledger_report_projects_only_safe_result_metadata(tmp_path: Pat
     assert "stderr" not in rendered
     assert "cwd" not in rendered
     _assert_no_raw_leak(rendered)
+
+
+def test_operator_ledger_result_metadata_requires_matching_artifact_hash(
+    tmp_path: Path,
+) -> None:
+    _write_result(tmp_path, "operator-plane.json", _result(experiment_id="C0SECRETID"))
+    ledger.write_operator_ledger_event(
+        _event(oracle_result_hash=_hash("different result bytes")),
+        repo_root=tmp_path,
+    )
+
+    report = ledger.build_operator_observability_report(repo_root=tmp_path)
+    rendered = json.dumps(report, sort_keys=True) + ledger.render_operator_observability_html(
+        report
+    )
+
+    assert report["by_result_artifact_status"] == {"invalid": 1}
+    assert report["latest"]["result_metadata"] == {
+        "artifact_status": "invalid",
+        "artifact_ref": "artifacts/orchestration/experiments/results/operator-plane.json",
+    }
+    _assert_no_raw_leak(rendered)
+
+
+def test_operator_ledger_report_latest_includes_operator_review_state(
+    tmp_path: Path,
+) -> None:
+    ledger.write_operator_ledger_event(
+        _event(
+            coauthor_decision="required",
+            coauthor_required=True,
+            command_kind="run-experiment",
+            dispatch_mode="execute",
+            human_review_outcome="approved",
+            oracle_result_hash="none",
+            oracle_result_ref="none",
+            status="dispatched",
+        ),
+        repo_root=tmp_path,
+    )
+
+    report = ledger.build_operator_observability_report(repo_root=tmp_path)
+    markdown = ledger.render_operator_observability_markdown(report)
+    html = ledger.render_operator_observability_html(report)
+
+    assert report["latest"]["dispatch_mode"] == "execute"
+    assert report["latest"]["coauthor_required"] is True
+    assert report["latest"]["coauthor_decision"] == "required"
+    assert report["latest"]["human_review_outcome"] == "approved"
+    assert "- dispatch_mode: `execute`" in markdown
+    assert "coauthor_decision" in html
+    assert "human_review_outcome" in html
 
 
 def test_operator_ledger_report_does_not_count_absent_result_refs(
@@ -514,7 +587,10 @@ def test_operator_ledger_result_metadata_fails_closed_for_malformed_artifact(
     result_path = tmp_path / ledger.EXPERIMENT_RESULTS_REPO_PREFIX / "operator-plane.json"
     result_path.parent.mkdir(parents=True)
     result_path.write_text("{not-json C0SECRET /Users/alice", encoding="utf-8")
-    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+    ledger.write_operator_ledger_event(
+        _event(oracle_result_hash=hashlib.sha256(result_path.read_bytes()).hexdigest()),
+        repo_root=tmp_path,
+    )
 
     report = ledger.build_operator_observability_report(repo_root=tmp_path)
     rendered = json.dumps(report, sort_keys=True) + ledger.render_operator_observability_html(
@@ -533,10 +609,9 @@ def test_operator_ledger_result_metadata_fails_closed_for_malformed_artifact(
 def test_operator_ledger_result_metadata_fails_closed_for_type_errors(
     tmp_path: Path,
 ) -> None:
-    _write_result(
+    event = _event_for_result(
         tmp_path,
-        "operator-plane.json",
-        _result(
+        payload=_result(
             oracle_results=[
                 {
                     "command": "pytest tests/test_experiment_operator_ledger.py -q",
@@ -548,7 +623,7 @@ def test_operator_ledger_result_metadata_fails_closed_for_type_errors(
             ]
         ),
     )
-    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+    ledger.write_operator_ledger_event(event, repo_root=tmp_path)
 
     report = ledger.build_operator_observability_report(repo_root=tmp_path)
     rendered = json.dumps(report, sort_keys=True) + ledger.render_operator_observability_html(
@@ -645,8 +720,12 @@ def test_operator_ledger_html_renderer_escapes_dynamic_values() -> None:
             "oracle_result_ref": "artifacts/orchestration/experiments/results/operator-plane.json",
             "result_metadata": {
                 "artifact_status": "valid",
-                "experiment_id": "<img src=x onerror=alert(1)>",
+                "experiment_id_hash": "<img src=x onerror=alert(1)>",
             },
+            "coauthor_decision": "not_required",
+            "coauthor_required": False,
+            "dispatch_mode": "dry-run",
+            "human_review_outcome": "pending",
             "status": "dry_run",
             "workflow_file": "none",
             "workflow_ref": "none",
@@ -1029,8 +1108,7 @@ def test_operator_ledger_cli_summary_writes_html_report(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(ledger, "REPO_ROOT", tmp_path)
-    _write_result(tmp_path, "operator-plane.json", _result())
-    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+    ledger.write_operator_ledger_event(_event_for_result(tmp_path), repo_root=tmp_path)
 
     assert (
         ledger.main(
@@ -1050,7 +1128,8 @@ def test_operator_ledger_cli_summary_writes_html_report(
 
     assert "<!doctype html>" in report
     assert "Latest Result Metadata" in report
-    assert "operator_report" in report
+    assert "experiment_id_hash" in report
+    assert _hash("operator_report")[:16] in report
     assert ">candidate_patch<" in report
     assert "diff --git a/secret" not in report
     assert "+token" not in report
@@ -1064,8 +1143,7 @@ def test_operator_ledger_cli_writes_default_observability_report_set(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     monkeypatch.setattr(ledger, "REPO_ROOT", tmp_path)
-    _write_result(tmp_path, "operator-plane.json", _result())
-    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+    ledger.write_operator_ledger_event(_event_for_result(tmp_path), repo_root=tmp_path)
 
     assert ledger.main(["--write-report-set"]) == 0
     stdout = capsys.readouterr().out
@@ -1095,7 +1173,8 @@ def test_operator_ledger_cli_writes_default_observability_report_set(
     )
 
     assert "Latest Result Metadata" in rendered
-    assert "operator_report" in rendered
+    assert "experiment_id_hash" in rendered
+    assert _hash("operator_report")[:16] in rendered
     assert "oracle_results" not in rendered
     assert "diff --git a/secret" not in rendered
     assert str(tmp_path) not in stdout
@@ -1160,7 +1239,10 @@ def test_operator_ledger_report_set_is_idempotent_and_preserves_result_artifacts
 ) -> None:
     result_path = _write_result(tmp_path, "operator-plane.json", _result())
     original_result = result_path.read_bytes()
-    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+    ledger.write_operator_ledger_event(
+        _event(oracle_result_hash=hashlib.sha256(original_result).hexdigest()),
+        repo_root=tmp_path,
+    )
     report = ledger.build_operator_observability_report(repo_root=tmp_path)
 
     first_outputs = ledger.write_operator_observability_report_set(report, repo_root=tmp_path)
@@ -1200,8 +1282,7 @@ def test_operator_ledger_cli_report_set_rejects_reserved_event_store(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     monkeypatch.setattr(ledger, "REPO_ROOT", tmp_path)
-    _write_result(tmp_path, "operator-plane.json", _result())
-    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+    ledger.write_operator_ledger_event(_event_for_result(tmp_path), repo_root=tmp_path)
 
     assert (
         ledger.main(

--- a/tests/test_experiment_operator_ledger.py
+++ b/tests/test_experiment_operator_ledger.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 import hashlib
 import json
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 
@@ -1433,6 +1434,20 @@ def test_operator_ledger_cli_output_write_errors_are_sanitized(
     assert str(tmp_path) not in failure
 
 
+def test_operator_ledger_cli_summary_requires_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(ledger, "REPO_ROOT", tmp_path)
+
+    assert ledger.main(["--summary", "--format", "json"]) == 1
+    failure = capsys.readouterr().out
+
+    assert failure == "FAIL: Experiment operator ledger summary output requires --output.\n"
+    _assert_no_raw_leak(failure)
+
+
 def test_operator_ledger_cli_stdout_fails_closed_on_unsafe_rendered_payload(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1441,11 +1456,11 @@ def test_operator_ledger_cli_stdout_fails_closed_on_unsafe_rendered_payload(
     monkeypatch.setattr(ledger, "REPO_ROOT", tmp_path)
     monkeypatch.setattr(
         ledger,
-        "build_operator_observability_report",
-        lambda **_: {"unsafe": "xoxb-secretsecretsecret /Users/alice diff --git raw hypothesis"},
+        "write_operator_observability_report_set",
+        lambda *_, **__: {"json": "xoxb-secretsecretsecret /Users/alice diff --git raw hypothesis"},
     )
 
-    assert ledger.main(["--summary", "--format", "json"]) == 1
+    assert ledger.main(["--write-report-set"]) == 1
     failure = capsys.readouterr().out
 
     assert failure == "FAIL: Experiment operator ledger output contains unsafe content.\n"
@@ -1453,28 +1468,37 @@ def test_operator_ledger_cli_stdout_fails_closed_on_unsafe_rendered_payload(
 
 
 def test_operator_ledger_direct_cli_summary_invocation_is_supported(tmp_path: Path) -> None:
-    isolated_ledger = (
-        "artifacts/orchestration/experiments/"
-        f"direct_cli_summary_{hashlib.sha256(str(tmp_path).encode('utf-8')).hexdigest()}"
-    )
-    result = subprocess.run(
-        [
-            sys.executable,
-            "scripts/orchestration/experiment_operator_ledger.py",
-            "--summary",
-            "--ledger-dir",
-            isolated_ledger,
-        ],
-        cwd=Path.cwd(),
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    run_id = hashlib.sha256(str(tmp_path).encode("utf-8")).hexdigest()
+    artifact_ref = f"artifacts/orchestration/experiments/direct_cli_summary_{run_id}"
+    isolated_ledger = f"{artifact_ref}/ledger"
+    output_ref = f"{artifact_ref}/summary.json"
+    output_path = Path(output_ref)
 
-    assert result.returncode == 0
-    assert "local_operator_plane_only" in result.stdout
-    assert "ModuleNotFoundError" not in result.stderr
-    _assert_no_raw_leak(result.stdout)
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/orchestration/experiment_operator_ledger.py",
+                "--summary",
+                "--ledger-dir",
+                isolated_ledger,
+                "--output",
+                output_ref,
+            ],
+            cwd=Path.cwd(),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert result.returncode == 0
+        assert result.stdout == ""
+        assert "ModuleNotFoundError" not in result.stderr
+        report = output_path.read_text(encoding="utf-8")
+        assert "local_operator_plane_only" in report
+        _assert_no_raw_leak(result.stdout + report)
+    finally:
+        shutil.rmtree(Path(artifact_ref), ignore_errors=True)
 
 
 def test_operator_plane_backlog_epic_documents_boundaries() -> None:

--- a/tests/test_experiment_operator_ledger.py
+++ b/tests/test_experiment_operator_ledger.py
@@ -487,6 +487,27 @@ def test_operator_ledger_report_projects_only_safe_result_metadata(tmp_path: Pat
     _assert_no_raw_leak(rendered)
 
 
+def test_operator_ledger_report_does_not_count_absent_result_refs(
+    tmp_path: Path,
+) -> None:
+    ledger.write_operator_ledger_event(
+        _event(oracle_result_ref="none", oracle_result_hash="none"),
+        repo_root=tmp_path,
+    )
+
+    report = ledger.build_operator_observability_report(repo_root=tmp_path)
+
+    assert report["by_result_artifact_status"] == {"absent": 1}
+    assert report["source_counts"] == {
+        "operator_ledger_events": 1,
+        "result_artifact_refs": 0,
+    }
+    assert report["latest"]["result_metadata"] == {
+        "artifact_ref": "none",
+        "artifact_status": "absent",
+    }
+
+
 def test_operator_ledger_result_metadata_fails_closed_for_malformed_artifact(
     tmp_path: Path,
 ) -> None:
@@ -1042,6 +1063,59 @@ def test_operator_ledger_cli_writes_default_observability_report_set(
     assert "diff --git a/secret" not in rendered
     assert str(tmp_path) not in stdout
     _assert_no_raw_leak(stdout + rendered)
+
+
+def test_operator_ledger_cli_writes_empty_observability_report_set(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(ledger, "REPO_ROOT", tmp_path)
+
+    assert ledger.main(["--write-report-set"]) == 0
+    stdout = capsys.readouterr().out
+    output = json.loads(stdout)
+    report_dir = ledger.default_observability_report_dir(tmp_path)
+    json_report = json.loads(
+        (report_dir / "operator_observability_report.json").read_text(encoding="utf-8")
+    )
+    markdown = (report_dir / "operator_observability_report.md").read_text(encoding="utf-8")
+    html = (report_dir / "operator_observability_report.html").read_text(encoding="utf-8")
+    rendered = stdout + json.dumps(json_report, sort_keys=True) + markdown + html
+
+    assert output["status"] == "written"
+    assert json_report["event_count"] == 0
+    assert json_report["latest"] is None
+    assert json_report["by_status"] == {}
+    assert json_report["by_dispatch_mode"] == {}
+    assert json_report["by_failure_class"] == {}
+    assert json_report["by_command_kind"] == {}
+    assert json_report["by_result_artifact_status"] == {}
+    assert json_report["result_artifacts"] == []
+    assert json_report["source_counts"] == {
+        "operator_ledger_events": 0,
+        "result_artifact_refs": 0,
+    }
+    assert json_report["malformed_artifact_counts"] == {
+        "invalid_result_artifacts": 0,
+        "missing_result_artifacts": 0,
+    }
+    assert json_report["redaction_summary"] == {
+        "approval_digests_stored": False,
+        "health_data_stored": False,
+        "local_paths_stored": False,
+        "patch_text_stored": False,
+        "provider_logs_stored": False,
+        "raw_branch_refs_stored": False,
+        "raw_hypotheses_stored": False,
+        "raw_slack_text_stored": False,
+        "slack_ids_stored": False,
+        "token_prefixes_stored": False,
+    }
+    assert "- Event count: `0`" in markdown
+    assert "<p>none</p>" in html
+    assert str(tmp_path) not in rendered
+    _assert_no_raw_leak(rendered)
 
 
 def test_operator_ledger_report_set_is_idempotent_and_preserves_result_artifacts(

--- a/tests/test_experiment_operator_ledger.py
+++ b/tests/test_experiment_operator_ledger.py
@@ -1468,24 +1468,25 @@ def test_operator_ledger_cli_stdout_fails_closed_on_unsafe_rendered_payload(
 
 
 def test_operator_ledger_direct_cli_summary_invocation_is_supported(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
     run_id = hashlib.sha256(str(tmp_path).encode("utf-8")).hexdigest()
     artifact_ref = f"artifacts/orchestration/experiments/direct_cli_summary_{run_id}"
     isolated_ledger = f"{artifact_ref}/ledger"
     output_ref = f"{artifact_ref}/summary.json"
-    output_path = Path(output_ref)
+    output_path = repo_root / output_ref
 
     try:
         result = subprocess.run(
             [
                 sys.executable,
-                "scripts/orchestration/experiment_operator_ledger.py",
+                str(repo_root / "scripts" / "orchestration" / "experiment_operator_ledger.py"),
                 "--summary",
                 "--ledger-dir",
                 isolated_ledger,
                 "--output",
                 output_ref,
             ],
-            cwd=Path.cwd(),
+            cwd=repo_root,
             text=True,
             capture_output=True,
             check=False,
@@ -1498,7 +1499,7 @@ def test_operator_ledger_direct_cli_summary_invocation_is_supported(tmp_path: Pa
         assert "local_operator_plane_only" in report
         _assert_no_raw_leak(result.stdout + report)
     finally:
-        shutil.rmtree(Path(artifact_ref), ignore_errors=True)
+        shutil.rmtree(repo_root / artifact_ref, ignore_errors=True)
 
 
 def test_operator_plane_backlog_epic_documents_boundaries() -> None:

--- a/tests/test_experiment_operator_ledger.py
+++ b/tests/test_experiment_operator_ledger.py
@@ -1457,7 +1457,7 @@ def test_operator_ledger_cli_stdout_fails_closed_on_unsafe_rendered_payload(
     monkeypatch.setattr(
         ledger,
         "write_operator_observability_report_set",
-        lambda *_, **__: {"json": "xoxb-secretsecretsecret /Users/alice diff --git raw hypothesis"},
+        lambda *_, **__: {"json": "`/Users/alice/operator-secret`"},
     )
 
     assert ledger.main(["--write-report-set"]) == 1

--- a/tests/test_experiment_operator_ledger.py
+++ b/tests/test_experiment_operator_ledger.py
@@ -1433,6 +1433,25 @@ def test_operator_ledger_cli_output_write_errors_are_sanitized(
     assert str(tmp_path) not in failure
 
 
+def test_operator_ledger_cli_stdout_fails_closed_on_unsafe_rendered_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(ledger, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        ledger,
+        "build_operator_observability_report",
+        lambda **_: {"unsafe": "xoxb-secretsecretsecret /Users/alice diff --git raw hypothesis"},
+    )
+
+    assert ledger.main(["--summary", "--format", "json"]) == 1
+    failure = capsys.readouterr().out
+
+    assert failure == "FAIL: Experiment operator ledger output contains unsafe content.\n"
+    _assert_no_raw_leak(failure)
+
+
 def test_operator_ledger_direct_cli_summary_invocation_is_supported(tmp_path: Path) -> None:
     isolated_ledger = (
         "artifacts/orchestration/experiments/"

--- a/tests/test_experiment_operator_ledger.py
+++ b/tests/test_experiment_operator_ledger.py
@@ -1343,6 +1343,32 @@ def test_operator_ledger_cli_report_set_rejects_reserved_event_store(
     ).exists()
 
 
+def test_operator_ledger_cli_report_set_rejects_unsafe_report_dir_before_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(ledger, "REPO_ROOT", tmp_path)
+    ledger.write_operator_ledger_event(_event_for_result(tmp_path), repo_root=tmp_path)
+
+    assert (
+        ledger.main(
+            [
+                "--write-report-set",
+                "--report-dir",
+                "artifacts/orchestration/experiments/C0SECRETID",
+            ]
+        )
+        == 1
+    )
+    failure = capsys.readouterr().out
+
+    assert "artifact reference is invalid" in failure
+    assert "C0SECRETID" not in failure
+    assert str(tmp_path) not in failure
+    assert not (tmp_path / "artifacts" / "orchestration" / "experiments" / "C0SECRETID").exists()
+
+
 def test_operator_ledger_cli_report_set_rejects_summary_combination(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_experiment_operator_ledger.py
+++ b/tests/test_experiment_operator_ledger.py
@@ -55,6 +55,44 @@ def _event(**overrides: object) -> dict[str, object]:
     return payload
 
 
+def _result(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "1.0",
+        "experiment_id": "operator_report",
+        "runner_mode": "candidate_patch",
+        "status": "accepted",
+        "failure_class": None,
+        "mutated_paths": ["scripts/orchestration/experiment_operator_ledger.py"],
+        "oracle_results": [
+            {
+                "command": "pytest tests/test_experiment_operator_ledger.py -q",
+                "returncode": 0,
+                "timed_out": False,
+                "truncated": False,
+                "stdout": "C0SECRET /Users/alice diff --git must not render",
+                "stderr": "xoxb-secretsecretsecret must not render",
+                "cwd": "/Users/alice/PulsePlate",
+            }
+        ],
+        "budget_observations": {"wall_clock_seconds": 1},
+        "shared_tree_untouched": True,
+        "promotion_ready": True,
+        "contribution_kind": "none",
+        "coauthor_required": False,
+        "coauthor_reason": "",
+        "candidate_patch": "diff --git a/secret b/secret\n+token",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_result(repo_root: Path, name: str, payload: dict[str, object]) -> Path:
+    path = repo_root / ledger.EXPERIMENT_RESULTS_REPO_PREFIX / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
 def _assert_no_raw_leak(value: str) -> None:
     forbidden = (
         "C0SECRET",
@@ -412,6 +450,166 @@ def test_operator_ledger_report_and_status_summary_are_redacted(tmp_path: Path) 
     _assert_no_raw_leak(rendered)
 
 
+def test_operator_ledger_report_projects_only_safe_result_metadata(tmp_path: Path) -> None:
+    _write_result(tmp_path, "operator-plane.json", _result())
+    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+
+    report = ledger.build_operator_observability_report(repo_root=tmp_path)
+    markdown = ledger.render_operator_observability_markdown(report)
+    html = ledger.render_operator_observability_html(report)
+    rendered = json.dumps(report, sort_keys=True) + markdown + html
+    metadata = report["latest"]["result_metadata"]
+
+    assert report["by_result_artifact_status"] == {"valid": 1}
+    assert metadata == {
+        "artifact_status": "valid",
+        "artifact_ref": "artifacts/orchestration/experiments/results/operator-plane.json",
+        "schema_version": "1.0",
+        "experiment_id": "operator_report",
+        "runner_mode": "candidate_patch",
+        "status": "accepted",
+        "failure_class": "none",
+        "mutated_paths_count": 1,
+        "shared_tree_untouched": True,
+        "promotion_ready": True,
+        "contribution_kind": "none",
+        "coauthor_required": False,
+    }
+    assert "oracle_results" not in rendered
+    assert '"candidate_patch":' not in rendered
+    assert "diff --git a/secret" not in rendered
+    assert "+token" not in rendered
+    assert "budget_observations" not in rendered
+    assert "coauthor_reason" not in rendered
+    assert "stdout" not in rendered
+    assert "stderr" not in rendered
+    assert "cwd" not in rendered
+    _assert_no_raw_leak(rendered)
+
+
+def test_operator_ledger_result_metadata_fails_closed_for_malformed_artifact(
+    tmp_path: Path,
+) -> None:
+    result_path = tmp_path / ledger.EXPERIMENT_RESULTS_REPO_PREFIX / "operator-plane.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text("{not-json C0SECRET /Users/alice", encoding="utf-8")
+    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+
+    report = ledger.build_operator_observability_report(repo_root=tmp_path)
+    rendered = json.dumps(report, sort_keys=True) + ledger.render_operator_observability_html(
+        report
+    )
+
+    assert report["by_result_artifact_status"] == {"invalid": 1}
+    assert report["latest"]["result_metadata"] == {
+        "artifact_status": "invalid",
+        "artifact_ref": "artifacts/orchestration/experiments/results/operator-plane.json",
+    }
+    assert "{not-json" not in rendered
+    _assert_no_raw_leak(rendered)
+
+
+def test_operator_ledger_result_metadata_fails_closed_for_symlinked_artifact(
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path / "outside-result.json"
+    outside.write_text(json.dumps(_result()), encoding="utf-8")
+    result_path = tmp_path / ledger.EXPERIMENT_RESULTS_REPO_PREFIX / "operator-plane.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.symlink_to(outside)
+    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+
+    report = ledger.build_operator_observability_report(repo_root=tmp_path)
+    rendered = json.dumps(report, sort_keys=True) + ledger.render_operator_observability_html(
+        report
+    )
+
+    assert report["by_result_artifact_status"] == {"invalid": 1}
+    assert report["latest"]["result_metadata"] == {
+        "artifact_status": "invalid",
+        "artifact_ref": "artifacts/orchestration/experiments/results/operator-plane.json",
+    }
+    assert str(outside) not in rendered
+    _assert_no_raw_leak(rendered)
+
+
+def test_operator_ledger_result_metadata_reports_missing_artifact(
+    tmp_path: Path,
+) -> None:
+    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+
+    report = ledger.build_operator_observability_report(repo_root=tmp_path)
+    rendered = (
+        json.dumps(report, sort_keys=True)
+        + ledger.render_operator_observability_markdown(report)
+        + ledger.render_operator_observability_html(report)
+    )
+
+    assert report["by_result_artifact_status"] == {"missing": 1}
+    assert report["latest"]["result_metadata"] == {
+        "artifact_status": "missing",
+        "artifact_ref": "artifacts/orchestration/experiments/results/operator-plane.json",
+    }
+    assert "operator-plane.json" in rendered
+    _assert_no_raw_leak(rendered)
+
+
+def test_operator_ledger_result_metadata_fails_closed_for_traversal_ref(
+    tmp_path: Path,
+) -> None:
+    metadata = ledger._safe_result_metadata_from_ref(
+        "artifacts/orchestration/experiments/results/../outside.json",
+        repo_root=tmp_path,
+    )
+
+    assert metadata == {"artifact_status": "invalid", "artifact_ref": "none"}
+
+
+def test_operator_ledger_html_renderer_escapes_dynamic_values() -> None:
+    report = {
+        "authority_boundary": {
+            "claimed_merge_readiness": False,
+            "created_pr": False,
+            "product_runtime_changed": False,
+            "resolved_review_threads": False,
+        },
+        "by_command_kind": {"<script>": 1},
+        "by_dispatch_mode": {},
+        "by_failure_class": {},
+        "by_result_artifact_status": {"valid": 1},
+        "by_status": {"dry_run": 1},
+        "event_count": 1,
+        "latest": {
+            "branch_hash": "<branch>",
+            "command_kind": "status",
+            "failure_class": "none",
+            "hypothesis_hash": "<hypothesis>",
+            "oracle_result_ref": "artifacts/orchestration/experiments/results/operator-plane.json",
+            "result_metadata": {
+                "artifact_status": "valid",
+                "experiment_id": "<img src=x onerror=alert(1)>",
+            },
+            "status": "dry_run",
+            "workflow_file": "none",
+            "workflow_ref": "none",
+        },
+        "policy_version": "<policy>",
+        "redaction_version": "<redaction>",
+        "report_scope": "local_operator_plane_only",
+        "result_artifacts": [],
+        "schema_version": ledger.SCHEMA_VERSION,
+    }
+
+    html = ledger.render_operator_observability_html(report)
+
+    assert "<script>" not in html
+    assert "<branch>" not in html
+    assert "<img src=x onerror=alert(1)>" not in html
+    assert "&lt;script&gt;" in html
+    assert "&lt;branch&gt;" in html
+    assert "&lt;img src=x onerror=alert(1)&gt;" in html
+
+
 def test_operator_ledger_invalid_local_artifact_summary_is_sanitized(tmp_path: Path) -> None:
     event_dir = ledger.default_ledger_dir(tmp_path) / "events"
     event_dir.mkdir(parents=True)
@@ -765,6 +963,173 @@ def test_operator_ledger_cli_summary_writes_under_artifacts_only(
     assert ledger.main(["--summary", "--output", str(tmp_path / "outside.json")]) == 1
     failure = capsys.readouterr().out
     assert "FAIL: Experiment operator ledger output must stay" in failure
+    assert str(tmp_path) not in failure
+
+
+def test_operator_ledger_cli_summary_writes_html_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ledger, "REPO_ROOT", tmp_path)
+    _write_result(tmp_path, "operator-plane.json", _result())
+    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+
+    assert (
+        ledger.main(
+            [
+                "--summary",
+                "--format",
+                "html",
+                "--output",
+                "artifacts/orchestration/experiments/operator_ledger/report.html",
+            ]
+        )
+        == 0
+    )
+    report = (
+        tmp_path / "artifacts" / "orchestration" / "experiments" / "operator_ledger" / "report.html"
+    ).read_text(encoding="utf-8")
+
+    assert "<!doctype html>" in report
+    assert "Latest Result Metadata" in report
+    assert "operator_report" in report
+    assert ">candidate_patch<" in report
+    assert "diff --git a/secret" not in report
+    assert "+token" not in report
+    assert "oracle_results" not in report
+    _assert_no_raw_leak(report)
+
+
+def test_operator_ledger_cli_writes_default_observability_report_set(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(ledger, "REPO_ROOT", tmp_path)
+    _write_result(tmp_path, "operator-plane.json", _result())
+    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+
+    assert ledger.main(["--write-report-set"]) == 0
+    stdout = capsys.readouterr().out
+    output = json.loads(stdout)
+
+    assert output == {
+        "outputs": {
+            "html": (
+                "artifacts/orchestration/experiments/operator_observability/"
+                "operator_observability_report.html"
+            ),
+            "json": (
+                "artifacts/orchestration/experiments/operator_observability/"
+                "operator_observability_report.json"
+            ),
+            "markdown": (
+                "artifacts/orchestration/experiments/operator_observability/"
+                "operator_observability_report.md"
+            ),
+        },
+        "status": "written",
+    }
+    report_dir = ledger.default_observability_report_dir(tmp_path)
+    rendered = "".join(
+        (report_dir / f"operator_observability_report.{suffix}").read_text(encoding="utf-8")
+        for suffix in ("json", "md", "html")
+    )
+
+    assert "Latest Result Metadata" in rendered
+    assert "operator_report" in rendered
+    assert "oracle_results" not in rendered
+    assert "diff --git a/secret" not in rendered
+    assert str(tmp_path) not in stdout
+    _assert_no_raw_leak(stdout + rendered)
+
+
+def test_operator_ledger_report_set_is_idempotent_and_preserves_result_artifacts(
+    tmp_path: Path,
+) -> None:
+    result_path = _write_result(tmp_path, "operator-plane.json", _result())
+    original_result = result_path.read_bytes()
+    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+    report = ledger.build_operator_observability_report(repo_root=tmp_path)
+
+    first_outputs = ledger.write_operator_observability_report_set(report, repo_root=tmp_path)
+    first_rendered = {
+        suffix: (
+            tmp_path
+            / "artifacts"
+            / "orchestration"
+            / "experiments"
+            / "operator_observability"
+            / f"operator_observability_report.{suffix}"
+        ).read_text(encoding="utf-8")
+        for suffix in ("json", "md", "html")
+    }
+    second_outputs = ledger.write_operator_observability_report_set(report, repo_root=tmp_path)
+    second_rendered = {
+        suffix: (
+            tmp_path
+            / "artifacts"
+            / "orchestration"
+            / "experiments"
+            / "operator_observability"
+            / f"operator_observability_report.{suffix}"
+        ).read_text(encoding="utf-8")
+        for suffix in ("json", "md", "html")
+    }
+
+    assert first_outputs == second_outputs
+    assert first_rendered == second_rendered
+    assert result_path.read_bytes() == original_result
+    _assert_no_raw_leak("".join(first_rendered.values()))
+
+
+def test_operator_ledger_cli_report_set_rejects_reserved_event_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(ledger, "REPO_ROOT", tmp_path)
+    _write_result(tmp_path, "operator-plane.json", _result())
+    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+
+    assert (
+        ledger.main(
+            [
+                "--write-report-set",
+                "--report-dir",
+                "artifacts/orchestration/experiments/operator_observability/events",
+            ]
+        )
+        == 1
+    )
+    failure = capsys.readouterr().out
+
+    assert "reserved event store" in failure
+    assert str(tmp_path) not in failure
+    assert not (
+        tmp_path
+        / "artifacts"
+        / "orchestration"
+        / "experiments"
+        / "operator_observability"
+        / "events"
+        / "operator_observability_report.json"
+    ).exists()
+
+
+def test_operator_ledger_cli_report_set_rejects_summary_combination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(ledger, "REPO_ROOT", tmp_path)
+    ledger.write_operator_ledger_event(_event(), repo_root=tmp_path)
+
+    assert ledger.main(["--write-report-set", "--summary", "--format", "markdown"]) == 1
+    failure = capsys.readouterr().out
+
+    assert "cannot combine with summary" in failure
+    assert not ledger.default_observability_report_dir(tmp_path).exists()
     assert str(tmp_path) not in failure
 
 

--- a/tests/test_experiment_slack_socket_bridge.py
+++ b/tests/test_experiment_slack_socket_bridge.py
@@ -2597,7 +2597,7 @@ def test_slack_operator_runbook_documents_status_evidence_authority_boundary() -
     assert "source, ownership, and allowed use" in runbook
     assert "Local Operator Ledger and Report" in runbook
     assert "artifacts/orchestration/experiments/operator_ledger/" in runbook
-    assert "No new Slack command is required" in runbook
+    assert "No new Slack command or Slack authority is added" in runbook
     assert "EXPERIMENT_OPERATOR_LEDGER_TASK_PACKET_ID" in runbook
     assert "operator-plane-slack-bridge" in runbook
     assert "dry_run: false" in runbook
@@ -2606,8 +2606,8 @@ def test_slack_operator_runbook_documents_status_evidence_authority_boundary() -
     assert "approval hash prefix" in runbook
     assert "Slack is not merge readiness" in runbook
     assert "dry_run`, `dispatched`, `failed`, and `rejected`" in runbook
-    assert "PR-2" in runbook
-    assert "closeout" in runbook
+    assert "operator_observability" in runbook
+    assert "--write-report-set" in runbook
     assert "invalid_local_artifact" in runbook
     execute_gate = "EXPERIMENT_SLACK_SOCKET_EXECUTE_ENABLED=" + "reviewed-dry-run-dispatch"
     assert execute_gate in runbook


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD033 -->

# Pull Request

## Summary

Adds a local/dev-only Experiment Runner operator observability report set over the existing operator ledger and sanitized Experiment Runner result metadata.

- [x] I reviewed `docs/ENGINEERING_LESSONS.md` and followed repo policies (determinism, import hygiene, contracts).
- [x] Select one change type:
  - [ ] Bug fix
  - [x] Feature
  - [ ] Refactor
  - [x] Docs
- [x] Linked issues/PRs: PR-3 operator-plane closeout lane; no GitHub issue.

## Goal

Generate deterministic sanitized JSON, Markdown, and single-file HTML reports under `artifacts/orchestration/experiments/operator_observability/` from `experiment_operator_ledger` plus allowlisted Experiment Runner result artifact metadata.

## Business reason

Operators need local evidence for Slack/operator-plane decisions without making Slack, runtime artifacts, semantic cache, RAG, or product AI surfaces canonical authority.

## Scope

- Add report-set generation to `scripts/orchestration/experiment_operator_ledger.py`.
- Include latest status, dispatch mode, failure class, workflow file/ref, branch hash, hypothesis hash, co-author decision, human review outcome, source counts, malformed artifact counts, and redaction summary.
- Project only safe Experiment Runner result metadata from `artifacts/orchestration/experiments/results/`.
- Reject traversal and symlink artifact inputs, and sanitize missing/malformed artifacts.
- Update focused tests and Slack/operator runbook documentation.
- Add canonical fixed-mapping artifact at `docs/review/PR_1874_FIXED_MAPPING.md`.

## Out of scope

- No RAG, semantic cache, product AI runtime, food data, CBT/coaching runtime, frontend MVP, iOS, backend API, OpenAPI, or database work.
- No new Slack commands.
- No Slack PR/review/merge authority.
- No runtime artifact commits under `artifacts/`.

## Files changed / likely touched

- `scripts/orchestration/experiment_operator_ledger.py`
- `tests/test_experiment_operator_ledger.py`
- `tests/test_experiment_slack_socket_bridge.py`
- `docs/orchestration/EXPERIMENT_RUNNER_SLACK_SOCKET_OPERATOR_RUNBOOK.md`
- `docs/review/PR_1874_FIXED_MAPPING.md`

## Key decisions

- Extended the existing ledger script instead of adding a second source of truth.
- Kept result artifact ingestion as an allowlisted metadata projection, not raw artifact embedding.
- Wrote report outputs only to gitignored local/dev artifact paths.
- Kept `/pulseplate-runner status` unchanged and non-authoritative.

## Risk & Impact

- [ ] User-facing change
- [ ] Data model/migration
- [x] Security-sensitive
- [ ] Performance-sensitive

Security-sensitive because the report must preserve fail-closed redaction and path-safety rules for operator evidence.

## Test Plan

- [x] Unit tests updated/added
- [ ] Integration/slow tests (not applicable)
- [x] Manual verification steps

Local evidence collected before and after PR open:

- `python3 scripts/orchestration/check_preflight.py` - PASS on final head.
- `python3 scripts/orchestration/check_agent_consistency.py` - PASS on final head.
- repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS on final head.
- `PREPUSH_DEBUG=1 make validate-changed` - PASS on final head.
- `pre-commit run --all-files` - PASS on final head.
- repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Codex result-artifact hash-read fail-closed fix in `d9502e88e`.
- repo-resolved Python `-m pytest -q tests/test_experiment_operator_ledger.py tests/test_experiment_slack_socket_bridge.py` - PASS after the Codex report-set output-ref prevalidation fix in `34a7bf36`.
- final `git push` to `b644b7ec1` pre-push hooks - PASS: yaml, EOF, whitespace, merge-conflict, large-file, detect-secrets, workflow check, Black, Ruff, MyPy, pip-audit, backend tests, Bandit, Docker build test.

## CI Gates

- [ ] PR tests green on current-head CI
- [ ] Diff coverage >= 97% on changed lines

Current-head CI is intentionally left for the post-open governance pass.

## Split Justification

- Why this PR cannot be split safely: it is one narrow local report generator plus focused tests/docs; changed LoC remains below the Tier 1 large-PR split threshold.
- What invariant, contract, or rollout constraint requires one PR: report shape, redaction, path safety, and docs need to land together to avoid an undocumented operator artifact contract.
- What follow-up PRs remain after this large change: none for this PR-3 slice.

## Lane Start Provenance

Packet: `artifacts/orchestration/task_packets/53883fa25886.json`
Starter: `scripts/orchestration/start_pr_lane.sh`

## Agent / Governance Evidence

- Startup packet: `artifacts/orchestration/task_packets/53883fa25886.json`
- Post-open packet: `artifacts/orchestration/task_packets/4a9b49d83f86.json`
- Base: fetched `origin/main` before branch creation
- Branch: `codex/experiment-runner-operator-observability-report`
- Role order executed pre-open: `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> dev-operator -> cursor-specialist-agent`
- Post-open mandatory role order completed: `qa-engineer-agent -> bug-hunter -> security-auditor`; QA and bug-hunter P2 findings were fixed, security-auditor passed
- Codex/Cubic review-thread fixes after post-open review:
  - `b557922c4` redacts result `experiment_id` to `experiment_id_hash`, verifies `oracle_result_hash` before metadata projection, and includes latest dispatch/coauthor/human-review state.
  - `98ef81928` fails closed on malformed validator type/coercion errors.
  - `7bca65ce` fixes the GitHub Advanced Security CodeQL stdout-sink alert structurally by requiring `--summary --output`, keeping full report payloads out of stdout, and leaving stdout only for bounded acknowledgement payloads.
  - `a4fc9c39` fixes the Cubic quoted/backticked local-path stdout guard finding.
  - `7dff0147` fixes the CodeRabbit direct CLI subprocess test anchoring finding.
  - `d9502e88e` fixes the Codex result-artifact hash-read fail-closed finding.
  - `34a7bf36` fixes the Codex report-set output-ref prevalidation finding.
- Codex Security diff scan: PASS/no findings, 1/1 source-like diff row covered, final report validated/rendered in local scan bundle `pr1874_22676d28ed_20260603T213013Z` after the review-thread fixes
- `pulseplate-pr-review`: one advisory large-diff-risk note in the final dry-run report, dispositioned NOT-A-BUG in `docs/review/PR_1874_FIXED_MAPPING.md` because the PR is one cohesive PR-3 slice with split justification and targeted gates
- Premortem decision: proceed with applied changes; stale runbook wording and redaction/path-safety failure modes were closed before PR open.
- Primary implementation commit: `a6fb3ec5d92294e26a9560ba0ac72f708fe3e23b`
- Post-open report-gap fix commit: `6903691a14b329541d9c87f368bcbf5b5e5bd2d3`
- Review-thread fix commits: `98ef819288ee8662a8b039402d2fac9c57b939b7`, `b557922c43609174096aa4ba62dd03eb4374059d`, `d9502e88ef8b254b079d8c7284e76fece26788b1`, `34a7bf36344f948bb33a7f18d8ee3609e11755c7`
- Fixed-mapping/evidence commits include: `8aa47d8a9`, `a3e15734d`, `9732d2243`, `d8a3fb057`, `75c9df2b2`, `4675924b5`, `b05a74f57`, `22676d28e`, `4f671e1e`, `cd00fb8d5`, `208ff3bf2`, `2d999e5b`, `96728d9f1`, `7bca65ce`, `e6ad13f49`, `a4fc9c39`, `54d8e8a39`, `84f159f6a`, `7dff0147`, `551d77b1b`, `a334e6106`, `1fb538700`, `b644b7ec1`

## Experiment Runner Evidence

Artifact: `artifacts/orchestration/experiments/results/exp-6560552e0103.json`
Status: `accepted`
Runner mode: `oracle_only_governance_reviewer`
Co-author: required; included on PR commit `22676d28e` that materially cites/uses the final oracle evidence.

## Security notes

- Report output excludes Slack IDs, raw Slack text, raw branch refs, raw hypotheses, approval digests, local paths, provider logs, oracle stdout/stderr, patch text, token prefixes, and health data. CLI stdout also has final fail-closed no-leak enforcement for token-shaped text, Slack IDs, local paths, and patch/log markers.
- Result artifact paths are accepted only from the canonical results directory and reject traversal/symlink inputs.
- HTML rendering escapes all dynamic values.
- Slack remains an operator interface only, not a source of review, merge, or runtime truth.

## Risks / rollback

- Risk: report schema drift could make local evidence misleading. Mitigation: strict schema tests, deterministic ordering, and malformed artifact counters.
- Risk: unsafe result artifact content could leak into report output. Mitigation: allowlisted metadata projection plus redaction regression probes.
- Rollback: revert the PR commits; generated runtime artifacts are local-only and gitignored.

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Exact review-comment URLs are mapped in `docs/review/PR_1874_FIXED_MAPPING.md`:
  - `discussion_r3351603200` -> `b557922c43609174096aa4ba62dd03eb4374059d`
  - `discussion_r3351603207` -> `98ef819288ee8662a8b039402d2fac9c57b939b7`
  - `discussion_r3351603215` -> `b557922c43609174096aa4ba62dd03eb4374059d`
  - `discussion_r3351688844` -> `98ef819288ee8662a8b039402d2fac9c57b939b7`
  - `discussion_r3351823142` -> `b557922c43609174096aa4ba62dd03eb4374059d`
- [x] GitHub Advanced Security CodeQL alerts mapped in `docs/review/PR_1874_FIXED_MAPPING.md`: `runs/79401457146`, `runs/79403670201`, and `discussion_r3352162506` -> `7bca65ce58e98ea435531233ed3e666e46a02180`
- [x] Cubic stdout path review mapped in `docs/review/PR_1874_FIXED_MAPPING.md`: `pullrequestreview-4423139717` and `discussion_r3352193033` -> `a4fc9c3943d822a69968e78f3cda75af5553bfdc`
- [x] CodeRabbit direct CLI subprocess test review mapped in `docs/review/PR_1874_FIXED_MAPPING.md`: `pullrequestreview-4424400038` and `discussion_r3353256420` -> `7dff01472d6a6fb045d612e3ce60c936e05b7e2a`
- [x] Codex result-artifact hash-read review mapped in `docs/review/PR_1874_FIXED_MAPPING.md`: `discussion_r3353259777` -> `d9502e88ef8b254b079d8c7284e76fece26788b1`
- [x] CodeRabbit wording nitpick review mapped in `docs/review/PR_1874_FIXED_MAPPING.md`: `pullrequestreview-4424514406` -> NOT-A-BUG
- [x] Codex report-set output-ref prevalidation review mapped in `docs/review/PR_1874_FIXED_MAPPING.md`: `discussion_r3353944709` -> `34a7bf36344f948bb33a7f18d8ee3609e11755c7`
- [ ] Final merge-readiness thread pass remains pending until current-head CI, bot state, unresolved-thread state, and wait-window are rechecked after this latest push.

### Fixed in Commit Mapping

- `docs/review/PR_1874_FIXED_MAPPING.md`

## Merge Readiness (Mandatory)

- [ ] PR is non-draft only when truly ready for merge
- [ ] All required checks are green on latest commit (no pending/rerun required)
- [ ] No unresolved review threads
- [ ] No actionable bot comments remain unmapped in `Fixed in Commit Mapping`
- [ ] Wait-window completed after latest bot/review activity (do not merge on first green tick)

## Deferred / Follow-ups

- [x] Ledger item(s): none for this PR-3 slice
- [x] GitHub issue(s): none

## Notes

### For Complex/High-Risk Changes

#### Deployment Strategy

- [x] No production deployment path affected.
- [x] No feature flag required; script output is local/dev-only.

#### Database & Data Changes

- [x] No database migrations required.
- [x] No data migration/backfill steps.

#### Monitoring & Observability

- [x] Adds local/dev-only operator observability report files under gitignored `artifacts/`.
- [x] Does not add product analytics, production dashboards, or runtime health truth.

#### Post-Deploy Verification

- [x] Run focused local pytest and local governance gates.
- [ ] Review current-head CI after PR opens.

#### Additional Context

- [x] No breaking API contracts.
- [x] No dependency updates.
- [x] No env var or secret changes.
- [x] Runbook updated.

<!-- markdownlint-enable MD013 MD033 -->










<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTML output added alongside JSON/Markdown for operator observability reports.
  * New "write report set" mode to generate a validated, deterministic local report set to disk; CLI enforces compatible options and requires explicit output when summarizing.

* **Documentation**
  * Runbook updated with explicit steps for generating local observability reports, output locations, and cleanup guidance; clarifies no new Slack authority/command is added.

* **Improvements**
  * Stronger result-artifact validation, safer CLI stdout handling, and richer/redacted result metadata.

* **Tests**
  * Expanded coverage for rendering, escaping, safety checks, idempotent writes, and CLI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

