### PR TITLE
feat(fitchef): add Markov coaching transition planner v1

### DIFF
--- a/app/schemas/user_coaching_state.py
+++ b/app/schemas/user_coaching_state.py
@@ -63,6 +63,16 @@ MARKOV_TRANSITION_BASE_CONFIDENCE_BY_STATE: dict[FitChefTransitionState, float] 
     "weekly_reflection_due": 0.66,
     "no_recommendation_available": 0.0,
 }
+MARKOV_TRANSITION_SCENARIO_TIEBREAK: tuple[FitChefCoachingScenario, ...] = (
+    "mascot_insight",
+    "weekly_reflection",
+    "slip_support",
+    "distortion_simulator",
+    "identity_loop_mapper",
+)
+_MARKOV_TRANSITION_SCENARIO_ORDER = {
+    scenario: index for index, scenario in enumerate(MARKOV_TRANSITION_SCENARIO_TIEBREAK)
+}
 MARKOV_TRANSITION_SCENARIO_WEIGHTS_BY_STATE: dict[
     FitChefTransitionState,
     dict[FitChefCoachingScenario, float],
@@ -316,11 +326,73 @@ class MarkovScenarioProbability(BaseModel):
     reasons: tuple[FitChefTransitionReason, ...] = ()
 
 
+def _expected_markov_ranked_policy(
+    *,
+    transition_state: FitChefTransitionState,
+    available_scenarios: tuple[FitChefCoachingScenario, ...],
+) -> tuple[tuple[FitChefCoachingScenario, float], ...]:
+    weights = MARKOV_TRANSITION_SCENARIO_WEIGHTS_BY_STATE[transition_state]
+    weighted = [
+        (scenario, weights.get(scenario, 0.0))
+        for scenario in MARKOV_TRANSITION_SCENARIO_TIEBREAK
+        if scenario in available_scenarios and weights.get(scenario, 0.0) > 0.0
+    ]
+    total = sum(weight for _, weight in weighted)
+    if total <= 0.0:
+        return ()
+
+    ranked = sorted(
+        ((scenario, weight / total) for scenario, weight in weighted),
+        key=lambda item: (-item[1], _MARKOV_TRANSITION_SCENARIO_ORDER[item[0]]),
+    )
+    probabilities = [round(probability, 4) for _, probability in ranked]
+    probabilities[0] = round(max(0.0, min(probabilities[0] + (1.0 - sum(probabilities)), 1.0)), 4)
+    return tuple((scenario, probabilities[index]) for index, (scenario, _) in enumerate(ranked))
+
+
+def _validate_markov_transition_reasons(
+    *,
+    transition_state: FitChefTransitionState,
+    reasons: tuple[FitChefTransitionReason, ...],
+) -> None:
+    reason_set = set(reasons)
+    slip_reasons = {
+        "observed_slip_like_behavior",
+        "explicit_slip_event",
+        "observed_high_risk_adherence",
+    }
+    cold_reasons = {"cold_start_default", "default_prior_not_observed_slip"}
+
+    if transition_state == "cold_start_default":
+        if not cold_reasons.issubset(reason_set):
+            raise ValueError("reasons must match transition_state")
+        if reason_set & (slip_reasons | {"day_close_observed", "no_available_scenarios"}):
+            raise ValueError("reasons must match transition_state")
+    elif transition_state == "slip_support_needed":
+        if not (reason_set & slip_reasons):
+            raise ValueError("reasons must match transition_state")
+        if reason_set & (cold_reasons | {"day_close_observed", "no_available_scenarios"}):
+            raise ValueError("reasons must match transition_state")
+    elif transition_state == "weekly_reflection_due":
+        if "day_close_observed" not in reason_set:
+            raise ValueError("reasons must match transition_state")
+        if reason_set & (slip_reasons | cold_reasons | {"no_available_scenarios"}):
+            raise ValueError("reasons must match transition_state")
+    elif transition_state == "steady_state_default":
+        if reason_set & (
+            slip_reasons | cold_reasons | {"day_close_observed", "no_available_scenarios"}
+        ):
+            raise ValueError("reasons must match transition_state")
+    elif "no_available_scenarios" not in reason_set:
+        raise ValueError("reasons must match transition_state")
+
+
 def _validate_markov_ranked_scenarios(
     *,
     transition_state: FitChefTransitionState,
     ranked_scenarios: tuple[MarkovScenarioProbability, ...],
     available_scenarios: tuple[FitChefCoachingScenario, ...] | None = None,
+    reasons: tuple[FitChefTransitionReason, ...],
 ) -> None:
     expected_ranks = tuple(range(1, len(ranked_scenarios) + 1))
     actual_ranks = tuple(ranked.rank for ranked in ranked_scenarios)
@@ -348,6 +420,17 @@ def _validate_markov_ranked_scenarios(
     total_probability = round(sum(ranked.probability for ranked in ranked_scenarios), 4)
     if total_probability != 1.0:
         raise ValueError("ranked_scenarios probabilities must sum to 1.0")
+    if available_scenarios is not None:
+        expected_policy = _expected_markov_ranked_policy(
+            transition_state=transition_state,
+            available_scenarios=available_scenarios,
+        )
+        actual_policy = tuple((ranked.scenario, ranked.probability) for ranked in ranked_scenarios)
+        if actual_policy != expected_policy:
+            raise ValueError("ranked_scenarios must match fixed transition policy")
+    if any(ranked.reasons != reasons for ranked in ranked_scenarios):
+        raise ValueError("ranked_scenarios reasons must match plan reasons")
+    _validate_markov_transition_reasons(transition_state=transition_state, reasons=reasons)
 
 
 class MarkovCoachingTransitionPlanV1(BaseModel):
@@ -374,6 +457,7 @@ class MarkovCoachingTransitionPlanV1(BaseModel):
             transition_state=self.transition_state,
             ranked_scenarios=ranked_scenarios,
             available_scenarios=self.available_scenarios,
+            reasons=self.reasons,
         )
         recommended = ranked_scenarios[0].scenario if ranked_scenarios else None
         confidence = _markov_transition_confidence_ceiling(
@@ -407,6 +491,7 @@ class PromptSafeMarkovTransitionContext(BaseModel):
         _validate_markov_ranked_scenarios(
             transition_state=self.transition_state,
             ranked_scenarios=ranked_scenarios,
+            reasons=self.reasons,
         )
         recommended = ranked_scenarios[0].scenario if ranked_scenarios else None
         confidence = _markov_transition_confidence_ceiling(

--- a/app/schemas/user_coaching_state.py
+++ b/app/schemas/user_coaching_state.py
@@ -304,6 +304,13 @@ class MarkovCoachingTransitionPlanV1(BaseModel):
         if actual_ranks != expected_ranks:
             raise ValueError("ranked_scenarios ranks must be consecutive from 1")
         if ranked_scenarios:
+            unavailable_scenarios = tuple(
+                ranked.scenario
+                for ranked in ranked_scenarios
+                if ranked.scenario not in self.available_scenarios
+            )
+            if unavailable_scenarios:
+                raise ValueError("ranked_scenarios must be limited to available_scenarios")
             total_probability = round(sum(ranked.probability for ranked in ranked_scenarios), 4)
             if total_probability != 1.0:
                 raise ValueError("ranked_scenarios probabilities must sum to 1.0")

--- a/app/schemas/user_coaching_state.py
+++ b/app/schemas/user_coaching_state.py
@@ -412,6 +412,12 @@ def _validate_markov_ranked_scenarios(
     if available_scenarios is not None and not available_scenarios:
         if transition_state != "no_recommendation_available":
             raise ValueError("transition_state must match no available scenarios")
+    if (
+        available_scenarios is not None
+        and available_scenarios
+        and transition_state == "no_recommendation_available"
+    ):
+        raise ValueError("transition_state must match no available scenarios")
 
     if ranked_scenarios and available_scenarios is not None:
         unavailable_scenarios = tuple(

--- a/app/schemas/user_coaching_state.py
+++ b/app/schemas/user_coaching_state.py
@@ -19,6 +19,33 @@ FitChefCoachingScenario = Literal[
     "distortion_simulator",
     "identity_loop_mapper",
 ]
+FitChefTransitionState = Literal[
+    "cold_start_default",
+    "steady_state_default",
+    "slip_support_needed",
+    "weekly_reflection_due",
+    "no_recommendation_available",
+]
+FitChefTransitionReason = Literal[
+    "cold_start_default",
+    "default_prior_not_observed_slip",
+    "observed_slip_like_behavior",
+    "explicit_slip_event",
+    "observed_high_risk_adherence",
+    "day_close_observed",
+    "mascot_fallback_allowed",
+    "scenario_unavailable",
+    "no_available_scenarios",
+    "recent_behavior_capped",
+    "recent_behavior_unavailable",
+    "adherence_state_invalid_degraded",
+]
+FitChefTransitionSafetyLabel = Literal[
+    "wellness_only",
+    "service_only",
+    "no_raw_user_text",
+    "deterministic_policy",
+]
 RiskBucket = Literal["low", "moderate", "high"]
 ConfidenceBucket = Literal["low", "high"]
 
@@ -207,12 +234,70 @@ class PromptSafeCoachingContext(BaseModel):
     )
 
 
+class MarkovScenarioProbability(BaseModel):
+    """Ranked fixed-policy transition probability for one eligible scenario."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    rank: int = Field(..., ge=1)
+    scenario: FitChefCoachingScenario
+    probability: float = Field(..., ge=0.0, le=1.0)
+    reasons: tuple[FitChefTransitionReason, ...] = ()
+
+
+class MarkovCoachingTransitionPlanV1(BaseModel):
+    """Internal transition plan derived from UserCoachingStateV1 only."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    plan_version: Literal["markov_transition_v1"] = "markov_transition_v1"
+    source_state_version: Literal["v1"] = "v1"
+    transition_state: FitChefTransitionState
+    available_scenarios: tuple[FitChefCoachingScenario, ...]
+    ranked_scenarios: tuple[MarkovScenarioProbability, ...] = ()
+    recommended_scenario: FitChefCoachingScenario | None = None
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    reasons: tuple[FitChefTransitionReason, ...] = ()
+    safety_labels: tuple[FitChefTransitionSafetyLabel, ...] = (
+        "wellness_only",
+        "service_only",
+        "no_raw_user_text",
+        "deterministic_policy",
+    )
+
+
+class PromptSafeMarkovTransitionContext(BaseModel):
+    """Prompt-safe transition projection with no identifiers or raw event data."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    plan_version: Literal["markov_transition_v1"] = "markov_transition_v1"
+    source_state_version: Literal["v1"] = "v1"
+    transition_state: FitChefTransitionState
+    recommended_scenario: FitChefCoachingScenario | None
+    ranked_scenarios: tuple[MarkovScenarioProbability, ...] = ()
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    reasons: tuple[FitChefTransitionReason, ...] = ()
+    safety_labels: tuple[FitChefTransitionSafetyLabel, ...] = (
+        "wellness_only",
+        "service_only",
+        "no_raw_user_text",
+        "deterministic_policy",
+    )
+
+
 __all__ = [
     "AdherenceSnapshot",
     "FitChefCoachingScenario",
+    "FitChefTransitionReason",
+    "FitChefTransitionSafetyLabel",
+    "FitChefTransitionState",
+    "MarkovCoachingTransitionPlanV1",
+    "MarkovScenarioProbability",
     "ProfileSignalSnapshot",
     "PromptSafeAdherenceContext",
     "PromptSafeCoachingContext",
+    "PromptSafeMarkovTransitionContext",
     "PromptSafeProfileSignalContext",
     "PromptSafeRecentBehaviorContext",
     "RecentBehaviorSnapshot",

--- a/app/schemas/user_coaching_state.py
+++ b/app/schemas/user_coaching_state.py
@@ -316,6 +316,40 @@ class MarkovScenarioProbability(BaseModel):
     reasons: tuple[FitChefTransitionReason, ...] = ()
 
 
+def _validate_markov_ranked_scenarios(
+    *,
+    transition_state: FitChefTransitionState,
+    ranked_scenarios: tuple[MarkovScenarioProbability, ...],
+    available_scenarios: tuple[FitChefCoachingScenario, ...] | None = None,
+) -> None:
+    expected_ranks = tuple(range(1, len(ranked_scenarios) + 1))
+    actual_ranks = tuple(ranked.rank for ranked in ranked_scenarios)
+    if actual_ranks != expected_ranks:
+        raise ValueError("ranked_scenarios ranks must be consecutive from 1")
+    if not ranked_scenarios:
+        return
+
+    if available_scenarios is not None:
+        unavailable_scenarios = tuple(
+            ranked.scenario
+            for ranked in ranked_scenarios
+            if ranked.scenario not in available_scenarios
+        )
+        if unavailable_scenarios:
+            raise ValueError("ranked_scenarios must be limited to available_scenarios")
+
+    impossible_scenarios = tuple(
+        ranked.scenario
+        for ranked in ranked_scenarios
+        if ranked.scenario not in MARKOV_TRANSITION_SCENARIOS_BY_STATE[transition_state]
+    )
+    if impossible_scenarios:
+        raise ValueError("ranked_scenarios must be valid for transition_state")
+    total_probability = round(sum(ranked.probability for ranked in ranked_scenarios), 4)
+    if total_probability != 1.0:
+        raise ValueError("ranked_scenarios probabilities must sum to 1.0")
+
+
 class MarkovCoachingTransitionPlanV1(BaseModel):
     """Internal transition plan derived from UserCoachingStateV1 only."""
 
@@ -336,30 +370,11 @@ class MarkovCoachingTransitionPlanV1(BaseModel):
         """Keep caller-supplied plan mutations from changing derived invariants."""
 
         ranked_scenarios = self.ranked_scenarios
-        expected_ranks = tuple(range(1, len(ranked_scenarios) + 1))
-        actual_ranks = tuple(ranked.rank for ranked in ranked_scenarios)
-        if actual_ranks != expected_ranks:
-            raise ValueError("ranked_scenarios ranks must be consecutive from 1")
-        if ranked_scenarios:
-            unavailable_scenarios = tuple(
-                ranked.scenario
-                for ranked in ranked_scenarios
-                if ranked.scenario not in self.available_scenarios
-            )
-            if unavailable_scenarios:
-                raise ValueError("ranked_scenarios must be limited to available_scenarios")
-            impossible_scenarios = tuple(
-                ranked.scenario
-                for ranked in ranked_scenarios
-                if ranked.scenario
-                not in MARKOV_TRANSITION_SCENARIOS_BY_STATE[self.transition_state]
-            )
-            if impossible_scenarios:
-                raise ValueError("ranked_scenarios must be valid for transition_state")
-            total_probability = round(sum(ranked.probability for ranked in ranked_scenarios), 4)
-            if total_probability != 1.0:
-                raise ValueError("ranked_scenarios probabilities must sum to 1.0")
-
+        _validate_markov_ranked_scenarios(
+            transition_state=self.transition_state,
+            ranked_scenarios=ranked_scenarios,
+            available_scenarios=self.available_scenarios,
+        )
         recommended = ranked_scenarios[0].scenario if ranked_scenarios else None
         confidence = _markov_transition_confidence_ceiling(
             transition_state=self.transition_state,
@@ -389,6 +404,10 @@ class PromptSafeMarkovTransitionContext(BaseModel):
     @model_validator(mode="after")
     def _recompute_prompt_safe_invariants(self) -> "PromptSafeMarkovTransitionContext":
         ranked_scenarios = self.ranked_scenarios
+        _validate_markov_ranked_scenarios(
+            transition_state=self.transition_state,
+            ranked_scenarios=ranked_scenarios,
+        )
         recommended = ranked_scenarios[0].scenario if ranked_scenarios else None
         confidence = _markov_transition_confidence_ceiling(
             transition_state=self.transition_state,

--- a/app/schemas/user_coaching_state.py
+++ b/app/schemas/user_coaching_state.py
@@ -398,10 +398,8 @@ def _validate_markov_ranked_scenarios(
     actual_ranks = tuple(ranked.rank for ranked in ranked_scenarios)
     if actual_ranks != expected_ranks:
         raise ValueError("ranked_scenarios ranks must be consecutive from 1")
-    if not ranked_scenarios:
-        return
 
-    if available_scenarios is not None:
+    if ranked_scenarios and available_scenarios is not None:
         unavailable_scenarios = tuple(
             ranked.scenario
             for ranked in ranked_scenarios
@@ -410,16 +408,18 @@ def _validate_markov_ranked_scenarios(
         if unavailable_scenarios:
             raise ValueError("ranked_scenarios must be limited to available_scenarios")
 
-    impossible_scenarios = tuple(
-        ranked.scenario
-        for ranked in ranked_scenarios
-        if ranked.scenario not in MARKOV_TRANSITION_SCENARIOS_BY_STATE[transition_state]
-    )
-    if impossible_scenarios:
-        raise ValueError("ranked_scenarios must be valid for transition_state")
-    total_probability = round(sum(ranked.probability for ranked in ranked_scenarios), 4)
-    if total_probability != 1.0:
-        raise ValueError("ranked_scenarios probabilities must sum to 1.0")
+    if ranked_scenarios:
+        impossible_scenarios = tuple(
+            ranked.scenario
+            for ranked in ranked_scenarios
+            if ranked.scenario not in MARKOV_TRANSITION_SCENARIOS_BY_STATE[transition_state]
+        )
+        if impossible_scenarios:
+            raise ValueError("ranked_scenarios must be valid for transition_state")
+        total_probability = round(sum(ranked.probability for ranked in ranked_scenarios), 4)
+        if total_probability != 1.0:
+            raise ValueError("ranked_scenarios probabilities must sum to 1.0")
+
     if available_scenarios is not None:
         expected_policy = _expected_markov_ranked_policy(
             transition_state=transition_state,
@@ -428,9 +428,11 @@ def _validate_markov_ranked_scenarios(
         actual_policy = tuple((ranked.scenario, ranked.probability) for ranked in ranked_scenarios)
         if actual_policy != expected_policy:
             raise ValueError("ranked_scenarios must match fixed transition policy")
+    _validate_markov_transition_reasons(transition_state=transition_state, reasons=reasons)
+    if not ranked_scenarios:
+        return
     if any(ranked.reasons != reasons for ranked in ranked_scenarios):
         raise ValueError("ranked_scenarios reasons must match plan reasons")
-    _validate_markov_transition_reasons(transition_state=transition_state, reasons=reasons)
 
 
 class MarkovCoachingTransitionPlanV1(BaseModel):

--- a/app/schemas/user_coaching_state.py
+++ b/app/schemas/user_coaching_state.py
@@ -49,6 +49,39 @@ FitChefTransitionSafetyLabel = Literal[
 ]
 RiskBucket = Literal["low", "moderate", "high"]
 ConfidenceBucket = Literal["low", "high"]
+MARKOV_TRANSITION_SAFETY_LABELS: tuple[FitChefTransitionSafetyLabel, ...] = (
+    "wellness_only",
+    "non_diagnostic",
+    "service_only",
+    "no_raw_user_text",
+    "deterministic_policy",
+)
+MARKOV_TRANSITION_BASE_CONFIDENCE_BY_STATE: dict[FitChefTransitionState, float] = {
+    "cold_start_default": 0.35,
+    "steady_state_default": 0.5,
+    "slip_support_needed": 0.78,
+    "weekly_reflection_due": 0.66,
+    "no_recommendation_available": 0.0,
+}
+
+
+def _markov_transition_confidence_ceiling(
+    *,
+    transition_state: FitChefTransitionState,
+    reasons: tuple[FitChefTransitionReason, ...],
+    has_recommendation: bool,
+) -> float:
+    if not has_recommendation:
+        return 0.0
+
+    value = MARKOV_TRANSITION_BASE_CONFIDENCE_BY_STATE[transition_state]
+    if "scenario_unavailable" in reasons:
+        value -= 0.25
+    if "recent_behavior_capped" in reasons:
+        value -= 0.15
+    if "adherence_state_invalid_degraded" in reasons:
+        value -= 0.2
+    return round(max(0.0, min(value, 1.0)), 4)
 
 
 class AdherenceSnapshot(BaseModel):
@@ -259,13 +292,32 @@ class MarkovCoachingTransitionPlanV1(BaseModel):
     recommended_scenario: FitChefCoachingScenario | None = None
     confidence: float = Field(..., ge=0.0, le=1.0)
     reasons: tuple[FitChefTransitionReason, ...] = ()
-    safety_labels: tuple[FitChefTransitionSafetyLabel, ...] = (
-        "wellness_only",
-        "non_diagnostic",
-        "service_only",
-        "no_raw_user_text",
-        "deterministic_policy",
-    )
+    safety_labels: tuple[FitChefTransitionSafetyLabel, ...] = MARKOV_TRANSITION_SAFETY_LABELS
+
+    @model_validator(mode="after")
+    def _recompute_prompt_safe_invariants(self) -> "MarkovCoachingTransitionPlanV1":
+        """Keep caller-supplied plan mutations from changing derived invariants."""
+
+        ranked_scenarios = self.ranked_scenarios
+        expected_ranks = tuple(range(1, len(ranked_scenarios) + 1))
+        actual_ranks = tuple(ranked.rank for ranked in ranked_scenarios)
+        if actual_ranks != expected_ranks:
+            raise ValueError("ranked_scenarios ranks must be consecutive from 1")
+        if ranked_scenarios:
+            total_probability = round(sum(ranked.probability for ranked in ranked_scenarios), 4)
+            if total_probability != 1.0:
+                raise ValueError("ranked_scenarios probabilities must sum to 1.0")
+
+        recommended = ranked_scenarios[0].scenario if ranked_scenarios else None
+        confidence = _markov_transition_confidence_ceiling(
+            transition_state=self.transition_state,
+            reasons=self.reasons,
+            has_recommendation=recommended is not None,
+        )
+        object.__setattr__(self, "recommended_scenario", recommended)
+        object.__setattr__(self, "confidence", confidence)
+        object.__setattr__(self, "safety_labels", MARKOV_TRANSITION_SAFETY_LABELS)
+        return self
 
 
 class PromptSafeMarkovTransitionContext(BaseModel):
@@ -280,13 +332,21 @@ class PromptSafeMarkovTransitionContext(BaseModel):
     ranked_scenarios: tuple[MarkovScenarioProbability, ...] = ()
     confidence: float = Field(..., ge=0.0, le=1.0)
     reasons: tuple[FitChefTransitionReason, ...] = ()
-    safety_labels: tuple[FitChefTransitionSafetyLabel, ...] = (
-        "wellness_only",
-        "non_diagnostic",
-        "service_only",
-        "no_raw_user_text",
-        "deterministic_policy",
-    )
+    safety_labels: tuple[FitChefTransitionSafetyLabel, ...] = MARKOV_TRANSITION_SAFETY_LABELS
+
+    @model_validator(mode="after")
+    def _recompute_prompt_safe_invariants(self) -> "PromptSafeMarkovTransitionContext":
+        ranked_scenarios = self.ranked_scenarios
+        recommended = ranked_scenarios[0].scenario if ranked_scenarios else None
+        confidence = _markov_transition_confidence_ceiling(
+            transition_state=self.transition_state,
+            reasons=self.reasons,
+            has_recommendation=recommended is not None,
+        )
+        object.__setattr__(self, "recommended_scenario", recommended)
+        object.__setattr__(self, "confidence", confidence)
+        object.__setattr__(self, "safety_labels", MARKOV_TRANSITION_SAFETY_LABELS)
+        return self
 
 
 __all__ = [
@@ -295,6 +355,8 @@ __all__ = [
     "FitChefTransitionReason",
     "FitChefTransitionSafetyLabel",
     "FitChefTransitionState",
+    "MARKOV_TRANSITION_BASE_CONFIDENCE_BY_STATE",
+    "MARKOV_TRANSITION_SAFETY_LABELS",
     "MarkovCoachingTransitionPlanV1",
     "MarkovScenarioProbability",
     "ProfileSignalSnapshot",

--- a/app/schemas/user_coaching_state.py
+++ b/app/schemas/user_coaching_state.py
@@ -63,6 +63,16 @@ MARKOV_TRANSITION_BASE_CONFIDENCE_BY_STATE: dict[FitChefTransitionState, float] 
     "weekly_reflection_due": 0.66,
     "no_recommendation_available": 0.0,
 }
+MARKOV_TRANSITION_PRIMARY_SCENARIO_BY_STATE: dict[
+    FitChefTransitionState,
+    FitChefCoachingScenario | None,
+] = {
+    "cold_start_default": "mascot_insight",
+    "steady_state_default": "mascot_insight",
+    "slip_support_needed": "slip_support",
+    "weekly_reflection_due": "weekly_reflection",
+    "no_recommendation_available": None,
+}
 MARKOV_TRANSITION_SCENARIO_TIEBREAK: tuple[FitChefCoachingScenario, ...] = (
     "mascot_insight",
     "weekly_reflection",
@@ -399,6 +409,10 @@ def _validate_markov_ranked_scenarios(
     if actual_ranks != expected_ranks:
         raise ValueError("ranked_scenarios ranks must be consecutive from 1")
 
+    if available_scenarios is not None and not available_scenarios:
+        if transition_state != "no_recommendation_available":
+            raise ValueError("transition_state must match no available scenarios")
+
     if ranked_scenarios and available_scenarios is not None:
         unavailable_scenarios = tuple(
             ranked.scenario
@@ -429,6 +443,16 @@ def _validate_markov_ranked_scenarios(
         if actual_policy != expected_policy:
             raise ValueError("ranked_scenarios must match fixed transition policy")
     _validate_markov_transition_reasons(transition_state=transition_state, reasons=reasons)
+    primary_scenario = MARKOV_TRANSITION_PRIMARY_SCENARIO_BY_STATE[transition_state]
+    primary_unavailable = False
+    if primary_scenario is not None and available_scenarios is not None:
+        primary_unavailable = (
+            bool(available_scenarios) and primary_scenario not in available_scenarios
+        )
+    elif primary_scenario is not None and ranked_scenarios:
+        primary_unavailable = ranked_scenarios[0].scenario != primary_scenario
+    if primary_unavailable and "scenario_unavailable" not in reasons:
+        raise ValueError("reasons must include scenario_unavailable for fallback scenarios")
     if not ranked_scenarios:
         return
     if any(ranked.reasons != reasons for ranked in ranked_scenarios):

--- a/app/schemas/user_coaching_state.py
+++ b/app/schemas/user_coaching_state.py
@@ -42,6 +42,7 @@ FitChefTransitionReason = Literal[
 ]
 FitChefTransitionSafetyLabel = Literal[
     "wellness_only",
+    "non_diagnostic",
     "service_only",
     "no_raw_user_text",
     "deterministic_policy",
@@ -260,6 +261,7 @@ class MarkovCoachingTransitionPlanV1(BaseModel):
     reasons: tuple[FitChefTransitionReason, ...] = ()
     safety_labels: tuple[FitChefTransitionSafetyLabel, ...] = (
         "wellness_only",
+        "non_diagnostic",
         "service_only",
         "no_raw_user_text",
         "deterministic_policy",
@@ -280,6 +282,7 @@ class PromptSafeMarkovTransitionContext(BaseModel):
     reasons: tuple[FitChefTransitionReason, ...] = ()
     safety_labels: tuple[FitChefTransitionSafetyLabel, ...] = (
         "wellness_only",
+        "non_diagnostic",
         "service_only",
         "no_raw_user_text",
         "deterministic_policy",

--- a/app/schemas/user_coaching_state.py
+++ b/app/schemas/user_coaching_state.py
@@ -360,6 +360,18 @@ def _expected_markov_ranked_policy(
     return tuple((scenario, probabilities[index]) for index, (scenario, _) in enumerate(ranked))
 
 
+def _expected_markov_ranked_subset_policy(
+    *,
+    transition_state: FitChefTransitionState,
+    ranked_scenarios: tuple[MarkovScenarioProbability, ...],
+) -> tuple[tuple[FitChefCoachingScenario, float], ...]:
+    scenarios = tuple(ranked.scenario for ranked in ranked_scenarios)
+    return _expected_markov_ranked_policy(
+        transition_state=transition_state,
+        available_scenarios=scenarios,
+    )
+
+
 def _validate_markov_transition_reasons(
     *,
     transition_state: FitChefTransitionState,
@@ -444,6 +456,14 @@ def _validate_markov_ranked_scenarios(
         expected_policy = _expected_markov_ranked_policy(
             transition_state=transition_state,
             available_scenarios=available_scenarios,
+        )
+        actual_policy = tuple((ranked.scenario, ranked.probability) for ranked in ranked_scenarios)
+        if actual_policy != expected_policy:
+            raise ValueError("ranked_scenarios must match fixed transition policy")
+    else:
+        expected_policy = _expected_markov_ranked_subset_policy(
+            transition_state=transition_state,
+            ranked_scenarios=ranked_scenarios,
         )
         actual_policy = tuple((ranked.scenario, ranked.probability) for ranked in ranked_scenarios)
         if actual_policy != expected_policy:

--- a/app/schemas/user_coaching_state.py
+++ b/app/schemas/user_coaching_state.py
@@ -63,6 +63,43 @@ MARKOV_TRANSITION_BASE_CONFIDENCE_BY_STATE: dict[FitChefTransitionState, float] 
     "weekly_reflection_due": 0.66,
     "no_recommendation_available": 0.0,
 }
+MARKOV_TRANSITION_SCENARIO_WEIGHTS_BY_STATE: dict[
+    FitChefTransitionState,
+    dict[FitChefCoachingScenario, float],
+] = {
+    "cold_start_default": {
+        "mascot_insight": 1.0,
+    },
+    "steady_state_default": {
+        "mascot_insight": 0.55,
+        "weekly_reflection": 0.2,
+        "distortion_simulator": 0.1,
+        "identity_loop_mapper": 0.1,
+        "slip_support": 0.05,
+    },
+    "slip_support_needed": {
+        "slip_support": 0.72,
+        "weekly_reflection": 0.12,
+        "mascot_insight": 0.1,
+        "distortion_simulator": 0.03,
+        "identity_loop_mapper": 0.03,
+    },
+    "weekly_reflection_due": {
+        "weekly_reflection": 0.65,
+        "mascot_insight": 0.2,
+        "distortion_simulator": 0.05,
+        "identity_loop_mapper": 0.05,
+        "slip_support": 0.05,
+    },
+    "no_recommendation_available": {},
+}
+MARKOV_TRANSITION_SCENARIOS_BY_STATE: dict[
+    FitChefTransitionState,
+    tuple[FitChefCoachingScenario, ...],
+] = {
+    transition_state: tuple(weights)
+    for transition_state, weights in MARKOV_TRANSITION_SCENARIO_WEIGHTS_BY_STATE.items()
+}
 
 
 def _markov_transition_confidence_ceiling(
@@ -311,6 +348,14 @@ class MarkovCoachingTransitionPlanV1(BaseModel):
             )
             if unavailable_scenarios:
                 raise ValueError("ranked_scenarios must be limited to available_scenarios")
+            impossible_scenarios = tuple(
+                ranked.scenario
+                for ranked in ranked_scenarios
+                if ranked.scenario
+                not in MARKOV_TRANSITION_SCENARIOS_BY_STATE[self.transition_state]
+            )
+            if impossible_scenarios:
+                raise ValueError("ranked_scenarios must be valid for transition_state")
             total_probability = round(sum(ranked.probability for ranked in ranked_scenarios), 4)
             if total_probability != 1.0:
                 raise ValueError("ranked_scenarios probabilities must sum to 1.0")

--- a/app/services/coaching_transition_planner.py
+++ b/app/services/coaching_transition_planner.py
@@ -12,6 +12,7 @@ from app.schemas.user_coaching_state import (
     FitChefTransitionReason,
     FitChefTransitionState,
     MARKOV_TRANSITION_BASE_CONFIDENCE_BY_STATE,
+    MARKOV_TRANSITION_SCENARIO_TIEBREAK,
     MARKOV_TRANSITION_SCENARIO_WEIGHTS_BY_STATE,
     MarkovCoachingTransitionPlanV1,
     MarkovScenarioProbability,
@@ -19,14 +20,9 @@ from app.schemas.user_coaching_state import (
     UserCoachingStateV1,
 )
 
-_SCENARIO_TIEBREAK: tuple[FitChefCoachingScenario, ...] = (
-    "mascot_insight",
-    "weekly_reflection",
-    "slip_support",
-    "distortion_simulator",
-    "identity_loop_mapper",
-)
-_SCENARIO_ORDER = {scenario: index for index, scenario in enumerate(_SCENARIO_TIEBREAK)}
+_SCENARIO_ORDER = {
+    scenario: index for index, scenario in enumerate(MARKOV_TRANSITION_SCENARIO_TIEBREAK)
+}
 
 _PRIMARY_SCENARIO_BY_STATE: dict[FitChefTransitionState, FitChefCoachingScenario | None] = {
     "cold_start_default": "mascot_insight",
@@ -131,7 +127,7 @@ def _rank_scenarios(
     weights = MARKOV_TRANSITION_SCENARIO_WEIGHTS_BY_STATE[transition_state]
     weighted = [
         (scenario, weights.get(scenario, 0.0))
-        for scenario in _SCENARIO_TIEBREAK
+        for scenario in MARKOV_TRANSITION_SCENARIO_TIEBREAK
         if scenario in available_scenarios and weights.get(scenario, 0.0) > 0.0
     ]
     total = sum(weight for _, weight in weighted)

--- a/app/services/coaching_transition_planner.py
+++ b/app/services/coaching_transition_planner.py
@@ -1,0 +1,274 @@
+"""Deterministic Markov-style coaching transition planner v1.
+
+The planner is internal service logic only. It consumes a validated
+UserCoachingStateV1 snapshot and returns fixed-policy transition probabilities;
+it does not learn, persist, retrieve, or call provider/runtime systems.
+"""
+
+from __future__ import annotations
+
+from app.schemas.user_coaching_state import (
+    FitChefCoachingScenario,
+    FitChefTransitionReason,
+    FitChefTransitionState,
+    MarkovCoachingTransitionPlanV1,
+    MarkovScenarioProbability,
+    PromptSafeMarkovTransitionContext,
+    UserCoachingStateV1,
+)
+
+_SCENARIO_TIEBREAK: tuple[FitChefCoachingScenario, ...] = (
+    "mascot_insight",
+    "weekly_reflection",
+    "slip_support",
+    "distortion_simulator",
+    "identity_loop_mapper",
+)
+_SCENARIO_ORDER = {scenario: index for index, scenario in enumerate(_SCENARIO_TIEBREAK)}
+
+_TRANSITION_WEIGHTS: dict[FitChefTransitionState, dict[FitChefCoachingScenario, float]] = {
+    "cold_start_default": {
+        "mascot_insight": 1.0,
+    },
+    "steady_state_default": {
+        "mascot_insight": 0.55,
+        "weekly_reflection": 0.2,
+        "distortion_simulator": 0.1,
+        "identity_loop_mapper": 0.1,
+        "slip_support": 0.05,
+    },
+    "slip_support_needed": {
+        "slip_support": 0.72,
+        "weekly_reflection": 0.12,
+        "mascot_insight": 0.1,
+        "distortion_simulator": 0.03,
+        "identity_loop_mapper": 0.03,
+    },
+    "weekly_reflection_due": {
+        "weekly_reflection": 0.65,
+        "mascot_insight": 0.2,
+        "distortion_simulator": 0.05,
+        "identity_loop_mapper": 0.05,
+        "slip_support": 0.05,
+    },
+    "no_recommendation_available": {},
+}
+
+_PRIMARY_SCENARIO_BY_STATE: dict[FitChefTransitionState, FitChefCoachingScenario | None] = {
+    "cold_start_default": "mascot_insight",
+    "steady_state_default": "mascot_insight",
+    "slip_support_needed": "slip_support",
+    "weekly_reflection_due": "weekly_reflection",
+    "no_recommendation_available": None,
+}
+
+_BASE_CONFIDENCE_BY_STATE: dict[FitChefTransitionState, float] = {
+    "cold_start_default": 0.35,
+    "steady_state_default": 0.5,
+    "slip_support_needed": 0.78,
+    "weekly_reflection_due": 0.66,
+    "no_recommendation_available": 0.0,
+}
+
+
+def _dedupe_scenarios(
+    scenarios: tuple[FitChefCoachingScenario, ...],
+) -> tuple[FitChefCoachingScenario, ...]:
+    return tuple(dict.fromkeys(scenarios))
+
+
+def _dedupe_reasons(
+    reasons: list[FitChefTransitionReason],
+) -> tuple[FitChefTransitionReason, ...]:
+    return tuple(dict.fromkeys(reasons))
+
+
+def _revalidated_state(state: UserCoachingStateV1) -> UserCoachingStateV1:
+    revalidated: UserCoachingStateV1
+    revalidated = UserCoachingStateV1.model_validate(state.model_dump(mode="python"))
+    return revalidated
+
+
+def _available_scenarios(
+    state: UserCoachingStateV1,
+    allowed_scenarios: tuple[FitChefCoachingScenario, ...] | None,
+) -> tuple[FitChefCoachingScenario, ...]:
+    state_available = _dedupe_scenarios(state.available_scenarios)
+    if allowed_scenarios is None:
+        return state_available
+    allowed = set(_dedupe_scenarios(allowed_scenarios))
+    return tuple(scenario for scenario in state_available if scenario in allowed)
+
+
+def _has_observed_high_risk_adherence(state: UserCoachingStateV1) -> bool:
+    adherence = state.adherence
+    return adherence.n > 0 and not adherence.needs_more_data and adherence.risk_slip >= 0.67
+
+
+def _classify_transition(
+    state: UserCoachingStateV1,
+) -> tuple[FitChefTransitionState, list[FitChefTransitionReason]]:
+    adherence = state.adherence
+    behavior = state.recent_behavior
+    reasons: list[FitChefTransitionReason] = []
+
+    has_slip_like = behavior.slip_like_count_7d > 0
+    has_explicit_slip = behavior.slip_count_7d > 0
+    has_observed_high_risk = _has_observed_high_risk_adherence(state)
+    if has_slip_like or has_explicit_slip or has_observed_high_risk:
+        if has_slip_like:
+            reasons.append("observed_slip_like_behavior")
+        if has_explicit_slip:
+            reasons.append("explicit_slip_event")
+        if has_observed_high_risk:
+            reasons.append("observed_high_risk_adherence")
+        return "slip_support_needed", reasons
+
+    is_cold_start = (
+        adherence.needs_more_data and adherence.n == 0 and behavior.scanned_event_count == 0
+    )
+    if is_cold_start:
+        reasons.extend(
+            [
+                "cold_start_default",
+                "default_prior_not_observed_slip",
+            ]
+        )
+        return "cold_start_default", reasons
+
+    if behavior.day_closed_count_7d > 0:
+        reasons.append("day_close_observed")
+        return "weekly_reflection_due", reasons
+
+    return "steady_state_default", reasons
+
+
+def _append_context_reasons(
+    state: UserCoachingStateV1,
+    reasons: list[FitChefTransitionReason],
+) -> None:
+    behavior = state.recent_behavior
+    if behavior.scanned_event_count == 0:
+        reasons.append("recent_behavior_unavailable")
+    if behavior.events_capped:
+        reasons.append("recent_behavior_capped")
+    if state.adherence.source_status == "invalid_degraded":
+        reasons.append("adherence_state_invalid_degraded")
+
+
+def _rank_scenarios(
+    *,
+    transition_state: FitChefTransitionState,
+    available_scenarios: tuple[FitChefCoachingScenario, ...],
+    reasons: tuple[FitChefTransitionReason, ...],
+) -> tuple[MarkovScenarioProbability, ...]:
+    weights = _TRANSITION_WEIGHTS[transition_state]
+    weighted = [
+        (scenario, weights.get(scenario, 0.0))
+        for scenario in _SCENARIO_TIEBREAK
+        if scenario in available_scenarios and weights.get(scenario, 0.0) > 0.0
+    ]
+    total = sum(weight for _, weight in weighted)
+    if total <= 0.0:
+        return ()
+
+    ranked = sorted(
+        ((scenario, weight / total) for scenario, weight in weighted),
+        key=lambda item: (-item[1], _SCENARIO_ORDER[item[0]]),
+    )
+    probabilities = [round(probability, 4) for _, probability in ranked]
+    probabilities[0] = round(max(0.0, min(probabilities[0] + (1.0 - sum(probabilities)), 1.0)), 4)
+
+    return tuple(
+        MarkovScenarioProbability(
+            rank=index + 1,
+            scenario=scenario,
+            probability=probabilities[index],
+            reasons=reasons,
+        )
+        for index, (scenario, _) in enumerate(ranked)
+    )
+
+
+def _confidence(
+    *,
+    transition_state: FitChefTransitionState,
+    state: UserCoachingStateV1,
+    has_recommendation: bool,
+) -> float:
+    if not has_recommendation:
+        return 0.0
+
+    value = _BASE_CONFIDENCE_BY_STATE[transition_state]
+    if state.recent_behavior.events_capped:
+        value -= 0.15
+    if state.adherence.source_status == "invalid_degraded":
+        value -= 0.2
+    return round(max(0.0, min(value, 1.0)), 4)
+
+
+def build_markov_coaching_transition_plan(
+    state: UserCoachingStateV1,
+    allowed_scenarios: tuple[FitChefCoachingScenario, ...] | None = None,
+) -> MarkovCoachingTransitionPlanV1:
+    """Build a fixed-policy transition plan from internal coaching state."""
+
+    safe_state = _revalidated_state(state)
+    available = _available_scenarios(safe_state, allowed_scenarios)
+
+    transition_state, reason_list = _classify_transition(safe_state)
+    _append_context_reasons(safe_state, reason_list)
+
+    if not available:
+        reason_list.append("no_available_scenarios")
+        transition_state = "no_recommendation_available"
+    else:
+        primary = _PRIMARY_SCENARIO_BY_STATE[transition_state]
+        if primary is not None and primary not in available:
+            reason_list.append("scenario_unavailable")
+        if transition_state == "cold_start_default" and "mascot_insight" in available:
+            reason_list.append("mascot_fallback_allowed")
+
+    reasons = _dedupe_reasons(reason_list)
+    ranked_scenarios = _rank_scenarios(
+        transition_state=transition_state,
+        available_scenarios=available,
+        reasons=reasons,
+    )
+    recommended_scenario = ranked_scenarios[0].scenario if ranked_scenarios else None
+
+    return MarkovCoachingTransitionPlanV1(
+        transition_state=transition_state,
+        available_scenarios=available,
+        ranked_scenarios=ranked_scenarios,
+        recommended_scenario=recommended_scenario,
+        confidence=_confidence(
+            transition_state=transition_state,
+            state=safe_state,
+            has_recommendation=recommended_scenario is not None,
+        ),
+        reasons=reasons,
+    )
+
+
+def to_prompt_safe_markov_context(
+    plan: MarkovCoachingTransitionPlanV1,
+) -> PromptSafeMarkovTransitionContext:
+    """Return the prompt-safe transition subset for future prompt assembly."""
+
+    safe_plan: MarkovCoachingTransitionPlanV1
+    safe_plan = MarkovCoachingTransitionPlanV1.model_validate(plan.model_dump(mode="python"))
+    return PromptSafeMarkovTransitionContext(
+        transition_state=safe_plan.transition_state,
+        recommended_scenario=safe_plan.recommended_scenario,
+        ranked_scenarios=safe_plan.ranked_scenarios,
+        confidence=safe_plan.confidence,
+        reasons=safe_plan.reasons,
+        safety_labels=safe_plan.safety_labels,
+    )
+
+
+__all__ = [
+    "build_markov_coaching_transition_plan",
+    "to_prompt_safe_markov_context",
+]

--- a/app/services/coaching_transition_planner.py
+++ b/app/services/coaching_transition_planner.py
@@ -12,6 +12,7 @@ from app.schemas.user_coaching_state import (
     FitChefTransitionReason,
     FitChefTransitionState,
     MARKOV_TRANSITION_BASE_CONFIDENCE_BY_STATE,
+    MARKOV_TRANSITION_PRIMARY_SCENARIO_BY_STATE,
     MARKOV_TRANSITION_SCENARIO_TIEBREAK,
     MARKOV_TRANSITION_SCENARIO_WEIGHTS_BY_STATE,
     MarkovCoachingTransitionPlanV1,
@@ -22,14 +23,6 @@ from app.schemas.user_coaching_state import (
 
 _SCENARIO_ORDER = {
     scenario: index for index, scenario in enumerate(MARKOV_TRANSITION_SCENARIO_TIEBREAK)
-}
-
-_PRIMARY_SCENARIO_BY_STATE: dict[FitChefTransitionState, FitChefCoachingScenario | None] = {
-    "cold_start_default": "mascot_insight",
-    "steady_state_default": "mascot_insight",
-    "slip_support_needed": "slip_support",
-    "weekly_reflection_due": "weekly_reflection",
-    "no_recommendation_available": None,
 }
 
 
@@ -188,7 +181,7 @@ def build_markov_coaching_transition_plan(
         reason_list.append("no_available_scenarios")
         transition_state = "no_recommendation_available"
     else:
-        primary = _PRIMARY_SCENARIO_BY_STATE[transition_state]
+        primary = MARKOV_TRANSITION_PRIMARY_SCENARIO_BY_STATE[transition_state]
         if primary is not None and primary not in available:
             reason_list.append("scenario_unavailable")
         if transition_state == "cold_start_default" and "mascot_insight" in available:

--- a/app/services/coaching_transition_planner.py
+++ b/app/services/coaching_transition_planner.py
@@ -11,6 +11,7 @@ from app.schemas.user_coaching_state import (
     FitChefCoachingScenario,
     FitChefTransitionReason,
     FitChefTransitionState,
+    MARKOV_TRANSITION_BASE_CONFIDENCE_BY_STATE,
     MarkovCoachingTransitionPlanV1,
     MarkovScenarioProbability,
     PromptSafeMarkovTransitionContext,
@@ -60,14 +61,6 @@ _PRIMARY_SCENARIO_BY_STATE: dict[FitChefTransitionState, FitChefCoachingScenario
     "slip_support_needed": "slip_support",
     "weekly_reflection_due": "weekly_reflection",
     "no_recommendation_available": None,
-}
-
-_BASE_CONFIDENCE_BY_STATE: dict[FitChefTransitionState, float] = {
-    "cold_start_default": 0.35,
-    "steady_state_default": 0.5,
-    "slip_support_needed": 0.78,
-    "weekly_reflection_due": 0.66,
-    "no_recommendation_available": 0.0,
 }
 
 
@@ -195,11 +188,14 @@ def _confidence(
     transition_state: FitChefTransitionState,
     state: UserCoachingStateV1,
     has_recommendation: bool,
+    primary_scenario_unavailable: bool,
 ) -> float:
     if not has_recommendation:
         return 0.0
 
-    value = _BASE_CONFIDENCE_BY_STATE[transition_state]
+    value = MARKOV_TRANSITION_BASE_CONFIDENCE_BY_STATE[transition_state]
+    if primary_scenario_unavailable:
+        value -= 0.25
     if state.recent_behavior.events_capped:
         value -= 0.15
     if state.adherence.source_status == "invalid_degraded":
@@ -246,6 +242,7 @@ def build_markov_coaching_transition_plan(
             transition_state=transition_state,
             state=safe_state,
             has_recommendation=recommended_scenario is not None,
+            primary_scenario_unavailable="scenario_unavailable" in reasons,
         ),
         reasons=reasons,
     )

--- a/app/services/coaching_transition_planner.py
+++ b/app/services/coaching_transition_planner.py
@@ -12,6 +12,7 @@ from app.schemas.user_coaching_state import (
     FitChefTransitionReason,
     FitChefTransitionState,
     MARKOV_TRANSITION_BASE_CONFIDENCE_BY_STATE,
+    MARKOV_TRANSITION_SCENARIO_WEIGHTS_BY_STATE,
     MarkovCoachingTransitionPlanV1,
     MarkovScenarioProbability,
     PromptSafeMarkovTransitionContext,
@@ -26,34 +27,6 @@ _SCENARIO_TIEBREAK: tuple[FitChefCoachingScenario, ...] = (
     "identity_loop_mapper",
 )
 _SCENARIO_ORDER = {scenario: index for index, scenario in enumerate(_SCENARIO_TIEBREAK)}
-
-_TRANSITION_WEIGHTS: dict[FitChefTransitionState, dict[FitChefCoachingScenario, float]] = {
-    "cold_start_default": {
-        "mascot_insight": 1.0,
-    },
-    "steady_state_default": {
-        "mascot_insight": 0.55,
-        "weekly_reflection": 0.2,
-        "distortion_simulator": 0.1,
-        "identity_loop_mapper": 0.1,
-        "slip_support": 0.05,
-    },
-    "slip_support_needed": {
-        "slip_support": 0.72,
-        "weekly_reflection": 0.12,
-        "mascot_insight": 0.1,
-        "distortion_simulator": 0.03,
-        "identity_loop_mapper": 0.03,
-    },
-    "weekly_reflection_due": {
-        "weekly_reflection": 0.65,
-        "mascot_insight": 0.2,
-        "distortion_simulator": 0.05,
-        "identity_loop_mapper": 0.05,
-        "slip_support": 0.05,
-    },
-    "no_recommendation_available": {},
-}
 
 _PRIMARY_SCENARIO_BY_STATE: dict[FitChefTransitionState, FitChefCoachingScenario | None] = {
     "cold_start_default": "mascot_insight",
@@ -155,7 +128,7 @@ def _rank_scenarios(
     available_scenarios: tuple[FitChefCoachingScenario, ...],
     reasons: tuple[FitChefTransitionReason, ...],
 ) -> tuple[MarkovScenarioProbability, ...]:
-    weights = _TRANSITION_WEIGHTS[transition_state]
+    weights = MARKOV_TRANSITION_SCENARIO_WEIGHTS_BY_STATE[transition_state]
     weighted = [
         (scenario, weights.get(scenario, 0.0))
         for scenario in _SCENARIO_TIEBREAK

--- a/docs/review/PR_1894_FIXED_MAPPING.md
+++ b/docs/review/PR_1894_FIXED_MAPPING.md
@@ -166,6 +166,12 @@ Evidence: `MarkovCoachingTransitionPlanV1` validates consecutive ranks and norma
     validation, internal schema-only service boundary, no route/OpenAPI/client/
     runtime/provider/DB/RAG/cache/RL/learning changes, and no Markov references
     in `coaching_state_builder.py`.
+- Codex Security diff scan
+  - Disposition: PASS
+  - Evidence: `/tmp/codex-security-scans/BMI-App_2025_clean/d94b67c55_mergebase_86e40c9f9_20260606T105235Z/report.md`
+    and `.html`; 2/2 diff-scoped source rows completed in
+    `artifacts/02_discovery/work_ledger.jsonl`, raw candidates empty, final
+    report validated and rendered, no reportable findings.
 - `app/services/coaching_transition_planner.py` contains no router/runtime,
   provider, RAG/cache, DB/session, or persistence imports.
 - `tests/test_coaching_transition_planner.py` covers default-prior handling,
@@ -226,13 +232,13 @@ Evidence: `MarkovCoachingTransitionPlanV1` validates consecutive ranks and norma
 - `make validate-changed VENV_PYTHON=.venv/bin/python` — PASS
 - `VENV_PYTHON=.venv/bin/python pre-commit run --all-files` — PASS
 - `VENV_PYTHON=.venv/bin/python git push -u origin codex/fitchef-markov-transition-planner-v1` — pre-push hooks PASS
+- Codex Security diff scan — PASS, no findings; report:
+  `/tmp/codex-security-scans/BMI-App_2025_clean/d94b67c55_mergebase_86e40c9f9_20260606T105235Z/report.md`
 
 ## Merge Readiness
 
 Not claimed. Pending:
 
-- Post-open `qa-engineer-agent -> bug-hunter -> security-auditor`
-- Codex Security diff scan / finding discovery
 - `pulseplate-pr-review`
 - External bot review disposition
 - Current-head CI evidence

--- a/docs/review/PR_1894_FIXED_MAPPING.md
+++ b/docs/review/PR_1894_FIXED_MAPPING.md
@@ -13,7 +13,7 @@ RL/MDP learning, hidden memory, or medical/therapy claims.
 
 - Branch: `codex/fitchef-markov-transition-planner-v1`
 - Base: `origin/main` at `86e40c9f9`
-- Startup packet: `artifacts/orchestration/task_packets/61fbd8909a0a.json`
+- Packet: `artifacts/orchestration/task_packets/61fbd8909a0a.json`
 - Declared pre-open role order:
   `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> backend-engineer`
 - Dispatch manifest:
@@ -21,16 +21,32 @@ RL/MDP learning, hidden memory, or medical/therapy claims.
 
 ## Discussion Thread Pass
 
-- [x] Discussion-thread pass completed for pre-open state.
-- [x] Fixed in commit mapping initialized.
-- Review threads inspected after PR open: none yet.
-- Bot reviews/actionables: pending post-open review cycle.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- Review threads inspected after PR open.
+- Bot reviews/actionables: CodeRabbit/Sourcery/Cubic inspected; actionable GitHub review threads are mapped below.
 
 ## Fixed in Commit Mapping
 
-No GitHub review threads exist yet for PR #1894. Future actionable review
-threads must be added here with `FIXED`, `NOT-A-BUG`, or `DEFERRED` disposition
-proof before any merge-readiness claim.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1894#discussion_r3367035663 -> 41010c3eba0f07092ec58ae00693398fbef27e16
+Disposition: FIXED
+Commit: 41010c3eba0f07092ec58ae00693398fbef27e16
+Evidence: `MarkovCoachingTransitionPlanV1` and `PromptSafeMarkovTransitionContext` reset canonical `MARKOV_TRANSITION_SAFETY_LABELS`; `test_prompt_safe_markov_context_recovers_tampered_plan_derived_fields` covers tamper recovery.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1894#discussion_r3367035672 -> 41010c3eba0f07092ec58ae00693398fbef27e16
+Disposition: FIXED
+Commit: 41010c3eba0f07092ec58ae00693398fbef27e16
+Evidence: `MarkovCoachingTransitionPlanV1` recomputes `recommended_scenario` from the first ranked scenario and `PromptSafeMarkovTransitionContext` mirrors the recomputed recommendation; `test_prompt_safe_markov_context_recovers_tampered_plan_derived_fields` covers injected recommendation override.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1894#discussion_r3367035674 -> 41010c3eba0f07092ec58ae00693398fbef27e16
+Disposition: FIXED
+Commit: 41010c3eba0f07092ec58ae00693398fbef27e16
+Evidence: `_confidence` now applies a scenario-unavailable downgrade and `test_scenario_filtering_and_empty_available_scenarios_degrade` asserts the filtered plan has lower confidence than the full plan.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1894#discussion_r3367040476 -> 41010c3eba0f07092ec58ae00693398fbef27e16
+Disposition: FIXED
+Commit: 41010c3eba0f07092ec58ae00693398fbef27e16
+Evidence: `MarkovCoachingTransitionPlanV1` validates consecutive ranks and normalized probability sums; `test_transition_plan_schema_rejects_impossible_rank_or_probability_shapes` covers invalid distributions.
 
 ## Implementation Evidence
 
@@ -38,6 +54,9 @@ proof before any merge-readiness claim.
   service, prompt-safe projection, and focused planner tests.
 - `f128e638d` — closes premortem safety-label drift by adding
   `non_diagnostic` to the Markov safety-label surface and tests.
+- `41010c3eb` — hardens derived-field recomputation, probability/rank
+  validation, canonical safety-label recovery, and scenario-unavailable
+  confidence degradation.
 - `app/services/coaching_transition_planner.py` contains no router/runtime,
   provider, RAG/cache, DB/session, or persistence imports.
 - `tests/test_coaching_transition_planner.py` covers default-prior handling,
@@ -74,7 +93,7 @@ proof before any merge-readiness claim.
 ## Experiment Runner Evidence
 
 - Packet: `artifacts/orchestration/experiments/exp-455d960da55d.json`
-- Result: `artifacts/orchestration/experiments/results/exp-455d960da55d.json`
+- Artifact: `artifacts/orchestration/experiments/results/exp-455d960da55d.json`
 - Status: `accepted`
 - Runner mode: `oracle_only_governance_reviewer`
 - Mutated paths: `[]`
@@ -92,8 +111,9 @@ proof before any merge-readiness claim.
 
 - `python3 scripts/orchestration/check_preflight.py --path app/schemas/user_coaching_state.py --path app/services/coaching_state_builder.py --path app/services/coaching_transition_planner.py --path tests/test_coaching_transition_planner.py --path tests/test_user_coaching_state.py` — PASS
 - `python3 scripts/orchestration/check_agent_consistency.py` — PASS
-- `.venv/bin/python -m pytest -q tests/test_user_coaching_state.py tests/test_coaching_transition_planner.py tests/test_bayes_adherence_model.py tests/test_bayes_adherence_service.py tests/test_nutrition_log_idempotency.py` — 61 passed
+- `.venv/bin/python -m pytest -q tests/test_user_coaching_state.py tests/test_coaching_transition_planner.py tests/test_bayes_adherence_model.py tests/test_bayes_adherence_service.py tests/test_nutrition_log_idempotency.py` — 64 passed
 - `.venv/bin/python -m mypy app/schemas/user_coaching_state.py app/services/coaching_transition_planner.py tests/test_coaching_transition_planner.py --no-incremental --cache-dir=/dev/null` — PASS
+- `.venv/bin/python -m diff_cover.diff_cover_tool coverage.xml --compare-branch=origin/main --include-untracked --fail-under=97 --json-report /tmp/markov-diff-cover.json` — PASS, 100%
 - `make validate-changed VENV_PYTHON=.venv/bin/python` — PASS
 - `VENV_PYTHON=.venv/bin/python pre-commit run --all-files` — PASS
 - `VENV_PYTHON=.venv/bin/python git push -u origin codex/fitchef-markov-transition-planner-v1` — pre-push hooks PASS

--- a/docs/review/PR_1894_FIXED_MAPPING.md
+++ b/docs/review/PR_1894_FIXED_MAPPING.md
@@ -172,6 +172,14 @@ Evidence: `MarkovCoachingTransitionPlanV1` validates consecutive ranks and norma
     and `.html`; 2/2 diff-scoped source rows completed in
     `artifacts/02_discovery/work_ledger.jsonl`, raw candidates empty, final
     report validated and rendered, no reportable findings.
+- Skill: `pulseplate-pr-review`
+  - Disposition: NOT-A-BUG
+  - Evidence: Dry-run report emitted one advisory large-diff-risk note
+    (`1644` changed lines) only. PR scope governance passed as a 5-file micro
+    PR, the operator requested a larger cohesive epic-line PR instead of
+    micro/docs-only slices, and local `make validate-changed`,
+    `pre-commit run --all-files`, focused pytest/mypy/diff-cover, role passes,
+    and Codex Security scan passed.
 - `app/services/coaching_transition_planner.py` contains no router/runtime,
   provider, RAG/cache, DB/session, or persistence imports.
 - `tests/test_coaching_transition_planner.py` covers default-prior handling,
@@ -234,12 +242,14 @@ Evidence: `MarkovCoachingTransitionPlanV1` validates consecutive ranks and norma
 - `VENV_PYTHON=.venv/bin/python git push -u origin codex/fitchef-markov-transition-planner-v1` — pre-push hooks PASS
 - Codex Security diff scan — PASS, no findings; report:
   `/tmp/codex-security-scans/BMI-App_2025_clean/d94b67c55_mergebase_86e40c9f9_20260606T105235Z/report.md`
+- `pulseplate-pr-review` — completed; advisory large-diff note dispositioned
+  as NOT-A-BUG because this is an operator-requested cohesive 5-file epic-line
+  PR with passing scope governance and targeted gates.
 
 ## Merge Readiness
 
 Not claimed. Pending:
 
-- `pulseplate-pr-review`
 - External bot review disposition
 - Current-head CI evidence
 - Strict merge-readiness check with required auth

--- a/docs/review/PR_1894_FIXED_MAPPING.md
+++ b/docs/review/PR_1894_FIXED_MAPPING.md
@@ -57,6 +57,76 @@ Evidence: `MarkovCoachingTransitionPlanV1` validates consecutive ranks and norma
 - `41010c3eb` — hardens derived-field recomputation, probability/rank
   validation, canonical safety-label recovery, and scenario-unavailable
   confidence degradation.
+- `621fe1c14` — closes post-open bug-hunter fallback invariant by rejecting
+  ranked scenarios outside `available_scenarios` and adding regression coverage.
+- `5315f1235` — closes post-open bug-hunter transition-state steering by moving
+  fixed-policy scenario weights into schema validation and reusing them in the
+  planner service.
+- `004af7447` — closes post-open bug-hunter direct prompt-safe construction
+  steering by reusing the same ranked-scenario validator in
+  `PromptSafeMarkovTransitionContext`.
+- `539dcfe26` — closes post-open bug-hunter self-consistent transition-state
+  steering by requiring plan-level ranked scenarios to match the exact fixed
+  policy for `transition_state + available_scenarios` and by validating
+  transition-state reasons.
+- `5a07e4c8b` — covers all fixed-policy validator branches after `539dcfe26`
+  so diff-cover remains above the branch threshold without weakening guards.
+- `7dd9a5b4f` — closes post-open bug-hunter fallback confidence inflation by
+  requiring `scenario_unavailable` for fallback rankings and
+  `no_recommendation_available` for empty allowlists.
+
+## Post-open Role Findings
+
+- Role: `bug-hunter`
+  - Disposition: FIXED
+  - Commit: `621fe1c1443e454daf9073482720bd2c7702fa5e`
+  - Evidence: `MarkovCoachingTransitionPlanV1` rejects ranked scenarios outside
+    `available_scenarios`; `test_transition_plan_schema_rejects_unavailable_ranked_scenarios`
+    covers unavailable non-empty rankings, including empty allowlist plans.
+- Role: `bug-hunter`
+  - Disposition: FIXED
+  - Commit: `5315f123555097669c8f7c97074532e6cfa35a02`
+  - Evidence: `MarkovCoachingTransitionPlanV1` rejects ranked scenarios not
+    valid for the current `transition_state`; `to_prompt_safe_markov_context`
+    revalidation fails closed for tampered transition-state steering in
+    `test_prompt_safe_markov_context_rejects_transition_state_steering`.
+- Role: `bug-hunter`
+  - Disposition: FIXED
+  - Commit: `004af744709ce86f3bfc5d35350a33e17043a2f4`
+  - Evidence: `PromptSafeMarkovTransitionContext` now reuses the same rank,
+    probability, and transition-state scenario validator as
+    `MarkovCoachingTransitionPlanV1`; `test_prompt_safe_markov_context_rejects_transition_state_steering`
+    covers direct prompt-safe schema construction.
+- Role: `bug-hunter`
+  - Disposition: FIXED
+  - Commit: `539dcfe26bfd61210d715cb0063966de52393447`
+  - Evidence: `MarkovCoachingTransitionPlanV1` now requires exact
+    fixed-policy ranked distributions and compatible transition-state reasons;
+    `test_transition_plan_schema_rejects_non_policy_ranked_distribution` and
+    `test_prompt_safe_markov_context_rejects_transition_state_steering` cover
+    self-consistent plan steering before prompt-safe projection.
+- Role: `bug-hunter`
+  - Disposition: FIXED
+  - Commit: `5a07e4c8be143cfb5774c03ae3a367e21445f79e`
+  - Evidence: `test_transition_plan_schema_allows_empty_policy_when_primary_is_unavailable`,
+    `test_markov_transition_schemas_reject_reason_mismatches`, and
+    `test_transition_plan_schema_rejects_ranked_reason_mismatch` cover the
+    fail-closed reason/policy branches added for bug-hunter findings.
+- Role: `bug-hunter`
+  - Disposition: FIXED
+  - Commit: `7dd9a5b4f2b5883f606360ef385a43ed2ab0582d`
+  - Evidence: `test_markov_schemas_require_scenario_unavailable_for_fallback_rankings`
+    rejects direct plan/prompt-safe fallback rankings without
+    `scenario_unavailable` and verifies fallback confidence is recomputed down;
+    `test_transition_plan_schema_requires_no_recommendation_state_for_empty_allowlist`
+    rejects empty-allowlist plans that do not use `no_recommendation_available`.
+- Role: `bug-hunter`
+  - Disposition: PASS
+  - Evidence: Repeat pass after `7dd9a5b4f2b5883f606360ef385a43ed2ab0582d`
+    found no correctness/regression findings and confirmed unavailable ranked
+    scenarios, transition-state impossible scenarios, prompt-safe steering,
+    fallback `scenario_unavailable`, confidence downgrade, and valid planner
+    round-trip probes.
 - `app/services/coaching_transition_planner.py` contains no router/runtime,
   provider, RAG/cache, DB/session, or persistence imports.
 - `tests/test_coaching_transition_planner.py` covers default-prior handling,
@@ -111,9 +181,9 @@ Evidence: `MarkovCoachingTransitionPlanV1` validates consecutive ranks and norma
 
 - `python3 scripts/orchestration/check_preflight.py --path app/schemas/user_coaching_state.py --path app/services/coaching_state_builder.py --path app/services/coaching_transition_planner.py --path tests/test_coaching_transition_planner.py --path tests/test_user_coaching_state.py` — PASS
 - `python3 scripts/orchestration/check_agent_consistency.py` — PASS
-- `.venv/bin/python -m pytest -q tests/test_user_coaching_state.py tests/test_coaching_transition_planner.py tests/test_bayes_adherence_model.py tests/test_bayes_adherence_service.py tests/test_nutrition_log_idempotency.py` — 64 passed
+- `.venv/bin/python -m pytest -q tests/test_user_coaching_state.py tests/test_coaching_transition_planner.py tests/test_bayes_adherence_model.py tests/test_bayes_adherence_service.py tests/test_nutrition_log_idempotency.py` — 72 passed after `7dd9a5b4f`
 - `.venv/bin/python -m mypy app/schemas/user_coaching_state.py app/services/coaching_transition_planner.py tests/test_coaching_transition_planner.py --no-incremental --cache-dir=/dev/null` — PASS
-- `.venv/bin/python -m diff_cover.diff_cover_tool coverage.xml --compare-branch=origin/main --include-untracked --fail-under=97 --json-report /tmp/markov-diff-cover.json` — PASS, 100%
+- `.venv/bin/python -m diff_cover.diff_cover_tool coverage.xml --compare-branch=origin/main --include-untracked --fail-under=97 --format json:/tmp/markov-diff-cover.json` — PASS, 100%
 - `make validate-changed VENV_PYTHON=.venv/bin/python` — PASS
 - `VENV_PYTHON=.venv/bin/python pre-commit run --all-files` — PASS
 - `VENV_PYTHON=.venv/bin/python git push -u origin codex/fitchef-markov-transition-planner-v1` — pre-push hooks PASS

--- a/docs/review/PR_1894_FIXED_MAPPING.md
+++ b/docs/review/PR_1894_FIXED_MAPPING.md
@@ -74,6 +74,12 @@ Evidence: `MarkovCoachingTransitionPlanV1` validates consecutive ranks and norma
 - `7dd9a5b4f` — closes post-open bug-hunter fallback confidence inflation by
   requiring `scenario_unavailable` for fallback rankings and
   `no_recommendation_available` for empty allowlists.
+- `6823411ad` — closes post-open backend-engineer inverse invariant by
+  rejecting `no_recommendation_available` plans with non-empty
+  `available_scenarios`.
+- `1e8526dac` — closes post-open architecture prompt-safe policy asymmetry by
+  validating direct `PromptSafeMarkovTransitionContext` probability vectors
+  against fixed-policy ratios for the ranked subset.
 
 ## Post-open Role Findings
 
@@ -127,6 +133,39 @@ Evidence: `MarkovCoachingTransitionPlanV1` validates consecutive ranks and norma
     scenarios, transition-state impossible scenarios, prompt-safe steering,
     fallback `scenario_unavailable`, confidence downgrade, and valid planner
     round-trip probes.
+- Role: `security-auditor`
+  - Disposition: PASS
+  - Evidence: Local HEAD `4a6fa6e47` review found no file/line security,
+    privacy, safety, or compliance findings; verified no route/OpenAPI/provider,
+    DB/cache/RAG/runtime wiring, prompt-safe identifier/raw-event exclusion,
+    fixed-policy/fallback validation, safety tests, and runtime-wiring guards.
+- Role: `backend-engineer`
+  - Disposition: FIXED
+  - Commit: `6823411ade1884106665eb15948c6208c2b2f753`
+  - Evidence: `test_transition_plan_schema_requires_no_recommendation_state_for_empty_allowlist`
+    now rejects non-empty `available_scenarios` paired with
+    `no_recommendation_available`; focused tests, mypy, flake8, and diff-cover
+    passed after the fix.
+- Role: `backend-engineer`
+  - Disposition: PASS
+  - Evidence: Repeat pass after `6823411ade1884106665eb15948c6208c2b2f753`
+    found no backend file/line findings; verified inverse invariant,
+    deterministic fixed-policy planner outputs, schema-only service imports,
+    and no router/provider/DB/RAG/cache/persistence matches.
+- Role: `architecture-specialist`
+  - Disposition: FIXED
+  - Commit: `1e8526dac6267f63343681663bd8e9a297939988`
+  - Evidence: `PromptSafeMarkovTransitionContext` now validates direct
+    prompt-safe ranked probability vectors against the fixed-policy ranked
+    subset; `test_transition_plan_schema_rejects_non_policy_ranked_distribution`
+    covers direct prompt-safe non-policy distributions.
+- Role: `architecture-specialist`
+  - Disposition: PASS
+  - Evidence: Repeat pass after `1e8526dac6267f63343681663bd8e9a297939988`
+    found no architecture file/line findings; verified prompt-safe fixed-policy
+    validation, internal schema-only service boundary, no route/OpenAPI/client/
+    runtime/provider/DB/RAG/cache/RL/learning changes, and no Markov references
+    in `coaching_state_builder.py`.
 - `app/services/coaching_transition_planner.py` contains no router/runtime,
   provider, RAG/cache, DB/session, or persistence imports.
 - `tests/test_coaching_transition_planner.py` covers default-prior handling,
@@ -181,7 +220,7 @@ Evidence: `MarkovCoachingTransitionPlanV1` validates consecutive ranks and norma
 
 - `python3 scripts/orchestration/check_preflight.py --path app/schemas/user_coaching_state.py --path app/services/coaching_state_builder.py --path app/services/coaching_transition_planner.py --path tests/test_coaching_transition_planner.py --path tests/test_user_coaching_state.py` — PASS
 - `python3 scripts/orchestration/check_agent_consistency.py` — PASS
-- `.venv/bin/python -m pytest -q tests/test_user_coaching_state.py tests/test_coaching_transition_planner.py tests/test_bayes_adherence_model.py tests/test_bayes_adherence_service.py tests/test_nutrition_log_idempotency.py` — 72 passed after `7dd9a5b4f`
+- `.venv/bin/python -m pytest -q tests/test_user_coaching_state.py tests/test_coaching_transition_planner.py tests/test_bayes_adherence_model.py tests/test_bayes_adherence_service.py tests/test_nutrition_log_idempotency.py` — 72 passed after `1e8526dac`
 - `.venv/bin/python -m mypy app/schemas/user_coaching_state.py app/services/coaching_transition_planner.py tests/test_coaching_transition_planner.py --no-incremental --cache-dir=/dev/null` — PASS
 - `.venv/bin/python -m diff_cover.diff_cover_tool coverage.xml --compare-branch=origin/main --include-untracked --fail-under=97 --format json:/tmp/markov-diff-cover.json` — PASS, 100%
 - `make validate-changed VENV_PYTHON=.venv/bin/python` — PASS

--- a/docs/review/PR_1894_FIXED_MAPPING.md
+++ b/docs/review/PR_1894_FIXED_MAPPING.md
@@ -1,0 +1,110 @@
+# PR #1894 Fixed in Commit Mapping
+
+## Scope
+
+This PR adds an internal FitChef Markov coaching transition planner v1 over
+`UserCoachingStateV1`. The planner is service-only and deterministic: it ranks
+allowed coaching scenarios from backend-derived sufficient state, then exposes a
+prompt-safe projection. It does not add public routes, OpenAPI/client changes,
+runtime prompt wiring, persistence, provider calls, semantic cache, RAG/GraphRAG,
+RL/MDP learning, hidden memory, or medical/therapy claims.
+
+## Lane Start Provenance
+
+- Branch: `codex/fitchef-markov-transition-planner-v1`
+- Base: `origin/main` at `86e40c9f9`
+- Startup packet: `artifacts/orchestration/task_packets/61fbd8909a0a.json`
+- Declared pre-open role order:
+  `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> backend-engineer`
+- Dispatch manifest:
+  `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/61fbd8909a0a.json --mode runtime --pr-phase pre_open --implementation-owner backend-engineer --pretty`
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed for pre-open state.
+- [x] Fixed in commit mapping initialized.
+- Review threads inspected after PR open: none yet.
+- Bot reviews/actionables: pending post-open review cycle.
+
+## Fixed in Commit Mapping
+
+No GitHub review threads exist yet for PR #1894. Future actionable review
+threads must be added here with `FIXED`, `NOT-A-BUG`, or `DEFERRED` disposition
+proof before any merge-readiness claim.
+
+## Implementation Evidence
+
+- `64c250fbb` — adds the Markov transition schemas, deterministic planner
+  service, prompt-safe projection, and focused planner tests.
+- `f128e638d` — closes premortem safety-label drift by adding
+  `non_diagnostic` to the Markov safety-label surface and tests.
+- `app/services/coaching_transition_planner.py` contains no router/runtime,
+  provider, RAG/cache, DB/session, or persistence imports.
+- `tests/test_coaching_transition_planner.py` covers default-prior handling,
+  slip evidence, weekly reflection routing, scenario allowlist filtering,
+  empty-scenario degradation, deterministic ranking, injection resistance,
+  prompt-safe leakage exclusions, and builder integration.
+- `tests/test_user_coaching_state.py` extends the service-only source guard to
+  include `app/services/coaching_transition_planner.py`.
+
+## Premortem Findings
+
+- Safety-label vocabulary drift
+  - Disposition: FIXED
+  - Commit: `f128e638d`
+  - Evidence: `PromptSafeMarkovTransitionContext` now carries
+    `non_diagnostic`, and `tests/test_coaching_transition_planner.py` asserts
+    that label while still blocking diagnosis, therapy, medical, and treatment
+    wording.
+- Slip-support promotion gap
+  - Disposition: NOT-A-BUG
+  - Evidence: This PR is explicitly service-only and does not claim runtime
+    slip-support enablement. `tests/test_coaching_transition_planner.py` proves
+    the builder integration degrades to `mascot_insight` with
+    `scenario_unavailable` when `slip_support` is not in `available_scenarios`.
+- Markov probability overclaim
+  - Disposition: NOT-A-BUG
+  - Evidence: The planner uses static fixed-policy weights, deterministic
+    tie-breaks, no random sampling, and no learning/persistence surface.
+- Dead foundation / follow-up risk
+  - Disposition: NOT-A-BUG
+  - Evidence: This is the approved internal foundation slice for the epic line;
+    runtime integration remains out of scope and must use a separate gate.
+
+## Experiment Runner Evidence
+
+- Packet: `artifacts/orchestration/experiments/exp-455d960da55d.json`
+- Result: `artifacts/orchestration/experiments/results/exp-455d960da55d.json`
+- Status: `accepted`
+- Runner mode: `oracle_only_governance_reviewer`
+- Mutated paths: `[]`
+- Shared tree untouched: `true`
+- Co-author trailer: not required; the result did not shape a subsequent code,
+  test, docs, mapping, review-disposition, or commit decision.
+- Oracle 1:
+  `python -m pytest -q tests/test_user_coaching_state.py tests/test_coaching_transition_planner.py`
+  returned `0`.
+- Oracle 2:
+  `python -m mypy app/schemas/user_coaching_state.py app/services/coaching_transition_planner.py tests/test_coaching_transition_planner.py --no-incremental --cache-dir=/dev/null`
+  returned `0`.
+
+## Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py --path app/schemas/user_coaching_state.py --path app/services/coaching_state_builder.py --path app/services/coaching_transition_planner.py --path tests/test_coaching_transition_planner.py --path tests/test_user_coaching_state.py` — PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` — PASS
+- `.venv/bin/python -m pytest -q tests/test_user_coaching_state.py tests/test_coaching_transition_planner.py tests/test_bayes_adherence_model.py tests/test_bayes_adherence_service.py tests/test_nutrition_log_idempotency.py` — 61 passed
+- `.venv/bin/python -m mypy app/schemas/user_coaching_state.py app/services/coaching_transition_planner.py tests/test_coaching_transition_planner.py --no-incremental --cache-dir=/dev/null` — PASS
+- `make validate-changed VENV_PYTHON=.venv/bin/python` — PASS
+- `VENV_PYTHON=.venv/bin/python pre-commit run --all-files` — PASS
+- `VENV_PYTHON=.venv/bin/python git push -u origin codex/fitchef-markov-transition-planner-v1` — pre-push hooks PASS
+
+## Merge Readiness
+
+Not claimed. Pending:
+
+- Post-open `qa-engineer-agent -> bug-hunter -> security-auditor`
+- Codex Security diff scan / finding discovery
+- `pulseplate-pr-review`
+- External bot review disposition
+- Current-head CI evidence
+- Strict merge-readiness check with required auth

--- a/tests/test_coaching_transition_planner.py
+++ b/tests/test_coaching_transition_planner.py
@@ -382,6 +382,98 @@ def test_transition_plan_schema_rejects_non_policy_ranked_distribution() -> None
         )
 
 
+def test_transition_plan_schema_allows_empty_policy_when_primary_is_unavailable() -> None:
+    plan = MarkovCoachingTransitionPlanV1(
+        transition_state="cold_start_default",
+        available_scenarios=("slip_support",),
+        ranked_scenarios=(),
+        recommended_scenario="slip_support",
+        confidence=0.99,
+        reasons=(
+            "cold_start_default",
+            "default_prior_not_observed_slip",
+            "scenario_unavailable",
+        ),
+    )
+
+    assert plan.ranked_scenarios == ()
+    assert plan.recommended_scenario is None
+    assert plan.confidence == 0.0
+
+
+def test_markov_transition_schemas_reject_reason_mismatches() -> None:
+    reason_cases = (
+        ("cold_start_default", "mascot_insight", ("cold_start_default",)),
+        (
+            "cold_start_default",
+            "mascot_insight",
+            (
+                "cold_start_default",
+                "default_prior_not_observed_slip",
+                "explicit_slip_event",
+            ),
+        ),
+        ("slip_support_needed", "slip_support", ()),
+        (
+            "slip_support_needed",
+            "slip_support",
+            ("explicit_slip_event", "cold_start_default"),
+        ),
+        ("weekly_reflection_due", "weekly_reflection", ()),
+        (
+            "weekly_reflection_due",
+            "weekly_reflection",
+            ("day_close_observed", "explicit_slip_event"),
+        ),
+        ("steady_state_default", "mascot_insight", ("explicit_slip_event",)),
+    )
+
+    for transition_state, scenario, reasons in reason_cases:
+        with pytest.raises(ValidationError, match="transition_state"):
+            PromptSafeMarkovTransitionContext.model_validate(
+                {
+                    "transition_state": transition_state,
+                    "recommended_scenario": scenario,
+                    "ranked_scenarios": (
+                        {
+                            "rank": 1,
+                            "scenario": scenario,
+                            "probability": 1.0,
+                            "reasons": reasons,
+                        },
+                    ),
+                    "confidence": 0.99,
+                    "reasons": reasons,
+                }
+            )
+
+    with pytest.raises(ValidationError, match="transition_state"):
+        PromptSafeMarkovTransitionContext(
+            transition_state="no_recommendation_available",
+            recommended_scenario=None,
+            ranked_scenarios=(),
+            confidence=0.0,
+        )
+
+
+def test_transition_plan_schema_rejects_ranked_reason_mismatch() -> None:
+    with pytest.raises(ValidationError, match="plan reasons"):
+        MarkovCoachingTransitionPlanV1(
+            transition_state="cold_start_default",
+            available_scenarios=("mascot_insight",),
+            ranked_scenarios=(
+                MarkovScenarioProbability(
+                    rank=1,
+                    scenario="mascot_insight",
+                    probability=1.0,
+                    reasons=("cold_start_default",),
+                ),
+            ),
+            confidence=0.35,
+            reasons=("cold_start_default", "default_prior_not_observed_slip"),
+        )
+
+
 def test_transition_plan_schema_rejects_unavailable_ranked_scenarios() -> None:
     unavailable_probability = MarkovScenarioProbability(
         rank=1,

--- a/tests/test_coaching_transition_planner.py
+++ b/tests/test_coaching_transition_planner.py
@@ -453,6 +453,15 @@ def test_transition_plan_schema_requires_no_recommendation_state_for_empty_allow
             reasons=("cold_start_default", "default_prior_not_observed_slip"),
         )
 
+    with pytest.raises(ValidationError, match="no available scenarios"):
+        MarkovCoachingTransitionPlanV1(
+            transition_state="no_recommendation_available",
+            available_scenarios=("mascot_insight",),
+            ranked_scenarios=(),
+            confidence=0.0,
+            reasons=("no_available_scenarios",),
+        )
+
 
 def test_markov_transition_schemas_reject_reason_mismatches() -> None:
     reason_cases = (

--- a/tests/test_coaching_transition_planner.py
+++ b/tests/test_coaching_transition_planner.py
@@ -17,6 +17,7 @@ from app.schemas.user_coaching_state import (
     AdherenceSnapshot,
     MarkovCoachingTransitionPlanV1,
     MarkovScenarioProbability,
+    PromptSafeMarkovTransitionContext,
     RecentBehaviorSnapshot,
     UserCoachingStateV1,
 )
@@ -408,6 +409,20 @@ def test_prompt_safe_markov_context_rejects_transition_state_steering() -> None:
     assert plan.recommended_scenario == "mascot_insight"
     with pytest.raises(ValidationError, match="transition_state"):
         to_prompt_safe_markov_context(tampered_plan)
+
+    with pytest.raises(ValidationError, match="transition_state"):
+        PromptSafeMarkovTransitionContext(
+            transition_state="cold_start_default",
+            recommended_scenario="slip_support",
+            ranked_scenarios=(
+                MarkovScenarioProbability(
+                    rank=1,
+                    scenario="slip_support",
+                    probability=1.0,
+                ),
+            ),
+            confidence=0.99,
+        )
 
 
 def test_capped_or_degraded_behavior_lowers_confidence_and_adds_reason() -> None:

--- a/tests/test_coaching_transition_planner.py
+++ b/tests/test_coaching_transition_planner.py
@@ -108,6 +108,7 @@ def test_markov_transition_schemas_are_frozen_strict_and_default_safe() -> None:
     assert plan.source_state_version == "v1"
     assert plan.safety_labels == (
         "wellness_only",
+        "non_diagnostic",
         "service_only",
         "no_raw_user_text",
         "deterministic_policy",
@@ -365,10 +366,10 @@ def test_prompt_safe_markov_context_excludes_sensitive_and_unsafe_fields() -> No
         "medical",
         "therapy",
         "diagnosis",
-        "diagnostic",
         "treatment",
     ):
         assert forbidden not in context_json
+    assert "non_diagnostic" in context_json
     assert context.recommended_scenario == "slip_support"
 
 

--- a/tests/test_coaching_transition_planner.py
+++ b/tests/test_coaching_transition_planner.py
@@ -401,6 +401,59 @@ def test_transition_plan_schema_allows_empty_policy_when_primary_is_unavailable(
     assert plan.confidence == 0.0
 
 
+def test_markov_schemas_require_scenario_unavailable_for_fallback_rankings() -> None:
+    fallback_probability = MarkovScenarioProbability(
+        rank=1,
+        scenario="mascot_insight",
+        probability=1.0,
+        reasons=("observed_slip_like_behavior",),
+    )
+    with pytest.raises(ValidationError, match="scenario_unavailable"):
+        MarkovCoachingTransitionPlanV1(
+            transition_state="slip_support_needed",
+            available_scenarios=("mascot_insight",),
+            ranked_scenarios=(fallback_probability,),
+            confidence=0.78,
+            reasons=("observed_slip_like_behavior",),
+        )
+
+    accepted_plan = MarkovCoachingTransitionPlanV1(
+        transition_state="slip_support_needed",
+        available_scenarios=("mascot_insight",),
+        ranked_scenarios=(
+            fallback_probability.model_copy(
+                update={
+                    "reasons": ("observed_slip_like_behavior", "scenario_unavailable"),
+                }
+            ),
+        ),
+        confidence=0.78,
+        reasons=("observed_slip_like_behavior", "scenario_unavailable"),
+    )
+    assert accepted_plan.recommended_scenario == "mascot_insight"
+    assert accepted_plan.confidence == pytest.approx(0.53)
+
+    with pytest.raises(ValidationError, match="scenario_unavailable"):
+        PromptSafeMarkovTransitionContext(
+            transition_state="slip_support_needed",
+            recommended_scenario="mascot_insight",
+            ranked_scenarios=(fallback_probability,),
+            confidence=0.78,
+            reasons=("observed_slip_like_behavior",),
+        )
+
+
+def test_transition_plan_schema_requires_no_recommendation_state_for_empty_allowlist() -> None:
+    with pytest.raises(ValidationError, match="no available scenarios"):
+        MarkovCoachingTransitionPlanV1(
+            transition_state="cold_start_default",
+            available_scenarios=(),
+            ranked_scenarios=(),
+            confidence=0.0,
+            reasons=("cold_start_default", "default_prior_not_observed_slip"),
+        )
+
+
 def test_markov_transition_schemas_reject_reason_mismatches() -> None:
     reason_cases = (
         ("cold_start_default", "mascot_insight", ("cold_start_default",)),

--- a/tests/test_coaching_transition_planner.py
+++ b/tests/test_coaching_transition_planner.py
@@ -381,6 +381,49 @@ def test_transition_plan_schema_rejects_non_policy_ranked_distribution() -> None
             reasons=("observed_slip_like_behavior",),
         )
 
+    with pytest.raises(ValidationError, match="fixed transition policy"):
+        PromptSafeMarkovTransitionContext(
+            transition_state="steady_state_default",
+            recommended_scenario="mascot_insight",
+            ranked_scenarios=(
+                MarkovScenarioProbability(
+                    rank=1,
+                    scenario="mascot_insight",
+                    probability=0.9,
+                    reasons=(),
+                ),
+                MarkovScenarioProbability(
+                    rank=2,
+                    scenario="weekly_reflection",
+                    probability=0.1,
+                    reasons=(),
+                ),
+            ),
+            confidence=0.5,
+        )
+
+    with pytest.raises(ValidationError, match="fixed transition policy"):
+        PromptSafeMarkovTransitionContext(
+            transition_state="slip_support_needed",
+            recommended_scenario="slip_support",
+            ranked_scenarios=(
+                MarkovScenarioProbability(
+                    rank=1,
+                    scenario="slip_support",
+                    probability=0.5,
+                    reasons=("observed_slip_like_behavior",),
+                ),
+                MarkovScenarioProbability(
+                    rank=2,
+                    scenario="mascot_insight",
+                    probability=0.5,
+                    reasons=("observed_slip_like_behavior",),
+                ),
+            ),
+            confidence=0.78,
+            reasons=("observed_slip_like_behavior",),
+        )
+
 
 def test_transition_plan_schema_allows_empty_policy_when_primary_is_unavailable() -> None:
     plan = MarkovCoachingTransitionPlanV1(

--- a/tests/test_coaching_transition_planner.py
+++ b/tests/test_coaching_transition_planner.py
@@ -234,11 +234,35 @@ def test_day_close_ranks_weekly_reflection_without_slip_evidence() -> None:
     assert "day_close_observed" in plan.reasons
 
 
+def test_steady_state_default_is_covered_without_slip_or_day_close() -> None:
+    state = _state(
+        adherence=AdherenceSnapshot(
+            alpha=2.0,
+            beta=8.0,
+            n=10,
+            risk_slip=0.2,
+            confidence=0.85,
+            needs_more_data=False,
+        ),
+        recent_behavior=RecentBehaviorSnapshot(
+            meal_logged_count_7d=2,
+            scanned_event_count=2,
+        ),
+    )
+
+    plan = build_markov_coaching_transition_plan(state)
+
+    assert plan.transition_state == "steady_state_default"
+    assert plan.recommended_scenario == "mascot_insight"
+    assert plan.confidence == pytest.approx(0.5)
+
+
 def test_scenario_filtering_and_empty_available_scenarios_degrade() -> None:
     state = _state(
         recent_behavior=RecentBehaviorSnapshot(slip_count_7d=1, slip_like_count_7d=1),
     )
 
+    full = build_markov_coaching_transition_plan(state)
     filtered = build_markov_coaching_transition_plan(
         state,
         allowed_scenarios=("weekly_reflection", "mascot_insight"),
@@ -246,6 +270,7 @@ def test_scenario_filtering_and_empty_available_scenarios_degrade() -> None:
     assert filtered.recommended_scenario == "weekly_reflection"
     assert "slip_support" not in {ranked.scenario for ranked in filtered.ranked_scenarios}
     assert "scenario_unavailable" in filtered.reasons
+    assert filtered.confidence < full.confidence
 
     empty = build_markov_coaching_transition_plan(state, allowed_scenarios=())
     assert empty.transition_state == "no_recommendation_available"
@@ -303,6 +328,39 @@ def test_caller_injected_derived_state_cannot_steer_transition_plan() -> None:
 
     assert plan.recommended_scenario == "slip_support"
     assert "caller_injected" not in json.dumps(plan.model_dump(mode="json"))
+
+
+def test_transition_plan_schema_rejects_impossible_rank_or_probability_shapes() -> None:
+    valid_probability = MarkovScenarioProbability(
+        rank=1,
+        scenario="mascot_insight",
+        probability=1.0,
+    )
+    with pytest.raises(ValidationError, match="probabilities must sum"):
+        MarkovCoachingTransitionPlanV1(
+            transition_state="steady_state_default",
+            available_scenarios=("mascot_insight", "weekly_reflection"),
+            ranked_scenarios=(
+                MarkovScenarioProbability(
+                    rank=1,
+                    scenario="mascot_insight",
+                    probability=0.6,
+                ),
+                MarkovScenarioProbability(
+                    rank=2,
+                    scenario="weekly_reflection",
+                    probability=0.3,
+                ),
+            ),
+            confidence=0.5,
+        )
+    with pytest.raises(ValidationError, match="consecutive"):
+        MarkovCoachingTransitionPlanV1(
+            transition_state="steady_state_default",
+            available_scenarios=("mascot_insight",),
+            ranked_scenarios=(valid_probability.model_copy(update={"rank": 2}),),
+            confidence=0.5,
+        )
 
 
 def test_capped_or_degraded_behavior_lowers_confidence_and_adds_reason() -> None:
@@ -371,6 +429,30 @@ def test_prompt_safe_markov_context_excludes_sensitive_and_unsafe_fields() -> No
         assert forbidden not in context_json
     assert "non_diagnostic" in context_json
     assert context.recommended_scenario == "slip_support"
+
+
+def test_prompt_safe_markov_context_recovers_tampered_plan_derived_fields() -> None:
+    state = _state(
+        recent_behavior=RecentBehaviorSnapshot(
+            slip_count_7d=1,
+            slip_like_count_7d=1,
+            scanned_event_count=1,
+        ),
+    )
+    plan = build_markov_coaching_transition_plan(state)
+    tampered_plan = plan.model_copy(
+        update={
+            "recommended_scenario": "mascot_insight",
+            "confidence": 0.99,
+            "safety_labels": (),
+        }
+    )
+
+    context = to_prompt_safe_markov_context(tampered_plan)
+
+    assert context.recommended_scenario == "slip_support"
+    assert context.safety_labels == plan.safety_labels
+    assert context.confidence == plan.confidence
 
 
 def test_planner_integrates_with_build_user_coaching_state(

--- a/tests/test_coaching_transition_planner.py
+++ b/tests/test_coaching_transition_planner.py
@@ -1,0 +1,429 @@
+"""Tests for the internal FitChef coaching transition planner v1."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from app.models import NutritionEvent
+from app.schemas.user_coaching_state import (
+    AdherenceSnapshot,
+    MarkovCoachingTransitionPlanV1,
+    MarkovScenarioProbability,
+    RecentBehaviorSnapshot,
+    UserCoachingStateV1,
+)
+from app.services import coaching_state_builder as builder_module
+from app.services.coaching_state_builder import build_user_coaching_state
+from app.services.coaching_transition_planner import (
+    build_markov_coaching_transition_plan,
+    to_prompt_safe_markov_context,
+)
+from core.models import AnalyzerStateModel, User
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXED_NOW = datetime(2026, 6, 6, 12, 0, tzinfo=timezone.utc)
+
+
+def _state(
+    *,
+    adherence: AdherenceSnapshot | None = None,
+    recent_behavior: RecentBehaviorSnapshot | None = None,
+    available_scenarios: tuple[str, ...] = (
+        "mascot_insight",
+        "weekly_reflection",
+        "slip_support",
+        "distortion_simulator",
+        "identity_loop_mapper",
+    ),
+) -> UserCoachingStateV1:
+    return UserCoachingStateV1.model_validate(
+        {
+            "user_id": 92_001,
+            "assembled_at": FIXED_NOW,
+            "adherence": adherence or AdherenceSnapshot(),
+            "recent_behavior": recent_behavior or RecentBehaviorSnapshot(),
+            "available_scenarios": available_scenarios,
+        }
+    )
+
+
+def _reset_subjects(session: Session, *user_ids: int) -> None:
+    session.execute(delete(NutritionEvent).where(NutritionEvent.subject_id.in_(user_ids)))
+    session.execute(delete(AnalyzerStateModel).where(AnalyzerStateModel.user_id.in_(user_ids)))
+    session.execute(delete(User).where(User.id.in_(user_ids)))
+    for user_id in user_ids:
+        session.add(
+            User(
+                id=user_id,
+                email=f"transition-planner-{user_id}@example.test",
+                name=f"Transition Planner {user_id}",
+            )
+        )
+
+
+def _event(
+    *,
+    user_id: int,
+    day: date,
+    event_type: str,
+    client_event_id: str,
+) -> NutritionEvent:
+    source = "day_close" if event_type == "day_closed" else "meal_log"
+    return NutritionEvent(
+        subject_id=user_id,
+        day=day,
+        source=source,
+        event_type=event_type,
+        client_event_id=client_event_id,
+        payload={"free_text": "raw transition planner fixture text"},
+        created_at=FIXED_NOW.replace(tzinfo=None),
+    )
+
+
+def test_markov_transition_schemas_are_frozen_strict_and_default_safe() -> None:
+    probability = MarkovScenarioProbability(
+        rank=1,
+        scenario="mascot_insight",
+        probability=1.0,
+        reasons=("cold_start_default",),
+    )
+    plan = MarkovCoachingTransitionPlanV1(
+        transition_state="cold_start_default",
+        available_scenarios=("mascot_insight",),
+        ranked_scenarios=(probability,),
+        recommended_scenario="mascot_insight",
+        confidence=0.35,
+        reasons=("cold_start_default",),
+    )
+
+    assert plan.plan_version == "markov_transition_v1"
+    assert plan.source_state_version == "v1"
+    assert plan.safety_labels == (
+        "wellness_only",
+        "service_only",
+        "no_raw_user_text",
+        "deterministic_policy",
+    )
+
+    with pytest.raises(ValidationError):
+        MarkovScenarioProbability.model_validate(
+            {
+                "rank": 1,
+                "scenario": "mascot_insight",
+                "probability": 1.2,
+            }
+        )
+    with pytest.raises(ValidationError):
+        MarkovCoachingTransitionPlanV1.model_validate(
+            {
+                "transition_state": "cold_start_default",
+                "available_scenarios": ("mascot_insight",),
+                "confidence": 0.35,
+                "extra_field": True,
+            }
+        )
+    with pytest.raises(ValidationError):
+        setattr(plan, "confidence", 0.1)
+
+
+def test_default_prior_does_not_escalate_to_slip_support() -> None:
+    state = _state(available_scenarios=("slip_support", "mascot_insight"))
+
+    plan = build_markov_coaching_transition_plan(state)
+
+    assert plan.transition_state == "cold_start_default"
+    assert plan.recommended_scenario == "mascot_insight"
+    assert plan.ranked_scenarios[0].scenario == "mascot_insight"
+    assert "slip_support" not in {ranked.scenario for ranked in plan.ranked_scenarios}
+    assert "default_prior_not_observed_slip" in plan.reasons
+    assert plan.confidence == pytest.approx(0.35)
+
+
+def test_cold_start_does_not_fallback_to_mascot_when_not_allowed() -> None:
+    state = _state(available_scenarios=("slip_support", "mascot_insight"))
+
+    plan = build_markov_coaching_transition_plan(
+        state,
+        allowed_scenarios=("slip_support",),
+    )
+
+    assert plan.transition_state == "cold_start_default"
+    assert plan.available_scenarios == ("slip_support",)
+    assert plan.ranked_scenarios == ()
+    assert plan.recommended_scenario is None
+    assert plan.confidence == 0.0
+    assert "scenario_unavailable" in plan.reasons
+
+
+@pytest.mark.parametrize(
+    ("adherence", "behavior", "expected_reason"),
+    [
+        (
+            AdherenceSnapshot(n=0, needs_more_data=True),
+            RecentBehaviorSnapshot(slip_like_count_7d=1, scanned_event_count=1),
+            "observed_slip_like_behavior",
+        ),
+        (
+            AdherenceSnapshot(n=0, needs_more_data=True),
+            RecentBehaviorSnapshot(
+                slip_count_7d=1,
+                slip_like_count_7d=1,
+                scanned_event_count=1,
+            ),
+            "explicit_slip_event",
+        ),
+        (
+            AdherenceSnapshot(
+                alpha=9.0,
+                beta=1.0,
+                n=10,
+                risk_slip=0.8,
+                confidence=0.85,
+                needs_more_data=False,
+            ),
+            RecentBehaviorSnapshot(scanned_event_count=1),
+            "observed_high_risk_adherence",
+        ),
+    ],
+)
+def test_slip_evidence_ranks_slip_support_when_available(
+    adherence: AdherenceSnapshot,
+    behavior: RecentBehaviorSnapshot,
+    expected_reason: str,
+) -> None:
+    state = _state(adherence=adherence, recent_behavior=behavior)
+
+    plan = build_markov_coaching_transition_plan(state)
+
+    assert plan.transition_state == "slip_support_needed"
+    assert plan.recommended_scenario == "slip_support"
+    assert plan.ranked_scenarios[0].scenario == "slip_support"
+    assert expected_reason in plan.reasons
+
+
+def test_day_close_ranks_weekly_reflection_without_slip_evidence() -> None:
+    state = _state(
+        adherence=AdherenceSnapshot(
+            alpha=2.0,
+            beta=8.0,
+            n=10,
+            risk_slip=0.2,
+            confidence=0.85,
+            needs_more_data=False,
+        ),
+        recent_behavior=RecentBehaviorSnapshot(
+            day_closed_count_7d=2,
+            scanned_event_count=2,
+        ),
+    )
+
+    plan = build_markov_coaching_transition_plan(state)
+
+    assert plan.transition_state == "weekly_reflection_due"
+    assert plan.recommended_scenario == "weekly_reflection"
+    assert plan.ranked_scenarios[0].scenario == "weekly_reflection"
+    assert "day_close_observed" in plan.reasons
+
+
+def test_scenario_filtering_and_empty_available_scenarios_degrade() -> None:
+    state = _state(
+        recent_behavior=RecentBehaviorSnapshot(slip_count_7d=1, slip_like_count_7d=1),
+    )
+
+    filtered = build_markov_coaching_transition_plan(
+        state,
+        allowed_scenarios=("weekly_reflection", "mascot_insight"),
+    )
+    assert filtered.recommended_scenario == "weekly_reflection"
+    assert "slip_support" not in {ranked.scenario for ranked in filtered.ranked_scenarios}
+    assert "scenario_unavailable" in filtered.reasons
+
+    empty = build_markov_coaching_transition_plan(state, allowed_scenarios=())
+    assert empty.transition_state == "no_recommendation_available"
+    assert empty.available_scenarios == ()
+    assert empty.ranked_scenarios == ()
+    assert empty.recommended_scenario is None
+    assert empty.confidence == 0.0
+    assert "no_available_scenarios" in empty.reasons
+
+
+def test_probability_normalization_and_deterministic_tie_break() -> None:
+    state = _state(
+        adherence=AdherenceSnapshot(n=3, needs_more_data=False, risk_slip=0.2),
+        recent_behavior=RecentBehaviorSnapshot(
+            day_closed_count_7d=1,
+            scanned_event_count=1,
+        ),
+        available_scenarios=(
+            "identity_loop_mapper",
+            "distortion_simulator",
+            "weekly_reflection",
+        ),
+    )
+
+    plan = build_markov_coaching_transition_plan(
+        state,
+        allowed_scenarios=("identity_loop_mapper", "distortion_simulator"),
+    )
+
+    assert [ranked.scenario for ranked in plan.ranked_scenarios] == [
+        "distortion_simulator",
+        "identity_loop_mapper",
+    ]
+    assert sum(ranked.probability for ranked in plan.ranked_scenarios) == pytest.approx(1.0)
+    assert [ranked.rank for ranked in plan.ranked_scenarios] == [1, 2]
+
+
+def test_caller_injected_derived_state_cannot_steer_transition_plan() -> None:
+    state = _state(
+        recent_behavior=RecentBehaviorSnapshot(
+            slip_count_7d=1,
+            slip_like_count_7d=1,
+            scanned_event_count=1,
+        ),
+    )
+    tampered_state = state.model_copy(
+        update={
+            "coaching_urgency": 0.0,
+            "next_recommended_scenario": "mascot_insight",
+            "degrade_reasons": ("caller_injected",),
+        }
+    )
+
+    plan = build_markov_coaching_transition_plan(tampered_state)
+
+    assert plan.recommended_scenario == "slip_support"
+    assert "caller_injected" not in json.dumps(plan.model_dump(mode="json"))
+
+
+def test_capped_or_degraded_behavior_lowers_confidence_and_adds_reason() -> None:
+    base_state = _state(
+        recent_behavior=RecentBehaviorSnapshot(
+            slip_count_7d=1,
+            slip_like_count_7d=1,
+            scanned_event_count=1,
+        ),
+    )
+    degraded_state = _state(
+        adherence=AdherenceSnapshot(source_status="invalid_degraded"),
+        recent_behavior=RecentBehaviorSnapshot(
+            slip_count_7d=1,
+            slip_like_count_7d=1,
+            scanned_event_count=1,
+            events_capped=True,
+        ),
+    )
+
+    base_plan = build_markov_coaching_transition_plan(base_state)
+    degraded_plan = build_markov_coaching_transition_plan(degraded_state)
+
+    assert degraded_plan.confidence < base_plan.confidence
+    assert "recent_behavior_capped" in degraded_plan.reasons
+    assert "adherence_state_invalid_degraded" in degraded_plan.reasons
+
+
+def test_prompt_safe_markov_context_excludes_sensitive_and_unsafe_fields() -> None:
+    state = _state(
+        adherence=AdherenceSnapshot(
+            alpha=9.0,
+            beta=1.0,
+            n=10,
+            risk_slip=0.8,
+            confidence=0.85,
+            needs_more_data=False,
+        ),
+        recent_behavior=RecentBehaviorSnapshot(
+            slip_count_7d=1,
+            slip_like_count_7d=1,
+            scanned_event_count=1,
+            last_slip_at=FIXED_NOW,
+        ),
+    )
+    plan = build_markov_coaching_transition_plan(state)
+
+    context = to_prompt_safe_markov_context(plan)
+
+    context_json = json.dumps(context.model_dump(mode="json"), sort_keys=True).lower()
+    for forbidden in (
+        "user_id",
+        "analyzer_key",
+        "alpha",
+        "beta",
+        "last_",
+        "email",
+        "client_event_id",
+        "client-secret",
+        "api_key",
+        "medical",
+        "therapy",
+        "diagnosis",
+        "diagnostic",
+        "treatment",
+    ):
+        assert forbidden not in context_json
+    assert context.recommended_scenario == "slip_support"
+
+
+def test_planner_integrates_with_build_user_coaching_state(
+    configure_sqlite_database: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = 92_002
+    monkeypatch.setattr(builder_module, "_now_utc", lambda: FIXED_NOW)
+    with configure_sqlite_database.session_scope() as session:
+        _reset_subjects(session, user_id)
+        session.add(
+            _event(
+                user_id=user_id,
+                day=FIXED_NOW.date(),
+                event_type="slip",
+                client_event_id="planner-slip-1",
+            )
+        )
+
+    with configure_sqlite_database.session_scope() as session:
+        state = build_user_coaching_state(user_id=user_id, session=session)
+        plan = build_markov_coaching_transition_plan(state)
+
+    assert state.recent_behavior.slip_like_count_7d == 1
+    assert state.available_scenarios == ("mascot_insight",)
+    assert plan.recommended_scenario == "mascot_insight"
+    assert "observed_slip_like_behavior" in plan.reasons
+    assert "scenario_unavailable" in plan.reasons
+    assert "raw transition planner fixture text" not in json.dumps(plan.model_dump(mode="json"))
+
+
+def test_planner_service_has_no_public_runtime_write_or_cache_imports() -> None:
+    planner_text = (REPO_ROOT / "app/services/coaching_transition_planner.py").read_text(
+        encoding="utf-8"
+    )
+
+    for forbidden in (
+        "APIRouter",
+        "FastAPI",
+        "legacy_app",
+        "fitchef_runtime",
+        "core.rag",
+        "from providers",
+        "import providers",
+        "get_provider",
+        "Redis",
+        "sqlalchemy",
+        "Session",
+        "session.",
+        "record_event(",
+        "upsert_state(",
+        "update_if_version_matches(",
+        "commit(",
+        "flush(",
+        "semantic_cache",
+    ):
+        assert forbidden not in planner_text

--- a/tests/test_coaching_transition_planner.py
+++ b/tests/test_coaching_transition_planner.py
@@ -363,6 +363,30 @@ def test_transition_plan_schema_rejects_impossible_rank_or_probability_shapes() 
         )
 
 
+def test_transition_plan_schema_rejects_unavailable_ranked_scenarios() -> None:
+    unavailable_probability = MarkovScenarioProbability(
+        rank=1,
+        scenario="slip_support",
+        probability=1.0,
+    )
+
+    with pytest.raises(ValidationError, match="available_scenarios"):
+        MarkovCoachingTransitionPlanV1(
+            transition_state="slip_support_needed",
+            available_scenarios=("mascot_insight",),
+            ranked_scenarios=(unavailable_probability,),
+            confidence=0.5,
+        )
+
+    with pytest.raises(ValidationError, match="available_scenarios"):
+        MarkovCoachingTransitionPlanV1(
+            transition_state="no_recommendation_available",
+            available_scenarios=(),
+            ranked_scenarios=(unavailable_probability,),
+            confidence=0.5,
+        )
+
+
 def test_capped_or_degraded_behavior_lowers_confidence_and_adds_reason() -> None:
     base_state = _state(
         recent_behavior=RecentBehaviorSnapshot(

--- a/tests/test_coaching_transition_planner.py
+++ b/tests/test_coaching_transition_planner.py
@@ -94,7 +94,7 @@ def test_markov_transition_schemas_are_frozen_strict_and_default_safe() -> None:
         rank=1,
         scenario="mascot_insight",
         probability=1.0,
-        reasons=("cold_start_default",),
+        reasons=("cold_start_default", "default_prior_not_observed_slip"),
     )
     plan = MarkovCoachingTransitionPlanV1(
         transition_state="cold_start_default",
@@ -102,7 +102,7 @@ def test_markov_transition_schemas_are_frozen_strict_and_default_safe() -> None:
         ranked_scenarios=(probability,),
         recommended_scenario="mascot_insight",
         confidence=0.35,
-        reasons=("cold_start_default",),
+        reasons=("cold_start_default", "default_prior_not_observed_slip"),
     )
 
     assert plan.plan_version == "markov_transition_v1"
@@ -364,6 +364,24 @@ def test_transition_plan_schema_rejects_impossible_rank_or_probability_shapes() 
         )
 
 
+def test_transition_plan_schema_rejects_non_policy_ranked_distribution() -> None:
+    with pytest.raises(ValidationError, match="fixed transition policy"):
+        MarkovCoachingTransitionPlanV1(
+            transition_state="slip_support_needed",
+            available_scenarios=("mascot_insight", "slip_support"),
+            ranked_scenarios=(
+                MarkovScenarioProbability(
+                    rank=1,
+                    scenario="slip_support",
+                    probability=1.0,
+                    reasons=("observed_slip_like_behavior",),
+                ),
+            ),
+            confidence=0.78,
+            reasons=("observed_slip_like_behavior",),
+        )
+
+
 def test_transition_plan_schema_rejects_unavailable_ranked_scenarios() -> None:
     unavailable_probability = MarkovScenarioProbability(
         rank=1,
@@ -409,6 +427,24 @@ def test_prompt_safe_markov_context_rejects_transition_state_steering() -> None:
     assert plan.recommended_scenario == "mascot_insight"
     with pytest.raises(ValidationError, match="transition_state"):
         to_prompt_safe_markov_context(tampered_plan)
+
+    self_consistent_tampered_plan = plan.model_copy(
+        update={
+            "transition_state": "slip_support_needed",
+            "ranked_scenarios": (
+                MarkovScenarioProbability(
+                    rank=1,
+                    scenario="slip_support",
+                    probability=1.0,
+                    reasons=plan.reasons,
+                ),
+            ),
+            "recommended_scenario": "slip_support",
+            "confidence": 0.99,
+        }
+    )
+    with pytest.raises(ValidationError, match="fixed transition policy|plan reasons"):
+        to_prompt_safe_markov_context(self_consistent_tampered_plan)
 
     with pytest.raises(ValidationError, match="transition_state"):
         PromptSafeMarkovTransitionContext(

--- a/tests/test_coaching_transition_planner.py
+++ b/tests/test_coaching_transition_planner.py
@@ -387,6 +387,29 @@ def test_transition_plan_schema_rejects_unavailable_ranked_scenarios() -> None:
         )
 
 
+def test_prompt_safe_markov_context_rejects_transition_state_steering() -> None:
+    state = _state(available_scenarios=("mascot_insight", "slip_support"))
+    plan = build_markov_coaching_transition_plan(state)
+    tampered_plan = plan.model_copy(
+        update={
+            "ranked_scenarios": (
+                MarkovScenarioProbability(
+                    rank=1,
+                    scenario="slip_support",
+                    probability=1.0,
+                ),
+            ),
+            "recommended_scenario": "slip_support",
+            "confidence": 0.99,
+        }
+    )
+
+    assert plan.transition_state == "cold_start_default"
+    assert plan.recommended_scenario == "mascot_insight"
+    with pytest.raises(ValidationError, match="transition_state"):
+        to_prompt_safe_markov_context(tampered_plan)
+
+
 def test_capped_or_degraded_behavior_lowers_confidence_and_adds_reason() -> None:
     base_state = _state(
         recent_behavior=RecentBehaviorSnapshot(

--- a/tests/test_user_coaching_state.py
+++ b/tests/test_user_coaching_state.py
@@ -609,6 +609,7 @@ def test_service_only_files_do_not_wire_public_runtime_or_write_paths() -> None:
         [
             (REPO_ROOT / "app/schemas/user_coaching_state.py").read_text(encoding="utf-8"),
             (REPO_ROOT / "app/services/coaching_state_builder.py").read_text(encoding="utf-8"),
+            (REPO_ROOT / "app/services/coaching_transition_planner.py").read_text(encoding="utf-8"),
         ]
     )
 


### PR DESCRIPTION
## Goal
Add internal FitChef Markov coaching transition planner v1 over `UserCoachingStateV1`.

## Business reason
FitChef needs a backend-owned personalization foundation that can rank safe coaching scenarios from canonical state without moving product truth into clients or prompts.

## Scope
- Adds frozen/strict internal transition schemas in `app/schemas/user_coaching_state.py`.
- Adds `app/services/coaching_transition_planner.py` with deterministic fixed-policy ranking and prompt-safe projection.
- Adds integration and safety tests for adherence/recent behavior, scenario filtering, default-prior handling, prompt-safe leakage, derived-field recomputation, and service-only boundaries.
- Adds canonical review artifact `docs/review/PR_1894_FIXED_MAPPING.md`.

## Out of scope
No public route, OpenAPI, generated client, frontend, iOS, DB migration, persistence, prompt/runtime injection, provider call, semantic cache, RAG/GraphRAG, RL/MDP learning, hidden memory, or medical/therapy claims.

## Files changed
- `app/schemas/user_coaching_state.py`
- `app/services/coaching_transition_planner.py`
- `tests/test_coaching_transition_planner.py`
- `tests/test_user_coaching_state.py`
- `docs/review/PR_1894_FIXED_MAPPING.md`

## Key decisions
- `Markov` means a fixed deterministic transition policy over the current sufficient-state snapshot, not learned state or RL.
- `UserCoachingStateV1` remains the source snapshot; the new planner is separate internal service output.
- Default adherence prior with no observed behavior is not treated as observed slip risk.
- Scenario recommendations are constrained by `available_scenarios` / explicit allowlist and degrade when a primary scenario is unavailable.
- Planner and prompt-safe context recompute derived recommendation, confidence, and canonical safety labels rather than trusting caller input.

## Tests
- `python3 scripts/orchestration/check_preflight.py --path app/schemas/user_coaching_state.py --path app/services/coaching_state_builder.py --path app/services/coaching_transition_planner.py --path tests/test_coaching_transition_planner.py --path tests/test_user_coaching_state.py` - PASS
- `python3 scripts/orchestration/check_agent_consistency.py` - PASS
- `.venv/bin/python -m pytest -q tests/test_user_coaching_state.py tests/test_coaching_transition_planner.py tests/test_bayes_adherence_model.py tests/test_bayes_adherence_service.py tests/test_nutrition_log_idempotency.py` - 72 passed
- `.venv/bin/python -m mypy app/schemas/user_coaching_state.py app/services/coaching_transition_planner.py tests/test_coaching_transition_planner.py --no-incremental --cache-dir=/dev/null` - PASS
- `.venv/bin/python -m diff_cover.diff_cover_tool coverage.xml --compare-branch=origin/main --include-untracked --fail-under=97 --format json:/tmp/markov-diff-cover.json` - PASS, 100%
- `make validate-changed VENV_PYTHON=.venv/bin/python` - PASS
- `VENV_PYTHON=.venv/bin/python pre-commit run --all-files` - PASS

## Lane Start Provenance
- Packet: `artifacts/orchestration/task_packets/61fbd8909a0a.json`
- Required pre-open role order executed: `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> backend-engineer`

## Role / governance evidence
- Premortem: `proceed with changes`; safety-label finding fixed in `f128e638d`; scenario-availability and foundation-only risks are NOT-A-BUG for this service-only PR because runtime enablement is explicitly out of scope.
- Post-open review found four actionable GitHub review threads; all four are mapped to `41010c3eba0f07092ec58ae00693398fbef27e16` in the canonical artifact.
- Post-open `bug-hunter` findings were fixed in `621fe1c1443e454daf9073482720bd2c7702fa5e`, `5315f123555097669c8f7c97074532e6cfa35a02`, `004af744709ce86f3bfc5d35350a33e17043a2f4`, `539dcfe26bfd61210d715cb0063966de52393447`, `5a07e4c8be143cfb5774c03ae3a367e21445f79e`, and `7dd9a5b4f2b5883f606360ef385a43ed2ab0582d`.
- Post-open `security-auditor` pass returned PASS on local HEAD with no security/privacy/safety/compliance findings.
- Post-open `backend-engineer` inverse no-recommendation invariant finding was fixed in `6823411ade1884106665eb15948c6208c2b2f753`.
- Post-open `architecture-specialist` prompt-safe policy asymmetry finding was fixed in `1e8526dac6267f63343681663bd8e9a297939988`.
- Codex Security diff scan returned PASS with no findings; report: `/tmp/codex-security-scans/BMI-App_2025_clean/d94b67c55_mergebase_86e40c9f9_20260606T105235Z/report.md`.
- `pulseplate-pr-review` completed; advisory large-diff note is dispositioned as NOT-A-BUG in `docs/review/PR_1894_FIXED_MAPPING.md`.

## Experiment Runner Evidence
- Artifact: `artifacts/orchestration/experiments/results/exp-455d960da55d.json`
- Packet: `artifacts/orchestration/experiments/exp-455d960da55d.json`
- Status: `accepted`
- Runner mode: `oracle_only_governance_reviewer`
- Mutated paths: `[]`
- Shared tree untouched: `true`
- Co-author trailer: not required; the result did not shape a subsequent code, test, docs, mapping, review-disposition, or commit decision.

## Security notes
- Planner imports no router/runtime/provider/RAG/cache/DB/session surface.
- Prompt-safe Markov context excludes identifiers, analyzer internals, raw event text, timestamps, API-key/client-id strings, and medical/therapy language.
- Safety labels include `wellness_only`, `non_diagnostic`, `service_only`, `no_raw_user_text`, and `deterministic_policy`.

## Risks / rollback
- Risk: future consumers may treat fixed weights as learned personalization. Mitigation: fixed-policy naming, tests, and service-only guard.
- Risk: future runtime wiring may expect `slip_support` while builder defaults to `mascot_insight` only. Mitigation: integration test proves constrained fallback with `scenario_unavailable`.
- Rollback: revert the branch commits; no DB/schema migration or public contract changes.

## Deferred / follow-ups
A later gated PR may enable runtime scenario availability and prompt/runtime integration. That PR must open a separate public/runtime gate and preserve tier/feature/input-guard ordering.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1894_FIXED_MAPPING.md`

## Merge Readiness
Current-head merge readiness is claimed for PR #1894 on head `be6ef188eed538cab143cbeaa25ff154b106db80` after the final rerun of the stale `Merge readiness gate`.

- Current-head CI: PASS; `gh pr checks 1894 --watch=false` shows no pending/failing checks, including `Merge readiness gate`, `lint`, `security`, `OpenAPI sync`, `test-pr (3.13)`, `coverage-pr`, `diff-coverage`, `CodeRabbit`, `cubic`, `CodeQL`, and `codecov/patch`.
- Strict wrapper: PASS; `GH_TOKEN=... GITHUB_TOKEN=... python3 scripts/orchestration/check_merge_ready.py --pr-number 1894 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth --experiment-runner-evidence-mode required`.
- Review threads: PASS; 0 unresolved threads and all 4 resolved threads have disposition proof plus commit-after-comment evidence.
- Bot disposition: CodeRabbit status PASS; cubic PASS/no issues; Sourcery skipped/rate-limited with no actionable code finding; Codecov patch PASS. Rate-limit/usage comments are external quota notices, not code actionables.
- Wait-window: latest bot/review activity predates the final current-head checks; no unresolved/actionable comments remain.

