### PR TITLE
fix(tests): update hardcoded pins for ruff 0.15.16 and transformers 5.10.2

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -587,7 +587,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "scripts/ci/emergency_python_wheels.json",
-        "hashed_secret": "5373c683b0a8de06925ce28bf3808da65818acf4",
+        "hashed_secret": "355dfe1db93ddbddea6c9370a480124267600dc9",
         "is_verified": false,
         "line_number": 222
       }
@@ -1750,5 +1750,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-06T09:09:58Z"
+  "generated_at": "2026-06-07T17:56:18Z"
 }

--- a/scripts/ci/emergency_python_wheels.json
+++ b/scripts/ci/emergency_python_wheels.json
@@ -1,225 +1,225 @@
 {
-  "schema_version": 1,
-  "generated_at": "2026-05-21",
-  "expires_at": "2026-06-15",
-  "reason": "Time-boxed mirror-lag bridge for the EXACT listed wheels only (manylinux x86_64 or pure wheel where applicable). NOT a generic Cloudflare 521 / proxy-outage fallback: if the approved private proxy is fully unhealthy, any locked install needing a wheel not enumerated in this manifest will still fail. Recovery is infra-owned: see RUNBOOK_AGENT.md (`Python private index proxy (PULSEPLATE_PYTHON_INDEX_URL) triage`) and BACKLOG_LEDGER.md (`ledger-p1-private-pypi-proxy-mirror-parity`).",
-  "artifacts": [
-    {
-      "package": "cryptography",
-      "version": "46.0.7",
-      "filename": "cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
-      "url": "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
-      "sha256": "5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308"
-    },
-    {
-      "package": "cryptography",
-      "version": "46.0.7",
-      "filename": "cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl",
-      "url": "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl",
-      "sha256": "42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b"
-    },
-    {
-      "package": "pillow",
-      "version": "12.2.0",
-      "filename": "pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
-      "url": "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
-      "sha256": "8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e"
-    },
-    {
-      "package": "pillow",
-      "version": "12.2.0",
-      "filename": "pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
-      "url": "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
-      "sha256": "e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176"
-    },
-    {
-      "package": "pillow",
-      "version": "12.2.0",
-      "filename": "pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
-      "url": "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
-      "sha256": "b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76"
-    },
-    {
-      "package": "pillow",
-      "version": "12.2.0",
-      "filename": "pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
-      "url": "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
-      "sha256": "62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780"
-    },
-    {
-      "package": "pillow",
-      "version": "12.2.0",
-      "filename": "pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
-      "url": "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
-      "sha256": "03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9"
-    },
-    {
-      "package": "pillow",
-      "version": "12.2.0",
-      "filename": "pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
-      "url": "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
-      "sha256": "eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3"
-    },
-    {
-      "package": "pytest",
-      "version": "9.0.3",
-      "filename": "pytest-9.0.3-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl",
-      "sha256": "2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"
-    },
-    {
-      "package": "pip",
-      "version": "26.1.1",
-      "expires_at": "2026-06-15",
-      "filename": "pip-26.1.1-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl",
-      "sha256": "99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb"
-    },
-    {
-      "package": "faker",
-      "version": "40.15.0",
-      "filename": "faker-40.15.0-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/a7/a7/a600f8f30d4505e89166de51dd121bd540ab8e560e8cf0901de00a81de8c/faker-40.15.0-py3-none-any.whl",
-      "sha256": "71ab3c3370da9d2205ab74ffb0fd51273063ad562b3a3bb69d0026a20923e318"
-    },
-    {
-      "package": "hypothesis",
-      "version": "6.152.4",
-      "filename": "hypothesis-6.152.4-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/19/89/0f50dd0d92e8a7dffc24f69ab910ff81db89b2f082ba42682bd57695e4d2/hypothesis-6.152.4-py3-none-any.whl",
-      "sha256": "e730fd93c7578182efadc7f90b3c5437ee4d55edf738930eb5043c81ac1d97e8"
-    },
-    {
-      "package": "pre-commit",
-      "version": "4.6.0",
-      "filename": "pre_commit-4.6.0-py2.py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl",
-      "sha256": "e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b"
-    },
-    {
-      "package": "protobuf",
-      "version": "6.33.5",
-      "expires_at": "2026-06-15",
-      "filename": "protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl",
-      "url": "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl",
-      "sha256": "cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0"
-    },
-    {
-      "package": "wrapt",
-      "version": "2.0.1",
-      "expires_at": "2026-06-15",
-      "filename": "wrapt-2.0.1-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/15/d1/b51471c11592ff9c012bd3e2f7334a6ff2f42a7aed2caffcf0bdddc9cb89/wrapt-2.0.1-py3-none-any.whl",
-      "sha256": "4d2ce1bf1a48c5277d7969259232b57645aae5686dba1eaeade39442277afbca"
-    },
-    {
-      "package": "mypy",
-      "version": "2.1.0",
-      "filename": "mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
-      "url": "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
-      "sha256": "e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285"
-    },
-    {
-      "package": "aiosqlite",
-      "version": "0.22.1",
-      "expires_at": "2026-06-15",
-      "filename": "aiosqlite-0.22.1-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl",
-      "sha256": "21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb"
-    },
-    {
-      "package": "alembic",
-      "version": "1.18.4",
-      "expires_at": "2026-06-15",
-      "filename": "alembic-1.18.4-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl",
-      "sha256": "a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a"
-    },
-    {
-      "package": "annotated-doc",
-      "version": "0.0.4",
-      "expires_at": "2026-06-15",
-      "filename": "annotated_doc-0.0.4-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl",
-      "sha256": "571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"
-    },
-    {
-      "package": "annotated-types",
-      "version": "0.7.0",
-      "expires_at": "2026-06-15",
-      "filename": "annotated_types-0.7.0-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl",
-      "sha256": "1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"
-    },
-    {
-      "package": "anyio",
-      "version": "4.12.0",
-      "expires_at": "2026-06-15",
-      "filename": "anyio-4.12.0-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/7f/9c/36c5c37947ebfb8c7f22e0eb6e4d188ee2d53aa3880f3f2744fb894f0cb1/anyio-4.12.0-py3-none-any.whl",
-      "sha256": "dad2376a628f98eeca4881fc56cd06affd18f659b17a747d3ff0307ced94b1bb"
-    },
-    {
-      "package": "bandit",
-      "version": "1.9.4",
-      "expires_at": "2026-06-15",
-      "filename": "bandit-1.9.4-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl",
-      "sha256": "f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e"
-    },
-    {
-      "package": "certifi",
-      "version": "2026.1.4",
-      "expires_at": "2026-06-15",
-      "filename": "certifi-2026.1.4-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl",
-      "sha256": "9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"
-    },
-    {
-      "package": "mako",
-      "version": "1.3.12",
-      "expires_at": "2026-05-17",
-      "filename": "mako-1.3.12-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl",
-      "sha256": "8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9"
-    },
-    {
-      "package": "python-multipart",
-      "version": "0.0.27",
-      "filename": "python_multipart-0.0.27-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl",
-      "sha256": "6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645"
-    },
-    {
-      "package": "requests",
-      "version": "2.33.0",
-      "expires_at": "2026-06-15",
-      "filename": "requests-2.33.0-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl",
-      "sha256": "3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b"
-    },
-    {
-      "package": "sentence-transformers",
-      "version": "5.5.1",
-      "expires_at": "2026-06-15",
-      "filename": "sentence_transformers-5.5.1-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/bf/03/ee99a6b030e7a2e056547729f8a4709dd93e13d9c6f07590f74c395c4017/sentence_transformers-5.5.1-py3-none-any.whl",
-      "sha256": "4fe11d433badc5282d32f7fc08bc714216b7a5aca426f9df77a45a554756deb7"
-    },
-    {
-      "package": "types-pyyaml",
-      "version": "6.0.12.20260408",
-      "filename": "types_pyyaml-6.0.12.20260408-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl",
-      "sha256": "fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384"
-    },
-    {
-      "package": "transformers",
-      "version": "5.9.0",
-      "expires_at": "2026-06-15",
-      "filename": "transformers-5.9.0-py3-none-any.whl",
-      "url": "https://files.pythonhosted.org/packages/02/ca/2eaa5359f2ccb8c2e1656bc26305ad0cf438aa392ce4b29ae67a315c186e/transformers-5.9.0-py3-none-any.whl",
-      "sha256": "1d19509bcff7028ebc6b277d71caa712e8353778463d38764237d14b42b52788"
-    }
-  ]
+    "schema_version": 1,
+    "generated_at": "2026-05-21",
+    "expires_at": "2026-06-15",
+    "reason": "Time-boxed mirror-lag bridge for the EXACT listed wheels only (manylinux x86_64 or pure wheel where applicable). NOT a generic Cloudflare 521 / proxy-outage fallback: if the approved private proxy is fully unhealthy, any locked install needing a wheel not enumerated in this manifest will still fail. Recovery is infra-owned: see RUNBOOK_AGENT.md (`Python private index proxy (PULSEPLATE_PYTHON_INDEX_URL) triage`) and BACKLOG_LEDGER.md (`ledger-p1-private-pypi-proxy-mirror-parity`).",
+    "artifacts": [
+        {
+            "package": "cryptography",
+            "version": "46.0.7",
+            "filename": "cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+            "url": "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+            "sha256": "5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308"
+        },
+        {
+            "package": "cryptography",
+            "version": "46.0.7",
+            "filename": "cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl",
+            "url": "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl",
+            "sha256": "42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b"
+        },
+        {
+            "package": "pillow",
+            "version": "12.2.0",
+            "filename": "pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+            "url": "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+            "sha256": "8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e"
+        },
+        {
+            "package": "pillow",
+            "version": "12.2.0",
+            "filename": "pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+            "url": "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+            "sha256": "e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176"
+        },
+        {
+            "package": "pillow",
+            "version": "12.2.0",
+            "filename": "pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+            "url": "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+            "sha256": "b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76"
+        },
+        {
+            "package": "pillow",
+            "version": "12.2.0",
+            "filename": "pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+            "url": "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+            "sha256": "62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780"
+        },
+        {
+            "package": "pillow",
+            "version": "12.2.0",
+            "filename": "pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+            "url": "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+            "sha256": "03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9"
+        },
+        {
+            "package": "pillow",
+            "version": "12.2.0",
+            "filename": "pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+            "url": "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+            "sha256": "eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3"
+        },
+        {
+            "package": "pytest",
+            "version": "9.0.3",
+            "filename": "pytest-9.0.3-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl",
+            "sha256": "2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"
+        },
+        {
+            "package": "pip",
+            "version": "26.1.1",
+            "expires_at": "2026-06-15",
+            "filename": "pip-26.1.1-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl",
+            "sha256": "99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb"
+        },
+        {
+            "package": "faker",
+            "version": "40.15.0",
+            "filename": "faker-40.15.0-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/a7/a7/a600f8f30d4505e89166de51dd121bd540ab8e560e8cf0901de00a81de8c/faker-40.15.0-py3-none-any.whl",
+            "sha256": "71ab3c3370da9d2205ab74ffb0fd51273063ad562b3a3bb69d0026a20923e318"
+        },
+        {
+            "package": "hypothesis",
+            "version": "6.152.4",
+            "filename": "hypothesis-6.152.4-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/19/89/0f50dd0d92e8a7dffc24f69ab910ff81db89b2f082ba42682bd57695e4d2/hypothesis-6.152.4-py3-none-any.whl",
+            "sha256": "e730fd93c7578182efadc7f90b3c5437ee4d55edf738930eb5043c81ac1d97e8"
+        },
+        {
+            "package": "pre-commit",
+            "version": "4.6.0",
+            "filename": "pre_commit-4.6.0-py2.py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl",
+            "sha256": "e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b"
+        },
+        {
+            "package": "protobuf",
+            "version": "6.33.5",
+            "expires_at": "2026-06-15",
+            "filename": "protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl",
+            "url": "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl",
+            "sha256": "cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0"
+        },
+        {
+            "package": "wrapt",
+            "version": "2.0.1",
+            "expires_at": "2026-06-15",
+            "filename": "wrapt-2.0.1-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/15/d1/b51471c11592ff9c012bd3e2f7334a6ff2f42a7aed2caffcf0bdddc9cb89/wrapt-2.0.1-py3-none-any.whl",
+            "sha256": "4d2ce1bf1a48c5277d7969259232b57645aae5686dba1eaeade39442277afbca"
+        },
+        {
+            "package": "mypy",
+            "version": "2.1.0",
+            "filename": "mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+            "url": "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+            "sha256": "e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285"
+        },
+        {
+            "package": "aiosqlite",
+            "version": "0.22.1",
+            "expires_at": "2026-06-15",
+            "filename": "aiosqlite-0.22.1-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl",
+            "sha256": "21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb"
+        },
+        {
+            "package": "alembic",
+            "version": "1.18.4",
+            "expires_at": "2026-06-15",
+            "filename": "alembic-1.18.4-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl",
+            "sha256": "a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a"
+        },
+        {
+            "package": "annotated-doc",
+            "version": "0.0.4",
+            "expires_at": "2026-06-15",
+            "filename": "annotated_doc-0.0.4-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl",
+            "sha256": "571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"
+        },
+        {
+            "package": "annotated-types",
+            "version": "0.7.0",
+            "expires_at": "2026-06-15",
+            "filename": "annotated_types-0.7.0-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl",
+            "sha256": "1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"
+        },
+        {
+            "package": "anyio",
+            "version": "4.12.0",
+            "expires_at": "2026-06-15",
+            "filename": "anyio-4.12.0-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/7f/9c/36c5c37947ebfb8c7f22e0eb6e4d188ee2d53aa3880f3f2744fb894f0cb1/anyio-4.12.0-py3-none-any.whl",
+            "sha256": "dad2376a628f98eeca4881fc56cd06affd18f659b17a747d3ff0307ced94b1bb"
+        },
+        {
+            "package": "bandit",
+            "version": "1.9.4",
+            "expires_at": "2026-06-15",
+            "filename": "bandit-1.9.4-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl",
+            "sha256": "f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e"
+        },
+        {
+            "package": "certifi",
+            "version": "2026.1.4",
+            "expires_at": "2026-06-15",
+            "filename": "certifi-2026.1.4-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl",
+            "sha256": "9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"
+        },
+        {
+            "package": "mako",
+            "version": "1.3.12",
+            "expires_at": "2026-05-17",
+            "filename": "mako-1.3.12-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl",
+            "sha256": "8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9"
+        },
+        {
+            "package": "python-multipart",
+            "version": "0.0.27",
+            "filename": "python_multipart-0.0.27-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl",
+            "sha256": "6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645"
+        },
+        {
+            "package": "requests",
+            "version": "2.33.0",
+            "expires_at": "2026-06-15",
+            "filename": "requests-2.33.0-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl",
+            "sha256": "3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b"
+        },
+        {
+            "package": "sentence-transformers",
+            "version": "5.5.1",
+            "expires_at": "2026-06-15",
+            "filename": "sentence_transformers-5.5.1-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/bf/03/ee99a6b030e7a2e056547729f8a4709dd93e13d9c6f07590f74c395c4017/sentence_transformers-5.5.1-py3-none-any.whl",
+            "sha256": "4fe11d433badc5282d32f7fc08bc714216b7a5aca426f9df77a45a554756deb7"
+        },
+        {
+            "package": "types-pyyaml",
+            "version": "6.0.12.20260408",
+            "filename": "types_pyyaml-6.0.12.20260408-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl",
+            "sha256": "fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384"
+        },
+        {
+            "package": "transformers",
+            "version": "5.10.2",
+            "expires_at": "2026-06-15",
+            "filename": "transformers-5.10.2-py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/73/6f/e1564b0cc182afa05e219a8e09a8e770ffaab879b6b824b56c819bd221da/transformers-5.10.2-py3-none-any.whl",
+            "sha256": "8a669db546f82c7c3618cb46ceb0f0afd89292bc70f319c058f8332ec63e268d"
+        }
+    ]
 }

--- a/tests/test_install_locked_python_requirements.py
+++ b/tests/test_install_locked_python_requirements.py
@@ -422,9 +422,9 @@ def test_repo_ruff_private_proxy_pin_is_not_stale_emergency_fallback() -> None:
     requirements_dev_txt = (REPO_ROOT / "requirements-dev.txt").read_text(encoding="utf-8")
     requirements_lock_txt = (REPO_ROOT / "requirements-lock.txt").read_text(encoding="utf-8")
 
-    assert _compatible_release_version(requirements_dev_in, "ruff") == "0.15.15"
-    assert ("ruff", "0.15.15") in _exact_requirement_pairs(requirements_dev_txt)
-    assert ("ruff", "0.15.15") in _exact_requirement_pairs(requirements_lock_txt)
+    assert _compatible_release_version(requirements_dev_in, "ruff") == "0.15.16"
+    assert ("ruff", "0.15.16") in _exact_requirement_pairs(requirements_dev_txt)
+    assert ("ruff", "0.15.16") in _exact_requirement_pairs(requirements_lock_txt)
     assert not any(package == "ruff" for package, _version in artifacts)
 
 
@@ -448,19 +448,19 @@ def test_repo_quality_tooling_profile_matches_dependabot_replacement_contract() 
 
     assert _minimum_requirement_version(constraints_text, "black") == "26.5.1"
     assert _minimum_requirement_version(constraints_text, "mypy") == "2.1.0"
-    assert _minimum_requirement_version(constraints_text, "ruff") == "0.15.15"
+    assert _minimum_requirement_version(constraints_text, "ruff") == "0.15.16"
     assert _minimum_requirement_version(requirements_all_text, "black") == "26.5.1"
     assert _minimum_requirement_version(requirements_all_text, "mypy") == "2.1.0"
-    assert _minimum_requirement_version(requirements_all_text, "ruff") == "0.15.15"
+    assert _minimum_requirement_version(requirements_all_text, "ruff") == "0.15.16"
 
     assert _compatible_release_version(requirements_dev_in, "black") == "26.5.1"
-    assert _compatible_release_version(requirements_dev_in, "ruff") == "0.15.15"
+    assert _compatible_release_version(requirements_dev_in, "ruff") == "0.15.16"
     assert ("mypy", "2.1.0") in _exact_requirement_pairs(requirements_dev_in)
     assert ("black", "26.5.1") in _exact_requirement_pairs(requirements_dev_txt)
     assert ("mypy", "2.1.0") in _exact_requirement_pairs(requirements_dev_txt)
-    assert ("ruff", "0.15.15") in _exact_requirement_pairs(requirements_dev_txt)
+    assert ("ruff", "0.15.16") in _exact_requirement_pairs(requirements_dev_txt)
     assert ("librt", "0.11.0") in _exact_requirement_pairs(requirements_dev_txt)
-    assert ("ruff", "0.15.15") in _exact_requirement_pairs(requirements_lock_txt)
+    assert ("ruff", "0.15.16") in _exact_requirement_pairs(requirements_lock_txt)
 
     assert ("mypy", "2.1.0") in artifacts
     assert not any(package == "ruff" for package, _version in artifacts)


### PR DESCRIPTION
## Scope
- Update hardcoded ruff version expectations in test_install_locked_python_requirements.py (0.15.15 → 0.15.16)
- Update transformers emergency wheel manifest entry (5.9.0 → 5.10.2)

## Context
Dependabot bumps #1899, #1900 updated dependency versions but test assertions and emergency manifest were not aligned, causing test-main failures on main.

## Tests
- pytest tests/test_install_locked_python_requirements.py (3 targeted tests): PASS locally

## Summary by Sourcery

Синхронизировать ожидаемые результаты тестов и конфигурацию аварийных колёс с обновлёнными версиями зависимостей.

Исправления ошибок:
- Обновить жёстко заданные ожидаемые версии ruff в тестах в соответствии с текущей закреплённой версией.
- Скорректировать запись в манифесте аварийного колеса для transformers до последней закреплённой версии, чтобы обеспечить согласованность резервных колёс CI.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align test expectations and emergency wheel configuration with updated dependency versions.

Bug Fixes:
- Update hardcoded ruff version expectations in tests to match the current pinned version.
- Adjust the transformers emergency wheel manifest entry to the latest pinned version to keep CI fallback wheels consistent.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI failures on main by aligning test pins and the emergency wheel manifest with recent dependency bumps. Updates `ruff` to 0.15.16 in tests and `transformers` to 5.10.2 in `scripts/ci/emergency_python_wheels.json`.

<sup>Written for commit 93306bbbf0c2202e679fb972b048466f24ab74a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated emergency Python wheels manifest with transformers library version 5.10.2
  * Refreshed secrets baseline metadata

* **Tests**
  * Updated test expectations for ruff version compatibility checks (0.15.16)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->