### PR TITLE
test(rag): lock verification provenance wiring — all fields confirmed

### DIFF
--- a/docs/review/PR_1906_FIXED_MAPPING.md
+++ b/docs/review/PR_1906_FIXED_MAPPING.md
@@ -5,4 +5,7 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1906#pullrequestreview-4447697669 -> 35ec23a38
+  Disposition: FIXED
+  Commit: 35ec23a38
+  Evidence: tests/test_remaining_modules.py:2015-2052 (extracted _build_rag_bundle/_build_runtime_bundle helpers), 2362-2365 (replaced generator trick with named _broken_redactor), 2388-2390 (parametrized whitespace test including \\n\\t)

--- a/docs/review/PR_1906_FIXED_MAPPING.md
+++ b/docs/review/PR_1906_FIXED_MAPPING.md
@@ -1,0 +1,8 @@
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -2012,6 +2012,36 @@ class TestVerificationRegistryCoverageTail:
             rail="product_ai_runtime",
         )
 
+    @staticmethod
+    def _build_rag_bundle(provenance, knowledge_policy):
+        from core.verification.registry import build_rag_verification_bundle
+
+        return build_rag_verification_bundle(
+            knowledge_policy=knowledge_policy,
+            confidence=0.92,
+            degraded_reason=None,
+            rag_actually_used=True,
+            philo_validation_enabled=True,
+            recursive_executed=False,
+            verification_calls=0,
+            evidence_refs=(),
+            provenance=provenance,
+        )
+
+    @staticmethod
+    def _build_runtime_bundle(rag_bundle, provenance):
+        from core.verification.registry import build_runtime_verification_bundle
+
+        return build_runtime_verification_bundle(
+            rag_bundle=rag_bundle,
+            verification_report=None,
+            falsification_report=None,
+            contradiction_count=0,
+            verification_first_path=False,
+            runtime_verification_enabled=False,
+            provenance=provenance,
+        )
+
     def test_runtime_bundle_fails_closed_without_rag_bundle(self) -> None:
         from core.verification.registry import build_runtime_verification_bundle
 
@@ -2348,47 +2378,21 @@ class TestVerificationRegistryCoverageTail:
         assert merged.provenance.verification_calls == runtime_provenance.verification_calls
 
     def test_merge_provenance_falsy_bool_preserved(self) -> None:
-        from core.verification.registry import (
-            build_rag_verification_bundle,
-            build_runtime_verification_bundle,
-            build_verification_provenance,
-        )
+        from core.verification.registry import build_verification_provenance
 
         base = build_verification_provenance(prompt_trimmed=True)
         overlay = build_verification_provenance(prompt_trimmed=False)
+        policy = self._knowledge_policy()
 
-        rag_bundle = build_rag_verification_bundle(
-            knowledge_policy=self._knowledge_policy(),
-            confidence=0.92,
-            degraded_reason=None,
-            rag_actually_used=True,
-            philo_validation_enabled=True,
-            recursive_executed=False,
-            verification_calls=0,
-            evidence_refs=(),
-            provenance=base,
-        )
-
-        merged = build_runtime_verification_bundle(
-            rag_bundle=rag_bundle,
-            verification_report=None,
-            falsification_report=None,
-            contradiction_count=0,
-            verification_first_path=False,
-            runtime_verification_enabled=False,
-            provenance=overlay,
-        )
+        rag_bundle = self._build_rag_bundle(provenance=base, knowledge_policy=policy)
+        merged = self._build_runtime_bundle(rag_bundle=rag_bundle, provenance=overlay)
 
         assert merged is not None
         assert merged.provenance is not None
         assert merged.provenance.prompt_trimmed is False
 
     def test_merge_provenance_is_idempotent(self) -> None:
-        from core.verification.registry import (
-            build_rag_verification_bundle,
-            build_runtime_verification_bundle,
-            build_verification_provenance,
-        )
+        from core.verification.registry import build_verification_provenance
 
         rag_provenance = build_verification_provenance(
             input_text="input",
@@ -2396,17 +2400,8 @@ class TestVerificationRegistryCoverageTail:
             verification_hops=2,
             verification_calls=2,
         )
-        rag_bundle = build_rag_verification_bundle(
-            knowledge_policy=self._knowledge_policy(),
-            confidence=0.92,
-            degraded_reason=None,
-            rag_actually_used=True,
-            philo_validation_enabled=True,
-            recursive_executed=False,
-            verification_calls=0,
-            evidence_refs=(),
-            provenance=rag_provenance,
-        )
+        policy = self._knowledge_policy()
+        rag_bundle = self._build_rag_bundle(provenance=rag_provenance, knowledge_policy=policy)
 
         runtime_provenance = build_verification_provenance(
             input_text="input",
@@ -2417,26 +2412,10 @@ class TestVerificationRegistryCoverageTail:
             verification_calls=3,
         )
 
-        m1 = build_runtime_verification_bundle(
-            rag_bundle=rag_bundle,
-            verification_report=None,
-            falsification_report=None,
-            contradiction_count=0,
-            verification_first_path=False,
-            runtime_verification_enabled=False,
-            provenance=runtime_provenance,
-        )
+        m1 = self._build_runtime_bundle(rag_bundle=rag_bundle, provenance=runtime_provenance)
         assert m1 is not None
 
-        m2 = build_runtime_verification_bundle(
-            rag_bundle=m1,
-            verification_report=None,
-            falsification_report=None,
-            contradiction_count=0,
-            verification_first_path=False,
-            runtime_verification_enabled=False,
-            provenance=runtime_provenance,
-        )
+        m2 = self._build_runtime_bundle(rag_bundle=m1, provenance=runtime_provenance)
         assert m2 is not None
 
         assert m1.provenance == m2.provenance
@@ -2449,21 +2428,20 @@ class TestVerificationRegistryCoverageTail:
     ) -> None:
         from core.verification.registry import redacted_sha256_label
 
+        def _broken_redactor(_value: str) -> str:
+            raise exc_class("boom")
+
         monkeypatch.setattr(
             "core.verification.registry._redact_provenance_text",
-            lambda _value: (_ for _ in ()).throw(exc_class("boom")),
+            _broken_redactor,
         )
         assert redacted_sha256_label("any text") is None
 
-    def test_redacted_sha256_label_empty_string_returns_none(self) -> None:
+    @pytest.mark.parametrize("input_text", ["", "   ", "\n\t"])
+    def test_redacted_sha256_label_empty_or_whitespace_returns_none(self, input_text: str) -> None:
         from core.verification.registry import redacted_sha256_label
 
-        assert redacted_sha256_label("") is None
-
-    def test_redacted_sha256_label_whitespace_returns_none(self) -> None:
-        from core.verification.registry import redacted_sha256_label
-
-        assert redacted_sha256_label("   ") is None
+        assert redacted_sha256_label(input_text) is None
 
     def test_rag_bundle_provenance_answer_digest_is_none(self) -> None:
         from core.verification.registry import build_verification_provenance

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -2347,6 +2347,135 @@ class TestVerificationRegistryCoverageTail:
         assert merged.provenance.verification_hops == rag_provenance.verification_hops
         assert merged.provenance.verification_calls == runtime_provenance.verification_calls
 
+    def test_merge_provenance_falsy_bool_preserved(self) -> None:
+        from core.verification.registry import (
+            build_rag_verification_bundle,
+            build_runtime_verification_bundle,
+            build_verification_provenance,
+        )
+
+        base = build_verification_provenance(prompt_trimmed=True)
+        overlay = build_verification_provenance(prompt_trimmed=False)
+
+        rag_bundle = build_rag_verification_bundle(
+            knowledge_policy=self._knowledge_policy(),
+            confidence=0.92,
+            degraded_reason=None,
+            rag_actually_used=True,
+            philo_validation_enabled=True,
+            recursive_executed=False,
+            verification_calls=0,
+            evidence_refs=(),
+            provenance=base,
+        )
+
+        merged = build_runtime_verification_bundle(
+            rag_bundle=rag_bundle,
+            verification_report=None,
+            falsification_report=None,
+            contradiction_count=0,
+            verification_first_path=False,
+            runtime_verification_enabled=False,
+            provenance=overlay,
+        )
+
+        assert merged is not None
+        assert merged.provenance is not None
+        assert merged.provenance.prompt_trimmed is False
+
+    def test_merge_provenance_is_idempotent(self) -> None:
+        from core.verification.registry import (
+            build_rag_verification_bundle,
+            build_runtime_verification_bundle,
+            build_verification_provenance,
+        )
+
+        rag_provenance = build_verification_provenance(
+            input_text="input",
+            context_items=("ctx",),
+            verification_hops=2,
+            verification_calls=2,
+        )
+        rag_bundle = build_rag_verification_bundle(
+            knowledge_policy=self._knowledge_policy(),
+            confidence=0.92,
+            degraded_reason=None,
+            rag_actually_used=True,
+            philo_validation_enabled=True,
+            recursive_executed=False,
+            verification_calls=0,
+            evidence_refs=(),
+            provenance=rag_provenance,
+        )
+
+        runtime_provenance = build_verification_provenance(
+            input_text="input",
+            prompt_text="prompt",
+            context_items=("ctx",),
+            answer_text="answer",
+            verification_hops=0,
+            verification_calls=3,
+        )
+
+        m1 = build_runtime_verification_bundle(
+            rag_bundle=rag_bundle,
+            verification_report=None,
+            falsification_report=None,
+            contradiction_count=0,
+            verification_first_path=False,
+            runtime_verification_enabled=False,
+            provenance=runtime_provenance,
+        )
+        assert m1 is not None
+
+        m2 = build_runtime_verification_bundle(
+            rag_bundle=m1,
+            verification_report=None,
+            falsification_report=None,
+            contradiction_count=0,
+            verification_first_path=False,
+            runtime_verification_enabled=False,
+            provenance=runtime_provenance,
+        )
+        assert m2 is not None
+
+        assert m1.provenance == m2.provenance
+
+    @pytest.mark.parametrize("exc_class", [RuntimeError, TypeError, ValueError])
+    def test_redacted_sha256_label_survives_redactor_exception(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        exc_class: type[BaseException],
+    ) -> None:
+        from core.verification.registry import redacted_sha256_label
+
+        monkeypatch.setattr(
+            "core.verification.registry._redact_provenance_text",
+            lambda _value: (_ for _ in ()).throw(exc_class("boom")),
+        )
+        assert redacted_sha256_label("any text") is None
+
+    def test_redacted_sha256_label_empty_string_returns_none(self) -> None:
+        from core.verification.registry import redacted_sha256_label
+
+        assert redacted_sha256_label("") is None
+
+    def test_redacted_sha256_label_whitespace_returns_none(self) -> None:
+        from core.verification.registry import redacted_sha256_label
+
+        assert redacted_sha256_label("   ") is None
+
+    def test_rag_bundle_provenance_answer_digest_is_none(self) -> None:
+        from core.verification.registry import build_verification_provenance
+
+        provenance = build_verification_provenance(
+            input_text="question",
+            prompt_text="prompt",
+            context_items=("chunk",),
+        )
+        assert provenance.answer_digest is None
+        assert provenance.answer_sha is None
+
     def test_verification_provenance_aliases_cannot_drift_when_constructed_directly(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
Locks provenance wiring invariants across RAG bundle generation and runtime bundle merging. Zero production code changes — test-only PR.

## Scope
- Regression tests for `_merge_provenance` (falsy-bool preservation, idempotency).
- Regression tests for `redacted_sha256_label` (exception survival, empty/whitespace input).
- Regression test for pre-generation `answer_digest`/`answer_sha` absence.

## Out of scope
- Production code changes.
- New fixtures or global test helpers.
- Coverage for orchestration-level degraded paths (already covered upstream).

## Tests
- 6 novel tests in `TestVerificationRegistryCoverageTail`:
  1. `test_merge_provenance_falsy_bool_preserved`
  2. `test_merge_provenance_is_idempotent`
  3. `test_redacted_sha256_label_survives_redactor_exception`
  4. `test_redacted_sha256_label_empty_or_whitespace_returns_none` (parametrized)
  5. `test_rag_bundle_provenance_answer_digest_is_none`
- All tests deterministic, pure-Python, no I/O.

## Local Gates
- `make lint` ✅
- `make test-fast` ✅
- `pre-commit run --all-files` ✅

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1906_FIXED_MAPPING.md`

## Merge Readiness
- [x] Local gates pass
- [x] CI green (current-head)
- [x] Review threads resolved with disposition
- [x] Bot comments clean (CodeRabbit, Sourcery, Cubic)
