### PR TITLE
fix(ci): require artifacts task-packet JSON for Lane Start Provenance (reject repo MD packets)

### DIFF
--- a/docs/review/PR_1913_FIXED_MAPPING.md
+++ b/docs/review/PR_1913_FIXED_MAPPING.md
@@ -1,8 +1,8 @@
 # PR 1913 Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [x] Discussion-thread pass completed for currently visible bot comments and reviews.
-- [x] Fixed in commit mapping completed for current PR findings.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
 ## Fixed in Commit Mapping
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#pullrequestreview-4452631808 -> daaaf4de0

--- a/docs/review/PR_1913_FIXED_MAPPING.md
+++ b/docs/review/PR_1913_FIXED_MAPPING.md
@@ -6,6 +6,7 @@
 
 ## Fixed in Commit Mapping
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#pullrequestreview-4452631808 -> daaaf4de0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#pullrequestreview-4453297292 -> daaaf4de0
 Disposition: FIXED
 Commit: daaaf4de0
 Evidence: tests/test_pr_body_phase2_gates.py:16; tests/test_pr_body_phase2_gates.py:483

--- a/docs/review/PR_1913_FIXED_MAPPING.md
+++ b/docs/review/PR_1913_FIXED_MAPPING.md
@@ -22,6 +22,11 @@ Disposition: NOT-A-BUG
 Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#issuecomment-4653373092
 Reason: CodeRabbit comment is a generated walkthrough/pre-merge summary with optional finishing-touch UI checkboxes and no required code or documentation change.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#discussion_r3376260436
+Disposition: NOT-A-BUG
+Evidence: scripts/ci/check_pr_body_phase2_gates.py:101; scripts/ci/check_pr_body_phase2_gates.py:108; scripts/ci/check_pr_body_phase2_gates.py:309
+Reason: Codex's P2 asks to promote unavailable task-packet references to hard failures, but this lane intentionally keeps Lane Start Provenance in dry-run advisory mode: missing provenance and unavailable local gitignored task-packet artifacts warn, while malformed present packet paths remain hard errors. This PR preserves that current phased contract and fixes advisory visibility without changing enforcement mode.
+
 ## Experiment Runner Evidence
 Not applicable: local oracle-only Experiment Runner has not materially shaped the implementation yet; if later used to make commit decisions, add its accepted artifact and governed co-author trailer before merge readiness.
 

--- a/docs/review/PR_1913_FIXED_MAPPING.md
+++ b/docs/review/PR_1913_FIXED_MAPPING.md
@@ -1,0 +1,37 @@
+# PR 1913 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed for currently visible bot comments and reviews.
+- [x] Fixed in commit mapping completed for current PR findings.
+
+## Fixed in Commit Mapping
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#pullrequestreview-4452631808 -> daaaf4de0
+Disposition: FIXED
+Commit: daaaf4de0
+Evidence: tests/test_pr_body_phase2_gates.py:16; tests/test_pr_body_phase2_gates.py:483
+Reason: Sourcery's test-maintainability feedback is fixed by centralizing the lane-start packet path on `gates.LANE_START_PACKET_PREFIX` and adding explicit `assert errors` checks before negative `any(...)` assertions.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#pullrequestreview-4452695002
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#pullrequestreview-4452695002
+Reason: Cubic reported no issues found across the PR diff.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#issuecomment-4653373092
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#issuecomment-4653373092
+Reason: CodeRabbit comment is a generated walkthrough/pre-merge summary with optional finishing-touch UI checkboxes and no required code or documentation change.
+
+## Experiment Runner Evidence
+Not applicable: local oracle-only Experiment Runner has not materially shaped the implementation yet; if later used to make commit decisions, add its accepted artifact and governed co-author trailer before merge readiness.
+
+## Lane Start Provenance
+Packet: artifacts/orchestration/task_packets/e570447fc1c4.json
+Starter: scripts/orchestration/start_pr_lane.sh
+
+## Evidence
+- `python3 -m scripts.orchestration.check_preflight` PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS: `OK: agent docs and files are consistent.`
+- `. .venv/bin/activate && python -m pytest -q tests/test_pr_body_phase2_gates.py` PASS: 101 tests.
+- `make validate-changed` PASS: `✅ Backend tests passed`.
+- `pre-commit run --all-files` PASS.
+- Full local `make verify` intentionally not run per operator instruction for this governance/tooling PR; use focused gates plus `make validate-changed` and `pre-commit run --all-files` before push.

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -79,7 +79,6 @@ FORBIDDEN_PREFLIGHT_AUTHORITY_RE = re.compile(
     r"[^\n]*\b(?:host/codex|host|codex|cursor|raw|local)\s+preflight\b"
 )
 LANE_START_PACKET_PREFIX = "artifacts/orchestration/task_packets/"
-LANE_START_REPO_PACKET_PREFIX = "docs/orchestration/"
 LANE_STARTER_PATH = "scripts/orchestration/start_pr_lane.sh"
 COMMIT_MESSAGE_SEPARATOR = "\x1e"
 MISSING_EXPERIMENT_RUNNER_EVIDENCE_WARNING = (
@@ -266,16 +265,6 @@ def _valid_lane_start_packet_path(path: str) -> bool:
             return False
         return len(path_parts[-1].removesuffix(".json")) > 0
 
-    if cleaned.startswith(LANE_START_REPO_PACKET_PREFIX):
-        if not cleaned.endswith(".md"):
-            return False
-        if "packet" not in Path(cleaned).name.lower():
-            return False
-        path_parts = cleaned.split("/")
-        if any(part in ("", ".", "..") for part in path_parts):
-            return False
-        return True
-
     return False
 
 
@@ -308,11 +297,6 @@ def _lane_start_packet_available(path: str, *, repo_root: Path) -> bool:
     except (OSError, RuntimeError, ValueError):
         return False
     return candidate.is_file()
-
-
-def _is_repo_tracked_lane_start_packet(path: str) -> bool:
-    cleaned = path.strip().strip("`")
-    return cleaned.startswith(LANE_START_REPO_PACKET_PREFIX)
 
 
 def check_lane_start_provenance(
@@ -350,21 +334,14 @@ def check_lane_start_provenance(
     if invalid_packets:
         errors.append(
             "Lane Start Provenance packet must be "
-            f"`{LANE_START_PACKET_PREFIX}<id>.json` or a repo-tracked "
-            "`docs/orchestration/*.md` packet: " + ", ".join(invalid_packets)
+            f"`{LANE_START_PACKET_PREFIX}<id>.json`: " + ", ".join(invalid_packets)
         )
     for match in packet_matches:
         path = match.group("path")
         if path not in invalid_packets and not _lane_start_packet_available(
             path, repo_root=repo_root
         ):
-            if _is_repo_tracked_lane_start_packet(path):
-                errors.append(
-                    "Lane Start Provenance repo packet is referenced but not available "
-                    f"locally: {path}"
-                )
-            else:
-                warnings.append(UNVERIFIED_LANE_START_PACKET_WARNING.format(path=path))
+            warnings.append(UNVERIFIED_LANE_START_PACKET_WARNING.format(path=path))
 
     if starter_matches and not packet_matches and not exception_matches:
         errors.append("Lane Start Provenance starter is supplemental and cannot be used alone.")

--- a/scripts/ci/check_pr_body_phase2_gates.py
+++ b/scripts/ci/check_pr_body_phase2_gates.py
@@ -112,6 +112,18 @@ UNVERIFIED_LANE_START_PACKET_WARNING = (
 )
 
 
+def _lane_start_missing_warnings(warnings: list[str]) -> list[str]:
+    return [warning for warning in warnings if warning == MISSING_LANE_START_PROVENANCE_WARNING]
+
+
+def _lane_start_non_missing_warnings(warnings: list[str]) -> list[str]:
+    return [warning for warning in warnings if warning != MISSING_LANE_START_PROVENANCE_WARNING]
+
+
+def _lane_start_source_seen(errors: list[str], warnings: list[str]) -> bool:
+    return not errors and MISSING_LANE_START_PROVENANCE_WARNING not in warnings
+
+
 class BodyValidationMode(str, Enum):
     """Explicit Phase2 body validation modes for artifact-first vs fallback checks."""
 
@@ -846,7 +858,7 @@ def main() -> int:
         lane_errors, lane_warnings = check_lane_start_provenance(artifact_text)
         artifact_errors.extend(lane_errors)
         lane_start_warning_candidates.extend(lane_warnings)
-        if not lane_errors and not lane_warnings:
+        if _lane_start_source_seen(lane_errors, lane_warnings):
             lane_start_seen = True
 
     if body.strip():
@@ -887,7 +899,7 @@ def main() -> int:
                 body_checked = True
             body_errors.extend(lane_errors)
             lane_start_warning_candidates.extend(lane_warnings)
-            if not lane_errors and not lane_warnings:
+            if _lane_start_source_seen(lane_errors, lane_warnings):
                 lane_start_seen = True
     elif not artifact_checked:
         print("ERROR: Empty PR body. Fill the required Phase2 checklist sections.")
@@ -928,8 +940,13 @@ def main() -> int:
                     for warning in advisory_warnings
                     if _required_experiment_runner_artifact_warning_to_error(warning) is None
                 ]
+    advisory_warnings.extend(
+        dict.fromkeys(_lane_start_non_missing_warnings(lane_start_warning_candidates))
+    )
     if not lane_start_seen:
-        advisory_warnings.extend(dict.fromkeys(lane_start_warning_candidates))
+        advisory_warnings.extend(
+            dict.fromkeys(_lane_start_missing_warnings(lane_start_warning_candidates))
+        )
     advisory_warnings = list(dict.fromkeys(advisory_warnings))
 
     errors = [*artifact_errors, *body_errors]

--- a/tests/test_pr_body_phase2_gates.py
+++ b/tests/test_pr_body_phase2_gates.py
@@ -27,7 +27,7 @@ Phase2 PR body gate implementation.
 Artifact: artifacts/orchestration/experiments/results/exp-719.json
 
 ## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Packet: artifacts/orchestration/task_packets/a733b2e09986.json
 Starter: scripts/orchestration/start_pr_lane.sh
 """
 
@@ -45,7 +45,7 @@ Phase2 PR body gate implementation.
 Artifact: artifacts/orchestration/experiments/results/exp-998.json
 
 ## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Packet: artifacts/orchestration/task_packets/a733b2e09986.json
 Starter: scripts/orchestration/start_pr_lane.sh
 """
 
@@ -465,21 +465,47 @@ Starter: scripts/orchestration/start_pr_lane.sh
     assert warnings == []
 
 
-def test_lane_start_provenance_accepts_repo_tracked_packet_reference() -> None:
+def test_lane_start_provenance_rejects_repo_markdown_packet_reference() -> None:
     errors, warnings = gates.check_lane_start_provenance("""## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Packet: docs/orchestration/EXPERIMENT_RUNNER_LANE_START_PROVENANCE_PACKET_2026-05-21.md
 """)
 
-    assert errors == []
     assert warnings == []
+    assert any("artifacts/orchestration/task_packets/" in error for error in errors)
 
 
-def test_lane_start_provenance_accepts_mixed_case_repo_packet_reference(
+def test_lane_start_provenance_rejects_fake_repo_packet_even_when_file_exists(
+    tmp_path: Path,
+) -> None:
+    packet = tmp_path / "docs" / "orchestration" / "FAKE_PACKET.md"
+    packet.parent.mkdir(parents=True)
+    packet.write_text("# Fake Packet\n", encoding="utf-8")
+
+    errors, warnings = gates.check_lane_start_provenance(
+        """## Lane Start Provenance
+Packet: docs/orchestration/FAKE_PACKET.md
+""",
+        repo_root=tmp_path,
+    )
+
+    assert warnings == []
+    assert any("artifacts/orchestration/task_packets/" in error for error in errors)
+
+
+def test_lane_start_provenance_rejects_mixed_case_repo_packet_reference(
     tmp_path: Path,
 ) -> None:
     packet = tmp_path / "docs" / "orchestration" / "Philosophy_Epic_V2_Packet_2026-05-20.md"
     packet.parent.mkdir(parents=True)
-    packet.write_text("# Packet\n", encoding="utf-8")
+    packet.write_text(
+        """# Packet
+
+Bootstrap packet: `artifacts/orchestration/task_packets/abc123.json`
+
+Coordinator start: check_preflight.py -> task_bootstrap.py -> agent-coordinator
+""",
+        encoding="utf-8",
+    )
 
     errors, warnings = gates.check_lane_start_provenance(
         """## Lane Start Provenance
@@ -488,8 +514,8 @@ Packet: docs/orchestration/Philosophy_Epic_V2_Packet_2026-05-20.md
         repo_root=tmp_path,
     )
 
-    assert errors == []
     assert warnings == []
+    assert any("artifacts/orchestration/task_packets/" in error for error in errors)
 
 
 def test_lane_start_provenance_accepts_narrow_exception() -> None:
@@ -525,7 +551,7 @@ Packet: docs/orchestration/AGENTS.md
 """)
 
     assert warnings == []
-    assert any("docs/orchestration/*.md` packet" in error for error in errors)
+    assert any("artifacts/orchestration/task_packets/" in error for error in errors)
 
 
 def test_lane_start_provenance_rejects_negated_exception_reason() -> None:
@@ -566,7 +592,9 @@ Starter: scripts/orchestration/start_pr_lane.sh
     assert any("not available locally" in warning for warning in warnings)
 
 
-def test_lane_start_provenance_rejects_unavailable_repo_packet(tmp_path: Path) -> None:
+def test_lane_start_provenance_rejects_unavailable_repo_packet_path(
+    tmp_path: Path,
+) -> None:
     errors, warnings = gates.check_lane_start_provenance(
         """## Lane Start Provenance
 Packet: docs/orchestration/MISSING_PACKET_2099-01-01.md
@@ -576,7 +604,7 @@ Starter: scripts/orchestration/start_pr_lane.sh
     )
 
     assert warnings == []
-    assert any("repo packet is referenced but not available" in error for error in errors)
+    assert any("artifacts/orchestration/task_packets/" in error for error in errors)
 
 
 def test_lane_start_provenance_warns_on_symlink_loop_packet(
@@ -609,7 +637,7 @@ Host preflight: Codex preflight already ran.
 
 def test_lane_start_provenance_rejects_host_preflight_sentence_authority() -> None:
     errors, warnings = gates.check_lane_start_provenance("""## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Exception: trivial docs cleanup
 Host preflight already ran.
 """)
 
@@ -619,7 +647,7 @@ Host preflight already ran.
 
 def test_lane_start_provenance_rejects_labeled_host_preflight_authority() -> None:
     errors, warnings = gates.check_lane_start_provenance("""## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Exception: trivial docs cleanup
 Authority note: host preflight already ran.
 """)
 
@@ -629,7 +657,7 @@ Authority note: host preflight already ran.
 
 def test_lane_start_provenance_rejects_weak_negation_preflight_authority() -> None:
     errors, warnings = gates.check_lane_start_provenance("""## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Exception: trivial docs cleanup
 Host preflight cannot be ignored; it already ran.
 """)
 
@@ -639,7 +667,7 @@ Host preflight cannot be ignored; it already ran.
 
 def test_lane_start_provenance_rejects_contradictory_negated_preflight() -> None:
     errors, warnings = gates.check_lane_start_provenance("""## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Exception: trivial docs cleanup
 Host preflight is not authoritative, but it already ran.
 """)
 
@@ -659,7 +687,7 @@ Cursor preflight: already ran.
 
 def test_lane_start_provenance_allows_negated_host_preflight_context() -> None:
     errors, warnings = gates.check_lane_start_provenance("""## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Exception: trivial docs cleanup
 Starter: scripts/orchestration/start_pr_lane.sh
 Host/Codex preflight is not authoritative lane provenance.
 """)
@@ -670,7 +698,7 @@ Host/Codex preflight is not authoritative lane provenance.
 
 def test_lane_start_provenance_allows_negated_host_preflight_explanation() -> None:
     errors, warnings = gates.check_lane_start_provenance("""## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Exception: trivial docs cleanup
 Starter: scripts/orchestration/start_pr_lane.sh
 Host/Codex preflight is not authoritative lane provenance; use repo bootstrap evidence.
 """)
@@ -1295,7 +1323,7 @@ Commit: abc1234
 Not applicable: canonical artifact evidence controls artifact-first mode.
 
 ## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Packet: artifacts/orchestration/task_packets/a733b2e09986.json
 Starter: scripts/orchestration/start_pr_lane.sh
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
@@ -1378,7 +1406,7 @@ def test_phase2_body_can_satisfy_lane_provenance_when_mapping_lacks_it(
 Body-owned lane provenance.
 
 ## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Packet: artifacts/orchestration/task_packets/a733b2e09986.json
 Starter: scripts/orchestration/start_pr_lane.sh
 """,
         }
@@ -1432,7 +1460,7 @@ Body-owned valid lane provenance.
 Not applicable: split-source negative fixture with no runner output.
 
 ## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Packet: artifacts/orchestration/task_packets/a733b2e09986.json
 Starter: scripts/orchestration/start_pr_lane.sh
 """,
         }
@@ -1491,7 +1519,7 @@ Commit: abc1234
 Not applicable: empty body fixture uses artifact-first validation only.
 
 ## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Packet: artifacts/orchestration/task_packets/a733b2e09986.json
 Starter: scripts/orchestration/start_pr_lane.sh
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
@@ -1532,7 +1560,7 @@ Commit: abc1234
 Not applicable: fixture artifact only checks body mirror failure behavior.
 
 ## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Packet: artifacts/orchestration/task_packets/a733b2e09986.json
 Starter: scripts/orchestration/start_pr_lane.sh
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
@@ -1579,7 +1607,7 @@ Commit: abc1234
 Not applicable: fixture artifact only checks body mirror failure behavior.
 
 ## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Packet: artifacts/orchestration/task_packets/a733b2e09986.json
 Starter: scripts/orchestration/start_pr_lane.sh
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
@@ -1620,7 +1648,7 @@ Commit: abc1234
 Artifact: artifacts/orchestration/experiments/results/exp-998.json
 
 ## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Packet: artifacts/orchestration/task_packets/a733b2e09986.json
 Starter: scripts/orchestration/start_pr_lane.sh
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
@@ -1668,7 +1696,7 @@ Commit: abc1234
 Not applicable: fixture artifact only checks body mirror failure behavior.
 
 ## Lane Start Provenance
-Packet: docs/orchestration/PHILOSOPHY_EPIC_V2_PR2_POLICY_ORACLE_PACKET_2026-05-20.md
+Packet: artifacts/orchestration/task_packets/a733b2e09986.json
 Starter: scripts/orchestration/start_pr_lane.sh
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")

--- a/tests/test_pr_body_phase2_gates.py
+++ b/tests/test_pr_body_phase2_gates.py
@@ -13,6 +13,9 @@ import pytest
 
 import scripts.ci.check_pr_body_phase2_gates as gates
 
+LANE_START_PACKET_ID = "a733b2e09986"
+LANE_START_PACKET_PATH = f"{gates.LANE_START_PACKET_PREFIX}{LANE_START_PACKET_ID}.json"
+
 VALID_BODY_WITH_MAPPING = """## Summary
 Phase2 PR body gate implementation.
 
@@ -27,9 +30,9 @@ Phase2 PR body gate implementation.
 Artifact: artifacts/orchestration/experiments/results/exp-719.json
 
 ## Lane Start Provenance
-Packet: artifacts/orchestration/task_packets/a733b2e09986.json
+Packet: {packet_path}
 Starter: scripts/orchestration/start_pr_lane.sh
-"""
+""".format(packet_path=LANE_START_PACKET_PATH)
 
 VALID_BODY_MIRROR_ONLY = """## Summary
 Phase2 PR body gate implementation.
@@ -45,9 +48,9 @@ Phase2 PR body gate implementation.
 Artifact: artifacts/orchestration/experiments/results/exp-998.json
 
 ## Lane Start Provenance
-Packet: artifacts/orchestration/task_packets/a733b2e09986.json
+Packet: {packet_path}
 Starter: scripts/orchestration/start_pr_lane.sh
-"""
+""".format(packet_path=LANE_START_PACKET_PATH)
 
 
 def _valid_experiment_result_payload(*, status: str = "accepted") -> dict[str, object]:
@@ -90,6 +93,17 @@ def _write_experiment_result(
         json.dumps(payload or _valid_experiment_result_payload()),
         encoding="utf-8",
     )
+
+
+def _write_lane_start_packet(repo_root: Path) -> None:
+    packet = repo_root / LANE_START_PACKET_PATH
+    packet.parent.mkdir(parents=True, exist_ok=True)
+    packet.write_text("{}", encoding="utf-8")
+
+
+def _cleanup_lane_start_packet(repo_root: Path) -> None:
+    packet = repo_root / LANE_START_PACKET_PATH
+    packet.unlink(missing_ok=True)
 
 
 def test_phase2_guard_accepts_valid_mapping() -> None:
@@ -449,13 +463,11 @@ Artifact: artifacts/orchestration/experiments/results/exp-719.json
 
 
 def test_lane_start_provenance_accepts_local_task_packet_and_starter(tmp_path: Path) -> None:
-    packet = tmp_path / "artifacts" / "orchestration" / "task_packets" / "a733b2e09986.json"
-    packet.parent.mkdir(parents=True)
-    packet.write_text("{}", encoding="utf-8")
+    _write_lane_start_packet(tmp_path)
 
     errors, warnings = gates.check_lane_start_provenance(
-        """## Lane Start Provenance
-Packet: artifacts/orchestration/task_packets/a733b2e09986.json
+        f"""## Lane Start Provenance
+Packet: {LANE_START_PACKET_PATH}
 Starter: scripts/orchestration/start_pr_lane.sh
 """,
         repo_root=tmp_path,
@@ -471,7 +483,8 @@ Packet: docs/orchestration/EXPERIMENT_RUNNER_LANE_START_PROVENANCE_PACKET_2026-0
 """)
 
     assert warnings == []
-    assert any("artifacts/orchestration/task_packets/" in error for error in errors)
+    assert errors
+    assert any(gates.LANE_START_PACKET_PREFIX in error for error in errors)
 
 
 def test_lane_start_provenance_rejects_fake_repo_packet_even_when_file_exists(
@@ -489,7 +502,8 @@ Packet: docs/orchestration/FAKE_PACKET.md
     )
 
     assert warnings == []
-    assert any("artifacts/orchestration/task_packets/" in error for error in errors)
+    assert errors
+    assert any(gates.LANE_START_PACKET_PREFIX in error for error in errors)
 
 
 def test_lane_start_provenance_rejects_mixed_case_repo_packet_reference(
@@ -515,7 +529,8 @@ Packet: docs/orchestration/Philosophy_Epic_V2_Packet_2026-05-20.md
     )
 
     assert warnings == []
-    assert any("artifacts/orchestration/task_packets/" in error for error in errors)
+    assert errors
+    assert any(gates.LANE_START_PACKET_PREFIX in error for error in errors)
 
 
 def test_lane_start_provenance_accepts_narrow_exception() -> None:
@@ -542,7 +557,8 @@ Packet: artifacts/orchestration/experiments/results/not-a-packet.json
 """)
 
     assert warnings == []
-    assert any("artifacts/orchestration/task_packets/" in error for error in errors)
+    assert errors
+    assert any(gates.LANE_START_PACKET_PREFIX in error for error in errors)
 
 
 def test_lane_start_provenance_rejects_non_packet_orchestration_doc() -> None:
@@ -551,7 +567,8 @@ Packet: docs/orchestration/AGENTS.md
 """)
 
     assert warnings == []
-    assert any("artifacts/orchestration/task_packets/" in error for error in errors)
+    assert errors
+    assert any(gates.LANE_START_PACKET_PREFIX in error for error in errors)
 
 
 def test_lane_start_provenance_rejects_negated_exception_reason() -> None:
@@ -604,7 +621,8 @@ Starter: scripts/orchestration/start_pr_lane.sh
     )
 
     assert warnings == []
-    assert any("artifacts/orchestration/task_packets/" in error for error in errors)
+    assert errors
+    assert any(gates.LANE_START_PACKET_PREFIX in error for error in errors)
 
 
 def test_lane_start_provenance_warns_on_symlink_loop_packet(
@@ -1308,7 +1326,7 @@ Artifact-first validation fixture.
 """
     event = {"pull_request": {"number": 998, "body": mirror_body}}
     (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
-    artifact_content = """# PR 998 — Fixed in Commit Mapping
+    artifact_content = f"""# PR 998 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
 - [x] Discussion-thread pass completed
@@ -1323,26 +1341,30 @@ Commit: abc1234
 Not applicable: canonical artifact evidence controls artifact-first mode.
 
 ## Lane Start Provenance
-Packet: artifacts/orchestration/task_packets/a733b2e09986.json
+Packet: {LANE_START_PACKET_PATH}
 Starter: scripts/orchestration/start_pr_lane.sh
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
     repo_root = Path(__file__).resolve().parents[1]
+    _write_lane_start_packet(repo_root)
     env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
-    result = subprocess.run(
-        [
-            sys.executable,
-            "scripts/ci/check_pr_body_phase2_gates.py",
-            "--event-path",
-            str(tmp_path / "event.json"),
-            "--experiment-runner-evidence-mode",
-            "required",
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(repo_root),
-        env=env,
-    )
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/ci/check_pr_body_phase2_gates.py",
+                "--event-path",
+                str(tmp_path / "event.json"),
+                "--experiment-runner-evidence-mode",
+                "required",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+            env=env,
+        )
+    finally:
+        _cleanup_lane_start_packet(repo_root)
     assert result.returncode == 0
     assert "canonical mapping artifact and PR body mirror passed" in result.stdout
     assert "WARNING:" not in result.stdout
@@ -1402,11 +1424,11 @@ def test_phase2_body_can_satisfy_lane_provenance_when_mapping_lacks_it(
     event = {
         "pull_request": {
             "number": 998,
-            "body": """## Summary
+            "body": f"""## Summary
 Body-owned lane provenance.
 
 ## Lane Start Provenance
-Packet: artifacts/orchestration/task_packets/a733b2e09986.json
+Packet: {LANE_START_PACKET_PATH}
 Starter: scripts/orchestration/start_pr_lane.sh
 """,
         }
@@ -1428,6 +1450,64 @@ Not applicable: fixture keeps runner evidence out of this split-source check.
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
     repo_root = Path(__file__).resolve().parents[1]
+    _write_lane_start_packet(repo_root)
+    env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/ci/check_pr_body_phase2_gates.py",
+                "--event-path",
+                str(tmp_path / "event.json"),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+            env=env,
+        )
+    finally:
+        _cleanup_lane_start_packet(repo_root)
+
+    assert result.returncode == 0
+    assert "missing `## Lane Start Provenance`" not in result.stdout
+
+
+def test_phase2_body_does_not_hide_unverified_mapping_packet_warning(
+    tmp_path: Path,
+) -> None:
+    """Body provenance should only satisfy missing sections, not hide artifact warnings."""
+    event = {
+        "pull_request": {
+            "number": 998,
+            "body": """## Summary
+Body-owned valid lane provenance.
+
+## Lane Start Provenance
+Exception: trivial docs cleanup: body mirror fixture.
+""",
+        }
+    }
+    (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
+    artifact_content = f"""# PR 998 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: abc1234
+- https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
+
+## Experiment Runner Evidence
+Not applicable: fixture only checks lane-start warning visibility.
+
+## Lane Start Provenance
+Packet: {LANE_START_PACKET_PATH}
+Starter: scripts/orchestration/start_pr_lane.sh
+"""
+    (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
+    repo_root = Path(__file__).resolve().parents[1]
     env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
     result = subprocess.run(
         [
@@ -1443,6 +1523,59 @@ Not applicable: fixture keeps runner evidence out of this split-source check.
     )
 
     assert result.returncode == 0
+    assert "not available locally" in result.stdout
+    assert "missing `## Lane Start Provenance`" not in result.stdout
+
+
+def test_phase2_unverified_body_packet_satisfies_missing_mapping_lane_section(
+    tmp_path: Path,
+) -> None:
+    """A valid packet reference still counts as present when only availability is advisory."""
+    event = {
+        "pull_request": {
+            "number": 998,
+            "body": f"""## Summary
+Body-owned lane provenance.
+
+## Lane Start Provenance
+Packet: {LANE_START_PACKET_PATH}
+Starter: scripts/orchestration/start_pr_lane.sh
+""",
+        }
+    }
+    (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
+    artifact_content = """# PR 998 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+Disposition: FIXED
+Commit: abc1234
+- https://github.com/org/repo/pull/998#discussion_r1 -> abc1234
+
+## Experiment Runner Evidence
+Not applicable: fixture only checks missing-section suppression.
+"""
+    (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
+    repo_root = Path(__file__).resolve().parents[1]
+    env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/ci/check_pr_body_phase2_gates.py",
+            "--event-path",
+            str(tmp_path / "event.json"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=env,
+    )
+
+    assert result.returncode == 0
+    assert "not available locally" in result.stdout
     assert "missing `## Lane Start Provenance`" not in result.stdout
 
 
@@ -1453,14 +1586,14 @@ def test_phase2_rejects_malformed_mapping_lane_even_when_body_is_valid(
     event = {
         "pull_request": {
             "number": 998,
-            "body": """## Summary
+            "body": f"""## Summary
 Body-owned valid lane provenance.
 
 ## Experiment Runner Evidence
 Not applicable: split-source negative fixture with no runner output.
 
 ## Lane Start Provenance
-Packet: artifacts/orchestration/task_packets/a733b2e09986.json
+Packet: {LANE_START_PACKET_PATH}
 Starter: scripts/orchestration/start_pr_lane.sh
 """,
         }
@@ -1504,7 +1637,7 @@ def test_phase2_accepts_empty_pr_body_when_artifact_is_valid(tmp_path: Path) -> 
     """Artifact-first mode does not fail solely because the body mirror is omitted."""
     event = {"pull_request": {"number": 998, "body": ""}}
     (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
-    artifact_content = """# PR 998 — Fixed in Commit Mapping
+    artifact_content = f"""# PR 998 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
 - [x] Discussion-thread pass completed
@@ -1519,24 +1652,28 @@ Commit: abc1234
 Not applicable: empty body fixture uses artifact-first validation only.
 
 ## Lane Start Provenance
-Packet: artifacts/orchestration/task_packets/a733b2e09986.json
+Packet: {LANE_START_PACKET_PATH}
 Starter: scripts/orchestration/start_pr_lane.sh
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
     repo_root = Path(__file__).resolve().parents[1]
+    _write_lane_start_packet(repo_root)
     env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
-    result = subprocess.run(
-        [
-            sys.executable,
-            "scripts/ci/check_pr_body_phase2_gates.py",
-            "--event-path",
-            str(tmp_path / "event.json"),
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(repo_root),
-        env=env,
-    )
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/ci/check_pr_body_phase2_gates.py",
+                "--event-path",
+                str(tmp_path / "event.json"),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+            env=env,
+        )
+    finally:
+        _cleanup_lane_start_packet(repo_root)
     assert result.returncode == 0
     assert "canonical mapping artifact passed" in result.stdout
 
@@ -1545,7 +1682,7 @@ def test_phase2_accepts_non_mirror_body_when_artifact_is_valid(tmp_path: Path) -
     """Artifact-first mode should not force optional PR body mirrors."""
     event = {"pull_request": {"number": 998, "body": "minimal"}}
     (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
-    artifact_content = """# PR 998 — Fixed in Commit Mapping
+    artifact_content = f"""# PR 998 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
 - [x] Discussion-thread pass completed
@@ -1560,24 +1697,28 @@ Commit: abc1234
 Not applicable: fixture artifact only checks body mirror failure behavior.
 
 ## Lane Start Provenance
-Packet: artifacts/orchestration/task_packets/a733b2e09986.json
+Packet: {LANE_START_PACKET_PATH}
 Starter: scripts/orchestration/start_pr_lane.sh
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
     repo_root = Path(__file__).resolve().parents[1]
+    _write_lane_start_packet(repo_root)
     env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
-    result = subprocess.run(
-        [
-            sys.executable,
-            "scripts/ci/check_pr_body_phase2_gates.py",
-            "--event-path",
-            str(tmp_path / "event.json"),
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(repo_root),
-        env=env,
-    )
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/ci/check_pr_body_phase2_gates.py",
+                "--event-path",
+                str(tmp_path / "event.json"),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+            env=env,
+        )
+    finally:
+        _cleanup_lane_start_packet(repo_root)
     assert result.returncode == 0
     assert "canonical mapping artifact passed" in result.stdout
 
@@ -1592,7 +1733,7 @@ def test_phase2_rejects_invalid_present_body_mirror_when_artifact_is_valid(
         }
     }
     (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
-    artifact_content = """# PR 998 — Fixed in Commit Mapping
+    artifact_content = f"""# PR 998 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
 - [x] Discussion-thread pass completed
@@ -1607,33 +1748,38 @@ Commit: abc1234
 Not applicable: fixture artifact only checks body mirror failure behavior.
 
 ## Lane Start Provenance
-Packet: artifacts/orchestration/task_packets/a733b2e09986.json
+Packet: {LANE_START_PACKET_PATH}
 Starter: scripts/orchestration/start_pr_lane.sh
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
     repo_root = Path(__file__).resolve().parents[1]
+    _write_lane_start_packet(repo_root)
     env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
-    result = subprocess.run(
-        [
-            sys.executable,
-            "scripts/ci/check_pr_body_phase2_gates.py",
-            "--event-path",
-            str(tmp_path / "event.json"),
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(repo_root),
-        env=env,
-    )
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/ci/check_pr_body_phase2_gates.py",
+                "--event-path",
+                str(tmp_path / "event.json"),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+            env=env,
+        )
+    finally:
+        _cleanup_lane_start_packet(repo_root)
     assert result.returncode == 1
     assert "PR body validation failed" in result.stdout
+    assert "canonical mapping artifact validation failed" not in result.stdout
     assert "Checklist item must be checked" in result.stdout
 
 
 def test_phase2_accepts_pr_number_without_explicit_body_when_artifact_is_valid(
     tmp_path: Path,
 ) -> None:
-    artifact_content = """# PR 998 — Fixed in Commit Mapping
+    artifact_content = f"""# PR 998 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
 - [x] Discussion-thread pass completed
@@ -1648,26 +1794,30 @@ Commit: abc1234
 Artifact: artifacts/orchestration/experiments/results/exp-998.json
 
 ## Lane Start Provenance
-Packet: artifacts/orchestration/task_packets/a733b2e09986.json
+Packet: {LANE_START_PACKET_PATH}
 Starter: scripts/orchestration/start_pr_lane.sh
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
     repo_root = Path(__file__).resolve().parents[1]
+    _write_lane_start_packet(repo_root)
     env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
-    result = subprocess.run(
-        [
-            sys.executable,
-            "scripts/ci/check_pr_body_phase2_gates.py",
-            "--pr-number",
-            "998",
-            "--commit-range",
-            "HEAD",
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(repo_root),
-        env=env,
-    )
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/ci/check_pr_body_phase2_gates.py",
+                "--pr-number",
+                "998",
+                "--commit-range",
+                "HEAD",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+            env=env,
+        )
+    finally:
+        _cleanup_lane_start_packet(repo_root)
     assert result.returncode == 0
     assert "canonical mapping artifact passed" in result.stdout
 
@@ -1681,7 +1831,7 @@ def test_phase2_failure_output_only_reports_failing_scope(tmp_path: Path) -> Non
         }
     }
     (tmp_path / "event.json").write_text(json.dumps(event), encoding="utf-8")
-    artifact_content = """# PR 998 — Fixed in Commit Mapping
+    artifact_content = f"""# PR 998 — Fixed in Commit Mapping
 
 ## Discussion Thread Pass
 - [x] Discussion-thread pass completed
@@ -1696,24 +1846,28 @@ Commit: abc1234
 Not applicable: fixture artifact only checks body mirror failure behavior.
 
 ## Lane Start Provenance
-Packet: artifacts/orchestration/task_packets/a733b2e09986.json
+Packet: {LANE_START_PACKET_PATH}
 Starter: scripts/orchestration/start_pr_lane.sh
 """
     (tmp_path / "PR_998_FIXED_MAPPING.md").write_text(artifact_content, encoding="utf-8")
     repo_root = Path(__file__).resolve().parents[1]
+    _write_lane_start_packet(repo_root)
     env = {**os.environ, "REVIEW_MAPPING_ARTIFACT_DIR": str(tmp_path)}
-    result = subprocess.run(
-        [
-            sys.executable,
-            "scripts/ci/check_pr_body_phase2_gates.py",
-            "--event-path",
-            str(tmp_path / "event.json"),
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(repo_root),
-        env=env,
-    )
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/ci/check_pr_body_phase2_gates.py",
+                "--event-path",
+                str(tmp_path / "event.json"),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+            env=env,
+        )
+    finally:
+        _cleanup_lane_start_packet(repo_root)
     assert result.returncode == 1
     assert "PR body validation failed" in result.stdout
     assert "canonical mapping artifact validation failed" not in result.stdout


### PR DESCRIPTION
### Motivation
- Close a provenance bypass where any `docs/orchestration/*packet*.md` file satisfied the Lane Start Provenance check, allowing arbitrary repo-tracked Markdown to act as bootstrap proof.
- Ensure lane-start provenance actually proves `task_bootstrap`/bootstrap execution by restricting accepted packet references to generated `artifacts/orchestration/task_packets/<id>.json` paths.

### Description
- Remove acceptance of `docs/orchestration/` Markdown packet references from the lane-start packet validator so only `artifacts/orchestration/task_packets/*.json` is considered valid.
- Tighten `_valid_lane_start_packet_path` to reject repo-markdown paths and simplify availability checks to treat missing artifacts as advisory warnings while treating malformed or non-artifact packet refs as errors.
- Update tests in `tests/test_pr_body_phase2_gates.py` to expect rejection of repo Markdown packet references and to cover fake/mixed-case Markdown packet files and valid JSON task-packet behavior.
- Preserve unavailable-packet dry-run advisories even when an optional PR body mirror has valid Lane Start Provenance, while still suppressing only duplicate missing-section warnings.
- Files changed: `scripts/ci/check_pr_body_phase2_gates.py`, `tests/test_pr_body_phase2_gates.py`, `docs/review/PR_1913_FIXED_MAPPING.md`.

### Testing
- `python3 -m scripts.orchestration.check_preflight` PASS.
- `python3 scripts/orchestration/check_agent_consistency.py` PASS: `OK: agent docs and files are consistent.`
- `python3 -m py_compile scripts/ci/check_pr_body_phase2_gates.py tests/test_pr_body_phase2_gates.py` PASS.
- `. .venv/bin/activate && python -m pytest -q tests/test_pr_body_phase2_gates.py` PASS: 101 tests.
- `make validate-changed` PASS: `✅ Backend tests passed`.
- `pre-commit run --all-files` PASS.
- Full local `make verify` intentionally not run per operator instruction for this governance/tooling PR; current-head CI remains the heavy signal after push.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#pullrequestreview-4452631808 -> daaaf4de0
Disposition: FIXED
Commit: daaaf4de0
Evidence: tests/test_pr_body_phase2_gates.py:16; tests/test_pr_body_phase2_gates.py:483
Reason: Sourcery's test-maintainability feedback is fixed by centralizing the lane-start packet path on `gates.LANE_START_PACKET_PREFIX` and adding explicit `assert errors` checks before negative `any(...)` assertions.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#pullrequestreview-4452695002
Disposition: NOT-A-BUG
Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#pullrequestreview-4452695002
Reason: Cubic reported no issues found across the PR diff.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#issuecomment-4653373092
Disposition: NOT-A-BUG
Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#issuecomment-4653373092
Reason: CodeRabbit comment is a generated walkthrough/pre-merge summary with optional finishing-touch UI checkboxes and no required code or documentation change.

- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1913#discussion_r3376260436
Disposition: NOT-A-BUG
Evidence: scripts/ci/check_pr_body_phase2_gates.py:101; scripts/ci/check_pr_body_phase2_gates.py:108; scripts/ci/check_pr_body_phase2_gates.py:309
Reason: Codex's P2 asks to promote unavailable task-packet references to hard failures, but this lane intentionally keeps Lane Start Provenance in dry-run advisory mode: missing provenance and unavailable local gitignored task-packet artifacts warn, while malformed present packet paths remain hard errors. This PR preserves that current phased contract and fixes advisory visibility without changing enforcement mode.

## Experiment Runner Evidence
Not applicable: local oracle-only Experiment Runner has not materially shaped the implementation yet; if later used to make commit decisions, add its accepted artifact and governed co-author trailer before merge readiness.

## Lane Start Provenance
Packet: artifacts/orchestration/task_packets/e570447fc1c4.json
Starter: scripts/orchestration/start_pr_lane.sh

## Merge Readiness
- [x] Local narrow gates completed (`check_preflight`, `check_agent_consistency`, focused pytest, `make validate-changed`, `pre-commit run --all-files`).
- [ ] Current-head CI required checks green.
- [ ] Final review-thread disposition guard and merge-readiness wrapper pass with GitHub auth.

## Deferred / Follow-ups
- None.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a271bc9787c832ca68e75e0cb6adda8)

## Summary by Sourcery

Ужесточить проверку происхождения при запуске lane, чтобы принимать только артефакты JSON task-packet и перестать считать отслеживаемые в репозитории файлы Markdown допустимым подтверждением происхождения.

Исправления ошибок:
- Не допускать выполнения требований к происхождению при запуске lane за счёт произвольных файлов `docs/orchestration/*.md` вместо сгенерированных артефактов task-packet.

Тесты:
- Обновить тесты CI gate, чтобы охватывать принятие ссылок на артефакты JSON task-packet и отклонение всех путей к Markdown packet в репозитории, включая существующие, с смешанным регистром и некорректные варианты.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten lane-start provenance validation to only accept JSON task-packet artifacts and stop treating repo-tracked Markdown files as valid provenance evidence.

Bug Fixes:
- Prevent lane-start provenance from being satisfied by arbitrary docs/orchestration/*.md files instead of generated task-packet artifacts.

Tests:
- Update CI gate tests to cover acceptance of JSON task-packet artifact references and rejection of all repo Markdown packet paths, including existing, mixed-case, and malformed cases.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens Lane Start Provenance to allow only JSON task-packet artifacts and reject repo Markdown; preserves advisory warnings and dedupes them. Updates `docs/review/PR_1913_FIXED_MAPPING.md` with checklist label fixes and a Sourcery review mapping.

- **Bug Fixes**
  - Accept only `artifacts/orchestration/task_packets/<id>.json`; reject `docs/orchestration/*.md` (including mixed case) as invalid.
  - Malformed/non-artifact paths error; missing local JSON artifacts warn.
  - Keep advisory warnings for unverified packets even when the body has valid provenance; only dedupe missing-section notices; add helpers to split missing vs non-missing warnings and detect a valid source.
  - Tests enforce JSON-only behavior, verify advisory visibility and artifact/body precedence, and use real packet fixtures; updated `docs/review/PR_1913_FIXED_MAPPING.md` with correct checklist labels and Sourcery review mapping.

<sup>Written for commit 3e22b6c58af4c1615bc09069f7ccc465aa073c11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lane-start "Packet" provenance now accepts only local JSON task-packet artifacts; markdown-based or repo-tracked packet references are rejected.
  * Warning aggregation refined so the missing-lane-start advisory is shown only when no canonical provenance source is present.

* **Tests**
  * Fixtures and tests updated to use local JSON task-packet artifacts; new tests reject unsupported, fake, or mixed-case packet references and assert canonical error text.

* **Documentation**
  * Added a review mapping document summarizing PR validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
