### PR TITLE
fix(evidence): normalize wiki metadata keys

### DIFF
--- a/core/evidence/wiki_bridge.py
+++ b/core/evidence/wiki_bridge.py
@@ -619,14 +619,6 @@ def _validate_metadata_string(value: str, key_path: tuple[str, ...]) -> None:
         raise ValueError("metadata contains unsafe path-like value")
     if lower.startswith(_PATH_VALUE_PREFIXES) or lower.endswith(_PATH_VALUE_SUFFIXES):
         raise ValueError("metadata contains unsafe path-like value")
-    if key_path:
-        normalized_key = _normalize_metadata_key(key_path[-1])
-        if any(
-            _normalize_metadata_claim_text(fragment) in normalized_key
-            for fragment in _AUTHORITY_KEY_FRAGMENTS
-        ):
-            if _metadata_claim_text_contains(value, _AUTHORITY_VALUE_FRAGMENTS):
-                raise ValueError("metadata contains forbidden authority claim")
 
 
 def _metadata_value_claims_authority(value: JsonValue) -> bool:

--- a/core/evidence/wiki_bridge.py
+++ b/core/evidence/wiki_bridge.py
@@ -575,8 +575,12 @@ def _validate_metadata(value: JsonValue, *, key_path: tuple[str, ...] = ()) -> N
     raise ValueError("metadata must be JSON-compatible")
 
 
+def _normalize_metadata_key(key: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", key.strip().lower()).strip("_")
+
+
 def _validate_metadata_key(key: str, value: JsonValue) -> None:
-    normalized_key = key.strip().lower().replace("-", "_")
+    normalized_key = _normalize_metadata_key(key)
     if not normalized_key:
         raise ValueError("metadata keys must not be blank")
     if any(fragment in normalized_key for fragment in _FORBIDDEN_METADATA_KEY_FRAGMENTS):
@@ -603,9 +607,11 @@ def _validate_metadata_string(value: str, key_path: tuple[str, ...]) -> None:
         raise ValueError("metadata contains unsafe path-like value")
     if lower.startswith(_PATH_VALUE_PREFIXES) or lower.endswith(_PATH_VALUE_SUFFIXES):
         raise ValueError("metadata contains unsafe path-like value")
-    if key_path and any(fragment in key_path[-1].lower() for fragment in _AUTHORITY_KEY_FRAGMENTS):
-        if any(fragment in lower for fragment in _AUTHORITY_VALUE_FRAGMENTS):
-            raise ValueError("metadata contains forbidden authority claim")
+    if key_path:
+        normalized_key = _normalize_metadata_key(key_path[-1])
+        if any(fragment in normalized_key for fragment in _AUTHORITY_KEY_FRAGMENTS):
+            if any(fragment in lower for fragment in _AUTHORITY_VALUE_FRAGMENTS):
+                raise ValueError("metadata contains forbidden authority claim")
 
 
 def _metadata_value_claims_authority(value: JsonValue) -> bool:

--- a/core/evidence/wiki_bridge.py
+++ b/core/evidence/wiki_bridge.py
@@ -575,17 +575,29 @@ def _validate_metadata(value: JsonValue, *, key_path: tuple[str, ...] = ()) -> N
     raise ValueError("metadata must be JSON-compatible")
 
 
+def _normalize_metadata_claim_text(value: str) -> str:
+    # Canonicalizes separator variants such as "api key" or "source.of.truth".
+    return re.sub(r"[^a-z0-9]+", "_", value.strip().lower()).strip("_")
+
+
 def _normalize_metadata_key(key: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "_", key.strip().lower()).strip("_")
+    return _normalize_metadata_claim_text(key)
+
+
+def _metadata_claim_text_contains(value: str, fragments: Iterable[str]) -> bool:
+    normalized_value = _normalize_metadata_claim_text(value)
+    return any(
+        _normalize_metadata_claim_text(fragment) in normalized_value for fragment in fragments
+    )
 
 
 def _validate_metadata_key(key: str, value: JsonValue) -> None:
     normalized_key = _normalize_metadata_key(key)
     if not normalized_key:
         raise ValueError("metadata keys must not be blank")
-    if any(fragment in normalized_key for fragment in _FORBIDDEN_METADATA_KEY_FRAGMENTS):
+    if _metadata_claim_text_contains(key, _FORBIDDEN_METADATA_KEY_FRAGMENTS):
         raise ValueError(f"metadata contains forbidden field: {key}")
-    if any(fragment in normalized_key for fragment in _AUTHORITY_KEY_FRAGMENTS):
+    if _metadata_claim_text_contains(key, _AUTHORITY_KEY_FRAGMENTS):
         if _metadata_value_claims_authority(value):
             raise ValueError(f"metadata contains forbidden authority claim: {key}")
     if normalized_key == "advisory_only" and value is not True:
@@ -609,8 +621,11 @@ def _validate_metadata_string(value: str, key_path: tuple[str, ...]) -> None:
         raise ValueError("metadata contains unsafe path-like value")
     if key_path:
         normalized_key = _normalize_metadata_key(key_path[-1])
-        if any(fragment in normalized_key for fragment in _AUTHORITY_KEY_FRAGMENTS):
-            if any(fragment in lower for fragment in _AUTHORITY_VALUE_FRAGMENTS):
+        if any(
+            _normalize_metadata_claim_text(fragment) in normalized_key
+            for fragment in _AUTHORITY_KEY_FRAGMENTS
+        ):
+            if _metadata_claim_text_contains(value, _AUTHORITY_VALUE_FRAGMENTS):
                 raise ValueError("metadata contains forbidden authority claim")
 
 
@@ -620,8 +635,7 @@ def _metadata_value_claims_authority(value: JsonValue) -> bool:
     if isinstance(value, (int, float)):
         return value != 0
     if isinstance(value, str):
-        lower = value.strip().lower()
-        return any(fragment in lower for fragment in _AUTHORITY_VALUE_FRAGMENTS)
+        return _metadata_claim_text_contains(value, _AUTHORITY_VALUE_FRAGMENTS)
     if isinstance(value, Mapping):
         return any(_metadata_value_claims_authority(child) for child in value.values())
     if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, memoryview)):

--- a/docs/review/PR_1917_FIXED_MAPPING.md
+++ b/docs/review/PR_1917_FIXED_MAPPING.md
@@ -17,7 +17,7 @@ authority.
 
 - Branch: `codex/fix-metadata-validation-for-forbidden-keys`
 - Worktree: `worktrees/pr-1917-closeout`
-- Task packet: `artifacts/orchestration/task_packets/e951467444d0.json`
+- Packet: `artifacts/orchestration/task_packets/e951467444d0.json`
 - Role dispatch command: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/e951467444d0.json --pretty`
 - Declared role order executed: `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor -> architecture-specialist`
 - Implementation commit: `b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa`

--- a/docs/review/PR_1917_FIXED_MAPPING.md
+++ b/docs/review/PR_1917_FIXED_MAPPING.md
@@ -76,10 +76,10 @@ Disposition: NOT-A-BUG
 Evidence: CodeRabbit reported "No actionable comments were generated in the recent review." Current fixed mapping separately covers the later actionable Codex/Cubic authority-value findings.
 Reason: The CodeRabbit comment is a no-actionable review summary, not a requested code change.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1917#issuecomment-4659248806 -> b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1917#issuecomment-4659248806 -> d168b40a98fa915ae6056d2ffef5c84e670ad639
 Disposition: FIXED
-Commit: b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa
-Evidence: `tests/core/evidence/test_wiki_bridge.py` adds regression coverage for previously missing wiki bridge authority branches, including dotted/dashed authority values and admission-adapter metadata. Focused pytest and Experiment Runner pytest oracle passed.
+Commit: d168b40a98fa915ae6056d2ffef5c84e670ad639
+Evidence: `core/evidence/wiki_bridge.py` removes a redundant, unreachable authority-string branch after coverage showed lines 628-629 below the 97% threshold. The same fail-closed behavior remains covered through `_validate_metadata_key(...)->_metadata_value_claims_authority(...)`; focused pytest and `make validate-changed` passed after the cleanup.
 
 ## Experiment Runner Evidence
 
@@ -155,6 +155,8 @@ Evidence: `tests/core/evidence/test_wiki_bridge.py` adds regression coverage for
 - PASS: Experiment Runner oracle-only governance review accepted with pytest and `git diff --check` oracle commands returning 0.
 - PASS: Codex Security diff scan / finding discovery with no diff-scoped findings.
 - PASS: `pre-commit run --all-files`
+- PASS: post-diff-coverage cleanup focused pytest for `tests/core/evidence/test_wiki_bridge.py`
+- PASS: post-diff-coverage cleanup `make validate-changed`
 - STOPPED: full local `make verify` was started, passed `verify-env`, and entered
   `mypy`; the operator then explicitly narrowed this PR lane to
   `make validate-changed` because full verify runs the repository-scale test

--- a/docs/review/PR_1917_FIXED_MAPPING.md
+++ b/docs/review/PR_1917_FIXED_MAPPING.md
@@ -1,0 +1,179 @@
+# PR #1917 Fixed in Commit Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1917>
+
+## Summary
+
+This closeout hardens advisory wiki metadata normalization so separator variants
+inside authority keys and values are compared through the same canonical text
+policy before any advisory evidence or admission mapping is created.
+
+The implementation stays inside `core/evidence/wiki_bridge.py` and focused
+tests. It does not add runtime writes, DB access, provider calls, cache
+admission, wiki compiler behavior, semantic cache behavior, or product-truth
+authority.
+
+## Lane Start Provenance
+
+- Branch: `codex/fix-metadata-validation-for-forbidden-keys`
+- Worktree: `worktrees/pr-1917-closeout`
+- Task packet: `artifacts/orchestration/task_packets/e951467444d0.json`
+- Role dispatch command: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/e951467444d0.json --pretty`
+- Declared role order executed: `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor -> architecture-specialist`
+- Implementation commit: `b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa`
+
+## Scope
+
+- Normalize authority-bearing metadata values with the same separator policy as
+  metadata keys before checking authority fragments.
+- Normalize configured authority fragments before fragment comparison.
+- Add public API and admission-adapter regressions for dotted, dashed, nested,
+  and list-shaped authority metadata values.
+- Add the canonical fixed-mapping artifact required by PR governance.
+
+## Out of Scope
+
+- No runtime authority promotion.
+- No advisory wiki compiler, ingest, query, or promotion behavior changes.
+- No DB, provider, cache, semantic-cache, FastAPI, OpenAPI, frontend, or iOS
+  changes.
+- No review-thread resolution before this artifact and strict disposition gates.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- Notes: Valid Codex/Cubic authority-value bypass findings are fixed and mapped
+  below. Sourcery's high-level maintainability suggestion is fixed with a short
+  canonicalization comment. CodeRabbit's latest review reported no actionable
+  comments. Codecov patch coverage is addressed by focused regression tests.
+  Final merge readiness remains pending current-head CI, external bot state,
+  strict disposition verification, strict merge-readiness verification, and the
+  mandatory wait window.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1917#discussion_r3380144634 -> b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1917#pullrequestreview-4458022943 -> b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa
+Disposition: FIXED
+Commit: b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa
+Evidence: `core/evidence/wiki_bridge.py` normalizes metadata claim text before authority key/value fragment comparisons, and `tests/core/evidence/test_wiki_bridge.py` covers the Codex-reported public API/admission bypass with `create_advisory_wiki_artifact_ref(..., metadata={"source.of.truth": "source.of.truth"})`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1917#discussion_r3380157273 -> b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1917#pullrequestreview-4458036564 -> b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa
+Disposition: FIXED
+Commit: b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa
+Evidence: `core/evidence/wiki_bridge.py` now applies separator normalization to authority values and normalized configured fragments before comparison, closing the Cubic-identified `source.of.truth` bypass. Focused pytest for `tests/core/evidence/test_wiki_bridge.py` passed.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1917#pullrequestreview-4458013142 -> b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1917#issuecomment-4659161223 -> b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa
+Disposition: FIXED
+Commit: b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa
+Evidence: `core/evidence/wiki_bridge.py` adds a concise comment above the canonical metadata claim normalizer explaining separator canonicalization with examples such as `api key` and `source.of.truth`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1917#issuecomment-4659160307
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit reported "No actionable comments were generated in the recent review." Current fixed mapping separately covers the later actionable Codex/Cubic authority-value findings.
+Reason: The CodeRabbit comment is a no-actionable review summary, not a requested code change.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1917#issuecomment-4659248806 -> b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa
+Disposition: FIXED
+Commit: b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa
+Evidence: `tests/core/evidence/test_wiki_bridge.py` adds regression coverage for previously missing wiki bridge authority branches, including dotted/dashed authority values and admission-adapter metadata. Focused pytest and Experiment Runner pytest oracle passed.
+
+## Experiment Runner Evidence
+
+- Packet: `artifacts/orchestration/experiments/exp-3cb504eeaa7b.json`
+- Artifact: `artifacts/orchestration/experiments/results/exp-3cb504eeaa7b.json`
+- Mode: `oracle_only_governance_reviewer`
+- Result: `accepted`
+- Contribution: `fixed_mapping_review`
+- `mutated_paths=[]`
+- `shared_tree_untouched=true`
+- `promotion_ready=false`
+- `coauthor_required=true`
+- Co-author reason: `Oracle-only governance evidence shapes PR 1917 fixed-mapping and validation evidence.`
+- Oracle commands:
+  - `python -m pytest -q tests/core/evidence/test_wiki_bridge.py`
+  - `git diff --check HEAD`
+
+## Post-Open Review Gates
+
+- [x] `agent-coordinator`
+  - Disposition: NOT-A-BUG
+  - Evidence: coordinator scoped the closeout to the wiki bridge, focused tests,
+    canonical mapping artifact, and PR body mirror, with no product-runtime,
+    cache, provider, DB, frontend, or iOS expansion.
+- [x] `qa-engineer-agent`
+  - Disposition: NOT-A-BUG
+  - Evidence: QA identified the public API/admission regression cases for
+    dotted and list-shaped authority values. Those tests are now present in
+    `tests/core/evidence/test_wiki_bridge.py`.
+- [x] `bug-hunter`
+  - Disposition: FIXED
+  - Evidence: bug-hunter confirmed the raw lowercase authority-value bypass in
+    `core/evidence/wiki_bridge.py`; commit
+    `b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa` fixes the root cause.
+- [x] `security-auditor`
+  - Disposition: FIXED
+  - Evidence: security-auditor confirmed separator variants such as
+    `source.of.truth`, `source-of-truth`, `user.facing`, nested mappings, and
+    list values. Commit `b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa` covers those
+    cases while preserving advisory-only evidence boundaries.
+- [x] `architecture-specialist`
+  - Disposition: NOT-A-BUG
+  - Evidence: architecture review accepted the narrow boundary in
+    `core/evidence/wiki_bridge.py` and `tests/core/evidence/test_wiki_bridge.py`
+    and found no runtime/compiler/cache/wiki-ingest/DB/provider expansion.
+- [x] Codex Security diff scan / finding discovery
+  - Disposition: NOT-A-BUG
+  - Evidence: Codex Security diff scan completed under
+    `/tmp/codex-security-scans/BMI-App_2025_clean/b738d4f5e_20260611T055446Z`.
+    Completion receipts cover both PR-scoped files in
+    `artifacts/02_discovery/work_ledger.jsonl`; final reports are `report.md`
+    and `report.html`; no diff-scoped findings were identified.
+- [x] `pulseplate-pr-review`
+  - Disposition: NOT-A-BUG
+  - Evidence: incremental dry-run from reviewed PR head
+    `7f229f5ca90bf968eff9d4256ed3525c25e3ac58` to
+    `b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa` reported 2 files, 53 additions,
+    7 deletions, and no deterministic findings. Report:
+    `/tmp/pr1917_pr_review_report_incremental.md`.
+  - Reason: the earlier raw-ancestry dry-run surfaced unrelated local base-drift
+    noise; the incremental closeout diff matches the post-open review delta.
+
+## Local Validation
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `python3 scripts/orchestration/task_bootstrap.py --goal "Close PR 1917 wiki metadata normalization hardening through merge-ready" --task-class security --path core/evidence/wiki_bridge.py --path tests/core/evidence/test_wiki_bridge.py --path docs/review/PR_1917_FIXED_MAPPING.md --requested-agent agent-coordinator --requested-agent security-auditor --requested-agent qa-engineer-agent --requested-agent bug-hunter --pr-phase post_open_review`
+- PASS: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/e951467444d0.json --pretty`
+- PASS: `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/core/evidence/test_wiki_bridge.py`
+- PASS: `git diff --check`
+- PASS: `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
+- PASS: code commit hooks for `b738d4f5ef57d6a8caca29bf7ac8f5f5f4601efa`, including Black, Ruff, Bandit, backend changed tests, and policy hooks.
+- PASS: Experiment Runner oracle-only governance review accepted with pytest and `git diff --check` oracle commands returning 0.
+- PASS: Codex Security diff scan / finding discovery with no diff-scoped findings.
+- PASS: `pre-commit run --all-files`
+- STOPPED: full local `make verify` was started, passed `verify-env`, and entered
+  `mypy`; the operator then explicitly narrowed this PR lane to
+  `make validate-changed` because full verify runs the repository-scale test
+  budget. No full-verify green claim is made.
+
+## Merge Readiness
+
+Not claimed.
+
+Required before merge readiness:
+
+- Run `pre-commit run --all-files`.
+- Push current head and wait for current-head GitHub checks.
+- Confirm CodeRabbit, Sourcery, Cubic, Codex, and Codecov have no remaining
+  actionable blockers at current head.
+- Run strict review-thread disposition with auth.
+- Run strict merge-readiness with auth.
+- Observe the mandatory wait window after latest review or bot activity.
+
+## Deferred / Follow-ups
+
+None.

--- a/tests/core/evidence/test_wiki_bridge.py
+++ b/tests/core/evidence/test_wiki_bridge.py
@@ -110,6 +110,10 @@ def test_rejects_docs_output_paths_as_canonical_authority(field: str) -> None:
         {"user_health": {"weight": 123}},
         {"sec" + "ret": "redacted credential payload"},
         {"note": "prompt: raw body"},
+        {"api key": "redacted credential payload"},
+        {"api.key": "redacted credential payload"},
+        {"health payload": {"weight": 123}},
+        {"medical.record": "redacted medical detail"},
     ],
 )
 def test_rejects_raw_prompt_response_query_user_health_secret_metadata(
@@ -130,6 +134,9 @@ def test_rejects_raw_prompt_response_query_user_health_secret_metadata(
         {"runtime": 1},
         {"canonical": 1.0},
         {"source_of_truth": [0, 1]},
+        {"source of truth": "runtime"},
+        {"source.of.truth": "source of truth"},
+        {"product.truth": "authoritative"},
     ],
 )
 def test_rejects_runtime_or_canonical_authority_claims(metadata: dict[str, object]) -> None:
@@ -176,6 +183,20 @@ def test_advisory_only_flag_survives_asset_and_admission_adapter() -> None:
     assert asset.rail == "advisory"
     assert admission_input.metadata["advisory_only"] is True
     assert admission_input.metadata["serve_scope"] == "advisory_review_only"
+
+
+def test_admission_adapter_rejects_separator_variant_bridge_metadata() -> None:
+    artifact = _artifact()
+
+    with pytest.raises(ValueError):
+        wiki_artifact_to_admission_input(
+            artifact,
+            produced_at=_PRODUCED_AT,
+            coverage_rate=1.0,
+            verification_rate=1.0,
+            fallback_rate=0.0,
+            metadata={"api.key": "redacted credential payload"},
+        )
 
 
 def test_admission_adapter_targets_advisory_evidence_asset_identity() -> None:

--- a/tests/core/evidence/test_wiki_bridge.py
+++ b/tests/core/evidence/test_wiki_bridge.py
@@ -136,7 +136,16 @@ def test_rejects_raw_prompt_response_query_user_health_secret_metadata(
         {"source_of_truth": [0, 1]},
         {"source of truth": "runtime"},
         {"source.of.truth": "source of truth"},
+        {"source.of.truth": "source.of.truth"},
+        {"source_of_truth": "source.of.truth"},
+        {"source_of_truth": "source-of-truth"},
         {"product.truth": "authoritative"},
+        {"product.truth": "product.truth"},
+        {"authority.claims": "product.runtime"},
+        {"runtime.context": {"nested": "source.of.truth"}},
+        {"authority.claims": ["neutral", "user.facing"]},
+        {"authority.claims": {"candidate": "product.truth"}},
+        {"canonical": "user.facing"},
     ],
 )
 def test_rejects_runtime_or_canonical_authority_claims(metadata: dict[str, object]) -> None:
@@ -196,6 +205,29 @@ def test_admission_adapter_rejects_separator_variant_bridge_metadata() -> None:
             verification_rate=1.0,
             fallback_rate=0.0,
             metadata={"api.key": "redacted credential payload"},
+        )
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"source.of.truth": "source.of.truth"},
+        {"authority.claims": ["neutral", "user.facing"]},
+    ],
+)
+def test_admission_adapter_rejects_separator_variant_authority_values(
+    metadata: dict[str, object],
+) -> None:
+    artifact = _artifact()
+
+    with pytest.raises(ValueError):
+        wiki_artifact_to_admission_input(
+            artifact,
+            produced_at=_PRODUCED_AT,
+            coverage_rate=1.0,
+            verification_rate=1.0,
+            fallback_rate=0.0,
+            metadata=metadata,
         )
 
 


### PR DESCRIPTION
## Goal

Close PR #1917 by hardening advisory wiki metadata normalization so separator-variant authority keys and values are rejected before advisory evidence or admission mapping is created.

## Business reason

This protects PulsePlate's evidence-rail boundary: advisory wiki metadata must not claim product runtime, canonical source-of-truth, user-facing, or other authority semantics through dotted/dashed/spaced bypass strings.

## Scope

- Normalize metadata claim text for authority-bearing key/value comparisons in `core/evidence/wiki_bridge.py`.
- Normalize configured authority fragments before comparison.
- Add regression coverage in `tests/core/evidence/test_wiki_bridge.py` for dotted, dashed, nested, list-shaped, and public API/admission authority bypasses.
- Add canonical governance artifact `docs/review/PR_1917_FIXED_MAPPING.md`.

## Out Of Scope

- No runtime authority promotion.
- No DB, provider, cache, semantic-cache, wiki compiler, ingest, query, OpenAPI, frontend, or iOS changes.
- No medical, nutrition, or user-facing product behavior changes.

## Key decisions

- Kept the fix pure inside `core/evidence/`.
- Reused the same separator canonicalization policy for metadata keys, metadata values, and configured fragments.
- Mapped Codex/Cubic/Sourcery/Codecov/CodeRabbit dispositions in the repo artifact before any merge-readiness claim.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1917_FIXED_MAPPING.md`

## Experiment Runner Evidence

- Artifact: `artifacts/orchestration/experiments/results/exp-3cb504eeaa7b.json`
- Mode: `oracle_only_governance_reviewer`
- Result: `accepted`
- Contribution: `fixed_mapping_review`
- `mutated_paths=[]`
- `shared_tree_untouched=true`
- `promotion_ready=false`
- `coauthor_required=true`

## Tests

Local gates run:

- PASS: `python3 scripts/orchestration/check_preflight.py`
- PASS: `python3 scripts/orchestration/check_preflight.py --path core/evidence/wiki_bridge.py --path tests/core/evidence/test_wiki_bridge.py --path docs/review/PR_1917_FIXED_MAPPING.md`
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
- PASS: `python3 scripts/orchestration/task_bootstrap.py --goal "Close PR 1917 wiki metadata normalization hardening through merge-ready" --task-class security --path core/evidence/wiki_bridge.py --path tests/core/evidence/test_wiki_bridge.py --path docs/review/PR_1917_FIXED_MAPPING.md --requested-agent agent-coordinator --requested-agent security-auditor --requested-agent qa-engineer-agent --requested-agent bug-hunter --pr-phase post_open_review`
- PASS: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/e951467444d0.json --pretty`
- PASS: `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")"; "$VENV_PYTHON" -m pytest -q tests/core/evidence/test_wiki_bridge.py`
- PASS: `git diff --check`
- PASS: `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
- PASS: `pre-commit run --all-files`
- PASS: pre-push hooks: changed-files mypy, pip-audit, backend pre-push tests, full-repo Bandit, Docker build test
- PASS: Codex Security diff scan / finding discovery, no diff-scoped findings
- PASS: `pulseplate-pr-review` incremental dry-run, no deterministic findings

Full local `make verify` is intentionally not claimed. It was started, passed `verify-env`, entered `mypy`, then was stopped after operator instruction to use the narrow `make validate-changed` gate because full verify runs the repository-scale test budget.

## Security notes

- The fix closes the Codex/Cubic authority-value bypass class for separator variants such as `source.of.truth`, `source-of-truth`, `product.runtime`, and `user.facing`.
- No new IO, subprocess, provider, DB, cache, compiler, FastAPI, semantic-cache, or runtime authority path was added.
- Codex Security diff scan found no diff-scoped findings.

## Risks / rollback

Risk is low and localized to stricter metadata rejection in advisory wiki evidence bridging. Rollback is the two new commits on this PR branch if a compatibility issue appears: `b738d4f5e` and `97e4de999`.

## Deferred / follow-ups

None.

## Merge readiness

Not claimed yet. Required before merge:

- Current-head CI must settle for `97e4de999a22e670a51df78dea7b2194281e8c7f`.
- CodeRabbit, Sourcery, Cubic, Codex, and Codecov must be PASS / no-actionable at current head.
- Strict review-thread disposition and merge-readiness guards must pass with auth.
- Mandatory wait-window after latest bot/review activity must be observed.
