### PR TITLE
fix(ci): avoid persisting devcontainer checkout token

### DIFF
--- a/.github/workflows/devcontainer-smoke.yml
+++ b/.github/workflows/devcontainer-smoke.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Build devcontainer tooling image
         run: |

--- a/docs/review/PR_1920_FIXED_MAPPING.md
+++ b/docs/review/PR_1920_FIXED_MAPPING.md
@@ -120,9 +120,9 @@ Artifact: `artifacts/orchestration/experiments/results/exp-9d45f3c08260.json`
 
 ## Codex Security Evidence
 
-- Diff scan id: `pr1920_8aa641197_20260611T183710Z`.
-- Scope basis: verified PR triple-dot diff, not the unrelated newer-main
-  two-dot diff after `origin/main` advanced.
+- Diff scan id: `pr1920_ade1ea137_20260611T184329Z`.
+- Scope basis: verified PR triple-dot diff on the final merged head, not
+  unrelated current-main two-dot deltas.
 - Coverage: 3/3 PR diff rows reviewed with completion receipts:
   `.github/workflows/devcontainer-smoke.yml`,
   `tests/test_devcontainer_smoke_workflow.py`, and
@@ -134,7 +134,7 @@ Artifact: `artifacts/orchestration/experiments/results/exp-9d45f3c08260.json`
 ## PulsePlate PR Review Evidence
 
 - `pulseplate-pr-review` dry run completed locally.
-- Scope reviewed: 3 changed files, 179 additions, 0 deletions.
+- Scope reviewed: 3 changed files, 198 additions, 0 deletions.
 - Findings: no deterministic findings.
 - Warnings: none.
 - GitHub posting: not eligible by design; dry-run only.

--- a/docs/review/PR_1920_FIXED_MAPPING.md
+++ b/docs/review/PR_1920_FIXED_MAPPING.md
@@ -126,13 +126,18 @@ Artifact: `artifacts/orchestration/experiments/results/exp-9d45f3c08260.json`
 - `python3 scripts/orchestration/check_agent_consistency.py --json` PASS.
 - `make validate-changed` PASS: selected
   `tests/test_devcontainer_smoke_workflow.py`, `10 passed`.
+- `pre-commit run --all-files` PASS after merging `origin/main`.
+- Full local `make verify` is operator-deferred for this narrow CI/tooling PR;
+  an in-progress run was terminated on operator instruction and is not used as
+  readiness evidence. Current-head GitHub CI remains the heavy validation
+  signal for merge readiness.
 
 ## Merge Readiness
 
 Not claimed. Required before merge:
 
-- `pre-commit run --all-files`
-- `make verify`
+- Current-head GitHub CI parity after push because full local `make verify` is
+  operator-deferred for this machine-heavy CI/tooling lane.
 - Codex Security diff scan / finding discovery
 - `pulseplate-pr-review` post-open review
 - strict review-thread disposition guard with auth

--- a/docs/review/PR_1920_FIXED_MAPPING.md
+++ b/docs/review/PR_1920_FIXED_MAPPING.md
@@ -118,6 +118,27 @@ Artifact: `artifacts/orchestration/experiments/results/exp-9d45f3c08260.json`
 - The workflow text still contains no `secrets.`, package proxy, dependency
   bootstrap, `continue-on-error: true`, or `|| true`.
 
+## Codex Security Evidence
+
+- Diff scan id: `pr1920_8aa641197_20260611T183710Z`.
+- Scope basis: verified PR triple-dot diff, not the unrelated newer-main
+  two-dot diff after `origin/main` advanced.
+- Coverage: 3/3 PR diff rows reviewed with completion receipts:
+  `.github/workflows/devcontainer-smoke.yml`,
+  `tests/test_devcontainer_smoke_workflow.py`, and
+  `docs/review/PR_1920_FIXED_MAPPING.md`.
+- Result: no reportable security findings.
+- Report validation: Codex Security `validate_report_format.py --report-md`
+  PASS; HTML report rendered locally.
+
+## PulsePlate PR Review Evidence
+
+- `pulseplate-pr-review` dry run completed locally.
+- Scope reviewed: 3 changed files, 179 additions, 0 deletions.
+- Findings: no deterministic findings.
+- Warnings: none.
+- GitHub posting: not eligible by design; dry-run only.
+
 ## Local Validation
 
 - `python3 -m py_compile tests/test_devcontainer_smoke_workflow.py` PASS.
@@ -140,8 +161,6 @@ Not claimed. Required before merge:
 
 - Current-head GitHub CI parity after push because full local `make verify` is
   operator-deferred for this machine-heavy CI/tooling lane.
-- Codex Security diff scan / finding discovery
-- `pulseplate-pr-review` post-open review
 - strict review-thread disposition guard with auth
 - strict merge-readiness guard with auth
 - current-head CI pass after push

--- a/docs/review/PR_1920_FIXED_MAPPING.md
+++ b/docs/review/PR_1920_FIXED_MAPPING.md
@@ -121,8 +121,10 @@ Artifact: `artifacts/orchestration/experiments/results/exp-9d45f3c08260.json`
 ## Local Validation
 
 - `python3 -m py_compile tests/test_devcontainer_smoke_workflow.py` PASS.
-- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_devcontainer_smoke_workflow.py` PASS: `10 passed`.
-- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m black --check tests/test_devcontainer_smoke_workflow.py` PASS.
+- `$ROOT_VENV_PYTHON -m pytest -q tests/test_devcontainer_smoke_workflow.py` PASS: `10 passed`.
+- `$ROOT_VENV_PYTHON -m black --check tests/test_devcontainer_smoke_workflow.py` PASS.
+- `$ROOT_VENV_PYTHON` resolves to the repo root `.venv/bin/python` for this
+  isolated worktree.
 - `python3 scripts/orchestration/check_agent_consistency.py --json` PASS.
 - `make validate-changed` PASS: selected
   `tests/test_devcontainer_smoke_workflow.py`, `10 passed`.

--- a/docs/review/PR_1920_FIXED_MAPPING.md
+++ b/docs/review/PR_1920_FIXED_MAPPING.md
@@ -1,0 +1,141 @@
+# PR #1920 Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1920
+Branch: `codex/fix-pr-smoke-workflow-token-exposure`
+Title: `fix(ci): avoid persisting devcontainer checkout token`
+
+## Scope
+
+Harden the devcontainer smoke workflow checkout step so PR-controlled
+devcontainer build/smoke inputs cannot read persisted checkout credentials from
+the runner git config.
+
+In scope:
+
+- `.github/workflows/devcontainer-smoke.yml`
+- `tests/test_devcontainer_smoke_workflow.py`
+- `docs/review/PR_1920_FIXED_MAPPING.md`
+
+Out of scope:
+
+- unrelated CI workflow consolidation
+- devcontainer image/package changes
+- application runtime, frontend, iOS, nutrition, or release-surface changes
+- PR #1930 or other active lanes
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/eddf928d9b97.json`
+- Starter: direct post-open coordinator bootstrap in isolated PR #1920 worktree.
+- Preflight: `python3 scripts/orchestration/check_preflight.py --mode analyze --path .github/workflows/devcontainer-smoke.yml --path tests/test_devcontainer_smoke_workflow.py --path docs/review/PR_1920_FIXED_MAPPING.md` PASS.
+- Agent consistency: `python3 scripts/orchestration/check_agent_consistency.py` PASS.
+- Role dispatch bridge: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/eddf928d9b97.json --pretty --pr-phase post_open_review` PASS.
+- Declared role order completed:
+  `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor -> cursor-specialist-agent -> web-research-agent`.
+
+## Implementation Commits
+
+- `a9c3c97a66d93257fc2fc36d0058ee74c1f428af` - `fix(ci): avoid persisting devcontainer checkout token`
+- `35e605ca9578936bbed6324ce6d6d70753fa307b` - `test(ci): harden devcontainer checkout guard`
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- GitHub GraphQL review-thread check reported `totalCount: 0`.
+- Sourcery aggregate review feedback is fixed below.
+- CodeRabbit walkthrough/pre-merge comment, Sourcery reviewer guide comment,
+  Cubic review, and Codecov coverage comment are non-actionable and
+  dispositioned below.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1920#pullrequestreview-4458544061 -> 35e605ca9578936bbed6324ce6d6d70753fa307b
+Disposition: FIXED
+Commit: 35e605ca9578936bbed6324ce6d6d70753fa307b
+Evidence: `tests/test_devcontainer_smoke_workflow.py` now parses workflow YAML with explicit mapping/job/steps assertions, requires at least one `actions/checkout@*` step, and verifies every checkout step sets `with.persist-credentials` to `false`; focused pytest passes with `10 passed`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1920#issuecomment-4659741542
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit's walkthrough/pre-merge comment reports passed pre-merge checks and contains finishing-touch options only; no required code or governance change is requested.
+Reason: Informational bot summary, not an actionable review finding.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1920#issuecomment-4659741647
+Disposition: NOT-A-BUG
+Evidence: Sourcery's reviewer-guide issue comment summarizes the PR diff and reviewer workflow; the actionable Sourcery review is mapped separately to `35e605ca9578936bbed6324ce6d6d70753fa307b`.
+Reason: Informational reviewer guide, not a distinct actionable finding.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1920#pullrequestreview-4458554784
+Disposition: NOT-A-BUG
+Evidence: Cubic review states "No issues found" across the two changed files.
+Reason: No Cubic-requested code, test, or documentation change exists to fix.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1920#issuecomment-4659928178
+Disposition: NOT-A-BUG
+Evidence: Codecov reports all modified and coverable lines are covered by tests.
+Reason: Coverage status comment only; no actionable finding.
+
+## Role-Agent Evidence
+
+- `agent-coordinator`: PASS. Scope locked to the workflow, workflow contract
+  test, and mapping artifact; Sourcery review should be FIXED after the test
+  contract change.
+- `qa-engineer-agent`: PASS after fix plan. Required behavior is explicit
+  workflow-structure assertions, at least one checkout step, and every checkout
+  step setting `persist-credentials: false`.
+- `bug-hunter`: FIXED. Black formatting and brittle exact-one-checkout contract
+  were addressed by `35e605ca9578936bbed6324ce6d6d70753fa307b`.
+- `security-auditor`: PASS for credential handling. Workflow uses
+  `permissions.contents: read`, pinned `actions/checkout`, and
+  `persist-credentials: false`; no additional security code edit required.
+- `cursor-specialist-agent`: FIXED by completing order 6, adding this canonical
+  mapping artifact, and recording post-open governance evidence.
+- `web-research-agent`: NOT-A-BUG. External research is not required because the
+  PR sets an explicit workflow input on an already pinned action and repo-local
+  tests enforce the exact credential-handling declaration.
+
+## Experiment Runner Evidence
+
+Artifact: `artifacts/orchestration/experiments/results/exp-9d45f3c08260.json`
+
+- Packet: `artifacts/orchestration/experiments/exp-9d45f3c08260.json`
+- Status: accepted.
+- Runner mode: `oracle_only_governance_reviewer`.
+- Contribution kind: `none`.
+- Co-author required: false.
+- Shared tree untouched: true.
+- Oracle results:
+  - `python -m py_compile tests/test_devcontainer_smoke_workflow.py` PASS.
+  - `python -m pytest -q tests/test_devcontainer_smoke_workflow.py` PASS.
+
+## Security Notes
+
+- `.github/workflows/devcontainer-smoke.yml` keeps `permissions: contents: read`.
+- The checkout step remains pinned to
+  `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd`.
+- `with.persist-credentials: false` prevents the checkout token from being
+  written into local git config before the devcontainer build and smoke run.
+- The workflow text still contains no `secrets.`, package proxy, dependency
+  bootstrap, `continue-on-error: true`, or `|| true`.
+
+## Local Validation
+
+- `python3 -m py_compile tests/test_devcontainer_smoke_workflow.py` PASS.
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_devcontainer_smoke_workflow.py` PASS: `10 passed`.
+- `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m black --check tests/test_devcontainer_smoke_workflow.py` PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py --json` PASS.
+- `make validate-changed` PASS: selected
+  `tests/test_devcontainer_smoke_workflow.py`, `10 passed`.
+
+## Merge Readiness
+
+Not claimed. Required before merge:
+
+- `pre-commit run --all-files`
+- `make verify`
+- Codex Security diff scan / finding discovery
+- `pulseplate-pr-review` post-open review
+- strict review-thread disposition guard with auth
+- strict merge-readiness guard with auth
+- current-head CI pass after push
+- mandatory wait-window after the latest bot/review activity

--- a/tests/test_devcontainer_smoke_workflow.py
+++ b/tests/test_devcontainer_smoke_workflow.py
@@ -70,6 +70,20 @@ def test_devcontainer_smoke_workflow_does_not_use_secrets_or_bootstrap() -> None
         assert token not in text, f"Workflow must not contain '{token}'"
 
 
+def test_devcontainer_smoke_workflow_does_not_persist_checkout_credentials() -> None:
+    """PR-controlled smoke inputs must not receive persisted checkout credentials."""
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = data["jobs"]["devcontainer-smoke"]["steps"]
+    checkout_steps = [
+        step
+        for step in steps
+        if str(step.get("uses", "")).startswith("actions/checkout@")
+    ]
+
+    assert len(checkout_steps) == 1, "Workflow must use exactly one checkout step"
+    assert checkout_steps[0].get("with", {}).get("persist-credentials") is False
+
+
 # ---------------------------------------------------------------------------
 # Docker: builds devcontainer Dockerfile, not production
 # ---------------------------------------------------------------------------

--- a/tests/test_devcontainer_smoke_workflow.py
+++ b/tests/test_devcontainer_smoke_workflow.py
@@ -73,15 +73,30 @@ def test_devcontainer_smoke_workflow_does_not_use_secrets_or_bootstrap() -> None
 def test_devcontainer_smoke_workflow_does_not_persist_checkout_credentials() -> None:
     """PR-controlled smoke inputs must not receive persisted checkout credentials."""
     data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
-    steps = data["jobs"]["devcontainer-smoke"]["steps"]
-    checkout_steps = [
-        step
-        for step in steps
-        if str(step.get("uses", "")).startswith("actions/checkout@")
-    ]
+    assert isinstance(data, dict), "Workflow YAML must parse to a mapping"
 
-    assert len(checkout_steps) == 1, "Workflow must use exactly one checkout step"
-    assert checkout_steps[0].get("with", {}).get("persist-credentials") is False
+    jobs = data.get("jobs")
+    assert isinstance(jobs, dict), "Workflow must define jobs"
+
+    checkout_steps = []
+    for job_name, job in jobs.items():
+        assert isinstance(job, dict), f"Workflow job '{job_name}' must be a mapping"
+        steps = job.get("steps")
+        assert isinstance(steps, list), f"Workflow job '{job_name}' must define steps"
+
+        checkout_steps.extend(
+            step
+            for step in steps
+            if isinstance(step, dict) and str(step.get("uses", "")).startswith("actions/checkout@")
+        )
+
+    assert checkout_steps, "Workflow must include at least one checkout step"
+    for step in checkout_steps:
+        checkout_with = step.get("with")
+        assert isinstance(checkout_with, dict), "Every checkout step must define a with mapping"
+        assert (
+            checkout_with.get("persist-credentials") is False
+        ), "Every checkout step must set with.persist-credentials to false"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Goal
Harden the devcontainer smoke workflow so PR-controlled devcontainer build and smoke inputs cannot read persisted `actions/checkout` credentials from runner git config.

## Business Reason
This keeps a developer-tooling CI lane low-risk while preserving the lightweight devcontainer smoke signal.

## Scope
- `.github/workflows/devcontainer-smoke.yml`: set `with.persist-credentials: false` on the pinned checkout step.
- `tests/test_devcontainer_smoke_workflow.py`: enforce explicit workflow structure, require at least one checkout step, and require every checkout step to disable credential persistence.
- `docs/review/PR_1920_FIXED_MAPPING.md`: canonical review disposition artifact.

## Out Of Scope
- PR #1930 and other active lanes.
- CI workflow consolidation beyond this devcontainer smoke credential fix.
- Runtime, frontend, iOS, nutrition, App Store, Slack, Sentry, Drive, or data-analytics changes.

## Key Decisions
- Keep the workflow on `pull_request` with `permissions: contents: read`.
- Keep `actions/checkout` pinned to the existing full SHA.
- Test the security invariant across all checkout steps instead of assuming exactly one checkout step.

## Lane Start Provenance
- Packet: `artifacts/orchestration/task_packets/eddf928d9b97.json`
- Preflight: `python3 scripts/orchestration/check_preflight.py --mode analyze --path .github/workflows/devcontainer-smoke.yml --path tests/test_devcontainer_smoke_workflow.py --path docs/review/PR_1920_FIXED_MAPPING.md` PASS.
- Agent consistency: `python3 scripts/orchestration/check_agent_consistency.py` PASS.
- Role dispatch bridge: PASS; declared order completed: `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor -> cursor-specialist-agent -> web-research-agent`.

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/exp-9d45f3c08260.json`

- Status: accepted.
- Runner mode: `oracle_only_governance_reviewer`.
- Contribution kind: `none`.
- Co-author required: false.
- Shared tree untouched: true.
- Oracles passed: `python -m py_compile tests/test_devcontainer_smoke_workflow.py`; `python -m pytest -q tests/test_devcontainer_smoke_workflow.py`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- GitHub GraphQL review-thread check reported `totalCount: 0`.

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1920_FIXED_MAPPING.md`

## Codex Security Evidence
- Diff scan id: `pr1920_ade1ea137_20260611T184329Z`.
- Scope basis: verified PR triple-dot diff on the final merged head; unrelated current-main two-dot deltas were excluded.
- Coverage: 3/3 PR diff rows reviewed with completion receipts.
- Result: no reportable security findings.
- Report validation: Codex Security report-format validator passed and HTML report rendered locally.

## PulsePlate PR Review Evidence
- `pulseplate-pr-review` dry run completed locally.
- Scope reviewed: 3 changed files, 198 additions, 0 deletions.
- Findings: no deterministic findings.
- Warnings: none.
- GitHub posting: not eligible by design; dry-run only.

## Validation
- `python3 -m py_compile tests/test_devcontainer_smoke_workflow.py` - PASS.
- `$ROOT_VENV_PYTHON -m pytest -q tests/test_devcontainer_smoke_workflow.py` - PASS: `10 passed`.
- `$ROOT_VENV_PYTHON -m black --check tests/test_devcontainer_smoke_workflow.py` - PASS.
- `$ROOT_VENV_PYTHON` resolves to the repo root `.venv/bin/python` for this isolated worktree.
- `python3 scripts/orchestration/check_agent_consistency.py --json` - PASS.
- `make validate-changed` - PASS: selected `tests/test_devcontainer_smoke_workflow.py`, `10 passed`.
- `pre-commit run --all-files` - PASS after merging `origin/main`.
- Full local `make verify` - operator-deferred for this narrow CI/tooling PR. An in-progress run was terminated on operator instruction and is not used as readiness evidence; current-head GitHub CI is the heavy validation signal.

## Security Notes
- The workflow keeps least-privilege `permissions: contents: read`.
- The checkout step remains pinned to `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd`.
- `with.persist-credentials: false` prevents the checkout token from being written into local git config before the devcontainer build/smoke path.
- The workflow guard still rejects `secrets.`, package proxy use, dependency bootstrap, `continue-on-error: true`, and `|| true`.

## Risks / Rollback
- Risk: future workflow refactors could add checkout steps without the credential setting. Mitigation: the test now scans every checkout step in every workflow job.
- Rollback: revert this PR to restore the previous checkout behavior and remove the guard test.

## Deferred / Follow-ups
- None for this PR scope.

## Merge Readiness
Not claimed yet. Remaining before merge: strict disposition and merge-readiness gates with auth, current-head CI after push as heavy signal because full local `make verify` is operator-deferred, and the required wait-window after latest bot/review activity.

