### PR TITLE
fix(security): harden MCP example defaults

### DIFF
--- a/.cursor/mcp.json.example
+++ b/.cursor/mcp.json.example
@@ -2,15 +2,25 @@
   "mcpServers": {
     "github": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github@latest"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github@2025.4.8"
+      ]
     },
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest", "--allow-unrestricted-file-access"]
+      "args": [
+        "-y",
+        "@playwright/mcp@0.0.75"
+      ],
+      "comment": "Default denies local filesystem access. Do not add --allow-unrestricted-file-access unless a scoped, reviewed local-only task explicitly requires it."
     },
     "context7": {
       "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp@latest"]
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@3.1.0"
+      ]
     },
     "figma": {
       "comment": "Cursor/Cloud: use hosted endpoint https://mcp.figma.com/mcp. Kimi CLI local: use http://127.0.0.1:3845/mcp with Figma Desktop plugin.",

--- a/.kimi/mcp.json.example
+++ b/.kimi/mcp.json.example
@@ -4,22 +4,22 @@
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-github@latest"
+        "@modelcontextprotocol/server-github@2025.4.8"
       ]
     },
     "playwright": {
       "command": "npx",
       "args": [
         "-y",
-        "@playwright/mcp@latest",
-        "--allow-unrestricted-file-access"
-      ]
+        "@playwright/mcp@0.0.75"
+      ],
+      "comment": "Default denies local filesystem access. Do not add --allow-unrestricted-file-access unless a scoped, reviewed local-only task explicitly requires it."
     },
     "context7": {
       "command": "npx",
       "args": [
         "-y",
-        "@upstash/context7-mcp@latest"
+        "@upstash/context7-mcp@3.1.0"
       ]
     },
     "figma": {

--- a/tests/guards/test_mcp_examples_safe_defaults.py
+++ b/tests/guards/test_mcp_examples_safe_defaults.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+
+MCP_EXAMPLES = (
+    Path(".cursor/mcp.json.example"),
+    Path(".kimi/mcp.json.example"),
+)
+
+
+def test_mcp_examples_do_not_enable_unrestricted_playwright_file_access() -> None:
+    for path in MCP_EXAMPLES:
+        data = json.loads(path.read_text())
+        playwright_args = data["mcpServers"]["playwright"]["args"]
+
+        assert "--allow-unrestricted-file-access" not in playwright_args, path
+
+
+def test_mcp_examples_pin_npx_mcp_packages() -> None:
+    for path in MCP_EXAMPLES:
+        data = json.loads(path.read_text())
+        for server_name, server_config in data["mcpServers"].items():
+            if server_config.get("command") != "npx":
+                continue
+
+            args = server_config["args"]
+            package_args = [
+                arg for arg in args if isinstance(arg, str) and arg.startswith("@")
+            ]
+            assert package_args, f"{path}:{server_name} has no scoped package arg"
+            assert all(not arg.endswith("@latest") for arg in package_args), (
+                f"{path}:{server_name} uses an unpinned @latest package"
+            )
+            assert all(arg.count("@") >= 2 for arg in package_args), (
+                f"{path}:{server_name} package is not version-pinned"
+            )


### PR DESCRIPTION
### Motivation
- Prevent accidental local-secret exposure by example MCP configs that enabled Playwright with unrestricted filesystem access.
- Reduce supply-chain risk by avoiding unpinned `@latest` package specs in example tooling commands.
- Provide a small automated guard so future changes don't reintroduce the unsafe defaults.

### Description
- Updated `.cursor/mcp.json.example` to remove `--allow-unrestricted-file-access`, pin MCP packages to explicit versions, and add a comment that local FS access is denied by default and must be a reviewed opt-in. 
- Added the same hardening to `.kimi/mcp.json.example` (remove unrestricted flag, pin package versions, add opt-in comment).
- Added `tests/guards/test_mcp_examples_safe_defaults.py` which asserts that the Playwright server args do not include `--allow-unrestricted-file-access` and that `npx` package specs are version-pinned (no `@latest`).
- Committed the changes on the current branch (`0877646 fix(security): harden MCP example defaults`).

### Testing
- `python3 scripts/orchestration/check_preflight.py` — PASSED.
- `python3 -m json.tool .cursor/mcp.json.example` and `python3 -m json.tool .kimi/mcp.json.example` (syntax validation) — PASSED.
- `python3 -m py_compile tests/guards/test_mcp_examples_safe_defaults.py` — PASSED (test file compiles).
- `PYENV_VERSION=3.13.13 python -m pytest -q tests/guards/test_mcp_examples_safe_defaults.py` — FAILED in this environment due to missing repository test dependencies (`ModuleNotFoundError: No module named 'fastapi'` from `conftest.py`).
- `pre-commit run --all-files` — NOT RUN / environment missing `pre-commit` binary (failed in this container).
- `make validate-changed` — NOT RUN / failed locally because no repo `.venv` is present for local hook execution.
- `make verify` — NOT RUN / failed at `verify-env` because `.venv` is missing in this environment.

No merge/readiness claim is made; local full-verify and pre-commit checks must be run in a properly provisioned dev environment (see `Makefile` and `RUNBOOK_AGENT.md`) before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27f7fbdd24832c9fbbda457094ebbe)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened MCP example configs to block unrestricted local file access and pin `npx` packages to exact versions, reducing secret exposure and supply‑chain risk. Added tests to prevent these unsafe defaults from coming back.

- **Bug Fixes**
  - Removed `--allow-unrestricted-file-access` from `.cursor/mcp.json.example` and `.kimi/mcp.json.example`, with a note that local FS access is opt-in.
  - Pinned example servers: `@modelcontextprotocol/server-github@2025.4.8`, `@playwright/mcp@0.0.75`, `@upstash/context7-mcp@3.1.0`.
  - Added `tests/guards/test_mcp_examples_safe_defaults.py` to ensure no unrestricted access and no `@latest` in `npx` args.

<sup>Written for commit d6a913f010c13913acd3a1d5136f84d4a02a6125. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

