### PR TITLE
fix(evidence): ignore non-object snapshot JSON

### DIFF
--- a/docs/review/PR_1925_FIXED_MAPPING.md
+++ b/docs/review/PR_1925_FIXED_MAPPING.md
@@ -23,6 +23,11 @@ Disposition: NOT-A-BUG
 Evidence: scripts/orchestration/mvp_evidence_snapshot.py:310; `read_latest_snapshot_line(...) -> MvpEvidenceSnapshotLine | None`; `python3 -m py_compile scripts/orchestration/mvp_evidence_snapshot.py scripts/orchestration/experiment_slack_bridge_rendering.py tests/test_mvp_evidence_snapshot.py` PASS via Experiment Runner artifact `artifacts/orchestration/experiments/results/exp-764916d504b7.json`.
 Reason: Sourcery asked to align the return type with a new `None` path, but the reader already returned `MvpEvidenceSnapshotLine | None` before this PR and callers already handle `None` as the corrupt/absent snapshot fallback.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1925#pullrequestreview-4458565471
+Disposition: NOT-A-BUG
+Evidence: scripts/orchestration/mvp_evidence_snapshot.py:310; `read_latest_snapshot_line(...) -> MvpEvidenceSnapshotLine | None`; `.venv/bin/python -m mypy scripts/orchestration/mvp_evidence_snapshot.py scripts/orchestration/experiment_slack_bridge_rendering.py` PASS.
+Reason: The Sourcery review-level bot finding duplicates the resolved review-thread concern. The current reader signature already includes `None`, so no return-type code change is required.
+
 ## Lane Start Provenance
 - Packet: `artifacts/orchestration/task_packets/ba8ef9ab93b5.json`
 - Starter: `scripts/orchestration/start_pr_lane.sh`

--- a/docs/review/PR_1925_FIXED_MAPPING.md
+++ b/docs/review/PR_1925_FIXED_MAPPING.md
@@ -33,6 +33,8 @@ Reason: The Sourcery review-level bot finding duplicates the resolved review-thr
 - Starter: `scripts/orchestration/start_pr_lane.sh`
 - Dispatch manifest: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/ba8ef9ab93b5.json --mode review --pr-phase post_open_review --pretty`.
 - Required role order executed: `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor -> cursor-specialist-agent -> architecture-specialist`.
+- Safety waiver packet: `artifacts/orchestration/task_packets/54c88592fdc7.json`.
+- Safety waiver dispatch manifest: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/54c88592fdc7.json --mode review --pr-phase post_open_review --pretty`.
 
 ## Post-Open Role Finding Closure
 - `agent-coordinator`: FIXED / planned by commit `9c2f23c8e`.
@@ -69,11 +71,14 @@ Evidence: production snapshot reader contract remains `MvpEvidenceSnapshotLine |
 - `.venv/bin/python -m mypy scripts/orchestration/mvp_evidence_snapshot.py scripts/orchestration/experiment_slack_bridge_rendering.py` PASS.
 - `make validate-changed` PASS.
 - `pre-commit run --all-files` PASS.
+- Safety policy local check PASS for optional vector manifests:
+  - `python -m safety check --policy-file safety-policy.yaml --json -r requirements-rag-vector.txt --save-json /tmp/pr1925-safety/vector.json` exits `0`, `vulns=0`, `ignored=1`, ignored ID `SFTY-20250331-30014`.
+  - `python -m safety check --policy-file safety-policy.yaml --json -r requirements-rag-vector-cpu.txt --save-json /tmp/pr1925-safety/cpu.json` exits `0`, `vulns=0`, `ignored=1`, ignored ID `SFTY-20250331-30014`.
 - `git diff --check` PASS before commit `9c2f23c8e`.
 
 ## Known Non-Ready Gate
 - Operator explicitly deferred full local `make verify` for this closeout pass; use the PR-scoped narrow bundle plus current-head CI/strict governance checks as the local evidence path.
 - Diagnostic full `make verify` attempt was stopped at repo-wide `make typecheck` failures outside this PR diff:
   `core/ai/semantic_cache_offline_admission_runner.py:294`, `:480`, `:545-550`, `:676`, `:681`, `:683-684`, and `core/ai/semantic_cache_shadow_admission_harness.py:495`.
-- CodeRabbit status check reported success but the PR comment says review was skipped because the review limit/credits were unavailable. Treat this as an external-review caveat until CodeRabbit provides a current-head no-actionables signal or an explicit coordinator/operator exception is recorded.
+- CodeRabbit current-head status check reports `pass` / `Review completed`.
 - Merge readiness is not claimed until current-head CI, strict merge wrapper with auth, review-thread disposition, bot no-actionables, and the mandatory wait-window pass.

--- a/docs/review/PR_1925_FIXED_MAPPING.md
+++ b/docs/review/PR_1925_FIXED_MAPPING.md
@@ -1,0 +1,74 @@
+# PR 1925 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] Post-open review-thread pass completed.
+
+## Fixed in Commit Mapping
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1925#discussion_r3380616198 -> 9c2f23c8e
+Disposition: FIXED
+Commit: 9c2f23c8e
+Evidence: tests/test_mvp_evidence_snapshot.py::test_non_object_snapshot_returns_none_and_render_falls_back; `.venv/bin/python -m pytest -q tests/test_mvp_evidence_snapshot.py::test_non_object_snapshot_returns_none_and_render_falls_back` PASS.
+Reason: Codex found that the regression expected `static_contract` even though the Slack evidence renderer's existing fallback status is `advisory_operator_summary`; commit `9c2f23c8e` updates the assertion and covers multiple non-object JSON roots.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1925#discussion_r3380641687 -> 9c2f23c8e
+Disposition: FIXED
+Commit: 9c2f23c8e
+Evidence: tests/test_mvp_evidence_snapshot.py::test_non_object_snapshot_returns_none_and_render_falls_back; `.venv/bin/python -m pytest -q tests/test_mvp_evidence_snapshot.py::test_non_object_snapshot_returns_none_and_render_falls_back` PASS.
+Reason: Cubic found the same fallback status mismatch; commit `9c2f23c8e` now asserts `advisory_operator_summary`, verifies the fallback message type, and checks safe static evidence fields.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1925#discussion_r3380620434
+Disposition: NOT-A-BUG
+Evidence: scripts/orchestration/mvp_evidence_snapshot.py:310; `read_latest_snapshot_line(...) -> MvpEvidenceSnapshotLine | None`; `python3 -m py_compile scripts/orchestration/mvp_evidence_snapshot.py scripts/orchestration/experiment_slack_bridge_rendering.py tests/test_mvp_evidence_snapshot.py` PASS via Experiment Runner artifact `artifacts/orchestration/experiments/results/exp-764916d504b7.json`.
+Reason: Sourcery asked to align the return type with a new `None` path, but the reader already returned `MvpEvidenceSnapshotLine | None` before this PR and callers already handle `None` as the corrupt/absent snapshot fallback.
+
+## Lane Start Provenance
+- Packet: `artifacts/orchestration/task_packets/ba8ef9ab93b5.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+- Dispatch manifest: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/ba8ef9ab93b5.json --mode review --pr-phase post_open_review --pretty`.
+- Required role order executed: `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor -> cursor-specialist-agent -> architecture-specialist`.
+
+## Post-Open Role Finding Closure
+- `agent-coordinator`: FIXED / planned by commit `9c2f23c8e`.
+Evidence: scope locked to snapshot reader/test behavior and review-governance artifact only.
+- `qa-engineer-agent`: FIXED by commit `9c2f23c8e`.
+Evidence: parametrized non-object JSON payloads and fallback evidence assertions in `tests/test_mvp_evidence_snapshot.py`.
+- `bug-hunter`: FIXED by commit `9c2f23c8e`.
+Evidence: fallback status assertion now matches the existing renderer contract; mapping artifact added in this closeout commit.
+- `security-auditor`: NOT-A-BUG for production security; governance blockers addressed by this artifact.
+Evidence: the `dict` guard fails closed before `.get()` access; existing symlink/path traversal guards remain in the reader.
+- `cursor-specialist-agent`: FIXED by sequencing.
+Evidence: test fix commit was created before FIXED mapping entries, preserving commit-after-comment proof.
+- `architecture-specialist`: NOT-A-BUG for architecture boundaries.
+Evidence: production snapshot reader contract remains `MvpEvidenceSnapshotLine | None`; no renderer status rename or new runtime authority was introduced.
+
+## Experiment Runner Evidence
+- Packet: `artifacts/orchestration/experiments/exp-764916d504b7.json`.
+- Artifact: `artifacts/orchestration/experiments/results/exp-764916d504b7.json`
+- Mode: `oracle_only_governance_reviewer`.
+- Status: `accepted`.
+- Shared tree untouched: `true`.
+- Mutated paths: `[]`.
+- Contribution kind: `review_disposition`.
+- Co-author trailer required: `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+- Oracle commands PASS:
+  - `python3 -m py_compile scripts/orchestration/mvp_evidence_snapshot.py scripts/orchestration/experiment_slack_bridge_rendering.py tests/test_mvp_evidence_snapshot.py`
+  - `python3 scripts/orchestration/check_agent_consistency.py`
+
+## Validation Evidence
+- `python3 scripts/orchestration/check_preflight.py` PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS.
+- `.venv/bin/python -m pytest -q tests/test_mvp_evidence_snapshot.py::test_non_object_snapshot_returns_none_and_render_falls_back` PASS (`5 passed`).
+- `.venv/bin/python -m pytest -q tests/test_mvp_evidence_snapshot.py` PASS (`35 passed`).
+- `.venv/bin/python -m mypy scripts/orchestration/mvp_evidence_snapshot.py scripts/orchestration/experiment_slack_bridge_rendering.py` PASS.
+- `make validate-changed` PASS.
+- `pre-commit run --all-files` PASS.
+- `git diff --check` PASS before commit `9c2f23c8e`.
+
+## Known Non-Ready Gate
+- Operator explicitly deferred full local `make verify` for this closeout pass; use the PR-scoped narrow bundle plus current-head CI/strict governance checks as the local evidence path.
+- Diagnostic full `make verify` attempt was stopped at repo-wide `make typecheck` failures outside this PR diff:
+  `core/ai/semantic_cache_offline_admission_runner.py:294`, `:480`, `:545-550`, `:676`, `:681`, `:683-684`, and `core/ai/semantic_cache_shadow_admission_harness.py:495`.
+- CodeRabbit status check reported success but the PR comment says review was skipped because the review limit/credits were unavailable. Treat this as an external-review caveat until CodeRabbit provides a current-head no-actionables signal or an explicit coordinator/operator exception is recorded.
+- Merge readiness is not claimed until current-head CI, strict merge wrapper with auth, review-thread disposition, bot no-actionables, and the mandatory wait-window pass.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -662,6 +662,35 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Locked install + Docker production target succeed against the private index; `make verify` green
     - Advisory updated (remove-by closed or docs-only follow-up per backlog policy)
 
+<a id="ledger-p1-pytorch-jit-cve-2025-3000-vector-profile"></a>
+- [ ] P1: Retire PyTorch TorchScript CVE-2025-3000 Safety waiver for optional vector profile
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (supply-chain / optional RAG-vector profile)
+  - Target PR: TBD (land by 2026-07-11 or earlier if fixed torch builds are available)
+  - Area: security / CI / dependencies / RAG-vector
+  - Reason (EN): PR #1925 current-head CI started failing Safety on
+    `SFTY-20250331-30014` / `CVE-2025-3000` for `torch==2.11.0` and
+    `torch==2.11.0+cpu` in optional RAG/vector manifests. Safety 3.8.1 reports
+    no fixed version for the advisory, while default production and Docker
+    runtime manifests pass Safety without torch. The waiver is scoped to the
+    optional vector profile and must be retired when a fixed build, upstream
+    advisory correction, or vector-profile replacement is available.
+  - Links:
+    - `docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md:1`
+    - `safety-policy.yaml:18`
+    - `requirements-rag-vector.txt:162`
+    - `requirements-rag-vector-cpu.txt:119`
+  - DoD:
+    - Re-check Safety, OSV, GitHub Advisory Database, and PyTorch upstream for
+      fixed-version truth before changing pins.
+    - If fixed torch builds exist and the approved index serves them, bump
+      `requirements-rag-vector.txt` and `requirements-rag-vector-cpu.txt`.
+    - If no fixed build exists, replace or disable the TorchScript-dependent
+      optional vector capability, or extend the waiver with fresh evidence and a
+      new remove-by date.
+    - Remove `SFTY-20250331-30014` from `safety-policy.yaml` and close this
+      ledger item in the same PR.
+
 <a id="ledger-p1-cryptography-private-index-sync"></a>
 - [ ] P1: Retire active emergency wheel manifest entries after approved mirror sync
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md
+++ b/docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md
@@ -1,0 +1,56 @@
+# PyTorch `torch.jit.script` CVE-2025-3000 advisory
+
+## Summary
+
+Safety 3.8.1 flags `torch` in the optional RAG/vector manifests for
+`SFTY-20250331-30014` / `CVE-2025-3000`. The advisory concerns
+`torch.jit.script` memory corruption. PulsePlate keeps `torch` out of the
+default production and Docker runtime manifests; the finding is limited to the
+optional vector profile.
+
+## Governance
+
+- **Owner:** @katsiaryna_kavaleuskaya
+- **Remove-by:** 2026-07-11
+- **Backlog:** `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-pytorch-jit-cve-2025-3000-vector-profile`
+- **Safety policy:** `safety-policy.yaml`
+
+## Current Repo State
+
+- `requirements.txt`: Safety PASS in PR #1925 current-head CI.
+- `requirements-docker-runtime.txt`: Safety PASS in PR #1925 current-head CI.
+- `requirements-rag-vector.txt`: Safety flags `torch==2.11.0`.
+- `requirements-rag-vector-cpu.txt`: Safety flags `torch==2.11.0+cpu`.
+- Safety 3.8.1 reports no fixed version for this advisory in the PR #1925 CI log.
+
+## Evidence Anchors
+
+- `requirements-rag-vector.txt:162`
+- `requirements-rag-vector-cpu.txt:119`
+- `safety-policy.yaml:23`
+- `docs/roadmap/BACKLOG_LEDGER.md:665`
+
+## Exposure Assessment
+
+The vulnerable surface is tied to PyTorch TorchScript (`torch.jit.script`) in an
+optional vector/RAG dependency profile. It is not installed by the default
+production or Docker runtime manifests. Reassess immediately if product runtime
+starts loading the vector profile by default, accepts untrusted TorchScript
+artifacts, or routes user-controlled data into TorchScript compilation.
+
+## Remediation
+
+1. Prefer a fixed `torch` release when Safety, OSV, GitHub Advisory Database, or
+   PyTorch upstream publishes one that satisfies the private package index.
+2. If no fixed release exists by the remove-by date, decide between extending
+   this waiver with fresh evidence, replacing the vector backend, or removing
+   TorchScript-dependent capability from the optional profile.
+3. Remove `SFTY-20250331-30014` from `safety-policy.yaml` in the same PR that
+   closes the backlog item.
+
+## References
+
+- CVE: `https://www.cve.org/CVERecord?id=CVE-2025-3000`
+- NVD: `https://nvd.nist.gov/vuln/detail/CVE-2025-3000`
+- GitHub Advisory Database: `https://github.com/advisories/GHSA-rrmf-rvhw-rf47`
+- Safety entry: `https://getsafety.com/v/SFTY-20250331-30014/97c`

--- a/safety-policy.yaml
+++ b/safety-policy.yaml
@@ -6,6 +6,12 @@
 # currently exposes only fonttools 4.61.1 while public PyPI has >=4.62.0.
 # Remove this ignore when requirements pin fonttools>=4.62.0 and the mirror syncs.
 # Advisory: docs/security/FONTTOOLS_TTX_EVAL_ADVISORY.md
+#
+# SFTY-20250331-30014 / CVE-2025-3000 (PyTorch torch.jit.script memory
+# corruption): optional RAG/vector manifests pin torch while Safety reports no
+# fixed version. Remove by 2026-07-11 or earlier when a fixed torch build,
+# upstream correction, or vector-profile replacement is available.
+# Advisory: docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md
 
 security:
   ignore-vulnerabilities:
@@ -14,3 +20,13 @@ security:
         Private PULSEPLATE_PYTHON_INDEX_URL mirrors fonttools 4.61.1 only (pip:
         "from versions: 4.61.1"). Bump pin to >=4.62.0 when the index publishes
         it; then drop this ignore. See docs/security/FONTTOOLS_TTX_EVAL_ADVISORY.md.
+    "SFTY-20250331-30014":
+      reason: >-
+        CVE-2025-3000 is reported against torch.jit.script in the optional
+        RAG/vector dependency manifests only. Safety 3.8.1 reports no fixed
+        torch version for this advisory as of 2026-06-11, while production and
+        Docker runtime manifests pass Safety without torch. Remove by
+        2026-07-11 or earlier when a fixed torch build, upstream advisory
+        correction, or vector-profile replacement is available. See
+        docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md and
+        docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-pytorch-jit-cve-2025-3000-vector-profile.

--- a/scripts/orchestration/mvp_evidence_snapshot.py
+++ b/scripts/orchestration/mvp_evidence_snapshot.py
@@ -348,6 +348,8 @@ def read_latest_snapshot_line(
     try:
         with open(latest, "r", encoding="utf-8") as f:
             data = json.load(f)
+        if not isinstance(data, dict):
+            return None
         # Policy version validation (fail closed on unknown versions)
         if data.get("policy_version") not in _SUPPORTED_POLICY_VERSIONS:
             return None

--- a/tests/test_mvp_evidence_snapshot.py
+++ b/tests/test_mvp_evidence_snapshot.py
@@ -460,8 +460,9 @@ def test_invalid_utf8_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     assert read_latest_snapshot_line() is None
 
 
+@pytest.mark.parametrize("payload", ["[]", "null", "true", "123", '"bad"'])
 def test_non_object_snapshot_returns_none_and_render_falls_back(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, payload: str
 ) -> None:
     repo = _configure_repo(monkeypatch, tmp_path)
     snap_dir = repo / "artifacts" / "orchestration" / "mvp_evidence_snapshots"
@@ -470,10 +471,14 @@ def test_non_object_snapshot_returns_none_and_render_falls_back(
         snap_dir
         / "mvp_evidence_snapshot_2026-05-30T00-00-00.000000+00-00_000000000000000000000000.json"
     )
-    bad.write_text("[]", encoding="utf-8")
+    bad.write_text(payload, encoding="utf-8")
 
     assert read_latest_snapshot_line() is None
-    assert bridge.render_mvp_evidence_summary().status_line == "static_contract"
+    msg = bridge.render_mvp_evidence_summary()
+    assert msg.message_type == "mvp_evidence_summary"
+    assert msg.status_line == "advisory_operator_summary"
+    assert "safe_event_count=12" in msg.evidence_summary
+    assert "forbidden_user_data=omitted" in msg.evidence_summary
 
 
 def test_non_string_payload_values_ignored() -> None:

--- a/tests/test_mvp_evidence_snapshot.py
+++ b/tests/test_mvp_evidence_snapshot.py
@@ -460,6 +460,22 @@ def test_invalid_utf8_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     assert read_latest_snapshot_line() is None
 
 
+def test_non_object_snapshot_returns_none_and_render_falls_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _configure_repo(monkeypatch, tmp_path)
+    snap_dir = repo / "artifacts" / "orchestration" / "mvp_evidence_snapshots"
+    snap_dir.mkdir(parents=True)
+    bad = (
+        snap_dir
+        / "mvp_evidence_snapshot_2026-05-30T00-00-00.000000+00-00_000000000000000000000000.json"
+    )
+    bad.write_text("[]", encoding="utf-8")
+
+    assert read_latest_snapshot_line() is None
+    assert bridge.render_mvp_evidence_summary().status_line == "static_contract"
+
+
 def test_non_string_payload_values_ignored() -> None:
     events = [
         {


### PR DESCRIPTION
## Goal
Finish PR #1925 by keeping non-object MVP evidence snapshot JSON fail-closed and completing review-governance evidence for the open bot findings.

## Business reason
Prevent malformed local evidence snapshots from breaking operator evidence rendering while preserving the advisory-only Slack evidence boundary. Also keep current-head security CI unblocked with a documented, time-boxed waiver for a newly surfaced optional vector-profile TorchScript advisory that has no fixed version in Safety 3.8.1.

## Scope
- Keep `read_latest_snapshot_line()` returning `None` for non-object JSON roots.
- Align the regression test with the existing `advisory_operator_summary` fallback contract.
- Add canonical fixed-mapping evidence for Codex, Cubic, and Sourcery review findings.
- Add a documented Safety waiver for `SFTY-20250331-30014` / `CVE-2025-3000` limited to optional `requirements-rag-vector*.txt` torch pins.

## Out of scope
- No production renderer status rename.
- No OpenAPI, backend route, frontend, iOS, billing, auth, nutrition, or wellness-copy changes.
- No semantic-cache/runtime expansion.
- No torch package bump in this closeout lane because Safety reports no fixed version for the advisory.

## Files changed
- `scripts/orchestration/mvp_evidence_snapshot.py`
- `tests/test_mvp_evidence_snapshot.py`
- `docs/review/PR_1925_FIXED_MAPPING.md`
- `safety-policy.yaml`
- `docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md`
- `docs/roadmap/BACKLOG_LEDGER.md`

## Key decisions
- Treat Codex and Cubic fallback-status findings as FIXED in commit `9c2f23c8e`.
- Treat Sourcery's return-type finding as NOT-A-BUG because `read_latest_snapshot_line(...)` already returns `MvpEvidenceSnapshotLine | None`.
- Map Sourcery's review-level bot finding separately as NOT-A-BUG because CI requires review-level actionable items in the canonical artifact.
- Scope the PyTorch Safety waiver to optional RAG/vector manifests only, with remove-by `2026-07-11` and ledger follow-up.
- Keep Experiment Runner evidence local and advisory; it does not resolve threads or claim readiness.

## Tests / validation
- PASS: `python3 scripts/orchestration/check_preflight.py`.
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`.
- PASS: `.venv/bin/python -m pytest -q tests/test_mvp_evidence_snapshot.py::test_non_object_snapshot_returns_none_and_render_falls_back` (`5 passed`).
- PASS: `.venv/bin/python -m pytest -q tests/test_mvp_evidence_snapshot.py` (`35 passed`).
- PASS: `.venv/bin/python -m mypy scripts/orchestration/mvp_evidence_snapshot.py scripts/orchestration/experiment_slack_bridge_rendering.py`.
- PASS: `make validate-changed`.
- PASS: `pre-commit run --all-files`.
- PASS: local Safety policy checks for `requirements-rag-vector.txt` and `requirements-rag-vector-cpu.txt` exit `0` with `vulns=0`, `ignored=1`, ignored ID `SFTY-20250331-30014`.
- PASS: pre-push hooks after commit `73a78d5b2`: `pip-audit`, backend tests, full-repo Bandit.
- NOTE: Full local `make verify` is operator-deferred for this closeout pass. A diagnostic attempt stopped at repo-wide mypy failures outside this PR diff in semantic-cache files; this PR uses PR-scoped narrow gates plus current-head CI/strict governance checks.

## Security notes
- Non-object JSON now fails closed before `.get()` access.
- Existing symlink/path traversal rejection stays unchanged.
- No secrets, auth, billing, LLM provider, or data-migration surfaces are changed.
- Safety waiver is documented, time-boxed, and limited to optional vector-profile torch manifests. Default production and Docker runtime manifests pass Safety without torch.

## Risks / rollback
- Risk: review-governance evidence can drift if body and artifact disagree. Mitigation: PR body mirrors the canonical artifact path.
- Risk: `SFTY-20250331-30014` remains real supply-chain debt until upstream/fixed-version truth changes. Mitigation: waiver has advisory, remove-by, and backlog item.
- Rollback: revert commits `73a78d5b2`, `62e81bec1`, `e98cff1b4`, and `9c2f23c8e` to remove the closeout governance/test updates; revert `435a8cc38` only if intentionally removing the production non-object JSON guard.

## Deferred / follow-ups
- `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-pytorch-jit-cve-2025-3000-vector-profile`: retire the PyTorch TorchScript Safety waiver by `2026-07-11` or earlier.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1925_FIXED_MAPPING.md`

## Experiment Runner Evidence
Artifact: artifacts/orchestration/experiments/results/exp-764916d504b7.json

## Lane Start Provenance
Packet: artifacts/orchestration/task_packets/ba8ef9ab93b5.json
Starter: scripts/orchestration/start_pr_lane.sh
Safety waiver packet: artifacts/orchestration/task_packets/54c88592fdc7.json

## Merge Readiness
Not claimed here. Required before merge: current-head CI, review-thread disposition, no actionable bot comments, strict merge wrapper with auth, and mandatory wait-window.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27f81a7700832cb7f923ac70ed5548)