### PR TITLE
fix(security): harden codex skill marker verification

### DIFF
--- a/docs/review/PR_1929_FIXED_MAPPING.md
+++ b/docs/review/PR_1929_FIXED_MAPPING.md
@@ -1,0 +1,164 @@
+# PR 1929 Fixed in Commit Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1929>
+
+## Summary
+
+This PR hardens Codex skill copy-marker verification against unsafe marker
+paths. The remediation keeps the verifier read-only, avoids CLI/API shape
+changes for valid repo-managed copies, and adds deterministic tests for
+symlink, missing no-follow support, path replacement, invalid UTF-8, and
+diagnostic redaction behavior.
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/f65232defe55.json`
+- Branch: `codex/propose-fix-for-marker-symlink-vulnerability`
+- PR phase: `post_open_review`
+- Role dispatch command executed: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/f65232defe55.json --pretty`
+- Declared role order executed: `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor -> cursor-specialist-agent -> web-research-agent`
+
+## Scope
+
+- Harden `scripts/verify_codex_skills_install.py` copy-marker reads.
+- Extend `tests/test_install_codex_skills.py` regression coverage.
+- Add this fixed-mapping artifact and mirror the required PR-body sections.
+
+## Out of Scope
+
+- No installer flag changes.
+- No runtime app, API, OpenAPI, web, iOS, nutrition, billing, or LLM behavior changes.
+- No full local `make verify`; this PR uses the operator-approved machine-heavy
+  exception with narrow local gates plus current-head CI parity before any
+  readiness claim.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [ ] Current-head CI parity confirmed after the latest push.
+- [ ] Strict merge-readiness wrapper passed.
+- [ ] Mandatory final wait-window completed.
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1929#discussion_r3380640466 -> 478cc4056fb344913242f93f6f85fd7f919fa2aa
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1929#pullrequestreview-4458588387 -> 478cc4056fb344913242f93f6f85fd7f919fa2aa
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1929#issuecomment-4659767730 -> 478cc4056fb344913242f93f6f85fd7f919fa2aa
+Disposition: FIXED
+Commit: 478cc4056fb344913242f93f6f85fd7f919fa2aa
+Evidence: `scripts/verify_codex_skills_install.py:109`; `tests/test_install_codex_skills.py:463`; `tests/test_install_codex_skills.py:479`
+Reason: Sourcery's security review was valid. The fix replaces ad hoc marker-error strings with constants, fails closed when `os.O_NOFOLLOW` is unavailable, compares the initial no-follow `stat` identity with `fstat()` before reading marker bytes, and adds deterministic tests for no-follow absence and stat/open path replacement.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1929#issuecomment-4659765270
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit selected only `scripts/verify_codex_skills_install.py` and `tests/test_install_codex_skills.py` but did not run a review because the organization hit review-rate/credit limits.
+Reason: The comment is a quota notice and finishing-touch prompt, not an actionable code, test, documentation, or governance finding.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1929#issuecomment-4659862582
+Disposition: NOT-A-BUG
+Evidence: Codecov reported all modified and coverable lines covered by tests.
+Reason: The comment contains no actionable follow-up.
+
+## Premortem Finding Closure
+
+- PM-1929-001: Marker path can be swapped between initial stat and open.
+  Disposition: FIXED. Evidence: `scripts/verify_codex_skills_install.py:137`
+  checks `fstat()` identity before any marker payload read; covered by
+  `tests/test_install_codex_skills.py:479`.
+- PM-1929-002: Platforms without `O_NOFOLLOW` could silently degrade to an
+  unsafe plain open. Disposition: FIXED. Evidence:
+  `scripts/verify_codex_skills_install.py:125` returns
+  `MARKER_ERROR_NO_NOFOLLOW`; covered by `tests/test_install_codex_skills.py:463`.
+- PM-1929-003: Marker error strings can drift through repeated literals.
+  Disposition: FIXED. Evidence: marker error constants are centralized in
+  `scripts/verify_codex_skills_install.py:63`.
+- PM-1929-004: Security regression tests could trip secret scanning.
+  Disposition: FIXED. Evidence: tests use benign marker payload names and
+  `.venv/bin/detect-secrets scan tests/test_install_codex_skills.py` returned
+  empty results.
+- PM-1929-005: Governance mapping before a real fix commit would violate
+  commit-after-comment policy. Disposition: FIXED. Evidence: this artifact maps
+  the Sourcery review to non-trigger fix commit
+  `478cc4056fb344913242f93f6f85fd7f919fa2aa`, created after the review comment.
+
+## Experiment Runner Evidence
+
+- Packet: `artifacts/orchestration/experiments/exp-9d32ff5a5966.json`
+- Artifact: `artifacts/orchestration/experiments/results/exp-9d32ff5a5966.json`
+- Result: `accepted`
+- Contribution kind: `fixed_mapping_review`
+- Co-author required: `true`
+- Oracle commands:
+  - `python3 -m py_compile scripts/verify_codex_skills_install.py tests/test_install_codex_skills.py`
+  - `python3 scripts/verify_codex_skills_install.py --help`
+  - `git diff --check HEAD~1 HEAD`
+- Rejected earlier oracle attempt: `artifacts/orchestration/experiments/results/exp-76731eec4574.json` was rejected because isolated checkout validation lacked a repo `.venv`; it is not used as readiness proof.
+
+## Role-Agent Evidence
+
+- `agent-coordinator`: completed scope/routing pass for packet `f65232defe55`; kept scope to the verifier, tests, fixed mapping, and PR body metadata.
+- `qa-engineer-agent`: reviewed the implementation and flagged deterministic path replacement test stability; fixed before commit by replacing the marker path with `Path.replace`.
+- `bug-hunter`: found no blocking runtime regression after py_compile, ruff, Black check, focused pytest, and detect-secrets scan passed.
+- `security-auditor`: found no blocking security regression after the marker read became fail-closed for missing no-follow support and rejected stat/open identity replacement before payload read.
+- `cursor-specialist-agent`: confirmed workflow/provenance requirements and required this parser-safe mapping artifact plus machine-heavy verify deferral.
+- `web-research-agent`: confirmed no external research was required and no browsing-derived authority should be used for this local tooling/security PR.
+
+## Codex Security Diff Scan
+
+- Scan path: `/tmp/codex-security-scans/BMI-App_2025_clean/478cc405_20260612T195545Z`
+- Final reports: `report.md` and `report.html`
+- Worklist: `artifacts/02_discovery/deep_review_input.csv`
+- Closure evidence: `artifacts/02_discovery/work_ledger.jsonl`
+- Result: no reportable findings for the scoped verifier/test remediation files.
+- Scope note: the deterministic rank helper preserved a broader full-branch
+  `rank_input.csv`, but the operator-approved remediation scan scope is
+  `scripts/verify_codex_skills_install.py` and
+  `tests/test_install_codex_skills.py`.
+
+## PulsePlate PR Review
+
+- Dry-run report: `/tmp/pulseplate_pr1929_review_report.md`
+- Disposition: FIXED for missing fixed-mapping findings.
+  Evidence: this artifact now exists and contains the canonical discussion
+  thread pass and fixed mapping.
+- Disposition: NOT-A-BUG for the large-diff planning note.
+  Evidence: the operator-approved scope for this remediation commit remains the
+  verifier, tests, fixed mapping, and PR body metadata; full local `make verify`
+  remains intentionally deferred under the machine-heavy exception.
+
+## Local Validation Evidence
+
+- PASS: `python3 scripts/orchestration/check_preflight.py --path scripts/verify_codex_skills_install.py --path tests/test_install_codex_skills.py --path docs/review/PR_1929_FIXED_MAPPING.md`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `python3 scripts/orchestration/task_bootstrap.py --goal "Bring PR #1929 Codex skill marker security hardening to merge readiness" --task-class "Security/Tooling" --path scripts/verify_codex_skills_install.py --path tests/test_install_codex_skills.py --path docs/review/PR_1929_FIXED_MAPPING.md --requested-agent agent-coordinator --requested-agent security-auditor --requested-agent qa-engineer-agent --requested-agent bug-hunter --pr-phase post_open_review --native-bridge-transport codex-native-subagents`
+- PASS: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/f65232defe55.json --pretty`
+- PASS: `python3 -m py_compile scripts/verify_codex_skills_install.py tests/test_install_codex_skills.py`
+- PASS: `.venv/bin/ruff check scripts/verify_codex_skills_install.py tests/test_install_codex_skills.py`
+- PASS: `.venv/bin/black --check scripts/verify_codex_skills_install.py tests/test_install_codex_skills.py`
+- PASS: `.venv/bin/python -m pytest tests/test_install_codex_skills.py -q` (`27 passed`)
+- PASS: `.venv/bin/detect-secrets scan tests/test_install_codex_skills.py` (`results: {}`)
+- PASS: `git diff --check`
+- PASS: `make validate-changed` (`tests/test_install_codex_skills.py`, `27 passed`)
+
+## Machine-Heavy Verify Exception
+
+Full local `make verify` is intentionally not run for this coordinator/tooling
+lane under the operator-approved machine-heavy exception. This PR must use the
+documented narrow local gates, `pre-commit run --all-files`, and current-head
+GitHub CI parity before any merge-readiness claim.
+
+## Merge Readiness
+
+Not claimed yet.
+
+Required before merge:
+
+- Run `PRE_COMMIT_HOME=/tmp/pre-commit-pr1929 pre-commit run --all-files`.
+- Push the mapping commit and refresh the PR body mirror.
+- Resolve the mapped Sourcery review thread only after this artifact is pushed.
+- Confirm current-head CI parity for the pushed SHA.
+- Confirm CodeRabbit, Sourcery, Cubic, Codecov, and GitHub review state have no
+  unresolved actionable findings.
+- Run `python3 scripts/orchestration/check_merge_ready.py --pr-number 1929 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`.
+- Complete the mandatory final wait-window after latest bot/review activity.

--- a/scripts/verify_codex_skills_install.py
+++ b/scripts/verify_codex_skills_install.py
@@ -10,9 +10,11 @@ No mutations, no network, no secrets, no shell profile access.
 from __future__ import annotations
 
 import argparse
+import errno
 import filecmp
 import json
 import os
+import stat
 import sys
 from pathlib import Path
 
@@ -57,6 +59,7 @@ def _resolve_destination(
 
 
 COPY_MARKER_FILE = ".pulseplate_codex_skill_source"
+COPY_MARKER_MAX_BYTES = 4096
 
 
 def _canonical_path(path: Path) -> str | None:
@@ -96,6 +99,47 @@ def _copied_skill_matches_source(skill_path: Path, source_skill: Path) -> bool:
     return True
 
 
+def _read_copy_marker(marker_path: Path) -> tuple[str, str | None]:
+    """Read a trusted copy marker without following symlinks or large files."""
+    try:
+        marker_stat = marker_path.stat(follow_symlinks=False)
+    except FileNotFoundError:
+        return "", None
+    except OSError:
+        return "", "marker_unreadable"
+
+    if not stat.S_ISREG(marker_stat.st_mode):
+        return "", "marker_not_regular"
+    if marker_stat.st_size > COPY_MARKER_MAX_BYTES:
+        return "", "marker_too_large"
+
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(marker_path, flags)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            return "", "marker_symlink"
+        return "", "marker_unreadable"
+
+    try:
+        with os.fdopen(fd, "rb") as marker_file:
+            marker_fd_stat = os.fstat(marker_file.fileno())
+            if not stat.S_ISREG(marker_fd_stat.st_mode):
+                return "", "marker_not_regular"
+            if marker_fd_stat.st_size > COPY_MARKER_MAX_BYTES:
+                return "", "marker_too_large"
+            marker_bytes = marker_file.read(COPY_MARKER_MAX_BYTES + 1)
+    except OSError:
+        return "", "marker_unreadable"
+
+    if len(marker_bytes) > COPY_MARKER_MAX_BYTES:
+        return "", "marker_too_large"
+    try:
+        return marker_bytes.decode("utf-8").strip(), None
+    except UnicodeDecodeError:
+        return "", "marker_invalid_utf8"
+
+
 def _inspect_installed_skill(
     dest_dir: Path,
     skill_name: str,
@@ -119,23 +163,25 @@ def _inspect_installed_skill(
         }
     if skill_path.is_dir():
         marker_path = skill_path / COPY_MARKER_FILE
-        marker_value = (
-            marker_path.read_text(encoding="utf-8").strip() if marker_path.exists() else ""
-        )
+        marker_value, marker_error = _read_copy_marker(marker_path)
         marker_resolved = _canonical_path(Path(marker_value)) if marker_value else None
         has_skill_md = (skill_path / "SKILL.md").exists()
         is_repo_managed = (
-            has_skill_md
+            marker_error is None
+            and has_skill_md
             and marker_resolved == expected_resolved
             and _copied_skill_matches_source(skill_path, source_skill)
         )
-        return {
+        info = {
             "name": skill_name,
             "status": "copied" if is_repo_managed else "copied_invalid",
             "type": "directory",
-            "marker": marker_value,
+            "marker": marker_value if is_repo_managed else "",
             "expected": expected_resolved or str(source_skill),
         }
+        if marker_error is not None:
+            info["marker_error"] = marker_error
+        return info
     return {
         "name": skill_name,
         "status": "missing",

--- a/scripts/verify_codex_skills_install.py
+++ b/scripts/verify_codex_skills_install.py
@@ -60,6 +60,13 @@ def _resolve_destination(
 
 COPY_MARKER_FILE = ".pulseplate_codex_skill_source"
 COPY_MARKER_MAX_BYTES = 4096
+MARKER_ERROR_INVALID_UTF8 = "marker_invalid_utf8"
+MARKER_ERROR_NO_NOFOLLOW = "marker_no_nofollow"
+MARKER_ERROR_NOT_REGULAR = "marker_not_regular"
+MARKER_ERROR_REPLACED = "marker_replaced"
+MARKER_ERROR_SYMLINK = "marker_symlink"
+MARKER_ERROR_TOO_LARGE = "marker_too_large"
+MARKER_ERROR_UNREADABLE = "marker_unreadable"
 
 
 def _canonical_path(path: Path) -> str | None:
@@ -106,38 +113,49 @@ def _read_copy_marker(marker_path: Path) -> tuple[str, str | None]:
     except FileNotFoundError:
         return "", None
     except OSError:
-        return "", "marker_unreadable"
+        return "", MARKER_ERROR_UNREADABLE
 
+    if stat.S_ISLNK(marker_stat.st_mode):
+        return "", MARKER_ERROR_SYMLINK
     if not stat.S_ISREG(marker_stat.st_mode):
-        return "", "marker_not_regular"
+        return "", MARKER_ERROR_NOT_REGULAR
     if marker_stat.st_size > COPY_MARKER_MAX_BYTES:
-        return "", "marker_too_large"
+        return "", MARKER_ERROR_TOO_LARGE
 
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    open_no_follow = getattr(os, "O_NOFOLLOW", None)
+    if open_no_follow is None:
+        return "", MARKER_ERROR_NO_NOFOLLOW
+
+    flags = os.O_RDONLY | open_no_follow
     try:
         fd = os.open(marker_path, flags)
     except OSError as exc:
         if exc.errno == errno.ELOOP:
-            return "", "marker_symlink"
-        return "", "marker_unreadable"
+            return "", MARKER_ERROR_SYMLINK
+        return "", MARKER_ERROR_UNREADABLE
 
     try:
         with os.fdopen(fd, "rb") as marker_file:
             marker_fd_stat = os.fstat(marker_file.fileno())
+            if (marker_fd_stat.st_dev, marker_fd_stat.st_ino) != (
+                marker_stat.st_dev,
+                marker_stat.st_ino,
+            ):
+                return "", MARKER_ERROR_REPLACED
             if not stat.S_ISREG(marker_fd_stat.st_mode):
-                return "", "marker_not_regular"
+                return "", MARKER_ERROR_NOT_REGULAR
             if marker_fd_stat.st_size > COPY_MARKER_MAX_BYTES:
-                return "", "marker_too_large"
+                return "", MARKER_ERROR_TOO_LARGE
             marker_bytes = marker_file.read(COPY_MARKER_MAX_BYTES + 1)
     except OSError:
-        return "", "marker_unreadable"
+        return "", MARKER_ERROR_UNREADABLE
 
     if len(marker_bytes) > COPY_MARKER_MAX_BYTES:
-        return "", "marker_too_large"
+        return "", MARKER_ERROR_TOO_LARGE
     try:
         return marker_bytes.decode("utf-8").strip(), None
     except UnicodeDecodeError:
-        return "", "marker_invalid_utf8"
+        return "", MARKER_ERROR_INVALID_UTF8
 
 
 def _inspect_installed_skill(

--- a/tests/test_install_codex_skills.py
+++ b/tests/test_install_codex_skills.py
@@ -428,6 +428,61 @@ def test_verify_codex_skills_install_rejects_modified_same_name_copy(
     assert "pulseplate-workflow" in result.stdout
 
 
+def test_verify_codex_skills_install_rejects_marker_symlink_without_leaking_target(
+    tmp_path: Path,
+) -> None:
+    """Verifier JSON must not disclose marker symlink target contents."""
+
+    import json as json_mod
+
+    _run_installer(tmp_path, "--copy", "--no-cybersec")
+    agents_skills = tmp_path / ".agents" / "skills"
+    copied_skill = agents_skills / "pulseplate-workflow"
+    secret_path = tmp_path / "secret.txt"
+    secret_value = "PULSEPLATE_VALIDATION_SECRET_DO_NOT_LOG"
+    secret_path.write_text(secret_value, encoding="utf-8")
+    marker = copied_skill / ".pulseplate_codex_skill_source"
+    marker.unlink()
+    marker.symlink_to(secret_path)
+
+    result = _run_verifier(tmp_path, "--dest", str(agents_skills), "--json", "--strict")
+    assert result.returncode == 1
+    assert secret_value not in result.stdout
+
+    report = json_mod.loads(result.stdout)
+    detail = next(
+        item for item in report["details"] if item["name"] == "pulseplate-workflow"
+    )
+    assert detail["status"] == "copied_invalid"
+    assert detail["marker"] == ""
+    assert detail["marker_error"] in {"marker_not_regular", "marker_symlink"}
+
+
+def test_verify_codex_skills_install_rejects_invalid_utf8_marker_without_crashing(
+    tmp_path: Path,
+) -> None:
+    """Malformed copy markers should be reported as invalid instead of crashing."""
+
+    import json as json_mod
+
+    _run_installer(tmp_path, "--copy", "--no-cybersec")
+    agents_skills = tmp_path / ".agents" / "skills"
+    copied_skill = agents_skills / "pulseplate-workflow"
+    marker = copied_skill / ".pulseplate_codex_skill_source"
+    marker.write_bytes(b"\xff\xfe\xfd")
+
+    result = _run_verifier(tmp_path, "--dest", str(agents_skills), "--json", "--strict")
+    assert result.returncode == 1
+
+    report = json_mod.loads(result.stdout)
+    detail = next(
+        item for item in report["details"] if item["name"] == "pulseplate-workflow"
+    )
+    assert detail["status"] == "copied_invalid"
+    assert detail["marker"] == ""
+    assert detail["marker_error"] == "marker_invalid_utf8"
+
+
 def test_verify_codex_skills_install_fails_when_skill_missing(tmp_path: Path) -> None:
     """Verifier with --strict should fail when a skill is missing from destination."""
 

--- a/tests/test_install_codex_skills.py
+++ b/tests/test_install_codex_skills.py
@@ -7,6 +7,10 @@ from pathlib import Path
 import shutil
 import subprocess
 
+import pytest
+
+from scripts import verify_codex_skills_install
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INSTALLER_PATH = REPO_ROOT / "scripts" / "install_codex_skills.sh"
 BASH_PATH = shutil.which("bash")
@@ -438,24 +442,61 @@ def test_verify_codex_skills_install_rejects_marker_symlink_without_leaking_targ
     _run_installer(tmp_path, "--copy", "--no-cybersec")
     agents_skills = tmp_path / ".agents" / "skills"
     copied_skill = agents_skills / "pulseplate-workflow"
-    secret_path = tmp_path / "secret.txt"
-    secret_value = "PULSEPLATE_VALIDATION_SECRET_DO_NOT_LOG"
-    secret_path.write_text(secret_value, encoding="utf-8")
+    payload_path = tmp_path / "marker-payload.txt"
+    marker_payload = "PULSEPLATE_MARKER_PAYLOAD_DO_NOT_LOG"
+    payload_path.write_text(marker_payload, encoding="utf-8")
     marker = copied_skill / ".pulseplate_codex_skill_source"
     marker.unlink()
-    marker.symlink_to(secret_path)
+    marker.symlink_to(payload_path)
 
     result = _run_verifier(tmp_path, "--dest", str(agents_skills), "--json", "--strict")
     assert result.returncode == 1
-    assert secret_value not in result.stdout
+    assert marker_payload not in result.stdout
 
     report = json_mod.loads(result.stdout)
-    detail = next(
-        item for item in report["details"] if item["name"] == "pulseplate-workflow"
-    )
+    detail = next(item for item in report["details"] if item["name"] == "pulseplate-workflow")
     assert detail["status"] == "copied_invalid"
     assert detail["marker"] == ""
     assert detail["marker_error"] in {"marker_not_regular", "marker_symlink"}
+
+
+def test_read_copy_marker_fails_closed_without_no_follow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing marker files must fail closed if no no-follow open flag exists."""
+
+    marker = tmp_path / ".pulseplate_codex_skill_source"
+    marker.write_text(str(REPO_ROOT / "tools" / "codex_skills"), encoding="utf-8")
+
+    monkeypatch.delattr(verify_codex_skills_install.os, "O_NOFOLLOW", raising=False)
+    read_copy_marker = getattr(verify_codex_skills_install, "_read_copy_marker")
+    marker_error = getattr(verify_codex_skills_install, "MARKER_ERROR_NO_NOFOLLOW")
+
+    assert read_copy_marker(marker) == ("", marker_error)
+
+
+def test_read_copy_marker_rejects_path_replacement_before_reading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A marker swapped after stat but before open must not be trusted."""
+
+    marker = tmp_path / ".pulseplate_codex_skill_source"
+    marker.write_text("original-marker", encoding="utf-8")
+    replacement = tmp_path / "replacement-marker"
+    replacement.write_text("replacement-marker", encoding="utf-8")
+    real_open = verify_codex_skills_install.os.open
+
+    def replacing_open(path: Path, flags: int) -> int:
+        replacement.replace(marker)
+        return real_open(path, flags)
+
+    monkeypatch.setattr(verify_codex_skills_install.os, "open", replacing_open)
+    read_copy_marker = getattr(verify_codex_skills_install, "_read_copy_marker")
+    marker_error = getattr(verify_codex_skills_install, "MARKER_ERROR_REPLACED")
+
+    assert read_copy_marker(marker) == ("", marker_error)
 
 
 def test_verify_codex_skills_install_rejects_invalid_utf8_marker_without_crashing(
@@ -475,9 +516,7 @@ def test_verify_codex_skills_install_rejects_invalid_utf8_marker_without_crashin
     assert result.returncode == 1
 
     report = json_mod.loads(result.stdout)
-    detail = next(
-        item for item in report["details"] if item["name"] == "pulseplate-workflow"
-    )
+    detail = next(item for item in report["details"] if item["name"] == "pulseplate-workflow")
     assert detail["status"] == "copied_invalid"
     assert detail["marker"] == ""
     assert detail["marker_error"] == "marker_invalid_utf8"


### PR DESCRIPTION
### Motivation
- Prevent information disclosure and robustness issues where the verifier read and serialized `.pulseplate_codex_skill_source` contents following symlinks, causing secret leakage or crashes on malformed files.

### Description
- Add a new helper ` _read_copy_marker(marker_path)` that performs symlink-safe checks (`stat(follow_symlinks=False)`), enforces a regular-file constraint, bounds marker size (`COPY_MARKER_MAX_BYTES=4096`), opens without following symlinks when possible, and returns a stable `marker_error` code instead of raising on unreadable/invalid targets.
- Replace direct `read_text()` usage in `_inspect_installed_skill` with `_read_copy_marker(...)` and only include the raw `marker` value in the JSON details when the copied skill is validated as a repo-managed copy; otherwise emit an empty `marker` and a `marker_error` field.
- Add regression tests in `tests/test_install_codex_skills.py` that assert a symlinked marker does not leak target contents in `--json` output and that invalid UTF-8 markers are reported as `marker_invalid_utf8` without crashing; changes touch `scripts/verify_codex_skills_install.py` and `tests/test_install_codex_skills.py`.

### Testing
- Passed static/quick checks: `python -m py_compile scripts/verify_codex_skills_install.py tests/test_install_codex_skills.py` and `ruff check scripts/verify_codex_skills_install.py tests/test_install_codex_skills.py` succeeded.
- Performed focused shell validation that installs copied skills and runs the verifier: valid copied-skill verification still passes, a marker symlink is rejected without the secret appearing in the `--json` output, and malformed UTF-8 marker bytes are rejected and reported as `marker_invalid_utf8` without crashing (all checks passed).
- Full local gates could not be run in this environment: `pytest` runs were blocked due to missing `fastapi`, `pre-commit` / `pre-commit run --all-files` was not available, `make verify` failed because `.venv` is missing, and `make typecheck` shows unrelated repository-wide `mypy` errors; these blockers are reported and prevent claiming full green/merge-ready status.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27f7fbb2c0832cbb3c51f06c20b2e9)

## Summary by Sourcery

Усилена проверка маркеров копирования codex skill, чтобы избежать утечек данных или сбоев при работе с недоверенными файлами маркеров и гарантировать, что только валидные копии, управляемые репозиторием, считаются доверенными.

Исправления ошибок:
- Предотвращено следование симлинкам при проверке маркеров копирования, а также чтение нерегулярных или слишком больших файлов маркеров, чтобы избежать раскрытия информации и сбоев.
- Обеспечено, что некорректное содержимое маркеров в кодировке UTF-8 рассматривается как недействительные маркеры, а не приводит к сбоям проверяющего.

Улучшения:
- Обнаружение копий, управляемых репозиторием, теперь зависит от успешной проверки маркера; при сбоях проверки «сырые» значения маркеров исключаются из JSON-деталей, вместо этого возвращается структурированный код `marker_error`.

Тесты:
- Добавлены регрессионные тесты, проверяющие, что симлинки маркеров не раскрывают секретное содержимое в JSON-выводе и что некорректные UTF-8 маркеры сообщаются как `marker_invalid_utf8` без сбоев.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden codex skill copy marker verification to avoid leaking or crashing on untrusted marker files and ensure only valid repo-managed copies are treated as trusted.

Bug Fixes:
- Prevent copy marker verification from following symlinks or reading non-regular or oversized marker files to avoid information disclosure and crashes.
- Ensure invalid UTF-8 marker contents are treated as invalid markers instead of causing verifier failures.

Enhancements:
- Gate repo-managed copy detection on marker validation and omit raw marker values from JSON details when verification fails, surfacing a structured marker_error code instead.

Tests:
- Add regression tests to verify marker symlinks do not leak secret contents in JSON output and that invalid UTF-8 markers are reported as marker_invalid_utf8 without crashing.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened codex skill source marker verification to prevent symlink/TOCTOU leaks and crashes on malformed files. Markers are read with no-follow, size bounds, and identity checks, and are only exposed in JSON for valid repo-managed copies; others return a `marker_error`.

- **Bug Fixes**
  - Added `_read_copy_marker(...)` that opens with no-follow, enforces regular-file and 4 KB limit, validates UTF-8, and checks stat/fstat identity to close TOCTOU.
  - Fail closed when `os.O_NOFOLLOW` is missing and return structured errors (`marker_no_nofollow`, `marker_replaced`, `marker_symlink`, `marker_invalid_utf8`, etc.).
  - Updated `_inspect_installed_skill` to use the helper and gate JSON exposure; added regression tests for symlinked markers, invalid UTF-8, missing no-follow, and path replacement.

<sup>Written for commit f790efe1a7055292e15487a7e67196ab6e6b2537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

---

<!-- pulseplate-governance-mirror:start -->

## Scope

- Harden Codex skill copy-marker verification in `scripts/verify_codex_skills_install.py`.
- Extend deterministic regression coverage in `tests/test_install_codex_skills.py`.
- Add canonical PR #1929 fixed-mapping governance in `docs/review/PR_1929_FIXED_MAPPING.md` and mirror this PR body metadata.

## Out of Scope

- No installer flag changes.
- No runtime app, API, OpenAPI, web, iOS, nutrition, billing, or LLM behavior changes.
- No full local `make verify`; this PR uses the operator-approved machine-heavy exception with narrow gates and current-head CI parity.

## Tests

- `python3 -m py_compile scripts/verify_codex_skills_install.py tests/test_install_codex_skills.py`
- `.venv/bin/ruff check scripts/verify_codex_skills_install.py tests/test_install_codex_skills.py`
- `.venv/bin/black --check scripts/verify_codex_skills_install.py tests/test_install_codex_skills.py`
- `.venv/bin/python -m pytest tests/test_install_codex_skills.py -q` (`27 passed`)
- `.venv/bin/detect-secrets scan tests/test_install_codex_skills.py` (`results: {}`)
- `make validate-changed` (`27 passed`)
- `PRE_COMMIT_HOME=/tmp/pre-commit-pr1929 pre-commit run --all-files`

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1929_FIXED_MAPPING.md`

## Lane Start Provenance

- Packet: `artifacts/orchestration/task_packets/f65232defe55.json`
- Branch: `codex/propose-fix-for-marker-symlink-vulnerability`
- Role dispatch: `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor -> cursor-specialist-agent -> web-research-agent`

## Experiment Runner Evidence

- Artifact: `artifacts/orchestration/experiments/results/exp-9d32ff5a5966.json`
- Result: `accepted`
- Contribution kind: `fixed_mapping_review`
- Co-author required: `true`; mapping commit includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.

## Merge Readiness

Not claimed yet.

- Full local `make verify` is operator-deferred under the machine-heavy PR exception.
- Narrow local gates are documented in `docs/review/PR_1929_FIXED_MAPPING.md`.
- Pending before merge: current-head CI parity, strict merge wrapper with auth, and the final wait-window.

<!-- pulseplate-governance-mirror:end -->
