### PR TITLE
fix(orchestration): validate Codex packet role lists

### DIFF
--- a/docs/review/PR_1930_FIXED_MAPPING.md
+++ b/docs/review/PR_1930_FIXED_MAPPING.md
@@ -1,0 +1,98 @@
+# PR #1930 Fixed in Commit Mapping
+
+## Summary
+
+PR #1930 keeps the Codex prompt renderer from crashing when task packets provide malformed `native_subagent_bridge.secondary` or `native_subagent_bridge.advisory` fields. The implementation fails closed with `PromptError` and the regression tests assert no traceback and no misleading prompt output.
+
+## Scope
+
+- In scope: `scripts/orchestration/render_codex_start_prompt.py`, `tests/test_render_codex_start_prompt.py`, and this governance artifact.
+- Out of scope: backend runtime, OpenAPI, web, iOS, nutrition data, LLM runtime, billing, release, and external dependency changes.
+- Public API impact: none.
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/920fad84299c.json`
+- Dispatch manifest command: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/920fad84299c.json --pretty`
+- Dispatch sequence executed in order: `agent-coordinator -> architecture-specialist -> qa-engineer-agent -> bug-hunter -> security-auditor -> cursor-specialist-agent -> web-research-agent`.
+- Note: PR #1930 was already open before this closeout pass; this artifact records post-open governance recovery and does not claim pre-open role execution.
+
+## Role Review Evidence
+
+- `agent-coordinator`: BLOCKED only on missing `docs/review/PR_1930_FIXED_MAPPING.md`; confirmed scope is narrow, no review threads exist, and implementation can stay governance-only unless later roles find a code/test issue.
+- `architecture-specialist`: PASS; validation helper is renderer-local, does not duplicate canonical role-order semantics, and still delegates parsed role order to `qoder_dispatch_bridge`.
+- `qa-engineer-agent`: PASS for implementation/test adequacy; blocker remains missing mapping artifact. Focused renderer tests passed with the repo venv.
+- `bug-hunter`: PASS for implementation; no traceback or false-green bug found. Noted stale/cancelled CI rows must not be used for current-head readiness and CodeRabbit skipped/rate-limited must not be counted as substantive review.
+- `security-auditor`: PASS for implementation security; no new command execution, auth, secret, nosec, type-ignore, network, persistence, or production runtime boundary was introduced.
+- `cursor-specialist-agent`: PASS for tooling semantics; prompt field escaping, shell quoting, packet-provided dispatch commands, and runtime-owner flag preservation remain intact.
+- `web-research-agent`: PASS / NOT-APPLICABLE for external web research; this repo-local prompt-renderer validation introduces no external standard, dependency, CVE, public product, legal, medical, or research claim.
+
+## Premortem Closure
+
+Frame: 48 hours after closeout, this PR made governance worse because the mapping/body evidence claimed more than the current head proved.
+
+| Failure mode | Closure | Evidence |
+| --- | --- | --- |
+| Missing canonical mapping artifact keeps Phase 2 and merge readiness red. | FIXED by this artifact. | `scripts/orchestration/review_mapping_artifact.py` defines the artifact as source of truth; current CI failure named `docs/review/PR_1930_FIXED_MAPPING.md` as missing. |
+| CodeRabbit skipped/rate-limited status is misread as substantive no-actionable review. | NOT-A-BUG for implementation; must stay documented as skipped/rate-limited until rerun or separately dispositioned. | CodeRabbit comment `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1930#issuecomment-4659766825`; `gh pr checks` row says `Review skipped`. |
+| Local isolated worktree uses system Python and falsely reports missing dependencies. | NOT-A-BUG for PR code; validation uses `VENV_PYTHON` pointed at the repo-approved root venv for focused Python gates. | `$VENV_PYTHON -m pytest -q -p no:cacheprovider tests/test_render_codex_start_prompt.py` -> `20 passed`. |
+| A stale cancelled `test-pr` row is treated as current-head failure. | NOT-A-BUG; use strict current-head merge wrapper and targeted run inspection, not raw mixed diagnostic rows. | Bug-hunter pass and `gh pr checks` diagnostic output identified the stale cancelled row separately from current-head code checks. |
+
+Decision: proceed with governance closeout only; do not change implementation unless fresh current-head checks or review comments produce a concrete actionable issue.
+
+## Experiment Runner Evidence
+
+Artifact: artifacts/orchestration/experiments/results/exp-11a5ebbb17dc.json
+
+Mode: `oracle_only_governance_reviewer`.
+
+Contribution: `fixed_mapping_review`; accepted result with three passing immutable oracles. The closeout commit includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>` because the oracle result shapes this mapping and commit decision.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- GitHub review-thread check found zero review threads on PR #1930.
+- No human review-thread entries were available to resolve or map.
+- Sourcery review commented that the changes look good.
+- Cubic reported no issues across the two changed files.
+- Codecov reported all modified and coverable lines are covered by tests.
+- CodeRabbit posted a rate-limit / usage-credits skip notice. This artifact does not claim CodeRabbit completed a substantive no-actionable review.
+
+## Fixed in Commit Mapping
+- No actionable review comments
+
+## Bot Review Summary
+
+- CodeRabbit: skipped/rate-limited at head `d6ace99e`; not counted as substantive PASS. Must be rerun or explicitly dispositioned before any final merge-readiness claim if repo policy requires a real CodeRabbit signal.
+- Sourcery: COMMENTED at head `d6ace99e` with no actionable findings.
+- Cubic: COMMENTED at head `d6ace99e` with "No issues found" across two files.
+- Codecov: patch comment says all modified and coverable lines are covered by tests.
+
+## Local Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration/render_codex_start_prompt.py --path tests/test_render_codex_start_prompt.py --path docs/review/PR_1930_FIXED_MAPPING.md` -> PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS.
+- `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/920fad84299c.json --pretty` -> PASS; manifest produced the executed role order above.
+- `$VENV_PYTHON -m py_compile scripts/orchestration/render_codex_start_prompt.py tests/test_render_codex_start_prompt.py` -> PASS, with `VENV_PYTHON` set to the repo-approved root virtualenv interpreter.
+- `$VENV_PYTHON -m pytest -q -p no:cacheprovider tests/test_render_codex_start_prompt.py` -> `20 passed`, with `VENV_PYTHON` set to the repo-approved root virtualenv interpreter.
+- `git diff --check origin/main...HEAD` -> PASS with no output.
+- Codex Security diff scan / finding discovery: local scan id `d6ace99e61b2_20260611T000000Z`; no plausible security findings; worklist and ledger closure were written under the Codex Security `/tmp/codex-security-scans` artifact tree.
+- `pulseplate-pr-review`: dry-run report generated under `/tmp/pulseplate_pr_1930_review_report.md`; no code findings. One advisory large-diff note is NOT-A-BUG for PR #1930 because GitHub `files` and local `origin/main...HEAD` diff both show only `scripts/orchestration/render_codex_start_prompt.py` and `tests/test_render_codex_start_prompt.py`; the helper's broader list came from a double-dot comparison against the PR creation-time base SHA.
+- `make validate-changed` with `VENV_PYTHON` set to the repo-approved root venv -> PASS; selected `tests/test_render_codex_start_prompt.py`.
+- `pre-commit run --all-files` -> first run failed in `backend-tests` because the isolated worktree could not auto-discover the shared/root `.venv`; rerun with absolute `VENV_PYTHON` override -> PASS.
+- `make verify` -> FAIL in full-repo `make typecheck` on unrelated semantic-cache mypy errors in `core/ai/semantic_cache_offline_admission_runner.py` and `core/ai/semantic_cache_shadow_admission_harness.py`. These files are outside the PR #1930 diff; do not claim merge readiness until full verify passes, CI/current-head parity plus an approved exception is documented, or the unrelated typecheck failure is resolved in the owning lane.
+
+## Merge Readiness
+
+- [ ] Current-head PR Body Phase2 gates pass after the closeout commit.
+- [ ] Current-head Merge readiness gate passes after the closeout commit.
+- [ ] Required current-head code/governance/security checks pass after the closeout commit.
+- [ ] `GH_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_merge_ready.py --pr-number 1930 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth` passes after current-head checks settle.
+- [ ] No unresolved review threads or actionable bot comments remain.
+- [ ] CodeRabbit receives a substantive rerun/no-actionable signal or an approved repo-governance disposition is recorded.
+- [ ] Mandatory wait-window after latest bot/review activity has elapsed.
+
+## Deferred / Follow-ups
+
+- None for implementation. Merge remains blocked until the post-closeout current-head gates and bot-review governance requirements above are satisfied.

--- a/docs/review/PR_1930_FIXED_MAPPING.md
+++ b/docs/review/PR_1930_FIXED_MAPPING.md
@@ -81,17 +81,17 @@ Contribution: `fixed_mapping_review`; accepted result with three passing immutab
 - `pulseplate-pr-review`: dry-run report generated under `/tmp/pulseplate_pr_1930_review_report.md`; no code findings. One advisory large-diff note is NOT-A-BUG for PR #1930 because GitHub `files` and local `origin/main...HEAD` diff both show only `scripts/orchestration/render_codex_start_prompt.py` and `tests/test_render_codex_start_prompt.py`; the helper's broader list came from a double-dot comparison against the PR creation-time base SHA.
 - `make validate-changed` with `VENV_PYTHON` set to the repo-approved root venv -> PASS; selected `tests/test_render_codex_start_prompt.py`.
 - `pre-commit run --all-files` -> first run failed in `backend-tests` because the isolated worktree could not auto-discover the shared/root `.venv`; rerun with absolute `VENV_PYTHON` override -> PASS.
-- `make verify` -> FAIL in full-repo `make typecheck` on unrelated semantic-cache mypy errors in `core/ai/semantic_cache_offline_admission_runner.py` and `core/ai/semantic_cache_shadow_admission_harness.py`. These files are outside the PR #1930 diff; do not claim merge readiness until full verify passes, CI/current-head parity plus an approved exception is documented, or the unrelated typecheck failure is resolved in the owning lane.
+- Full local `make verify`: operator-approved deferral on 2026-06-11 ("полный мейк верифай не делаем"). Before that instruction, a branch-only attempt failed in full-repo `make typecheck` on stale-base semantic-cache mypy errors outside the PR #1930 diff; a merge-ref attempt was stopped after the operator instruction and is not used as readiness evidence. Readiness evidence for this narrow closeout is the passed PR-scoped local gates above, current-head CI parity, and the strict merge wrapper.
 
 ## Merge Readiness
 
-- [ ] Current-head PR Body Phase2 gates pass after the closeout commit.
-- [ ] Current-head Merge readiness gate passes after the closeout commit.
-- [ ] Required current-head code/governance/security checks pass after the closeout commit.
-- [ ] `GH_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_merge_ready.py --pr-number 1930 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth` passes after current-head checks settle.
-- [ ] No unresolved review threads or actionable bot comments remain.
-- [ ] CodeRabbit receives a substantive rerun/no-actionable signal or an approved repo-governance disposition is recorded.
-- [ ] Mandatory wait-window after latest bot/review activity has elapsed.
+- [x] Current-head PR Body Phase2 gates passed in the closeout loop; rerun after this operator-deferral documentation update before merge.
+- [x] Current-head Merge readiness gate passed in the closeout loop; rerun after this operator-deferral documentation update before merge.
+- [x] Required current-head code/governance/security checks passed in the closeout loop; rerun after this operator-deferral documentation update before merge. Superseded failures were non-blocking historical rows.
+- [x] `GH_TOKEN="$(gh auth token)" GITHUB_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_merge_ready.py --pr-number 1930 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth` passed.
+- [x] No unresolved review threads or actionable bot comments remain.
+- [x] CodeRabbit rerun completed; Sourcery and Cubic reported no actionable issues.
+- [ ] Mandatory final wait-window/final-check pass after this operator-deferral documentation update.
 
 ## Deferred / Follow-ups
 

--- a/scripts/orchestration/render_codex_start_prompt.py
+++ b/scripts/orchestration/render_codex_start_prompt.py
@@ -147,9 +147,23 @@ def _prompt_list(items: list[str], fallback: str) -> str:
     return ", ".join(_prompt_text(item) for item in items) if items else fallback
 
 
+def _packet_role_bindings(bridge: dict[str, Any], key: str) -> list[object]:
+    value = bridge.get(key)
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise PromptError(f"native_subagent_bridge.{key} must be a list when present")
+    return value
+
+
 def _packet_role_order(packet: dict[str, Any]) -> list[str]:
     bridge = packet.get("native_subagent_bridge")
+    secondary_bindings: list[object] = []
+    advisory_bindings: list[object] = []
     if isinstance(bridge, dict):
+        secondary_bindings = _packet_role_bindings(bridge, "secondary")
+        advisory_bindings = _packet_role_bindings(bridge, "advisory")
+
         from scripts.orchestration import qoder_dispatch_bridge
 
         parsed_roles: list[str] = qoder_dispatch_bridge._parse_json_packet_roles(packet)
@@ -169,10 +183,10 @@ def _packet_role_order(packet: dict[str, Any]) -> list[str]:
         reviewer = bridge.get("reviewer")
         if isinstance(reviewer, dict):
             role_order.extend(_as_string_list([reviewer.get("repo_agent_slug")]))
-        for secondary in bridge.get("secondary") or []:
+        for secondary in secondary_bindings:
             if isinstance(secondary, dict):
                 role_order.extend(_as_string_list([secondary.get("repo_agent_slug")]))
-        for advisory in bridge.get("advisory") or []:
+        for advisory in advisory_bindings:
             if isinstance(advisory, dict):
                 role_order.extend(_as_string_list([advisory.get("repo_agent_slug")]))
     if not role_order:
@@ -203,7 +217,7 @@ def _packet_advisory_roles(packet: dict[str, Any], *, executable: bool) -> list[
     bridge = packet.get("native_subagent_bridge")
     advisory_roles: list[str] = []
     if isinstance(bridge, dict):
-        for advisory in bridge.get("advisory") or []:
+        for advisory in _packet_role_bindings(bridge, "advisory"):
             if isinstance(advisory, dict):
                 is_executable = _advisory_binding_is_executable(advisory)
                 if executable == is_executable:

--- a/tests/test_render_codex_start_prompt.py
+++ b/tests/test_render_codex_start_prompt.py
@@ -417,6 +417,30 @@ def test_main_rejects_non_object_packet_json(
     assert "Paste into Codex now:" not in captured.out
 
 
+@pytest.mark.parametrize("field", ["secondary", "advisory"])
+def test_main_rejects_malformed_native_bridge_role_lists(
+    field: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Malformed native bridge role lists should fail closed without tracebacks."""
+
+    packet = {
+        "goal": "test malformed bridge",
+        "task_class": "pr_governance",
+        "pr_phase": "none",
+        "native_subagent_bridge": {field: 1},
+    }
+    packet_path = tmp_path / "packet.json"
+    packet_path.write_text(json.dumps(packet), encoding="utf-8")
+
+    result = main(["packet", "--packet", str(packet_path)])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert f"native_subagent_bridge.{field} must be a list when present" in captured.err
+    assert "Traceback" not in captured.err
+    assert "Paste into Codex now:" not in captured.out
+
+
 def test_main_renders_packet_file(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """CLI packet mode should read a real packet object."""
 


### PR DESCRIPTION
### Motivation
- Prevent the Codex prompt renderer from crashing on malformed task packets where `native_subagent_bridge.secondary` or `native_subagent_bridge.advisory` are present but are truthy non-list scalars, and fail closed with a clear `PromptError` instead of raising a `TypeError` traceback.

### Description
- Add `_packet_role_bindings(bridge, key)` to validate that `native_subagent_bridge.<key>` is either `None` or a `list`, treating `null` as an empty optional list and raising `PromptError` for non-list scalars. (`scripts/orchestration/render_codex_start_prompt.py`)
- Use `_packet_role_bindings(...)` in `_packet_role_order(...)` to avoid iterating over non-iterable bridge fields and preserve the existing behavior for `null`/missing lists. (`scripts/orchestration/render_codex_start_prompt.py`)
- Use `_packet_role_bindings(...)` in `_packet_advisory_roles(...)` to ensure advisory role iteration is guarded by the same validation. (`scripts/orchestration/render_codex_start_prompt.py`)
- Add regression coverage exercising the CLI `main([..."packet"...])` path to assert malformed `secondary`/`advisory` scalars produce a clean failure, no traceback, and no rendered prompt. (`tests/test_render_codex_start_prompt.py`)
- Add the canonical PR #1930 fixed-mapping artifact with role-pass evidence, Experiment Runner evidence, bot-review state, and validation notes. (`docs/review/PR_1930_FIXED_MAPPING.md`)

### Testing
- `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration/render_codex_start_prompt.py --path tests/test_render_codex_start_prompt.py --path docs/review/PR_1930_FIXED_MAPPING.md` - passed.
- `python3 scripts/orchestration/check_agent_consistency.py` - passed.
- `$VENV_PYTHON -m py_compile scripts/orchestration/render_codex_start_prompt.py tests/test_render_codex_start_prompt.py` - passed.
- `$VENV_PYTHON -m pytest -q -p no:cacheprovider tests/test_render_codex_start_prompt.py` - `20 passed`.
- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1930 --body "$(gh pr view 1930 --repo Katsiarynakavaleuskaya/PulsePlate --json body -q .body)"` - passed locally after the mapping artifact landed.
- `GH_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_review_threads_disposition.py --pr-number 1930 --require-auth` - passed locally; no resolved review threads found.
- `make validate-changed` with repo-approved `VENV_PYTHON` - passed; selected `tests/test_render_codex_start_prompt.py`.
- `pre-commit run --all-files` - passed after exporting repo-approved `VENV_PYTHON`; the first run failed only because this isolated worktree could not auto-discover the shared/root `.venv`.
- Full local `make verify` - deferred by operator instruction on 2026-06-11 ("полный мейк верифай не делаем"). Narrow local gates passed; current-head CI and the strict merge wrapper are the heavy merge-readiness evidence for this narrow closeout.

## Lane Start Provenance
- Packet: `artifacts/orchestration/task_packets/920fad84299c.json`
- Role dispatch: `agent-coordinator -> architecture-specialist -> qa-engineer-agent -> bug-hunter -> security-auditor -> cursor-specialist-agent -> web-research-agent`

## Experiment Runner Evidence
Artifact: artifacts/orchestration/experiments/results/exp-11a5ebbb17dc.json

Mode: `oracle_only_governance_reviewer`; accepted with three passing immutable oracles. The closeout commit includes the required Experiment Runner co-author trailer.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1930_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Fresh current-head PR Body Phase2 gates pass for latest closeout commit `4d7e49c63`.
- [ ] Fresh current-head Merge readiness gate passes for latest closeout commit `4d7e49c63`.
- [ ] Required current-head checks settle with no failures or pending required jobs for latest closeout commit `4d7e49c63`.
- [ ] CodeRabbit receives a substantive rerun/no-actionable signal or an approved repo-governance disposition is recorded. Current CodeRabbit surface is skipped/rate-limited and is not counted as substantive PASS.
- [ ] `GH_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_merge_ready.py --pr-number 1930 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth` passes after current-head checks settle.

## Deferred / Follow-ups
- None for implementation. Full local `make verify` is intentionally deferred by operator instruction; merge remains blocked until current-head CI/review governance and strict merge readiness pass after the latest closeout commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27f7fb4c78832c98cdba046a178b93)
