### PR TITLE
fix(ci): prevent stale Trivy SARIF upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,10 +280,12 @@ jobs:
             echo "::warning::GHCR_READ_TOKEN is set but docker login was denied; continuing without registry auth."
           fi
 
-      # SARIF path must stay relative to GITHUB_WORKSPACE (hashFiles/upload-sarif assume repo root).
-      - name: Prepare Trivy ignore policy
+      - name: Prepare Trivy SARIF output path and ignore policy
         run: |
           set -euo pipefail
+          rm -rf -- trivy-results.sarif
+          rm -rf "${RUNNER_TEMP}/pulseplate-trivy"
+          mkdir -p "${RUNNER_TEMP}/pulseplate-trivy"
           test -f trivy/ignore-policy.rego
           cp trivy/ignore-policy.rego .trivy-ignore-policy.rego
           ls -la .trivy-ignore-policy.rego
@@ -299,23 +301,32 @@ jobs:
           ignore-policy: .trivy-ignore-policy.rego
           scanners: vuln
           format: sarif
-          output: trivy-results.sarif
+          output: ${{ runner.temp }}/pulseplate-trivy/trivy-results.sarif
           severity: CRITICAL,HIGH
           limit-severities-for-sarif: true
           exit-code: '1'
           trivyignores: .trivyignore
           version: v0.69.3
 
-      - name: Warn when Trivy filesystem SARIF is missing
-        if: ${{ always() && hashFiles('trivy-results.sarif') == '' }}
+      - name: Check Trivy filesystem SARIF output
+        id: trivy_fs_sarif
+        if: ${{ always() }}
         run: |
-          echo "::warning::Trivy filesystem SARIF not produced; Security tab upload skipped."
+          set -euo pipefail
+          sarif_path="${RUNNER_TEMP}/pulseplate-trivy/trivy-results.sarif"
+          if [ -s "$sarif_path" ]; then
+            cp -- "$sarif_path" trivy-results.sarif
+            echo "present=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "present=false" >> "${GITHUB_OUTPUT}"
+            echo "::warning::Trivy filesystem SARIF not produced; Security tab upload skipped."
+          fi
 
       - name: Upload Trivy scan results to GitHub Security tab
-        if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}
+        if: ${{ always() && steps.trivy_fs_sarif.outputs.present == 'true' }}
         uses: github/codeql-action/upload-sarif@c00e4aee0547167576bc6663920491135a3dee27 # v4
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: trivy-results.sarif
 
   # Publish tested Docker image
   publish:

--- a/docs/review/PR_1936_FIXED_MAPPING.md
+++ b/docs/review/PR_1936_FIXED_MAPPING.md
@@ -1,0 +1,68 @@
+# PR 1936 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] Post-open review-thread pass completed.
+
+## Fixed in Commit Mapping
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1936#discussion_r3386553212 -> d5272007d9ec2ec494b583db7769a151a66e143e
+Disposition: FIXED
+Commit: d5272007d9ec2ec494b583db7769a151a66e143e
+Evidence: tests/test_ci_workflow_pr_size_governance_contract.py; python3 -m pytest -q tests/test_ci_workflow_pr_size_governance_contract.py
+Reason: The Trivy workflow guard now expects the filesystem scan to write SARIF under the runner temp directory and verifies the copy-back/upload-gating contract before Security tab upload.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1936#discussion_r3386577720 -> d5272007d9ec2ec494b583db7769a151a66e143e
+Disposition: FIXED
+Commit: d5272007d9ec2ec494b583db7769a151a66e143e
+Evidence: tests/test_ci_workflow_pr_size_governance_contract.py; python3 -m pytest -q tests/test_ci_workflow_pr_size_governance_contract.py
+Reason: CodeRabbit's contract-test drift finding is addressed by updating the expected `with.output` value and adding explicit assertions for `trivy_fs_sarif.outputs.present`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1936#discussion_r3386588472 -> d5272007d9ec2ec494b583db7769a151a66e143e
+Disposition: FIXED
+Commit: d5272007d9ec2ec494b583db7769a151a66e143e
+Evidence: tests/test_ci_workflow_pr_size_governance_contract.py; python3 -m pytest -q tests/test_ci_workflow_pr_size_governance_contract.py
+Reason: cubic found the same stale test-contract expectation; the committed test now preserves the temp-output security behavior instead of reverting the workflow to workspace output.
+
+## Lane Start Provenance
+Packet: `artifacts/orchestration/task_packets/7313715fbcd1.json`
+Dispatch manifest: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/7313715fbcd1.json --pretty`
+PR branch: `codex/propose-fix-for-sarif-upload-vulnerability`
+
+## Role Dispatch Evidence
+- Declared role order from dispatch manifest: `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor -> architecture-specialist`.
+- `agent-coordinator` review pass completed through native sub-agent transport. Findings matched live blockers: stale Trivy contract test, missing fixed-mapping artifact, and remote merge-state not ready.
+- `qa-engineer-agent` review pass completed through native sub-agent transport. Finding: this artifact was untracked before the governance commit; disposition is FIXED once this artifact commit lands. QA also confirmed the focused workflow contract test covers temp SARIF output, copy-back, explicit upload gating, and the updated Trivy action output path.
+- `pulseplate-pr-review` dry-run report completed with a local context artifact. It found the missing fixed-mapping artifact as the only deterministic governance finding before this artifact was added.
+- Remaining post-open role transport attempts were not treated as readiness proof while sub-agent responses were pending or unavailable; deterministic gate evidence below is the merge-governance proof for this update.
+
+## Premortem Finding Closure
+- P1 stale workflow contract test could keep current-head CI red after the security workflow fix: FIXED in commit `d5272007d9ec2ec494b583db7769a151a66e143e`.
+Evidence: `tests/test_ci_workflow_pr_size_governance_contract.py`; `python3 -m pytest -q tests/test_ci_workflow_pr_size_governance_contract.py`.
+- P1 mapping artifact absence could leave Phase2 and merge-readiness red after the code fix: FIXED by this artifact.
+Evidence: `docs/review/PR_1936_FIXED_MAPPING.md`; `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1936`.
+- P2 reverting to workspace SARIF output would reopen stale artifact upload risk: NOT-A-BUG for current scope.
+Evidence: `.github/workflows/build.yml`; `tests/test_ci_workflow_pr_size_governance_contract.py`.
+Reason: The workflow keeps temp-dir SARIF generation and gates upload on the explicit `trivy_fs_sarif.outputs.present` flag.
+
+## Experiment Runner Evidence
+- Artifact: `artifacts/orchestration/experiments/results/exp-dcc0a27b03b5.json`
+- Mode: `oracle_only_governance_reviewer`.
+- Status: `accepted`.
+- Shared tree untouched: `true`.
+- Mutated paths: `[]`.
+- Co-author trailer: not used; result was validation evidence only and did not materially author the fix.
+
+## Validation Evidence
+- `python3 scripts/orchestration/check_preflight.py` PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` PASS.
+- `python3 scripts/orchestration/task_bootstrap.py --goal "Close PR 1936 by fixing Trivy SARIF workflow contract test and review governance" --task-class security --pr-phase post_open_review --path .github/workflows/build.yml --path tests/test_ci_workflow_pr_size_governance_contract.py --path docs/review/PR_1936_FIXED_MAPPING.md --requested-agent agent-coordinator --requested-agent qa-engineer-agent --requested-agent bug-hunter --requested-agent security-auditor` PASS.
+- `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/7313715fbcd1.json --pretty` PASS.
+- YAML parse for `.github/workflows/build.yml` and `.github/workflows/trivy.yml` PASS.
+- `python3 -m pytest -q tests/test_ci_workflow_pr_size_governance_contract.py` PASS.
+- `VENV_PYTHON=<repo-root>/.venv/bin/python make validate-changed` PASS in QA role pass.
+- Experiment Runner oracle command `python3 -m pytest -q tests/test_ci_workflow_pr_size_governance_contract.py` PASS in artifact `artifacts/orchestration/experiments/results/exp-dcc0a27b03b5.json`.
+
+## Known Non-Ready Gate
+- Remote PR #1936 current-head state before pushing this artifact was `DIRTY` with failing `test-pr (3.13)`, `PR Body Phase2 gates`, and `Merge readiness gate` on commit `a5a067074e7a757e42922d3885780a7224495cf5`.
+Disposition: FIXED by local commits pending push and current-head CI rerun; do not claim merge readiness until new current-head checks and strict merge wrapper pass.

--- a/docs/review/PR_1936_FIXED_MAPPING.md
+++ b/docs/review/PR_1936_FIXED_MAPPING.md
@@ -24,6 +24,18 @@ Commit: d5272007d9ec2ec494b583db7769a151a66e143e
 Evidence: tests/test_ci_workflow_pr_size_governance_contract.py; python3 -m pytest -q tests/test_ci_workflow_pr_size_governance_contract.py
 Reason: cubic found the same stale test-contract expectation; the committed test now preserves the temp-output security behavior instead of reverting the workflow to workspace output.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1936#pullrequestreview-4465821357 -> d5272007d9ec2ec494b583db7769a151a66e143e
+Disposition: FIXED
+Commit: d5272007d9ec2ec494b583db7769a151a66e143e
+Evidence: tests/test_ci_workflow_pr_size_governance_contract.py; python3 -m pytest -q tests/test_ci_workflow_pr_size_governance_contract.py
+Reason: CodeRabbit's review-level actionable item is the same stale workflow contract test mismatch covered by the discussion mapping above.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1936#pullrequestreview-4465835196 -> d5272007d9ec2ec494b583db7769a151a66e143e
+Disposition: FIXED
+Commit: d5272007d9ec2ec494b583db7769a151a66e143e
+Evidence: tests/test_ci_workflow_pr_size_governance_contract.py; python3 -m pytest -q tests/test_ci_workflow_pr_size_governance_contract.py
+Reason: Cubic's review-level actionable item is the same stale workflow contract test mismatch covered by the discussion mapping above.
+
 ## Lane Start Provenance
 Packet: `artifacts/orchestration/task_packets/7313715fbcd1.json`
 Dispatch manifest: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/7313715fbcd1.json --pretty`

--- a/tests/test_ci_workflow_pr_size_governance_contract.py
+++ b/tests/test_ci_workflow_pr_size_governance_contract.py
@@ -1091,7 +1091,7 @@ def test_node24_checkout_and_docker_action_pins_use_verified_commit_shas() -> No
                 "ignore-policy": ".trivy-ignore-policy.rego",
                 "scanners": "vuln",
                 "format": "sarif",
-                "output": "trivy-results.sarif",
+                "output": "${{ runner.temp }}/pulseplate-trivy/trivy-results.sarif",
                 "severity": "CRITICAL,HIGH",
                 "limit-severities-for-sarif": True,
                 "exit-code": "1",
@@ -1150,6 +1150,52 @@ def test_node24_checkout_and_docker_action_pins_use_verified_commit_shas() -> No
             None,
         ),
     ]
+
+
+def test_build_workflow_trivy_fs_sarif_is_temp_isolated_before_upload() -> None:
+    workflow = _load_workflow(BUILD_WORKFLOW_PATH)
+    prepare_step = _job_step_by_name(
+        workflow,
+        job_id="security-scan",
+        step_name="Prepare Trivy SARIF output path and ignore policy",
+    )
+    scanner_step = _job_step_by_name(
+        workflow,
+        job_id="security-scan",
+        step_name="Run Trivy vulnerability scanner (filesystem scan)",
+    )
+    sarif_check_step = _job_step_by_name(
+        workflow,
+        job_id="security-scan",
+        step_name="Check Trivy filesystem SARIF output",
+    )
+    upload_step = _job_step_by_name(
+        workflow,
+        job_id="security-scan",
+        step_name="Upload Trivy scan results to GitHub Security tab",
+    )
+
+    prepare_run = str(prepare_step["run"])
+    assert "rm -rf -- trivy-results.sarif" in prepare_run
+    assert 'rm -rf "${RUNNER_TEMP}/pulseplate-trivy"' in prepare_run
+    assert 'mkdir -p "${RUNNER_TEMP}/pulseplate-trivy"' in prepare_run
+    assert scanner_step["with"]["output"] == (
+        "${{ runner.temp }}/pulseplate-trivy/trivy-results.sarif"
+    )
+
+    sarif_check_run = str(sarif_check_step["run"])
+    assert sarif_check_step["id"] == "trivy_fs_sarif"
+    assert sarif_check_step["if"] == "${{ always() }}"
+    assert 'sarif_path="${RUNNER_TEMP}/pulseplate-trivy/trivy-results.sarif"' in sarif_check_run
+    assert 'if [ -s "$sarif_path" ]; then' in sarif_check_run
+    assert 'cp -- "$sarif_path" trivy-results.sarif' in sarif_check_run
+    assert 'echo "present=true" >> "${GITHUB_OUTPUT}"' in sarif_check_run
+    assert 'echo "present=false" >> "${GITHUB_OUTPUT}"' in sarif_check_run
+
+    assert upload_step["if"] == (
+        "${{ always() && steps.trivy_fs_sarif.outputs.present == 'true' }}"
+    )
+    assert upload_step["with"]["sarif_file"] == "trivy-results.sarif"
 
 
 def test_active_upload_artifact_refs_all_use_node24_sha() -> None:


### PR DESCRIPTION
### Motivation
- A security scan integrity issue was reported where a pre-existing `trivy-results.sarif` in the checked-out workspace could be uploaded when the Trivy step failed before producing fresh output, allowing an attacker-controlled SARIF to pollute code-scanning results. 
- The intent is to ensure only SARIF files actually produced by the scanner are uploaded while preserving the existing `exit-code: '1'` failure gate for HIGH/CRITICAL findings.

### Description
- Remove any workspace-controlled SARIF before scanning by adding `rm -rf -- trivy-results.sarif` and create an isolated temp output directory under `${{ runner.temp }}/pulseplate-trivy`.
- Configure Trivy to write SARIF to `${{ runner.temp }}/pulseplate-trivy/trivy-results.sarif` instead of the repository workspace to avoid trusting checkout-controlled files.
- Add a validation step `trivy_fs_sarif` that checks the temp SARIF, copies it into the workspace only when the scanner actually produced it, and exposes `steps.trivy_fs_sarif.outputs.present` for gating.
- Gate the `upload-sarif` action on `steps.trivy_fs_sarif.outputs.present == 'true'` (instead of `hashFiles('trivy-results.sarif')`) and keep `exit-code: '1'` to preserve the hard failure semantics.

### Testing
- `python3 scripts/orchestration/check_preflight.py` — passed.
- `python3 scripts/orchestration/check_agent_consistency.py` — passed.
- `python3 scripts/orchestration/task_bootstrap.py --goal "Remediate stale attacker-controlled Trivy SARIF upload after failed filesystem scan" --task-class security --pr-phase pre_open` — passed and the generated local packet was removed before commit.
- `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/9d9ee6d96bda.json --mode review --pretty` — passed.
- YAML parse (`yaml.safe_load`) of `.github/workflows/build.yml`, targeted assertions that verify the new temp output path and gating logic, and `git diff --check` — all passed.
- Environment-limited checks could not be executed in this container: `pre-commit run --all-files`, `make validate-changed`, and `make validate-min` / `pytest` were not runnable due to missing `pre-commit`, `.venv`, `pip`, and `pytest` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2914b1caf8832cafc8dbdbe32ce627)

## Summary by Sourcery

CI:
- Переработать шаги генерации и загрузки Trivy SARIF в workflow сборки так, чтобы вывод записывался во временный каталог, проверялось его наличие и чтобы загрузка выполнялась на основе явного флага «произведено», а не хеш-проверок.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Rework the Trivy SARIF generation and upload steps in the build workflow to write output to a temp directory, validate its presence, and gate the upload on an explicit produced flag instead of hash-based checks.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale or attacker-controlled Trivy SARIF uploads by writing results to runner temp, verifying presence, and uploading only when freshly produced. Keeps the scan fail-closed with exit-code '1' while making the upload advisory.

- **Bug Fixes**
  - Write SARIF to `${{ runner.temp }}/pulseplate-trivy/trivy-results.sarif`; clean any workspace `trivy-results.sarif` and create the temp dir.
  - Add `trivy_fs_sarif` step to copy back only when present and set `present`; warn when missing.
  - Gate `github/codeql-action/upload-sarif` on `steps.trivy_fs_sarif.outputs.present == 'true'`; keep `continue-on-error: true`.
  - Update `tests/test_ci_workflow_pr_size_governance_contract.py` for temp path, copy-back, explicit gating, and the new prepare step.
  - Add `docs/review/PR_1936_FIXED_MAPPING.md` with bot review mapping.

<sup>Written for commit b4ea419c0f84801a5840ee688b07aeeb2a909f3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved security scanning workflow: scan results are written to an isolated temporary location and are only uploaded to the Security tab when a valid report exists.
* **Documentation**
  * Added a review/traceability document capturing the fix, validation steps, evidence trail, and merge-readiness notes.
* **Tests**
  * Added regression tests to verify temporary isolation of scan output and the gated upload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1936_FIXED_MAPPING.md`


## Merge Readiness
- [ ] Current-head CI has rerun on `7e8401c22` and required checks pass.
- [ ] Strict merge-readiness wrapper passes with GitHub auth.
- [ ] Review threads are resolved only after pushed fixed-mapping proof.
- [ ] Final bot pass confirms CodeRabbit, Sourcery, and Cubic have no actionable items.

## Experiment Runner Evidence
- Artifact: `artifacts/orchestration/experiments/results/exp-dcc0a27b03b5.json`
- Mode: `oracle_only_governance_reviewer`; status: accepted; mutated paths: `[]`; co-author trailer not used.
