### PR TITLE
fix(orchestration): allow derived role fingerprints

### DIFF
--- a/docs/review/PR_1939_FIXED_MAPPING.md
+++ b/docs/review/PR_1939_FIXED_MAPPING.md
@@ -5,9 +5,9 @@
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1939#pullrequestreview-4471267899 -> de15b9684
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1939#pullrequestreview-4471267899 -> de15b9684ecb6c035c56a35b8c58918be60ec118
 Disposition: FIXED
-Commit: de15b9684
+Commit: de15b9684ecb6c035c56a35b8c58918be60ec118
 Evidence: scripts/orchestration/context_pack_compression.py:859; tests/test_task_bootstrap.py:25
 
 ## Experiment Runner Evidence

--- a/docs/review/PR_1939_FIXED_MAPPING.md
+++ b/docs/review/PR_1939_FIXED_MAPPING.md
@@ -10,9 +10,9 @@ Disposition: FIXED
 Commit: de15b9684ecb6c035c56a35b8c58918be60ec118
 Evidence: scripts/orchestration/context_pack_compression.py:859; tests/test_task_bootstrap.py:25
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1939#discussion_r3391439188 -> 7bf51f8a944190557943bbfb989b2b66b4749241
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1939#discussion_r3391439188 -> 7bf51f8a9707efd45edc85cd4c48dc77b25b8eac
 Disposition: FIXED
-Commit: 7bf51f8a944190557943bbfb989b2b66b4749241
+Commit: 7bf51f8a9707efd45edc85cd4c48dc77b25b8eac
 Evidence: docs/review/PR_1939_FIXED_MAPPING.md:8
 
 ## Experiment Runner Evidence

--- a/docs/review/PR_1939_FIXED_MAPPING.md
+++ b/docs/review/PR_1939_FIXED_MAPPING.md
@@ -5,7 +5,10 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1939#pullrequestreview-4471267899 -> de15b9684
+Disposition: FIXED
+Commit: de15b9684
+Evidence: scripts/orchestration/context_pack_compression.py:859; tests/test_task_bootstrap.py:25
 
 ## Experiment Runner Evidence
 

--- a/docs/review/PR_1939_FIXED_MAPPING.md
+++ b/docs/review/PR_1939_FIXED_MAPPING.md
@@ -1,0 +1,17 @@
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Experiment Runner Evidence
+
+- Artifact: `artifacts/orchestration/experiments/results/exp-d522813da677.json`
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/b12af8a03f91.json`
+- Packet: `artifacts/orchestration/task_packets/a67bb2c27ac3.json`

--- a/docs/review/PR_1939_FIXED_MAPPING.md
+++ b/docs/review/PR_1939_FIXED_MAPPING.md
@@ -10,6 +10,11 @@ Disposition: FIXED
 Commit: de15b9684ecb6c035c56a35b8c58918be60ec118
 Evidence: scripts/orchestration/context_pack_compression.py:859; tests/test_task_bootstrap.py:25
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1939#discussion_r3391439188 -> 7bf51f8a944190557943bbfb989b2b66b4749241
+Disposition: FIXED
+Commit: 7bf51f8a944190557943bbfb989b2b66b4749241
+Evidence: docs/review/PR_1939_FIXED_MAPPING.md:8
+
 ## Experiment Runner Evidence
 
 - Artifact: `artifacts/orchestration/experiments/results/exp-d522813da677.json`

--- a/scripts/orchestration/context_pack_compression.py
+++ b/scripts/orchestration/context_pack_compression.py
@@ -856,14 +856,14 @@ def _validate_metadata_budget(value: Mapping[str, JsonValue]) -> None:
 def _validate_safe_metadata_string(name: str, value: str) -> None:
     if len(value) > MAX_STRING_LENGTH:
         raise ValueError(f"{name} exceeds maximum length")
-    if "role-fingerprint:" in value.lower() and not _ROLE_FINGERPRINT_RE.match(value):
-        raise ValueError(f"{name} contains unsafe metadata")
     if (
         _FINGERPRINT_RE.match(value)
         or _NODE_ID_RE.match(value)
         or _ROLE_FINGERPRINT_RE.match(value)
     ):
         return
+    if "role-fingerprint:" in value.lower():
+        raise ValueError(f"{name} contains unsafe metadata")
     if _UNSAFE_METADATA_RE.search(value) or _PATH_RE.search(value):
         raise ValueError(f"{name} contains unsafe metadata")
 

--- a/scripts/orchestration/context_pack_compression.py
+++ b/scripts/orchestration/context_pack_compression.py
@@ -856,7 +856,7 @@ def _validate_metadata_budget(value: Mapping[str, JsonValue]) -> None:
 def _validate_safe_metadata_string(name: str, value: str) -> None:
     if len(value) > MAX_STRING_LENGTH:
         raise ValueError(f"{name} exceeds maximum length")
-    if value.startswith("role-fingerprint:") and not _ROLE_FINGERPRINT_RE.match(value):
+    if "role-fingerprint:" in value.lower() and not _ROLE_FINGERPRINT_RE.match(value):
         raise ValueError(f"{name} contains unsafe metadata")
     if (
         _FINGERPRINT_RE.match(value)

--- a/scripts/orchestration/context_pack_compression.py
+++ b/scripts/orchestration/context_pack_compression.py
@@ -79,6 +79,7 @@ MAX_METADATA_DEPTH = 8
 _TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
 _NODE_ID_RE = re.compile(r"^(?:ctx-node|ctx-edge|ctx-pack|ctx-estimate):[0-9a-f]{24}$")
 _FINGERPRINT_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_ROLE_FINGERPRINT_RE = re.compile(r"^role-fingerprint:[0-9a-f]{24}$")
 _PATH_RE = re.compile(
     r"(?:(?:^|[\s=(;,]|:(?!//))(?:/|~[/\\]|[A-Za-z]:[\\/]|\\\\)|(?:^|[\s=(:;,])file://)"
 )
@@ -855,7 +856,13 @@ def _validate_metadata_budget(value: Mapping[str, JsonValue]) -> None:
 def _validate_safe_metadata_string(name: str, value: str) -> None:
     if len(value) > MAX_STRING_LENGTH:
         raise ValueError(f"{name} exceeds maximum length")
-    if _FINGERPRINT_RE.match(value) or _NODE_ID_RE.match(value):
+    if value.startswith("role-fingerprint:") and not _ROLE_FINGERPRINT_RE.match(value):
+        raise ValueError(f"{name} contains unsafe metadata")
+    if (
+        _FINGERPRINT_RE.match(value)
+        or _NODE_ID_RE.match(value)
+        or _ROLE_FINGERPRINT_RE.match(value)
+    ):
         return
     if _UNSAFE_METADATA_RE.search(value) or _PATH_RE.search(value):
         raise ValueError(f"{name} contains unsafe metadata")

--- a/tests/test_context_pack_compression.py
+++ b/tests/test_context_pack_compression.py
@@ -137,6 +137,46 @@ def test_context_pack_compression_allows_safe_prompt_engineering_role_slug() -> 
     assert "prompt-engineering-eval-agent" not in serialized
 
 
+def test_context_pack_compression_allows_safe_derived_role_fingerprint_metadata() -> None:
+    node = ContextGraphNode(
+        node_id="ctx-node:" + "1" * 24,
+        node_type="changed_file",
+        path="AGENTS.md",
+        path_fingerprint="sha256:" + "2" * 64,
+        token_estimate=1,
+        required=False,
+        metadata={"primary_agent_fingerprint": "role-fingerprint:" + "a" * 24},
+    )
+
+    assert dict(to_stable_mapping(node))["metadata"] == {
+        "primary_agent_fingerprint": "role-fingerprint:" + "a" * 24,
+    }
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    (
+        {"primary_agent_fingerprint": "role-fingerprint:prompt"},
+        {"primary_agent_fingerprint": "role-fingerprint:architecture-specialist"},
+        {"nested": {"reviewer_fingerprint": "role-fingerprint:qa-engineer-agent"}},
+        {"items": ["role-fingerprint:security-auditor"]},
+    ),
+)
+def test_context_pack_compression_rejects_malformed_role_fingerprint_metadata(
+    metadata: dict[str, JsonValue],
+) -> None:
+    with pytest.raises(ValueError, match="unsafe metadata"):
+        ContextGraphNode(
+            node_id="ctx-node:" + "1" * 24,
+            node_type="changed_file",
+            path="AGENTS.md",
+            path_fingerprint="sha256:" + "2" * 64,
+            token_estimate=1,
+            required=False,
+            metadata=metadata,
+        )
+
+
 def test_context_pack_compression_estimates_without_reading_raw_file_payloads(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_context_pack_compression.py
+++ b/tests/test_context_pack_compression.py
@@ -158,6 +158,9 @@ def test_context_pack_compression_allows_safe_derived_role_fingerprint_metadata(
     (
         {"primary_agent_fingerprint": "role-fingerprint:prompt"},
         {"primary_agent_fingerprint": "role-fingerprint:architecture-specialist"},
+        {"primary_agent_fingerprint": " role-fingerprint:architecture-specialist"},
+        {"primary_agent_fingerprint": "Role-fingerprint:architecture-specialist"},
+        {"primary_agent_fingerprint": "safe-role-fingerprint:architecture-specialist"},
         {"nested": {"reviewer_fingerprint": "role-fingerprint:qa-engineer-agent"}},
         {"items": ["role-fingerprint:security-auditor"]},
     ),

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from pathlib import Path
 
@@ -89,6 +90,10 @@ def test_task_bootstrap_resolves_orchestration_domain() -> None:
     assert packet["native_subagent_bridge"]["reviewer"]["repo_agent_slug"] == (
         "architecture-specialist"
     )
+    compression = packet["context_pack_compression"]
+    role_fingerprint_re = re.compile(r"^role-fingerprint:[0-9a-f]{24}$")
+    assert role_fingerprint_re.match(compression["metadata"]["primary_agent_fingerprint"])
+    assert role_fingerprint_re.match(compression["metadata"]["reviewer_fingerprint"])
 
 
 def test_task_bootstrap_adds_automation_metadata_defaults() -> None:

--- a/tests/test_task_bootstrap.py
+++ b/tests/test_task_bootstrap.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import re
 import uuid
 from pathlib import Path
 
@@ -23,6 +22,7 @@ from scripts.orchestration.bootstrap_sync_policy import (
     resolve_analysis_envelope_mode,
 )
 from scripts.orchestration.context_pack import repo_relative_paths
+from scripts.orchestration.context_pack_compression import _ROLE_FINGERPRINT_RE
 from scripts.orchestration.design_lane_contract import canonicalize_design_blockers
 from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
 from scripts.orchestration.routing_graph_loader import (
@@ -91,9 +91,8 @@ def test_task_bootstrap_resolves_orchestration_domain() -> None:
         "architecture-specialist"
     )
     compression = packet["context_pack_compression"]
-    role_fingerprint_re = re.compile(r"^role-fingerprint:[0-9a-f]{24}$")
-    assert role_fingerprint_re.match(compression["metadata"]["primary_agent_fingerprint"])
-    assert role_fingerprint_re.match(compression["metadata"]["reviewer_fingerprint"])
+    assert _ROLE_FINGERPRINT_RE.match(compression["metadata"]["primary_agent_fingerprint"])
+    assert _ROLE_FINGERPRINT_RE.match(compression["metadata"]["reviewer_fingerprint"])
 
 
 def test_task_bootstrap_adds_automation_metadata_defaults() -> None:


### PR DESCRIPTION
## Summary
Fix the current-head task bootstrap sanitizer regression where deterministic derived role fingerprints were rejected as unsafe metadata.

## Root Cause
context_pack_compression generated safe derived metadata values like role-fingerprint:<24 hex> for primary_agent_fingerprint and reviewer_fingerprint, but _validate_safe_metadata_string only exempted sha256: and ctx-* derived identifiers before applying the raw-payload unsafe metadata scanner. Because the value contains fingerprint, bootstrap packet creation failed in tests/test_task_bootstrap.py on test-main shards.

## Scope
- Allow exact role-fingerprint:[0-9a-f]{24} metadata values.
- Reject malformed role-fingerprint:* values, including leading text, leading whitespace, and case variants, before generic metadata validation.
- Add direct and task-bootstrap regression coverage.
- Address Sourcery review feedback by reusing the context compression role fingerprint validator in bootstrap tests and simplifying the validator branch order.

## Out of scope
- Runtime semantic cache
- Provider routing runtime
- Model downgrade / provider calls
- DB, OpenAPI, frontend, iOS
- Docker / Trivy / CodeQL fixes

## Validation
- python3 scripts/orchestration/check_preflight.py PASS
- python3 scripts/orchestration/check_agent_consistency.py PASS
- python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open PASS after fix
- python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/b12af8a03f91.json --mode runtime --implementation-owner security-auditor --pretty PASS
- /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_context_pack_compression.py tests/test_task_bootstrap.py tests/test_provider_model_tier_policy.py PASS
- python3 scripts/ci/check_semantic_cache_gate.py PASS
- VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed PASS
- VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python pre-commit run --all-files PASS
- Pre-push hooks PASS with VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python

## Local full verify
Not run by operator request. This PR uses the narrow hotfix validation bundle plus current-head CI as the heavy signal.

## Premortem / Experiment Runner
- Premortem decision: proceed with changes; finding fixed by exact regex assertions in tests/test_task_bootstrap.py.
- Experiment Runner oracle-only governance review ran and wrote a local result artifact; commits include the required co-author trailer because the result shaped validation/commit decision.

## Post-open role review
- qa-engineer-agent: PASS, no blockers.
- bug-hunter: FOUND blocker for malformed role-fingerprint marker variants; FIXED in f9b234d95.
- security-auditor: PASS, no blockers after f9b234d95.
- pulseplate-pr-review: PASS, no findings.
- Sourcery review feedback: FIXED in de15b9684 and mapped in docs/review/PR_1939_FIXED_MAPPING.md.
- Cubic: no issues found on reviewed commit.
- CodeRabbit: latest review still processing after current-head updates.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: docs/review/PR_1939_FIXED_MAPPING.md

## Deferred / Follow-ups
None.

## Rollback
Revert 49ef5d747, f9b234d95, de15b9684, 71b80680c, and c15325280. No DB, OpenAPI, runtime serving, provider wiring, or client artifacts are changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened metadata validation so context compression only accepts properly formatted role-fingerprint values and rejects malformed or unsafe variants; existing fingerprint allowances remain unchanged.

* **Tests**
  * Added tests to confirm valid role-fingerprint metadata is preserved and malformed structures are rejected.
  * Strengthened bootstrap tests to assert fingerprint-format compliance.

* **Documentation**
  * Added a review checklist and evidence notes documenting the fix and review status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->