### PR TITLE
feat(food-data): preserve USDA FDC record metadata

### DIFF
--- a/core/food_merge.py
+++ b/core/food_merge.py
@@ -54,6 +54,15 @@ def _merge_values(values: List[float], strategy: str = "median") -> float:
     return float(vals[0])
 
 
+def _first_non_empty_metadata(values: Iterable[str | None]) -> str | None:
+    """Preserve the first metadata value seen in the existing source order."""
+
+    for value in values:
+        if value:
+            return value
+    return None
+
+
 def merge_records(streams: List[Iterable[FoodRecord]]) -> List[Dict]:
     """
     RU: Объединить записи из нескольких источников.
@@ -141,6 +150,9 @@ def merge_records(streams: List[Iterable[FoodRecord]]) -> List[Dict]:
             **{k: round(compat[k], 3) for k in MICROS},
             "flags": list(sorted(all_flags)),
             "price": 0.0,  # Can be populated from OFF later
+            "brand": _first_non_empty_metadata(row.brand for row in rows),
+            "gtin": _first_non_empty_metadata(row.gtin for row in rows),
+            "fdc_id": _first_non_empty_metadata(row.fdc_id for row in rows),
             "source": "MERGED(" + ",".join(sources) + ")",
             "version_date": today,
             "nutrition_inputs": [entry.to_dict() for entry in resolved.raw_inputs],

--- a/core/food_sources/base.py
+++ b/core/food_sources/base.py
@@ -8,7 +8,9 @@ EN: Base adapter interface.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Mapping
+
+_NULL_METADATA_MARKERS = {"none", "null", "nan"}
 
 
 @dataclass
@@ -38,6 +40,50 @@ class FoodRecord:
     price: float  # price per 100g
     source: str  # data source
     version_date: str  # ISO date
+    brand: str | None = None  # product brand
+    gtin: str | None = None  # GTIN/barcode
+    fdc_id: str | None = None  # USDA FoodData Central ID
+
+
+def normalize_optional_metadata(value: object) -> str | None:
+    """Return stripped metadata text or None for blank/null CSV markers."""
+
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw or raw.lower() in _NULL_METADATA_MARKERS:
+        return None
+    return raw
+
+
+def normalize_optional_gtin(value: object) -> str | None:
+    """Return digit-only GTIN text while preserving leading zeroes."""
+
+    raw = normalize_optional_metadata(value)
+    if raw is None:
+        return None
+    digits = "".join(ch for ch in raw if ch.isdigit())
+    return digits or None
+
+
+def first_metadata_value(row: Mapping[str, object], keys: tuple[str, ...]) -> str | None:
+    """Return the first present metadata value across candidate source fields."""
+
+    for key in keys:
+        value = normalize_optional_metadata(row.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def first_gtin_value(row: Mapping[str, object], keys: tuple[str, ...]) -> str | None:
+    """Return the first present GTIN value across candidate source fields."""
+
+    for key in keys:
+        value = normalize_optional_gtin(row.get(key))
+        if value is not None:
+            return value
+    return None
 
 
 class BaseAdapter:

--- a/core/food_sources/base.py
+++ b/core/food_sources/base.py
@@ -62,7 +62,7 @@ def normalize_optional_gtin(value: object) -> str | None:
     raw = normalize_optional_metadata(value)
     if raw is None:
         return None
-    digits = "".join(ch for ch in raw if ch.isdigit())
+    digits = "".join(ch for ch in raw if ch in "0123456789")
     return digits or None
 
 

--- a/core/food_sources/off.py
+++ b/core/food_sources/off.py
@@ -16,6 +16,9 @@ from ..aliases import map_to_canonical
 from ..units import iu_vitd_from_ug
 from .base import BaseAdapter, FoodRecord, first_gtin_value, first_metadata_value
 
+OFF_BRAND_KEYS = ("brands", "brands_en", "brand")
+OFF_GTIN_KEYS = ("code", "gtin", "barcode")
+
 
 class OFFAdapter(BaseAdapter):
     """
@@ -120,8 +123,8 @@ class OFFAdapter(BaseAdapter):
                 flags.append("LOW_COST")
             if row.get("dairy_free") == "yes":
                 flags.append("DAIRY_FREE")
-            brand = first_metadata_value(row, ("brands", "brands_en", "brand"))
-            gtin = first_gtin_value(row, ("code", "gtin", "barcode"))
+            brand = first_metadata_value(row, OFF_BRAND_KEYS)
+            gtin = first_gtin_value(row, OFF_GTIN_KEYS)
 
             yield FoodRecord(
                 name=canonical,

--- a/core/food_sources/off.py
+++ b/core/food_sources/off.py
@@ -14,7 +14,7 @@ from typing import Dict, Iterable, Optional
 
 from ..aliases import map_to_canonical
 from ..units import iu_vitd_from_ug
-from .base import BaseAdapter, FoodRecord
+from .base import BaseAdapter, FoodRecord, first_gtin_value, first_metadata_value
 
 
 class OFFAdapter(BaseAdapter):
@@ -120,6 +120,8 @@ class OFFAdapter(BaseAdapter):
                 flags.append("LOW_COST")
             if row.get("dairy_free") == "yes":
                 flags.append("DAIRY_FREE")
+            brand = first_metadata_value(row, ("brands", "brands_en", "brand"))
+            gtin = first_gtin_value(row, ("code", "gtin", "barcode"))
 
             yield FoodRecord(
                 name=canonical,
@@ -142,4 +144,7 @@ class OFFAdapter(BaseAdapter):
                 price=0.0,
                 source="OFF",
                 version_date=today,
+                brand=brand,
+                gtin=gtin,
+                fdc_id=None,
             )

--- a/core/food_sources/usda.py
+++ b/core/food_sources/usda.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, Iterable, Optional
 
 from ..aliases import map_to_canonical
 from ..units import iu_vitd_from_ug
-from .base import BaseAdapter, FoodRecord
+from .base import BaseAdapter, FoodRecord, first_gtin_value, first_metadata_value
 
 
 class USDAAdapter(BaseAdapter):
@@ -86,6 +86,15 @@ class USDAAdapter(BaseAdapter):
             Iodine_ug = float(row.get("iodine_ug", 0) or 0)
             K_mg = float(row.get("potassium_mg", 0) or 0)
             Mg_mg = float(row.get("magnesium_mg", 0) or 0)
+            fdc_id = first_metadata_value(row, ("fdc_id", "fdcId"))
+            brand = first_metadata_value(
+                row,
+                ("brand_owner", "brandOwner", "brand_name", "brandName", "brand"),
+            )
+            gtin = first_gtin_value(
+                row,
+                ("gtin_upc", "gtinUpc", "gtinUPC", "gtin", "upc", "barcode"),
+            )
 
             yield FoodRecord(
                 name=canonical,
@@ -108,4 +117,7 @@ class USDAAdapter(BaseAdapter):
                 price=0.0,
                 source="USDA",
                 version_date=today,
+                brand=brand,
+                gtin=gtin,
+                fdc_id=fdc_id,
             )

--- a/core/food_sources/usda.py
+++ b/core/food_sources/usda.py
@@ -16,6 +16,10 @@ from ..aliases import map_to_canonical
 from ..units import iu_vitd_from_ug
 from .base import BaseAdapter, FoodRecord, first_gtin_value, first_metadata_value
 
+USDA_FDC_ID_KEYS = ("fdc_id", "fdcId")
+USDA_BRAND_KEYS = ("brand_owner", "brandOwner", "brand_name", "brandName", "brand")
+USDA_GTIN_KEYS = ("gtin_upc", "gtinUpc", "gtinUPC", "gtin", "upc", "barcode")
+
 
 class USDAAdapter(BaseAdapter):
     """
@@ -86,15 +90,9 @@ class USDAAdapter(BaseAdapter):
             Iodine_ug = float(row.get("iodine_ug", 0) or 0)
             K_mg = float(row.get("potassium_mg", 0) or 0)
             Mg_mg = float(row.get("magnesium_mg", 0) or 0)
-            fdc_id = first_metadata_value(row, ("fdc_id", "fdcId"))
-            brand = first_metadata_value(
-                row,
-                ("brand_owner", "brandOwner", "brand_name", "brandName", "brand"),
-            )
-            gtin = first_gtin_value(
-                row,
-                ("gtin_upc", "gtinUpc", "gtinUPC", "gtin", "upc", "barcode"),
-            )
+            fdc_id = first_metadata_value(row, USDA_FDC_ID_KEYS)
+            brand = first_metadata_value(row, USDA_BRAND_KEYS)
+            gtin = first_gtin_value(row, USDA_GTIN_KEYS)
 
             yield FoodRecord(
                 name=canonical,

--- a/docs/review/PR_1941_FIXED_MAPPING.md
+++ b/docs/review/PR_1941_FIXED_MAPPING.md
@@ -1,0 +1,78 @@
+# PR 1941 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Initial discussion-thread pass completed at PR open.
+- [x] Fixed in commit mapping artifact created after PR number allocation.
+- [ ] Post-open review-thread pass completed.
+
+## Fixed in Commit Mapping
+- No GitHub review threads existed at PR open.
+- New human, bot, or role-agent findings must be added here with `FIXED`,
+  `NOT-A-BUG`, or `DEFERRED` disposition before readiness claims.
+
+## Lane Start Provenance
+- Packet: `artifacts/orchestration/task_packets/897c356ac39e.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+- Branch: `codex/food-data-fdc-record-metadata-passthrough`
+- Worktree: `worktrees/food-data-fdc-record-metadata-passthrough`
+
+## Role Dispatch Evidence
+- Dispatch manifest:
+  `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python; "$VENV_PYTHON" scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/897c356ac39e.json --mode runtime --implementation-owner security-auditor --implementation-owner backend-engineer --pretty`
+- Required pre-open role order executed:
+  `agent-coordinator -> backend-engineer -> qa-engineer-agent -> security-auditor -> architecture-specialist`.
+- Mandatory post-open order pending:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`, then Codex Security
+  diff/finding discovery and `pulseplate-pr-review`.
+
+## Premortem Finding Closure
+- Artifact: `docs/review/PR_FOOD_DATA_FDC_METADATA_PASSTHROUGH_PREMORTEM.md`
+- PM-FDC-META-001 `FoodRecord` constructor compatibility: FIXED in commit
+  `fdeebc3d7`.
+  Evidence: `core/food_sources/base.py`;
+  `tests/test_food_sources_simple.py`.
+- PM-FDC-META-002 GTIN cleanup and leading-zero preservation: FIXED in commit
+  `fdeebc3d7`.
+  Evidence: `core/food_sources/base.py`;
+  `tests/test_food_sources_simple.py`.
+- PM-FDC-META-003 merge metadata passthrough: FIXED in commit `fdeebc3d7`.
+  Evidence: `core/food_merge.py`; `tests/test_food_merge.py`.
+- PM-FDC-META-004 barcode storage lookup metadata round-trip: FIXED in commit
+  `fdeebc3d7`.
+  Evidence: `tests/test_food_store_service.py`.
+- PM-FDC-META-005 runtime/cutover scope creep: NOT-A-BUG.
+  Evidence: branch diff changes only food source normalization, merge behavior,
+  focused tests, and review artifacts; no Alembic/Postgres migration, OpenAPI,
+  route, live provider client, or scheduler files changed.
+
+## Experiment Runner Evidence
+- Packet: `artifacts/orchestration/experiments/food-data-fdc-record-metadata-passthrough-packet.json`
+- Result artifact:
+  `artifacts/orchestration/experiments/results/food-data-fdc-record-metadata-passthrough-oracle.json`
+- Mode: `oracle_only_governance_reviewer`.
+- Status: `accepted`.
+- Mutated paths: `[]`.
+- Co-author required: `false`.
+- Note: an initial runner packet that included `make validate-changed` was
+  rejected because the isolated checkout intentionally lacks the shared repo
+  `.venv`; the accepted oracle uses portable focused pytest, while local
+  `make validate-changed` evidence is recorded below.
+
+## Validation Evidence
+- PASS: `python3 scripts/orchestration/check_preflight.py` via
+  `scripts/orchestration/start_pr_lane.sh`.
+- PASS: `role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/897c356ac39e.json --mode runtime ...`.
+- PASS after rebase onto current `origin/main`: `$VENV_PYTHON -m pytest -q tests/test_food_sources_simple.py tests/test_food_merge.py tests/test_food_store_service.py`.
+- PASS after rebase onto current `origin/main`: `make validate-changed`.
+- PASS after rebase onto current `origin/main`: `pre-commit run --all-files`.
+- PASS during push hooks: changed-file mypy, pip-audit, backend tests,
+  full-repo Bandit, docker build test.
+
+## Known Non-Ready Gate
+- Full `make verify` was operator-deferred for this narrow lane because it runs
+  the full repository coverage path with roughly 10k tests.
+- An attempted `make verify` was stopped by operator direction at `diff-cov`
+  after `verify-env`, flake8, mypy, and `test-fast` had passed.
+- This PR does not claim merge readiness from local full-suite evidence; current
+  head CI, post-open review passes, fixed-mapping/body checks, strict
+  merge-readiness with auth, and the required wait window remain pending.

--- a/docs/review/PR_1941_FIXED_MAPPING.md
+++ b/docs/review/PR_1941_FIXED_MAPPING.md
@@ -1,14 +1,14 @@
 # PR 1941 Fixed in Commit Mapping
 
 ## Discussion Thread Pass
-- [x] Initial discussion-thread pass completed at PR open.
-- [x] Fixed in commit mapping artifact created after PR number allocation.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 - [ ] Post-open review-thread pass completed.
 
 ## Fixed in Commit Mapping
-- No GitHub review threads existed at PR open.
-- New human, bot, or role-agent findings must be added here with `FIXED`,
-  `NOT-A-BUG`, or `DEFERRED` disposition before readiness claims.
+No GitHub review threads existed at PR open. New human, bot, or role-agent
+findings must be added here with `FIXED`, `NOT-A-BUG`, or `DEFERRED`
+disposition before readiness claims.
 
 ## Lane Start Provenance
 - Packet: `artifacts/orchestration/task_packets/897c356ac39e.json`
@@ -47,7 +47,7 @@
 
 ## Experiment Runner Evidence
 - Packet: `artifacts/orchestration/experiments/food-data-fdc-record-metadata-passthrough-packet.json`
-- Result artifact:
+- Artifact:
   `artifacts/orchestration/experiments/results/food-data-fdc-record-metadata-passthrough-oracle.json`
 - Mode: `oracle_only_governance_reviewer`.
 - Status: `accepted`.

--- a/docs/review/PR_1941_FIXED_MAPPING.md
+++ b/docs/review/PR_1941_FIXED_MAPPING.md
@@ -6,7 +6,14 @@
 - [x] Post-open review-thread pass completed.
 
 ## Fixed in Commit Mapping
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1941#pullrequestreview-4476704156 -> f50ad992ae6cf40d1f40aa3d740347903462c28a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1941#discussion_r3395862301 -> f50ad992ae6cf40d1f40aa3d740347903462c28a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1941#pullrequestreview-4476732670 -> f50ad992ae6cf40d1f40aa3d740347903462c28a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1941#discussion_r3395886502 -> f50ad992ae6cf40d1f40aa3d740347903462c28a
+Disposition: FIXED
+Commit: f50ad992ae6cf40d1f40aa3d740347903462c28a
+Evidence: `core/food_sources/base.py`; `core/food_sources/usda.py`; `core/food_sources/off.py`; `tests/edges/test_food_metadata_diff_coverage.py`; `tests/test_food_sources_simple.py`.
+Reason: Sourcery and Cubic identified the same GTIN cleanup bug risk: `str.isdigit()` accepted non-ASCII digit code points. Commit `f50ad992` restricts GTIN cleanup to ASCII `0-9`, adds focused ASCII-only regression coverage, and names USDA/OFF metadata key tuples to reduce schema-update drift.
 
 ## Lane Start Provenance
 - Packet: `artifacts/orchestration/task_packets/897c356ac39e.json`
@@ -19,7 +26,7 @@
   `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python; "$VENV_PYTHON" scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/897c356ac39e.json --mode runtime --implementation-owner security-auditor --implementation-owner backend-engineer --pretty`
 - Required pre-open role order executed:
   `agent-coordinator -> backend-engineer -> qa-engineer-agent -> security-auditor -> architecture-specialist`.
-- Mandatory post-open order pending:
+- Mandatory post-open order completed:
   completed as local read-only role passes after the Codex subagent transport
   returned `403 Forbidden` for `qa-engineer-agent`.
   Order: `qa-engineer-agent -> bug-hunter -> security-auditor`, then Codex
@@ -107,12 +114,34 @@
   `scripts/ci/check_pr_size_governance.py --base-sha <merge-base> --head-sha HEAD --body <PR body>`.
 - PASS after PR body/mapping repair:
   `scripts/ci/check_pr_body_phase2_gates.py --body <PR body> --pr-number 1941`.
+- PASS after bot-finding fix:
+  `$VENV_PYTHON -m pytest -q tests/test_food_sources_simple.py tests/test_food_merge.py tests/test_food_store_service.py tests/edges/test_food_metadata_diff_coverage.py`.
+- PASS after bot-finding fix:
+  targeted local diff-cover from focused coverage:
+  `core/food_merge.py (100%)`, `core/food_sources/base.py (100%)`,
+  `core/food_sources/off.py (100%)`, `core/food_sources/usda.py (100%)`,
+  `Coverage: 100%`.
+- PASS after bot-finding fix: `make validate-changed`.
+- PASS after bot-finding fix: `pre-commit run --all-files`.
 
 ## Known Non-Ready Gate
 - Full `make verify` was operator-deferred for this narrow lane because it runs
   the full repository coverage path with roughly 10k tests.
 - An attempted `make verify` was stopped by operator direction at `diff-cov`
   after `verify-env`, flake8, mypy, and `test-fast` had passed.
-- This PR does not claim merge readiness from local full-suite evidence; current
-  head CI, post-open review passes, fixed-mapping/body checks, strict
-  merge-readiness with auth, and the required wait window remain pending.
+- Current-head `security` failed on the repository-wide Safety audit for
+  existing `torch==2.11.0+cpu` entries in `requirements-rag-vector.txt` and
+  `requirements-rag-vector-cpu.txt`.
+  Evidence: GitHub job `security`
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/actions/runs/27349056881/job/80805623648`
+  reported `ERROR: Safety found high/critical/unknown vulnerabilities in
+  requirements-rag-vector.txt` and `requirements-rag-vector-cpu.txt`.
+  This food metadata PR does not modify dependency requirements and does not
+  widen into the RAG/torch dependency cutover.
+- Previous current-head `diff-coverage` failed before commit `f50ad992`; local
+  targeted diff-cover now reports 100% for all changed source files. A fresh
+  current-head CI rerun is required after pushing this mapping/fix.
+- Previous current-head merge-readiness failed because Sourcery/Cubic bot
+  findings were unmapped. This artifact now maps those findings to commit
+  `f50ad992`; PR body mirror, fresh current-head CI, strict merge-readiness with
+  auth, and the required wait window remain pending.

--- a/docs/review/PR_1941_FIXED_MAPPING.md
+++ b/docs/review/PR_1941_FIXED_MAPPING.md
@@ -3,7 +3,7 @@
 ## Discussion Thread Pass
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
-- [ ] Post-open review-thread pass completed.
+- [x] Post-open review-thread pass completed.
 
 ## Fixed in Commit Mapping
 - No actionable review comments
@@ -20,8 +20,44 @@
 - Required pre-open role order executed:
   `agent-coordinator -> backend-engineer -> qa-engineer-agent -> security-auditor -> architecture-specialist`.
 - Mandatory post-open order pending:
-  `qa-engineer-agent -> bug-hunter -> security-auditor`, then Codex Security
-  diff/finding discovery and `pulseplate-pr-review`.
+  completed as local read-only role passes after the Codex subagent transport
+  returned `403 Forbidden` for `qa-engineer-agent`.
+  Order: `qa-engineer-agent -> bug-hunter -> security-auditor`, then Codex
+  Security diff/finding discovery and `pulseplate-pr-review`.
+
+## Post-Open Role Finding Closure
+- `qa-engineer-agent`: PASS / no blocking findings.
+  Evidence: reviewed diff-scoped code/tests and reran
+  `$VENV_PYTHON -m pytest -q tests/test_food_sources_simple.py tests/test_food_merge.py tests/test_food_store_service.py`;
+  `make validate-changed`.
+  Reason: tests cover USDA/OFF metadata normalization, blank/null handling,
+  GTIN digit cleanup, merge passthrough, and SQLite barcode lookup round-trip.
+- `bug-hunter`: PASS / no blocking findings.
+  Evidence: reviewed first-non-empty merge behavior and barcode fallback tests;
+  `tests/test_food_merge.py::TestMergeRecords::test_merge_records_preserves_first_non_empty_metadata_fields`;
+  `tests/test_food_store_service.py::test_get_food_by_barcode_returns_stored_metadata_from_sqlite`.
+  Reason: no edge-case regression found in the requested bounded path; broad
+  branded-product dedupe remains explicitly out of scope.
+- `security-auditor`: PASS / no blocking findings.
+  Evidence: reviewed changed source files and searched for new auth, SQL,
+  network, subprocess, LLM/provider, and privileged surfaces; no runtime sink
+  added. Added SQL appears only in a parameterized temp-SQLite test fixture.
+  Reason: the diff is offline metadata normalization/merge passthrough only.
+- Codex Security diff scan / finding discovery: NOT-A-BUG / no reportable
+  findings.
+  Evidence: `/tmp/codex-security-scans/food-data-fdc-record-metadata-passthrough/9cbcf933610b_20260611T125527Z/report.md`;
+  all four source worklist rows have completion receipts in
+  `/tmp/codex-security-scans/food-data-fdc-record-metadata-passthrough/9cbcf933610b_20260611T125527Z/artifacts/02_discovery/work_ledger.jsonl`.
+  Reason: scan found no new network, auth, SQL construction, subprocess,
+  deserialization, secrets, LLM/provider, or privileged workflow behavior.
+- `pulseplate-pr-review` large-diff-risk advisory: NOT-A-BUG for PR #1941 scope.
+  Evidence: `/tmp/pulseplate_pr_review_1941.md`;
+  `python3 -m pytest tests/test_pr_review_report.py -q` PASS;
+  `python3 -m pytest tests/test_pr_review_context.py -q` PASS;
+  `make validate-changed` PASS.
+  Reason: the diff is 9 files and 407 changed lines because focused tests plus
+  review artifacts are included; the implementation remains a single bounded
+  compatibility slice with Postgres/runtime/provider expansion out of scope.
 
 ## Premortem Finding Closure
 - Artifact: `docs/review/PR_FOOD_DATA_FDC_METADATA_PASSTHROUGH_PREMORTEM.md`
@@ -65,6 +101,12 @@
 - PASS after rebase onto current `origin/main`: `pre-commit run --all-files`.
 - PASS during push hooks: changed-file mypy, pip-audit, backend tests,
   full-repo Bandit, docker build test.
+- PASS after governance mapping updates: `python3 -m pytest tests/test_pr_review_report.py -q`.
+- PASS after governance mapping updates: `python3 -m pytest tests/test_pr_review_context.py -q`.
+- PASS after PR body/mapping repair:
+  `scripts/ci/check_pr_size_governance.py --base-sha <merge-base> --head-sha HEAD --body <PR body>`.
+- PASS after PR body/mapping repair:
+  `scripts/ci/check_pr_body_phase2_gates.py --body <PR body> --pr-number 1941`.
 
 ## Known Non-Ready Gate
 - Full `make verify` was operator-deferred for this narrow lane because it runs

--- a/docs/review/PR_1941_FIXED_MAPPING.md
+++ b/docs/review/PR_1941_FIXED_MAPPING.md
@@ -6,9 +6,7 @@
 - [ ] Post-open review-thread pass completed.
 
 ## Fixed in Commit Mapping
-No GitHub review threads existed at PR open. New human, bot, or role-agent
-findings must be added here with `FIXED`, `NOT-A-BUG`, or `DEFERRED`
-disposition before readiness claims.
+- No actionable review comments
 
 ## Lane Start Provenance
 - Packet: `artifacts/orchestration/task_packets/897c356ac39e.json`

--- a/docs/review/PR_FOOD_DATA_FDC_METADATA_PASSTHROUGH_PREMORTEM.md
+++ b/docs/review/PR_FOOD_DATA_FDC_METADATA_PASSTHROUGH_PREMORTEM.md
@@ -1,0 +1,99 @@
+# Food Data FDC Metadata Passthrough Premortem
+
+Mode: `pr-premortem`
+Skill: `pulseplate-premortem-risk-review`
+Task packet: `artifacts/orchestration/task_packets/897c356ac39e.json`
+Experiment Runner artifact: `artifacts/orchestration/experiments/results/food-data-fdc-record-metadata-passthrough-oracle.json`
+Branch: `codex/food-data-fdc-record-metadata-passthrough`
+
+## Summary
+
+It is six months from now. This metadata passthrough slice failed because a
+small compatibility update either broke legacy `FoodRecord` construction,
+damaged barcode identifiers, or was misread as approval for a broader food-data
+runtime/cutover change.
+
+## Findings And Closure
+
+### PM-FDC-META-001: FoodRecord Constructors Break
+
+Failure story: Adding metadata fields to `FoodRecord` changes positional
+constructor behavior or requires every existing call site to pass new values.
+Older tests and import paths then fail even though the feature is meant to be
+additive.
+
+Disposition: FIXED
+
+Evidence:
+- `core/food_sources/base.py` adds `brand`, `gtin`, and `fdc_id` as optional
+  fields with `None` defaults at the end of the dataclass.
+- `tests/test_food_sources_simple.py` asserts existing `FoodRecord`
+  construction still yields `None` metadata defaults.
+
+### PM-FDC-META-002: GTIN Cleanup Destroys Barcode Identity
+
+Failure story: USDA or OFF rows preserve non-digit barcode separators, or the
+cleanup path casts values through numbers and drops leading zeroes. Stored
+barcodes then stop matching existing lookup surfaces.
+
+Disposition: FIXED
+
+Evidence:
+- `core/food_sources/base.py` centralizes optional metadata and GTIN cleanup.
+- `tests/test_food_sources_simple.py` covers USDA/OFF blank handling and digit
+  cleanup while preserving leading zeroes from string inputs.
+
+### PM-FDC-META-003: Merge Drops Representative Metadata
+
+Failure story: Source normalization keeps metadata, but the name-based merge
+output omits it, so downstream storage still cannot populate the existing
+barcode columns.
+
+Disposition: FIXED
+
+Evidence:
+- `core/food_merge.py` carries the first non-empty `brand`, `gtin`, and
+  `fdc_id` into merged records without changing merge keys, provenance, or
+  source-priority semantics.
+- `tests/test_food_merge.py` proves merged records preserve metadata from
+  USDA/OFF inputs.
+
+### PM-FDC-META-004: Barcode Storage Surface Still Loses Metadata
+
+Failure story: The storage lookup API already exposes `brand`, `gtin`, and
+`fdc_id`, but a temp SQLite path fails to round-trip the new normalized values.
+
+Disposition: FIXED
+
+Evidence:
+- `tests/test_food_store_service.py` adds a temp-SQLite barcode lookup case for
+  stored `brand`, `gtin`, and `fdc_id` through `get_food_by_barcode()`.
+
+### PM-FDC-META-005: Compatibility Slice Becomes Runtime Expansion
+
+Failure story: Reviewers see USDA/OFF metadata fields and infer approval for
+live provider calls, a Postgres cutover, new source activation, or OpenAPI/client
+regeneration.
+
+Disposition: NOT-A-BUG
+
+Evidence:
+- The branch changes only food source normalization, merge behavior, tests, and
+  this review artifact.
+- No Alembic/Postgres migration, OpenAPI schema, runtime route expansion,
+  provider client, or ingestion scheduler files are changed.
+
+## Decision
+
+`proceed with changes`. The identified implementation risks are closed by the
+code/tests in this branch, and the scope-creep risk is closed by the unchanged
+runtime/cutover surfaces.
+
+## Pre-Open Checklist
+
+- Focused USDA/OFF source, merge, and store-service pytest passes.
+- `make validate-changed` passes against the committed branch diff.
+- `pre-commit run --all-files` passes before push.
+- Experiment Runner oracle-only evidence is accepted with no mutations.
+- PR body keeps Postgres cutover, new data sources, runtime food-pipeline
+  expansion, and live USDA/OFF calls out of scope.

--- a/tests/edges/test_food_metadata_diff_coverage.py
+++ b/tests/edges/test_food_metadata_diff_coverage.py
@@ -1,0 +1,70 @@
+"""Diff-coverage smoke tests for bounded food metadata passthrough."""
+
+from __future__ import annotations
+
+from core.food_sources.base import (
+    first_gtin_value,
+    first_metadata_value,
+    normalize_optional_gtin,
+    normalize_optional_metadata,
+)
+from core.food_sources.off import OFFAdapter
+from core.food_sources.usda import USDAAdapter
+
+
+def test_food_metadata_helpers_cover_blank_fallbacks_and_ascii_gtin() -> None:
+    """Shared metadata helpers keep blank/null values out and GTINs ASCII-only."""
+
+    assert normalize_optional_metadata(None) is None
+    assert normalize_optional_metadata(" null ") is None
+    assert normalize_optional_metadata(" Brand ") == "Brand"
+    assert normalize_optional_gtin(None) is None
+    assert normalize_optional_gtin("nan") is None
+    assert normalize_optional_gtin(" 0-12 ٣٤-56 ") == "01256"
+    assert first_metadata_value({"a": " ", "b": "null", "c": "Chosen"}, ("a", "b", "c")) == "Chosen"
+    assert first_metadata_value({"a": None}, ("a", "b")) is None
+    assert first_gtin_value({"a": "abc", "b": " 00-12 "}, ("a", "b")) == "0012"
+    assert first_gtin_value({"a": "abc", "b": None}, ("a", "b")) is None
+
+
+def test_usda_and_off_metadata_assignments_are_in_fast_coverage(
+    monkeypatch,
+) -> None:
+    """The CI fast lane should exercise adapter metadata assignment lines."""
+
+    usda = USDAAdapter(csv_path="/tmp/unused.csv")
+    monkeypatch.setattr(
+        usda,
+        "fetch",
+        lambda: [
+            {
+                "description": "Granola Bar",
+                "fdcId": " 234567 ",
+                "brandName": " Test Foods ",
+                "upc": "00 123-456 78905",
+            }
+        ],
+    )
+
+    usda_food = next(iter(usda.normalize()))
+    assert usda_food.fdc_id == "234567"
+    assert usda_food.brand == "Test Foods"
+    assert usda_food.gtin == "0012345678905"
+
+    off = OFFAdapter(csv_path="/tmp/unused.csv")
+    monkeypatch.setattr(
+        off,
+        "fetch",
+        lambda: [
+            {
+                "product_name": "Chocolate Bar",
+                "brands_en": " ChocoCorp ",
+                "barcode": "0 301-7620422003",
+            }
+        ],
+    )
+
+    off_food = next(iter(off.normalize()))
+    assert off_food.brand == "ChocoCorp"
+    assert off_food.gtin == "03017620422003"
+    assert off_food.fdc_id is None

--- a/tests/test_food_merge.py
+++ b/tests/test_food_merge.py
@@ -581,6 +581,35 @@ class TestMergeRecords:
         assert len(result) == 1
         assert set(result[0]["flags"]) == {"DAIRY", "ORGANIC", "LOW_FAT"}
 
+    def test_merge_records_preserves_first_non_empty_metadata_fields(self):
+        """Merged records should keep representative source identifiers."""
+        records1 = [
+            self.create_food_record(
+                "granola bar",
+                "USDA",
+                brand="USDA Brand",
+                gtin=None,
+                fdc_id="234567",
+            )
+        ]
+        records2 = [
+            self.create_food_record(
+                "granola bar",
+                "OFF",
+                brand="OFF Brand",
+                gtin="0012345678905",
+                fdc_id=None,
+            )
+        ]
+        streams = [records1, records2]
+
+        result = merge_records(streams)
+
+        assert len(result) == 1
+        assert result[0]["brand"] == "USDA Brand"
+        assert result[0]["gtin"] == "0012345678905"
+        assert result[0]["fdc_id"] == "234567"
+
     def test_merge_records_multiple_foods(self):
         """Test merging multiple different foods."""
         records1 = [

--- a/tests/test_food_sources_simple.py
+++ b/tests/test_food_sources_simple.py
@@ -102,6 +102,52 @@ class TestUSDAAdapter:
 
         os.unlink(f.name)
 
+    def test_usda_normalize_preserves_fdc_brand_and_gtin_metadata(self):
+        """USDA branded rows should keep source identifiers for downstream lookup."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+            writer = csv.writer(f)
+            writer.writerow(
+                [
+                    "description",
+                    "energy_kcal",
+                    "fdc_id",
+                    "gtin_upc",
+                    "brand_owner",
+                ]
+            )
+            writer.writerow(["Granola Bar", "250", "234567", "00 123-456 78905", "Test Foods"])
+            f.flush()
+
+            adapter = USDAAdapter(csv_path=f.name)
+            results = list(adapter.normalize())
+
+            assert len(results) == 1
+            food = results[0]
+            assert food.fdc_id == "234567"
+            assert food.brand == "Test Foods"
+            assert food.gtin == "0012345678905"
+
+        os.unlink(f.name)
+
+    def test_usda_normalize_treats_blank_metadata_as_none(self):
+        """Blank/null-like source metadata should not become persisted strings."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+            writer = csv.writer(f)
+            writer.writerow(["description", "fdcId", "gtin", "brandName"])
+            writer.writerow(["Plain Oats", " null ", "nan", "  "])
+            f.flush()
+
+            adapter = USDAAdapter(csv_path=f.name)
+            results = list(adapter.normalize())
+
+            assert len(results) == 1
+            food = results[0]
+            assert food.fdc_id is None
+            assert food.brand is None
+            assert food.gtin is None
+
+        os.unlink(f.name)
+
 
 class TestOFFAdapter:
     """Test OFF adapter error handling scenarios."""
@@ -239,6 +285,44 @@ class TestOFFAdapter:
         assert len(results) == 1
         assert results[0].name
 
+    def test_off_normalize_preserves_brand_and_gtin_metadata(self) -> None:
+        """OFF rows should map barcode and brands into FoodRecord metadata."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+            writer = csv.writer(f)
+            writer.writerow(["product_name", "code", "brands", "energy-kcal_100g"])
+            writer.writerow(["Chocolate Bar", "0 301-7620422003", "ChocoCorp", "540"])
+            f.flush()
+
+            adapter = OFFAdapter(csv_path=f.name)
+            results = list(adapter.normalize())
+
+            assert len(results) == 1
+            food = results[0]
+            assert food.brand == "ChocoCorp"
+            assert food.gtin == "03017620422003"
+            assert food.fdc_id is None
+
+        os.unlink(f.name)
+
+    def test_off_normalize_treats_blank_metadata_as_none(self) -> None:
+        """OFF null markers should not leak into brand or GTIN fields."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".csv") as f:
+            writer = csv.writer(f)
+            writer.writerow(["product_name", "code", "gtin", "barcode", "brands"])
+            writer.writerow(["Plain Crackers", "nan", " null ", "", "None"])
+            f.flush()
+
+            adapter = OFFAdapter(csv_path=f.name)
+            results = list(adapter.normalize())
+
+            assert len(results) == 1
+            food = results[0]
+            assert food.brand is None
+            assert food.gtin is None
+            assert food.fdc_id is None
+
+        os.unlink(f.name)
+
 
 class TestBaseAdapter:
     """Test base adapter abstract methods."""
@@ -282,6 +366,9 @@ class TestBaseAdapter:
         assert record.kcal == 250.0
         assert record.flags == ["GF"]
         assert record.source == "TEST"
+        assert record.brand is None
+        assert record.gtin is None
+        assert record.fdc_id is None
 
 
 class TestFoodSourcesIntegration:

--- a/tests/test_food_sources_simple.py
+++ b/tests/test_food_sources_simple.py
@@ -13,7 +13,7 @@ import tempfile
 
 import pytest
 
-from core.food_sources.base import BaseAdapter, FoodRecord
+from core.food_sources.base import BaseAdapter, FoodRecord, normalize_optional_gtin
 from core.food_sources.off import OFFAdapter
 from core.food_sources.usda import USDAAdapter
 
@@ -369,6 +369,11 @@ class TestBaseAdapter:
         assert record.brand is None
         assert record.gtin is None
         assert record.fdc_id is None
+
+    def test_gtin_cleanup_keeps_ascii_digits_only(self) -> None:
+        """Barcode cleanup should not translate non-ASCII digit code points."""
+
+        assert normalize_optional_gtin(" 0-12 ٣٤-56 ") == "01256"
 
 
 class TestFoodSourcesIntegration:

--- a/tests/test_food_store_service.py
+++ b/tests/test_food_store_service.py
@@ -603,6 +603,41 @@ def test_get_food_by_barcode_returns_row_with_normalized_input(
     assert conn.calls == ["00012345678905"]
 
 
+def test_get_food_by_barcode_returns_stored_metadata_from_sqlite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "food.sqlite"
+    with sqlite3.connect(db_path) as con:
+        con.execute("""
+            CREATE TABLE foods (
+                id TEXT PRIMARY KEY,
+                canonical_name TEXT,
+                gtin TEXT,
+                brand TEXT,
+                fdc_id TEXT,
+                nutrition_confidence REAL
+            )
+            """)
+        con.execute(
+            "INSERT INTO foods (id, canonical_name, gtin, brand, fdc_id, nutrition_confidence) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("food-gtin", "Granola Bar", "0012345678905", "USDA Brand", "234567", 0.8),
+        )
+
+    monkeypatch.setattr(food_store, "DB_PATH", db_path)
+    food_store.reset_foods_nutrition_confidence_column_cache()
+
+    result = food_store.get_food_by_barcode("00 123-456 78905")
+
+    assert result is not None
+    assert result["id"] == "food-gtin"
+    assert result["brand"] == "USDA Brand"
+    assert result["gtin"] == "0012345678905"
+    assert result["fdc_id"] == "234567"
+    assert result["nutrition_confidence"] == 0.8
+
+
 def test_get_food_by_barcode_uses_leading_zero_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     conn = _DummyBarcodeConn(
         rows_by_barcode={


### PR DESCRIPTION
## Goal
Propagate optional `fdc_id`, `brand`, and `gtin` metadata through the existing compatibility-first food data path: `FoodRecord`, USDA/OFF normalization, merge output, and the existing SQLite barcode lookup/storage surface.

## Business reason
This preserves representative branded-product metadata already expected by barcode lookup/storage code, without widening food pipeline runtime behavior or approving a data-source/cutover change.

## Scope
- Add optional `FoodRecord.brand`, `FoodRecord.gtin`, and `FoodRecord.fdc_id` fields with `None` defaults.
- Normalize USDA metadata from `fdc_id`/`fdcId`, `gtin_upc`/`gtin`/`upc`/`barcode`, and `brand_owner`/`brand_name`/`brand`.
- Normalize OFF metadata from `code`/`gtin`/`barcode` and `brands`/`brand`, with `fdc_id=None`.
- Carry first non-empty metadata values through `merge_records()`.
- Prove existing `get_food_by_barcode()` returns stored `brand`, `gtin`, and `fdc_id` from temp SQLite.

## Out of scope
- No Postgres/Alembic cutover or schema migration.
- No new data source or live USDA/OFF calls.
- No runtime food-pipeline expansion.
- No OpenAPI/client regeneration.
- No merge-key, provenance, or source-priority redesign.

## Files changed
- `core/food_sources/base.py`
- `core/food_sources/usda.py`
- `core/food_sources/off.py`
- `core/food_merge.py`
- `tests/edges/test_food_metadata_diff_coverage.py`
- `tests/test_food_sources_simple.py`
- `tests/test_food_merge.py`
- `tests/test_food_store_service.py`
- `docs/review/PR_FOOD_DATA_FDC_METADATA_PASSTHROUGH_PREMORTEM.md`
- `docs/review/PR_1941_FIXED_MAPPING.md`

## Key decisions
- Missing, blank, `None`, `null`, and `nan` upstream metadata stays `None`.
- GTIN cleanup keeps only ASCII digits (`0-9`) and preserves leading zeroes from string inputs.
- Merge output carries one representative first-non-empty metadata value per current name-based merged record.
- Existing `FoodItem`, SQLite columns, and barcode route shape stay unchanged.

## Tests
- PASS: `python3 scripts/orchestration/check_preflight.py` via `scripts/orchestration/start_pr_lane.sh`.
- PASS: `role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/897c356ac39e.json --mode runtime ...` with coordinator-declared role order executed.
- PASS after governance mapping updates: `$VENV_PYTHON -m pytest -q tests/test_food_sources_simple.py tests/test_food_merge.py tests/test_food_store_service.py`.
- PASS after governance mapping updates: `make validate-changed`.
- PASS after governance mapping updates: `pre-commit run --all-files`.
- PASS after governance mapping updates: `python3 -m pytest tests/test_pr_review_report.py -q`.
- PASS after governance mapping updates: `python3 -m pytest tests/test_pr_review_context.py -q`.
- PASS local body/scope gates: `check_pr_size_governance.py` and `check_pr_body_phase2_gates.py`.
- PASS after bot-finding fix: `$VENV_PYTHON -m pytest -q tests/test_food_sources_simple.py tests/test_food_merge.py tests/test_food_store_service.py tests/edges/test_food_metadata_diff_coverage.py`.
- PASS after bot-finding fix: focused local `diff-cover` reported 100% for `core/food_merge.py`, `core/food_sources/base.py`, `core/food_sources/off.py`, and `core/food_sources/usda.py`.
- PASS after bot-finding fix: `make validate-changed`.
- PASS after bot-finding fix: `pre-commit run --all-files`.
- PASS during push hooks: changed-file mypy where applicable, pip-audit, backend tests, full-repo Bandit, docker build test where applicable.
- Full `make verify`: operator-deferred for this narrow lane because the suite runs the full ~10k-test coverage path. An attempted run was stopped at `diff-cov` by operator direction after `verify-env`, flake8, mypy, and `test-fast` had passed; readiness evidence for this PR is the narrow gate set above plus current-head CI.

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/food-data-fdc-record-metadata-passthrough-oracle.json`

- Mode: `oracle_only_governance_reviewer`.
- Status: `accepted`.
- Mutated paths: `[]`.
- Co-author required: `false`.

## Security notes
- Offline-only normalization and test changes.
- No auth, secrets, network, subprocess, LLM, billing, or privileged CI surface changes.
- No weakened guards, suppressions, or skipped tests.
- Codex Security diff scan/finding discovery completed with no reportable findings: `/tmp/codex-security-scans/food-data-fdc-record-metadata-passthrough/9cbcf933610b_20260611T125527Z/report.md`.

## Risks / rollback
- Risk: representative metadata on merged name-based records may not distinguish all branded variants. This is accepted for this bounded passthrough slice and does not redesign product identity.
- Rollback: revert the branch commits to remove the additive metadata passthrough and review artifacts.

## Deferred / follow-ups
- Postgres cutover, runtime ingestion expansion, and broader branded product dedupe remain out of scope for this PR.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Post-open review-thread pass completed
- Post-open role passes completed locally after Codex subagent transport returned `403 Forbidden`: `qa-engineer-agent -> bug-hunter -> security-auditor`, Codex Security diff/finding scan, and `pulseplate-pr-review`.

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1941#pullrequestreview-4476704156 -> f50ad992ae6cf40d1f40aa3d740347903462c28a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1941#discussion_r3395862301 -> f50ad992ae6cf40d1f40aa3d740347903462c28a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1941#pullrequestreview-4476732670 -> f50ad992ae6cf40d1f40aa3d740347903462c28a
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1941#discussion_r3395886502 -> f50ad992ae6cf40d1f40aa3d740347903462c28a
- Commit: f50ad992ae6cf40d1f40aa3d740347903462c28a
- Disposition: FIXED. Cubic and Sourcery both identified the GTIN Unicode-digit issue; commit `f50ad992` restricts cleanup to ASCII digits and adds fast-lane diff coverage.

## Merge Readiness
- Not claiming merge readiness.
- Current-head `security` is blocked by the repository-wide Safety audit for existing `torch==2.11.0+cpu` entries in `requirements-rag-vector.txt` and `requirements-rag-vector-cpu.txt`; this PR does not modify dependency requirements and does not widen into the RAG/torch cutover.
- A fresh current-head CI run is required after the bot-finding fix/mapping push; prior `diff-coverage` and merge-readiness failures were before commit `f50ad992` / mapping commit `8f74fcf`.
- Merge readiness remains blocked on current-head CI, any new bot/actionable review disposition, strict merge-readiness with auth, and the required wait window.
