### PR TITLE
ci(security): migrate Safety audit to scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,6 +533,8 @@ jobs:
             "${install_args[@]}"
 
       - name: Dependency audit with Safety
+        env:
+          SAFETY_API_KEY: ${{ secrets.SAFETY_API_KEY }}
         run: |
           set -euo pipefail
           python3 scripts/ci/run_safety_audit.py

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Run security checks
         if: matrix.shard_id == 1  # Run once (shard 1 only) - codebase-wide check
+        env:
+          SAFETY_API_KEY: ${{ secrets.SAFETY_API_KEY }}
         run: |
           set +e  # Disable immediate exit on error
           set -u  # Check undefined variables
@@ -102,17 +104,15 @@ jobs:
           # Only fail on MEDIUM/HIGH severity (-ll) and MEDIUM/HIGH confidence (-ii)
           bandit -r . -f json -o bandit-report.json --exclude './tests,./tests_strict' -ll -ii || BANDIT_EXIT=$?
 
-          # Safety (v3 preferred: scan with --save-as, fallback to deprecated check)
+          # Safety scan remains advisory in nightly; PR CI owns the blocking gate.
           # Only run if safety is installed
           if [ "$SAFETY_INSTALLED" -eq 1 ]; then
-            safety --stage cicd scan --save-as json safety-report.json > safety-text-report.txt 2> safety-stderr.log
-            SAFETY_EXIT=$?
-
-            if [ "$SAFETY_EXIT" -ne 0 ]; then
-              echo "safety scan failed (exit=$SAFETY_EXIT). Falling back to deprecated 'safety check'..."
-              : > safety-stderr.log
-              safety check --json > safety-report.json 2> safety-stderr.log
+            if [ -n "${SAFETY_API_KEY:-}" ]; then
+              safety --stage cicd --disable-optional-telemetry scan --save-as json safety-report.json > safety-text-report.txt 2> safety-stderr.log
               SAFETY_EXIT=$?
+            else
+              echo "WARNING: SAFETY_API_KEY is not configured; skipping advisory nightly Safety scan." | tee safety-stderr.log
+              SAFETY_EXIT=1
             fi
 
             echo "--- safety-stderr.log (first 120 lines) ---"
@@ -136,7 +136,7 @@ jobs:
 
           # Warn but don't fail if safety failed (when installed)
           if [ "$SAFETY_INSTALLED" -eq 1 ] && [ "$SAFETY_EXIT" -ne 0 ]; then
-            echo "WARNING: safety check failed (exit=$SAFETY_EXIT) - review safety-report.json"
+            echo "WARNING: safety scan failed or skipped (exit=$SAFETY_EXIT) - review safety-report.json"
           fi
 
       - name: Run tests with coverage (shard ${{ matrix.shard_id }}/${{ env.SHARD_TOTAL }})

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -92,6 +92,8 @@ jobs:
           fi
 
       - name: Run Safety (dependency audit with policy)
+        env:
+          SAFETY_API_KEY: ${{ secrets.SAFETY_API_KEY }}
         run: |
           set -euo pipefail
           python3 scripts/ci/run_safety_audit.py

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,7 +166,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 664
+        "line_number": 666
       }
     ],
     ".github/workflows/frontend-ci.yml": [
@@ -1750,5 +1750,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-10T12:31:58Z"
+  "generated_at": "2026-06-11T13:15:47Z"
 }

--- a/docs/review/PR_1942_FIXED_MAPPING.md
+++ b/docs/review/PR_1942_FIXED_MAPPING.md
@@ -26,9 +26,10 @@ Evidence: tests/test_run_safety_audit.py:177 covers nested include copying; test
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#discussion_r3396494884 -> 841b0ce6769a9f7b420532c1049d98e3e8c9eda4
 
 Disposition: FIXED
-Commit: 5bda41d10
+Commit: 5bda41d10, 530cf9b6c
 Evidence: current-head `security` job failed because authenticated Safety Platform scan reported `fonttools` vulnerability `88739` as `ignored: null` while the repo policy carries a non-expired waiver for the private-index lag.
 Evidence: scripts/ci/run_safety_audit.py:256 loads active repo policy waivers; scripts/ci/run_safety_audit.py:469 moves matching active Safety findings to ignored only when the waiver is valid; scripts/ci/run_safety_audit.py:737 keeps non-zero Safety exits fail-closed unless explained by repo-policy waivers.
+Evidence: scripts/ci/run_safety_audit.py:258 loads PyYAML dynamically so the pre-push mypy hook does not require import stubs or a `type: ignore` suppression.
 Evidence: tests/test_run_safety_audit.py:265 covers the cloud-policy-not-ignored case; tests/test_run_safety_audit.py:294 covers expired waiver blocking; tests/test_run_safety_audit.py:418 covers non-zero Safety exits with only repo-policy-waived findings.
 Evidence: focused gates PASS: `pytest -q tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py`; `make validate-changed`; `pre-commit run --all-files`.
 

--- a/docs/review/PR_1942_FIXED_MAPPING.md
+++ b/docs/review/PR_1942_FIXED_MAPPING.md
@@ -33,6 +33,15 @@ Evidence: scripts/ci/run_safety_audit.py:258 loads PyYAML dynamically so the pre
 Evidence: tests/test_run_safety_audit.py:265 covers the cloud-policy-not-ignored case; tests/test_run_safety_audit.py:294 covers expired waiver blocking; tests/test_run_safety_audit.py:418 covers non-zero Safety exits with only repo-policy-waived findings.
 Evidence: focused gates PASS: `pytest -q tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py`; `make validate-changed`; `pre-commit run --all-files`.
 
+Disposition: FIXED
+Commit: 066b6b8749b6de1e59b028fd1dbe194e10a0bbee
+Evidence: scripts/ci/run_safety_audit.py:585 validates every top-level and nested requirement/constraint manifest source against the resolved repo root before reading it.
+Evidence: scripts/ci/run_safety_audit.py:614 now passes the resolved repo root into recursive manifest collection, so nested out-of-root references fail through the intended SafetyAuditError path before any nested read.
+Evidence: tests/test_run_safety_audit.py:154 covers the Cubic-reported nested manifest escape case.
+Evidence: focused gates PASS: `pytest -q tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py`; `ruff check scripts/ci/run_safety_audit.py tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py`; `pre-commit run mypy --hook-stage pre-push --files scripts/ci/run_safety_audit.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#pullrequestreview-4477542316 -> 066b6b8749b6de1e59b028fd1dbe194e10a0bbee
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#discussion_r3396586707 -> 066b6b8749b6de1e59b028fd1dbe194e10a0bbee
+
 ## External Review Availability Notes
 
 External bot capacity or availability notices are not treated as code-actionable

--- a/docs/review/PR_1942_FIXED_MAPPING.md
+++ b/docs/review/PR_1942_FIXED_MAPPING.md
@@ -7,13 +7,32 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#pullrequestreview-4477183535 is a Sourcery rate-limit notice and contains no code-actionable finding.
+Reason: External reviewer quota notice; no repository code or documentation change is requested by the bot comment.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#pullrequestreview-4477183535
+
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#issuecomment-4681105440 is a CodeRabbit rate-limit notice and contains no code-actionable finding.
+Reason: External reviewer quota notice; no repository code or documentation change is requested by the bot comment.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#issuecomment-4681105440
+
+Disposition: NOT-A-BUG
+Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#issuecomment-4681091305 is a Codex review quota notice and contains no code-actionable finding.
+Reason: External reviewer quota notice; no repository code or documentation change is requested by the bot comment.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#issuecomment-4681091305
+
+## External Review Availability Notes
+
+External bot capacity or availability notices are not treated as code-actionable
+findings or approval. This PR still waits for current-head CI, strict
+merge-readiness, and the mandatory wait-window before any merge claim.
 
 ## Merge Readiness
 
 - [ ] Current-head CI terminal success confirmed.
 - [ ] Required checks complete with no pending jobs.
-- [ ] Bot review completed with no unmapped actionable comments.
+- [ ] Bot review/governance completed with no unmapped actionable comments.
 - [ ] Strict review-thread disposition passes with auth.
 - [ ] Strict merge-readiness guard passes with auth.
 - [ ] Mandatory wait-window after latest bot/review activity completed.

--- a/docs/review/PR_1942_FIXED_MAPPING.md
+++ b/docs/review/PR_1942_FIXED_MAPPING.md
@@ -1,0 +1,19 @@
+# PR 1942 — Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Merge Readiness
+
+- [ ] Current-head CI terminal success confirmed.
+- [ ] Required checks complete with no pending jobs.
+- [ ] Bot review completed with no unmapped actionable comments.
+- [ ] Strict review-thread disposition passes with auth.
+- [ ] Strict merge-readiness guard passes with auth.
+- [ ] Mandatory wait-window after latest bot/review activity completed.

--- a/docs/review/PR_1942_FIXED_MAPPING.md
+++ b/docs/review/PR_1942_FIXED_MAPPING.md
@@ -44,6 +44,18 @@ Evidence: focused gates PASS: `pytest -q tests/test_run_safety_audit.py tests/te
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#discussion_r3397707944 -> 066b6b8749b6de1e59b028fd1dbe194e10a0bbee
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#discussion_r3397707946 -> 066b6b8749b6de1e59b028fd1dbe194e10a0bbee
 
+Disposition: FIXED
+Commit: d2e87590c8aca82cc9c1725eeff3e2ae8e2104d9
+Evidence: scripts/ci/run_safety_audit.py:260 skips repo waiver overlay parsing for non-YAML policy files so TOML policies remain Safety-owned instead of failing through PyYAML.
+Evidence: scripts/ci/run_safety_audit.py:539 wraps repo-policy waiver loading and application in the same write-and-reraise diagnostic path used by Safety report normalization.
+Evidence: tests/test_run_safety_audit.py:344 covers TOML policy skip behavior; tests/test_run_safety_audit.py:351 covers malformed YAML policy errors writing the safety summary artifact before failing closed.
+Evidence: focused gates PASS: `pytest -q tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py`; `ruff check scripts/ci/run_safety_audit.py tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py`; `ruff format --check scripts/ci/run_safety_audit.py tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py`; `pre-commit run mypy --hook-stage pre-push --files scripts/ci/run_safety_audit.py`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#pullrequestreview-4478857702 -> d2e87590c8aca82cc9c1725eeff3e2ae8e2104d9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#discussion_r3397707933 -> d2e87590c8aca82cc9c1725eeff3e2ae8e2104d9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#discussion_r3397707940 -> d2e87590c8aca82cc9c1725eeff3e2ae8e2104d9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#pullrequestreview-4478873734 -> d2e87590c8aca82cc9c1725eeff3e2ae8e2104d9
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#discussion_r3397721876 -> d2e87590c8aca82cc9c1725eeff3e2ae8e2104d9
+
 ## External Review Availability Notes
 
 External bot capacity or availability notices are not treated as code-actionable

--- a/docs/review/PR_1942_FIXED_MAPPING.md
+++ b/docs/review/PR_1942_FIXED_MAPPING.md
@@ -13,14 +13,17 @@ Reason: External reviewer quota notice; no repository code or documentation chan
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#pullrequestreview-4477183535
 
 Disposition: NOT-A-BUG
-Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#issuecomment-4681105440 is a CodeRabbit rate-limit notice and contains no code-actionable finding.
-Reason: External reviewer quota notice; no repository code or documentation change is requested by the bot comment.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#issuecomment-4681105440
-
-Disposition: NOT-A-BUG
 Evidence: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#issuecomment-4681091305 is a Codex review quota notice and contains no code-actionable finding.
 Reason: External reviewer quota notice; no repository code or documentation change is requested by the bot comment.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#issuecomment-4681091305
+
+Disposition: FIXED
+Commit: 841b0ce6769a9f7b420532c1049d98e3e8c9eda4
+Evidence: scripts/ci/run_safety_audit.py:425 adds transitive requirement/constraint include collection with cycle protection; scripts/ci/run_safety_audit.py:444 uses it when preparing the temp scan target.
+Evidence: scripts/ci/run_safety_audit.py:581 folds non-zero Safety exit codes into the aggregate workflow verdict; scripts/ci/run_safety_audit.py:659 prints non-zero Safety exits as errors in main.
+Evidence: tests/test_run_safety_audit.py:177 covers nested include copying; tests/test_run_safety_audit.py:198 covers include cycles; tests/test_run_safety_audit.py:310 covers non-zero Safety exits with below-HIGH parsed findings.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#pullrequestreview-4477432600 -> 841b0ce6769a9f7b420532c1049d98e3e8c9eda4
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#discussion_r3396494884 -> 841b0ce6769a9f7b420532c1049d98e3e8c9eda4
 
 ## External Review Availability Notes
 

--- a/docs/review/PR_1942_FIXED_MAPPING.md
+++ b/docs/review/PR_1942_FIXED_MAPPING.md
@@ -26,10 +26,10 @@ Evidence: tests/test_run_safety_audit.py:177 covers nested include copying; test
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#discussion_r3396494884 -> 841b0ce6769a9f7b420532c1049d98e3e8c9eda4
 
 Disposition: FIXED
-Commit: 5bda41d10, 530cf9b6c
+Commit: 5bda41d10cf08514fc1fe726db556b9d8cabfef5
 Evidence: current-head `security` job failed because authenticated Safety Platform scan reported `fonttools` vulnerability `88739` as `ignored: null` while the repo policy carries a non-expired waiver for the private-index lag.
 Evidence: scripts/ci/run_safety_audit.py:256 loads active repo policy waivers; scripts/ci/run_safety_audit.py:469 moves matching active Safety findings to ignored only when the waiver is valid; scripts/ci/run_safety_audit.py:737 keeps non-zero Safety exits fail-closed unless explained by repo-policy waivers.
-Evidence: scripts/ci/run_safety_audit.py:258 loads PyYAML dynamically so the pre-push mypy hook does not require import stubs or a `type: ignore` suppression.
+Evidence: follow-up commit 530cf9b6ceaa5e4a51d60f597ec32a5dad354a83 loads PyYAML dynamically so the pre-push mypy hook does not require import stubs or a `type: ignore` suppression.
 Evidence: tests/test_run_safety_audit.py:265 covers the cloud-policy-not-ignored case; tests/test_run_safety_audit.py:294 covers expired waiver blocking; tests/test_run_safety_audit.py:418 covers non-zero Safety exits with only repo-policy-waived findings.
 Evidence: focused gates PASS: `pytest -q tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py`; `make validate-changed`; `pre-commit run --all-files`.
 
@@ -41,6 +41,8 @@ Evidence: tests/test_run_safety_audit.py:154 covers the Cubic-reported nested ma
 Evidence: focused gates PASS: `pytest -q tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py`; `ruff check scripts/ci/run_safety_audit.py tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py`; `pre-commit run mypy --hook-stage pre-push --files scripts/ci/run_safety_audit.py`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#pullrequestreview-4477542316 -> 066b6b8749b6de1e59b028fd1dbe194e10a0bbee
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#discussion_r3396586707 -> 066b6b8749b6de1e59b028fd1dbe194e10a0bbee
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#discussion_r3397707944 -> 066b6b8749b6de1e59b028fd1dbe194e10a0bbee
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#discussion_r3397707946 -> 066b6b8749b6de1e59b028fd1dbe194e10a0bbee
 
 ## External Review Availability Notes
 

--- a/docs/review/PR_1942_FIXED_MAPPING.md
+++ b/docs/review/PR_1942_FIXED_MAPPING.md
@@ -25,6 +25,13 @@ Evidence: tests/test_run_safety_audit.py:177 covers nested include copying; test
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#pullrequestreview-4477432600 -> 841b0ce6769a9f7b420532c1049d98e3e8c9eda4
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1942#discussion_r3396494884 -> 841b0ce6769a9f7b420532c1049d98e3e8c9eda4
 
+Disposition: FIXED
+Commit: 5bda41d10
+Evidence: current-head `security` job failed because authenticated Safety Platform scan reported `fonttools` vulnerability `88739` as `ignored: null` while the repo policy carries a non-expired waiver for the private-index lag.
+Evidence: scripts/ci/run_safety_audit.py:256 loads active repo policy waivers; scripts/ci/run_safety_audit.py:469 moves matching active Safety findings to ignored only when the waiver is valid; scripts/ci/run_safety_audit.py:737 keeps non-zero Safety exits fail-closed unless explained by repo-policy waivers.
+Evidence: tests/test_run_safety_audit.py:265 covers the cloud-policy-not-ignored case; tests/test_run_safety_audit.py:294 covers expired waiver blocking; tests/test_run_safety_audit.py:418 covers non-zero Safety exits with only repo-policy-waived findings.
+Evidence: focused gates PASS: `pytest -q tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py`; `make validate-changed`; `pre-commit run --all-files`.
+
 ## External Review Availability Notes
 
 External bot capacity or availability notices are not treated as code-actionable

--- a/requirements-security.txt
+++ b/requirements-security.txt
@@ -1,4 +1,5 @@
 # Security CI tooling pins.
 # Keep Safety install deterministic through the approved private proxy and governed emergency wheel fallback.
 safety==3.8.1
+pyyaml==6.0.3
 regex==2026.5.9

--- a/safety-policy.yaml
+++ b/safety-policy.yaml
@@ -1,5 +1,5 @@
-# Safety policy file for ignoring known vulnerabilities
-# Format: YAML (required by Safety 3.6.2+)
+# Safety policy file for Safety CLI 3 scan.
+# Format: YAML v3.0 (required by Safety scan).
 # Documentation: https://docs.safetycli.com/
 #
 # PyUp ID 88739 (fonttools TTX eval): approved private CI/Docker package index
@@ -7,10 +7,59 @@
 # Remove this ignore when requirements pin fonttools>=4.62.0 and the mirror syncs.
 # Advisory: docs/security/FONTTOOLS_TTX_EVAL_ADVISORY.md
 
-security:
-  ignore-vulnerabilities:
-    "88739":
-      reason: >-
-        Private PULSEPLATE_PYTHON_INDEX_URL mirrors fonttools 4.61.1 only (pip:
-        "from versions: 4.61.1"). Bump pin to >=4.62.0 when the index publishes
-        it; then drop this ignore. See docs/security/FONTTOOLS_TTX_EVAL_ADVISORY.md.
+version: "3.0"
+
+scanning-settings:
+  max-depth: 6
+  exclude: []
+  include-files: []
+  system:
+    targets: []
+
+report:
+  dependency-vulnerabilities:
+    enabled: true
+    auto-ignore-in-report:
+      python:
+        environment-results: true
+        unpinned-requirements: true
+      vulnerabilities:
+        "88739":
+          reason: >-
+            Private package index still mirrors fonttools 4.61.1 only; remove
+            when docs/security/FONTTOOLS_TTX_EVAL_ADVISORY.md is closed.
+          expires: "2026-07-08"
+      cvss-severity: []
+
+fail-scan-with-exit-code:
+  dependency-vulnerabilities:
+    enabled: true
+    fail-on-any-of:
+      cvss-severity:
+        - critical
+        - high
+        - unknown
+      exploitability:
+        - critical
+        - high
+        - unknown
+
+security-updates:
+  dependency-vulnerabilities:
+    auto-security-updates-limit:
+      - patch
+
+installation:
+  default-action: allow
+  audit-logging:
+    enabled: true
+  allow:
+    packages: []
+    vulnerabilities: {}
+  deny:
+    packages: {}
+    vulnerabilities:
+      warning-on-any-of:
+        cvss-severity: []
+      block-on-any-of:
+        cvss-severity: []

--- a/scripts/ci/run_safety_audit.py
+++ b/scripts/ci/run_safety_audit.py
@@ -582,10 +582,20 @@ def _manifest_reference_paths(manifest: Path) -> tuple[Path, ...]:
     return tuple(references)
 
 
-def _collect_manifest_paths(manifest: Path, seen: set[Path] | None = None) -> tuple[Path, ...]:
+def _validate_manifest_source(root: Path, source: Path) -> None:
+    if root not in (source, *source.parents):
+        raise SafetyAuditError(f"Safety manifest reference escapes repo root: {source}")
+    if not source.is_file():
+        raise SafetyAuditError(f"Safety manifest reference not found: {source}")
+
+
+def _collect_manifest_paths(
+    root: Path, manifest: Path, seen: set[Path] | None = None
+) -> tuple[Path, ...]:
     """Return a manifest and all nested requirement/constraint references."""
 
     resolved_manifest = manifest.resolve()
+    _validate_manifest_source(root, resolved_manifest)
     visited = set() if seen is None else seen
     if resolved_manifest in visited:
         return ()
@@ -593,7 +603,7 @@ def _collect_manifest_paths(manifest: Path, seen: set[Path] | None = None) -> tu
 
     collected = [resolved_manifest]
     for reference in _manifest_reference_paths(resolved_manifest):
-        collected.extend(_collect_manifest_paths(reference, visited))
+        collected.extend(_collect_manifest_paths(root, reference, visited))
     return tuple(collected)
 
 
@@ -601,12 +611,8 @@ def _prepare_scan_target(root: Path, manifest: Path, target_dir: Path) -> Path:
     """Copy one manifest and its local requirement references into a scan target."""
 
     root_resolved = root.resolve()
-    paths = _collect_manifest_paths(manifest)
+    paths = _collect_manifest_paths(root_resolved, manifest)
     for source in paths:
-        if root_resolved not in (source, *source.parents):
-            raise SafetyAuditError(f"Safety manifest reference escapes repo root: {source}")
-        if not source.is_file():
-            raise SafetyAuditError(f"Safety manifest reference not found: {source}")
         destination = target_dir / source.relative_to(root_resolved)
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, destination)

--- a/scripts/ci/run_safety_audit.py
+++ b/scripts/ci/run_safety_audit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+from datetime import date, datetime
 import json
 import os
 from pathlib import Path
@@ -13,6 +14,8 @@ import subprocess  # nosec B404: Safety CLI execution is the bounded CI audit pu
 import sys
 import tempfile
 from typing import Any, Mapping, Sequence
+
+import yaml
 
 REQUIRED_MANIFEST = "requirements.txt"
 OPTIONAL_MANIFESTS: tuple[str, ...] = (
@@ -45,6 +48,7 @@ class SafetyAnalysis:
     status: int
     high_risk_count: int
     other_count: int
+    repo_policy_ignored_count: int
     lines: tuple[str, ...]
 
 
@@ -70,6 +74,15 @@ class SafetyAuditConfig:
     policy_file_args: tuple[str, ...]
     safety_binary: str
     safety_stage: str
+
+
+@dataclass(frozen=True)
+class RepoPolicyWaiver:
+    """Local repo policy waiver for a Safety vulnerability ID."""
+
+    vulnerability_id: str
+    reason: str
+    expires: date
 
 
 def artifact_stem(manifest: Path) -> str:
@@ -159,6 +172,12 @@ def _version_from_spec(spec: object) -> str:
     return ""
 
 
+def _vulnerability_id(entry: Mapping[str, Any]) -> str:
+    """Return the stable vulnerability identifier from a normalized entry."""
+
+    return str(entry.get("vuln_id") or entry.get("advisory_id") or "")
+
+
 def _scan_vulnerability_severity(vulnerability: Mapping[str, Any]) -> Mapping[str, Any]:
     """Return a legacy-compatible severity mapping for Safety scan v3 reports."""
 
@@ -192,14 +211,105 @@ def _legacy_entry_from_scan_vulnerability(
 ) -> dict[str, Any]:
     """Convert one Safety scan v3 vulnerability to the legacy parser shape."""
 
-    raw_spec = specification.get("raw") or vulnerability.get("vulnerable_spec") or ""
+    raw_spec = specification.get("raw") or ""
     return {
         "package_name": dependency.get("name") or "<unknown package>",
-        "analyzed_version": _version_from_spec(vulnerability.get("vulnerable_spec") or raw_spec),
+        "analyzed_version": _version_from_spec(raw_spec or vulnerability.get("vulnerable_spec")),
         "vuln_id": vulnerability.get("id") or vulnerability.get("vuln_id") or "",
         "advisory": vulnerability.get("advisory") or f"Found in {file_location}: {raw_spec}",
         "severity": _scan_vulnerability_severity(vulnerability),
     }
+
+
+def _policy_path_from_args(policy_file_args: Sequence[str]) -> Path | None:
+    """Return the configured Safety policy path from command arguments."""
+
+    if "--policy-file" not in policy_file_args:
+        return None
+    index = policy_file_args.index("--policy-file")
+    if index + 1 >= len(policy_file_args):
+        return None
+    return Path(policy_file_args[index + 1])
+
+
+def _parse_policy_expiry(value: object, vulnerability_id: str) -> date:
+    """Parse and validate a repo policy waiver expiry date."""
+
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError as exc:
+            raise SafetyAuditError(
+                f"Safety policy waiver {vulnerability_id} has invalid expires date: {value}",
+                PARSE_ERROR,
+            ) from exc
+    raise SafetyAuditError(
+        f"Safety policy waiver {vulnerability_id} must include an expires date.",
+        PARSE_ERROR,
+    )
+
+
+def repo_policy_waivers(policy_path: Path | None) -> dict[str, RepoPolicyWaiver]:
+    """Load active vulnerability waivers from the repo Safety policy file."""
+
+    if policy_path is None:
+        return {}
+    try:
+        payload = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise SafetyAuditError(f"Failed to parse Safety policy file: {exc}", PARSE_ERROR) from exc
+
+    if not isinstance(payload, Mapping):
+        raise SafetyAuditError("Safety policy file must be a YAML mapping.", PARSE_ERROR)
+    report = payload.get("report") or {}
+    if not isinstance(report, Mapping):
+        raise SafetyAuditError("Safety policy report section must be a mapping.", PARSE_ERROR)
+    dependency_vulnerabilities = report.get("dependency-vulnerabilities") or {}
+    if not isinstance(dependency_vulnerabilities, Mapping):
+        raise SafetyAuditError(
+            "Safety policy dependency-vulnerabilities section must be a mapping.",
+            PARSE_ERROR,
+        )
+    auto_ignore = dependency_vulnerabilities.get("auto-ignore-in-report") or {}
+    if not isinstance(auto_ignore, Mapping):
+        raise SafetyAuditError(
+            "Safety policy auto-ignore-in-report section must be a mapping.",
+            PARSE_ERROR,
+        )
+    vulnerabilities = auto_ignore.get("vulnerabilities") or {}
+    if not isinstance(vulnerabilities, Mapping):
+        raise SafetyAuditError(
+            "Safety policy auto-ignore-in-report vulnerabilities must be a mapping.",
+            PARSE_ERROR,
+        )
+
+    today = date.today()
+    waivers: dict[str, RepoPolicyWaiver] = {}
+    for raw_vulnerability_id, raw_waiver in vulnerabilities.items():
+        vulnerability_id = str(raw_vulnerability_id)
+        if not isinstance(raw_waiver, Mapping):
+            raise SafetyAuditError(
+                f"Safety policy waiver {vulnerability_id} must be a mapping.",
+                PARSE_ERROR,
+            )
+        reason = raw_waiver.get("reason")
+        if not isinstance(reason, str) or not reason.strip():
+            raise SafetyAuditError(
+                f"Safety policy waiver {vulnerability_id} must include a reason.",
+                PARSE_ERROR,
+            )
+        expires = _parse_policy_expiry(raw_waiver.get("expires"), vulnerability_id)
+        if expires >= today:
+            waivers[vulnerability_id] = RepoPolicyWaiver(
+                vulnerability_id=vulnerability_id,
+                reason=reason,
+                expires=expires,
+            )
+    return waivers
 
 
 def _normalize_scan_v3_report(
@@ -356,7 +466,41 @@ def build_summary_lines(
     return tuple(lines)
 
 
-def analyze_report(report_path: Path, summary_path: Path) -> SafetyAnalysis:
+def _apply_repo_policy_waivers(
+    vulnerabilities: Sequence[Mapping[str, Any]],
+    ignored: Sequence[Mapping[str, Any]],
+    waivers: Mapping[str, RepoPolicyWaiver],
+) -> tuple[list[Mapping[str, Any]], list[Mapping[str, Any]], int]:
+    """Move active Safety findings to ignored when covered by active repo waivers."""
+
+    active: list[Mapping[str, Any]] = []
+    ignored_vulnerabilities = list(ignored)
+    repo_policy_ignored_count = 0
+    for vulnerability in vulnerabilities:
+        waiver = waivers.get(_vulnerability_id(vulnerability))
+        if waiver is None:
+            active.append(vulnerability)
+            continue
+        ignored_vulnerabilities.append(
+            {
+                **vulnerability,
+                "ignored": {
+                    "source": "repo-policy",
+                    "reason": waiver.reason,
+                    "expires": waiver.expires.isoformat(),
+                },
+            }
+        )
+        repo_policy_ignored_count += 1
+    return active, ignored_vulnerabilities, repo_policy_ignored_count
+
+
+def analyze_report(
+    report_path: Path,
+    summary_path: Path,
+    *,
+    policy_path: Path | None = None,
+) -> SafetyAnalysis:
     """Parse one Safety JSON report, write summary text, and return severity status."""
 
     if not report_path.is_file() or report_path.stat().st_size == 0:
@@ -381,6 +525,12 @@ def analyze_report(report_path: Path, summary_path: Path) -> SafetyAnalysis:
         summary_path.write_text(f"{message}\n", encoding="utf-8")
         raise
 
+    waivers = repo_policy_waivers(policy_path)
+    vulnerabilities, ignored, repo_policy_ignored_count = _apply_repo_policy_waivers(
+        vulnerabilities,
+        ignored,
+        waivers,
+    )
     lines = build_summary_lines(vulnerabilities, ignored)
     summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     high_risk_count = sum(
@@ -397,6 +547,7 @@ def analyze_report(report_path: Path, summary_path: Path) -> SafetyAnalysis:
         status=status,
         high_risk_count=high_risk_count,
         other_count=other_count,
+        repo_policy_ignored_count=repo_policy_ignored_count,
         lines=lines,
     )
 
@@ -516,8 +667,16 @@ def run_safety_for_manifest(
         report_txt.write_text(f"{message}\n", encoding="utf-8")
         raise SafetyAuditError(message, completed.returncode or 1)
 
-    analysis = analyze_report(report_json, report_txt)
-    if completed.returncode != 0 and analysis.status == PARSE_OK:
+    analysis = analyze_report(
+        report_json,
+        report_txt,
+        policy_path=_policy_path_from_args(config.policy_file_args),
+    )
+    if (
+        completed.returncode != 0
+        and analysis.status == PARSE_OK
+        and analysis.repo_policy_ignored_count == 0
+    ):
         message = (
             f"Safety exited with code {completed.returncode} for {manifest.name}, "
             "but the report contained no parsed vulnerabilities."
@@ -578,7 +737,10 @@ def run_audit(config: SafetyAuditConfig) -> tuple[ManifestAuditResult, ...]:
 def exit_code_for_results(results: Sequence[ManifestAuditResult]) -> int:
     """Return aggregate workflow exit code for parsed Safety results."""
 
-    if any(result.safety_exit_code != 0 for result in results):
+    if any(
+        result.safety_exit_code != 0 and result.analysis.repo_policy_ignored_count == 0
+        for result in results
+    ):
         return 1
     if any(result.analysis.status == PARSE_BLOCKING for result in results):
         return 1
@@ -659,7 +821,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     exit_code = exit_code_for_results(results)
     for result in results:
         manifest_name = result.manifest.name
-        if result.safety_exit_code != 0:
+        if (
+            result.safety_exit_code != 0
+            and result.analysis.repo_policy_ignored_count > 0
+            and result.analysis.status != PARSE_BLOCKING
+        ):
+            print(
+                "OK: Safety scan passed for "
+                f"{manifest_name} after {result.analysis.repo_policy_ignored_count} "
+                "repo-policy waiver(s)"
+            )
+        elif result.safety_exit_code != 0:
             print(
                 f"ERROR: Safety scan exited with code {result.safety_exit_code} for {manifest_name}"
             )

--- a/scripts/ci/run_safety_audit.py
+++ b/scripts/ci/run_safety_audit.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 import argparse
 from dataclasses import dataclass
 import json
+import os
 from pathlib import Path
 import shutil
 import subprocess  # nosec B404: Safety CLI execution is the bounded CI audit purpose (remove-by: 2026-07-31, ref: ledger-p1-safety-audit-shared-script-after-pr1479)
 import sys
+import tempfile
 from typing import Any, Mapping, Sequence
 
 REQUIRED_MANIFEST = "requirements.txt"
@@ -20,6 +22,8 @@ OPTIONAL_MANIFESTS: tuple[str, ...] = (
 )
 HIGH_RISK_SEVERITIES = {"HIGH", "CRITICAL", "UNKNOWN"}
 SAFETY_BINARY = "safety"
+SAFETY_AUTH_ENV = "SAFETY_" + "API_KEY"
+DEFAULT_SAFETY_STAGE = "cicd"
 PARSE_OK = 0
 PARSE_WARNING = 2
 PARSE_BLOCKING = 10
@@ -65,6 +69,7 @@ class SafetyAuditConfig:
     manifests: tuple[Path, ...]
     policy_file_args: tuple[str, ...]
     safety_binary: str
+    safety_stage: str
 
 
 def artifact_stem(manifest: Path) -> str:
@@ -143,6 +148,189 @@ def base_severity(entry: Mapping[str, Any]) -> str:
     return "UNKNOWN"
 
 
+def _version_from_spec(spec: object) -> str:
+    """Best-effort version extraction from a package specification string."""
+
+    if not isinstance(spec, str):
+        return ""
+    for operator in ("===", "==", ">=", "<=", "~=", "!=", ">", "<"):
+        if operator in spec:
+            return spec.split(operator, maxsplit=1)[1].strip()
+    return ""
+
+
+def _scan_vulnerability_severity(vulnerability: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return a legacy-compatible severity mapping for Safety scan v3 reports."""
+
+    severity = vulnerability.get("severity")
+    if isinstance(severity, Mapping):
+        return severity
+
+    cve = vulnerability.get("CVE") or vulnerability.get("cve")
+    if isinstance(cve, Mapping):
+        cvssv3 = cve.get("cvssv3")
+        if isinstance(cvssv3, Mapping):
+            return {"cvssv3": cvssv3}
+        cvssv2 = cve.get("cvssv2")
+        if isinstance(cvssv2, Mapping):
+            return {"cvssv2": cvssv2}
+
+    ignored = vulnerability.get("ignored")
+    if isinstance(ignored, Mapping):
+        reason = ignored.get("reason")
+        if isinstance(reason, str) and "severity" in reason.lower():
+            return {"severity": reason}
+    return {}
+
+
+def _legacy_entry_from_scan_vulnerability(
+    *,
+    dependency: Mapping[str, Any],
+    specification: Mapping[str, Any],
+    vulnerability: Mapping[str, Any],
+    file_location: str,
+) -> dict[str, Any]:
+    """Convert one Safety scan v3 vulnerability to the legacy parser shape."""
+
+    raw_spec = specification.get("raw") or vulnerability.get("vulnerable_spec") or ""
+    return {
+        "package_name": dependency.get("name") or "<unknown package>",
+        "analyzed_version": _version_from_spec(vulnerability.get("vulnerable_spec") or raw_spec),
+        "vuln_id": vulnerability.get("id") or vulnerability.get("vuln_id") or "",
+        "advisory": vulnerability.get("advisory") or f"Found in {file_location}: {raw_spec}",
+        "severity": _scan_vulnerability_severity(vulnerability),
+    }
+
+
+def _normalize_scan_v3_report(
+    payload: Mapping[str, Any],
+) -> tuple[list[Mapping[str, Any]], list[Mapping[str, Any]]]:
+    """Extract active and ignored vulnerabilities from Safety scan v3 JSON."""
+
+    scan_results = payload.get("scan_results")
+    if not isinstance(scan_results, Mapping):
+        raise SafetyAuditError("Safety scan report missing scan_results object.", PARSE_ERROR)
+
+    projects = scan_results.get("projects")
+    if not isinstance(projects, list):
+        raise SafetyAuditError(
+            "Safety scan report scan_results.projects must be a list.", PARSE_ERROR
+        )
+
+    vulnerabilities: list[Mapping[str, Any]] = []
+    ignored_vulnerabilities: list[Mapping[str, Any]] = []
+    for project in projects:
+        if not isinstance(project, Mapping):
+            raise SafetyAuditError(
+                "Safety scan report project entries must be objects.", PARSE_ERROR
+            )
+        files = project.get("files", [])
+        if files is None:
+            files = []
+        if not isinstance(files, list):
+            raise SafetyAuditError("Safety scan report project files must be a list.", PARSE_ERROR)
+        for scanned_file in files:
+            if not isinstance(scanned_file, Mapping):
+                raise SafetyAuditError(
+                    "Safety scan report file entries must be objects.", PARSE_ERROR
+                )
+            file_location = str(scanned_file.get("location") or "<unknown file>")
+            results = scanned_file.get("results") or {}
+            if not isinstance(results, Mapping):
+                raise SafetyAuditError(
+                    "Safety scan report file results must be objects.", PARSE_ERROR
+                )
+            dependencies = results.get("dependencies", [])
+            if dependencies is None:
+                dependencies = []
+            if not isinstance(dependencies, list):
+                raise SafetyAuditError(
+                    "Safety scan report file dependencies must be a list.",
+                    PARSE_ERROR,
+                )
+            for dependency in dependencies:
+                if not isinstance(dependency, Mapping):
+                    raise SafetyAuditError(
+                        "Safety scan report dependency entries must be objects.",
+                        PARSE_ERROR,
+                    )
+                specifications = dependency.get("specifications", [])
+                if specifications is None:
+                    specifications = []
+                if not isinstance(specifications, list):
+                    raise SafetyAuditError(
+                        "Safety scan report dependency specifications must be a list.",
+                        PARSE_ERROR,
+                    )
+                for specification in specifications:
+                    if not isinstance(specification, Mapping):
+                        raise SafetyAuditError(
+                            "Safety scan report specification entries must be objects.",
+                            PARSE_ERROR,
+                        )
+                    spec_vulnerabilities = specification.get("vulnerabilities") or {}
+                    if not isinstance(spec_vulnerabilities, Mapping):
+                        raise SafetyAuditError(
+                            "Safety scan report specification vulnerabilities must be objects.",
+                            PARSE_ERROR,
+                        )
+                    known = spec_vulnerabilities.get("known_vulnerabilities", [])
+                    if known is None:
+                        known = []
+                    if not isinstance(known, list):
+                        raise SafetyAuditError(
+                            "Safety scan report known_vulnerabilities must be a list.",
+                            PARSE_ERROR,
+                        )
+                    for vulnerability in known:
+                        if not isinstance(vulnerability, Mapping):
+                            raise SafetyAuditError(
+                                "Safety scan vulnerability entries must be objects.",
+                                PARSE_ERROR,
+                            )
+                        entry = _legacy_entry_from_scan_vulnerability(
+                            dependency=dependency,
+                            specification=specification,
+                            vulnerability=vulnerability,
+                            file_location=file_location,
+                        )
+                        if vulnerability.get("ignored"):
+                            ignored_vulnerabilities.append(entry)
+                        else:
+                            vulnerabilities.append(entry)
+
+    return vulnerabilities, ignored_vulnerabilities
+
+
+def normalized_vulnerabilities(
+    payload: Mapping[str, Any],
+) -> tuple[list[Mapping[str, Any]], list[Mapping[str, Any]]]:
+    """Return active and ignored vulnerabilities for supported Safety report schemas."""
+
+    if isinstance(payload.get("scan_results"), Mapping):
+        return _normalize_scan_v3_report(payload)
+
+    vulnerabilities = payload.get("vulnerabilities", [])
+    if vulnerabilities is None:
+        vulnerabilities = []
+    ignored = payload.get("ignored_vulnerabilities", [])
+    if ignored is None:
+        ignored = []
+    if not isinstance(vulnerabilities, list):
+        raise SafetyAuditError("Safety report vulnerabilities field must be a list.", PARSE_ERROR)
+    if not isinstance(ignored, list):
+        raise SafetyAuditError(
+            "Safety report ignored_vulnerabilities field must be a list.", PARSE_ERROR
+        )
+    if not all(isinstance(item, Mapping) for item in vulnerabilities):
+        raise SafetyAuditError("Safety report vulnerability entries must be objects.", PARSE_ERROR)
+    if not all(isinstance(item, Mapping) for item in ignored):
+        raise SafetyAuditError(
+            "Safety report ignored vulnerability entries must be objects.", PARSE_ERROR
+        )
+    return vulnerabilities, ignored
+
+
 def build_summary_lines(
     vulnerabilities: Sequence[Mapping[str, Any]], ignored: Sequence[object]
 ) -> tuple[str, ...]:
@@ -186,24 +374,12 @@ def analyze_report(report_path: Path, summary_path: Path) -> SafetyAnalysis:
         summary_path.write_text(f"{message}\n", encoding="utf-8")
         raise SafetyAuditError(message, PARSE_ERROR)
 
-    vulnerabilities = payload.get("vulnerabilities", [])
-    if vulnerabilities is None:
-        vulnerabilities = []
-    ignored = payload.get("ignored_vulnerabilities", [])
-    if ignored is None:
-        ignored = []
-    if not isinstance(vulnerabilities, list):
-        message = "Safety report vulnerabilities field must be a list."
+    try:
+        vulnerabilities, ignored = normalized_vulnerabilities(payload)
+    except SafetyAuditError as exc:
+        message = str(exc)
         summary_path.write_text(f"{message}\n", encoding="utf-8")
-        raise SafetyAuditError(message, PARSE_ERROR)
-    if not isinstance(ignored, list):
-        message = "Safety report ignored_vulnerabilities field must be a list."
-        summary_path.write_text(f"{message}\n", encoding="utf-8")
-        raise SafetyAuditError(message, PARSE_ERROR)
-    if not all(isinstance(item, Mapping) for item in vulnerabilities):
-        message = "Safety report vulnerability entries must be objects."
-        summary_path.write_text(f"{message}\n", encoding="utf-8")
-        raise SafetyAuditError(message, PARSE_ERROR)
+        raise
 
     lines = build_summary_lines(vulnerabilities, ignored)
     summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -225,6 +401,52 @@ def analyze_report(report_path: Path, summary_path: Path) -> SafetyAnalysis:
     )
 
 
+def _manifest_reference_paths(manifest: Path) -> tuple[Path, ...]:
+    """Return local requirement/constraint files referenced by a manifest."""
+
+    references: list[Path] = []
+    for raw_line in manifest.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if not parts:
+            continue
+        option = parts[0]
+        if option in {"-r", "--requirement", "-c", "--constraint"} and len(parts) >= 2:
+            references.append((manifest.parent / parts[1]).resolve())
+        elif option.startswith(("-r", "-c")) and len(option) > 2:
+            references.append((manifest.parent / option[2:]).resolve())
+    return tuple(references)
+
+
+def _prepare_scan_target(root: Path, manifest: Path, target_dir: Path) -> Path:
+    """Copy one manifest and its local requirement references into a scan target."""
+
+    root_resolved = root.resolve()
+    paths = [manifest.resolve()]
+    paths.extend(_manifest_reference_paths(manifest))
+    for source in paths:
+        if root_resolved not in (source, *source.parents):
+            raise SafetyAuditError(f"Safety manifest reference escapes repo root: {source}")
+        if not source.is_file():
+            raise SafetyAuditError(f"Safety manifest reference not found: {source}")
+        destination = target_dir / source.relative_to(root_resolved)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+    return target_dir
+
+
+def _require_scan_auth(stage: str) -> None:
+    """Fail before invoking Safety scan when CI authentication is missing."""
+
+    if stage in {"cicd", "production"} and not os.environ.get(SAFETY_AUTH_ENV):
+        raise SafetyAuditError(
+            "SAFETY_API_KEY is required for Safety scan in cicd/production stage. "
+            "Add the GitHub Actions secret and expose it to this job as SAFETY_API_KEY.",
+        )
+
+
 def run_safety_for_manifest(
     *,
     config: SafetyAuditConfig,
@@ -239,24 +461,32 @@ def run_safety_for_manifest(
     for artifact_path in (report_json, report_txt, console_log):
         artifact_path.unlink(missing_ok=True)
 
-    print(f"Running Safety audit for {manifest.name}")
-    command = [
-        config.safety_binary,
-        "check",
-        *config.policy_file_args,
-        "--json",
-        "-r",
-        str(manifest),
-        "--save-json",
-        str(report_json),
-    ]
-    completed = subprocess.run(  # nosec B603: argv uses resolved Safety CLI and manifest paths from canonical discovery only (remove-by: 2026-07-31, ref: ledger-p1-safety-audit-shared-script-after-pr1479)
-        command,
-        cwd=config.root,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    print(f"Running Safety scan for {manifest.name}")
+    _require_scan_auth(config.safety_stage)
+    with tempfile.TemporaryDirectory(prefix=f"pulseplate-safety-{stem}-") as temp_root:
+        scan_target = _prepare_scan_target(config.root, manifest, Path(temp_root))
+        command = [
+            config.safety_binary,
+            "--stage",
+            config.safety_stage,
+            "--disable-optional-telemetry",
+            "scan",
+            "--target",
+            str(scan_target),
+            "--output",
+            "json",
+            "--save-as",
+            "json",
+            str(report_json),
+            *config.policy_file_args,
+        ]
+        completed = subprocess.run(  # nosec B603: argv uses resolved Safety CLI and manifest paths from canonical discovery only (remove-by: 2026-07-31, ref: ledger-p1-safety-audit-shared-script-after-pr1479)
+            command,
+            cwd=config.root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
     console_log.write_text((completed.stdout or "") + (completed.stderr or ""), encoding="utf-8")
     if console_log.stat().st_size > 0:
         print(f"=== Raw Safety Output ({manifest.name}) ===")
@@ -300,6 +530,7 @@ def build_config(
     manifest_names: Sequence[str] | None = None,
     policy_file: str | None = None,
     safety_binary: str = SAFETY_BINARY,
+    safety_stage: str = DEFAULT_SAFETY_STAGE,
 ) -> SafetyAuditConfig:
     """Build and validate Safety audit runtime configuration."""
 
@@ -310,6 +541,7 @@ def build_config(
         manifests=discover_manifests(root, manifest_names),
         policy_file_args=policy_args(root, policy_file),
         safety_binary=safety_binary_path(safety_binary),
+        safety_stage=safety_stage,
     )
 
 
@@ -377,6 +609,12 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
         default=SAFETY_BINARY,
         help="Safety executable name or path.",
     )
+    parser.add_argument(
+        "--safety-stage",
+        default=DEFAULT_SAFETY_STAGE,
+        choices=("development", "cicd", "production"),
+        help="Safety lifecycle stage for scan execution.",
+    )
     return parser.parse_args(argv)
 
 
@@ -393,6 +631,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             manifest_names=args.manifests,
             policy_file=args.policy_file,
             safety_binary=args.safety_binary,
+            safety_stage=args.safety_stage,
         )
         results = run_audit(config)
     except SafetyAuditError as exc:
@@ -409,7 +648,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 f"WARNING: Safety reported vulnerabilities below HIGH severity in {manifest_name}"
             )
         else:
-            print(f"OK: Safety check passed for {manifest_name}")
+            print(f"OK: Safety scan passed for {manifest_name}")
     return exit_code
 
 

--- a/scripts/ci/run_safety_audit.py
+++ b/scripts/ci/run_safety_audit.py
@@ -415,17 +415,33 @@ def _manifest_reference_paths(manifest: Path) -> tuple[Path, ...]:
         option = parts[0]
         if option in {"-r", "--requirement", "-c", "--constraint"} and len(parts) >= 2:
             references.append((manifest.parent / parts[1]).resolve())
+        elif option.startswith(("--requirement=", "--constraint=")):
+            references.append((manifest.parent / option.split("=", 1)[1]).resolve())
         elif option.startswith(("-r", "-c")) and len(option) > 2:
             references.append((manifest.parent / option[2:]).resolve())
     return tuple(references)
+
+
+def _collect_manifest_paths(manifest: Path, seen: set[Path] | None = None) -> tuple[Path, ...]:
+    """Return a manifest and all nested requirement/constraint references."""
+
+    resolved_manifest = manifest.resolve()
+    visited = set() if seen is None else seen
+    if resolved_manifest in visited:
+        return ()
+    visited.add(resolved_manifest)
+
+    collected = [resolved_manifest]
+    for reference in _manifest_reference_paths(resolved_manifest):
+        collected.extend(_collect_manifest_paths(reference, visited))
+    return tuple(collected)
 
 
 def _prepare_scan_target(root: Path, manifest: Path, target_dir: Path) -> Path:
     """Copy one manifest and its local requirement references into a scan target."""
 
     root_resolved = root.resolve()
-    paths = [manifest.resolve()]
-    paths.extend(_manifest_reference_paths(manifest))
+    paths = _collect_manifest_paths(manifest)
     for source in paths:
         if root_resolved not in (source, *source.parents):
             raise SafetyAuditError(f"Safety manifest reference escapes repo root: {source}")
@@ -562,6 +578,8 @@ def run_audit(config: SafetyAuditConfig) -> tuple[ManifestAuditResult, ...]:
 def exit_code_for_results(results: Sequence[ManifestAuditResult]) -> int:
     """Return aggregate workflow exit code for parsed Safety results."""
 
+    if any(result.safety_exit_code != 0 for result in results):
+        return 1
     if any(result.analysis.status == PARSE_BLOCKING for result in results):
         return 1
     return 0
@@ -641,7 +659,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     exit_code = exit_code_for_results(results)
     for result in results:
         manifest_name = result.manifest.name
-        if result.analysis.status == PARSE_BLOCKING:
+        if result.safety_exit_code != 0:
+            print(
+                f"ERROR: Safety scan exited with code {result.safety_exit_code} for {manifest_name}"
+            )
+        elif result.analysis.status == PARSE_BLOCKING:
             print(f"ERROR: Safety found high/critical/unknown vulnerabilities in {manifest_name}")
         elif result.analysis.status == PARSE_WARNING:
             print(

--- a/scripts/ci/run_safety_audit.py
+++ b/scripts/ci/run_safety_audit.py
@@ -257,6 +257,8 @@ def repo_policy_waivers(policy_path: Path | None) -> dict[str, RepoPolicyWaiver]
 
     if policy_path is None:
         return {}
+    if policy_path.suffix.lower() not in {".yaml", ".yml"}:
+        return {}
     try:
         yaml_module = importlib.import_module("yaml")
     except ImportError as exc:
@@ -534,12 +536,17 @@ def analyze_report(
         summary_path.write_text(f"{message}\n", encoding="utf-8")
         raise
 
-    waivers = repo_policy_waivers(policy_path)
-    vulnerabilities, ignored, repo_policy_ignored_count = _apply_repo_policy_waivers(
-        vulnerabilities,
-        ignored,
-        waivers,
-    )
+    try:
+        waivers = repo_policy_waivers(policy_path)
+        vulnerabilities, ignored, repo_policy_ignored_count = _apply_repo_policy_waivers(
+            vulnerabilities,
+            ignored,
+            waivers,
+        )
+    except SafetyAuditError as exc:
+        message = str(exc)
+        summary_path.write_text(f"{message}\n", encoding="utf-8")
+        raise
     lines = build_summary_lines(vulnerabilities, ignored)
     summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     high_risk_count = sum(

--- a/scripts/ci/run_safety_audit.py
+++ b/scripts/ci/run_safety_audit.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 from dataclasses import dataclass
 from datetime import date, datetime
+import importlib
 import json
 import os
 from pathlib import Path
@@ -14,8 +15,6 @@ import subprocess  # nosec B404: Safety CLI execution is the bounded CI audit pu
 import sys
 import tempfile
 from typing import Any, Mapping, Sequence
-
-import yaml
 
 REQUIRED_MANIFEST = "requirements.txt"
 OPTIONAL_MANIFESTS: tuple[str, ...] = (
@@ -259,8 +258,18 @@ def repo_policy_waivers(policy_path: Path | None) -> dict[str, RepoPolicyWaiver]
     if policy_path is None:
         return {}
     try:
-        payload = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
-    except yaml.YAMLError as exc:
+        yaml_module = importlib.import_module("yaml")
+    except ImportError as exc:
+        raise SafetyAuditError(
+            "PyYAML is required to apply repo Safety policy waivers.",
+            PARSE_ERROR,
+        ) from exc
+    safe_load = getattr(yaml_module, "safe_load", None)
+    if not callable(safe_load):
+        raise SafetyAuditError("PyYAML safe_load is unavailable.", PARSE_ERROR)
+    try:
+        payload = safe_load(policy_path.read_text(encoding="utf-8"))
+    except Exception as exc:
         raise SafetyAuditError(f"Failed to parse Safety policy file: {exc}", PARSE_ERROR) from exc
 
     if not isinstance(payload, Mapping):

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -440,8 +440,7 @@ def test_frontend_build_keeps_codecov_token_out_of_branch_controlled_build() -> 
     assert "CODECOV_TOKEN" not in build_env
     assert "secrets.CODECOV_TOKEN" not in str(build_step)
     assert build_env["CODECOV_BUNDLE_ANALYSIS"] == (
-        "${{ github.event_name == 'push' && github.ref == "
-        "'refs/heads/main' && 'true' || 'false' }}"
+        "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'true' || 'false' }}"
     )
     assert "uploadToken" not in vite_config
     assert "process.env.CODECOV_TOKEN" not in vite_config
@@ -700,17 +699,36 @@ def test_safety_dependency_audit_uses_shared_helper_without_shell_loop() -> None
         ".github/workflows/ci.yml",
         ".github/workflows/security.yml",
     )
+    safety_audit_text = (REPO_ROOT / "scripts" / "ci" / "run_safety_audit.py").read_text(
+        encoding="utf-8"
+    )
 
     for workflow_path in workflow_paths:
         workflow_text = (REPO_ROOT / workflow_path).read_text(encoding="utf-8")
+        step_name = (
+            "Dependency audit with Safety"
+            if workflow_path.endswith("ci.yml")
+            else "Run Safety (dependency audit with policy)"
+        )
+        job_name = "security" if workflow_path.endswith("ci.yml") else "bandit"
+        safety_step = _workflow_step_by_name(workflow_path, job_name, step_name)
 
         assert "python3 scripts/ci/run_safety_audit.py" in workflow_text
+        assert safety_step["env"]["SAFETY_API_KEY"] == "${{ secrets.SAFETY_API_KEY }}"
         assert "safety-*.json" in workflow_text
         assert "safety-*.txt" in workflow_text
         assert "safety-*.log" in workflow_text
         assert 'manifests=("requirements.txt")' not in workflow_text
         assert 'cp "${report_json}" safety-report.json' not in workflow_text
         assert ".github/scripts/parse-safety-report.py" not in workflow_text
+
+    assert '"scan"' in safety_audit_text
+    assert '"check"' not in safety_audit_text
+    assert "SAFETY_API_KEY" in safety_audit_text
+
+    nightly_text = (REPO_ROOT / ".github" / "workflows" / "nightly.yml").read_text(encoding="utf-8")
+    assert "safety check --json" not in nightly_text
+    assert "SAFETY_API_KEY" in nightly_text
 
 
 def test_requirements_lock_excludes_optional_rag_vector_stack() -> None:

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -344,6 +344,7 @@ def test_security_requirements_pin_safety_and_regex_floor() -> None:
     )
 
     assert "safety==3.8.1" in requirements_text
+    assert "pyyaml==6.0.3" in requirements_text
     assert "regex==2026.5.9" in requirements_text
     assert any(
         artifact.get("package") == "regex"

--- a/tests/test_run_safety_audit.py
+++ b/tests/test_run_safety_audit.py
@@ -341,6 +341,33 @@ def test_scan_v3_expired_repo_policy_waiver_stays_blocking(tmp_path: Path) -> No
     assert "- [UNKNOWN] fonttools 4.61.1 - 88739" in summary_path.read_text(encoding="utf-8")
 
 
+def test_repo_policy_waivers_skip_toml_policy_files(tmp_path: Path) -> None:
+    policy_path = tmp_path / "safety-policy.toml"
+    policy_path.write_text("not: yaml: report:\n", encoding="utf-8")
+
+    assert safety_audit.repo_policy_waivers(policy_path) == {}
+
+
+def test_repo_policy_parse_errors_write_summary_artifact(tmp_path: Path) -> None:
+    report_path = tmp_path / "safety-requirements.json"
+    summary_path = tmp_path / "safety-requirements.txt"
+    policy_path = tmp_path / "safety-policy.yaml"
+    policy_path.write_text("[]\n", encoding="utf-8")
+    _write_scan_report(report_path, ["LOW"])
+
+    with pytest.raises(
+        safety_audit.SafetyAuditError,
+        match="Safety policy file must be a YAML mapping",
+    ):
+        safety_audit.analyze_report(
+            report_path,
+            summary_path,
+            policy_path=policy_path,
+        )
+
+    assert "Safety policy file must be a YAML mapping" in summary_path.read_text(encoding="utf-8")
+
+
 def test_cpu_rag_vector_manifest_high_risk_finding_fails_aggregate(tmp_path: Path) -> None:
     report_path = tmp_path / "safety-requirements-rag-vector-cpu.json"
     summary_path = tmp_path / "safety-requirements-rag-vector-cpu.txt"

--- a/tests/test_run_safety_audit.py
+++ b/tests/test_run_safety_audit.py
@@ -85,8 +85,10 @@ def _write_scan_report(path: Path, severities: list[str], *, ignored: bool = Fal
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
-def _write_manifest(root: Path, name: str) -> None:
-    (root / name).write_text("example==1.0.0\n", encoding="utf-8")
+def _write_manifest(root: Path, name: str, content: str = "example==1.0.0\n") -> None:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
 
 
 def _report_path_from_scan_command(command: list[str]) -> Path:
@@ -172,6 +174,38 @@ def test_run_audit_emits_per_manifest_artifacts(
     )
 
 
+def test_scan_target_copies_nested_requirement_references(tmp_path: Path) -> None:
+    _write_manifest(
+        tmp_path,
+        "requirements.txt",
+        "-r requirements/base.txt\n-c constraints/global.txt\n",
+    )
+    _write_manifest(
+        tmp_path, "requirements/base.txt", "--constraint nested/pins.txt\nexample==1.0.0\n"
+    )
+    _write_manifest(tmp_path, "requirements/nested/pins.txt", "example==1.0.0\n")
+    _write_manifest(tmp_path, "constraints/global.txt", "example<2\n")
+    target_dir = tmp_path / "scan-target"
+
+    safety_audit._prepare_scan_target(tmp_path, tmp_path / "requirements.txt", target_dir)
+
+    assert (target_dir / "requirements.txt").is_file()
+    assert (target_dir / "requirements/base.txt").is_file()
+    assert (target_dir / "requirements/nested/pins.txt").is_file()
+    assert (target_dir / "constraints/global.txt").is_file()
+
+
+def test_scan_target_handles_cyclic_requirement_references(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, "requirements.txt", "-r requirements/base.txt\n")
+    _write_manifest(tmp_path, "requirements/base.txt", "-r ../requirements.txt\n")
+    target_dir = tmp_path / "scan-target"
+
+    safety_audit._prepare_scan_target(tmp_path, tmp_path / "requirements.txt", target_dir)
+
+    assert (target_dir / "requirements.txt").is_file()
+    assert (target_dir / "requirements/base.txt").is_file()
+
+
 def test_scan_v3_report_high_risk_finding_fails_aggregate(tmp_path: Path) -> None:
     report_path = tmp_path / "safety-requirements.json"
     summary_path = tmp_path / "safety-requirements.txt"
@@ -251,7 +285,9 @@ def test_high_risk_findings_fail_aggregate(tmp_path: Path, severity: str) -> Non
 
 
 @pytest.mark.parametrize("severity", ["LOW", "MEDIUM"])
-def test_low_and_medium_findings_warn_without_failing(tmp_path: Path, severity: str) -> None:
+def test_low_and_medium_findings_warn_without_failing_when_safety_exits_zero(
+    tmp_path: Path, severity: str
+) -> None:
     report_path = tmp_path / "safety-requirements.json"
     summary_path = tmp_path / "safety-requirements.txt"
     _write_report(report_path, [severity])
@@ -265,10 +301,32 @@ def test_low_and_medium_findings_warn_without_failing(tmp_path: Path, severity: 
         report_json=report_path,
         report_txt=summary_path,
         console_log=tmp_path / "safety-requirements.log",
-        safety_exit_code=64,
+        safety_exit_code=0,
         analysis=analysis,
     )
     assert safety_audit.exit_code_for_results([result]) == 0
+
+
+@pytest.mark.parametrize("severity", ["LOW", "MEDIUM"])
+def test_low_and_medium_findings_fail_when_safety_exits_nonzero(
+    tmp_path: Path, severity: str
+) -> None:
+    report_path = tmp_path / "safety-requirements.json"
+    summary_path = tmp_path / "safety-requirements.txt"
+    _write_report(report_path, [severity])
+
+    analysis = safety_audit.analyze_report(report_path, summary_path)
+    result = safety_audit.ManifestAuditResult(
+        manifest=tmp_path / "requirements.txt",
+        report_json=report_path,
+        report_txt=summary_path,
+        console_log=tmp_path / "safety-requirements.log",
+        safety_exit_code=64,
+        analysis=analysis,
+    )
+
+    assert analysis.status == safety_audit.PARSE_WARNING
+    assert safety_audit.exit_code_for_results([result]) == 1
 
 
 def test_missing_or_empty_report_fails_closed(tmp_path: Path) -> None:

--- a/tests/test_run_safety_audit.py
+++ b/tests/test_run_safety_audit.py
@@ -151,6 +151,31 @@ def test_discovery_fails_when_required_manifest_is_missing(tmp_path: Path) -> No
         safety_audit.discover_manifests(tmp_path)
 
 
+def test_prepare_scan_target_rejects_nested_manifest_escape(tmp_path: Path) -> None:
+    outside = tmp_path.parent / f"{tmp_path.name}-outside.txt"
+    outside.write_text("outside==1.0.0\n", encoding="utf-8")
+    _write_manifest(
+        tmp_path,
+        "requirements.txt",
+        "-r nested/constraints.txt\n",
+    )
+    _write_manifest(
+        tmp_path,
+        "nested/constraints.txt",
+        f"-r ../../{outside.name}\n",
+    )
+
+    with pytest.raises(
+        safety_audit.SafetyAuditError,
+        match="Safety manifest reference escapes repo root",
+    ):
+        safety_audit._prepare_scan_target(
+            tmp_path,
+            tmp_path / "requirements.txt",
+            tmp_path / "scan-target",
+        )
+
+
 def test_policy_file_precedence_prefers_yaml_over_toml(tmp_path: Path) -> None:
     (tmp_path / "safety-policy.toml").write_text("[policy]\n", encoding="utf-8")
     (tmp_path / "safety-policy.yaml").write_text("policy: {}\n", encoding="utf-8")

--- a/tests/test_run_safety_audit.py
+++ b/tests/test_run_safety_audit.py
@@ -28,8 +28,72 @@ def _write_report(path: Path, severities: list[str]) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
+def _write_scan_report(path: Path, severities: list[str], *, ignored: bool = False) -> None:
+    payload = {
+        "meta": {"scan_type": "scan"},
+        "scan_results": {
+            "projects": [
+                {
+                    "files": [
+                        {
+                            "location": "requirements.txt",
+                            "results": {
+                                "dependencies": [
+                                    {
+                                        "name": "example",
+                                        "specifications": [
+                                            {
+                                                "raw": "example==1.0.0",
+                                                "vulnerabilities": {
+                                                    "known_vulnerabilities": [
+                                                        {
+                                                            "id": f"VULN-{index}",
+                                                            "vulnerable_spec": "example==1.0.0",
+                                                            "CVE": {
+                                                                "cvssv3": {
+                                                                    "base_severity": severity,
+                                                                },
+                                                            },
+                                                            **(
+                                                                {
+                                                                    "ignored": {
+                                                                        "code": "manual",
+                                                                        "reason": "test policy",
+                                                                        "expires": "2026-07-08",
+                                                                    }
+                                                                }
+                                                                if ignored
+                                                                else {}
+                                                            ),
+                                                        }
+                                                        for index, severity in enumerate(
+                                                            severities, start=1
+                                                        )
+                                                    ],
+                                                },
+                                            }
+                                        ],
+                                    }
+                                ],
+                            },
+                        }
+                    ]
+                }
+            ]
+        },
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 def _write_manifest(root: Path, name: str) -> None:
     (root / name).write_text("example==1.0.0\n", encoding="utf-8")
+
+
+def _report_path_from_scan_command(command: list[str]) -> Path:
+    assert "scan" in command
+    assert "check" not in command
+    assert command[command.index("--save-as") + 1] == "json"
+    return Path(command[command.index("--save-as") + 2])
 
 
 def test_discovers_required_and_optional_manifests(tmp_path: Path) -> None:
@@ -71,13 +135,17 @@ def test_run_audit_emits_per_manifest_artifacts(
     _write_manifest(tmp_path, "requirements-rag-vector-cpu.txt")
     output_dir = tmp_path / "reports"
     commands: list[list[str]] = []
+    scan_target_files: list[set[str]] = []
 
     def fake_run(command: list[str], **_: Any) -> SimpleNamespace:
         commands.append(command)
-        report_path = Path(command[command.index("--save-json") + 1])
+        target_path = Path(command[command.index("--target") + 1])
+        scan_target_files.append({path.name for path in target_path.rglob("*") if path.is_file()})
+        report_path = _report_path_from_scan_command(command)
         _write_report(report_path, [])
         return SimpleNamespace(returncode=0, stdout="safety output\n", stderr="")
 
+    monkeypatch.setenv("SAFETY_API_KEY", "test-key")
     monkeypatch.setattr(safety_audit.shutil, "which", lambda _: "/usr/bin/safety")
     monkeypatch.setattr(safety_audit.subprocess, "run", fake_run)
 
@@ -96,11 +164,36 @@ def test_run_audit_emits_per_manifest_artifacts(
         "safety-requirements.log",
         "safety-requirements.txt",
     ]
-    assert any(
-        "requirements-rag-vector-cpu.txt" in str(command_part)
+    assert any("requirements-rag-vector-cpu.txt" in files for files in scan_target_files)
+    assert all("--target" in command for command in commands)
+    assert all(
+        command[:4] == ["/usr/bin/safety", "--stage", "cicd", "--disable-optional-telemetry"]
         for command in commands
-        for command_part in command
     )
+
+
+def test_scan_v3_report_high_risk_finding_fails_aggregate(tmp_path: Path) -> None:
+    report_path = tmp_path / "safety-requirements.json"
+    summary_path = tmp_path / "safety-requirements.txt"
+    _write_scan_report(report_path, ["HIGH"])
+
+    analysis = safety_audit.analyze_report(report_path, summary_path)
+
+    assert analysis.status == safety_audit.PARSE_BLOCKING
+    assert analysis.high_risk_count == 1
+    assert "VULN-1" in summary_path.read_text(encoding="utf-8")
+
+
+def test_scan_v3_ignored_findings_do_not_fail_aggregate(tmp_path: Path) -> None:
+    report_path = tmp_path / "safety-requirements.json"
+    summary_path = tmp_path / "safety-requirements.txt"
+    _write_scan_report(report_path, ["HIGH"], ignored=True)
+
+    analysis = safety_audit.analyze_report(report_path, summary_path)
+
+    assert analysis.status == safety_audit.PARSE_OK
+    assert analysis.high_risk_count == 0
+    assert "Ignored vulnerabilities: 1" in summary_path.read_text(encoding="utf-8")
 
 
 def test_cpu_rag_vector_manifest_high_risk_finding_fails_aggregate(tmp_path: Path) -> None:
@@ -130,10 +223,11 @@ def test_run_audit_removes_stale_report_before_safety_execution(
     _write_report(stale_report, [])
 
     def fake_run(command: list[str], **_: Any) -> SimpleNamespace:
-        assert Path(command[command.index("--save-json") + 1]) == stale_report
+        assert _report_path_from_scan_command(command) == stale_report
         assert not stale_report.exists()
         return SimpleNamespace(returncode=64, stdout="", stderr="failed before report\n")
 
+    monkeypatch.setenv("SAFETY_API_KEY", "test-key")
     monkeypatch.setattr(safety_audit.shutil, "which", lambda _: "/usr/bin/safety")
     monkeypatch.setattr(safety_audit.subprocess, "run", fake_run)
 
@@ -260,10 +354,11 @@ def test_run_audit_writes_summary_when_report_is_missing(
     _write_manifest(tmp_path, "requirements.txt")
 
     def fake_run(command: list[str], **_: Any) -> SimpleNamespace:
-        report_path = Path(command[command.index("--save-json") + 1])
+        report_path = _report_path_from_scan_command(command)
         assert report_path.name == "safety-requirements.json"
         return SimpleNamespace(returncode=3, stdout="", stderr="no json\n")
 
+    monkeypatch.setenv("SAFETY_API_KEY", "test-key")
     monkeypatch.setattr(safety_audit.shutil, "which", lambda _: "/usr/bin/safety")
     monkeypatch.setattr(safety_audit.subprocess, "run", fake_run)
     config = safety_audit.build_config(root=tmp_path, output_dir=tmp_path)
@@ -283,10 +378,11 @@ def test_nonzero_safety_exit_with_empty_report_fails_closed(
     _write_manifest(tmp_path, "requirements.txt")
 
     def fake_run(command: list[str], **_: Any) -> SimpleNamespace:
-        report_path = Path(command[command.index("--save-json") + 1])
+        report_path = _report_path_from_scan_command(command)
         _write_report(report_path, [])
         return SimpleNamespace(returncode=3, stdout="", stderr="tool error\n")
 
+    monkeypatch.setenv("SAFETY_API_KEY", "test-key")
     monkeypatch.setattr(safety_audit.shutil, "which", lambda _: "/usr/bin/safety")
     monkeypatch.setattr(safety_audit.subprocess, "run", fake_run)
     config = safety_audit.build_config(root=tmp_path, output_dir=tmp_path)
@@ -298,3 +394,16 @@ def test_nonzero_safety_exit_with_empty_report_fails_closed(
     assert "report contained no parsed vulnerabilities" in (
         tmp_path / "safety-requirements.txt"
     ).read_text(encoding="utf-8")
+
+
+def test_scan_requires_api_key_for_cicd_stage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_manifest(tmp_path, "requirements.txt")
+    monkeypatch.delenv("SAFETY_API_KEY", raising=False)
+    monkeypatch.setattr(safety_audit.shutil, "which", lambda _: "/usr/bin/safety")
+
+    config = safety_audit.build_config(root=tmp_path, output_dir=tmp_path)
+
+    with pytest.raises(safety_audit.SafetyAuditError, match="SAFETY_API_KEY is required"):
+        safety_audit.run_audit(config)

--- a/tests/test_run_safety_audit.py
+++ b/tests/test_run_safety_audit.py
@@ -28,7 +28,16 @@ def _write_report(path: Path, severities: list[str]) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
-def _write_scan_report(path: Path, severities: list[str], *, ignored: bool = False) -> None:
+def _write_scan_report(
+    path: Path,
+    severities: list[str],
+    *,
+    ignored: bool = False,
+    package_name: str = "example",
+    raw_spec: str = "example==1.0.0",
+    vulnerable_spec: str = "example==1.0.0",
+    vuln_id: str = "VULN",
+) -> None:
     payload = {
         "meta": {"scan_type": "scan"},
         "scan_results": {
@@ -40,15 +49,19 @@ def _write_scan_report(path: Path, severities: list[str], *, ignored: bool = Fal
                             "results": {
                                 "dependencies": [
                                     {
-                                        "name": "example",
+                                        "name": package_name,
                                         "specifications": [
                                             {
-                                                "raw": "example==1.0.0",
+                                                "raw": raw_spec,
                                                 "vulnerabilities": {
                                                     "known_vulnerabilities": [
                                                         {
-                                                            "id": f"VULN-{index}",
-                                                            "vulnerable_spec": "example==1.0.0",
+                                                            "id": (
+                                                                f"{vuln_id}-{index}"
+                                                                if vuln_id == "VULN"
+                                                                else vuln_id
+                                                            ),
+                                                            "vulnerable_spec": vulnerable_spec,
                                                             "CVE": {
                                                                 "cvssv3": {
                                                                     "base_severity": severity,
@@ -89,6 +102,25 @@ def _write_manifest(root: Path, name: str, content: str = "example==1.0.0\n") ->
     path = root / name
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
+
+
+def _write_policy(root: Path, vulnerability_id: str, expires: str = "2099-01-01") -> Path:
+    policy_path = root / "safety-policy.yaml"
+    policy_path.write_text(
+        f"""
+version: "3.0"
+report:
+  dependency-vulnerabilities:
+    enabled: true
+    auto-ignore-in-report:
+      vulnerabilities:
+        "{vulnerability_id}":
+          reason: test waiver
+          expires: "{expires}"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return policy_path
 
 
 def _report_path_from_scan_command(command: list[str]) -> Path:
@@ -230,6 +262,60 @@ def test_scan_v3_ignored_findings_do_not_fail_aggregate(tmp_path: Path) -> None:
     assert "Ignored vulnerabilities: 1" in summary_path.read_text(encoding="utf-8")
 
 
+def test_scan_v3_applies_active_repo_policy_waiver_when_cloud_policy_does_not(
+    tmp_path: Path,
+) -> None:
+    report_path = tmp_path / "safety-requirements.json"
+    summary_path = tmp_path / "safety-requirements.txt"
+    policy_path = _write_policy(tmp_path, "88739")
+    _write_scan_report(
+        report_path,
+        ["UNKNOWN"],
+        package_name="fonttools",
+        raw_spec="fonttools==4.61.1",
+        vulnerable_spec="<4.62.0",
+        vuln_id="88739",
+    )
+
+    analysis = safety_audit.analyze_report(
+        report_path,
+        summary_path,
+        policy_path=policy_path,
+    )
+
+    assert analysis.status == safety_audit.PARSE_OK
+    assert analysis.high_risk_count == 0
+    assert analysis.repo_policy_ignored_count == 1
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "No vulnerabilities reported by Safety." in summary
+    assert "Ignored vulnerabilities: 1" in summary
+
+
+def test_scan_v3_expired_repo_policy_waiver_stays_blocking(tmp_path: Path) -> None:
+    report_path = tmp_path / "safety-requirements.json"
+    summary_path = tmp_path / "safety-requirements.txt"
+    policy_path = _write_policy(tmp_path, "88739", expires="2000-01-01")
+    _write_scan_report(
+        report_path,
+        ["UNKNOWN"],
+        package_name="fonttools",
+        raw_spec="fonttools==4.61.1",
+        vulnerable_spec="<4.62.0",
+        vuln_id="88739",
+    )
+
+    analysis = safety_audit.analyze_report(
+        report_path,
+        summary_path,
+        policy_path=policy_path,
+    )
+
+    assert analysis.status == safety_audit.PARSE_BLOCKING
+    assert analysis.high_risk_count == 1
+    assert analysis.repo_policy_ignored_count == 0
+    assert "- [UNKNOWN] fonttools 4.61.1 - 88739" in summary_path.read_text(encoding="utf-8")
+
+
 def test_cpu_rag_vector_manifest_high_risk_finding_fails_aggregate(tmp_path: Path) -> None:
     report_path = tmp_path / "safety-requirements-rag-vector-cpu.json"
     summary_path = tmp_path / "safety-requirements-rag-vector-cpu.txt"
@@ -327,6 +413,37 @@ def test_low_and_medium_findings_fail_when_safety_exits_nonzero(
 
     assert analysis.status == safety_audit.PARSE_WARNING
     assert safety_audit.exit_code_for_results([result]) == 1
+
+
+def test_nonzero_safety_exit_with_only_repo_policy_waiver_passes_aggregate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_manifest(tmp_path, "requirements.txt")
+    _write_policy(tmp_path, "88739")
+
+    def fake_run(command: list[str], **_: Any) -> SimpleNamespace:
+        report_path = _report_path_from_scan_command(command)
+        _write_scan_report(
+            report_path,
+            ["UNKNOWN"],
+            package_name="fonttools",
+            raw_spec="fonttools==4.61.1",
+            vulnerable_spec="<4.62.0",
+            vuln_id="88739",
+        )
+        return SimpleNamespace(returncode=64, stdout="", stderr="")
+
+    monkeypatch.setenv("SAFETY_API_KEY", "test-key")
+    monkeypatch.setattr(safety_audit.shutil, "which", lambda _: "/usr/bin/safety")
+    monkeypatch.setattr(safety_audit.subprocess, "run", fake_run)
+
+    config = safety_audit.build_config(root=tmp_path, output_dir=tmp_path)
+    results = safety_audit.run_audit(config)
+
+    assert results[0].safety_exit_code == 64
+    assert results[0].analysis.repo_policy_ignored_count == 1
+    assert safety_audit.exit_code_for_results(results) == 0
 
 
 def test_missing_or_empty_report_fails_closed(tmp_path: Path) -> None:


### PR DESCRIPTION
## Goal

Migrate the canonical multi-manifest Safety dependency audit from deprecated `safety check` to Safety CLI 3 `scan` while preserving fail-closed CI behavior and per-manifest artifacts.

## Business reason

PR 1924 is blocked by the dependency-audit lane. Safety itself recommends replacing deprecated `check`; this PR performs that tooling migration separately so PR 1924 can remain scoped to operator-ledger compatibility.

## Scope

- `scripts/ci/run_safety_audit.py` now invokes `safety --stage cicd --disable-optional-telemetry scan` per manifest and writes the existing `safety-*.json`, `safety-*.txt`, and `safety-*.log` artifacts.
- Safety scan JSON v3 is normalized into the existing severity gate model; legacy report parsing remains for the compatibility wrapper.
- `safety-policy.yaml` is migrated to Safety policy version `3.0` and preserves the existing fonttools waiver plus the current-main PyTorch advisory waiver, both with expiries.
- CI/security workflows expose `secrets.SAFETY_API_KEY` to the audit step; the helper fails closed with a clear diagnostic when the key is absent.
- Nightly advisory Safety no longer falls back to deprecated `safety check`.

## Out of scope

- No new Torch waiver is introduced; the existing governed main-branch PyTorch advisory waiver is translated to Safety policy v3.
- No requirements pins are changed.
- No PR 1924 operator-ledger code is changed.

## Tests / validation

- PASS: `python3 scripts/orchestration/check_preflight.py`
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
- PASS: Safety policy v3 parse via Safety 3.8.1 using a temp `.safety-policy.yml` copy.
- PASS: `PYTHONPATH=. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py`
- PASS: `PYTHONPATH=. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m ruff check scripts/ci/run_safety_audit.py tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py`
- PASS: `PYTHONPATH=. /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m ruff format --check scripts/ci/run_safety_audit.py tests/test_run_safety_audit.py tests/test_python_supply_chain_controls.py`
- PASS: `pre-commit run --all-files`
- PASS: `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`; ran `tests/test_python_supply_chain_controls.py tests/test_run_safety_audit.py`.
- PASS: normal `git push` pre-push hooks after the mypy-safe YAML load fix: mypy changed files, pip-audit, backend tests, full Bandit, and docker build test.
- PASS: real no-key failure path: `python3 scripts/ci/run_safety_audit.py --manifest requirements-rag-vector-cpu.txt --output-dir /tmp/pulseplate-safety-no-key-check` exits 1 with `SAFETY_API_KEY is required...`.

## Security notes

- `SAFETY_API_KEY` is read from environment only; the helper does not pass the key through argv.
- Earlier pre-push surfaced a mypy missing-stubs issue for direct PyYAML imports; the helper now loads PyYAML dynamically without `type: ignore`. Final push used the normal pre-push hook path and passed `mypy`, `pip-audit`, backend tests, full Bandit, and docker build.
- `.secrets.baseline` changed only because detect-secrets updated the line number for an existing `.github/workflows/ci.yml` baseline entry after workflow line insertions.
- CodeRabbit, Sourcery, and Codex review-capacity notices are governance availability notes, not bot approvals and not code-actionable findings.

## Risks / rollback

- CI now requires `secrets.SAFETY_API_KEY` for the blocking Safety scan. If the secret is not configured, the job fails closed with setup instructions instead of opening an interactive auth prompt.
- Rollback is to revert this PR and restore the prior `check` helper, but that would reintroduce deprecated Safety CLI behavior.

## Deferred / follow-ups

- After this PR is merged and current-head CI confirms the new scan path, return to PR 1924 and rerun its security/current-head checks.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1942_FIXED_MAPPING.md`

## Merge Readiness

Not merge-ready until current-head CI, bot review/governance, review-thread disposition, fixed-mapping artifact, and strict merge-readiness checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD security scans now require an API key and run API-key-gated authenticated dependency audits with updated Safety scan behavior and staged scan modes.
  * Security policy/config updated to Safety CLI v3 semantics with refined reporting and fail-on rules.
  * Pinned YAML parser in security requirements.

* **Documentation**
  * Added a review summary documenting fixes, dispositions, and merge-readiness.
  * Updated baseline secrets metadata.

* **Tests**
  * Expanded and hardened tests for scan v3, waiver semantics, target preparation, and workflow step behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
