### PR TITLE
fix(ci): avoid PR token exposure in docker baseline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,14 @@ jobs:
             --blocked-debian-package libgnutls30 \
             --output-json docker-runtime-dependency-surface.json
 
+      - name: Use checked-in Docker image telemetry baseline on pull requests
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          cp docs/telemetry/docker_image_baseline.production.json docker-image-baseline.json
+
       - name: Resolve Docker image telemetry baseline
+        if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/review/PR_1948_FIXED_MAPPING.md
+++ b/docs/review/PR_1948_FIXED_MAPPING.md
@@ -54,7 +54,13 @@ backend, client, OpenAPI, database, app runtime, or release behavior.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1948#discussion_r3399097640 -> abdf3794a
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1948#pullrequestreview-4480510516 -> abdf3794a
+Disposition: FIXED
+Commit: abdf3794a
+Evidence: docs/review/PR_1948_FIXED_MAPPING.md:172
+Evidence: docs/review/PR_1948_FIXED_MAPPING.md:173
+Reason: The `Merge Readiness` checklist now keeps `make validate-changed` and `pre-commit run --all-files` unchecked until the final merge cycle while completed gate evidence remains recorded under `Validation Evidence`.
 
 ## External Bot And Review Dispositions
 

--- a/docs/review/PR_1948_FIXED_MAPPING.md
+++ b/docs/review/PR_1948_FIXED_MAPPING.md
@@ -169,8 +169,8 @@ Reason: Coverage status notice, not a code-actionable review finding.
 ## Merge Readiness
 
 - [ ] PR body mirror updated with this artifact and current pushed head.
-- [x] `make validate-changed` passed after this artifact was added.
-- [x] `pre-commit run --all-files` passed before push.
+- [ ] `make validate-changed` passed after this artifact was added.
+- [ ] `pre-commit run --all-files` passed before push.
 - [ ] Phase2 PR body gate passed against the live PR body.
 - [ ] Strict merge-readiness wrapper passed with auth.
 - [ ] Current-head CI is terminal with required checks passing.

--- a/docs/review/PR_1948_FIXED_MAPPING.md
+++ b/docs/review/PR_1948_FIXED_MAPPING.md
@@ -1,0 +1,178 @@
+# PR #1948 Fixed in Commit Mapping
+
+PR: `#1948` (https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1948)
+
+Lane: `codex/propose-fix-for-github_token-exposure`
+
+## Scope Boundary
+
+PR #1948 closes one narrow CI security boundary: on `pull_request` runs, the
+Docker telemetry baseline is copied from the checked-in production baseline
+instead of invoking checked-out PR code with `GH_TOKEN` / `GITHUB_TOKEN`.
+Trusted non-PR runs continue to use the token-backed remote baseline resolver.
+
+Scope note: this PR does not claim broad workflow token isolation, does not
+change `actions/checkout` credential persistence, does not change Docker
+BuildKit secret-env handling for package index secrets, and does not change
+backend, client, OpenAPI, database, app runtime, or release behavior.
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/pr1948_post_open_packet.json`
+- Packet id: `4d21ca87ac9c`
+- PR phase: `post_open_review`
+- Task class: `Security`
+- Base reviewed: `b20f807a5c61cb166f909d9aacbe86b3044ee31e`
+- Implementation head reviewed before closeout commit:
+  `099a067bc8d25d4be7a403c049a9be9fbe65cac1`
+- Startup evidence: `python3 scripts/orchestration/check_preflight.py` -> PASS.
+- Startup evidence: `python3 scripts/orchestration/check_agent_consistency.py` -> PASS.
+- Role dispatch evidence:
+  `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/pr1948_post_open_packet.json --pretty`
+  -> PASS; declared order was `agent-coordinator -> dev-operator ->
+  qa-engineer-agent -> bug-hunter -> security-auditor ->
+  architecture-specialist`.
+
+## Experiment Runner Evidence
+
+- Artifact: `artifacts/orchestration/experiments/results/pr1948-token-exposure-oracle-result.json`
+- Packet: `artifacts/orchestration/experiments/pr1948-token-exposure-oracle-packet.json`
+- Status: `accepted`
+- Runner mode: `oracle_only_governance_reviewer`
+- Contribution: `fixed_mapping_review`
+- Co-author required: `true`
+- Evidence: 2/2 oracle commands passed:
+  `python3 scripts/orchestration/check_agent_consistency.py` and
+  `python3 -m pytest -q tests/test_docker_workflow_build_path_contract.py`.
+- Boundary: `mutated_paths=[]`, `source_diff_paths=[]`, and
+  `shared_tree_untouched=true`.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## External Bot And Review Dispositions
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1948#issuecomment-4683580025
+Disposition: NOT-A-BUG
+Evidence: Codex usage-limit notice contains no code-actionable finding.
+Reason: External reviewer availability notice only.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1948#pullrequestreview-4479343049
+Disposition: NOT-A-BUG
+Evidence: Sourcery weekly diff-character rate-limit notice contains no code-actionable finding.
+Reason: External reviewer availability notice only.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1948#issuecomment-4683580468
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit review-rate/usage-credit notice contains no code-actionable finding.
+Reason: External reviewer availability notice only.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1948#pullrequestreview-4479377780
+Disposition: NOT-A-BUG
+Evidence: Cubic review for head `099a067bc8d25d4be7a403c049a9be9fbe65cac1`
+reported "No issues found" across the two changed files.
+Reason: External reviewer completed without code-actionable findings.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1948#issuecomment-4683763227
+Disposition: NOT-A-BUG
+Evidence: Codecov reported all modified and coverable lines are covered by tests.
+Reason: Coverage status notice, not a code-actionable review finding.
+
+## Role-Agent Findings
+
+| Role | Result | Evidence |
+| --- | --- | --- |
+| `agent-coordinator` | No implementation blocker; governance artifact/body was the blocker. | Scope locked to `.github/workflows/build.yml` and `tests/test_docker_workflow_build_path_contract.py`; review threads count was zero; current head was `099a067bc8d25d4be7a403c049a9be9fbe65cac1`. |
+| `dev-operator` | Proceed with governance artifact, PR-body mirror, and narrow gate path. | Confirmed current CI failures were `PR Body Phase2 gates` and `Merge readiness gate` due to missing `docs/review/PR_1948_FIXED_MAPPING.md`; no replacement PR required. |
+| `qa-engineer-agent` | No QA code blocker for the narrow regression contract. | `.github/workflows/build.yml:80`, `.github/workflows/build.yml:86`, and `tests/test_docker_workflow_build_path_contract.py:81` lock the PR fallback/non-PR resolver split. |
+| `bug-hunter` | No code-blocking bug found; avoid broad token-isolation claims. | `scripts/ci/fetch_docker_image_baseline.py:41` requires `GH_TOKEN` / `GITHUB_TOKEN`; `.github/workflows/build.yml:80` avoids that script on PR runs; `.github/workflows/build.yml:29` checkout credentials remain out of scope. |
+| `security-auditor` | No additional security fix required for the narrow baseline-fetch exposure. | `.github/workflows/build.yml:88` scopes token env to the non-PR resolver; `tests/test_docker_workflow_build_path_contract.py:101` asserts PR fallback has no token env. |
+| `architecture-specialist` | No architecture blocker. | Docker build/validation ownership remains in `.github/workflows/build.yml`; no `app/`, `core/`, web, iOS, OpenAPI, DB, or route surface changed. |
+
+## Premortem Evidence
+
+- Skill: `pulseplate-premortem-risk-review`
+- Mode: `pr-premortem`
+- Artifact: `artifacts/orchestration/premortem/pr-1948-token-exposure-premortem.md`
+- Decision: `proceed with changes`.
+- Closed risks:
+  - Missing fixed-mapping artifact -> fixed by this closeout artifact.
+  - Stale PR body commit evidence -> fixed by PR body mirror update after push.
+  - Overbroad security wording -> closed by narrow scope note in this artifact
+    and PR body.
+  - Full local `make verify` deferral ambiguity -> closed by the explicit
+    operator-approved deferral below.
+
+## Codex Security Diff Scan
+
+- Scan status: PASS, no reportable findings.
+- Base: `b20f807a5c61cb166f909d9aacbe86b3044ee31e`
+- Head: `099a067bc8d25d4be7a403c049a9be9fbe65cac1`
+- Reviewed surfaces:
+  - `.github/workflows/build.yml`
+  - `tests/test_docker_workflow_build_path_contract.py`
+- Evidence: the work ledger recorded completed/no-findings receipts for both PR
+  files. The workflow receipt cites `.github/workflows/build.yml:80-84` and
+  `.github/workflows/build.yml:86-98`; the test receipt cites
+  `tests/test_docker_workflow_build_path_contract.py:81-113`.
+- Limitation: the Codex Security worklist helper excludes `.github/` and
+  `tests/` by default, so the two PR files were manually added to the scan
+  input to preserve exact PR diff coverage.
+
+## PulsePlate PR Review Evidence
+
+- Context artifact: `/tmp/pulseplate_pr_review_1948_context.json`
+- Markdown report: `/tmp/pulseplate_pr_review_1948.md`
+- JSON report: `/tmp/pulseplate_pr_review_1948.report.json`
+- Result: advisory dry-run report found two governance notes before this
+  closeout: missing fixed-mapping artifact and warning-bearing context. This
+  artifact resolves that blocker.
+
+## Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py` -> PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS.
+- `.venv/bin/python -m pytest -q tests/test_docker_workflow_build_path_contract.py`
+  via the repo/shared Python resolver -> PASS (`...... [100%]`).
+- `python3 scripts/orchestration/experiment_runner.py --packet artifacts/orchestration/experiments/pr1948-token-exposure-oracle-packet.json --output pr1948-token-exposure-oracle-result.json --contribution-kind fixed_mapping_review --coauthor-required --coauthor-reason "Experiment Runner oracle-only evidence shaped PR 1948 fixed mapping, validation evidence, and commit decision."`
+  -> PASS.
+- `make validate-changed` -> PASS; selected
+  `tests/test_docker_workflow_build_path_contract.py` and reported `6 passed`.
+- `pre-commit run --all-files` -> PASS on rerun; hooks included
+  `check-github-workflows`, `ruff`, changed-file Bandit, frontend tests,
+  changed-file backend tests, and iOS syntax check.
+- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1948 --body "$(gh pr view 1948 --repo Katsiarynakavaleuskaya/PulsePlate --json body -q .body)"`
+  -> pending rerun after PR body mirror update.
+- `GITHUB_TOKEN="$(gh auth token)" GH_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_merge_ready.py --pr-number 1948 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`
+  -> pending rerun after push/current-head CI.
+
+## Local Full Verify Deferral
+
+- Full local `make verify`: deferred by operator approval for this machine-heavy
+  PR because the full suite is too large for this lane.
+- Replacement local gate path: preflight, agent consistency, focused workflow
+  contract test, `make validate-changed`, `pre-commit run --all-files`, Phase2
+  PR body gate, and strict merge-readiness wrapper with auth.
+- Heavy parity signal: current-head GitHub CI must provide lint, diff coverage,
+  workflow/security checks, PR Body Phase2 gates, Merge readiness gate, and the
+  Docker/build surface checks attached to the changed workflow.
+- This deferral does not permit ignored failures, weakened coverage,
+  `continue-on-error`, unresolved review threads, or merge-readiness claims
+  while narrow gates or current-head CI are pending.
+
+## Merge Readiness
+
+- [ ] PR body mirror updated with this artifact and current pushed head.
+- [x] `make validate-changed` passed after this artifact was added.
+- [x] `pre-commit run --all-files` passed before push.
+- [ ] Phase2 PR body gate passed against the live PR body.
+- [ ] Strict merge-readiness wrapper passed with auth.
+- [ ] Current-head CI is terminal with required checks passing.
+- [ ] No unresolved review threads or actionable bot comments remain.
+- [ ] Mandatory wait-window completed after latest review/bot activity.

--- a/tests/test_docker_workflow_build_path_contract.py
+++ b/tests/test_docker_workflow_build_path_contract.py
@@ -78,6 +78,41 @@ def test_build_workflow_owns_docker_validation_contract() -> None:
     ) in run_script
 
 
+def test_build_workflow_does_not_expose_github_token_to_pr_baseline_script() -> None:
+    """PR builds must not pass workflow tokens to checked-out baseline code."""
+    workflow = _load_workflow(WORKFLOWS_DIR / "build.yml")
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    build_job = jobs["build"]
+    assert isinstance(build_job, dict)
+    steps = build_job["steps"]
+    assert isinstance(steps, list)
+
+    fallback_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict)
+        and step.get("name") == "Use checked-in Docker image telemetry baseline on pull requests"
+    )
+    assert fallback_step["if"] == "github.event_name == 'pull_request'"
+    fallback_run = fallback_step["run"]
+    assert isinstance(fallback_run, str)
+    assert "fetch_docker_image_baseline.py" not in fallback_run
+    assert "GH_TOKEN" not in fallback_step.get("env", {})
+    assert "GITHUB_TOKEN" not in fallback_step.get("env", {})
+
+    resolve_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == "Resolve Docker image telemetry baseline"
+    )
+    assert resolve_step["if"] == "github.event_name != 'pull_request'"
+    resolve_env = resolve_step["env"]
+    assert isinstance(resolve_env, dict)
+    assert resolve_env["GH_TOKEN"] == "${{ secrets.GITHUB_TOKEN }}"
+    assert resolve_env["GITHUB_TOKEN"] == "${{ secrets.GITHUB_TOKEN }}"
+
+
 def test_production_dockerfile_prunes_package_manager_surface() -> None:
     """Production target removes package-manager packages after runtime-base."""
     dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")


### PR DESCRIPTION
### Motivation
- A PR-time workflow step exported `GH_TOKEN`/`GITHUB_TOKEN` into a Python script from the PR checkout, enabling a malicious PR to read/exfiltrate the workflow token.
- The change prevents tokens from being exposed to PR-controlled code while preserving remote baseline resolution for trusted runs.

### Description
- Modify `.github/workflows/build.yml` to add a PR-only step that copies the checked-in baseline (`docs/telemetry/docker_image_baseline.production.json`) and to gate the `scripts/ci/fetch_docker_image_baseline.py` invocation behind `if: github.event_name != 'pull_request'` so the remote `gh` fetch runs only on non-PR events.
- Add a regression guard in `tests/test_docker_workflow_build_path_contract.py` that asserts the PR fallback step does not call `fetch_docker_image_baseline.py` and does not receive `GH_TOKEN`/`GITHUB_TOKEN`, and that the resolver step is gated to non-PR runs.
- Evidence of the fix is committed in branch HEAD: commit `f665d91` (message: "fix(ci): avoid PR token exposure in docker baseline").

### Testing
- Passed: `python3 scripts/orchestration/check_preflight.py` (preflight checks).
- Passed: `PYENV_VERSION=3.13.13 python -m py_compile tests/test_docker_workflow_build_path_contract.py` (test file compiles cleanly).
- Passed: ad-hoc workflow assertions that validate the new `if:` gating and absence of tokens in the PR fallback step (small inline Python check executed in this environment).
- Passed: `git diff --check` (no whitespace/conflict markers).
- Warnings: running the full local pytest suite and pre-commit hooks was blocked in this container because the repository `.venv` and several test dependencies (`pytest`, `fastapi`, `pre-commit`, `flake8`) are not installed here, so I did not claim local full-gate success; CI should run the canonical `make verify` / `validate-changed` bundle to complete the gating.
- Do not claim merge readiness here; recommend verifying CI `make verify` (or the repo's canonical CI) and resolving any review threads before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2af0ae0ea0832cae5df0dab82108ea)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `GITHUB_TOKEN`/`GH_TOKEN` exposure in PR builds by using a checked‑in Docker image telemetry baseline on PRs and gating the remote resolver to trusted (non‑PR) runs. Adds and updates the governance closeout doc to satisfy CI body/gate checks and keep the readiness checklist open.

- **Bug Fixes**
  - In `.github/workflows/build.yml`, add a PR-only step to copy `docs/telemetry/docker_image_baseline.production.json` to `docker-image-baseline.json`.
  - Gate "Resolve Docker image telemetry baseline" with `if: github.event_name != 'pull_request'` and pass tokens only there.
  - Update `tests/test_docker_workflow_build_path_contract.py` to assert the PR fallback uses the checked-in baseline, doesn’t call the resolver, and has no `GH_TOKEN`/`GITHUB_TOKEN`.
  - Add/refresh `docs/review/PR_1948_FIXED_MAPPING.md` as the governance closeout artifact; keeps the readiness checklist open and maps the CodeRabbit note.

<sup>Written for commit 15291cd07affb5c9f43a431f6650e72c8d0ecba2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to ensure secure build configuration.

* **Chores**
  * Updated Docker image telemetry baseline handling in build workflow to properly isolate credentials based on event type.
  * Added security documentation for build process verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->