### PR TITLE
fix(evals): fail-closed on live LLM/embedding creds in RAGAS runner

### DIFF
--- a/docs/evals/RAGAS_SETUP.md
+++ b/docs/evals/RAGAS_SETUP.md
@@ -35,6 +35,9 @@
 - Do not add `ragas` or `datasets` to `requirements.txt` or `requirements-dev.txt`
 - Keep `ragas` imports lazy inside the runner entrypoint
 - Do not call live providers or runtime routes from this lane
+- The CLI fails closed when known live LLM/embedding provider credential
+  environment variables are present; unset those variables or inject a local,
+  offline evaluator when running this companion lane
 - Do not claim a second canonical evaluation source of truth beside
   `docs/evals/PULSEPLATE_RAG_RELEASE_GATES.md`
 - Keep outputs out of tracked repo paths by default

--- a/docs/review/PR_1952_FIXED_MAPPING.md
+++ b/docs/review/PR_1952_FIXED_MAPPING.md
@@ -1,0 +1,133 @@
+# PR 1952 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] Post-open review-thread pass completed.
+
+## Fixed in Commit Mapping
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1952#issuecomment-4683697349 -> a93504962ebc13b362e8187b947255c8d299c967
+Disposition: FIXED
+Commit: a93504962ebc13b362e8187b947255c8d299c967
+Evidence: `evals/ragas/run_ragas_eval.py`; `tests/test_remaining_modules.py`; `tests/evals/test_ragas_runner_contract.py`; local focused RAGAS pytest; local diff-cover.
+Reason: Codecov/diff-coverage reported missing guard coverage for the live-provider credential branch. Commit `a93504962` mirrors the fail-closed credential guard into the CI fast-lane smoke suite, covers every configured prohibited provider variable, asserts secret values are not emitted, and keeps the default-evaluator smoke deterministic when local shells have provider variables set.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1952#issuecomment-4683617816
+Disposition: NOT-A-BUG
+Evidence: Codex connector comment reported code-review quota limits only and requested no code, docs, or test change.
+Reason: Quota notice is not an actionable review finding for this PR.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1952#pullrequestreview-4479378960
+Disposition: NOT-A-BUG
+Evidence: Sourcery review reported weekly diff-character rate limits only and requested no code, docs, or test change.
+Reason: Rate-limit notice is not an actionable review finding for this PR.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1952#issuecomment-4683618135
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit comment reported PR review rate limits; no inline review threads were present, and the generated finishing-touch options were generic optional actions rather than diff-specific findings.
+Reason: Rate-limit notice is not an actionable review finding for this PR.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1952#pullrequestreview-4479413480
+Disposition: NOT-A-BUG
+Evidence: Cubic reported "No issues found" across the three files reviewed at the previous PR head.
+Reason: No code, docs, or test change was requested by this review.
+
+## Lane Start Provenance
+- PR: `#1952`
+- Branch: `codex/fix-ragas-runner-data-leak-issue`
+- Worktree: `worktrees/pr-1952-ragas-live-provider-creds`
+- Packet: `artifacts/orchestration/task_packets/772e858b24b4.json`
+- Phase: `post_open_review`
+- Operator override: start was allowed while `main` was pending; merge remains blocked unless `main` is healthy.
+
+## Role Dispatch Evidence
+- Preflight: `python3 scripts/orchestration/check_preflight.py --path ...` PASS with scoped AGENTS resolved.
+- Agent consistency: `python3 scripts/orchestration/check_agent_consistency.py` PASS.
+- Dispatch manifest: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/772e858b24b4.json --pretty` PASS.
+- Declared role order executed through native Codex subagents:
+  `agent-coordinator -> qa-engineer-agent -> bug-hunter -> security-auditor -> backend-engineer -> architecture-specialist`.
+- Mandatory post-open review stack executed:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`, then Codex Security diff/finding discovery and `pulseplate-pr-review`.
+
+## Post-Open Role Finding Closure
+- `agent-coordinator`: PASS / scope locked.
+  Evidence: role pass confirmed current blockers were Black formatting, diff-coverage for `evals/ragas/run_ragas_eval.py:224-225`, and the missing fixed-mapping artifact.
+  Reason: no widening into runtime providers, semantic cache, product routes, or dependency changes.
+- `qa-engineer-agent`: FIXED in commit `a93504962`.
+  Evidence: added `tests/test_remaining_modules.py::TestOfflineEvalBootstrapSmoke::test_ragas_runner_rejects_live_provider_credentials_before_ragas_load`.
+  Reason: CI `coverage-pr`/diff-cover uses the fast-lane smoke suite, not only `tests/evals/**`.
+- `bug-hunter`: FIXED in commit `a93504962`.
+  Evidence: Black-format complaint in `evals/ragas/run_ragas_eval.py` fixed; focused RAGAS tests and targeted diff-cover passed.
+  Reason: branch no longer relies on a behavior-only test outside the coverage-producing CI lane.
+- `security-auditor`: FIXED / NOT-A-BUG split.
+  Evidence: commit `a93504962` covers every configured prohibited provider env var and asserts secret values are absent from the error. The custom `evaluator=` bypass remains a documented local/offline injection seam.
+  Reason: default RAGAS path fails closed before provider-backed dependencies load; local custom evaluators stay operator-owned and out of product runtime scope.
+- `backend-engineer`: FIXED in commit `a93504962`.
+  Evidence: existing default-evaluator smoke now clears `runner.PROHIBITED_LIVE_PROVIDER_ENV_VARS` before exercising mocked offline dependencies.
+  Reason: local shells with provider variables can no longer turn the happy-path smoke into a false red.
+- `architecture-specialist`: FIXED / NOT-A-BUG split.
+  Evidence: diff remains limited to eval docs, eval runner, and tests; no `app/`, `core/`, `frontend/`, `ios/`, OpenAPI, provider selection, or semantic-cache runtime files changed.
+  Reason: the fast-lane mirror is acceptable as a coverage bridge while `tests/evals/test_ragas_runner_contract.py` remains the contract owner.
+
+## Premortem Finding Closure
+- `PM-1952-001` Coverage is attached to the wrong lane: FIXED in commit `a93504962`.
+  Evidence: local diff-cover over focused RAGAS coverage reports `evals/ragas/run_ragas_eval.py (100%)`, `Missing: 0`, `Coverage: 100%`.
+- `PM-1952-002` Operator shell provider credentials break deterministic smoke tests: FIXED in commit `a93504962`.
+  Evidence: `OPENAI_API_KEY=sk-test-not-real ... pytest tests/test_remaining_modules.py::TestOfflineEvalBootstrapSmoke::test_ragas_default_evaluator_and_score_extractors -q` PASS.
+- `PM-1952-003` Error messaging leaks secret values: NOT-A-BUG after commit `a93504962`.
+  Evidence: fast-lane test loops over `PROHIBITED_LIVE_PROVIDER_ENV_VARS` and asserts `secret_value not in message`.
+- `PM-1952-004` Fix widens into product runtime/provider behavior: NOT-A-BUG.
+  Evidence: branch diff touches only `docs/evals/RAGAS_SETUP.md`, `evals/ragas/run_ragas_eval.py`, `tests/evals/test_ragas_runner_contract.py`, `tests/test_remaining_modules.py`, and this review artifact.
+
+## Experiment Runner Evidence
+- Packet: `artifacts/orchestration/experiments/artifacts/orchestration/experiments/pr-1952-ragas-credential-guard-oracle-packet.json`
+- Artifact: `artifacts/orchestration/experiments/results/pr-1952-ragas-credential-guard-oracle-result.json`
+- Mode: `oracle_only_governance_reviewer`
+- Status: `accepted`
+- Experiment ID: `exp-89b3270400ee`
+- Oracle commands: 2 configured, 2 returned `0`.
+- Mutated paths: `[]`
+- Shared tree untouched: `true`
+- Contribution: `commit_decision`
+- Co-author required: `true`
+- Commit trailer used on `a93504962`:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+- Note: first packet-bootstrap attempt failed before artifact creation because the Experiment Runner contract requires at least two `--negative-control` values. The accepted packet uses two controls: no credential-value leakage and no app/core/frontend/iOS/provider runtime widening.
+
+## Codex Security Diff Scan / Finding Discovery
+- Scan directory: `/tmp/codex-security-scans/pr-1952-ragas-live-provider-creds/a93504962_20260611T210203Z_prdiff`
+- Markdown report: `/tmp/codex-security-scans/pr-1952-ragas-live-provider-creds/a93504962_20260611T210203Z_prdiff/report.md`
+- HTML report: `/tmp/codex-security-scans/pr-1952-ragas-live-provider-creds/a93504962_20260611T210203Z_prdiff/report.html`
+- Worklist: `/tmp/codex-security-scans/pr-1952-ragas-live-provider-creds/a93504962_20260611T210203Z_prdiff/artifacts/02_discovery/deep_review_input.csv`
+- Work ledger: `/tmp/codex-security-scans/pr-1952-ragas-live-provider-creds/a93504962_20260611T210203Z_prdiff/artifacts/02_discovery/work_ledger.jsonl`
+- Result: NOT-A-BUG / no reportable findings.
+- Evidence: generated PR-diff worklist closed `evals/ragas/run_ragas_eval.py`; report validator passed; HTML report rendered.
+- Note: an initial helper run with `--base origin/main` produced stale two-dot rows because this branch was cut before current `origin/main`; the accepted scan was regenerated from the exact merge-base `b20f807a5c61cb166f909d9aacbe86b3044ee31e` to match GitHub PR diff semantics.
+
+## PulsePlate PR Review
+- Initial dry-run report: `/tmp/pulseplate_pr_review_1952.md`
+- Initial result: advisory findings only for the missing fixed-mapping artifact.
+- Disposition: FIXED by this artifact and follow-up PR body mirror.
+- Rerun required after this artifact is committed so the report no longer flags the missing mapping.
+
+## Validation Evidence
+- PASS: `python3 scripts/orchestration/check_preflight.py --path docs/evals/RAGAS_SETUP.md --path evals/ragas/run_ragas_eval.py --path tests/evals/test_ragas_runner_contract.py --path tests/test_remaining_modules.py --path docs/review/PR_1952_FIXED_MAPPING.md`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review`
+- PASS: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/772e858b24b4.json --pretty`
+- PASS: `$VENV_PYTHON -m compileall -q evals/ragas/run_ragas_eval.py tests/evals/test_ragas_runner_contract.py tests/test_remaining_modules.py`
+- PASS: `$VENV_PYTHON -m pytest -q tests/test_remaining_modules.py::TestOfflineEvalBootstrapSmoke::test_ragas_runner_rejects_live_provider_credentials_before_ragas_load tests/test_remaining_modules.py::TestOfflineEvalBootstrapSmoke::test_ragas_default_evaluator_and_score_extractors tests/evals/test_ragas_runner_contract.py::test_evaluate_records_rejects_live_provider_credentials_before_ragas_load`
+- PASS: `OPENAI_API_KEY=sk-test-not-real $VENV_PYTHON -m pytest -q tests/test_remaining_modules.py::TestOfflineEvalBootstrapSmoke::test_ragas_default_evaluator_and_score_extractors`
+- PASS: `$VENV_PYTHON -m pytest -q tests/test_remaining_modules.py::TestOfflineEvalBootstrapSmoke tests/evals/test_ragas_runner_contract.py` (`17 passed`)
+- PASS: targeted local diff-cover from focused RAGAS coverage:
+  `evals/ragas/run_ragas_eval.py (100%)`; `Total: 7 lines`; `Missing: 0 lines`; `Coverage: 100%`
+- PASS: `$VENV_PYTHON -m black --check evals/ragas/run_ragas_eval.py tests/evals/test_ragas_runner_contract.py tests/test_remaining_modules.py`
+- PASS: `VENV_PYTHON=$VENV_PYTHON make validate-changed`
+- PASS: `PRE_COMMIT_HOME=/tmp/pre-commit-pr1952 VENV_PYTHON=$VENV_PYTHON $VENV_PYTHON -m pre_commit run --all-files`
+- PASS: commit hooks on `a93504962`: file hygiene, secrets, Black, Ruff, Bandit changed files, changed-file backend tests, and commitizen.
+
+## Current Non-Ready Gates
+- Local PR body Phase 2 and strict merge-readiness checks still need rerun after this artifact is committed and the PR body mirror is updated.
+- Current-head GitHub CI still reflects the previous remote head until the local branch is pushed.
+- Merge remains blocked if `main` is red, pending, or unstable despite the operator start override.
+- Fresh current-head PR CI, strict wrapper with auth, no unresolved/actionable review items, mandatory wait-window, and healthy `main` are required before merge.

--- a/evals/ragas/run_ragas_eval.py
+++ b/evals/ragas/run_ragas_eval.py
@@ -6,6 +6,7 @@ import argparse
 import inspect
 import json
 import math
+import os
 import sys
 from pathlib import Path
 from statistics import mean
@@ -17,6 +18,24 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_DATASET_PATH = REPO_ROOT / "evals" / "ragas" / "testset.jsonl"
 
 REQUIRED_METRIC_NAMES: tuple[str, ...] = DEFAULT_RAGAS_METRICS
+PROHIBITED_LIVE_PROVIDER_ENV_VARS: tuple[str, ...] = (
+    "AI21_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "COHERE_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "FIREWORKS_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GROQ_API_KEY",
+    "HUGGINGFACEHUB_API_TOKEN",
+    "HUGGINGFACE_API_KEY",
+    "MISTRAL_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "TOGETHER_API_KEY",
+)
 
 
 MetricEvaluator = Callable[[list[dict[str, Any]], tuple[str, ...]], Mapping[str, float]]
@@ -195,6 +214,21 @@ def _validate_metric_names(metric_names: tuple[str, ...]) -> tuple[str, ...]:
     return metric_names
 
 
+def _assert_no_live_provider_credentials() -> None:
+    """RU: Запретить live provider creds. EN: Block live provider credentials."""
+
+    present = [
+        name for name in PROHIBITED_LIVE_PROVIDER_ENV_VARS if os.environ.get(name)
+    ]
+    if present:
+        joined_names = ", ".join(sorted(present))
+        raise RuntimeError(
+            "RAGAS companion evals are offline-only and must not run with live "
+            f"provider credentials in the environment: {joined_names}. "
+            "Unset these variables or inject a local/offline evaluator.",
+        )
+
+
 def _load_ragas_dependencies() -> tuple[Any, Any, Mapping[str, Any]]:
     """RU: Lazy import RAGAS deps. EN: Lazy import RAGAS dependencies."""
 
@@ -301,6 +335,7 @@ def evaluate_records(
         scores = evaluator(rows, metric_names)
         return _validate_metric_scores(scores, metric_names, source="custom evaluator")
 
+    _assert_no_live_provider_credentials()
     dataset_cls, evaluate, metric_map = _load_ragas_dependencies()
     ragas_rows = [
         {

--- a/evals/ragas/run_ragas_eval.py
+++ b/evals/ragas/run_ragas_eval.py
@@ -217,9 +217,7 @@ def _validate_metric_names(metric_names: tuple[str, ...]) -> tuple[str, ...]:
 def _assert_no_live_provider_credentials() -> None:
     """RU: Запретить live provider creds. EN: Block live provider credentials."""
 
-    present = [
-        name for name in PROHIBITED_LIVE_PROVIDER_ENV_VARS if os.environ.get(name)
-    ]
+    present = [name for name in PROHIBITED_LIVE_PROVIDER_ENV_VARS if os.environ.get(name)]
     if present:
         joined_names = ", ".join(sorted(present))
         raise RuntimeError(

--- a/tests/evals/test_ragas_runner_contract.py
+++ b/tests/evals/test_ragas_runner_contract.py
@@ -128,6 +128,32 @@ def test_run_report_is_deterministic_and_lazy(
     assert "NO-GO" not in summary
 
 
+def test_evaluate_records_rejects_live_provider_credentials_before_ragas_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Offline runner must fail closed before data can reach provider-backed RAGAS."""
+
+    runner = importlib.import_module("evals.ragas.run_ragas_eval")
+    rows = [
+        {
+            "question": "private CBT question",
+            "answer": "private candidate answer",
+            "contexts": ["private context"],
+            "reference": "private reference",
+            "ground_truth": "private reference",
+        }
+    ]
+
+    def _boom() -> tuple[object, object, object]:
+        raise AssertionError("ragas must not load while live provider creds are set")
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-not-real")
+    monkeypatch.setattr(runner, "_load_ragas_dependencies", _boom)
+
+    with pytest.raises(RuntimeError, match="offline-only.*OPENAI_API_KEY"):
+        runner.evaluate_records(rows, runner.DEFAULT_RAGAS_METRICS)
+
+
 def test_run_report_uses_repo_relative_dataset_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_remaining_modules.py
+++ b/tests/test_remaining_modules.py
@@ -80,6 +80,20 @@ def _write_ragas_bootstrap_dataset(path: Path) -> None:
     )
 
 
+def _clear_ragas_live_provider_env(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: ModuleType,
+) -> None:
+    """Keep RAGAS smoke tests independent from the operator shell environment."""
+
+    prohibited_env_vars = cast(
+        Sequence[str],
+        getattr(runner, "PROHIBITED_LIVE_PROVIDER_ENV_VARS"),
+    )
+    for name in prohibited_env_vars:
+        monkeypatch.delenv(name, raising=False)
+
+
 class TestOfflineEvalBootstrapSmoke:
     """Exercise the eval bootstrap lane in the always-on smoke suite."""
 
@@ -209,6 +223,44 @@ class TestOfflineEvalBootstrapSmoke:
                 ("faithfulness", "answer_relevancy", "context_precision"),
             )
 
+    def test_ragas_runner_rejects_live_provider_credentials_before_ragas_load(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """The fast lane must cover fail-closed credential guards before RAGAS loads."""
+
+        runner = importlib.import_module("evals.ragas.run_ragas_eval")
+        dataset_path = tmp_path / "testset.jsonl"
+        _write_ragas_bootstrap_dataset(dataset_path)
+        rows = runner.load_dataset_rows(dataset_path)
+        prohibited_env_vars = cast(
+            Sequence[str],
+            getattr(runner, "PROHIBITED_LIVE_PROVIDER_ENV_VARS"),
+        )
+        load_attempts = 0
+
+        def _boom() -> tuple[object, object, object]:
+            nonlocal load_attempts
+            load_attempts += 1
+            raise AssertionError("ragas must not load while live provider creds are set")
+
+        monkeypatch.setattr(runner, "_load_ragas_dependencies", _boom)
+
+        for index, name in enumerate(prohibited_env_vars):
+            secret_value = f"test-secret-{index}"
+            _clear_ragas_live_provider_env(monkeypatch, runner)
+            monkeypatch.setenv(name, secret_value)
+
+            with pytest.raises(RuntimeError) as exc_info:
+                runner.evaluate_records(rows, runner.REQUIRED_METRIC_NAMES)
+
+            message = str(exc_info.value)
+            assert "offline-only" in message
+            assert name in message
+            assert secret_value not in message
+            assert load_attempts == 0
+
     def test_ragas_dataset_validation_paths(self, tmp_path: Path) -> None:
         """Dataset parsing must fail closed on malformed bootstrap inputs."""
 
@@ -288,6 +340,7 @@ class TestOfflineEvalBootstrapSmoke:
         """Default evaluator branches must stay covered in the deterministic smoke suite."""
 
         runner = importlib.import_module("evals.ragas.run_ragas_eval")
+        _clear_ragas_live_provider_env(monkeypatch, runner)
         dataset_path = tmp_path / "testset.jsonl"
         _write_ragas_bootstrap_dataset(dataset_path)
         rows = runner.load_dataset_rows(dataset_path)


### PR DESCRIPTION
### Motivation
- The offline RAGAS companion runner constructed provider-backed payloads and invoked `evaluate()` without enforcing an offline/local-only boundary, which can leak dataset rows to external LLM/embedding providers when provider credentials are present in the environment. 
- The change prevents accidental data disclosure from a developer/CI running the offline runner while live provider keys exist.

### Description
- Add a curated `PROHIBITED_LIVE_PROVIDER_ENV_VARS` tuple listing common LLM/embedding credential environment variable names. 
- Add `_assert_no_live_provider_credentials()` which fails closed with a `RuntimeError` if any prohibited env var is present. 
- Call `_assert_no_live_provider_credentials()` at the start of the default `evaluate_records()` path before lazy-loading `ragas` or building provider-backed payloads. 
- Update `docs/evals/RAGAS_SETUP.md` to document the new fail-closed behavior. 
- Add a regression test `test_evaluate_records_rejects_live_provider_credentials_before_ragas_load` to `tests/evals/test_ragas_runner_contract.py` that asserts `evaluate_records()` raises when `OPENAI_API_KEY` is set and `_load_ragas_dependencies` is prevented from loading.

### Testing
- PASS: `python3 scripts/orchestration/check_preflight.py --path ...` with scoped AGENTS resolved.
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`.
- PASS: `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review` and role dispatch manifest for packet `772e858b24b4`.
- PASS: focused RAGAS tests: `tests/test_remaining_modules.py::TestOfflineEvalBootstrapSmoke` and `tests/evals/test_ragas_runner_contract.py` (`17 passed`).
- PASS: dummy credential contamination check: `OPENAI_API_KEY=sk-test-not-real ... test_ragas_default_evaluator_and_score_extractors`.
- PASS: targeted local diff-cover from focused coverage: `evals/ragas/run_ragas_eval.py (100%)`, `Missing: 0`, `Coverage: 100%`.
- PASS: `make validate-changed` with repo `VENV_PYTHON`.
- PASS: `pre-commit run --all-files` using `/tmp/pre-commit-pr1952` cache.
- PASS: Codex Security diff/finding discovery no-findings scan for the PR diff.
- Full `make verify` is not claimed here; merge remains gated by fresh current-head CI, strict merge-readiness checks, review governance, wait-window, and healthy `main`.

## Scope
- Keep PR #1952 narrowly scoped to the offline RAGAS runner credential fail-closed guard, its deterministic test coverage, RAGAS setup docs, and canonical review mapping.
- Preserve the existing RAGAS contract regression and add fast-lane coverage in `tests/test_remaining_modules.py` so CI-owned smoke/diff-coverage paths exercise the guard.
- Keep the PR as a post-open review fix lane on `codex/fix-ragas-runner-data-leak-issue`.

## Out of scope
- No app/core/frontend/iOS runtime behavior, OpenAPI contract, provider selection, semantic-cache, release-gate, or production AI endpoint changes.
- No broad cleanup, dependency migration, or unrelated CI/workflow changes.
- No merge while current-head PR checks, review governance, the wait-window, or `main` health are unstable.

## Tests
- PASS: `python3 scripts/orchestration/check_preflight.py --path ...` with scoped AGENTS resolved.
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`.
- PASS: `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review` and role dispatch manifest for packet `772e858b24b4`.
- PASS: focused RAGAS tests: `tests/test_remaining_modules.py::TestOfflineEvalBootstrapSmoke` and `tests/evals/test_ragas_runner_contract.py` (`17 passed`).
- PASS: dummy credential contamination check: `OPENAI_API_KEY=sk-test-not-real ... test_ragas_default_evaluator_and_score_extractors`.
- PASS: targeted local diff-cover from focused coverage: `evals/ragas/run_ragas_eval.py (100%)`, `Missing: 0`, `Coverage: 100%`.
- PASS: `make validate-changed` with repo `VENV_PYTHON`.
- PASS: `pre-commit run --all-files` using `/tmp/pre-commit-pr1952` cache.
- PASS: Codex Security diff/finding discovery no-findings scan for the PR diff.
- Full `make verify` is not claimed; local full verify passed verify-env, flake8, mypy, and test-fast, then terminated during full coverage pytest before a pytest summary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2af3aea034832c964ab10a3d5b2281)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-closed the offline RAGAS runner when live LLM/embedding credentials are present to prevent leaking dataset rows to external providers. The guard runs before `ragas` is loaded or any provider-backed payloads are built.

- **Bug Fixes**
  - Added `PROHIBITED_LIVE_PROVIDER_ENV_VARS` with common provider keys (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`).
  - Implemented `_assert_no_live_provider_credentials()` that raises `RuntimeError` if any are set.
  - Invoked the guard at the start of `evaluate_records()` before `_load_ragas_dependencies()`.
  - Documented the fail-closed behavior in `docs/evals/RAGAS_SETUP.md` (unset keys or use a local/offline evaluator).
  - Added tests to cover the fail-closed path and keep smoke runs deterministic: contract test in `tests/evals/test_ragas_runner_contract.py` and fast-lane smoke coverage in `tests/test_remaining_modules.py` that clears prohibited env vars and ensures no secret values appear in errors.

<sup>Written for commit 661c426a6d83b81b0fc7fb5d3f5ebad98d87da4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Post-open review-thread pass completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1952_FIXED_MAPPING.md`

## Experiment Runner Evidence
- Packet: `artifacts/orchestration/experiments/artifacts/orchestration/experiments/pr-1952-ragas-credential-guard-oracle-packet.json`
- Artifact: `artifacts/orchestration/experiments/results/pr-1952-ragas-credential-guard-oracle-result.json`
- Mode: `oracle_only_governance_reviewer`
- Status: `accepted`
- Mutated paths: `[]`
- Shared tree untouched: `true`
- Contribution: `commit_decision`
- Co-author required: `true`
- Commit trailer used on `a93504962ebc13b362e8187b947255c8d299c967`.

## Lane Start Provenance
- Packet: `artifacts/orchestration/task_packets/772e858b24b4.json`
- Branch: `codex/fix-ragas-runner-data-leak-issue`
- Worktree: `worktrees/pr-1952-ragas-live-provider-creds`
- Phase: `post_open_review`
- Operator override: start permitted while `main` is pending; merge remains blocked unless `main` is healthy.

## Security Notes
- The default RAGAS path now fails closed before lazy provider-backed dependency loading when configured live provider credential variables are present.
- Error text reports environment variable names only; fast-lane coverage asserts secret values are absent.
- No app/core/frontend/iOS runtime, provider selection, OpenAPI, semantic-cache, or release-gates authority was changed.

## Merge Readiness
- Not claimed in this body update.
- Pending after push: fresh current-head PR CI, strict governance/merge-readiness checks with auth, no unresolved/actionable review items, mandatory wait-window, and healthy `main`.

