### PR TITLE
chore(orchestration): add creative research adoption metrics report

### DIFF
--- a/docs/orchestration/CREATIVE_RESEARCH_OFFLINE_EVAL_PROTOCOL.md
+++ b/docs/orchestration/CREATIVE_RESEARCH_OFFLINE_EVAL_PROTOCOL.md
@@ -169,3 +169,55 @@ PR-B must not commit:
 - local brainstorming logs
 - provider traces
 - raw hidden-memory artifacts
+
+---
+
+## 7. Manual adoption metrics
+
+The adoption/conversion loop is a manual operator report, not a merge gate.
+It reads local eval artifacts and experiment promotion decisions, then writes
+aggregate-only local artifacts under:
+
+- `artifacts/orchestration/creative_research/metrics/`
+
+Manual command:
+
+```bash
+python3 scripts/orchestration/creative_research_metrics.py \
+  --output-json artifacts/orchestration/creative_research/metrics/latest.json \
+  --output-md artifacts/orchestration/creative_research/metrics/latest.md
+```
+
+Report contract:
+
+- `schema_version = creative-research-metrics-v1`
+- counts are aggregated from evaluated candidate rows, not trusted from summary alone
+- conversion grain is `(bundle_id, candidate_id)`
+- destination type and sanitized repo-relative ref come from existing promotion
+  fields: `promotion_target` and `durable_artifact_path`
+- raw prompts, claims, mechanisms, evidence text, provider output, local absolute
+  paths, and secrets must not appear in the JSON or Markdown report
+
+Optional origin link convention for experiment promotion packets:
+
+```json
+{
+  "creative_research_origin": {
+    "bundle_id": "creative-research-valid",
+    "candidate_id": "hyp-batch",
+    "promotion_decision": "promote"
+  }
+}
+```
+
+Rules:
+
+- `creative_research_origin` is passive provenance only
+- it must not change promotion policy, result status, target selection, or
+  durable artifact path semantics
+- unsupported fields or invalid `promotion_decision` values fail promotion
+  cleanly
+- absence of origin metadata remains backward-compatible
+
+Future enforcement, telemetry rollups, or CI-required checks require a separate
+coordinator-owned PR after this report proves low-noise.

--- a/docs/review/PR_1953_FIXED_MAPPING.md
+++ b/docs/review/PR_1953_FIXED_MAPPING.md
@@ -78,7 +78,12 @@
 - PASS: `.venv/bin/python -m py_compile scripts/orchestration/creative_research_metrics.py scripts/orchestration/experiment_promote.py`
 - PASS: `.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/creative_research_metrics.py scripts/orchestration/experiment_promote.py`
 - PASS: `make validate-changed`
-- PASS: `pre-commit run --all-files`
+- PASS: `pre-commit run --files docs/review/PR_1953_FIXED_MAPPING.md tests/test_experiment_promote.py scripts/orchestration/creative_research_metrics.py scripts/orchestration/experiment_promote.py tests/test_creative_research_metrics.py docs/orchestration/CREATIVE_RESEARCH_OFFLINE_EVAL_PROTOCOL.md`
+- NOTE: final `pre-commit run --all-files` rerun was interrupted after the
+  `check-added-large-files` hook stalled on the full repository file list;
+  earlier all-files pre-commit had passed before the post-open docs/test
+  updates, and the bounded changed-file hooks plus pre-push hooks passed for
+  the current head.
 - PASS: pre-push hooks, including `mypy (type-check, changed files)`, `backend tests (pytest, pre-push)`, `bandit (pre-push, full repo)`, and `docker build test`.
 - PARTIAL / NOT CLAIMED: `make verify` passed `verify-env`, `flake8`, `mypy app core`, and `test-fast`, then the local harness exited during full coverage pytest without a completed diff-cover result. Local merge readiness from `make verify` is not claimed.
 

--- a/docs/review/PR_1953_FIXED_MAPPING.md
+++ b/docs/review/PR_1953_FIXED_MAPPING.md
@@ -21,6 +21,34 @@
     decision.
   - Validation: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_experiment_promote.py tests/test_creative_research_metrics.py`
     passed with `29 passed`.
+- `bug-hunter`: NOT-A-BUG for the PulsePlate review dry-run large-diff advisory.
+  - Evidence: the diff is intentionally concentrated in one manual
+    orchestration report, passive promotion metadata, focused tests, docs, and
+    this governance artifact; no runtime/API/DB/client/provider surface is
+    touched.
+  - Validation: `make validate-changed` passed for the branch scope, and the
+    focused metrics/promotion pytest suite passed after the QA coverage fix.
+- `security-auditor`: no reportable post-open security finding.
+  - Evidence: the change is local-artifact only; report inputs and outputs are
+    confined to gitignored orchestration artifact roots; promotion origin
+    metadata is strict-schema and passive.
+  - Validation: `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH make bandit-full`
+    passed; pre-push `bandit (pre-push, full repo)` also passed.
+- Codex Security diff scan / finding discovery: no diff-scoped candidate finding
+  promoted.
+  - Evidence: reviewed changed source-like files
+    `scripts/orchestration/creative_research_metrics.py` and
+    `scripts/orchestration/experiment_promote.py`; the script rejects path
+    escapes/symlinks and omits raw prompt, claim, mechanism, provider output,
+    local absolute path, and secret payloads from reports.
+  - Validation: no raw-leak/path-containment tests pass in
+    `tests/test_creative_research_metrics.py`; full-repo Bandit passed.
+- `pulseplate-pr-review`: advisory dry-run report generated from
+  `/tmp/pulseplate_pr_1953_review_context.json`.
+  - Evidence: report found one `note` only for large diff review-planning risk,
+    owned by `bug-hunter`, with `make validate-changed` as the proving gate.
+  - Disposition: NOT-A-BUG; the diff size is from deterministic tests and local
+    orchestration/reporting code within the declared narrow scope.
 
 ## Experiment Runner Evidence
 

--- a/docs/review/PR_1953_FIXED_MAPPING.md
+++ b/docs/review/PR_1953_FIXED_MAPPING.md
@@ -89,9 +89,29 @@
 
 ## Merge Readiness
 
-- [ ] Current-head CI terminal success confirmed.
-- [ ] Required checks complete with no pending jobs.
-- [ ] Bot review/governance completed with no unmapped actionable comments.
-- [ ] Strict review-thread disposition passes with auth.
-- [ ] Strict merge-readiness guard passes with auth.
-- [ ] Mandatory wait-window after latest bot/review activity completed.
+- [x] Current-head CI terminal success confirmed.
+- [x] Required checks complete with no pending jobs.
+- [x] Bot review/governance completed with no unmapped actionable comments.
+- [x] Strict review-thread disposition passes with auth.
+- [x] Strict merge-readiness guard passes with auth.
+- [x] Mandatory wait-window after latest bot/review activity completed.
+
+Evidence:
+
+- Current-head CI for `333c5c4776dd415493a792209a2dc9a85287235e`
+  completed successfully on workflow run `27376256534`, attempt 2.
+- Required/current-head checks were terminal with no pending jobs:
+  `lint`, `test-pr (3.13)`, `coverage-pr`, `diff-coverage`,
+  `security`, `OpenAPI sync (backend -> frontend artifacts)`,
+  `Merge readiness gate`, `PR Body Phase2 gates`, docs/governance guards,
+  CodeQL, CodeRabbit, Sourcery review, Cubic, and Codecov patch.
+- `GH_TOKEN=$(gh auth token) ../../.venv/bin/python scripts/orchestration/check_review_threads_disposition.py --pr-number 1953 --require-auth`
+  passed with no resolved review threads to enforce.
+- `GITHUB_TOKEN=$(gh auth token) ../../.venv/bin/python scripts/ci/check_pr_merge_readiness.py --pr-number 1953 --repo Katsiarynakavaleuskaya/PulsePlate`
+  passed with zero unresolved threads and all actionable bot comments mapped.
+- Latest external bot review activity was before the final current-head CI pass;
+  the final verification pass completed after `2026-06-11T21:28:21Z` UTC.
+
+Note: this mapping update is documentation-only. If it changes the PR head, the
+same current-head CI and strict merge-readiness checks must be reconfirmed
+before merge.

--- a/docs/review/PR_1953_FIXED_MAPPING.md
+++ b/docs/review/PR_1953_FIXED_MAPPING.md
@@ -19,7 +19,7 @@
     `promotion_target="backlog_entry"` with `creative_research_origin` and
     asserts the ledger preserves bundle ID, candidate ID, and promotion
     decision.
-  - Validation: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_experiment_promote.py tests/test_creative_research_metrics.py`
+  - Validation: `.venv/bin/python -m pytest -q tests/test_experiment_promote.py tests/test_creative_research_metrics.py`
     passed with `29 passed`.
 - `bug-hunter`: NOT-A-BUG for the PulsePlate review dry-run large-diff advisory.
   - Evidence: the diff is intentionally concentrated in one manual
@@ -32,7 +32,7 @@
   - Evidence: the change is local-artifact only; report inputs and outputs are
     confined to gitignored orchestration artifact roots; promotion origin
     metadata is strict-schema and passive.
-  - Validation: `PATH=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin:$PATH make bandit-full`
+  - Validation: `make bandit-full`
     passed; pre-push `bandit (pre-push, full repo)` also passed.
 - Codex Security diff scan / finding discovery: no diff-scoped candidate finding
   promoted.
@@ -43,8 +43,8 @@
     local absolute path, and secret payloads from reports.
   - Validation: no raw-leak/path-containment tests pass in
     `tests/test_creative_research_metrics.py`; full-repo Bandit passed.
-- `pulseplate-pr-review`: advisory dry-run report generated from
-  `/tmp/pulseplate_pr_1953_review_context.json`.
+- `pulseplate-pr-review`: advisory dry-run report generated from sanitized local
+  PR review context.
   - Evidence: report found one `note` only for large diff review-planning risk,
     owned by `bug-hunter`, with `make validate-changed` as the proving gate.
   - Disposition: NOT-A-BUG; the diff size is from deterministic tests and local
@@ -66,10 +66,10 @@
 - PASS: `python3 scripts/orchestration/check_agent_consistency.py`
 - PASS: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/creative_research_adoption_metrics_pre_open.json --pretty`
 - PASS: required pre-open role passes completed in order: `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> data-scientist-agent -> cursor-specialist-agent`.
-- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_creative_research_metrics.py tests/test_creative_research_eval.py tests/test_creative_research_eval_contract.py tests/test_experiment_promote.py`
-- PASS after QA fix: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_experiment_promote.py tests/test_creative_research_metrics.py` (`29 passed`).
-- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m py_compile scripts/orchestration/creative_research_metrics.py scripts/orchestration/experiment_promote.py`
-- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/creative_research_metrics.py scripts/orchestration/experiment_promote.py`
+- PASS: `.venv/bin/python -m pytest -q tests/test_creative_research_metrics.py tests/test_creative_research_eval.py tests/test_creative_research_eval_contract.py tests/test_experiment_promote.py`
+- PASS after QA fix: `.venv/bin/python -m pytest -q tests/test_experiment_promote.py tests/test_creative_research_metrics.py` (`29 passed`).
+- PASS: `.venv/bin/python -m py_compile scripts/orchestration/creative_research_metrics.py scripts/orchestration/experiment_promote.py`
+- PASS: `.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/creative_research_metrics.py scripts/orchestration/experiment_promote.py`
 - PASS: `make validate-changed`
 - PASS: `pre-commit run --all-files`
 - PASS: pre-push hooks, including `mypy (type-check, changed files)`, `backend tests (pytest, pre-push)`, `bandit (pre-push, full repo)`, and `docker build test`.

--- a/docs/review/PR_1953_FIXED_MAPPING.md
+++ b/docs/review/PR_1953_FIXED_MAPPING.md
@@ -9,6 +9,19 @@
 
 - No actionable review comments
 
+## Post-Open Role Review
+
+- `qa-engineer-agent`: FIXED missing target-specific test coverage for
+  `creative_research_origin` rendered through rejected/deferred `backlog_entry`
+  promotion.
+  - Commit: `5bb31f57d`
+  - Evidence: `tests/test_experiment_promote.py` covers
+    `promotion_target="backlog_entry"` with `creative_research_origin` and
+    asserts the ledger preserves bundle ID, candidate ID, and promotion
+    decision.
+  - Validation: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_experiment_promote.py tests/test_creative_research_metrics.py`
+    passed with `29 passed`.
+
 ## Experiment Runner Evidence
 
 - Artifact: `artifacts/orchestration/experiments/results/creative_research_adoption_metrics_oracle_result.json`
@@ -26,6 +39,7 @@
 - PASS: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/creative_research_adoption_metrics_pre_open.json --pretty`
 - PASS: required pre-open role passes completed in order: `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> data-scientist-agent -> cursor-specialist-agent`.
 - PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_creative_research_metrics.py tests/test_creative_research_eval.py tests/test_creative_research_eval_contract.py tests/test_experiment_promote.py`
+- PASS after QA fix: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_experiment_promote.py tests/test_creative_research_metrics.py` (`29 passed`).
 - PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m py_compile scripts/orchestration/creative_research_metrics.py scripts/orchestration/experiment_promote.py`
 - PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/creative_research_metrics.py scripts/orchestration/experiment_promote.py`
 - PASS: `make validate-changed`

--- a/docs/review/PR_1953_FIXED_MAPPING.md
+++ b/docs/review/PR_1953_FIXED_MAPPING.md
@@ -28,6 +28,13 @@
     touched.
   - Validation: `make validate-changed` passed for the branch scope, and the
     focused metrics/promotion pytest suite passed after the QA coverage fix.
+- `bug-hunter`: FIXED local absolute-path leakage in the review mapping
+  artifact.
+  - Commit: `13e7dad82`
+  - Evidence: `docs/review/PR_1953_FIXED_MAPPING.md` now uses repo-relative
+    validation commands and sanitized local review-context wording.
+  - Validation: `../../.venv/bin/python -m pytest -q tests/guards/test_security_devtooling_regression_guards.py::test_changed_docs_do_not_add_local_users_absolute_paths -p no:cacheprovider`
+    passed.
 - `security-auditor`: no reportable post-open security finding.
   - Evidence: the change is local-artifact only; report inputs and outputs are
     confined to gitignored orchestration artifact roots; promotion origin

--- a/docs/review/PR_1953_FIXED_MAPPING.md
+++ b/docs/review/PR_1953_FIXED_MAPPING.md
@@ -1,0 +1,43 @@
+# PR 1953 Fixed in Commit Mapping
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Experiment Runner Evidence
+
+- Artifact: `artifacts/orchestration/experiments/results/creative_research_adoption_metrics_oracle_result.json`
+- Experiment ID: `exp-039ef7427573`
+- Runner mode: `oracle_only_governance_reviewer`
+- Status: `accepted`
+- Shared tree untouched: `true`
+- Oracle count: `2`
+- Commit attribution: `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+
+## Local Validation Evidence
+
+- PASS: `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration/creative_research_metrics.py --path scripts/orchestration/experiment_promote.py --path tests/test_creative_research_metrics.py --path tests/test_experiment_promote.py --path docs/orchestration/CREATIVE_RESEARCH_OFFLINE_EVAL_PROTOCOL.md`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/creative_research_adoption_metrics_pre_open.json --pretty`
+- PASS: required pre-open role passes completed in order: `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> data-scientist-agent -> cursor-specialist-agent`.
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_creative_research_metrics.py tests/test_creative_research_eval.py tests/test_creative_research_eval_contract.py tests/test_experiment_promote.py`
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m py_compile scripts/orchestration/creative_research_metrics.py scripts/orchestration/experiment_promote.py`
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/creative_research_metrics.py scripts/orchestration/experiment_promote.py`
+- PASS: `make validate-changed`
+- PASS: `pre-commit run --all-files`
+- PASS: pre-push hooks, including `mypy (type-check, changed files)`, `backend tests (pytest, pre-push)`, `bandit (pre-push, full repo)`, and `docker build test`.
+- PARTIAL / NOT CLAIMED: `make verify` passed `verify-env`, `flake8`, `mypy app core`, and `test-fast`, then the local harness exited during full coverage pytest without a completed diff-cover result. Local merge readiness from `make verify` is not claimed.
+
+## Merge Readiness
+
+- [ ] Current-head CI terminal success confirmed.
+- [ ] Required checks complete with no pending jobs.
+- [ ] Bot review/governance completed with no unmapped actionable comments.
+- [ ] Strict review-thread disposition passes with auth.
+- [ ] Strict merge-readiness guard passes with auth.
+- [ ] Mandatory wait-window after latest bot/review activity completed.

--- a/scripts/orchestration/creative_research_metrics.py
+++ b/scripts/orchestration/creative_research_metrics.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+"""Aggregate local creative research adoption metrics.
+
+Manual local-only eval -> promotion metrics with no runtime side effects.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+RUNNER_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(RUNNER_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(RUNNER_REPO_ROOT))
+
+from scripts.orchestration.context_pack import REPO_ROOT, normalize_repo_path
+from scripts.orchestration.creative_research_eval_contract import (
+    OUTPUT_CLASSES,
+    PROMOTION_DECISIONS,
+    SCHEMA_VERSION as CREATIVE_RESEARCH_SCHEMA_VERSION,
+    TASK_CLASS,
+    VALID_PHASES,
+)
+from scripts.orchestration.experiment_contract import PROMOTION_TARGETS
+
+REPORT_SCHEMA_VERSION = "creative-research-metrics-v1"
+ARTIFACT_ROOT = REPO_ROOT / "artifacts" / "orchestration"
+EVALS_DIR = ARTIFACT_ROOT / "creative_research" / "evals"
+PROMOTIONS_DIR = ARTIFACT_ROOT / "experiments" / "promotions"
+METRICS_DIR = ARTIFACT_ROOT / "creative_research" / "metrics"
+DEFAULT_OUTPUT_JSON = METRICS_DIR / "latest.json"
+DEFAULT_OUTPUT_MD = METRICS_DIR / "latest.md"
+
+SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+SAFE_CONTROL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+SAFE_DESTINATION_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,255}$")
+DESTINATION_REF_PREFIX_BY_TARGET = {
+    "pr_packet": ("docs/orchestration/experiment_pr_packets/",),
+    "audit_artifact": ("docs/audit/",),
+    "guard_test_proposal": ("docs/orchestration/experiment_guard_proposals/",),
+    "memory_capsule": ("docs/memory/",),
+}
+DESTINATION_REF_EXACT_BY_TARGET = {"backlog_entry": frozenset({"docs/roadmap/BACKLOG_LEDGER.md"})}
+CREATIVE_RESEARCH_ORIGIN_KEYS = frozenset({"bundle_id", "candidate_id", "promotion_decision"})
+
+
+class CreativeResearchMetricsError(RuntimeError):
+    """Raised when local metrics inputs or paths violate the report contract."""
+
+
+@dataclass(frozen=True)
+class EvalCandidateSignal:
+    """Sanitized candidate-level signal from one evaluated bundle."""
+
+    bundle_id: str
+    candidate_id: str
+    phase: str
+    output_class: str
+    promotion_decision: str
+    negative_controls: tuple[str, ...]
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.bundle_id, self.candidate_id)
+
+
+@dataclass(frozen=True)
+class PromotionOriginSignal:
+    """Sanitized optional creative-research origin from a promotion artifact."""
+
+    bundle_id: str
+    candidate_id: str
+    promotion_decision: str
+    promotion_target: str
+    durable_artifact_path: str
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.bundle_id, self.candidate_id)
+
+
+def _artifact_root() -> Path:
+    return Path(ARTIFACT_ROOT).resolve()
+
+
+def _path_label(path: Path) -> str:
+    try:
+        return str(normalize_repo_path(path))
+    except ValueError:
+        return path.name
+
+
+def _reject_symlinked_path(candidate: Path, *, anchor: Path, label: str) -> Path:
+    """Fail closed if candidate or an ancestor under anchor is a symlink."""
+
+    resolved_anchor = Path(anchor).resolve()
+    absolute_candidate = candidate if candidate.is_absolute() else Path(REPO_ROOT) / candidate
+    for part in [absolute_candidate, *absolute_candidate.parents]:
+        if part == resolved_anchor or part == anchor:
+            break
+        if part.is_symlink():
+            raise CreativeResearchMetricsError(f"{label} must not traverse symlinks.")
+    resolved_candidate = Path(absolute_candidate).resolve()
+    try:
+        resolved_candidate.relative_to(resolved_anchor)
+    except ValueError as exc:
+        raise CreativeResearchMetricsError(
+            f"{label} must stay within {_path_label(resolved_anchor)}."
+        ) from exc
+    return Path(resolved_candidate)
+
+
+def _resolve_input_dir(raw_path: str | None, *, default: Path, label: str) -> Path:
+    if raw_path is None:
+        candidate = default
+    else:
+        raw_candidate = Path(raw_path).expanduser()
+        if raw_candidate.is_absolute():
+            candidate = raw_candidate
+        else:
+            repo_candidate = REPO_ROOT / raw_candidate
+            try:
+                repo_candidate.resolve().relative_to(_artifact_root())
+                candidate = repo_candidate
+            except ValueError:
+                candidate = default / raw_candidate
+    return _reject_symlinked_path(candidate, anchor=_artifact_root(), label=label)
+
+
+def _resolve_output_path(raw_path: str | None, *, default: Path, label: str) -> Path:
+    if raw_path is None:
+        candidate = default
+    else:
+        raw_candidate = Path(raw_path).expanduser()
+        if raw_candidate.is_absolute():
+            candidate = raw_candidate
+        else:
+            repo_candidate = REPO_ROOT / raw_candidate
+            try:
+                repo_candidate.resolve().relative_to(METRICS_DIR.resolve())
+                candidate = repo_candidate
+            except ValueError:
+                candidate = METRICS_DIR / raw_candidate
+    return _reject_symlinked_path(candidate, anchor=METRICS_DIR.resolve(), label=label)
+
+
+def _iter_json_files(root: Path) -> list[Path]:
+    if not root.exists():
+        return []
+    return sorted(path for path in root.rglob("*.json") if path.is_file())
+
+
+def _relative_artifact_path(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.name
+
+
+def _read_json_artifact(
+    path: Path,
+    *,
+    root: Path,
+    category: str,
+) -> tuple[dict[str, Any] | None, dict[str, str] | None]:
+    file_ref = _relative_artifact_path(path, root)
+    try:
+        _reject_symlinked_path(path, anchor=_artifact_root(), label=f"{category} artifact")
+    except CreativeResearchMetricsError:
+        return None, {"category": category, "file": file_ref, "reason": "symlink_path"}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None, {"category": category, "file": file_ref, "reason": "malformed_json"}
+    except (OSError, UnicodeDecodeError):
+        return None, {"category": category, "file": file_ref, "reason": "unreadable_json"}
+    if not isinstance(payload, dict):
+        return None, {"category": category, "file": file_ref, "reason": "non_object_json"}
+    return payload, None
+
+
+def _safe_identifier(value: object, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise CreativeResearchMetricsError(f"{field} must be a string.")
+    normalized = value.strip()
+    if not SAFE_ID_RE.fullmatch(normalized):
+        raise CreativeResearchMetricsError(f"{field} must be a safe local identifier.")
+    return normalized
+
+
+def _safe_count(value: object, *, field: str) -> int:
+    if type(value) is not int or value < 0:
+        raise CreativeResearchMetricsError(f"{field} must be a non-negative integer.")
+    return value
+
+
+def _safe_controls(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise CreativeResearchMetricsError("negative_controls_triggered must be a list.")
+    controls: set[str] = set()
+    for item in value:
+        if not isinstance(item, str):
+            raise CreativeResearchMetricsError(
+                "negative_controls_triggered entries must be strings."
+            )
+        normalized = item.strip()
+        if not normalized:
+            continue
+        if not SAFE_CONTROL_RE.fullmatch(normalized):
+            raise CreativeResearchMetricsError(
+                "negative_controls_triggered entries must be safe identifiers."
+            )
+        controls.add(normalized)
+    return tuple(sorted(controls))
+
+
+def _safe_phase(value: object) -> str:
+    phase = _safe_identifier(value, field="phase")
+    if phase not in VALID_PHASES:
+        raise CreativeResearchMetricsError("phase is not recognized.")
+    return phase
+
+
+def _safe_promotion_target(value: object) -> str:
+    if not isinstance(value, str):
+        raise CreativeResearchMetricsError("promotion_target must be a string.")
+    target = value.strip()
+    if target not in PROMOTION_TARGETS:
+        raise CreativeResearchMetricsError("promotion_target is not recognized.")
+    return target
+
+
+def _safe_destination_ref(value: object, *, target: str) -> str:
+    if not isinstance(value, str):
+        raise CreativeResearchMetricsError("durable_artifact_path must be a string.")
+    ref = value.strip()
+    if not ref or Path(ref).is_absolute() or ".." in Path(ref).parts:
+        raise CreativeResearchMetricsError("durable_artifact_path must be repo-relative.")
+    if not SAFE_DESTINATION_REF_RE.fullmatch(ref):
+        raise CreativeResearchMetricsError("durable_artifact_path must be a safe repo ref.")
+    exact_refs = DESTINATION_REF_EXACT_BY_TARGET.get(target, frozenset())
+    allowed_prefixes = DESTINATION_REF_PREFIX_BY_TARGET.get(target, ())
+    if ref not in exact_refs and not ref.startswith(allowed_prefixes):
+        raise CreativeResearchMetricsError("durable_artifact_path uses an unsupported repo ref.")
+    return ref
+
+
+def _extract_eval_candidates(
+    payload: dict[str, Any],
+) -> tuple[list[EvalCandidateSignal], bool]:
+    if (
+        payload.get("schema_version") != CREATIVE_RESEARCH_SCHEMA_VERSION
+        or payload.get("task_class") != TASK_CLASS
+    ):
+        raise CreativeResearchMetricsError("artifact is not a creative research eval result.")
+    bundle_id = _safe_identifier(payload.get("bundle_id"), field="bundle_id")
+    phase = _safe_phase(payload.get("phase"))
+    candidates_raw = payload.get("candidates")
+    if not isinstance(candidates_raw, list):
+        raise CreativeResearchMetricsError("candidates must be a list.")
+    if not candidates_raw:
+        raise CreativeResearchMetricsError("candidates must not be empty.")
+
+    summary_raw = payload.get("summary")
+    if not isinstance(summary_raw, dict):
+        raise CreativeResearchMetricsError("summary must be an object.")
+    summary = {
+        "candidate_count": _safe_count(
+            summary_raw.get("candidate_count"), field="summary.candidate_count"
+        ),
+        "promote": _safe_count(summary_raw.get("promote"), field="summary.promote"),
+        "defer": _safe_count(summary_raw.get("defer"), field="summary.defer"),
+        "discard": _safe_count(summary_raw.get("discard"), field="summary.discard"),
+    }
+
+    candidate_ids: set[str] = set()
+    candidates: list[EvalCandidateSignal] = []
+    decision_counts = {decision: 0 for decision in PROMOTION_DECISIONS}
+    for candidate_raw in candidates_raw:
+        if not isinstance(candidate_raw, dict):
+            raise CreativeResearchMetricsError("candidate entries must be objects.")
+        candidate_id = _safe_identifier(candidate_raw.get("candidate_id"), field="candidate_id")
+        if candidate_id in candidate_ids:
+            raise CreativeResearchMetricsError("duplicate candidate_id in eval artifact.")
+        candidate_ids.add(candidate_id)
+        output_class = _safe_identifier(candidate_raw.get("output_class"), field="output_class")
+        if output_class not in OUTPUT_CLASSES:
+            raise CreativeResearchMetricsError("output_class is not recognized.")
+        promotion_decision = _safe_identifier(
+            candidate_raw.get("promotion_decision"), field="promotion_decision"
+        )
+        if promotion_decision not in PROMOTION_DECISIONS:
+            raise CreativeResearchMetricsError("promotion_decision is not recognized.")
+        decision_counts[promotion_decision] += 1
+        candidates.append(
+            EvalCandidateSignal(
+                bundle_id=bundle_id,
+                candidate_id=candidate_id,
+                phase=phase,
+                output_class=output_class,
+                promotion_decision=promotion_decision,
+                negative_controls=_safe_controls(
+                    candidate_raw.get("negative_controls_triggered", [])
+                ),
+            )
+        )
+
+    summary_mismatch = (
+        summary["candidate_count"] != len(candidates)
+        or summary["promote"] != decision_counts["promote"]
+        or summary["defer"] != decision_counts["defer"]
+        or summary["discard"] != decision_counts["discard"]
+    )
+    return candidates, summary_mismatch
+
+
+def _extract_origin_signal(payload: dict[str, Any]) -> PromotionOriginSignal | None:
+    target = _safe_promotion_target(payload.get("promotion_target"))
+    destination_ref = _safe_destination_ref(payload.get("durable_artifact_path"), target=target)
+    origin = payload.get("creative_research_origin")
+    if origin is None:
+        return None
+    if not isinstance(origin, dict):
+        raise CreativeResearchMetricsError("creative_research_origin must be an object.")
+    if set(origin) != CREATIVE_RESEARCH_ORIGIN_KEYS:
+        raise CreativeResearchMetricsError("creative_research_origin has unsupported fields.")
+    promotion_decision = _safe_identifier(
+        origin.get("promotion_decision"), field="creative_research_origin.promotion_decision"
+    )
+    if promotion_decision not in PROMOTION_DECISIONS:
+        raise CreativeResearchMetricsError(
+            "creative_research_origin.promotion_decision is not recognized."
+        )
+    return PromotionOriginSignal(
+        bundle_id=_safe_identifier(
+            origin.get("bundle_id"), field="creative_research_origin.bundle_id"
+        ),
+        candidate_id=_safe_identifier(
+            origin.get("candidate_id"), field="creative_research_origin.candidate_id"
+        ),
+        promotion_decision=promotion_decision,
+        promotion_target=target,
+        durable_artifact_path=destination_ref,
+    )
+
+
+def build_metrics_report(
+    evals_dir: Path = EVALS_DIR, promotions_dir: Path = PROMOTIONS_DIR
+) -> dict[str, Any]:
+    """Build a sanitized metrics report from local eval and promotion artifacts."""
+
+    skipped: list[dict[str, str]] = []
+    candidate_signals: dict[tuple[str, str], EvalCandidateSignal] = {}
+    loaded_bundle_ids: set[str] = set()
+    eval_seen = 0
+    eval_loaded = 0
+    summary_mismatch_count = 0
+
+    for path in _iter_json_files(evals_dir):
+        eval_seen += 1
+        payload, skip = _read_json_artifact(path, root=evals_dir, category="eval")
+        if skip is not None:
+            skipped.append(skip)
+            continue
+        if payload is None:
+            continue
+        try:
+            candidates, summary_mismatch = _extract_eval_candidates(payload)
+        except CreativeResearchMetricsError as exc:
+            skipped.append(
+                {
+                    "category": "eval",
+                    "file": _relative_artifact_path(path, evals_dir),
+                    "reason": str(exc),
+                }
+            )
+            continue
+        bundle_id = candidates[0].bundle_id if candidates else ""
+        if bundle_id in loaded_bundle_ids:
+            skipped.append(
+                {
+                    "category": "eval",
+                    "file": _relative_artifact_path(path, evals_dir),
+                    "reason": "duplicate_bundle_id",
+                }
+            )
+            continue
+        loaded_bundle_ids.add(bundle_id)
+        eval_loaded += 1
+        if summary_mismatch:
+            summary_mismatch_count += 1
+        for signal in candidates:
+            candidate_signals[signal.key] = signal
+
+    promotion_seen = 0
+    promotion_loaded = 0
+    destination_counts: Counter[str] = Counter()
+    destination_ref_counts: Counter[str] = Counter()
+    origin_destination_counts: Counter[str] = Counter()
+    origin_destination_ref_counts: Counter[str] = Counter()
+    linked_promotion_count = 0
+    origin_mismatch_count = 0
+    duplicate_origin_link_count = 0
+    linked_candidate_keys: set[tuple[str, str]] = set()
+
+    for path in _iter_json_files(promotions_dir):
+        promotion_seen += 1
+        payload, skip = _read_json_artifact(path, root=promotions_dir, category="promotion")
+        if skip is not None:
+            skipped.append(skip)
+            continue
+        if payload is None:
+            continue
+        try:
+            origin = _extract_origin_signal(payload)
+            target = _safe_promotion_target(payload.get("promotion_target"))
+            destination_ref = _safe_destination_ref(
+                payload.get("durable_artifact_path"), target=target
+            )
+        except CreativeResearchMetricsError as exc:
+            skipped.append(
+                {
+                    "category": "promotion",
+                    "file": _relative_artifact_path(path, promotions_dir),
+                    "reason": str(exc),
+                }
+            )
+            continue
+        promotion_loaded += 1
+        destination_counts[target] += 1
+        destination_ref_counts[f"{target}:{destination_ref}"] += 1
+        if origin is None:
+            continue
+        candidate = candidate_signals.get(origin.key)
+        if candidate is None or candidate.promotion_decision != origin.promotion_decision:
+            origin_mismatch_count += 1
+            continue
+        linked_promotion_count += 1
+        origin_destination_counts[origin.promotion_target] += 1
+        origin_destination_ref_counts[
+            f"{origin.promotion_target}:{origin.durable_artifact_path}"
+        ] += 1
+        if origin.key in linked_candidate_keys:
+            duplicate_origin_link_count += 1
+        linked_candidate_keys.add(origin.key)
+
+    decision_counts: Counter[str] = Counter()
+    output_class_counts: Counter[str] = Counter()
+    phase_counts: Counter[str] = Counter()
+    negative_control_counts: Counter[str] = Counter()
+    negative_control_candidate_count = 0
+    for signal in candidate_signals.values():
+        decision_counts[signal.promotion_decision] += 1
+        output_class_counts[signal.output_class] += 1
+        phase_counts[signal.phase] += 1
+        if signal.negative_controls:
+            negative_control_candidate_count += 1
+        for control in signal.negative_controls:
+            negative_control_counts[control] += 1
+
+    promoted_keys = {
+        key for key, signal in candidate_signals.items() if signal.promotion_decision == "promote"
+    }
+    missing_conversion_links = [
+        {"bundle_id": bundle_id, "candidate_id": candidate_id}
+        for bundle_id, candidate_id in sorted(promoted_keys - linked_candidate_keys)
+    ]
+
+    status = "empty" if eval_seen == 0 and promotion_seen == 0 else "ok"
+    if eval_seen > 0 and not candidate_signals:
+        status = "no_valid_eval_artifacts"
+
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "status": status,
+        "sources": {
+            "eval_artifacts_seen": eval_seen,
+            "eval_artifacts_loaded": eval_loaded,
+            "eval_artifacts_skipped": eval_seen - eval_loaded,
+            "promotion_artifacts_seen": promotion_seen,
+            "promotion_artifacts_loaded": promotion_loaded,
+            "promotion_artifacts_skipped": promotion_seen - promotion_loaded,
+            "summary_mismatch_count": summary_mismatch_count,
+            "skipped_artifacts": sorted(
+                skipped,
+                key=lambda item: (item["category"], item["file"], item["reason"]),
+            ),
+        },
+        "candidate_totals": {
+            "bundle_count": len(loaded_bundle_ids),
+            "candidate_count": len(candidate_signals),
+            "by_decision": {
+                decision: decision_counts.get(decision, 0) for decision in PROMOTION_DECISIONS
+            },
+            "by_output_class": {
+                output_class: output_class_counts.get(output_class, 0)
+                for output_class in OUTPUT_CLASSES
+            },
+            "by_phase": dict(sorted(phase_counts.items())),
+        },
+        "negative_controls": {
+            "candidate_count": negative_control_candidate_count,
+            "counts": dict(sorted(negative_control_counts.items())),
+        },
+        "conversion": {
+            "promoted_candidate_count": len(promoted_keys),
+            "linked_promotion_count": linked_promotion_count,
+            "linked_candidate_count": len(linked_candidate_keys),
+            "missing_conversion_link_count": len(missing_conversion_links),
+            "missing_conversion_links": missing_conversion_links,
+            "origin_mismatch_count": origin_mismatch_count,
+            "duplicate_origin_link_count": duplicate_origin_link_count,
+            "destination_counts": dict(sorted(destination_counts.items())),
+            "destination_ref_counts": dict(sorted(destination_ref_counts.items())),
+            "origin_destination_counts": dict(sorted(origin_destination_counts.items())),
+            "origin_destination_ref_counts": dict(sorted(origin_destination_ref_counts.items())),
+        },
+    }
+
+
+def render_markdown_report(report: dict[str, Any]) -> str:
+    """Render a compact operator-readable Markdown report from sanitized metrics."""
+
+    sources = report["sources"]
+    totals = report["candidate_totals"]
+    conversion = report["conversion"]
+    negative_controls = report["negative_controls"]
+    lines = [
+        "# Creative Research Adoption Metrics",
+        "",
+        f"- Schema version: `{report['schema_version']}`",
+        f"- Status: `{report['status']}`",
+        f"- Eval artifacts loaded: `{sources['eval_artifacts_loaded']}` of `{sources['eval_artifacts_seen']}`",
+        f"- Promotion artifacts loaded: `{sources['promotion_artifacts_loaded']}` of `{sources['promotion_artifacts_seen']}`",
+        f"- Bundles: `{totals['bundle_count']}`",
+        f"- Candidates: `{totals['candidate_count']}`",
+        f"- Promoted candidates: `{conversion['promoted_candidate_count']}`",
+        f"- Linked promotions: `{conversion['linked_promotion_count']}`",
+        f"- Missing conversion links: `{conversion['missing_conversion_link_count']}`",
+        "",
+        "## Decision Counts",
+        "",
+    ]
+    for decision, count in totals["by_decision"].items():
+        lines.append(f"- `{decision}`: `{count}`")
+    lines.extend(["", "## Output Classes", ""])
+    for output_class, count in totals["by_output_class"].items():
+        lines.append(f"- `{output_class}`: `{count}`")
+    lines.extend(["", "## Negative Controls", ""])
+    lines.append(f"- Candidates with negative controls: `{negative_controls['candidate_count']}`")
+    if negative_controls["counts"]:
+        for control, count in negative_controls["counts"].items():
+            lines.append(f"- `{control}`: `{count}`")
+    else:
+        lines.append("- None observed.")
+    lines.extend(["", "## Destination Counts", ""])
+    if conversion["destination_counts"]:
+        for destination, count in conversion["destination_counts"].items():
+            lines.append(f"- `{destination}`: `{count}`")
+    else:
+        lines.append("- None observed.")
+    lines.extend(["", "## Destination Refs", ""])
+    if conversion["destination_ref_counts"]:
+        for destination, count in conversion["destination_ref_counts"].items():
+            lines.append(f"- `{destination}`: `{count}`")
+    else:
+        lines.append("- None observed.")
+    lines.extend(["", "## Missing Conversion Links", ""])
+    if conversion["missing_conversion_links"]:
+        for row in conversion["missing_conversion_links"]:
+            lines.append(f"- `{row['bundle_id']}` / `{row['candidate_id']}`")
+    else:
+        lines.append("- None.")
+    lines.extend(["", "## Skipped Artifacts", ""])
+    if sources["skipped_artifacts"]:
+        for item in sources["skipped_artifacts"]:
+            lines.append(f"- `{item['category']}` `{item['file']}`: `{item['reason']}`")
+    else:
+        lines.append("- None.")
+    return "\n".join(lines) + "\n"
+
+
+def _write_report(output_json: Path, output_md: Path, report: dict[str, Any]) -> None:
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_md.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(
+        json.dumps(report, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    output_md.write_text(render_markdown_report(report), encoding="utf-8")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Aggregate local creative_research eval and promotion adoption metrics."
+    )
+    parser.add_argument(
+        "--evals-dir",
+        default=None,
+        help="Eval artifact directory under artifacts/orchestration/creative_research/evals/.",
+    )
+    parser.add_argument(
+        "--promotions-dir",
+        default=None,
+        help="Promotion artifact directory under artifacts/orchestration/experiments/promotions/.",
+    )
+    parser.add_argument(
+        "--output-json",
+        default=None,
+        help="Output JSON path under artifacts/orchestration/creative_research/metrics/.",
+    )
+    parser.add_argument(
+        "--output-md",
+        default=None,
+        help="Output Markdown path under artifacts/orchestration/creative_research/metrics/.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        evals_dir = _resolve_input_dir(args.evals_dir, default=EVALS_DIR, label="--evals-dir")
+        promotions_dir = _resolve_input_dir(
+            args.promotions_dir,
+            default=PROMOTIONS_DIR,
+            label="--promotions-dir",
+        )
+        output_json = _resolve_output_path(
+            args.output_json,
+            default=DEFAULT_OUTPUT_JSON,
+            label="--output-json",
+        )
+        output_md = _resolve_output_path(
+            args.output_md,
+            default=DEFAULT_OUTPUT_MD,
+            label="--output-md",
+        )
+        report = build_metrics_report(evals_dir=evals_dir, promotions_dir=promotions_dir)
+        _write_report(output_json, output_md, report)
+    except (CreativeResearchMetricsError, OSError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "schema_version": report["schema_version"],
+                "status": report["status"],
+                "output_json": normalize_repo_path(output_json),
+                "output_md": normalize_repo_path(output_md),
+            },
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/experiment_promote.py
+++ b/scripts/orchestration/experiment_promote.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import re
 from typing import Any
 
 try:
@@ -52,10 +53,50 @@ DEFAULT_BACKLOG_PRIORITY = "P1"
 DEFAULT_BACKLOG_TARGET_PR_PREFIX = "PR_TBD_"
 DEFAULT_BACKLOG_AREA = "orchestration / experimentation"
 RESULT_PROMOTION_STATUSES: tuple[str, ...] = ("promoted", "deferred")
+CREATIVE_RESEARCH_ORIGIN_KEYS = frozenset({"bundle_id", "candidate_id", "promotion_decision"})
+CREATIVE_RESEARCH_PROMOTION_DECISIONS: tuple[str, ...] = (
+    "promote",
+    "defer",
+    "discard",
+)
+CREATIVE_RESEARCH_ORIGIN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 
 
 class ExperimentPromotionError(RuntimeError):
     """Base error for promotion contract violations."""
+
+
+def _validate_creative_research_origin(raw_origin: Any) -> dict[str, str] | None:
+    """Validate optional passive creative-research origin metadata."""
+
+    if raw_origin is None:
+        return None
+    if not isinstance(raw_origin, dict):
+        raise ExperimentPromotionError("creative_research_origin must be a JSON object.")
+    if set(raw_origin) != CREATIVE_RESEARCH_ORIGIN_KEYS:
+        raise ExperimentPromotionError("creative_research_origin has unsupported fields.")
+
+    normalized: dict[str, str] = {}
+    for field in ("bundle_id", "candidate_id", "promotion_decision"):
+        value = raw_origin.get(field)
+        if not isinstance(value, str):
+            raise ExperimentPromotionError(f"creative_research_origin.{field} must be a string.")
+        value = value.strip()
+        if not value:
+            raise ExperimentPromotionError(f"creative_research_origin.{field} must be non-empty.")
+        if field in {"bundle_id", "candidate_id"}:
+            if not CREATIVE_RESEARCH_ORIGIN_ID_RE.fullmatch(value):
+                raise ExperimentPromotionError(
+                    f"creative_research_origin.{field} must be a safe local identifier."
+                )
+        normalized[field] = value
+
+    if normalized["promotion_decision"] not in CREATIVE_RESEARCH_PROMOTION_DECISIONS:
+        raise ExperimentPromotionError(
+            "creative_research_origin.promotion_decision must be one of: "
+            + ", ".join(CREATIVE_RESEARCH_PROMOTION_DECISIONS)
+        )
+    return normalized
 
 
 def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
@@ -157,7 +198,19 @@ def _evidence_lines(result: dict[str, Any]) -> list[str]:
     return oracle_lines
 
 
+def _creative_research_origin_markdown(origin: dict[str, str] | None) -> str:
+    if origin is None:
+        return ""
+    return (
+        "\n## Creative Research Origin\n\n"
+        f"- Bundle ID: `{origin['bundle_id']}`\n"
+        f"- Candidate ID: `{origin['candidate_id']}`\n"
+        f"- Promotion decision: `{origin['promotion_decision']}`\n"
+    )
+
+
 def _base_markdown(packet: dict[str, Any], result: dict[str, Any], disposition: str) -> str:
+    origin = _validate_creative_research_origin(packet.get("creative_research_origin"))
     mutated = (
         "\n".join(f"- `{path}`" for path in result["mutated_paths"])
         if result["mutated_paths"]
@@ -176,6 +229,7 @@ def _base_markdown(packet: dict[str, Any], result: dict[str, Any], disposition: 
         f"- Disposition: `{disposition}`\n"
         f"- Result status: `{result['status']}`\n"
         f"- Failure class: `{failure_class}`\n\n"
+        f"{_creative_research_origin_markdown(origin)}"
         "## Mutable Surface\n\n"
         f"{mutated}\n\n"
         "## Immutable Oracles\n\n"
@@ -241,6 +295,15 @@ def _insert_once(path: Path, marker: str, block: str) -> None:
 def _render_backlog_entry(packet: dict[str, Any], result: dict[str, Any], disposition: str) -> str:
     experiment_slug = packet["experiment_id"].replace("_", "-")
     failure_class = result["failure_class"] if result["failure_class"] is not None else "none"
+    origin = _validate_creative_research_origin(packet.get("creative_research_origin"))
+    origin_lines = ""
+    if origin is not None:
+        origin_lines = (
+            "  - Creative research origin:\n"
+            f"    - Bundle ID: `{origin['bundle_id']}`\n"
+            f"    - Candidate ID: `{origin['candidate_id']}`\n"
+            f"    - Promotion decision: `{origin['promotion_decision']}`\n"
+        )
     return (
         f'<a id="ledger-{experiment_slug}"></a>\n'
         f"- [ ] P1: Experiment follow-up for {packet['experiment_id']}\n"
@@ -251,6 +314,7 @@ def _render_backlog_entry(packet: dict[str, Any], result: dict[str, Any], dispos
         f"  - Status: {'Deferred' if disposition == 'deferred' else 'Planned'}\n"
         f"  - Reason (EN): Experiment `{packet['experiment_id']}` ended with status `{result['status']}` "
         f"and failure class `{failure_class}`; follow-up is tracked via KPP-only promotion.\n"
+        f"{origin_lines}"
         "  - Links:\n"
         f"    - `docs/orchestration/AGENT_EXPERIMENTATION_PROTOCOL.md`\n"
         f"    - `docs/memory/kpp_knowledge_promotion_pipeline.md`\n"
@@ -310,11 +374,14 @@ def _write_durable_artifacts(
 
 def build_promotion_decision(packet: dict[str, Any], result: dict[str, Any]) -> dict[str, Any]:
     _require_matching_experiment(packet, result)
+    creative_research_origin = _validate_creative_research_origin(
+        packet.get("creative_research_origin")
+    )
     disposition = _result_policy(packet, result)
     if disposition not in RESULT_PROMOTION_STATUSES:
         raise ExperimentPromotionError(f"Unsupported disposition: {disposition}")
     durable_artifact_path = _write_durable_artifacts(packet, result, disposition)
-    return {
+    decision = {
         "schema_version": SCHEMA_VERSION,
         "experiment_id": packet["experiment_id"],
         "result_status": result["status"],
@@ -330,6 +397,9 @@ def build_promotion_decision(packet: dict[str, Any], result: dict[str, Any]) -> 
             "oracle_count": len(result["oracle_results"]),
         },
     }
+    if creative_research_origin is not None:
+        decision["creative_research_origin"] = creative_research_origin
+    return decision
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/tests/test_creative_research_metrics.py
+++ b/tests/test_creative_research_metrics.py
@@ -1,0 +1,481 @@
+"""Tests for local-only creative research adoption metrics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import scripts.orchestration.context_pack as context_pack
+import scripts.orchestration.creative_research_metrics as metrics
+
+
+def _configure_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, Path]:
+    repo = tmp_path / "repo"
+    artifact_root = repo / "artifacts" / "orchestration"
+    evals_dir = artifact_root / "creative_research" / "evals"
+    promotions_dir = artifact_root / "experiments" / "promotions"
+    metrics_dir = artifact_root / "creative_research" / "metrics"
+    evals_dir.mkdir(parents=True)
+    promotions_dir.mkdir(parents=True)
+    metrics_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(context_pack, "REPO_ROOT", repo)
+    monkeypatch.setattr(metrics, "REPO_ROOT", repo)
+    monkeypatch.setattr(metrics, "ARTIFACT_ROOT", artifact_root)
+    monkeypatch.setattr(metrics, "EVALS_DIR", evals_dir)
+    monkeypatch.setattr(metrics, "PROMOTIONS_DIR", promotions_dir)
+    monkeypatch.setattr(metrics, "METRICS_DIR", metrics_dir)
+    monkeypatch.setattr(metrics, "DEFAULT_OUTPUT_JSON", metrics_dir / "latest.json")
+    monkeypatch.setattr(metrics, "DEFAULT_OUTPUT_MD", metrics_dir / "latest.md")
+    return {
+        "repo": repo,
+        "artifact_root": artifact_root,
+        "evals_dir": evals_dir,
+        "promotions_dir": promotions_dir,
+        "metrics_dir": metrics_dir,
+    }
+
+
+def _candidate(
+    candidate_id: str,
+    *,
+    decision: str = "promote",
+    output_class: str = "mechanistic_hypothesis",
+    negative_controls: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "candidate_id": candidate_id,
+        "claim": "RAW CLAIM THAT MUST NOT LEAK",
+        "mechanism": "RAW MECHANISM THAT MUST NOT LEAK",
+        "evidence_needed": "RAW EVIDENCE THAT MUST NOT LEAK",
+        "falsifier": "RAW FALSIFIER THAT MUST NOT LEAK",
+        "confidence": "medium",
+        "known_risks": ["RAW RISK THAT MUST NOT LEAK"],
+        "wellness_boundary": "wellness only",
+        "alternative_explanations": [],
+        "counterevidence": [],
+        "stopping_rule": "stop",
+        "decision_rule": "decide",
+        "minimum_observation": "observe",
+        "output_class": output_class,
+        "reference_overlap": 0.2,
+        "peer_overlap": 0.1,
+        "negative_controls_triggered": negative_controls or [],
+        "scorecard": {
+            "originality": 4,
+            "flexibility": 4,
+            "mechanism_specificity": 4,
+            "groundedness": 4,
+            "falsifiability": 4,
+            "wellness_safety": 5,
+            "hallucination_risk": 1,
+        },
+        "promotion_decision": decision,
+        "presentation_label": None,
+    }
+
+
+def _eval_result(
+    bundle_id: str,
+    candidates: list[dict[str, object]],
+    *,
+    phase: str = "divergence",
+    summary_override: dict[str, int] | None = None,
+) -> dict[str, object]:
+    counts = {"promote": 0, "defer": 0, "discard": 0}
+    for candidate in candidates:
+        counts[str(candidate["promotion_decision"])] += 1
+    summary = {
+        "candidate_count": len(candidates),
+        "promote": counts["promote"],
+        "defer": counts["defer"],
+        "discard": counts["discard"],
+    }
+    if summary_override is not None:
+        summary = summary_override
+    return {
+        "schema_version": "1.0",
+        "bundle_id": bundle_id,
+        "task_class": "creative_research",
+        "phase": phase,
+        "prompt_seed": "RAW PROMPT SEED THAT MUST NOT LEAK",
+        "reference_corpus_size": 1,
+        "summary": summary,
+        "candidates": candidates,
+    }
+
+
+def _promotion(
+    *,
+    bundle_id: str | None = None,
+    candidate_id: str | None = None,
+    decision: str = "promote",
+    target: str = "pr_packet",
+    durable_artifact_path: str | None = None,
+) -> dict[str, object]:
+    if durable_artifact_path is None:
+        durable_artifact_path = {
+            "pr_packet": "docs/orchestration/experiment_pr_packets/exp-promote.md",
+            "audit_artifact": "docs/audit/EXPERIMENT_EXP_PROMOTE.md",
+            "guard_test_proposal": ("docs/orchestration/experiment_guard_proposals/exp-promote.md"),
+            "backlog_entry": "docs/roadmap/BACKLOG_LEDGER.md",
+            "memory_capsule": "docs/memory/exp-promote_capsule.md",
+        }.get(target, "docs/orchestration/experiment_pr_packets/exp-promote.md")
+    payload: dict[str, object] = {
+        "schema_version": "1.0",
+        "experiment_id": "exp-promote",
+        "result_status": "accepted",
+        "failure_class": None,
+        "promotion_target": target,
+        "disposition": "promoted",
+        "durable_artifact_path": durable_artifact_path,
+        "shared_tree_untouched": True,
+        "domain": "orchestration",
+        "evidence": {"oracle_commands": [], "mutated_paths": [], "oracle_count": 0},
+    }
+    if bundle_id is not None and candidate_id is not None:
+        payload["creative_research_origin"] = {
+            "bundle_id": bundle_id,
+            "candidate_id": candidate_id,
+            "promotion_decision": decision,
+        }
+    return payload
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def test_empty_dirs_report_zero_counts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _configure_repo(monkeypatch, tmp_path)
+
+    report = metrics.build_metrics_report(paths["evals_dir"], paths["promotions_dir"])
+
+    assert report["schema_version"] == "creative-research-metrics-v1"
+    assert report["status"] == "empty"
+    assert report["candidate_totals"]["bundle_count"] == 0
+    assert report["candidate_totals"]["candidate_count"] == 0
+    assert report["conversion"]["missing_conversion_link_count"] == 0
+
+
+def test_eval_aggregation_recomputes_counts_and_negative_controls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _configure_repo(monkeypatch, tmp_path)
+    _write_json(
+        paths["evals_dir"] / "bundle-a.json",
+        _eval_result(
+            "bundle-a",
+            [
+                _candidate(
+                    "candidate-promote",
+                    negative_controls=["shallow_corpus_overlap", "shallow_corpus_overlap"],
+                ),
+                _candidate(
+                    "candidate-defer",
+                    decision="defer",
+                    output_class="experimental_proposal",
+                    negative_controls=["missing_scientific_research_fields"],
+                ),
+                _candidate(
+                    "candidate-discard",
+                    decision="discard",
+                    output_class="creative_ideation",
+                ),
+            ],
+        ),
+    )
+
+    report = metrics.build_metrics_report(paths["evals_dir"], paths["promotions_dir"])
+
+    assert report["candidate_totals"]["bundle_count"] == 1
+    assert report["candidate_totals"]["candidate_count"] == 3
+    assert report["candidate_totals"]["by_decision"] == {
+        "promote": 1,
+        "defer": 1,
+        "discard": 1,
+    }
+    assert report["negative_controls"]["candidate_count"] == 2
+    assert report["negative_controls"]["counts"] == {
+        "missing_scientific_research_fields": 1,
+        "shallow_corpus_overlap": 1,
+    }
+
+
+def test_conversion_links_and_missing_promoted_candidates_are_reported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _configure_repo(monkeypatch, tmp_path)
+    _write_json(
+        paths["evals_dir"] / "bundle-a.json",
+        _eval_result(
+            "bundle-a",
+            [
+                _candidate("candidate-linked"),
+                _candidate("candidate-missing"),
+                _candidate("candidate-discard", decision="discard"),
+            ],
+        ),
+    )
+    _write_json(
+        paths["promotions_dir"] / "linked.json",
+        _promotion(bundle_id="bundle-a", candidate_id="candidate-linked"),
+    )
+    _write_json(paths["promotions_dir"] / "plain.json", _promotion(target="audit_artifact"))
+
+    report = metrics.build_metrics_report(paths["evals_dir"], paths["promotions_dir"])
+
+    assert report["conversion"]["promoted_candidate_count"] == 2
+    assert report["conversion"]["linked_promotion_count"] == 1
+    assert report["conversion"]["linked_candidate_count"] == 1
+    assert report["conversion"]["missing_conversion_links"] == [
+        {"bundle_id": "bundle-a", "candidate_id": "candidate-missing"}
+    ]
+    assert report["conversion"]["destination_counts"] == {
+        "audit_artifact": 1,
+        "pr_packet": 1,
+    }
+    assert report["conversion"]["origin_destination_counts"] == {"pr_packet": 1}
+    assert report["conversion"]["destination_ref_counts"] == {
+        "audit_artifact:docs/audit/EXPERIMENT_EXP_PROMOTE.md": 1,
+        "pr_packet:docs/orchestration/experiment_pr_packets/exp-promote.md": 1,
+    }
+    assert report["conversion"]["origin_destination_ref_counts"] == {
+        "pr_packet:docs/orchestration/experiment_pr_packets/exp-promote.md": 1
+    }
+
+
+def test_duplicate_origin_links_and_mismatches_are_accounted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _configure_repo(monkeypatch, tmp_path)
+    _write_json(
+        paths["evals_dir"] / "bundle-a.json",
+        _eval_result(
+            "bundle-a",
+            [
+                _candidate("candidate-linked"),
+                _candidate("candidate-missing"),
+                _candidate("candidate-defer", decision="defer"),
+            ],
+        ),
+    )
+    _write_json(
+        paths["promotions_dir"] / "linked-a.json",
+        _promotion(bundle_id="bundle-a", candidate_id="candidate-linked"),
+    )
+    _write_json(
+        paths["promotions_dir"] / "linked-b.json",
+        _promotion(bundle_id="bundle-a", candidate_id="candidate-linked"),
+    )
+    _write_json(
+        paths["promotions_dir"] / "mismatch-missing.json",
+        _promotion(bundle_id="bundle-a", candidate_id="candidate-unknown"),
+    )
+    _write_json(
+        paths["promotions_dir"] / "mismatch-decision.json",
+        _promotion(bundle_id="bundle-a", candidate_id="candidate-defer", decision="promote"),
+    )
+
+    report = metrics.build_metrics_report(paths["evals_dir"], paths["promotions_dir"])
+
+    assert report["conversion"]["linked_promotion_count"] == 2
+    assert report["conversion"]["linked_candidate_count"] == 1
+    assert report["conversion"]["duplicate_origin_link_count"] == 1
+    assert report["conversion"]["origin_mismatch_count"] == 2
+    assert report["conversion"]["missing_conversion_links"] == [
+        {"bundle_id": "bundle-a", "candidate_id": "candidate-missing"}
+    ]
+
+
+def test_malformed_duplicates_and_summary_mismatch_are_accounted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _configure_repo(monkeypatch, tmp_path)
+    _write_json(
+        paths["evals_dir"] / "00-good.json",
+        _eval_result(
+            "bundle-a",
+            [_candidate("candidate-a")],
+            summary_override={"candidate_count": 9, "promote": 9, "defer": 0, "discard": 0},
+        ),
+    )
+    _write_json(
+        paths["evals_dir"] / "duplicate-bundle.json",
+        _eval_result("bundle-a", [_candidate("candidate-b")]),
+    )
+    _write_json(
+        paths["evals_dir"] / "duplicate-candidate.json",
+        _eval_result("bundle-b", [_candidate("dup"), _candidate("dup")]),
+    )
+    (paths["evals_dir"] / "bad.json").write_text("{not-json", encoding="utf-8")
+    (paths["evals_dir"] / "array.json").write_text("[]\n", encoding="utf-8")
+
+    report = metrics.build_metrics_report(paths["evals_dir"], paths["promotions_dir"])
+
+    reasons = [item["reason"] for item in report["sources"]["skipped_artifacts"]]
+    assert report["sources"]["summary_mismatch_count"] == 1
+    assert "duplicate_bundle_id" in reasons
+    assert "duplicate candidate_id in eval artifact." in reasons
+    assert "malformed_json" in reasons
+    assert "non_object_json" in reasons
+
+
+def test_invalid_eval_phase_empty_candidates_and_promotion_refs_are_skipped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _configure_repo(monkeypatch, tmp_path)
+    _write_json(
+        paths["evals_dir"] / "invalid-phase.json",
+        _eval_result("bundle-phase", [_candidate("candidate-a")], phase="runtime"),
+    )
+    _write_json(paths["evals_dir"] / "empty.json", _eval_result("bundle-empty", []))
+    _write_json(
+        paths["promotions_dir"] / "invalid-target.json",
+        _promotion(target="runtime_cache"),
+    )
+    _write_json(
+        paths["promotions_dir"] / "invalid-ref.json",
+        _promotion(durable_artifact_path="/tmp/raw-secret-path.md"),
+    )
+
+    report = metrics.build_metrics_report(paths["evals_dir"], paths["promotions_dir"])
+
+    reasons = {item["reason"] for item in report["sources"]["skipped_artifacts"]}
+    assert "phase is not recognized." in reasons
+    assert "candidates must not be empty." in reasons
+    assert "promotion_target is not recognized." in reasons
+    assert "durable_artifact_path must be repo-relative." in reasons
+    assert report["sources"]["eval_artifacts_loaded"] == 0
+    assert report["sources"]["promotion_artifacts_loaded"] == 0
+
+
+def test_report_outputs_do_not_leak_raw_text_or_absolute_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _configure_repo(monkeypatch, tmp_path)
+    _write_json(paths["evals_dir"] / "bundle-a.json", _eval_result("bundle-a", [_candidate("c1")]))
+
+    exit_code = metrics.main(
+        [
+            "--output-json",
+            "artifacts/orchestration/creative_research/metrics/latest.json",
+            "--output-md",
+            "artifacts/orchestration/creative_research/metrics/latest.md",
+        ]
+    )
+
+    assert exit_code == 0
+    json_text = (paths["metrics_dir"] / "latest.json").read_text(encoding="utf-8")
+    markdown_text = (paths["metrics_dir"] / "latest.md").read_text(encoding="utf-8")
+    combined = json_text + markdown_text
+    assert "RAW PROMPT SEED THAT MUST NOT LEAK" not in combined
+    assert "RAW CLAIM THAT MUST NOT LEAK" not in combined
+    assert "RAW MECHANISM THAT MUST NOT LEAK" not in combined
+    assert "RAW EVIDENCE THAT MUST NOT LEAK" not in combined
+    assert "RAW FALSIFIER THAT MUST NOT LEAK" not in combined
+    assert "RAW RISK THAT MUST NOT LEAK" not in combined
+    assert str(tmp_path) not in combined
+    assert "bundle-a" in combined
+    assert "c1" in combined
+
+
+def test_metrics_outputs_are_byte_stable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _configure_repo(monkeypatch, tmp_path)
+    _write_json(
+        paths["evals_dir"] / "b.json",
+        _eval_result("bundle-b", [_candidate("candidate-b", decision="discard")]),
+    )
+    _write_json(
+        paths["evals_dir"] / "a.json",
+        _eval_result("bundle-a", [_candidate("candidate-a")]),
+    )
+    first_json = paths["metrics_dir"] / "first.json"
+    first_md = paths["metrics_dir"] / "first.md"
+    second_json = paths["metrics_dir"] / "second.json"
+    second_md = paths["metrics_dir"] / "second.md"
+
+    first_exit = metrics.main(["--output-json", str(first_json), "--output-md", str(first_md)])
+    second_exit = metrics.main(["--output-json", str(second_json), "--output-md", str(second_md)])
+
+    assert first_exit == 0
+    assert second_exit == 0
+    assert first_json.read_bytes() == second_json.read_bytes()
+    assert first_md.read_bytes() == second_md.read_bytes()
+
+
+def test_output_escape_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _configure_repo(monkeypatch, tmp_path)
+
+    exit_code = metrics.main(["--output-json", "../escape.json"])
+
+    assert exit_code == 1
+    assert "--output-json must stay within artifacts/orchestration/creative_research/metrics" in (
+        capsys.readouterr().err
+    )
+
+
+def test_symlinked_eval_artifact_is_skipped_without_reading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _configure_repo(monkeypatch, tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    outside_payload = outside / "payload.json"
+    _write_json(outside_payload, _eval_result("bundle-outside", [_candidate("candidate-a")]))
+    (paths["evals_dir"] / "escape.json").symlink_to(outside_payload)
+
+    report = metrics.build_metrics_report(paths["evals_dir"], paths["promotions_dir"])
+
+    assert report["status"] == "no_valid_eval_artifacts"
+    assert report["sources"]["skipped_artifacts"] == [
+        {"category": "eval", "file": "escape.json", "reason": "symlink_path"}
+    ]
+
+
+def test_invalid_origin_artifact_is_skipped_and_counted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _configure_repo(monkeypatch, tmp_path)
+    _write_json(paths["evals_dir"] / "bundle-a.json", _eval_result("bundle-a", [_candidate("c1")]))
+    invalid = _promotion(bundle_id="bundle-a", candidate_id="c1")
+    invalid["creative_research_origin"] = {
+        "bundle_id": "bundle-a",
+        "candidate_id": "c1",
+        "promotion_decision": "promote",
+        "raw_prompt": "RAW PROMPT THAT MUST NOT LEAK",
+    }
+    _write_json(paths["promotions_dir"] / "invalid.json", invalid)
+
+    report = metrics.build_metrics_report(paths["evals_dir"], paths["promotions_dir"])
+
+    assert report["sources"]["promotion_artifacts_skipped"] == 1
+    assert report["sources"]["skipped_artifacts"] == [
+        {
+            "category": "promotion",
+            "file": "invalid.json",
+            "reason": "creative_research_origin has unsupported fields.",
+        }
+    ]
+    rendered = json.dumps(report, ensure_ascii=True, sort_keys=True)
+    assert "RAW PROMPT THAT MUST NOT LEAK" not in rendered

--- a/tests/test_experiment_promote.py
+++ b/tests/test_experiment_promote.py
@@ -93,8 +93,9 @@ def _packet(
     *,
     experiment_id: str = "exp-promote",
     promotion_target: str = "pr_packet",
+    creative_research_origin: dict[str, str] | None = None,
 ) -> dict[str, object]:
-    return {
+    packet: dict[str, object] = {
         "schema_version": "1.0",
         "experiment_id": experiment_id,
         "decision_question": "Promote governed experiment result",
@@ -122,6 +123,9 @@ def _packet(
         "negative_controls": ["oracle file unchanged", "no hidden memory"],
         "promotion_target": promotion_target,
     }
+    if creative_research_origin is not None:
+        packet["creative_research_origin"] = creative_research_origin
+    return packet
 
 
 def _result(
@@ -226,6 +230,80 @@ def test_build_promotion_decision_writes_guard_proposal(
     )
     assert proposal_path.exists()
     assert "Experiment Guard Proposal" in proposal_path.read_text(encoding="utf-8")
+
+
+def test_creative_research_origin_is_copied_to_decision_and_markdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    origin = {
+        "bundle_id": "creative-research-valid",
+        "candidate_id": "hyp-batch",
+        "promotion_decision": "promote",
+    }
+    packet = experiment_contract.validate_experiment_packet(
+        _packet(creative_research_origin=origin)
+    )
+    result = experiment_contract.validate_experiment_result(_result())
+
+    decision = experiment_promote.build_promotion_decision(packet, result)
+
+    assert decision["promotion_target"] == "pr_packet"
+    assert decision["disposition"] == "promoted"
+    assert decision["creative_research_origin"] == origin
+    packet_output = repo / "docs" / "orchestration" / "experiment_pr_packets" / "exp-promote.md"
+    markdown = packet_output.read_text(encoding="utf-8")
+    assert "Creative Research Origin" in markdown
+    assert "creative-research-valid" in markdown
+    assert "hyp-batch" in markdown
+
+
+def test_invalid_creative_research_origin_fails_before_artifact_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    packet = experiment_contract.validate_experiment_packet(
+        _packet(
+            creative_research_origin={
+                "bundle_id": "creative-research-valid",
+                "candidate_id": "hyp-batch",
+                "promotion_decision": "promote",
+                "raw_prompt": "must not be accepted",
+            }
+        )
+    )
+    result = experiment_contract.validate_experiment_result(_result())
+
+    with pytest.raises(experiment_promote.ExperimentPromotionError, match="unsupported"):
+        experiment_promote.build_promotion_decision(packet, result)
+
+    packet_output = repo / "docs" / "orchestration" / "experiment_pr_packets" / "exp-promote.md"
+    assert not packet_output.exists()
+
+
+def test_invalid_creative_research_origin_decision_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    packet = experiment_contract.validate_experiment_packet(
+        _packet(
+            creative_research_origin={
+                "bundle_id": "creative-research-valid",
+                "candidate_id": "hyp-batch",
+                "promotion_decision": "ship",
+            }
+        )
+    )
+    result = experiment_contract.validate_experiment_result(_result())
+
+    with pytest.raises(experiment_promote.ExperimentPromotionError, match="must be one of"):
+        experiment_promote.build_promotion_decision(packet, result)
 
 
 def test_memory_capsule_updates_index_once(

--- a/tests/test_experiment_promote.py
+++ b/tests/test_experiment_promote.py
@@ -348,6 +348,38 @@ def test_rejected_result_backlog_entry_is_allowed(
     assert ledger.count("ledger-exp-promote") == 1
 
 
+def test_rejected_backlog_entry_preserves_creative_research_origin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _configure_repo(monkeypatch, repo)
+    origin = {
+        "bundle_id": "creative-research-valid",
+        "candidate_id": "hyp-batch",
+        "promotion_decision": "defer",
+    }
+    packet = experiment_contract.validate_experiment_packet(
+        _packet(
+            promotion_target="backlog_entry",
+            creative_research_origin=origin,
+        )
+    )
+    result = experiment_contract.validate_experiment_result(
+        _result(status="rejected", failure_class="guard_failure")
+    )
+
+    decision = experiment_promote.build_promotion_decision(packet, result)
+
+    assert decision["disposition"] == "deferred"
+    assert decision["creative_research_origin"] == origin
+    ledger = (repo / "docs" / "roadmap" / "BACKLOG_LEDGER.md").read_text(encoding="utf-8")
+    assert "Creative research origin:" in ledger
+    assert "Bundle ID: `creative-research-valid`" in ledger
+    assert "Candidate ID: `hyp-batch`" in ledger
+    assert "Promotion decision: `defer`" in ledger
+
+
 def test_rejected_result_with_non_backlog_target_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Goal
Add a manual local-only creative_research adoption metrics report and passive promotion origin metadata so operators can see eval-to-promotion conversion without runtime/API changes.

## Business reason
creative_research is implemented and tested, but active adoption visibility was missing. This PR gives operators a low-risk report for bundle/candidate adoption, conversion gaps, and destination counts before any stronger enforcement is considered.

## Scope
- Add `scripts/orchestration/creative_research_metrics.py` for aggregate JSON + Markdown reports under `artifacts/orchestration/creative_research/metrics/`.
- Add optional `creative_research_origin` metadata handling in `scripts/orchestration/experiment_promote.py`.
- Add focused tests for aggregation, malformed/skipped artifacts, negative controls, conversion links, path containment, deterministic output, and no raw-content leakage.
- Update `docs/orchestration/CREATIVE_RESEARCH_OFFLINE_EVAL_PROTOCOL.md` with the manual command and origin-link convention.
- Add `docs/review/PR_1953_FIXED_MAPPING.md` as the canonical review-governance mapping artifact.

## Out of scope
- No public API, OpenAPI, frontend, iOS, DB, provider, runtime, telemetry rollup, or CI-required behavior changes.
- No semantic-cache serving or product-runtime promotion authority.
- No automatic GitHub review-thread resolution or merge-readiness claim.

## Files changed
- `scripts/orchestration/creative_research_metrics.py`
- `scripts/orchestration/experiment_promote.py`
- `tests/test_creative_research_metrics.py`
- `tests/test_experiment_promote.py`
- `docs/orchestration/CREATIVE_RESEARCH_OFFLINE_EVAL_PROTOCOL.md`
- `docs/review/PR_1953_FIXED_MAPPING.md`

## Key decisions
- Metrics use evaluated candidate rows as source of truth; summary mismatches are counted but do not override candidate-grain counts.
- Conversion grain is `(bundle_id, candidate_id)`.
- Promotion origin metadata is optional, passive, strict-schema, and does not affect promotion policy or durable path selection.
- Report output is sanitized: no raw prompt, claim, mechanism, evidence text, provider output, local absolute path, or secret payloads.
- Destination refs are repo-relative and constrained to known experiment promotion destinations.

## Premortem risk closure
- Raw creative-research content leakage: fixed with sanitized extraction and no-leak tests.
- False conversion accounting: fixed with candidate-grain aggregation, summary-mismatch accounting, duplicate-origin-link counts, and origin-mismatch counts.
- Local path escape/symlink reads: fixed with artifact-root confinement and symlink skip tests.
- Runtime scope creep: avoided by keeping this as a manual script + docs/tests only.
- Full local verify resource risk: not closed locally; see validation note below. No merge-ready claim is made.

## Lane Start Provenance
- Packet: `artifacts/orchestration/task_packets/creative_research_adoption_metrics_pre_open.json`
- Task packet id: `9a90db45b2e4`
- Coordinator route: `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> data-scientist-agent -> cursor-specialist-agent`

## Experiment Runner Evidence
- Artifact: `artifacts/orchestration/experiments/results/creative_research_adoption_metrics_oracle_result.json`
- Result: accepted oracle-only governance reviewer evidence (`exp-039ef7427573`).
- Co-author trailer included because runner oracle shaped pre-open validation and commit decision.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1953_FIXED_MAPPING.md`

## Post-open governance
- PASS: `qa-engineer-agent` found missing backlog-entry origin rendering coverage; fixed in `5bb31f57d`.
- PASS: `bug-hunter` / `pulseplate-pr-review` flagged only large-diff review-planning risk; dispositioned as NOT-A-BUG in the mapping artifact because scope is one local report plus tests/docs.
- PASS: `security-auditor` and Codex Security diff/finding-discovery pass found no promoted diff-scoped candidate finding.
- PASS: `GITHUB_TOKEN=$(gh auth token) .venv/bin/python scripts/ci/check_pr_merge_readiness.py --pr-number 1953 --repo Katsiarynakavaleuskaya/PulsePlate`
- PASS: `GH_TOKEN=$(gh auth token) .venv/bin/python scripts/orchestration/check_review_threads_disposition.py --pr-number 1953 --require-auth`

## Tests / validation
- PASS: `python3 scripts/orchestration/check_preflight.py --path scripts/orchestration/creative_research_metrics.py --path scripts/orchestration/experiment_promote.py --path tests/test_creative_research_metrics.py --path tests/test_experiment_promote.py --path docs/orchestration/CREATIVE_RESEARCH_OFFLINE_EVAL_PROTOCOL.md`
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
- PASS: `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/creative_research_adoption_metrics_pre_open.json --pretty`
- PASS: required pre-open role passes completed in order: `agent-coordinator -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter -> data-scientist-agent -> cursor-specialist-agent`.
- PASS: `.venv/bin/python -m pytest -q tests/test_creative_research_metrics.py tests/test_creative_research_eval.py tests/test_creative_research_eval_contract.py tests/test_experiment_promote.py` (49 passed).
- PASS after QA fix: `.venv/bin/python -m pytest -q tests/test_experiment_promote.py tests/test_creative_research_metrics.py` (29 passed).
- PASS: `.venv/bin/python -m py_compile scripts/orchestration/creative_research_metrics.py scripts/orchestration/experiment_promote.py`
- PASS: `.venv/bin/python -m mypy --no-incremental --cache-dir=/dev/null scripts/orchestration/creative_research_metrics.py scripts/orchestration/experiment_promote.py`
- PASS: `make validate-changed`
- PASS: `pre-commit run --files docs/review/PR_1953_FIXED_MAPPING.md tests/test_experiment_promote.py scripts/orchestration/creative_research_metrics.py scripts/orchestration/experiment_promote.py tests/test_creative_research_metrics.py docs/orchestration/CREATIVE_RESEARCH_OFFLINE_EVAL_PROTOCOL.md`
- NOTE: final `pre-commit run --all-files` rerun was interrupted after `check-added-large-files` stalled on the full repository file list; earlier all-files pre-commit passed before post-open docs/test updates, and bounded changed-file hooks plus pre-push hooks passed for current head.
- PASS: pre-push hooks, including `pip-audit`, `backend tests (pytest, pre-push)`, `bandit (pre-push, full repo)`, and `docker build test` skip/no-files where applicable.
- PARTIAL/FAILED: `make verify` passed `verify-env`, `flake8`, `mypy`, and smoke tests, then OS-killed the full coverage phase at `coverage run -m pytest -q` before diff-cover completed. This PR is not claiming local merge readiness from `make verify`.

## Security notes
- Offline artifact-only report; no network/provider/API/runtime path.
- Input/output paths are constrained to local gitignored orchestration artifact roots.
- Malformed and unsupported artifacts are skipped and counted without echoing raw payloads.
- Promotion origin metadata is strict-schema passive provenance only.

## Risks / rollback
- Risk: operator may overinterpret report as a gate. Mitigation: docs and PR body state manual/advisory only.
- Risk: local artifacts could be malformed. Mitigation: stable skip accounting and sanitized reason codes.
- Rollback: revert this orchestration-only PR; no migrations, runtime flags, DB, API, or client changes are involved.

## Deferred / follow-ups
- CI-required enforcement, telemetry rollup integration, or stronger CRSLP adoption gates should be separate coordinator-owned PRs after this report proves low-noise.

## Merge Readiness
Claimed only after the current-head CI and strict wrapper pass for `39597c19afcf4dc0f3c2d4c87acb7735394e8a6c`.

- [x] Current-head CI terminal success must be confirmed for `39597c19afcf4dc0f3c2d4c87acb7735394e8a6c` after this body edit.
- [x] Required checks complete with no pending jobs: lint, test-pr (3.13), coverage-pr, diff-coverage, security, OpenAPI sync, docs/governance checks, CodeQL, CodeRabbit, Cubic, Codecov patch.
- [x] Bot review/governance has no unmapped actionable comments by local review-governance gate.
- [x] Strict review-thread disposition passes with auth.
- [x] Strict merge wrapper / merge-readiness guard passes with auth.
- [x] Mandatory wait-window after latest bot/review activity completed before merge.

Final strict commands to rerun after current-head CI:

```bash
GH_TOKEN=$(gh auth token) ../../.venv/bin/python scripts/orchestration/check_review_threads_disposition.py --pr-number 1953 --require-auth
GITHUB_TOKEN=$(gh auth token) ../../.venv/bin/python scripts/orchestration/check_merge_ready.py --pr-number 1953 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth
```
