### PR TITLE
fix(security): bound restaurant shadow reads

### DIFF
--- a/app/routers/restaurants.py
+++ b/app/routers/restaurants.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from typing import Any, Mapping, Protocol, Sequence, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -25,6 +26,8 @@ moderation_router = APIRouter(tags=["restaurants"])
 logger = logging.getLogger(__name__)
 FEATURE_RESTAURANT_POSTGRES_SHADOW_READS = "FEATURE_RESTAURANT_POSTGRES_SHADOW_READS"
 RESTAURANT_POSTGRES_SHADOW_READS_URL = "RESTAURANT_POSTGRES_SHADOW_READS_URL"
+SHADOW_READ_CIRCUIT_BREAKER_SECONDS = 30.0
+_shadow_read_circuit_open_until: dict[tuple[str, str], float] = {}
 
 
 class RestaurantStore(Protocol):
@@ -136,6 +139,31 @@ def _log_shadow_read_mismatch(
     )
 
 
+def _shadow_circuit_key(operation: str, pg_url: str) -> tuple[str, str]:
+    return (operation, pg_url)
+
+
+def _shadow_read_circuit_is_open(operation: str, pg_url: str) -> bool:
+    open_until = _shadow_read_circuit_open_until.get(_shadow_circuit_key(operation, pg_url), 0.0)
+    if open_until <= time.monotonic():
+        return False
+    logger.debug(
+        "restaurant PostgreSQL shadow %s skipped while failure circuit is open",
+        operation,
+    )
+    return True
+
+
+def _record_shadow_read_success(operation: str, pg_url: str) -> None:
+    _shadow_read_circuit_open_until.pop(_shadow_circuit_key(operation, pg_url), None)
+
+
+def _record_shadow_read_failure(operation: str, pg_url: str) -> None:
+    _shadow_read_circuit_open_until[_shadow_circuit_key(operation, pg_url)] = (
+        time.monotonic() + SHADOW_READ_CIRCUIT_BREAKER_SECONDS
+    )
+
+
 class _RestaurantStoreShadowCompat(_RestaurantStoreCompat):
     """SQLite-authoritative adapter with optional PostgreSQL shadow reads."""
 
@@ -167,6 +195,9 @@ class _RestaurantStoreShadowCompat(_RestaurantStoreCompat):
                 "restaurant PostgreSQL shadow reads enabled for search without a PostgreSQL URL"
             )
             return
+        operation = "search_restaurants"
+        if _shadow_read_circuit_is_open(operation, pg_url):
+            return
         try:
             pg_rows = restaurant_postgres_read.search_restaurants_pg(
                 pg_url=pg_url,
@@ -176,8 +207,10 @@ class _RestaurantStoreShadowCompat(_RestaurantStoreCompat):
             )
             parity = restaurant_shadow_parity.compare_restaurant_hits(sqlite_rows, pg_rows)
             if not parity.match:
-                _log_shadow_read_mismatch("search_restaurants", parity)
+                _log_shadow_read_mismatch(operation, parity)
+            _record_shadow_read_success(operation, pg_url)
         except Exception:
+            _record_shadow_read_failure(operation, pg_url)
             logger.warning(
                 "restaurant PostgreSQL shadow search failed; keeping SQLite canonical response",
                 exc_info=True,
@@ -198,6 +231,9 @@ class _RestaurantStoreShadowCompat(_RestaurantStoreCompat):
                 "restaurant PostgreSQL shadow reads enabled for menu without a PostgreSQL URL"
             )
             return
+        operation = "get_restaurant_menu"
+        if _shadow_read_circuit_is_open(operation, pg_url):
+            return
         try:
             pg_rows = restaurant_postgres_read.get_restaurant_menu_pg(
                 pg_url=pg_url,
@@ -206,8 +242,10 @@ class _RestaurantStoreShadowCompat(_RestaurantStoreCompat):
             )
             parity = restaurant_shadow_parity.compare_restaurant_menu(sqlite_rows, pg_rows)
             if not parity.match:
-                _log_shadow_read_mismatch("get_restaurant_menu", parity)
+                _log_shadow_read_mismatch(operation, parity)
+            _record_shadow_read_success(operation, pg_url)
         except Exception:
+            _record_shadow_read_failure(operation, pg_url)
             logger.warning(
                 "restaurant PostgreSQL shadow menu read failed; keeping SQLite canonical response",
                 exc_info=True,

--- a/app/routers/restaurants.py
+++ b/app/routers/restaurants.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+from threading import RLock
 from typing import Any, Mapping, Protocol, Sequence, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -28,6 +29,7 @@ FEATURE_RESTAURANT_POSTGRES_SHADOW_READS = "FEATURE_RESTAURANT_POSTGRES_SHADOW_R
 RESTAURANT_POSTGRES_SHADOW_READS_URL = "RESTAURANT_POSTGRES_SHADOW_READS_URL"
 SHADOW_READ_CIRCUIT_BREAKER_SECONDS = 30.0
 _shadow_read_circuit_open_until: dict[tuple[str, str], float] = {}
+_shadow_read_circuit_lock = RLock()
 
 
 class RestaurantStore(Protocol):
@@ -144,9 +146,13 @@ def _shadow_circuit_key(operation: str, pg_url: str) -> tuple[str, str]:
 
 
 def _shadow_read_circuit_is_open(operation: str, pg_url: str) -> bool:
-    open_until = _shadow_read_circuit_open_until.get(_shadow_circuit_key(operation, pg_url), 0.0)
-    if open_until <= time.monotonic():
-        return False
+    key = _shadow_circuit_key(operation, pg_url)
+    now = time.monotonic()
+    with _shadow_read_circuit_lock:
+        open_until = _shadow_read_circuit_open_until.get(key, 0.0)
+        if open_until <= now:
+            _shadow_read_circuit_open_until.pop(key, None)
+            return False
     logger.debug(
         "restaurant PostgreSQL shadow %s skipped while failure circuit is open",
         operation,
@@ -154,14 +160,39 @@ def _shadow_read_circuit_is_open(operation: str, pg_url: str) -> bool:
     return True
 
 
-def _record_shadow_read_success(operation: str, pg_url: str) -> None:
-    _shadow_read_circuit_open_until.pop(_shadow_circuit_key(operation, pg_url), None)
+def _begin_shadow_read_attempt(operation: str, pg_url: str) -> float | None:
+    attempt_started_at = time.monotonic()
+    if _shadow_read_circuit_is_open(operation, pg_url):
+        return None
+    return attempt_started_at
 
 
-def _record_shadow_read_failure(operation: str, pg_url: str) -> None:
-    _shadow_read_circuit_open_until[_shadow_circuit_key(operation, pg_url)] = (
-        time.monotonic() + SHADOW_READ_CIRCUIT_BREAKER_SECONDS
-    )
+def _record_shadow_read_success(
+    operation: str,
+    pg_url: str,
+    *,
+    started_at: float | None = None,
+) -> None:
+    attempt_started_at = time.monotonic() if started_at is None else started_at
+    key = _shadow_circuit_key(operation, pg_url)
+    with _shadow_read_circuit_lock:
+        open_until = _shadow_read_circuit_open_until.get(key)
+        if open_until is not None and open_until <= attempt_started_at:
+            _shadow_read_circuit_open_until.pop(key, None)
+
+
+def _record_shadow_read_failure(
+    operation: str,
+    pg_url: str,
+    *,
+    started_at: float | None = None,
+) -> None:
+    attempt_started_at = time.monotonic() if started_at is None else started_at
+    key = _shadow_circuit_key(operation, pg_url)
+    open_until = attempt_started_at + SHADOW_READ_CIRCUIT_BREAKER_SECONDS
+    with _shadow_read_circuit_lock:
+        existing_open_until = _shadow_read_circuit_open_until.get(key, 0.0)
+        _shadow_read_circuit_open_until[key] = max(existing_open_until, open_until)
 
 
 class _RestaurantStoreShadowCompat(_RestaurantStoreCompat):
@@ -196,7 +227,8 @@ class _RestaurantStoreShadowCompat(_RestaurantStoreCompat):
             )
             return
         operation = "search_restaurants"
-        if _shadow_read_circuit_is_open(operation, pg_url):
+        attempt_started_at = _begin_shadow_read_attempt(operation, pg_url)
+        if attempt_started_at is None:
             return
         try:
             pg_rows = restaurant_postgres_read.search_restaurants_pg(
@@ -208,9 +240,9 @@ class _RestaurantStoreShadowCompat(_RestaurantStoreCompat):
             parity = restaurant_shadow_parity.compare_restaurant_hits(sqlite_rows, pg_rows)
             if not parity.match:
                 _log_shadow_read_mismatch(operation, parity)
-            _record_shadow_read_success(operation, pg_url)
+            _record_shadow_read_success(operation, pg_url, started_at=attempt_started_at)
         except Exception:
-            _record_shadow_read_failure(operation, pg_url)
+            _record_shadow_read_failure(operation, pg_url, started_at=attempt_started_at)
             logger.warning(
                 "restaurant PostgreSQL shadow search failed; keeping SQLite canonical response",
                 exc_info=True,
@@ -232,7 +264,8 @@ class _RestaurantStoreShadowCompat(_RestaurantStoreCompat):
             )
             return
         operation = "get_restaurant_menu"
-        if _shadow_read_circuit_is_open(operation, pg_url):
+        attempt_started_at = _begin_shadow_read_attempt(operation, pg_url)
+        if attempt_started_at is None:
             return
         try:
             pg_rows = restaurant_postgres_read.get_restaurant_menu_pg(
@@ -243,9 +276,9 @@ class _RestaurantStoreShadowCompat(_RestaurantStoreCompat):
             parity = restaurant_shadow_parity.compare_restaurant_menu(sqlite_rows, pg_rows)
             if not parity.match:
                 _log_shadow_read_mismatch(operation, parity)
-            _record_shadow_read_success(operation, pg_url)
+            _record_shadow_read_success(operation, pg_url, started_at=attempt_started_at)
         except Exception:
-            _record_shadow_read_failure(operation, pg_url)
+            _record_shadow_read_failure(operation, pg_url, started_at=attempt_started_at)
             logger.warning(
                 "restaurant PostgreSQL shadow menu read failed; keeping SQLite canonical response",
                 exc_info=True,

--- a/app/services/restaurant_postgres_read.py
+++ b/app/services/restaurant_postgres_read.py
@@ -8,10 +8,12 @@ EN: No runtime cutover here — this module serves shadow-read path only.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+from threading import RLock
 from typing import Any
 
 from sqlalchemy import MetaData, Table, create_engine, text
-from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.engine import Connection, Engine, make_url
 from sqlalchemy.exc import NoSuchTableError
 
 RESTAURANT_CHAINS_TABLE = "restaurant_chains"
@@ -35,7 +37,21 @@ REQUIRED_MENU_COLUMNS = frozenset(
     }
 )
 POSTGRES_CONNECT_TIMEOUT_SECONDS = 5
+POSTGRES_STATEMENT_TIMEOUT_MS = 1_000
+POSTGRES_POOL_SIZE = 2
+POSTGRES_MAX_OVERFLOW = 0
+POSTGRES_POOL_TIMEOUT_SECONDS = 1
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _RestaurantPostgresRuntime:
+    engine: Engine
+    schema_validated: bool = False
+
+
+_runtime_lock = RLock()
+_runtime_cache: dict[str, _RestaurantPostgresRuntime] = {}
 
 
 class RestaurantPostgresReadError(RuntimeError):
@@ -48,11 +64,25 @@ def _build_pg_engine(pg_url: str) -> Engine:
     EN: Build a PostgreSQL engine and fail-closed validate dialect.
     """
 
+    url = make_url(pg_url)
+    if url.get_backend_name() != "postgresql":
+        logger.debug(
+            "restaurant shadow-read adapter rejected non-PostgreSQL dialect: %s",
+            url.get_backend_name(),
+        )
+        raise RestaurantPostgresReadError("target database must be PostgreSQL")
+
     engine = create_engine(
-        pg_url,
+        url,
         pool_pre_ping=True,
         future=True,
-        connect_args={"connect_timeout": POSTGRES_CONNECT_TIMEOUT_SECONDS},
+        pool_size=POSTGRES_POOL_SIZE,
+        max_overflow=POSTGRES_MAX_OVERFLOW,
+        pool_timeout=POSTGRES_POOL_TIMEOUT_SECONDS,
+        connect_args={
+            "connect_timeout": POSTGRES_CONNECT_TIMEOUT_SECONDS,
+            "options": f"-c statement_timeout={POSTGRES_STATEMENT_TIMEOUT_MS}",
+        },
     )
     if engine.dialect.name != "postgresql":
         logger.debug(
@@ -168,6 +198,39 @@ def _fetch_menu_rows(connection: Connection, *, chain_id: str, limit: int) -> li
     return menu_rows
 
 
+def _get_pg_runtime(pg_url: str) -> _RestaurantPostgresRuntime:
+    with _runtime_lock:
+        runtime = _runtime_cache.get(pg_url)
+        if runtime is None:
+            runtime = _RestaurantPostgresRuntime(engine=_build_pg_engine(pg_url))
+            _runtime_cache[pg_url] = runtime
+        return runtime
+
+
+def reset_restaurant_postgres_runtime_cache() -> None:
+    """RU/EN: Dispose cached shadow-read engines; intended for deterministic tests/shutdown."""
+
+    with _runtime_lock:
+        runtimes = list(_runtime_cache.values())
+        _runtime_cache.clear()
+    for runtime in runtimes:
+        runtime.engine.dispose()
+
+
+def _drop_pg_runtime(pg_url: str) -> None:
+    with _runtime_lock:
+        runtime = _runtime_cache.pop(pg_url, None)
+    if runtime is not None:
+        runtime.engine.dispose()
+
+
+def _ensure_schema_validated(runtime: _RestaurantPostgresRuntime, connection: Connection) -> None:
+    with _runtime_lock:
+        if not runtime.schema_validated:
+            _reflect_read_tables(connection)
+            runtime.schema_validated = True
+
+
 def search_restaurants_pg(
     *,
     pg_url: str,
@@ -180,13 +243,14 @@ def search_restaurants_pg(
     EN: Read search rows from PostgreSQL for shadow comparison.
     """
 
-    engine = _build_pg_engine(pg_url)
+    runtime = _get_pg_runtime(pg_url)
     try:
-        with engine.connect() as connection:
-            _reflect_read_tables(connection)
+        with runtime.engine.connect() as connection:
+            _ensure_schema_validated(runtime, connection)
             return _fetch_search_rows(connection, query=query, limit=limit, offset=offset)
-    finally:
-        engine.dispose()
+    except Exception:
+        _drop_pg_runtime(pg_url)
+        raise
 
 
 def get_restaurant_menu_pg(*, pg_url: str, chain_id: str, limit: int) -> list[dict[str, Any]]:
@@ -195,10 +259,11 @@ def get_restaurant_menu_pg(*, pg_url: str, chain_id: str, limit: int) -> list[di
     EN: Read menu rows from PostgreSQL for shadow comparison.
     """
 
-    engine = _build_pg_engine(pg_url)
+    runtime = _get_pg_runtime(pg_url)
     try:
-        with engine.connect() as connection:
-            _reflect_read_tables(connection)
+        with runtime.engine.connect() as connection:
+            _ensure_schema_validated(runtime, connection)
             return _fetch_menu_rows(connection, chain_id=chain_id, limit=limit)
-    finally:
-        engine.dispose()
+    except Exception:
+        _drop_pg_runtime(pg_url)
+        raise

--- a/docs/review/PR_1955_FIXED_MAPPING.md
+++ b/docs/review/PR_1955_FIXED_MAPPING.md
@@ -34,6 +34,11 @@ Disposition: NOT-A-BUG
 Evidence: Sourcery review body says the weekly diff-character rate limit was reached and asks to try later or upgrade; it contains no file/line/code finding.
 Reason: This is a Sourcery capacity notice, not a code finding.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1955#issuecomment-4691107752
+Disposition: NOT-A-BUG
+Evidence: Codecov reported patch coverage at 99.01961%; current-head `codecov/patch` passed; current-head `diff-coverage` passed; focused local diff-cover reported `Coverage: 100%`.
+Reason: This is a non-blocking partial-line coverage advisory above the repo threshold, not an actionable missing-test blocker for this PR.
+
 ## Internal Finding Dispositions
 
 - Disposition: FIXED

--- a/docs/review/PR_1955_FIXED_MAPPING.md
+++ b/docs/review/PR_1955_FIXED_MAPPING.md
@@ -1,0 +1,96 @@
+# PR 1955 Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1955
+Branch: `codex/fix-public-shadow-reads-vulnerability`
+Local reviewed head: `ad43007d95f2e655d9df9626c168e0ac9b2eda67`
+Task packet: `artifacts/orchestration/task_packets/257279560c6f.json`
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1955#discussion_r3399232220 -> 979f999e882a7265513628238ecfe5bbfaae8762
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1955#pullrequestreview-4480674103 -> 979f999e882a7265513628238ecfe5bbfaae8762
+Disposition: FIXED
+Commit: 979f999e882a7265513628238ecfe5bbfaae8762
+Evidence: `app/routers/restaurants.py` now protects shadow-read circuit state with `RLock`, records attempt-start timestamps, and only clears an older circuit; `tests/test_restaurants_router.py` covers stale success, longer cooldown preservation, search/menu circuit skips, and fail-open behavior; focused pytest and diff-cover passed.
+Reason: cubic identified that a concurrent successful shadow read could clear a newer failure cooldown; the fix prevents stale success from nullifying the failure window while preserving SQLite as canonical.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1955#issuecomment-4685147271
+Disposition: NOT-A-BUG
+Evidence: The comment body says the Codex connector reached code-review usage limits and gives account/billing settings; it names no code path, file, line, test, or remediation request.
+Reason: This is an external capacity notice, not an actionable code review finding.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1955#issuecomment-4685147525
+Disposition: NOT-A-BUG
+Evidence: The CodeRabbit comment states review limit reached and selected files for processing; it did not start a review and contains no concrete code finding.
+Reason: This is a rate-limit/capacity notice. The optional finishing-touch checkboxes are not review findings and do not override the deterministic tests added in this PR.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1955#pullrequestreview-4480656944
+Disposition: NOT-A-BUG
+Evidence: Sourcery review body says the weekly diff-character rate limit was reached and asks to try later or upgrade; it contains no file/line/code finding.
+Reason: This is a Sourcery capacity notice, not a code finding.
+
+## Internal Finding Dispositions
+
+- Disposition: FIXED
+  Source: `qa-engineer-agent` post-open review.
+  Evidence: QA found diff-cover at 95% with uncovered changed lines in `app/routers/restaurants.py` and `app/services/restaurant_postgres_read.py`; commit `ad43007d95f2e655d9df9626c168e0ac9b2eda67` added deterministic coverage. Rerun evidence: diff-cover reported `Coverage: 100%` for 102 changed lines.
+  Reason: Test coverage was expanded before mapping and before any readiness claim.
+
+- Disposition: FIXED
+  Source: `bug-hunter` post-open review.
+  Evidence: Bug-hunter flagged missing CI-visible tail wrappers for the new circuit tests; commit `ad43007d95f2e655d9df9626c168e0ac9b2eda67` added tail wrappers for stale success preservation, longer cooldown preservation, and search circuit skip. Rerun evidence: bug-hunter PASS on local head `ad43007d9`.
+  Reason: Route-shard false-green risk was closed with CI-visible test forwarding.
+
+- Disposition: FIXED
+  Source: `pulseplate-pr-review` dry-run report.
+  Evidence: Initial dry-run reported missing `docs/review/PR_1955_FIXED_MAPPING.md`; this artifact supplies the canonical mapping and will be mirrored in the PR body.
+  Reason: Governance artifact was intentionally created after code/test fixes and review passes.
+
+## Role Dispatch Evidence
+
+- Startup preflight passed with scoped paths:
+  `python3 scripts/orchestration/check_preflight.py --path app/routers/restaurants.py --path app/services/restaurant_postgres_read.py --path tests/test_restaurant_postgres_read.py --path tests/test_restaurants_router.py --path tests/test_app_extended_coverage.py --path docs/review/PR_1955_FIXED_MAPPING.md`
+- Agent consistency passed:
+  `python3 scripts/orchestration/check_agent_consistency.py`
+- Bootstrap packet created:
+  `python3 scripts/orchestration/task_bootstrap.py --goal "PR 1955 post-open security rescue for restaurant PostgreSQL shadow reads and merge governance" --task-class security ... --pr-phase post_open_review`
+- Dispatch manifest enforced non-parallel role order:
+  `agent-coordinator -> backend-engineer -> qa-engineer-agent -> bug-hunter -> security-auditor -> architecture-specialist`
+- Pre-implementation role passes completed in order and found the same narrow scope.
+- Post-open role passes completed on local head `ad43007d9`:
+  `qa-engineer-agent` PASS, `bug-hunter` PASS, `security-auditor` PASS.
+
+## Premortem And Security Evidence
+
+- Premortem finding: stale success could clear newer failure circuit. Disposition: FIXED by `979f999e882a7265513628238ecfe5bbfaae8762`.
+- Premortem finding: coverage-tail state leakage and stale test wrappers could hide regressions. Disposition: FIXED by `979f999e882a7265513628238ecfe5bbfaae8762` and `ad43007d95f2e655d9df9626c168e0ac9b2eda67`.
+- Experiment Runner oracle result: `exp-9757993a7a1c`, status `accepted`; focused pytest and py_compile returned 0 in oracle-only governance reviewer mode.
+- Codex Security diff scan: no findings; validated report at `/tmp/codex-security-scans/BMI-App_2025_clean/ad43007d9_20260612T113548Z/report.md`; rendered report at `/tmp/codex-security-scans/BMI-App_2025_clean/ad43007d9_20260612T113548Z/report.html`.
+- `pulseplate-pr-review` initial dry-run produced only missing-mapping governance notes; this artifact closes that note.
+- `pulseplate-pr-review` rerun after creating this artifact reported: `No deterministic findings from supplied context`.
+
+## Local Validation Evidence
+
+- PASS: `. .venv/bin/activate && pytest -q tests/test_restaurant_postgres_read.py tests/test_restaurants_router.py tests/test_app_extended_coverage.py::TestRestaurantShadowReadCoverageTail`
+- PASS: `python3 -m py_compile app/routers/restaurants.py app/services/restaurant_postgres_read.py tests/test_restaurant_postgres_read.py tests/test_restaurants_router.py tests/test_app_extended_coverage.py`
+- PASS: `git diff --check`
+- PASS: `diff-cover /tmp/pr1955-coverage.xml --compare-branch=origin/main --fail-under=97` reported `Coverage: 100%`.
+- PASS: `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
+- PASS: `PRE_COMMIT_HOME=/tmp/pre-commit-pr1955 pre-commit run --all-files`
+- Pending before merge-readiness claim: PR body Phase2 gates after PR-body edit, review-thread disposition strict gate after thread resolution, merge-readiness strict gate, and current-head CI.
+
+## Merge Readiness
+
+- [x] Code/test fix landed before mapping.
+- [x] Fixed-mapping artifact created after the code/test fix.
+- [x] Full local `make verify` intentionally deferred per operator machine-heavy exception.
+- [ ] PR body mirror updated after this artifact.
+- [x] Required narrow local gates completed after mapping.
+- [ ] Current-head CI green after push.
+- [ ] Strict merge-readiness gate passes with `--require-auth`.
+- [ ] No unresolved or actionable review threads remain.

--- a/tests/test_app_extended_coverage.py
+++ b/tests/test_app_extended_coverage.py
@@ -753,6 +753,13 @@ class TestRestaurantShadowReadCoverageTail:
             monkeypatch
         )
 
+    def test_restaurant_postgres_menu_fetch_error_cache_drop_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_pg_tests.test_get_restaurant_menu_pg_drops_cached_runtime_on_fetch_error(
+            monkeypatch
+        )
+
     def test_restaurant_postgres_search_cache_reuse_tail(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -830,6 +837,39 @@ class TestRestaurantShadowReadCoverageTail:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         restaurant_router_tests.test_shadow_wrapper_fails_open_when_postgres_menu_errors(
+            monkeypatch, caplog
+        )
+
+    def test_restaurant_router_shadow_success_preserves_newer_circuit_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_router_tests.test_shadow_read_success_does_not_close_newer_failure_circuit(
+            monkeypatch
+        )
+
+    def test_restaurant_router_shadow_success_closes_older_circuit_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_router_tests.test_shadow_read_success_closes_older_failure_circuit(monkeypatch)
+
+    def test_restaurant_router_shadow_failure_keeps_longer_circuit_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_router_tests.test_shadow_read_failure_does_not_shorten_newer_circuit(monkeypatch)
+
+    def test_restaurant_router_shadow_menu_circuit_skip_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_router_tests.test_shadow_wrapper_skips_postgres_menu_when_circuit_open(
+            monkeypatch
+        )
+
+    def test_restaurant_router_shadow_search_circuit_skip_tail(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        restaurant_router_tests.test_shadow_wrapper_opens_circuit_after_search_failure(
             monkeypatch, caplog
         )
 

--- a/tests/test_app_extended_coverage.py
+++ b/tests/test_app_extended_coverage.py
@@ -702,6 +702,14 @@ class TestRestaurantShadowReadCoverageTail:
     EN: Re-run canonical restaurant B3 tests inside the CI-visible route suite.
     """
 
+    def setup_method(self) -> None:
+        restaurant_router_tests.restaurants._shadow_read_circuit_open_until.clear()
+        restaurant_pg_tests.restaurant_postgres_read.reset_restaurant_postgres_runtime_cache()
+
+    def teardown_method(self) -> None:
+        restaurant_router_tests.restaurants._shadow_read_circuit_open_until.clear()
+        restaurant_pg_tests.restaurant_postgres_read.reset_restaurant_postgres_runtime_cache()
+
     def test_restaurant_postgres_build_engine_tail(self, monkeypatch: pytest.MonkeyPatch) -> None:
         restaurant_pg_tests.test_build_pg_engine_sets_bounded_connect_timeout(monkeypatch)
 
@@ -736,10 +744,28 @@ class TestRestaurantShadowReadCoverageTail:
     def test_restaurant_postgres_search_lifecycle_tail(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        restaurant_pg_tests.test_search_restaurants_pg_builds_reflects_and_disposes(monkeypatch)
+        restaurant_pg_tests.test_search_restaurants_pg_builds_reflects_and_keeps_engine_cached(
+            monkeypatch
+        )
 
     def test_restaurant_postgres_menu_lifecycle_tail(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        restaurant_pg_tests.test_get_restaurant_menu_pg_builds_reflects_and_disposes(monkeypatch)
+        restaurant_pg_tests.test_get_restaurant_menu_pg_builds_reflects_and_keeps_engine_cached(
+            monkeypatch
+        )
+
+    def test_restaurant_postgres_search_cache_reuse_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_pg_tests.test_search_restaurants_pg_reuses_cached_engine_and_schema_validation(
+            monkeypatch
+        )
+
+    def test_restaurant_postgres_reset_runtime_cache_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        restaurant_pg_tests.test_reset_restaurant_postgres_runtime_cache_disposes_cached_engine(
+            monkeypatch
+        )
 
     def test_restaurant_shadow_numeric_tail(self) -> None:
         restaurant_parity_tests.test_normalize_numeric_handles_none_invalid_and_fractional_values()

--- a/tests/test_restaurant_postgres_read.py
+++ b/tests/test_restaurant_postgres_read.py
@@ -296,6 +296,36 @@ def test_get_restaurant_menu_pg_builds_reflects_and_keeps_engine_cached(
     assert fake_engine.disposed is False
 
 
+def test_get_restaurant_menu_pg_drops_cached_runtime_on_fetch_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_connection = _RecordingConnection([])
+    fake_engine = _FakeEngine(fake_connection)
+    build_calls: list[str] = []
+
+    def _build(pg_url: str) -> _FakeEngine:
+        build_calls.append(pg_url)
+        return fake_engine
+
+    monkeypatch.setattr(restaurant_postgres_read, "_build_pg_engine", _build)
+    monkeypatch.setattr(restaurant_postgres_read, "_reflect_read_tables", lambda connection: None)
+    monkeypatch.setattr(
+        restaurant_postgres_read,
+        "_fetch_menu_rows",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("menu fetch failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="menu fetch failed"):
+        restaurant_postgres_read.get_restaurant_menu_pg(
+            pg_url="postgresql://shadow",
+            chain_id="c1",
+            limit=25,
+        )
+
+    assert fake_engine.disposed is True
+    assert build_calls == ["postgresql://shadow"]
+
+
 def test_search_restaurants_pg_reuses_cached_engine_and_schema_validation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_restaurant_postgres_read.py
+++ b/tests/test_restaurant_postgres_read.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
 from sqlalchemy.exc import NoSuchTableError
 
 from app.services import restaurant_postgres_read
+
+
+@pytest.fixture(autouse=True)
+def _reset_pg_runtime_cache() -> Iterator[None]:
+    restaurant_postgres_read.reset_restaurant_postgres_runtime_cache()
+    yield
+    restaurant_postgres_read.reset_restaurant_postgres_runtime_cache()
 
 
 class _FakeMappingsResult:
@@ -72,16 +80,27 @@ def test_build_pg_engine_sets_bounded_connect_timeout(monkeypatch: pytest.Monkey
 
     assert engine is fake_engine
     assert captured["kwargs"]["connect_args"] == {
-        "connect_timeout": restaurant_postgres_read.POSTGRES_CONNECT_TIMEOUT_SECONDS
+        "connect_timeout": restaurant_postgres_read.POSTGRES_CONNECT_TIMEOUT_SECONDS,
+        "options": (
+            f"-c statement_timeout="
+            f"{restaurant_postgres_read.POSTGRES_STATEMENT_TIMEOUT_MS}"
+        ),
     }
+    assert captured["kwargs"]["pool_size"] == restaurant_postgres_read.POSTGRES_POOL_SIZE
+    assert captured["kwargs"]["max_overflow"] == restaurant_postgres_read.POSTGRES_MAX_OVERFLOW
+    assert captured["kwargs"]["pool_timeout"] == (
+        restaurant_postgres_read.POSTGRES_POOL_TIMEOUT_SECONDS
+    )
 
 
 def test_search_restaurants_pg_rejects_non_postgres_dialect(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    fake_engine = _FakeEngine(object(), dialect_name="sqlite")
-    monkeypatch.setattr(restaurant_postgres_read, "create_engine", lambda *a, **k: fake_engine)
+    def _unexpected_create_engine(*args: Any, **kwargs: Any) -> _FakeEngine:
+        raise AssertionError("non-PostgreSQL URLs must be rejected before engine creation")
+
+    monkeypatch.setattr(restaurant_postgres_read, "create_engine", _unexpected_create_engine)
 
     with caplog.at_level("DEBUG"):
         with pytest.raises(restaurant_postgres_read.RestaurantPostgresReadError) as exc:
@@ -93,7 +112,6 @@ def test_search_restaurants_pg_rejects_non_postgres_dialect(
             )
 
     assert "target database must be PostgreSQL" in str(exc.value)
-    assert fake_engine.disposed is True
     assert "rejected non-PostgreSQL dialect: sqlite" in caplog.text
 
 
@@ -201,7 +219,7 @@ def test_reflect_read_tables_rejects_missing_required_columns(
     assert "missing required columns" in str(exc.value)
 
 
-def test_search_restaurants_pg_builds_reflects_and_disposes(
+def test_search_restaurants_pg_builds_reflects_and_keeps_engine_cached(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake_connection = _RecordingConnection(
@@ -230,10 +248,10 @@ def test_search_restaurants_pg_builds_reflects_and_disposes(
 
     assert rows[0]["id"] == "c1"
     assert reflected_connections == [fake_connection]
-    assert fake_engine.disposed is True
+    assert fake_engine.disposed is False
 
 
-def test_get_restaurant_menu_pg_builds_reflects_and_disposes(
+def test_get_restaurant_menu_pg_builds_reflects_and_keeps_engine_cached(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake_connection = _RecordingConnection(
@@ -277,4 +295,57 @@ def test_get_restaurant_menu_pg_builds_reflects_and_disposes(
 
     assert rows[0]["id"] == "m1"
     assert reflected_connections == [fake_connection]
+    assert fake_engine.disposed is False
+
+
+def test_search_restaurants_pg_reuses_cached_engine_and_schema_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_connection = _RecordingConnection(
+        [{"id": "c1", "name": "Alpha", "country": "US", "source": "menustat"}]
+    )
+    fake_engine = _FakeEngine(fake_connection)
+    build_calls: list[str] = []
+    reflected_connections: list[Any] = []
+
+    def _build(pg_url: str) -> _FakeEngine:
+        build_calls.append(pg_url)
+        return fake_engine
+
+    monkeypatch.setattr(restaurant_postgres_read, "_build_pg_engine", _build)
+    monkeypatch.setattr(
+        restaurant_postgres_read,
+        "_reflect_read_tables",
+        lambda connection: reflected_connections.append(connection),
+    )
+
+    first = restaurant_postgres_read.search_restaurants_pg(
+        pg_url="postgresql://shadow", query="alp", limit=10, offset=0
+    )
+    second = restaurant_postgres_read.search_restaurants_pg(
+        pg_url="postgresql://shadow", query="bet", limit=10, offset=0
+    )
+
+    assert first[0]["id"] == "c1"
+    assert second[0]["id"] == "c1"
+    assert build_calls == ["postgresql://shadow"]
+    assert reflected_connections == [fake_connection]
+    assert fake_engine.disposed is False
+
+
+def test_reset_restaurant_postgres_runtime_cache_disposes_cached_engine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_connection = _RecordingConnection(
+        [{"id": "c1", "name": "Alpha", "country": "US", "source": "menustat"}]
+    )
+    fake_engine = _FakeEngine(fake_connection)
+    monkeypatch.setattr(restaurant_postgres_read, "_build_pg_engine", lambda pg_url: fake_engine)
+    monkeypatch.setattr(restaurant_postgres_read, "_reflect_read_tables", lambda connection: None)
+
+    restaurant_postgres_read.search_restaurants_pg(
+        pg_url="postgresql://shadow", query="alp", limit=10, offset=0
+    )
+    restaurant_postgres_read.reset_restaurant_postgres_runtime_cache()
+
     assert fake_engine.disposed is True

--- a/tests/test_restaurant_postgres_read.py
+++ b/tests/test_restaurant_postgres_read.py
@@ -81,10 +81,8 @@ def test_build_pg_engine_sets_bounded_connect_timeout(monkeypatch: pytest.Monkey
     assert engine is fake_engine
     assert captured["kwargs"]["connect_args"] == {
         "connect_timeout": restaurant_postgres_read.POSTGRES_CONNECT_TIMEOUT_SECONDS,
-        "options": (
-            f"-c statement_timeout="
-            f"{restaurant_postgres_read.POSTGRES_STATEMENT_TIMEOUT_MS}"
-        ),
+        "options": f"-c statement_timeout="
+        f"{restaurant_postgres_read.POSTGRES_STATEMENT_TIMEOUT_MS}",
     }
     assert captured["kwargs"]["pool_size"] == restaurant_postgres_read.POSTGRES_POOL_SIZE
     assert captured["kwargs"]["max_overflow"] == restaurant_postgres_read.POSTGRES_MAX_OVERFLOW

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -520,6 +520,40 @@ def test_shadow_wrapper_fails_open_when_postgres_menu_errors(
     assert "keeping SQLite canonical response" in caplog.text
 
 
+def test_shadow_read_success_does_not_close_newer_failure_circuit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation = "get_restaurant_menu"
+    pg_url = "postgresql://shadow"
+    now = {"value": 111.0}
+    monkeypatch.setattr(restaurants.time, "monotonic", lambda: now["value"])
+
+    restaurants._record_shadow_read_failure(operation, pg_url, started_at=110.0)
+    restaurants._record_shadow_read_success(operation, pg_url, started_at=100.0)
+
+    assert restaurants._shadow_read_circuit_is_open(operation, pg_url) is True
+
+    now["value"] = 141.0
+    assert restaurants._shadow_read_circuit_is_open(operation, pg_url) is False
+
+
+def test_shadow_read_failure_does_not_shorten_newer_circuit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation = "search_restaurants"
+    pg_url = "postgresql://shadow"
+    now = {"value": 140.0}
+    monkeypatch.setattr(restaurants.time, "monotonic", lambda: now["value"])
+
+    restaurants._record_shadow_read_failure(operation, pg_url, started_at=120.0)
+    restaurants._record_shadow_read_failure(operation, pg_url, started_at=100.0)
+
+    assert restaurants._shadow_read_circuit_is_open(operation, pg_url) is True
+
+    now["value"] = 151.0
+    assert restaurants._shadow_read_circuit_is_open(operation, pg_url) is False
+
+
 def test_shadow_wrapper_menu_skips_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
     wrapper = restaurants._RestaurantStoreShadowCompat()
     monkeypatch.delenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, raising=False)

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any, Dict, Mapping, Sequence
 
@@ -18,6 +19,13 @@ from app.schemas.restaurants import (
     SubmissionReviewStatus,
     SubmissionStatus,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_shadow_read_circuit() -> Iterator[None]:
+    restaurants._shadow_read_circuit_open_until.clear()
+    yield
+    restaurants._shadow_read_circuit_open_until.clear()
 
 
 @dataclass
@@ -634,3 +642,34 @@ def test_shadow_wrapper_submission_paths_remain_sqlite_only(
     )
     assert wrapper.get_submission("s1")["id"] == "s1"
     assert wrapper.review_submission("s1", status="approved", reviewer_notes=None)["id"] == "s1"
+
+
+def test_shadow_wrapper_opens_circuit_after_search_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    wrapper = restaurants._RestaurantStoreShadowCompat()
+    calls = 0
+    monkeypatch.setenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "true")
+    monkeypatch.delenv(restaurants.RESTAURANT_POSTGRES_SHADOW_READS_URL, raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://shadow")
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "search_restaurants",
+        lambda **_: [{"id": "c1", "name": "Chain 1", "country": "US", "source": "menustat"}],
+    )
+
+    def _boom(**kwargs: Any) -> list[dict[str, Any]]:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("pg down")
+
+    monkeypatch.setattr(restaurants.restaurant_postgres_read, "search_restaurants_pg", _boom)
+
+    with caplog.at_level("WARNING"):
+        first = wrapper.search_restaurants("chain", 10, 0)
+        second = wrapper.search_restaurants("chain", 10, 0)
+
+    assert list(first)[0]["id"] == "c1"
+    assert list(second)[0]["id"] == "c1"
+    assert calls == 1
+    assert "keeping SQLite canonical response" in caplog.text

--- a/tests/test_restaurants_router.py
+++ b/tests/test_restaurants_router.py
@@ -537,6 +537,20 @@ def test_shadow_read_success_does_not_close_newer_failure_circuit(
     assert restaurants._shadow_read_circuit_is_open(operation, pg_url) is False
 
 
+def test_shadow_read_success_closes_older_failure_circuit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation = "get_restaurant_menu"
+    pg_url = "postgresql://shadow"
+    now = {"value": 111.0}
+    monkeypatch.setattr(restaurants.time, "monotonic", lambda: now["value"])
+
+    restaurants._record_shadow_read_failure(operation, pg_url, started_at=100.0)
+    restaurants._record_shadow_read_success(operation, pg_url, started_at=131.0)
+
+    assert restaurants._shadow_read_circuit_is_open(operation, pg_url) is False
+
+
 def test_shadow_read_failure_does_not_shorten_newer_circuit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -552,6 +566,33 @@ def test_shadow_read_failure_does_not_shorten_newer_circuit(
 
     now["value"] = 151.0
     assert restaurants._shadow_read_circuit_is_open(operation, pg_url) is False
+
+
+def test_shadow_wrapper_skips_postgres_menu_when_circuit_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wrapper = restaurants._RestaurantStoreShadowCompat()
+    monkeypatch.setenv(restaurants.FEATURE_RESTAURANT_POSTGRES_SHADOW_READS, "true")
+    monkeypatch.delenv(restaurants.RESTAURANT_POSTGRES_SHADOW_READS_URL, raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://shadow")
+    monkeypatch.setattr(
+        restaurants.restaurant_store,
+        "get_restaurant_menu",
+        lambda **_: [{"id": "m1", "chain_id": "c1", "item_name": "Protein Bowl"}],
+    )
+    monkeypatch.setattr(
+        restaurants.restaurant_postgres_read,
+        "get_restaurant_menu_pg",
+        lambda **_: (_ for _ in ()).throw(AssertionError("open circuit should skip menu")),
+    )
+    restaurants._record_shadow_read_failure(
+        "get_restaurant_menu",
+        "postgresql://shadow",
+    )
+
+    rows = wrapper.get_restaurant_menu("c1", 10)
+
+    assert list(rows)[0]["id"] == "m1"
 
 
 def test_shadow_wrapper_menu_skips_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Goal
Rescue PR #1955 by closing the shadow-read circuit-breaker concurrency bug and restoring governance evidence for post-open merge review.

## Business reason
Public restaurant endpoints must keep SQLite as canonical response truth while optional PostgreSQL shadow reads stay bounded, fail-open, and unable to amplify public traffic into repeated database/worker pressure.

## Scope
- Harden restaurant PostgreSQL shadow-read circuit state in `app/routers/restaurants.py` with locked attempt bookkeeping.
- Keep `app/services/restaurant_postgres_read.py` bounded runtime/cache behavior unchanged except for test-covered cache-drop coverage.
- Update deterministic backend tests for stale success, longer cooldown preservation, search/menu circuit skips, cache reuse/reset, and coverage-tail forwarding.
- Add canonical review-governance artifact for PR #1955.

## Out of scope
- No public API, OpenAPI, iOS, frontend, database migration, billing, entitlement, nutrition, wellness-copy, or new environment variable changes.
- Full local `make verify` is intentionally out of scope for this rescue lane per operator machine-heavy exception; narrow local gates and current-head CI are the validation route.

## Files changed / likely touched
- `app/routers/restaurants.py`
- `app/services/restaurant_postgres_read.py`
- `tests/test_restaurant_postgres_read.py`
- `tests/test_restaurants_router.py`
- `tests/test_app_extended_coverage.py`
- `docs/review/PR_1955_FIXED_MAPPING.md`

## Key decisions
- Use `RLock` around circuit state only; do not hold the lock during PostgreSQL shadow I/O.
- Record attempt-start timestamps so an older successful shadow read cannot clear a newer failure cooldown.
- Preserve SQLite canonical responses and fail-open shadow-read degradation.
- Fix tests before mapping, then add fixed-mapping evidence after the code/test commits.

## Tests
- PASS: `python3 scripts/orchestration/check_preflight.py --path app/routers/restaurants.py --path app/services/restaurant_postgres_read.py --path tests/test_restaurant_postgres_read.py --path tests/test_restaurants_router.py --path tests/test_app_extended_coverage.py --path docs/review/PR_1955_FIXED_MAPPING.md`
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
- PASS: `. .venv/bin/activate && pytest -q tests/test_restaurant_postgres_read.py tests/test_restaurants_router.py tests/test_app_extended_coverage.py::TestRestaurantShadowReadCoverageTail`
- PASS: `python3 -m py_compile app/routers/restaurants.py app/services/restaurant_postgres_read.py tests/test_restaurant_postgres_read.py tests/test_restaurants_router.py tests/test_app_extended_coverage.py`
- PASS: focused diff-cover reported `Coverage: 100%` for changed backend lines.
- PASS: `DEV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
- PASS: `PRE_COMMIT_HOME=/tmp/pre-commit-pr1955 pre-commit run --all-files`
- PASS: `git diff --check`
- Deferred: full local `make verify` was not run by operator instruction because this lane uses the documented machine-heavy narrow-gate exception.

## Security notes
- Cubic P1 concurrency finding is mapped as FIXED in `docs/review/PR_1955_FIXED_MAPPING.md`.
- Codex Security diff scan/finding discovery reported no findings for the touched backend files.
- No secrets, auth, billing, entitlement, OpenAPI, release, or medical/wellness-copy surfaces changed.

## Risks / rollback
- Main residual risk is behavioral drift in optional PostgreSQL shadow-read diagnostics; rollback is to revert this PR branch because SQLite remains canonical and no migration or external contract is changed.
- If current-head CI finds a regression, hold merge and fix before changing mapping or resolving review threads.

## Deferred / follow-ups
- No product follow-up is required for this narrow rescue.
- Full local `make verify` remains deferred to current-head CI parity under the operator-approved machine-heavy exception.

## AGENTS.md or agent-instruction updates if process/patterns change
- None.

## Next best step
Push the current branch, watch current-head CI only, resolve any review-thread state with disposition evidence, then run strict merge-readiness gates with auth before merge.

## Experiment Runner Evidence
- Artifact: artifacts/orchestration/experiments/results/exp-9757993a7a1c.json
- Result: accepted oracle-only governance review; focused pytest and py_compile returned 0.
- Attribution: commit `979f999e882a7265513628238ecfe5bbfaae8762` includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>` because the accepted artifact shaped the code-fix commit decision.

## Lane Start Provenance
- Packet: artifacts/orchestration/task_packets/257279560c6f.json
- Dispatch order: `agent-coordinator -> backend-engineer -> qa-engineer-agent -> bug-hunter -> security-auditor -> architecture-specialist`.
- Post-open order completed: `qa-engineer-agent -> bug-hunter -> security-auditor`, Codex Security diff scan/finding discovery, and `pulseplate-pr-review`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1955_FIXED_MAPPING.md`
- Cubic P1 shadow-read circuit comment mapped as FIXED to `979f999e882a7265513628238ecfe5bbfaae8762`.
- Codex, CodeRabbit, and Sourcery rate-limit/capacity notices mapped as NOT-A-BUG with evidence.

## Merge Readiness
- [x] Code/test fix landed before fixed mapping.
- [x] Canonical fixed-mapping artifact added after the fix commits.
- [x] Required narrow local gates completed.
- [x] Full local `make verify` intentionally deferred per operator machine-heavy exception.
- [ ] Current-head CI completed after push.
- [ ] Strict review-thread disposition gate passes with `--require-auth` after thread resolution state is current.
- [ ] Strict merge-readiness gate passes with `--require-auth`.
- [ ] No unresolved or actionable review threads remain after the mandatory review cycle.
