### PR TITLE
fix(ci): fail Safety scans with unwaived findings

### DIFF
--- a/docs/review/PR_1957_FIXED_MAPPING.md
+++ b/docs/review/PR_1957_FIXED_MAPPING.md
@@ -1,0 +1,205 @@
+# PR #1957 Fixed in Commit Mapping
+
+## Summary
+
+PR #1957 tightens the CI Safety audit gate so a non-zero Safety exit fails
+unless it is fully explained by active repo-policy waivers and no active parsed
+findings remain. This closeout adds the canonical review governance artifact,
+records post-open role/security review evidence, and keeps the operator-approved
+machine-heavy validation path explicit.
+
+## Scope
+
+- CI Safety audit aggregation and CLI output in `scripts/ci/run_safety_audit.py`.
+- Focused regression coverage in `tests/test_run_safety_audit.py`.
+- Canonical PR governance artifact for PR #1957.
+
+## Out Of Scope
+
+- Product runtime behavior, public API/OpenAPI, frontend, iOS, nutrition data,
+  wellness copy, medical claims, billing, auth, exports, LLM/RAG/runtime AI,
+  deployment topology, and dependency version changes.
+
+## Implementation Commits
+
+- `91a5172cf33930b51b48c03b65965303c0bf7bfc` - implementation and focused
+  regression coverage for fail-closed Safety waiver handling.
+- `c5831b349d5f` - Black formatter closeout for `scripts/ci/run_safety_audit.py`.
+
+## Lane Start Provenance
+
+- PR: #1957
+- Branch: `codex/task-title`
+- Packet: `artifacts/orchestration/task_packets/5227de7d3e6b.json`
+- PR phase: `post_open_review`
+- Machine-heavy exception: operator-approved; full local `make verify` is
+  intentionally deferred. Narrow local gates, `make validate-changed`,
+  `pre-commit run --all-files`, current-head CI, and strict merge-readiness are
+  required before merge.
+
+## Role Dispatch Evidence
+
+Startup gates completed before implementation closeout:
+
+- `python3 scripts/orchestration/check_preflight.py --path scripts/ci/run_safety_audit.py --path tests/test_run_safety_audit.py --path docs/review/PR_1957_FIXED_MAPPING.md`: PASS.
+- `python3 scripts/orchestration/check_agent_consistency.py`: PASS.
+- `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review`: PASS; packet `5227de7d3e6b`.
+- `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/5227de7d3e6b.json --pretty --mode runtime`: PASS.
+
+Declared role order executed:
+
+1. `agent-coordinator`
+2. `qa-engineer-agent`
+3. `bug-hunter`
+4. `security-auditor`
+5. `cursor-specialist-agent`
+6. `web-research-agent`
+
+Mandatory post-open stack executed:
+
+1. `qa-engineer-agent`
+2. `bug-hunter`
+3. `security-auditor`
+4. Codex Security diff scan / finding discovery
+5. `pulseplate-pr-review`
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Discussion Thread Evidence
+
+- GitHub review threads GraphQL query on 2026-06-12 returned `[]`.
+- GitHub pull request review comments query on 2026-06-12 returned no line
+  comments.
+- Any new review thread after the next push must be dispositioned before merge
+  readiness.
+
+## Bot And Review Noise Dispositions
+
+- Codex connector usage-limit comment: NOT-A-BUG.
+  Evidence:
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1957#issuecomment-4685254913`.
+  Reason: account usage-limit notice only; no code, docs, tests, security, or
+  governance actionable.
+- CodeRabbit rate-limit / usage-credit comment: NOT-A-BUG.
+  Evidence:
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1957#issuecomment-4685255236`.
+  Reason: bot review was rate-limited and did not identify a code actionable or
+  substantive approval.
+- Sourcery weekly rate-limit review: NOT-A-BUG.
+  Evidence:
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1957#pullrequestreview-4480936307`.
+  Reason: weekly rate-limit notice only; no code actionable.
+- Cubic no-issues review and usage warning: NOT-A-BUG.
+  Evidence:
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1957#pullrequestreview-4480783364`.
+  Reason: no issues found across two files, plus usage warning; recorded as
+  bot-noise evidence and not treated as a substantive human approval.
+- Codecov coverage comment: NOT-A-BUG.
+  Evidence:
+  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1957#issuecomment-4685408398`.
+  Reason: coverage report says all modified coverable lines are covered; no
+  action item.
+
+## Premortem Finding Closure
+
+- PM-1957-001: Formatter drift could keep `lint` red after the behavioral fix.
+  Disposition: FIXED.
+  Evidence: `c5831b349d5f` formats `scripts/ci/run_safety_audit.py`; focused
+  syntax and test gates passed before this artifact was created.
+- PM-1957-002: Bot usage-limit comments could be mistaken for substantive
+  approvals or actionable review threads.
+  Disposition: FIXED.
+  Evidence: bot comments are recorded in `## Bot And Review Noise Dispositions`
+  outside the parser-sensitive mapping section.
+- PM-1957-003: Machine-heavy exception could be under-documented.
+  Disposition: FIXED.
+  Evidence: `## Lane Start Provenance`, `## Validation Evidence`, and the PR
+  body mirror document no full local `make verify` and require narrow gates plus
+  current-head CI.
+- PM-1957-004: Missing Experiment Runner or Codex Security evidence could block
+  governance closeout.
+  Disposition: FIXED.
+  Evidence: `## Experiment Runner Evidence` and
+  `## Codex Security Diff Scan / Finding Discovery`.
+- PM-1957-005: Stale CI could be misread after post-open commits.
+  Disposition: NOT-A-BUG at this artifact stage.
+  Evidence: current-head CI remains a mandatory post-push merge-readiness gate
+  and is not claimed here.
+
+## Experiment Runner Evidence
+
+- Packet: `artifacts/orchestration/experiments/exp-cae8730c8789.json`
+- Artifact: `artifacts/orchestration/experiments/results/exp-cae8730c8789.json`
+- Mode: `oracle_only_governance_reviewer`
+- Status: accepted
+- Oracle results: 2/2 passed
+- Shared tree untouched: true
+- Contribution: `fixed_mapping_review`
+- Co-author required: true
+- Commit trailer required on the governance commit:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+- Oracles:
+  - `python3 -m py_compile scripts/ci/run_safety_audit.py tests/test_run_safety_audit.py`
+  - `python3 -m pytest -q tests/test_run_safety_audit.py`
+
+## Codex Security Diff Scan / Finding Discovery
+
+- Scan path:
+  `/tmp/codex-security-scans/pr-1957-safety-closeout/c5831b349d5f_20260612T104855Z/`
+- Final report:
+  `/tmp/codex-security-scans/pr-1957-safety-closeout/c5831b349d5f_20260612T104855Z/report.md`
+- HTML report:
+  `/tmp/codex-security-scans/pr-1957-safety-closeout/c5831b349d5f_20260612T104855Z/report.html`
+- Report validation:
+  `validate_report_format.py --report-md .../report.md`: PASS.
+- Coverage:
+  - `scripts/ci/run_safety_audit.py`: full-file receipt, lines 1-878.
+  - `tests/test_run_safety_audit.py`: full-file receipt, lines 1-713.
+- Result: PASS / no reportable findings.
+- Note: the shared worklist helper emitted zero rows because it excludes
+  directory names `ci` and `tests`; the scan recorded an explicit exhaustive
+  worklist for this diff and documented the helper limitation in the report.
+
+## PulsePlate PR Review
+
+- Report: `/tmp/pr1957_pr_review_report_mergebase.md`
+- Context: explicit merge-base diff
+  `1090ae112b87a13448e71961d2ee582c1ef6b23e..HEAD`.
+- Scope reviewed: 2 files, 91 additions, 8 deletions.
+- Result: PASS / no deterministic findings.
+- Note: the earlier GitHub API context for remote head `91a5172cf` observed a
+  stale 5-file diff before this branch was pushed. It is not used as final
+  current-head evidence.
+
+## Agent Run Summary
+
+- Artifact:
+  `artifacts/agent_runs/pr1957__agent-coordinator__security_ci_tooling.json`
+- Run id: `a6260d0524ad`
+- Outcome: `governance_closeout_in_progress`
+- Gate status at artifact generation: `pending_final_local_gates`
+- Local artifact only; not committed.
+
+## Local Validation Evidence
+
+- `python3 -m py_compile scripts/ci/run_safety_audit.py tests/test_run_safety_audit.py`: PASS.
+- `python3 -m pytest -q tests/test_run_safety_audit.py`: PASS, 33 tests.
+- `git diff --check origin/main...HEAD`: PASS.
+- `make validate-changed`: PASS.
+- `PRE_COMMIT_HOME=/tmp/pre-commit-pr1957 pre-commit run --all-files`: PASS.
+- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1957 --body "$(gh pr view 1957 --json body --jq .body)"`: PASS after the Experiment Runner co-author trailer was committed.
+- `GH_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_review_threads_disposition.py --pr-number 1957 --require-auth`: PASS; no resolved review threads found.
+- `GH_TOKEN="$(gh auth token)" GITHUB_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_merge_ready.py --pr-number 1957 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`: pending after push/current-head CI.
+
+## Merge Readiness
+
+Not claimed. Current-head CI, strict merge-readiness, no unresolved threads, no
+actionable bot comments, and the mandatory final review cycle remain required
+before merge.

--- a/scripts/ci/run_safety_audit.py
+++ b/scripts/ci/run_safety_audit.py
@@ -756,15 +756,26 @@ def run_audit(config: SafetyAuditConfig) -> tuple[ManifestAuditResult, ...]:
     return tuple(results)
 
 
+def _nonzero_safety_exit_is_fully_waived(analysis: SafetyAnalysis) -> bool:
+    """Return whether a non-zero Safety exit is fully explained by repo waivers."""
+
+    return (
+        analysis.repo_policy_ignored_count > 0
+        and analysis.high_risk_count == 0
+        and analysis.other_count == 0
+    )
+
+
 def exit_code_for_results(results: Sequence[ManifestAuditResult]) -> int:
     """Return aggregate workflow exit code for parsed Safety results."""
 
+    if any(result.analysis.status == PARSE_BLOCKING for result in results):
+        return 1
     if any(
-        result.safety_exit_code != 0 and result.analysis.repo_policy_ignored_count == 0
+        result.safety_exit_code != 0
+        and not _nonzero_safety_exit_is_fully_waived(result.analysis)
         for result in results
     ):
-        return 1
-    if any(result.analysis.status == PARSE_BLOCKING for result in results):
         return 1
     return 0
 
@@ -845,8 +856,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         manifest_name = result.manifest.name
         if (
             result.safety_exit_code != 0
-            and result.analysis.repo_policy_ignored_count > 0
-            and result.analysis.status != PARSE_BLOCKING
+            and _nonzero_safety_exit_is_fully_waived(result.analysis)
         ):
             print(
                 "OK: Safety scan passed for "

--- a/scripts/ci/run_safety_audit.py
+++ b/scripts/ci/run_safety_audit.py
@@ -772,8 +772,7 @@ def exit_code_for_results(results: Sequence[ManifestAuditResult]) -> int:
     if any(result.analysis.status == PARSE_BLOCKING for result in results):
         return 1
     if any(
-        result.safety_exit_code != 0
-        and not _nonzero_safety_exit_is_fully_waived(result.analysis)
+        result.safety_exit_code != 0 and not _nonzero_safety_exit_is_fully_waived(result.analysis)
         for result in results
     ):
         return 1
@@ -854,10 +853,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     exit_code = exit_code_for_results(results)
     for result in results:
         manifest_name = result.manifest.name
-        if (
-            result.safety_exit_code != 0
-            and _nonzero_safety_exit_is_fully_waived(result.analysis)
-        ):
+        if result.safety_exit_code != 0 and _nonzero_safety_exit_is_fully_waived(result.analysis):
             print(
                 "OK: Safety scan passed for "
                 f"{manifest_name} after {result.analysis.repo_policy_ignored_count} "

--- a/tests/test_run_safety_audit.py
+++ b/tests/test_run_safety_audit.py
@@ -98,6 +98,58 @@ def _write_scan_report(
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
+def _write_mixed_repo_policy_scan_report(path: Path) -> None:
+    payload = {
+        "meta": {"scan_type": "scan"},
+        "scan_results": {
+            "projects": [
+                {
+                    "files": [
+                        {
+                            "location": "requirements.txt",
+                            "results": {
+                                "dependencies": [
+                                    {
+                                        "name": "fonttools",
+                                        "specifications": [
+                                            {
+                                                "raw": "fonttools==4.61.1",
+                                                "vulnerabilities": {
+                                                    "known_vulnerabilities": [
+                                                        {
+                                                            "id": "88739",
+                                                            "vulnerable_spec": "<4.62.0",
+                                                            "CVE": {
+                                                                "cvssv3": {
+                                                                    "base_severity": "UNKNOWN",
+                                                                },
+                                                            },
+                                                        },
+                                                        {
+                                                            "id": "ACTIVE-MEDIUM-HIGH-EXPLOIT",
+                                                            "vulnerable_spec": "<4.62.0",
+                                                            "CVE": {
+                                                                "cvssv3": {
+                                                                    "base_severity": "MEDIUM",
+                                                                },
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            }
+                                        ],
+                                    }
+                                ],
+                            },
+                        }
+                    ]
+                }
+            ]
+        },
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 def _write_manifest(root: Path, name: str, content: str = "example==1.0.0\n") -> None:
     path = root / name
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -465,6 +517,31 @@ def test_low_and_medium_findings_fail_when_safety_exits_nonzero(
 
     assert analysis.status == safety_audit.PARSE_WARNING
     assert safety_audit.exit_code_for_results([result]) == 1
+
+
+def test_nonzero_safety_exit_with_repo_policy_waiver_and_active_finding_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_manifest(tmp_path, "requirements.txt")
+    _write_policy(tmp_path, "88739")
+
+    def fake_run(command: list[str], **_: Any) -> SimpleNamespace:
+        report_path = _report_path_from_scan_command(command)
+        _write_mixed_repo_policy_scan_report(report_path)
+        return SimpleNamespace(returncode=64, stdout="", stderr="")
+
+    monkeypatch.setenv("SAFETY_API_KEY", "test-key")
+    monkeypatch.setattr(safety_audit.shutil, "which", lambda _: "/usr/bin/safety")
+    monkeypatch.setattr(safety_audit.subprocess, "run", fake_run)
+
+    exit_code = safety_audit.main(["--root", str(tmp_path), "--output-dir", str(tmp_path)])
+
+    output = capsys.readouterr().out
+    assert exit_code == 1
+    assert "ERROR: Safety scan exited with code 64 for requirements.txt" in output
+    assert "OK: Safety scan passed for requirements.txt after 1 repo-policy waiver(s)" not in output
 
 
 def test_nonzero_safety_exit_with_only_repo_policy_waiver_passes_aggregate(


### PR DESCRIPTION
### Motivation
- The Safety waiver handling previously allowed a non-zero Safety exit to be treated as success whenever any repo-policy waiver existed, which could mask unwaived active findings (e.g., exploitability failures) and bypass the CI supply-chain gate. 
- The intent is to fail CI for any non-zero Safety exit unless the non-zero exit is fully explained by active repo waivers and no active parsed findings remain.

### Description
- Add a helper `_nonzero_safety_exit_is_fully_waived(analysis: SafetyAnalysis) -> bool` that returns true only when `repo_policy_ignored_count > 0` and `high_risk_count == 0` and `other_count == 0`, and use it to tighten aggregate exit logic in `exit_code_for_results` in `scripts/ci/run_safety_audit.py`.
- Reorder and tighten the aggregate exit logic so `PARSE_BLOCKING` findings fail first and non-zero Safety exits are rejected unless `_nonzero_safety_exit_is_fully_waived(...)` is true.
- Update CLI status reporting in `scripts/ci/run_safety_audit.py` to print the "repo-policy waiver(s)" success message only for fully-waived non-zero exits and to report an error for mixed waived + active findings.
- Add a regression payload helper and test in `tests/test_run_safety_audit.py` that models a mixed report (one waived fonttools finding `88739` plus one active MEDIUM finding with high exploitability) and asserts the scan fails (exit code `1`) and that the waiver success message is not printed.

### Testing
- Ran `python3 scripts/orchestration/check_preflight.py` which passed locally (preflight checks OK).
- Verified syntax by running `python3 -m py_compile scripts/ci/run_safety_audit.py tests/test_run_safety_audit.py` which passed with no syntax errors.
- Performed two manual Python simulations that stubbed `subprocess.run` and exercised `main(...)`: the mixed waived+active report returned `EXIT_CODE=1` (expected fail) and the only- waived report returned `EXIT_CODE=0` (expected pass).
- Note: full `pytest` and Make-based gates (`pre-commit`, `make lint`, `make typecheck`, `make test-fast`, `make diff-cov`) could not be executed in this environment due to missing tooling or interpreter/version differences (`pre-commit` not installed, `pytest`/`fastapi`/`flake8`/`mypy`/`coverage` not available), so the new test file was added but could not be run end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b25987df0832c8549965b45e44db3)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened the CI Safety gate to fail whenever there are unwaived findings. Also formatted the gate script and added a governance mapping doc.

- **Bug Fixes**
  - Enforce fully waived handling for non-zero exits via a new helper and reordered logic; `PARSE_BLOCKING` fails first and mixed waived + active findings fail.
  - Updated CLI messages and added a regression test for mixed reports (fails with exit code 1 and no waiver success message).

<sup>Written for commit 7cd0563d91f5433614895ed062d1f97b0204584f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---
## PR #1957 Governance Closeout

## Lane Start Provenance
- Packet: `artifacts/orchestration/task_packets/5227de7d3e6b.json`
- PR phase: `post_open_review`
- Branch: `codex/task-title`
- Scope: CI Safety audit fail-closed semantics plus canonical governance closeout only.
- Machine-heavy exception: operator-approved; full local `make verify` is intentionally deferred for this PR. Required evidence is narrow local gates, `make validate-changed`, `pre-commit run --all-files`, current-head CI, and strict merge-readiness.

## Experiment Runner Evidence
- Artifact: `artifacts/orchestration/experiments/results/exp-cae8730c8789.json`
- Mode: `oracle_only_governance_reviewer`
- Status: accepted; 2/2 oracle commands passed.
- Contribution: `fixed_mapping_review`; governance commit includes the canonical Experiment Runner co-author trailer.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1957_FIXED_MAPPING.md`

## Merge Readiness
- Not claimed until current-head CI is fresh after push, strict merge readiness passes with auth, review threads remain empty/resolved, bot comments remain no-actionable or dispositioned, and the final review cycle has elapsed.
- Bot-noise dispositions for Codex usage limit, CodeRabbit usage limit, Sourcery usage limit, Cubic no-issues/usage notice, and Codecov coverage are recorded in `docs/review/PR_1957_FIXED_MAPPING.md`.

## Closeout Validation Plan
- `python3 -m py_compile scripts/ci/run_safety_audit.py tests/test_run_safety_audit.py`
- `python3 -m pytest -q tests/test_run_safety_audit.py`
- `git diff --check origin/main...HEAD`
- `make validate-changed`
- `PRE_COMMIT_HOME=/tmp/pre-commit-pr1957 pre-commit run --all-files`
- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1957 --body <current body>`
- `GH_TOKEN=... python3 scripts/orchestration/check_review_threads_disposition.py --pr-number 1957 --require-auth`
- After push/current-head CI: `GH_TOKEN=... GITHUB_TOKEN=... python3 scripts/orchestration/check_merge_ready.py --pr-number 1957 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth`
