### PR TITLE
fix(ci): fail Safety scans with unwaived findings

### DIFF
--- a/scripts/ci/run_safety_audit.py
+++ b/scripts/ci/run_safety_audit.py
@@ -756,15 +756,26 @@ def run_audit(config: SafetyAuditConfig) -> tuple[ManifestAuditResult, ...]:
     return tuple(results)
 
 
+def _nonzero_safety_exit_is_fully_waived(analysis: SafetyAnalysis) -> bool:
+    """Return whether a non-zero Safety exit is fully explained by repo waivers."""
+
+    return (
+        analysis.repo_policy_ignored_count > 0
+        and analysis.high_risk_count == 0
+        and analysis.other_count == 0
+    )
+
+
 def exit_code_for_results(results: Sequence[ManifestAuditResult]) -> int:
     """Return aggregate workflow exit code for parsed Safety results."""
 
+    if any(result.analysis.status == PARSE_BLOCKING for result in results):
+        return 1
     if any(
-        result.safety_exit_code != 0 and result.analysis.repo_policy_ignored_count == 0
+        result.safety_exit_code != 0
+        and not _nonzero_safety_exit_is_fully_waived(result.analysis)
         for result in results
     ):
-        return 1
-    if any(result.analysis.status == PARSE_BLOCKING for result in results):
         return 1
     return 0
 
@@ -845,8 +856,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         manifest_name = result.manifest.name
         if (
             result.safety_exit_code != 0
-            and result.analysis.repo_policy_ignored_count > 0
-            and result.analysis.status != PARSE_BLOCKING
+            and _nonzero_safety_exit_is_fully_waived(result.analysis)
         ):
             print(
                 "OK: Safety scan passed for "

--- a/tests/test_run_safety_audit.py
+++ b/tests/test_run_safety_audit.py
@@ -98,6 +98,58 @@ def _write_scan_report(
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
+def _write_mixed_repo_policy_scan_report(path: Path) -> None:
+    payload = {
+        "meta": {"scan_type": "scan"},
+        "scan_results": {
+            "projects": [
+                {
+                    "files": [
+                        {
+                            "location": "requirements.txt",
+                            "results": {
+                                "dependencies": [
+                                    {
+                                        "name": "fonttools",
+                                        "specifications": [
+                                            {
+                                                "raw": "fonttools==4.61.1",
+                                                "vulnerabilities": {
+                                                    "known_vulnerabilities": [
+                                                        {
+                                                            "id": "88739",
+                                                            "vulnerable_spec": "<4.62.0",
+                                                            "CVE": {
+                                                                "cvssv3": {
+                                                                    "base_severity": "UNKNOWN",
+                                                                },
+                                                            },
+                                                        },
+                                                        {
+                                                            "id": "ACTIVE-MEDIUM-HIGH-EXPLOIT",
+                                                            "vulnerable_spec": "<4.62.0",
+                                                            "CVE": {
+                                                                "cvssv3": {
+                                                                    "base_severity": "MEDIUM",
+                                                                },
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            }
+                                        ],
+                                    }
+                                ],
+                            },
+                        }
+                    ]
+                }
+            ]
+        },
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 def _write_manifest(root: Path, name: str, content: str = "example==1.0.0\n") -> None:
     path = root / name
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -465,6 +517,31 @@ def test_low_and_medium_findings_fail_when_safety_exits_nonzero(
 
     assert analysis.status == safety_audit.PARSE_WARNING
     assert safety_audit.exit_code_for_results([result]) == 1
+
+
+def test_nonzero_safety_exit_with_repo_policy_waiver_and_active_finding_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_manifest(tmp_path, "requirements.txt")
+    _write_policy(tmp_path, "88739")
+
+    def fake_run(command: list[str], **_: Any) -> SimpleNamespace:
+        report_path = _report_path_from_scan_command(command)
+        _write_mixed_repo_policy_scan_report(report_path)
+        return SimpleNamespace(returncode=64, stdout="", stderr="")
+
+    monkeypatch.setenv("SAFETY_API_KEY", "test-key")
+    monkeypatch.setattr(safety_audit.shutil, "which", lambda _: "/usr/bin/safety")
+    monkeypatch.setattr(safety_audit.subprocess, "run", fake_run)
+
+    exit_code = safety_audit.main(["--root", str(tmp_path), "--output-dir", str(tmp_path)])
+
+    output = capsys.readouterr().out
+    assert exit_code == 1
+    assert "ERROR: Safety scan exited with code 64 for requirements.txt" in output
+    assert "OK: Safety scan passed for requirements.txt after 1 repo-policy waiver(s)" not in output
 
 
 def test_nonzero_safety_exit_with_only_repo_policy_waiver_passes_aggregate(


### PR DESCRIPTION
### Motivation
- The Safety waiver handling previously allowed a non-zero Safety exit to be treated as success whenever any repo-policy waiver existed, which could mask unwaived active findings (e.g., exploitability failures) and bypass the CI supply-chain gate. 
- The intent is to fail CI for any non-zero Safety exit unless the non-zero exit is fully explained by active repo waivers and no active parsed findings remain.

### Description
- Add a helper `_nonzero_safety_exit_is_fully_waived(analysis: SafetyAnalysis) -> bool` that returns true only when `repo_policy_ignored_count > 0` and `high_risk_count == 0` and `other_count == 0`, and use it to tighten aggregate exit logic in `exit_code_for_results` in `scripts/ci/run_safety_audit.py`.
- Reorder and tighten the aggregate exit logic so `PARSE_BLOCKING` findings fail first and non-zero Safety exits are rejected unless `_nonzero_safety_exit_is_fully_waived(...)` is true.
- Update CLI status reporting in `scripts/ci/run_safety_audit.py` to print the "repo-policy waiver(s)" success message only for fully-waived non-zero exits and to report an error for mixed waived + active findings.
- Add a regression payload helper and test in `tests/test_run_safety_audit.py` that models a mixed report (one waived fonttools finding `88739` plus one active MEDIUM finding with high exploitability) and asserts the scan fails (exit code `1`) and that the waiver success message is not printed.

### Testing
- Ran `python3 scripts/orchestration/check_preflight.py` which passed locally (preflight checks OK).
- Verified syntax by running `python3 -m py_compile scripts/ci/run_safety_audit.py tests/test_run_safety_audit.py` which passed with no syntax errors.
- Performed two manual Python simulations that stubbed `subprocess.run` and exercised `main(...)`: the mixed waived+active report returned `EXIT_CODE=1` (expected fail) and the only- waived report returned `EXIT_CODE=0` (expected pass).
- Note: full `pytest` and Make-based gates (`pre-commit`, `make lint`, `make typecheck`, `make test-fast`, `make diff-cov`) could not be executed in this environment due to missing tooling or interpreter/version differences (`pre-commit` not installed, `pytest`/`fastapi`/`flake8`/`mypy`/`coverage` not available), so the new test file was added but could not be run end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b25987df0832c8549965b45e44db3)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Safety scans fail in CI when there are unwaived active findings. Non-zero Safety exits now only pass if they’re fully covered by repo-policy waivers with no remaining active findings.

- **Bug Fixes**
  - Tightened exit logic: fail on PARSE_BLOCKING first; non-zero Safety exits pass only if fully waived.
  - Added `_nonzero_safety_exit_is_fully_waived(...)` to require waivers and zero high/other findings.
  - Updated CLI messages and added a regression test for mixed waived + active findings.

<sup>Written for commit c453de483778cef2939a872629313e95d75fe450. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

