### PR TITLE
fix(security): suppress exact perl-base Trivy alert

### DIFF
--- a/docs/review/PR_1968_FIXED_MAPPING.md
+++ b/docs/review/PR_1968_FIXED_MAPPING.md
@@ -171,11 +171,13 @@ OUT:
 
 ## Merge Readiness
 
-- [x] Real implementation commit exists.
-- [x] Canonical fixed-mapping artifact exists.
-- [x] Focused local gates passed.
-- [x] Full local `make verify` deferral is documented.
-- [x] Post-open role loop completed after bot review.
+- Final merge-cycle checklist is intentionally left unchecked until the final
+  strict merge-readiness pass immediately before merge.
+- [ ] Real implementation commit exists.
+- [ ] Canonical fixed-mapping artifact exists.
+- [ ] Focused local gates passed.
+- [ ] Full local `make verify` deferral is documented.
+- [ ] Post-open role loop completed after bot review.
 - [ ] `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1968 --body "$(gh pr view 1968 --repo Katsiarynakavaleuskaya/PulsePlate --json body --jq .body)"` passes after this artifact update is mirrored to the PR body.
 - [ ] `GH_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_review_threads_disposition.py --pr-number 1968 --require-auth` passes after this artifact update is pushed.
 - [ ] `GH_TOKEN="$(gh auth token)" GITHUB_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_merge_ready.py --pr-number 1968 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth` passes.

--- a/docs/review/PR_1968_FIXED_MAPPING.md
+++ b/docs/review/PR_1968_FIXED_MAPPING.md
@@ -31,17 +31,17 @@ finding without weakening fail-closed Trivy scan behavior.
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#discussion_r3405939500 -> `1a37e7820eab7baedfb94bf4a3f9fec4c21e937c`
-  Disposition: FIXED.
-  Evidence: `docs/security/CVE-2026-48959-perl-base.md:31` replaces the
-  ambiguous `lane` wording with `finding` for the blank fixed-version
-  disposition.
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#pullrequestreview-4488809272 -> `1a37e7820eab7baedfb94bf4a3f9fec4c21e937c`
-  Disposition: FIXED.
-  Evidence: `docs/security/CVE-2026-48959-perl-base.md:63` states the source
-  policy file is `trivy/ignore-policy.rego`; lines 63-65 state the workflow
-  copies it to `.trivy-ignore-policy.rego` before passing that generated path
-  to Trivy in `.github/workflows/build.yml:441`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#discussion_r3405939500 -> 1a37e7820eab7baedfb94bf4a3f9fec4c21e937c
+Disposition: FIXED
+Commit: 1a37e7820eab7baedfb94bf4a3f9fec4c21e937c
+Evidence: `docs/security/CVE-2026-48959-perl-base.md:31` replaces the ambiguous `lane` wording with `finding` for the blank fixed-version disposition.
+Reason: Sourcery flagged the wording as a typo; the committed doc text now uses the reviewed finding terminology.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#pullrequestreview-4488809272 -> 1a37e7820eab7baedfb94bf4a3f9fec4c21e937c
+Disposition: FIXED
+Commit: 1a37e7820eab7baedfb94bf4a3f9fec4c21e937c
+Evidence: `docs/security/CVE-2026-48959-perl-base.md:63` names `trivy/ignore-policy.rego`; `docs/security/CVE-2026-48959-perl-base.md:64` documents the generated `.trivy-ignore-policy.rego` path used by `.github/workflows/build.yml:441`.
+Reason: Sourcery flagged a policy-path ambiguity; the committed doc text now separates source policy path from the workflow-generated Trivy path.
 
 ## Scope
 

--- a/docs/review/PR_1968_FIXED_MAPPING.md
+++ b/docs/review/PR_1968_FIXED_MAPPING.md
@@ -14,7 +14,7 @@ finding without weakening fail-closed Trivy scan behavior.
 - Branch: `codex/stabilize-main-trivy-perl-base-cve-2026-48959`
 - PR phase: `post_open_review`
 - Implementation commit: `1d47d65c7aecba1700fa341b0b60fee30b3500a0`
-- Sourcery doc-clarity fix commit: `1a37e7820eab7baedfb94bf4a3f9fec4c21e937c`
+- Sourcery doc-clarity fix commit: `1a37e7820a3764d3e11e383f5600841ed324ae78`
 - Packet: `artifacts/orchestration/task_packets/7d26be3d0cc9.json`
 - Pre-open packet: `artifacts/orchestration/task_packets/6338fa0a7e51.json`
 - Post-open packet: `artifacts/orchestration/task_packets/7d26be3d0cc9.json`
@@ -31,15 +31,15 @@ finding without weakening fail-closed Trivy scan behavior.
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#discussion_r3405939500 -> 1a37e7820eab7baedfb94bf4a3f9fec4c21e937c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#discussion_r3405939500 -> 1a37e7820a3764d3e11e383f5600841ed324ae78
 Disposition: FIXED
-Commit: 1a37e7820eab7baedfb94bf4a3f9fec4c21e937c
+Commit: 1a37e7820a3764d3e11e383f5600841ed324ae78
 Evidence: `docs/security/CVE-2026-48959-perl-base.md:31` replaces the ambiguous `lane` wording with `finding` for the blank fixed-version disposition.
 Reason: Sourcery flagged the wording as a typo; the committed doc text now uses the reviewed finding terminology.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#pullrequestreview-4488809272 -> 1a37e7820eab7baedfb94bf4a3f9fec4c21e937c
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#pullrequestreview-4488809272 -> 1a37e7820a3764d3e11e383f5600841ed324ae78
 Disposition: FIXED
-Commit: 1a37e7820eab7baedfb94bf4a3f9fec4c21e937c
+Commit: 1a37e7820a3764d3e11e383f5600841ed324ae78
 Evidence: `docs/security/CVE-2026-48959-perl-base.md:63` names `trivy/ignore-policy.rego`; `docs/security/CVE-2026-48959-perl-base.md:64` documents the generated `.trivy-ignore-policy.rego` path used by `.github/workflows/build.yml:441`.
 Reason: Sourcery flagged a policy-path ambiguity; the committed doc text now separates source policy path from the workflow-generated Trivy path.
 
@@ -122,7 +122,7 @@ OUT:
 - PASS: `pre-commit run --all-files`
 - PASS: commit hooks and pre-push hooks with repo-approved `VENV_PYTHON`.
 - PASS: Sourcery doc-clarity focused rerun after commit
-  `1a37e7820eab7baedfb94bf4a3f9fec4c21e937c`:
+  `1a37e7820a3764d3e11e383f5600841ed324ae78`:
   `python3 scripts/ci/check_trivy_ignore_policy_expiry.py`,
   `python -m pytest -q tests/test_trivy_ignore_policy_expiry.py`
   (`12 passed`), `python scripts/ci/check_docs_phase1_gates.py --files

--- a/docs/review/PR_1968_FIXED_MAPPING.md
+++ b/docs/review/PR_1968_FIXED_MAPPING.md
@@ -14,6 +14,7 @@ finding without weakening fail-closed Trivy scan behavior.
 - Branch: `codex/stabilize-main-trivy-perl-base-cve-2026-48959`
 - PR phase: `post_open_review`
 - Implementation commit: `1d47d65c7aecba1700fa341b0b60fee30b3500a0`
+- Sourcery doc-clarity fix commit: `1a37e7820eab7baedfb94bf4a3f9fec4c21e937c`
 - Packet: `artifacts/orchestration/task_packets/7d26be3d0cc9.json`
 - Pre-open packet: `artifacts/orchestration/task_packets/6338fa0a7e51.json`
 - Post-open packet: `artifacts/orchestration/task_packets/7d26be3d0cc9.json`
@@ -25,12 +26,22 @@ finding without weakening fail-closed Trivy scan behavior.
 
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
-- [x] No actionable review threads existed when this artifact was created.
-- [ ] Re-check review threads after bot review completes.
+- [x] Sourcery review feedback mapped with FIXED disposition.
+- [ ] Re-check review threads after resolving the mapped Sourcery discussion.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#discussion_r3405939500 -> `1a37e7820eab7baedfb94bf4a3f9fec4c21e937c`
+  Disposition: FIXED.
+  Evidence: `docs/security/CVE-2026-48959-perl-base.md:31` replaces the
+  ambiguous `lane` wording with `finding` for the blank fixed-version
+  disposition.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#pullrequestreview-4488809272 -> `1a37e7820eab7baedfb94bf4a3f9fec4c21e937c`
+  Disposition: FIXED.
+  Evidence: `docs/security/CVE-2026-48959-perl-base.md:63` states the source
+  policy file is `trivy/ignore-policy.rego`; lines 63-65 state the workflow
+  copies it to `.trivy-ignore-policy.rego` before passing that generated path
+  to Trivy in `.github/workflows/build.yml:441`.
 
 ## Scope
 
@@ -110,6 +121,13 @@ OUT:
 - PASS: `make validate-changed`
 - PASS: `pre-commit run --all-files`
 - PASS: commit hooks and pre-push hooks with repo-approved `VENV_PYTHON`.
+- PASS: Sourcery doc-clarity focused rerun after commit
+  `1a37e7820eab7baedfb94bf4a3f9fec4c21e937c`:
+  `python3 scripts/ci/check_trivy_ignore_policy_expiry.py`,
+  `python -m pytest -q tests/test_trivy_ignore_policy_expiry.py`
+  (`12 passed`), `python scripts/ci/check_docs_phase1_gates.py --files
+  docs/security/CVE-2026-48959-perl-base.md`, `git diff --check`,
+  `make validate-changed`, and `pre-commit run --all-files`.
 - NOT RUN: full local `make verify`; intentionally deferred under the
   operator-approved machine-heavy exception.
 

--- a/docs/review/PR_1968_FIXED_MAPPING.md
+++ b/docs/review/PR_1968_FIXED_MAPPING.md
@@ -1,0 +1,134 @@
+# PR 1968 Fixed in Commit Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968>
+
+## Summary
+
+This PR stabilizes the Docker publish path after PR #1935 correctly blocked
+post-merge GHCR publish on Trivy alert `#610` / `CVE-2026-48959`. The hotfix
+adds a temporary exact Rego policy disposition for the observed `perl-base`
+finding without weakening fail-closed Trivy scan behavior.
+
+## Lane Start Provenance
+
+- Branch: `codex/stabilize-main-trivy-perl-base-cve-2026-48959`
+- PR phase: `post_open_review`
+- Implementation commit: `1d47d65c7aecba1700fa341b0b60fee30b3500a0`
+- Packet: `artifacts/orchestration/task_packets/7d26be3d0cc9.json`
+- Pre-open packet: `artifacts/orchestration/task_packets/6338fa0a7e51.json`
+- Post-open packet: `artifacts/orchestration/task_packets/7d26be3d0cc9.json`
+- Machine-heavy exception: full local `make verify` is intentionally deferred
+  under the operator-approved CI/tooling machine-heavy exception. Focused local
+  gates plus current-head CI and Docker publish evidence are required.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] No actionable review threads existed when this artifact was created.
+- [ ] Re-check review threads after bot review completes.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Scope
+
+IN:
+
+- `trivy/ignore-policy.rego`
+- `docs/security/CVE-2026-48959-perl-base.md`
+- `tests/test_trivy_ignore_policy_expiry.py`
+- `docs/roadmap/BACKLOG_LEDGER.md`
+- `docs/review/PR_1968_FIXED_MAPPING.md`
+
+OUT:
+
+- Dockerfile/base-image migration.
+- Workflow or Trivy fail-closed behavior changes.
+- `.trivyignore` broad CVE-only suppression for `CVE-2026-48959`.
+- Product runtime, API, OpenAPI, frontend, or iOS changes.
+
+## Role Dispatch Evidence
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open`
+- PASS: `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase post_open_review`
+- Declared pre-open role order executed:
+  `agent-coordinator -> security-auditor -> qa-engineer-agent -> bug-hunter -> architecture-specialist`.
+- `agent-coordinator`: constrained the hotfix to exact Rego policy, security doc,
+  tests, and backlog tracking.
+- `security-auditor`: accepted only a temporary exact policy disposition and
+  required CVE/package/version/PkgID/fixed-version-unavailable matching.
+- `qa-engineer-agent`: required negative controls for populated `FixedVersion`,
+  no `.trivyignore` entry, and remote Docker publish proof.
+- `bug-hunter`: identified stale anchor and false-suppression risks; the new doc
+  uses current anchors and tests include negative canary cases.
+- `architecture-specialist`: confirmed this is policy/docs/tests/backlog only,
+  with no Dockerfile/workflow/app changes.
+
+## Premortem Finding Closure
+
+- `PM-1968-001` Suppression is too broad and hides future fixed versions.
+  Disposition: FIXED.
+  Evidence: commit `1d47d65c7aecba1700fa341b0b60fee30b3500a0` matches exact CVE,
+  package, installed version, PkgID prefix, and absent/empty/null `FixedVersion`.
+- `PM-1968-002` Hotfix weakens the fail-closed publish gate.
+  Disposition: NOT-A-BUG.
+  Evidence: no `.github/workflows/*` files changed; PR #1935 publish gate remains
+  fail-closed.
+- `PM-1968-003` Temporary suppression becomes untracked debt.
+  Disposition: FIXED.
+  Evidence: `docs/roadmap/BACKLOG_LEDGER.md` tracks alert `#610`, removal
+  conditions, and the Perl-family remediation deadline.
+- `PM-1968-004` Local tests cannot prove GitHub publish SARIF behavior.
+  Disposition: NOT-A-BUG.
+  Evidence: current-head Docker publish evidence is required before merge.
+
+## Experiment Runner Evidence
+
+- Artifact:
+  `artifacts/orchestration/experiments/results/artifacts/orchestration/experiments/results/pr-main-cve-2026-48959-oracle-result.json`
+- Experiment ID: `exp-8a06dbffc0b9`
+- Mode: `oracle_only_governance_reviewer`
+- Status: `accepted`
+- Contribution: `oracle_review`
+- Co-author required: `true`; implementation commit uses
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+
+## Validation Evidence
+
+- PASS: `python3 scripts/orchestration/check_preflight.py --path docs/roadmap/BACKLOG_LEDGER.md --path docs/security/CVE-2026-48959-perl-base.md --path tests/test_trivy_ignore_policy_expiry.py --path trivy/ignore-policy.rego`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `python3 scripts/ci/check_trivy_ignore_policy_expiry.py`
+- PASS: `python -m pytest -q tests/test_trivy_ignore_policy_expiry.py` (`12 passed`).
+- PASS: `python scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-48959-perl-base.md`
+- PASS: focused workflow contract pytest for publish scan and Trivy action
+  contracts (`3 passed`).
+- PASS: `git diff --check`
+- PASS: `make validate-changed`
+- PASS: `pre-commit run --all-files`
+- PASS: commit hooks and pre-push hooks with repo-approved `VENV_PYTHON`.
+- NOT RUN: full local `make verify`; intentionally deferred under the
+  operator-approved machine-heavy exception.
+
+## Deferred / Follow-ups
+
+- Existing backlog item `ledger-p1-container-perl-cve-remediation` tracks
+  removal through fixed Debian package, base-image migration, or runtime Perl
+  removal.
+
+## Merge Readiness
+
+- [x] Real implementation commit exists.
+- [x] Canonical fixed-mapping artifact exists.
+- [x] Focused local gates passed.
+- [x] Full local `make verify` deferral is documented.
+- [ ] Post-open role loop completed after bot review.
+- [ ] `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1968 --body "$(gh pr view 1968 --repo Katsiarynakavaleuskaya/PulsePlate --json body --jq .body)"` passes.
+- [ ] `GH_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_review_threads_disposition.py --pr-number 1968 --require-auth` passes.
+- [ ] `GH_TOKEN="$(gh auth token)" GITHUB_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_merge_ready.py --pr-number 1968 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth` passes.
+- [ ] Current-head PR CI is green.
+- [ ] Docker publish path proves Trivy/SARIF passes before GHCR publish on the
+  relevant current head.

--- a/docs/review/PR_1968_FIXED_MAPPING.md
+++ b/docs/review/PR_1968_FIXED_MAPPING.md
@@ -27,7 +27,7 @@ finding without weakening fail-closed Trivy scan behavior.
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 - [x] Sourcery review feedback mapped with FIXED disposition.
-- [ ] Re-check review threads after resolving the mapped Sourcery discussion.
+- [x] Re-check review threads after resolving the mapped Sourcery discussion.
 
 ## Fixed in Commit Mapping
 
@@ -78,6 +78,20 @@ OUT:
   uses current anchors and tests include negative canary cases.
 - `architecture-specialist`: confirmed this is policy/docs/tests/backlog only,
   with no Dockerfile/workflow/app changes.
+- Mandatory post-open review stack executed after bot review:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- Post-open `qa-engineer-agent`: no QA/test-sufficiency blocker; identified
+  Sourcery mapping/disposition as the remaining governance blocker.
+- Post-open `bug-hunter`: no Rego/Trivy implementation blocker; confirmed the
+  Sourcery feedback was documentation clarity and mapping/disposition work.
+- Post-open `security-auditor`: no blocking or nonblocking findings; confirmed
+  the suppression remains exact, `.trivyignore` is not broadened, fail-closed
+  publish behavior is unchanged, and docs/mapping do not claim premature proof.
+- Codex Security diff scan: current-head report
+  `/tmp/codex-security-scans/PulsePlate-main-trivy-hotfix/1b6fbf4b8b00_20260612T210539Z/report.md`
+  validated with zero reportable findings.
+- `pulseplate-pr-review`: dry-run report generated at
+  `/tmp/pr1968_pr_review_report.md`; calibration tests passed.
 
 ## Premortem Finding Closure
 
@@ -96,6 +110,13 @@ OUT:
 - `PM-1968-004` Local tests cannot prove GitHub publish SARIF behavior.
   Disposition: NOT-A-BUG.
   Evidence: current-head Docker publish evidence is required before merge.
+- `PPR-1968-001` `pulseplate-pr-review` advisory large-diff note.
+  Disposition: NOT-A-BUG.
+  Evidence: current GitHub PR diff contains the five intended files only;
+  `make validate-changed` passed; Codex Security current-head diff scan found
+  zero reportable findings; the line count is expected for a security note plus
+  canonical mapping artifact and does not indicate an unscoped implementation
+  expansion.
 
 ## Experiment Runner Evidence
 
@@ -128,6 +149,17 @@ OUT:
   (`12 passed`), `python scripts/ci/check_docs_phase1_gates.py --files
   docs/security/CVE-2026-48959-perl-base.md`, `git diff --check`,
   `make validate-changed`, and `pre-commit run --all-files`.
+- PASS: after merging latest `origin/main` to current head
+  `1b6fbf4b8b00bc5b7f9776b9f6bd320817326f97`:
+  `python3 scripts/orchestration/check_preflight.py --path ...`,
+  `python3 scripts/orchestration/check_agent_consistency.py`,
+  `python3 scripts/ci/check_trivy_ignore_policy_expiry.py`,
+  `python -m pytest -q tests/test_trivy_ignore_policy_expiry.py`
+  (`12 passed`), `python scripts/ci/check_docs_phase1_gates.py --files
+  docs/security/CVE-2026-48959-perl-base.md`, `git diff --check`,
+  `make validate-changed`, `pre-commit run --all-files`, and pre-push hooks.
+- PASS: `python3 -m pytest tests/test_pr_review_context.py
+  tests/test_pr_review_report.py -q` (`13 passed`) with repo venv.
 - NOT RUN: full local `make verify`; intentionally deferred under the
   operator-approved machine-heavy exception.
 
@@ -143,9 +175,9 @@ OUT:
 - [x] Canonical fixed-mapping artifact exists.
 - [x] Focused local gates passed.
 - [x] Full local `make verify` deferral is documented.
-- [ ] Post-open role loop completed after bot review.
-- [ ] `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1968 --body "$(gh pr view 1968 --repo Katsiarynakavaleuskaya/PulsePlate --json body --jq .body)"` passes.
-- [ ] `GH_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_review_threads_disposition.py --pr-number 1968 --require-auth` passes.
+- [x] Post-open role loop completed after bot review.
+- [ ] `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1968 --body "$(gh pr view 1968 --repo Katsiarynakavaleuskaya/PulsePlate --json body --jq .body)"` passes after this artifact update is mirrored to the PR body.
+- [ ] `GH_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_review_threads_disposition.py --pr-number 1968 --require-auth` passes after this artifact update is pushed.
 - [ ] `GH_TOKEN="$(gh auth token)" GITHUB_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_merge_ready.py --pr-number 1968 --repo Katsiarynakavaleuskaya/PulsePlate --require-auth` passes.
 - [ ] Current-head PR CI is green.
 - [ ] Docker publish path proves Trivy/SARIF passes before GHCR publish on the

--- a/docs/review/PR_1968_FIXED_MAPPING.md
+++ b/docs/review/PR_1968_FIXED_MAPPING.md
@@ -43,6 +43,18 @@ Commit: 1a37e7820a3764d3e11e383f5600841ed324ae78
 Evidence: `docs/security/CVE-2026-48959-perl-base.md:63` names `trivy/ignore-policy.rego`; `docs/security/CVE-2026-48959-perl-base.md:64` documents the generated `.trivy-ignore-policy.rego` path used by `.github/workflows/build.yml:441`.
 Reason: Sourcery flagged a policy-path ambiguity; the committed doc text now separates source policy path from the workflow-generated Trivy path.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#discussion_r3406133288 -> 6b4920ce884a250836cc9203b6262ed07700b69f
+Disposition: FIXED
+Commit: 6b4920ce884a250836cc9203b6262ed07700b69f
+Evidence: `docs/review/PR_1968_FIXED_MAPPING.md:186` states the final merge-cycle checklist remains unchecked until the strict merge-readiness pass before merge.
+Reason: CodeRabbit flagged pre-checked merge-readiness boxes; the artifact now separates validation evidence from final merge-cycle checklist completion.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#pullrequestreview-4489078532 -> 6b4920ce884a250836cc9203b6262ed07700b69f
+Disposition: FIXED
+Commit: 6b4920ce884a250836cc9203b6262ed07700b69f
+Evidence: `docs/review/PR_1968_FIXED_MAPPING.md:186` states the final merge-cycle checklist remains unchecked until the strict merge-readiness pass before merge.
+Reason: CodeRabbit review summarized the same actionable checklist issue; fixed by leaving final merge-cycle boxes unchecked.
+
 ## Scope
 
 IN:

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -142,14 +142,14 @@ If it is not recorded here — it does not exist.
     - Each implementation PR runs coordinator-first startup, explicit role passes, premortem closure, Experiment Runner oracle-only evidence, post-open QA/bug/security passes, Codex Security scan when available, and `pulseplate-pr-review`.
 
 <a id="ledger-p1-container-perl-cve-remediation"></a>
-- [ ] P1: Container image Perl / IO::Compress / Archive::Tar CVE remediation (CVE-2026-9538, CVE-2026-42497, CVE-2026-8376, CVE-2026-42496, CVE-2026-48962)
+- [ ] P1: Container image Perl / IO::Compress / Archive::Tar CVE remediation (CVE-2026-9538, CVE-2026-42497, CVE-2026-8376, CVE-2026-42496, CVE-2026-48959, CVE-2026-48962)
   - Owner: @katsiaryna_kavaleuskaya (Security/SRE)
   - Priority: P1
   - Target PR: TBD (evaluation deadline 2026-08-27)
   - Status: Open
   - Area: security / container / supply-chain
-  - Reason (EN): Perl-family CVEs are suppressed because Debian bookworm has no actionable upstream fix for the observed image package lines. Four Archive::Tar CVEs are currently tracked in `.trivyignore`; GitHub code-scanning alert #602 reports CVE-2026-48962 against `perl-base 5.36.0-7+deb12u3` with blank fixed version, covered by exact `trivy/ignore-policy.rego` matching. Our Python-only runtime does not execute Perl, Archive::Tar, or IO::Compress/File::GlobMapper on attacker-controlled input, but suppression without a remediation path is technical debt. This item tracks the 90-day re-evaluation trigger mandated by the security fix PRs.
-  - Links: `.trivyignore` (Perl CVE block), `trivy/ignore-policy.rego`, `Dockerfile`, `docs/security/CVE-2026-48962-perl-base.md`, `docs/security/`
+  - Reason (EN): Perl-family CVEs are suppressed because Debian bookworm has no actionable upstream fix for the observed image package lines. Four Archive::Tar CVEs are currently tracked in `.trivyignore`; GitHub code-scanning alert #610 reports CVE-2026-48959 and alert #602 reports CVE-2026-48962 against `perl-base 5.36.0-7+deb12u3` with blank fixed versions, covered by exact `trivy/ignore-policy.rego` matching. Our Python-only runtime does not execute Perl, Archive::Tar, IO::Uncompress::Unzip, or IO::Compress/File::GlobMapper on attacker-controlled input, but suppression without a remediation path is technical debt. This item tracks the 90-day re-evaluation trigger mandated by the security fix PRs.
+  - Links: `.trivyignore` (Perl CVE block), `trivy/ignore-policy.rego`, `Dockerfile`, `docs/security/CVE-2026-48959-perl-base.md`, `docs/security/CVE-2026-48962-perl-base.md`, `docs/security/`
   - DoD: Either (a) Debian bookworm publishes fixed perl-base/perl-modules-5.36 / IO::Compress package lines and the `.trivyignore` / `trivy/ignore-policy.rego` entries are removed, or (b) project migrates to a base image that eliminates Perl from the runtime (e.g., `python:3.13.x-slim-trixie`, `gcr.io/distroless/python3`, or custom minimal image) with passing Trivy scan and green CI.
 
 <a id="ledger-p1-private-pypi-proxy-mirror-parity"></a>

--- a/docs/security/CVE-2026-48959-perl-base.md
+++ b/docs/security/CVE-2026-48959-perl-base.md
@@ -28,7 +28,7 @@ Severity: HIGH
 Fixed Version:
 ```
 
-The blank fixed version is the reason this lane uses a policy disposition
+The blank fixed version is the reason this finding uses a policy disposition
 instead of a package bump.
 
 ## Upstream status
@@ -59,9 +59,10 @@ PulsePlate's production application is a Python FastAPI runtime. The current
 repository evidence shows package presence in the Debian base image, not a
 product API, OpenAPI contract, backend route, frontend, iOS, or SQLite runtime
 exposure. The production Docker image is built from
-`python:3.13.13-slim-bookworm` in `Dockerfile:9` and `Dockerfile:121`, and the
-publish image scan uses `.trivy-ignore-policy.rego` in
-`.github/workflows/build.yml:441`.
+`python:3.13.13-slim-bookworm` in `Dockerfile:9` and `Dockerfile:121`. The
+source suppression policy is `trivy/ignore-policy.rego`; the publish workflow
+copies it to `.trivy-ignore-policy.rego` before passing that generated path to
+Trivy in `.github/workflows/build.yml:441`.
 
 This does not make the vulnerable package acceptable indefinitely. The
 suppression is temporary because the vulnerable OS package is still present in

--- a/docs/security/CVE-2026-48959-perl-base.md
+++ b/docs/security/CVE-2026-48959-perl-base.md
@@ -1,0 +1,106 @@
+# CVE-2026-48959 - perl-base / IO::Uncompress::Unzip - Trivy alert #610 policy disposition
+
+## Summary
+
+- **CVE**: CVE-2026-48959
+- **Package**: `perl-base`
+- **Observed installed version**: `5.36.0-7+deb12u3`
+- **Trivy rule**: `OsPackageVulnerability`
+- **Severity**: High
+- **GitHub alert**: `security/code-scanning/610`
+- **Disposition**: temporary, exact Trivy Rego policy suppression
+
+This is an OS package finding inherited from the Debian bookworm Python base
+image used by the production container. This hotfix does not remediate upstream
+Perl packages and does not close the vulnerability by package upgrade. It keeps
+the Trivy signal exact and time-boxed while Debian/Trivy metadata remains
+unactionable for the current image context.
+
+## Observed alert evidence
+
+GitHub code scanning reports alert `#610` as:
+
+```text
+Package: perl-base
+Installed Version: 5.36.0-7+deb12u3
+Vulnerability CVE-2026-48959
+Severity: HIGH
+Fixed Version:
+```
+
+The blank fixed version is the reason this lane uses a policy disposition
+instead of a package bump.
+
+## Upstream status
+
+- **Debian Security Tracker**:
+  <https://security-tracker.debian.org/tracker/CVE-2026-48959>
+- **NVD**:
+  <https://nvd.nist.gov/vuln/detail/CVE-2026-48959>
+- **IO-Compress upstream changes**:
+  <https://metacpan.org/release/PMQS/IO-Compress-2.220/changes>
+- **Debian status at review time**:
+  - `perl` source package: vulnerable in bookworm
+  - bookworm `perl 5.36.0-7+deb12u3`: vulnerable
+  - fixed package line appears in forky/sid as `5.40.1-8`, not in the
+    bookworm package line used by the production image
+- **NVD status at review time**:
+  - NVD assessment not yet provided
+  - CISA ADP score: `7.5 HIGH`
+
+## Runtime exposure assessment
+
+CVE-2026-48959 affects `IO::Uncompress::Unzip` behavior where processing a ZIP
+file with many entries can consume excessive CPU resources. Exploitation
+requires Perl code that processes attacker-controlled ZIP input through the
+affected Perl `IO::Uncompress::Unzip` path.
+
+PulsePlate's production application is a Python FastAPI runtime. The current
+repository evidence shows package presence in the Debian base image, not a
+product API, OpenAPI contract, backend route, frontend, iOS, or SQLite runtime
+exposure. The production Docker image is built from
+`python:3.13.13-slim-bookworm` in `Dockerfile:9` and `Dockerfile:121`, and the
+publish image scan uses `.trivy-ignore-policy.rego` in
+`.github/workflows/build.yml:441`.
+
+This does not make the vulnerable package acceptable indefinitely. The
+suppression is temporary because the vulnerable OS package is still present in
+the image.
+
+## Suppression implementation
+
+- Policy file: `trivy/ignore-policy.rego`
+- Shared expiry marker: `Suppression expires: 2026-06-27`
+- Per-rule review marker: `Review-by: 2026-06-27`
+- Rule matches:
+  - `input.VulnerabilityID == "CVE-2026-48959"`
+  - `input.PkgName == "perl-base"`
+  - `input.InstalledVersion == "5.36.0-7+deb12u3"`
+  - `startswith(input.PkgID, "perl-base@5.36.0-7+deb12u3")`
+  - fixed version remains unavailable (`FixedVersion` absent, empty, or null)
+
+The CVE is intentionally not added to `.trivyignore`; that file is CVE-only and
+would be too broad for this alert.
+
+## Removal condition
+
+Remove this suppression when any of the following is true:
+
+1. Debian bookworm publishes a fixed `perl` / `perl-base` package for
+   CVE-2026-48959.
+2. Trivy or GitHub code scanning reports a fixed version for alert `#610` in
+   the production image context.
+3. Production removes `perl-base` with passing Docker smoke and Trivy image
+   evidence.
+
+## Local evidence limitations
+
+Local policy and coupling tests can prove the suppression is exact and
+time-boxed. They cannot prove GitHub's publish image SARIF path closes alert
+`#610`. Current-head Docker publish evidence is required after push before any
+readiness claim for this hotfix.
+
+## Review / expiry
+
+- **Review-by**: 2026-06-27
+- **Last reviewed**: 2026-06-12

--- a/tests/test_trivy_ignore_policy_expiry.py
+++ b/tests/test_trivy_ignore_policy_expiry.py
@@ -9,7 +9,8 @@ from scripts.ci.check_trivy_ignore_policy_expiry import evaluate_policy_file
 REPO_ROOT = Path(__file__).resolve().parents[1]
 POLICY_PATH = REPO_ROOT / "trivy" / "ignore-policy.rego"
 TRIVYIGNORE_PATH = REPO_ROOT / ".trivyignore"
-SECURITY_DOC_PATH = REPO_ROOT / "docs" / "security" / "CVE-2026-48962-perl-base.md"
+SECURITY_DOC_48959_PATH = REPO_ROOT / "docs" / "security" / "CVE-2026-48959-perl-base.md"
+SECURITY_DOC_48962_PATH = REPO_ROOT / "docs" / "security" / "CVE-2026-48962-perl-base.md"
 BACKLOG_PATH = REPO_ROOT / "docs" / "roadmap" / "BACKLOG_LEDGER.md"
 
 
@@ -26,6 +27,28 @@ def _cve_2026_48962_policy_block() -> str:
     )
     assert match is not None, "missing CVE-2026-48962 perl-base Rego block"
     return match.group(0)
+
+
+def _cve_2026_48959_policy_block() -> str:
+    text = _policy_text()
+    match = re.search(
+        r"# CVE-2026-48959 \(perl-base / IO::Uncompress::Unzip\).*?(?=\n# CVE-|\Z)",
+        text,
+        flags=re.DOTALL,
+    )
+    assert match is not None, "missing CVE-2026-48959 perl-base Rego block"
+    return match.group(0)
+
+
+def _cve_2026_48959_expected_match(finding: dict[str, object]) -> bool:
+    fixed_version = finding.get("FixedVersion")
+    return (
+        finding.get("VulnerabilityID") == "CVE-2026-48959"
+        and finding.get("PkgName") == "perl-base"
+        and finding.get("InstalledVersion") == "5.36.0-7+deb12u3"
+        and str(finding.get("PkgID", "")).startswith("perl-base@5.36.0-7+deb12u3")
+        and (fixed_version is None or fixed_version == "")
+    )
 
 
 def test_trivy_policy_guard_accepts_unexpired_policy_and_review_dates(tmp_path: Path) -> None:
@@ -150,14 +173,68 @@ def test_cve_2026_48962_policy_is_exact_and_timeboxed() -> None:
     assert len(re.findall(r"^# Suppression expires:", policy, flags=re.MULTILINE)) == 1
 
 
+def test_cve_2026_48959_policy_is_exact_and_timeboxed() -> None:
+    block = _cve_2026_48959_policy_block()
+
+    assert "# Review-by: 2026-06-27 (manual removal)" in block
+    assert 'input.VulnerabilityID == "CVE-2026-48959"' in block
+    assert 'input.PkgName == "perl-base"' in block
+    assert 'input.InstalledVersion == "5.36.0-7+deb12u3"' in block
+    assert 'startswith(input.PkgID, "perl-base@5.36.0-7+deb12u3")' in block
+    assert "cve_2026_48959_perl_base_fixed_version_unavailable" in block
+    assert "not input.FixedVersion" in block
+    assert 'input.FixedVersion == ""' in block
+    assert "input.FixedVersion == null" in block
+    assert "contains(input.PkgID" not in block
+    assert "IO::Uncompress::Unzip" in block
+    assert "File::GlobMapper" not in block
+
+    policy = _policy_text()
+    assert len(re.findall(r"^# Suppression expires:", policy, flags=re.MULTILINE)) == 1
+
+
+def test_cve_2026_48959_policy_canary_cases_are_exact() -> None:
+    block = _cve_2026_48959_policy_block()
+    assert "cve_2026_48959_perl_base_version_match" in block
+    assert "cve_2026_48959_perl_base_pkgid_match" in block
+    assert "cve_2026_48959_perl_base_fixed_version_unavailable" in block
+
+    matching_finding = {
+        "VulnerabilityID": "CVE-2026-48959",
+        "PkgName": "perl-base",
+        "InstalledVersion": "5.36.0-7+deb12u3",
+        "PkgID": "perl-base@5.36.0-7+deb12u3",
+    }
+
+    cases = [
+        (matching_finding, True),
+        ({**matching_finding, "FixedVersion": ""}, True),
+        ({**matching_finding, "FixedVersion": None}, True),
+        ({**matching_finding, "FixedVersion": "5.40.1-8"}, False),
+        ({**matching_finding, "VulnerabilityID": "CVE-2026-48962"}, False),
+        ({**matching_finding, "PkgName": "perl-modules-5.36"}, False),
+        ({**matching_finding, "InstalledVersion": "5.36.0-7+deb12u4"}, False),
+        ({**matching_finding, "PkgID": "perl-modules-5.36@5.36.0-7+deb12u3"}, False),
+    ]
+
+    for finding, expected in cases:
+        assert _cve_2026_48959_expected_match(finding) is expected
+
+
 def test_cve_2026_48962_is_not_broadly_ignored_in_trivyignore() -> None:
     trivyignore = TRIVYIGNORE_PATH.read_text(encoding="utf-8")
 
     assert "CVE-2026-48962" not in trivyignore
 
 
+def test_cve_2026_48959_is_not_broadly_ignored_in_trivyignore() -> None:
+    trivyignore = TRIVYIGNORE_PATH.read_text(encoding="utf-8")
+
+    assert "CVE-2026-48959" not in trivyignore
+
+
 def test_cve_2026_48962_doc_and_backlog_coupling() -> None:
-    doc_text = SECURITY_DOC_PATH.read_text(encoding="utf-8")
+    doc_text = SECURITY_DOC_48962_PATH.read_text(encoding="utf-8")
     backlog_text = BACKLOG_PATH.read_text(encoding="utf-8")
 
     assert "CVE-2026-48962" in doc_text
@@ -176,3 +253,28 @@ def test_cve_2026_48962_doc_and_backlog_coupling() -> None:
     assert "alert #602" in ledger_entry
     assert "trivy/ignore-policy.rego" in ledger_entry
     assert "docs/security/CVE-2026-48962-perl-base.md" in ledger_entry
+
+
+def test_cve_2026_48959_doc_and_backlog_coupling() -> None:
+    doc_text = SECURITY_DOC_48959_PATH.read_text(encoding="utf-8")
+    backlog_text = BACKLOG_PATH.read_text(encoding="utf-8")
+
+    assert "CVE-2026-48959" in doc_text
+    assert "alert `#610`" in doc_text
+    assert "policy disposition" in doc_text
+    assert "Dockerfile:9" in doc_text
+    assert "Dockerfile:121" in doc_text
+    assert ".github/workflows/build.yml:441" in doc_text
+    assert "fixed version remains unavailable" in doc_text
+    assert "IO::Uncompress::Unzip" in doc_text
+    assert "File::GlobMapper" not in doc_text
+
+    ledger_start = backlog_text.index('<a id="ledger-p1-container-perl-cve-remediation"></a>')
+    next_anchor = backlog_text.find("<a id=", ledger_start + 1)
+    ledger_end = next_anchor if next_anchor != -1 else len(backlog_text)
+    ledger_entry = backlog_text[ledger_start:ledger_end]
+
+    assert "CVE-2026-48959" in ledger_entry
+    assert "alert #610" in ledger_entry
+    assert "trivy/ignore-policy.rego" in ledger_entry
+    assert "docs/security/CVE-2026-48959-perl-base.md" in ledger_entry

--- a/trivy/ignore-policy.rego
+++ b/trivy/ignore-policy.rego
@@ -11,7 +11,7 @@ default ignore := false
 #
 # Suppression expires: 2026-06-27 (manual removal)
 # Last reviewed: 2026-05-28
-# Documented in: docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-69720-ncurses.md, docs/security/CVE-2026-48962-perl-base.md
+# Documented in: docs/security/CVE-2026-27171-zlib1g.md, docs/security/CVE-2026-3184-util-linux.md, docs/security/CVE-2025-69720-ncurses.md, docs/security/CVE-2026-48959-perl-base.md, docs/security/CVE-2026-48962-perl-base.md
 
 # CVE-2026-27171 (zlib1g) - no fixed release for Debian bookworm at review time
 # Review-by: 2026-06-27 (manual removal)
@@ -134,4 +134,39 @@ ignore if {
 	cve_2026_48962_perl_base_version_match
 	cve_2026_48962_perl_base_pkgid_match
 	cve_2026_48962_perl_base_fixed_version_unavailable
+}
+
+# CVE-2026-48959 (perl-base / IO::Uncompress::Unzip) - no fixed Debian bookworm perl source at review time
+# Review-by: 2026-06-27 (manual removal)
+# Rationale: Debian bookworm perl-base remains vulnerable with no actionable fixed version in this image context; PulsePlate's Python runtime does not execute Perl IO::Uncompress::Unzip on attacker-controlled ZIP entries.
+# Monitor: https://security-tracker.debian.org/tracker/CVE-2026-48959
+# Documented in: docs/security/CVE-2026-48959-perl-base.md
+# Removal condition: Remove when Debian bookworm publishes a fixed perl/perl-base package, Trivy reports a fixed version for alert #610, or production removes perl-base with passing Docker/Trivy evidence.
+
+cve_2026_48959_perl_base_version_match if {
+	input.InstalledVersion == "5.36.0-7+deb12u3"
+}
+
+cve_2026_48959_perl_base_pkgid_match if {
+	startswith(input.PkgID, "perl-base@5.36.0-7+deb12u3")
+}
+
+cve_2026_48959_perl_base_fixed_version_unavailable if {
+	not input.FixedVersion
+}
+
+cve_2026_48959_perl_base_fixed_version_unavailable if {
+	input.FixedVersion == ""
+}
+
+cve_2026_48959_perl_base_fixed_version_unavailable if {
+	input.FixedVersion == null
+}
+
+ignore if {
+	input.VulnerabilityID == "CVE-2026-48959"
+	input.PkgName == "perl-base"
+	cve_2026_48959_perl_base_version_match
+	cve_2026_48959_perl_base_pkgid_match
+	cve_2026_48959_perl_base_fixed_version_unavailable
 }


### PR DESCRIPTION
## Goal

Stabilize `main` after PR #1935 made Docker publish fail closed and the post-merge publish image scan blocked on Trivy alert `#610` / `CVE-2026-48959`.

## Business reason

Restore the governed Docker publish path without weakening the new scan-before-publish gate. GHCR publish, SBOM, and provenance must stay blocked unless Trivy image scanning and SARIF evidence pass.

## Scope

- Add an exact, time-boxed Rego policy disposition for `CVE-2026-48959` on `perl-base 5.36.0-7+deb12u3` with no fixed version.
- Add a dedicated security note for GitHub code-scanning alert `#610`.
- Extend Trivy policy tests for exact matching, fixed-version negative control, `.trivyignore` no-go, and doc/backlog coupling.
- Update the existing Perl-family remediation ledger entry.

## Out of scope

- No workflow weakening, no Dockerfile/base-image migration, no `.trivyignore` entry for `CVE-2026-48959`, no app/runtime/OpenAPI changes.
- Full local `make verify` is intentionally deferred under the operator-approved machine-heavy CI/tooling exception.

## Files changed

- `trivy/ignore-policy.rego`
- `docs/security/CVE-2026-48959-perl-base.md`
- `tests/test_trivy_ignore_policy_expiry.py`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/review/PR_1968_FIXED_MAPPING.md`

## Key decisions

- Keep fail-closed Trivy behavior from PR #1935 intact.
- Suppress only the exact observed alert shape: CVE, package, installed version, PkgID prefix, and blank/missing `FixedVersion`.
- Track this as temporary technical debt with review-by/removal conditions instead of broad CVE-only ignore.

## Tests / validation

- PASS: `python3 scripts/orchestration/check_preflight.py --path docs/roadmap/BACKLOG_LEDGER.md --path docs/security/CVE-2026-48959-perl-base.md --path tests/test_trivy_ignore_policy_expiry.py --path trivy/ignore-policy.rego`
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
- PASS: `python3 scripts/ci/check_trivy_ignore_policy_expiry.py`
- PASS: `python -m pytest -q tests/test_trivy_ignore_policy_expiry.py` (`12 passed`)
- PASS: `python scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-48959-perl-base.md`
- PASS: focused workflow contract pytest for publish scan and Trivy action contracts (`3 passed`)
- PASS: `git diff --check`
- PASS: `make validate-changed`
- PASS: `pre-commit run --all-files`
- PASS: commit hooks and pre-push hooks with repo-approved `VENV_PYTHON`
- PASS: Experiment Runner oracle-only reviewer accepted, `exp-8a06dbffc0b9`
- PASS: Sourcery doc-clarity rerun after commit `1a37e7820a3764d3e11e383f5600841ed324ae78`:
  `python3 scripts/ci/check_trivy_ignore_policy_expiry.py`,
  `python -m pytest -q tests/test_trivy_ignore_policy_expiry.py` (`12 passed`),
  `python scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-48959-perl-base.md`,
  `git diff --check`, `make validate-changed`, and `pre-commit run --all-files`.
- PASS: after merging latest `origin/main` to current head
  `1b6fbf4b8b00bc5b7f9776b9f6bd320817326f97`:
  `python3 scripts/orchestration/check_preflight.py --path ...`,
  `python3 scripts/orchestration/check_agent_consistency.py`,
  `python3 scripts/ci/check_trivy_ignore_policy_expiry.py`,
  `python -m pytest -q tests/test_trivy_ignore_policy_expiry.py` (`12 passed`),
  `python scripts/ci/check_docs_phase1_gates.py --files docs/security/CVE-2026-48959-perl-base.md`,
  `git diff --check`, `make validate-changed`, `pre-commit run --all-files`, and pre-push hooks.
- PASS: Codex Security current-head diff scan found zero reportable findings:
  `/tmp/codex-security-scans/PulsePlate-main-trivy-hotfix/1b6fbf4b8b00_20260612T210539Z/report.md`.
- PASS: `pulseplate-pr-review` current-head dry-run report generated at
  `/tmp/pr1968_pr_review_report.md`; calibration tests passed (`13 passed`).
- Disposition: `pulseplate-pr-review` large-diff advisory is NOT-A-BUG. The
  current GitHub PR diff contains only the five intended files, scoped local
  gates passed, and Codex Security found no reportable security regression.
- NOT RUN: full local `make verify`; intentionally deferred under the operator-approved machine-heavy exception.

## Security notes

- This is a temporary risk disposition, not package remediation.
- Debian bookworm currently reports `perl 5.36.0-7+deb12u3` vulnerable for `CVE-2026-48959`; the observed GitHub alert has blank fixed version.
- The production app is Python FastAPI and does not execute Perl `IO::Uncompress::Unzip` on attacker-controlled ZIP input.
- If Trivy reports a fixed version or package/version changes, the Rego rule stops matching and the publish gate fails closed again.

## Risks / rollback

- Residual risk: `perl-base` remains present in the Debian base image until upstream package fix, base image migration, or runtime Perl removal.
- Rollback: revert this PR. Expected result is that Docker publish fails closed again on alert `#610`, blocking GHCR publish.

## Deferred / follow-ups

- Existing ledger item `ledger-p1-container-perl-cve-remediation` tracks removing these Perl-family suppressions by fixed package or base-image/runtime remediation.

## Fixed mapping

- Canonical artifact: `docs/review/PR_1968_FIXED_MAPPING.md`
- Sourcery inline thread:
  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#discussion_r3405939500`
  -> `1a37e7820a3764d3e11e383f5600841ed324ae78`
- Sourcery review:
  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#pullrequestreview-4488809272`
  -> `1a37e7820a3764d3e11e383f5600841ed324ae78`
- CodeRabbit inline thread:
  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#discussion_r3406133288`
  -> `6b4920ce884a250836cc9203b6262ed07700b69f`
- CodeRabbit review:
  `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#pullrequestreview-4489078532`
  -> `6b4920ce884a250836cc9203b6262ed07700b69f`

## Discussion Thread Pass

- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Sourcery review feedback mapped with FIXED disposition.
- [x] Fixed mapping artifact added after PR number assignment.
- [x] Post-open review loop completed.

### Fixed in Commit Mapping

- canonical artifact: `docs/review/PR_1968_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#discussion_r3405939500 -> 1a37e7820a3764d3e11e383f5600841ed324ae78
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#pullrequestreview-4488809272 -> 1a37e7820a3764d3e11e383f5600841ed324ae78
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#discussion_r3406133288 -> 6b4920ce884a250836cc9203b6262ed07700b69f
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1968#pullrequestreview-4489078532 -> 6b4920ce884a250836cc9203b6262ed07700b69f

## Experiment Runner Evidence

- Artifact: `artifacts/orchestration/experiments/results/artifacts/orchestration/experiments/results/pr-main-cve-2026-48959-oracle-result.json`
- Experiment ID: `exp-8a06dbffc0b9`
- Mode: `oracle_only_governance_reviewer`
- Status: `accepted`
- Contribution: `oracle_review`
- Co-author required: `true`

## Lane Start Provenance

- Packet: `artifacts/orchestration/task_packets/7d26be3d0cc9.json`

## Merge Readiness

- Final merge-cycle checklist is intentionally left unchecked until the final
  strict merge-readiness pass immediately before merge.
- [ ] Coordinator-first startup and declared role order completed.
- [ ] Focused local gates passed.
- [ ] Full local `make verify` deferral documented.
- [ ] Review-thread disposition passed locally after resolving Sourcery thread.
- [ ] Current-head PR CI passes.
- [ ] Docker Build and Push publish path is proven through Trivy/SARIF before publish on the relevant current head.
- [ ] Strict merge-readiness wrapper passes on current head.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security documentation for CVE-2026-48959 including vulnerability disposition and suppression details.
  * Updated backlog ledger with additional tracked CVE references and remediation scope.

* **Tests**
  * Expanded test coverage for vulnerability suppression policy validation and expiry enforcement.

* **Chores**
  * Updated vulnerability suppression policy to include handling for an additional CVE with specific version matching criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
