### PR TITLE
refactor(api): extract health readiness routes from legacy

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -284,7 +284,9 @@ Avoid `# type: ignore[no-any-return]` and prefer typed locals over `cast()`.
 - If logic is needed in multiple endpoints, put it into `core/` and call it.
 - BMI math (formulas/thresholds/grouping/interpretation) MUST live only in `core/bmi/*`; `app/*` is adapters/rendering only.
 - `legacy_app.py` is compatibility-only: do not add new behavior there unless it is purely shim/bridge.
-  - **Exception (approved)**: Observability endpoints (`/metrics`, `/health`, `/ready`, `/health/db`) are infrastructure concerns and may be added to `legacy_app.py` for operational visibility.
+  - Observability and operational endpoints are infrastructure concerns, but their route
+    ownership belongs in canonical routers/bootstrap such as `app/routers/health.py`
+    and `app/main.py`, not new `legacy_app.py` decorators.
 
 ## Common pitfalls
 

--- a/app/main.py
+++ b/app/main.py
@@ -213,6 +213,10 @@ def _include_health_router_if_needed(target_app: FastAPI) -> None:
             or getattr(matching_routes[0], "endpoint", None) is not endpoint
         ):
             raise RuntimeError(f"Duplicate {path} route detected with a different health handler.")
+        if getattr(matching_routes[0], "include_in_schema", True):
+            raise RuntimeError(
+                f"Existing {path} route does not preserve hidden OpenAPI visibility."
+            )
 
 
 def _internalize_users_openapi_surface(target_app: FastAPI) -> None:

--- a/app/main.py
+++ b/app/main.py
@@ -34,6 +34,7 @@ from app.routers.billing import register_billing_routes
 from app.routers.cbt_insight import router as cbt_insight_router
 from app.routers.feedback import router as feedback_router
 from app.routers.fitchef_structured import router as fitchef_structured_router
+from app.routers.health import router as health_router
 from app.routers.legal import router as legal_router
 from app.routers.vip_registration import register_vip_routes
 from app.schemas.direct_api_root import DirectApiRootProbe
@@ -45,6 +46,16 @@ _FEEDBACK_ROUTE_PATH: str = "/api/v1/feedback/rag"
 _PRIVACY_ROUTE_PATH: str = "/privacy"
 _TERMS_ROUTE_PATH: str = "/terms"
 _LEGAL_ROUTE_PATHS: tuple[str, str] = (_PRIVACY_ROUTE_PATH, _TERMS_ROUTE_PATH)
+_HEALTH_ROUTE_PATH: str = "/health"
+_HEALTH_V1_ROUTE_PATH: str = "/api/v1/health"
+_HEALTH_DB_ROUTE_PATH: str = "/health/db"
+_READY_ROUTE_PATH: str = "/ready"
+_HEALTH_ROUTE_PATHS: tuple[str, str, str, str] = (
+    _HEALTH_ROUTE_PATH,
+    _HEALTH_V1_ROUTE_PATH,
+    _HEALTH_DB_ROUTE_PATH,
+    _READY_ROUTE_PATH,
+)
 _CBT_INSIGHT_ROUTE_PATH: str = "/api/v1/pro/cbt/insight"
 _FITCHEF_STRUCTURED_ROUTE_PATH: str = "/api/v1/pro/fitchef/explain"
 _CREATIVE_RESEARCH_PILOT_ROUTE_PATH: str = "/api/v1/internal/creative-research/pilot"
@@ -156,6 +167,54 @@ def _include_legal_router_if_needed(target_app: FastAPI) -> None:
             raise RuntimeError(f"Duplicate {path} route detected with a different legal handler.")
 
 
+def _include_health_router_if_needed(target_app: FastAPI) -> None:
+    """Register health/readiness routes as one atomic route family."""
+
+    expected_paths = set(_HEALTH_ROUTE_PATHS)
+    expected_endpoints: dict[str, object] = {}
+    expected_route_counts = dict.fromkeys(expected_paths, 0)
+    for route in health_router.routes:
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None) or set()
+        if path in expected_paths and "GET" in methods:
+            expected_route_counts[str(path)] += 1
+            expected_endpoints[str(path)] = getattr(route, "endpoint", None)
+            if getattr(route, "include_in_schema", True):
+                raise RuntimeError("Health router does not preserve hidden OpenAPI visibility.")
+
+    if set(expected_endpoints) != expected_paths or any(
+        count != 1 for count in expected_route_counts.values()
+    ):
+        raise RuntimeError("Health router does not define the expected route family.")
+
+    health_paths_present = {path for path in expected_paths if _has_route(target_app, path, "GET")}
+
+    if not health_paths_present:
+        target_app.include_router(health_router)
+        return
+
+    if health_paths_present != expected_paths:
+        existing = ", ".join(sorted(health_paths_present))
+        missing = ", ".join(sorted(expected_paths - health_paths_present))
+        raise RuntimeError(
+            "Partial health route registration detected. "
+            f"Existing: {existing or '<none>'}; missing: {missing or '<none>'}."
+        )
+
+    for path, endpoint in expected_endpoints.items():
+        matching_routes = [
+            route
+            for route in target_app.routes
+            if getattr(route, "path", None) == path
+            and "GET" in (getattr(route, "methods", None) or set())
+        ]
+        if (
+            len(matching_routes) != 1
+            or getattr(matching_routes[0], "endpoint", None) is not endpoint
+        ):
+            raise RuntimeError(f"Duplicate {path} route detected with a different health handler.")
+
+
 def _internalize_users_openapi_surface(target_app: FastAPI) -> None:
     """Hide legacy users CRUD from the public OpenAPI contract.
 
@@ -237,6 +296,7 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     if not _has_route(app, _FEEDBACK_ROUTE_PATH, "POST"):
         app.include_router(feedback_router)
 
+    _include_health_router_if_needed(app)
     _include_legal_router_if_needed(app)
 
     register_billing_routes(app)

--- a/app/routers/health.py
+++ b/app/routers/health.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+from starlette.concurrency import run_in_threadpool
+
+from app.utils.helpers import _short_git_sha
+from core.db import get_session
+from settings import get_runtime_env_name
+
+router = APIRouter(tags=["health"])
+logger = logging.getLogger(__name__)
+
+
+def _health_payload() -> dict[str, Any]:
+    environment = get_runtime_env_name()
+
+    git_sha = _short_git_sha(os.getenv("GIT_SHA"))
+
+    return {
+        "status": "ok",
+        "version": "1.0.0",  # TODO: Read from pyproject.toml
+        "git_sha": git_sha,
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "environment": environment,
+    }
+
+
+@router.get("/health", include_in_schema=False)
+async def health() -> dict[str, Any]:
+    """Health check endpoint with version info for debugging."""
+
+    return _health_payload()
+
+
+@router.get("/api/v1/health", include_in_schema=False)
+async def health_v1() -> dict[str, Any]:
+    """Health check endpoint (v1 alias) with version info for debugging."""
+
+    return _health_payload()
+
+
+@router.get("/health/db", include_in_schema=False)
+async def database_health(session: Session = Depends(get_session)) -> dict[str, str]:
+    """Lightweight database connectivity check."""
+
+    try:
+        import core.db_fallback as _fallback_mod
+
+        if _fallback_mod.is_fallback_active() or os.getenv("DB_HEALTH_DEGRADED") == "1":
+            raise HTTPException(status_code=503, detail="Database unavailable")
+
+        exec_fn = getattr(session, "execute", None)
+        if exec_fn is None or not callable(exec_fn):
+            raise HTTPException(status_code=503, detail="Database unavailable")
+        if getattr(session, "bind", None) is None:
+            raise HTTPException(status_code=503, detail="Database unavailable")
+        await run_in_threadpool(session.execute, text("SELECT 1"))
+    except Exception as exc:  # pragma: no cover - defensive path hit via tests
+        logger.error("Database health check failed: %s", exc)
+        raise HTTPException(status_code=503, detail="Database unavailable") from exc
+    return {"status": "ok"}
+
+
+@router.get("/ready", include_in_schema=False)
+async def ready(session: Session = Depends(get_session)) -> dict[str, object]:
+    """Readiness probe for orchestrators (alias for /health/db).
+
+    Returns 200 if DB is available, 503 otherwise.
+    Use this for Kubernetes/Docker readiness checks.
+    Hidden from OpenAPI - semantics live in /health/db.
+    """
+
+    readiness_payload = await database_health(session=session)
+    insight_runtime: dict[str, object] = {"status": "unavailable"}
+
+    try:
+        from llm import get_insight_runtime_readiness
+
+        insight_runtime = get_insight_runtime_readiness()
+    except Exception as exc:
+        logger.warning("Insight runtime readiness unavailable on /ready: %s", exc)
+
+    return {
+        **readiness_payload,
+        "insight_runtime": insight_runtime,
+    }

--- a/docs/architecture/LEGACY_COMPATIBILITY_SEAM.md
+++ b/docs/architecture/LEGACY_COMPATIBILITY_SEAM.md
@@ -56,6 +56,7 @@ Forbidden in `legacy_app.py`:
 | Existing legacy compatibility aliases | `legacy_app.py` | Runtime compatibility only; no growth. |
 | Canonical app bootstrap | `app/main.py` | Additive, idempotent registration over the compatibility base. |
 | New route implementations | `app/routers/` | Canonical route families own new behavior. |
+| Operational health/readiness routes | `app/routers/health.py` + `app/main.py` | Runtime paths unchanged; no legacy decorator ownership. |
 | Infra and observability bootstrap | `app/bootstrap/` | Register from canonical entrypoint, not from `legacy_app.py`. |
 | Domain logic | `core/` and `app/services/` | Backend truth stays outside route shims. |
 | Public API contract | Backend OpenAPI gates | Legacy aliases must not become client contract truth. |

--- a/docs/deploy/OPERATIONAL_SIGNALS.md
+++ b/docs/deploy/OPERATIONAL_SIGNALS.md
@@ -6,10 +6,10 @@ Operator-facing index for the runtime signals that already exist in PulsePlate t
 
 | Surface | Purpose | Expected behavior | Source of truth |
 | --- | --- | --- | --- |
-| `/health` | Liveness | Always `200`; does not depend on the DB | `legacy_app.py`, `app/AGENTS.md` |
-| `/health/db` | DB readiness | `200` when DB is reachable, `503` otherwise | `legacy_app.py`, `app/AGENTS.md` |
-| `/ready` | Readiness alias | Same behavior as `/health/db`; hidden from OpenAPI | `legacy_app.py`, `app/AGENTS.md` |
-| `/api/v1/health` | Compatibility alias | Mirrors `/health` payload | `legacy_app.py` |
+| `/health` | Liveness | Always `200`; does not depend on the DB | `app/routers/health.py`, `app/main.py`, `app/AGENTS.md` |
+| `/health/db` | DB readiness | `200` when DB is reachable, `503` otherwise | `app/routers/health.py`, `app/main.py`, `app/AGENTS.md` |
+| `/ready` | Readiness alias | Same behavior as `/health/db`; hidden from OpenAPI | `app/routers/health.py`, `app/main.py`, `app/AGENTS.md` |
+| `/api/v1/health` | Compatibility alias | Mirrors `/health` payload | `app/routers/health.py`, `app/main.py` |
 | `/debug_env` | Local/operator debug surface | Returns a gated env dump when debug/operator access is enabled; otherwise stays unavailable to avoid production leakage | `legacy_app.py` |
 
 Use `/health` for liveness checks and `/ready` or `/health/db` for dependency-aware readiness checks.
@@ -41,8 +41,10 @@ Use `/health` for liveness checks and `/ready` or `/health/db` for dependency-aw
 
 - The repo already has health, readiness, metrics, and tracing entrypoints.
 - These surfaces are intentionally split:
-  - health/readiness endpoints live on the legacy compatibility app surface
-  - metrics/tracing/request telemetry are registered from the canonical `app.main` bootstrap
+  - health/readiness endpoints live in the canonical `app.routers.health` router
+    registered from `app.main`
+  - metrics/tracing/request telemetry are also registered from the canonical
+    `app.main` bootstrap
 - When documenting or validating runtime behavior, prefer linking to this file first instead of rediscovering those surfaces from code.
 
 ## Current gap

--- a/docs/review/PR_1969_FIXED_MAPPING.md
+++ b/docs/review/PR_1969_FIXED_MAPPING.md
@@ -80,6 +80,15 @@
 - Final current-head review thread, bot actionable, and strict disposition
   checks are still required before any merge-readiness claim.
 
+## Post-Open Role Review Evidence
+
+- `qa-engineer-agent`: found one blocker. `tests/test_legacy_app_git_sha.py`
+  still imports `legacy_app._short_git_sha`, and the implementation commit had
+  removed that compatibility re-export while moving route ownership. Disposition:
+  FIXED by commit `79c44aae0`, which restores the explicit
+  `_short_git_sha as _short_git_sha` legacy compatibility re-export without
+  returning health/readiness route ownership to `legacy_app.py`.
+
 ## Fixed in Commit Mapping
 
 - No actionable review comments
@@ -94,6 +103,8 @@
 - `make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python`: PASS after rebase and after the typed helper fix.
 - `PRE_COMMIT_HOME=/tmp/pre-commit-health-readiness-routes .venv/bin/pre-commit run --all-files`: PASS.
 - `PRE_COMMIT_HOME=/tmp/pre-commit-health-readiness-routes .venv/bin/pre-commit run mypy --hook-stage pre-push --files app/routers/health.py app/main.py legacy_app.py`: PASS after the typed helper fix.
+- `.venv/bin/python -m pytest -q tests/test_legacy_app_git_sha.py`: PASS after
+  commit `79c44aae0`.
 - `git push` pre-push hooks: PASS for mypy, pip-audit, backend pytest,
   full-repo bandit, and Docker build test.
 

--- a/docs/review/PR_1969_FIXED_MAPPING.md
+++ b/docs/review/PR_1969_FIXED_MAPPING.md
@@ -1,0 +1,127 @@
+# PR 1969 Fixed in Commit Mapping
+
+## Summary
+
+- Scope: extract operational health/readiness route ownership from
+  `legacy_app.py` into canonical `app.routers.health` plus `app/main.py`
+  bootstrap.
+- Branch: `codex/extract-health-readiness-routes-from-legacy`.
+- Implementation commit:
+  `0f69ec1855355de99f0c1cc6fd628921e49f406f`.
+- Runtime paths and envelopes: unchanged for `/health`, `/api/v1/health`,
+  `/health/db`, and `/ready`.
+- OpenAPI/client artifacts: unchanged; the extracted routes remain hidden from
+  public OpenAPI.
+- Full local `make verify`: not run by explicit operator instruction for this
+  machine-heavy repository. This artifact does not claim full local verify.
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/54dec1a9e980.json`
+- Branch: `codex/extract-health-readiness-routes-from-legacy`.
+- Task class: `Backend API`.
+- PR phase: `pre_open`.
+- Dispatch evidence:
+  `scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/54dec1a9e980.json --mode runtime --implementation-owner security-auditor --implementation-owner backend-engineer --pretty`.
+- Pre-open role order completed:
+  `agent-coordinator -> architecture-specialist -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`.
+
+## Premortem Finding Closure
+
+- Artifact: `docs/review/PR_HEALTH_READINESS_ROUTE_EXTRACTION_PREMORTEM.md`.
+- Skill: `pulseplate-premortem-risk-review`.
+- Mode: `pr-premortem`.
+- Decision: proceed with changes. Findings are fixed or dispositioned in this
+  PR diff.
+- PM-HEALTH-001 OpenAPI leak risk: FIXED by `include_in_schema=False`,
+  bootstrap rejection of OpenAPI-visible health router state, and
+  `tests/test_app_endpoints_combined.py` OpenAPI assertions.
+- PM-HEALTH-002 duplicate/foreign handler risk: FIXED by atomic
+  `_include_health_router_if_needed` checks and
+  `tests/test_main_paywall_bootstrap.py` negative cases.
+- PM-HEALTH-003 DB readiness semantic drift: FIXED by preserving fallback,
+  degraded env var, session-shape, `SELECT 1`, and `503 Database unavailable`
+  behavior in `app/routers/health.py`, with `tests/test_health_db.py` coverage.
+- PM-HEALTH-004 `/ready` insight runtime fallback drift: FIXED by preserving
+  fail-soft fallback and warning behavior, covered by `tests/test_health_db.py`
+  and `tests/test_legacy_app_diff_coverage.py`.
+- PM-HEALTH-005 stale legacy guard allowlist: FIXED by shrinking
+  `scripts/ci/check_legacy_growth_guard.py` and adding
+  `tests/test_legacy_growth_guard.py` health/readiness reintroduction coverage.
+- PM-HEALTH-006 raw `legacy_app:app` serving risk: NOT-A-BUG for this canonical
+  entrypoint migration. Evidence: `docs/deploy/OPERATIONAL_SIGNALS.md` and
+  `docs/architecture/LEGACY_COMPATIBILITY_SEAM.md` now name canonical health
+  ownership.
+
+## Experiment Runner Evidence
+
+- Packet: `artifacts/orchestration/experiments/health-readiness-oracle-packet.json`.
+- Artifact: `artifacts/orchestration/experiments/results/health-readiness-oracle-result.json`
+- Experiment id: `exp-f74309e63c52`.
+- Runner mode: `oracle_only_governance_reviewer`.
+- Status: accepted.
+- Oracles:
+  - `python3 -m pytest -q tests/test_health_db.py tests/test_app_endpoints_combined.py tests/test_main_paywall_bootstrap.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/test_app_openapi_coverage.py tests/test_legacy_app_diff_coverage.py` returned 0.
+  - `python3 scripts/ci/check_legacy_growth_guard.py` returned 0.
+- Mutation boundary: `mutated_paths=[]`, `shared_tree_untouched=true`,
+  `promotion_ready=false`.
+- Material contribution: `oracle_review`.
+- Co-author trailer required: yes, because the accepted oracle result shaped
+  validation and commit decision.
+- Commit trailer present on implementation commit:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- Review threads at PR open: none known.
+- Bot review/actionables at PR open: pending.
+- Final current-head review thread, bot actionable, and strict disposition
+  checks are still required before any merge-readiness claim.
+
+## Fixed in Commit Mapping
+
+- No actionable review comments
+
+## Local Validation Evidence
+
+- `python3 scripts/orchestration/check_preflight.py`: PASS after rebase onto
+  `origin/main`.
+- `.venv/bin/python -m py_compile app/routers/health.py app/main.py legacy_app.py scripts/ci/check_legacy_growth_guard.py`: PASS.
+- `.venv/bin/python -m pytest -q tests/test_health_db.py tests/test_app_endpoints_combined.py tests/test_main_paywall_bootstrap.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/test_app_openapi_coverage.py tests/test_legacy_app_diff_coverage.py`: PASS.
+- `.venv/bin/python scripts/ci/check_legacy_growth_guard.py`: PASS.
+- `make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python`: PASS after rebase and after the typed helper fix.
+- `PRE_COMMIT_HOME=/tmp/pre-commit-health-readiness-routes .venv/bin/pre-commit run --all-files`: PASS.
+- `PRE_COMMIT_HOME=/tmp/pre-commit-health-readiness-routes .venv/bin/pre-commit run mypy --hook-stage pre-push --files app/routers/health.py app/main.py legacy_app.py`: PASS after the typed helper fix.
+- `git push` pre-push hooks: PASS for mypy, pip-audit, backend pytest,
+  full-repo bandit, and Docker build test.
+
+## Machine-Heavy Verify Deferral
+
+- Full local `make verify` was not run by explicit operator instruction because
+  this repository has a very large test suite and this lane is using narrow
+  backend/API validation.
+- The accepted local validation authority for this PR before merge discussion is
+  focused tests, guard script, `make validate-changed`, pre-commit, current-head
+  CI parity, review disposition governance, and strict merge-readiness wrapper.
+- No response, PR body, or mapping artifact may claim full local `make verify`
+  passed.
+
+## Merge Readiness
+
+- [ ] Post-open required role pass:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- [ ] Codex Security diff scan / finding discovery.
+- [ ] `pulseplate-pr-review`.
+- [ ] Current-head CI terminal success.
+- [ ] PR body Phase2 gate against the live PR body.
+- [ ] Strict review-thread disposition with auth.
+- [ ] Strict merge-readiness wrapper with auth.
+- [ ] CodeRabbit / Sourcery / Cubic / Codex review actionables checked and
+  mapped or dispositioned on the current head.
+- [ ] Mandatory wait-window after latest bot/review activity completed.
+
+## Deferred / Follow-ups
+
+- None for this slice.

--- a/docs/review/PR_1969_FIXED_MAPPING.md
+++ b/docs/review/PR_1969_FIXED_MAPPING.md
@@ -132,6 +132,21 @@
   guard, legacy handler removal, and guard shrink. Focused gates and
   post-open role reviews have run.
 
+## Current-Head CI Findings
+
+- `test-pr (3.13)` initial current-head run `27444774843` failed with exit 139
+  after a Python/coverage segmentation fault around 78% of the contract/risk
+  suite. Local reproduction slice covering the surrounding cumulative test
+  window passed under Python 3.13.6 and coverage. Disposition: NOT-A-BUG for
+  PR code after rerun; rerun attempt 2 passed `test-pr (3.13)`.
+- `diff-coverage` current-head attempt 2 failed at 96% with missing lines
+  `app/routers/health.py:57`, `app/routers/health.py:61`, and
+  `app/routers/health.py:63`. Disposition: FIXED by commit `e4dd4914e`, which
+  adds selected-CI coverage in `tests/test_app_endpoints_combined.py` for
+  degraded DB readiness, missing `execute`, and unbound session failure paths.
+  Local diff-cover evidence after the fix reports `app/routers/health.py
+  (100%)`, total diff coverage `100%`.
+
 ## Fixed in Commit Mapping
 
 - No actionable review comments
@@ -141,14 +156,16 @@
 - `python3 scripts/orchestration/check_preflight.py`: PASS after rebase onto
   `origin/main`.
 - `.venv/bin/python -m py_compile app/routers/health.py app/main.py legacy_app.py scripts/ci/check_legacy_growth_guard.py`: PASS.
-- `.venv/bin/python -m pytest -q tests/test_health_db.py tests/test_app_endpoints_combined.py tests/test_main_paywall_bootstrap.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/test_app_openapi_coverage.py tests/test_legacy_app_diff_coverage.py`: PASS.
+- `.venv/bin/python -m pytest -q tests/test_health_db.py tests/test_app_endpoints_combined.py tests/test_main_paywall_bootstrap.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/test_app_openapi_coverage.py tests/test_legacy_app_diff_coverage.py tests/test_legacy_app_git_sha.py`: PASS.
 - `.venv/bin/python scripts/ci/check_legacy_growth_guard.py`: PASS.
 - `make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python`: PASS after rebase and after the typed helper fix.
-- `PRE_COMMIT_HOME=/tmp/pre-commit-health-readiness-routes .venv/bin/pre-commit run --all-files`: PASS.
+- `PRE_COMMIT_HOME=/tmp/pre-commit-health-readiness-routes /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pre-commit run --all-files`: PASS after commit `e4dd4914e` formatting rerun.
 - `PRE_COMMIT_HOME=/tmp/pre-commit-health-readiness-routes .venv/bin/pre-commit run mypy --hook-stage pre-push --files app/routers/health.py app/main.py legacy_app.py`: PASS after the typed helper fix.
 - `.venv/bin/python -m pytest -q tests/test_legacy_app_git_sha.py`: PASS after
   commit `79c44aae0`.
 - `.venv/bin/python -m pytest -q tests/test_main_paywall_bootstrap.py::test_health_route_registration_rejects_visible_existing_canonical_handlers tests/test_main_paywall_bootstrap.py::test_health_route_registration_is_idempotent`: PASS after commit `a0041d9e8`.
+- `COVERAGE_FILE=/tmp/pulseplate-pr1969-diff.coverage python -m coverage run --source=app,legacy_app,scripts -m pytest -q tests/test_health_db.py tests/test_app_endpoints_combined.py tests/test_main_paywall_bootstrap.py tests/test_legacy_growth_guard.py tests/test_legacy_app_diff_coverage.py tests/test_legacy_app_git_sha.py`: PASS after commit `e4dd4914e`.
+- `diff-cover /tmp/pulseplate-pr1969-coverage.xml --compare-branch origin/main --fail-under 97 ...`: PASS, `Coverage: 100%`.
 - `git push` pre-push hooks: PASS for mypy, pip-audit, backend pytest,
   full-repo bandit, and Docker build test.
 

--- a/docs/review/PR_1969_FIXED_MAPPING.md
+++ b/docs/review/PR_1969_FIXED_MAPPING.md
@@ -94,6 +94,11 @@
   Disposition: FIXED by commit `a0041d9e8`, which rejects visible pre-existing
   health routes and adds
   `test_health_route_registration_rejects_visible_existing_canonical_handlers`.
+- `security-auditor`: found one procedural blocker. The remote PR ref still
+  pointed at `79c44aae0` while local reviewed `HEAD` included the
+  bug-hunter fix and mapping evidence. Disposition: FIXED by pushing through
+  current PR head `8be6db630b1fb257be583d0d76a8aee8f6590a66`. Security-auditor
+  found no security code blockers on that local reviewed head.
 
 ## Fixed in Commit Mapping
 

--- a/docs/review/PR_1969_FIXED_MAPPING.md
+++ b/docs/review/PR_1969_FIXED_MAPPING.md
@@ -88,6 +88,12 @@
   FIXED by commit `79c44aae0`, which restores the explicit
   `_short_git_sha as _short_git_sha` legacy compatibility re-export without
   returning health/readiness route ownership to `legacy_app.py`.
+- `bug-hunter`: found one blocker. `_include_health_router_if_needed` accepted
+  pre-existing canonical endpoint routes if those routes had
+  `include_in_schema=True`, leaving health/readiness probes visible in OpenAPI.
+  Disposition: FIXED by commit `a0041d9e8`, which rejects visible pre-existing
+  health routes and adds
+  `test_health_route_registration_rejects_visible_existing_canonical_handlers`.
 
 ## Fixed in Commit Mapping
 
@@ -105,6 +111,7 @@
 - `PRE_COMMIT_HOME=/tmp/pre-commit-health-readiness-routes .venv/bin/pre-commit run mypy --hook-stage pre-push --files app/routers/health.py app/main.py legacy_app.py`: PASS after the typed helper fix.
 - `.venv/bin/python -m pytest -q tests/test_legacy_app_git_sha.py`: PASS after
   commit `79c44aae0`.
+- `.venv/bin/python -m pytest -q tests/test_main_paywall_bootstrap.py::test_health_route_registration_rejects_visible_existing_canonical_handlers tests/test_main_paywall_bootstrap.py::test_health_route_registration_is_idempotent`: PASS after commit `a0041d9e8`.
 - `git push` pre-push hooks: PASS for mypy, pip-audit, backend pytest,
   full-repo bandit, and Docker build test.
 

--- a/docs/review/PR_1969_FIXED_MAPPING.md
+++ b/docs/review/PR_1969_FIXED_MAPPING.md
@@ -100,6 +100,38 @@
   current PR head `8be6db630b1fb257be583d0d76a8aee8f6590a66`. Security-auditor
   found no security code blockers on that local reviewed head.
 
+## Codex Security Diff Scan / Finding Discovery
+
+- Skill: `codex-security:security-diff-scan`.
+- Scope: PR diff `origin/main...HEAD` for source-like changed files
+  `app/main.py`, `app/routers/health.py`, and `legacy_app.py`.
+- Report: `/tmp/codex-security-scans/BMI-App_2025_clean/pr-1969-health-readiness-routes/report.md`.
+- HTML report: `/tmp/codex-security-scans/BMI-App_2025_clean/pr-1969-health-readiness-routes/report.html`.
+- Work ledger:
+  `/tmp/codex-security-scans/BMI-App_2025_clean/pr-1969-health-readiness-routes/artifacts/02_discovery/work_ledger.jsonl`.
+- Result: PASS, no reportable findings. Every diff-scoped source-like row has
+  a completion receipt, and discovery produced no plausible candidates requiring
+  validation or attack-path analysis.
+- Validator:
+  `python3 .../codex-security/0.1.8/scripts/validate_report_format.py --report-md /tmp/codex-security-scans/BMI-App_2025_clean/pr-1969-health-readiness-routes/report.md`: PASS.
+
+## PulsePlate PR Review
+
+- Skill: `pulseplate-pr-review`.
+- Context: `/tmp/pulseplate_pr_1969_review_context.json`.
+- Markdown report: `/tmp/pulseplate_pr_1969_review_report.md`.
+- JSON report: `/tmp/pulseplate_pr_1969_review_report.json`.
+- Result: one advisory `note` for large-diff review planning because the PR
+  diff exceeds the 800 changed-line threshold.
+- Disposition: NOT-A-BUG.
+- Evidence: this PR is intentionally the bounded health/readiness extraction
+  slice; the oversized line count is dominated by review/governance artifacts
+  (`docs/review/PR_1969_FIXED_MAPPING.md` and
+  `docs/review/PR_HEALTH_READINESS_ROUTE_EXTRACTION_PREMORTEM.md`) plus tests.
+  The code scope remains the planned canonical route extraction, bootstrap
+  guard, legacy handler removal, and guard shrink. Focused gates and
+  post-open role reviews have run.
+
 ## Fixed in Commit Mapping
 
 - No actionable review comments
@@ -133,10 +165,10 @@
 
 ## Merge Readiness
 
-- [ ] Post-open required role pass:
+- [x] Post-open required role pass:
   `qa-engineer-agent -> bug-hunter -> security-auditor`.
-- [ ] Codex Security diff scan / finding discovery.
-- [ ] `pulseplate-pr-review`.
+- [x] Codex Security diff scan / finding discovery.
+- [x] `pulseplate-pr-review`.
 - [ ] Current-head CI terminal success.
 - [ ] PR body Phase2 gate against the live PR body.
 - [ ] Strict review-thread disposition with auth.

--- a/docs/review/PR_HEALTH_READINESS_ROUTE_EXTRACTION_PREMORTEM.md
+++ b/docs/review/PR_HEALTH_READINESS_ROUTE_EXTRACTION_PREMORTEM.md
@@ -1,0 +1,176 @@
+# Health Readiness Route Extraction Premortem
+
+Date: 2026-06-12
+
+Task packet: `artifacts/orchestration/task_packets/54dec1a9e980.json`
+
+Branch: `codex/extract-health-readiness-routes-from-legacy`
+
+Mode: `pr-premortem`
+
+## Summary
+
+Plan: extract `/health`, `/api/v1/health`, `/health/db`, and `/ready` from
+`legacy_app.py` into canonical `app.routers.health`, with idempotent
+registration owned by `app/main.py`.
+
+Failure frame: six months from now, the extraction looked like a narrow legacy
+shrink but changed probe behavior, route ownership, or operational visibility.
+
+Decision: proceed with changes. All premortem findings below are fixed or
+dispositioned in the current PR diff before PR open.
+
+## Findings And Closure
+
+### PM-HEALTH-001: Health routes leak into public OpenAPI
+
+Failure story: moving the operational probe routes into a canonical router makes
+them appear in `app.openapi()["paths"]`. Generated clients then start treating
+liveness and readiness probes as public product API contract, adding noisy churn
+and making future probe-only changes look like client-facing API breaks.
+
+Underlying assumption: changing route ownership does not change OpenAPI
+visibility.
+
+Early warning signs: `/health`, `/api/v1/health`, `/health/db`, or `/ready`
+appears under `app.openapi()["paths"]`, or generated OpenAPI/client artifacts
+change in this route extraction PR.
+
+Disposition: FIXED.
+
+Evidence:
+
+- `app/routers/health.py` registers all four routes with
+  `include_in_schema=False`.
+- `app/main.py` rejects a health router that exposes any route in OpenAPI.
+- `tests/test_app_endpoints_combined.py` asserts the four health/readiness paths
+  remain absent from public OpenAPI.
+
+### PM-HEALTH-002: Bootstrap accepts duplicate or foreign probe handlers
+
+Failure story: a reload path, test fixture, or future router includes one of the
+probe paths before canonical bootstrap. The app silently accepts the path as
+present, leaving route order to decide whether the legacy, foreign, or canonical
+handler serves production health checks.
+
+Underlying assumption: path presence is enough to prove canonical ownership.
+
+Early warning signs: more than one GET route exists for any health/readiness
+path, or a route endpoint module is not `app.routers.health`.
+
+Disposition: FIXED.
+
+Evidence:
+
+- `app/main.py` registers health/readiness as an atomic route family and fails
+  closed on partial state, malformed canonical routers, duplicate canonical
+  routes, or foreign handlers.
+- `tests/test_main_paywall_bootstrap.py` covers idempotent registration,
+  partial-state rejection, foreign handler rejection, OpenAPI-visible router
+  rejection, and duplicate route rejection.
+- `tests/test_app_endpoints_combined.py` asserts route ownership is
+  `app.routers.health`.
+
+### PM-HEALTH-003: DB readiness semantics drift during extraction
+
+Failure story: `/health/db` stops honoring fallback detection,
+`DB_HEALTH_DEGRADED`, missing `session.execute`, missing `session.bind`, or the
+`SELECT 1` connectivity check. Infrastructure probes report healthy while the DB
+is unavailable, or fail in a new way that operators have not configured.
+
+Underlying assumption: copying the route body is enough without focused parity
+coverage.
+
+Early warning signs: readiness tests stop exercising fallback mode, degraded
+mode, or session shape failures; response detail changes from
+`Database unavailable`.
+
+Disposition: FIXED.
+
+Evidence:
+
+- `app/routers/health.py` preserves the existing fallback, degraded env var,
+  session shape, `SELECT 1`, and `503 Database unavailable` behavior.
+- `tests/test_health_db.py` covers `/health/db` and `/ready` success/failure
+  behavior.
+- Focused pytest includes `tests/test_health_db.py` and passed before PR open.
+
+### PM-HEALTH-004: `/ready` insight runtime fallback becomes fail-closed
+
+Failure story: `/ready` starts returning 500 or dropping its additive
+`insight_runtime` fallback when the insight runtime readiness helper raises.
+Orchestrators that depend on DB readiness get coupled to an unrelated LLM
+runtime status path.
+
+Underlying assumption: readiness is only DB behavior, so the additive runtime
+payload can be moved without a negative fallback test.
+
+Early warning signs: logs no longer include the readiness warning, or `/ready`
+returns anything other than `{"status": "unavailable"}` for the insight runtime
+fallback.
+
+Disposition: FIXED.
+
+Evidence:
+
+- `app/routers/health.py` preserves fail-soft insight runtime readiness handling.
+- `tests/test_health_db.py` and `tests/test_legacy_app_diff_coverage.py` assert
+  the fallback payload and warning behavior against `app.routers.health`.
+
+### PM-HEALTH-005: Legacy guard still permits probe route ownership to return
+
+Failure story: the handlers move out of `legacy_app.py`, but the legacy growth
+guard keeps allowlisted facts for `/health`, `/api/v1/health`, `/health/db`, and
+`/ready`. A later change can reintroduce the decorators in legacy while the guard
+still passes.
+
+Underlying assumption: deleting the handlers is enough to make the migration
+durable.
+
+Early warning signs: `scripts/ci/check_legacy_growth_guard.py` still contains
+allowed route facts for the extracted health/readiness paths.
+
+Disposition: FIXED.
+
+Evidence:
+
+- `scripts/ci/check_legacy_growth_guard.py` removes the allowed legacy route
+  facts for all four extracted paths.
+- `tests/test_legacy_growth_guard.py` rejects reintroduced health/readiness
+  decorators.
+- `scripts/ci/check_legacy_growth_guard.py` passed before PR open.
+
+### PM-HEALTH-006: Raw `legacy_app:app` direct serving loses probe routes
+
+Failure story: an operator serves raw `legacy_app:app` directly instead of the
+canonical `app.main:app` entrypoint and sees the extracted routes disappear. The
+production entrypoint still works, but the operational blast radius is higher
+for health/readiness than it was for legal publication pages.
+
+Underlying assumption: all runtime serving goes through `app.main:app`.
+
+Early warning signs: Docker, Kubernetes, Make, Caddy, or deployment docs point
+health/readiness traffic at raw `legacy_app:app`.
+
+Disposition: NOT-A-BUG.
+
+Evidence:
+
+- The PR scope intentionally keeps canonical route registration in `app/main.py`
+  and does not preserve raw legacy decorator ownership.
+- `docs/deploy/OPERATIONAL_SIGNALS.md` now names `app/routers/health.py` and
+  `app/main.py` as the health/readiness source of truth.
+- `docs/architecture/LEGACY_COMPATIBILITY_SEAM.md` documents operational
+  health/readiness route ownership outside `legacy_app.py`.
+
+## Pre-Merge Checklist
+
+- Focused health/readiness, bootstrap, OpenAPI, and legacy guard tests pass.
+- `scripts/ci/check_legacy_growth_guard.py` passes.
+- `make validate-changed VENV_PYTHON=.venv/bin/python` passes after branch
+  commit creation.
+- `pre-commit run --all-files` passes before push.
+- PR body records lane start provenance, premortem closure, and Experiment
+  Runner oracle evidence.
+- Post-open role passes and review governance are completed before any readiness
+  claim.

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -39,8 +39,6 @@ from pydantic import (
     ValidationError,
     model_validator,
 )
-from sqlalchemy import text
-from sqlalchemy.orm import Session
 from starlette import status as fastapi_status
 from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
@@ -124,7 +122,7 @@ from app.scheduler_helpers import (
     execute_async_starter,
     safe_stop_with_cleanup,
 )
-from app.utils.helpers import _resolve_app_callable, _short_git_sha
+from app.utils.helpers import _resolve_app_callable
 from app.utils.feature_flags import _is_truthy
 from app.middleware.api_tiers import derive_subject_id_from_api_key, require_vip_tier
 from app.security.llm_monthly_quota import (
@@ -1132,59 +1130,6 @@ async def log_requests(request: Request, call_next: CallNextHandler) -> Response
     return response
 
 
-@app.get("/health/db")
-async def database_health(session: Session = Depends(get_session)) -> Dict[str, str]:
-    """RU: Мини-проверка подключения к базе данных.
-
-    EN: Lightweight database connectivity check.
-    """
-
-    try:
-        import core.db_fallback as _fallback_mod
-
-        if _fallback_mod.is_fallback_active() or os.getenv("DB_HEALTH_DEGRADED") == "1":
-            raise HTTPException(status_code=503, detail="Database unavailable")
-
-        exec_fn = getattr(session, "execute", None)
-        if exec_fn is None or not callable(exec_fn):
-            raise HTTPException(status_code=503, detail="Database unavailable")
-        if getattr(session, "bind", None) is None:
-            raise HTTPException(status_code=503, detail="Database unavailable")
-        await run_in_threadpool(session.execute, text("SELECT 1"))
-    except Exception as exc:  # pragma: no cover - defensive path hit via tests
-        logger.error("Database health check failed: %s", exc)
-        raise HTTPException(status_code=503, detail="Database unavailable") from exc
-    return {"status": "ok"}
-
-
-@app.get("/ready", include_in_schema=False)
-async def ready(session: Session = Depends(get_session)) -> Dict[str, object]:
-    """RU: Readiness probe (alias для /health/db).
-
-    EN: Readiness probe for orchestrators (alias for /health/db).
-
-    Returns 200 if DB is available, 503 otherwise.
-    Use this for Kubernetes/Docker readiness checks.
-    Hidden from OpenAPI — semantics live in /health/db.
-    """
-    readiness_payload = await database_health(session=session)
-    insight_runtime: dict[str, object] = {"status": "unavailable"}
-
-    try:
-        # RU: Добавляем только безопасную runtime-видимость для insight без секретов.
-        # EN: Add only safe insight runtime visibility without leaking secrets.
-        from llm import get_insight_runtime_readiness
-
-        insight_runtime = get_insight_runtime_readiness()
-    except Exception as exc:
-        logger.warning("Insight runtime readiness unavailable on /ready: %s", exc)
-
-    return {
-        **readiness_payload,
-        "insight_runtime": insight_runtime,
-    }
-
-
 # ---------- Helpers ----------
 
 
@@ -1499,40 +1444,6 @@ def add_visualization_if_requested(result: Dict[str, Any], req: BMIRequest) -> N
 @app.get("/favicon.ico")
 async def favicon() -> Response:
     return Response(status_code=204)
-
-
-@app.get("/health")
-async def health() -> Dict[str, Any]:
-    """Health check endpoint with version info for debugging.
-
-    Returns server status, version, and timestamp for iOS debugging.
-    Helps diagnose "Connection refused" errors (backend offline).
-    """
-    import datetime
-
-    # RU: Окружение должно приходить из env. В проде ставим production по умолчанию.
-    # EN: Environment must come from env vars. Default to production in prod.
-    environment = get_runtime_env_name()
-
-    # Get git SHA if available (for version tracking)
-    git_sha = _short_git_sha(os.getenv("GIT_SHA"))
-
-    return {
-        "status": "ok",
-        "version": "1.0.0",  # TODO: Read from pyproject.toml
-        "git_sha": git_sha,
-        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
-        "environment": environment,
-    }
-
-
-@app.get("/api/v1/health")
-async def health_v1() -> Dict[str, Any]:
-    """Health check endpoint (v1 alias) with version info for debugging.
-
-    Returns the same extended payload as /health for consistency.
-    """
-    return await health()
 
 
 @app.post("/admin/logs/cleanup", dependencies=[Depends(_get_api_key_dynamic)])

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -122,7 +122,7 @@ from app.scheduler_helpers import (
     execute_async_starter,
     safe_stop_with_cleanup,
 )
-from app.utils.helpers import _resolve_app_callable
+from app.utils.helpers import _resolve_app_callable, _short_git_sha as _short_git_sha
 from app.utils.feature_flags import _is_truthy
 from app.middleware.api_tiers import derive_subject_id_from_api_key, require_vip_tier
 from app.security.llm_monthly_quota import (

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -88,11 +88,7 @@ SENSITIVE_APP_SURFACE_LIMITS: Mapping[str, int] = {
 ALLOWED_LEGACY_ROUTE_FACTS = frozenset(
     {
         LegacyFact("decorator", "get", "/api/v1/admin/status", "admin_status"),
-        LegacyFact("decorator", "get", "/health/db", "database_health"),
-        LegacyFact("decorator", "get", "/ready", "ready"),
         LegacyFact("decorator", "get", "/favicon.ico", "favicon"),
-        LegacyFact("decorator", "get", "/health", "health"),
-        LegacyFact("decorator", "get", "/api/v1/health", "health_v1"),
         LegacyFact("decorator", "middleware", "http", "csp_nonce_middleware"),
         LegacyFact("decorator", "middleware", "http", "log_requests"),
         LegacyFact("decorator", "post", "/admin/logs/cleanup", "cleanup_expired_logs"),

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -15,10 +15,13 @@ from typing import cast
 from xml.etree import ElementTree
 from fastapi import FastAPI, Request
 from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import HTTPException
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
 
 import app as apppkg
+from app.routers import health as health_router
 from app.routers.legal import build_terms_endpoint_payload
 from app.bootstrap import public_discovery
 from core.compliance import build_privacy_endpoint_payload
@@ -74,6 +77,43 @@ class TestHealthAndMonitoringEndpoints:
         assert "/api/v1/health" not in paths
         assert "/health/db" not in paths
         assert "/ready" not in paths
+
+    def test_database_health_rejects_degraded_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """DB degraded mode keeps the readiness failure contract."""
+        monkeypatch.setenv("DB_HEALTH_DEGRADED", "1")
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(health_router.database_health(session=cast(Session, object())))
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Database unavailable"
+
+    def test_database_health_rejects_session_without_execute(self) -> None:
+        """DB readiness fails closed when the session cannot execute SQL."""
+
+        class _NoExecuteSession:
+            bind = object()
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(health_router.database_health(session=cast(Session, _NoExecuteSession())))
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Database unavailable"
+
+    def test_database_health_rejects_unbound_session(self) -> None:
+        """DB readiness fails closed when the session has no bound engine."""
+
+        class _UnboundSession:
+            bind = None
+
+            def execute(self, query: object) -> None:
+                raise AssertionError(f"unexpected execute call: {query!r}")
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(health_router.database_health(session=cast(Session, _UnboundSession())))
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Database unavailable"
 
     @pytest.mark.skipif(
         os.getenv("METRICS_ENABLED", "true").lower() != "true",

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -59,6 +59,22 @@ class TestHealthAndMonitoringEndpoints:
         # Verify new fields exist (version, git_sha, timestamp, environment)
         assert {"version", "git_sha", "timestamp", "environment"}.issubset(data.keys())
 
+    def test_health_routes_are_owned_by_canonical_router(self, client: TestClient) -> None:
+        """Operational health/readiness routes are served by app.routers.health."""
+        for path in ("/health", "/api/v1/health", "/health/db", "/ready"):
+            route = _find_route(client, path)
+            assert route.endpoint.__module__ == "app.routers.health"
+
+    def test_health_routes_stay_hidden_from_public_openapi(self, client: TestClient) -> None:
+        """Health/readiness routes remain runtime-only, not public OpenAPI paths."""
+        app = cast(FastAPI, client.app)
+        paths = app.openapi()["paths"]
+
+        assert "/health" not in paths
+        assert "/api/v1/health" not in paths
+        assert "/health/db" not in paths
+        assert "/ready" not in paths
+
     @pytest.mark.skipif(
         os.getenv("METRICS_ENABLED", "true").lower() != "true",
         reason="Metrics disabled in this build",

--- a/tests/test_health_db.py
+++ b/tests/test_health_db.py
@@ -101,6 +101,22 @@ def test_ready_falls_back_to_unavailable_runtime_when_insight_readiness_raises(
     )
 
 
+def test_health_v1_preserves_health_payload_shape() -> None:
+    """The v1 health alias keeps the same payload shape and stable fields."""
+    with TestClient(cast(ASGIApp, app.app)) as client:
+        health_response = client.get("/health")
+        v1_response = client.get("/api/v1/health")
+
+    assert health_response.status_code == 200
+    assert v1_response.status_code == 200
+    health_payload = health_response.json()
+    v1_payload = v1_response.json()
+    assert set(v1_payload) == set(health_payload)
+    for field in ("status", "version", "git_sha", "environment"):
+        assert v1_payload[field] == health_payload[field]
+    assert isinstance(v1_payload["timestamp"], str)
+
+
 @pytest.mark.parametrize("path", ["/health/db", "/ready"])
 def test_readiness_failure(monkeypatch: pytest.MonkeyPatch, path: str) -> None:
     """RU: Ошибка БД приводит к 503.

--- a/tests/test_legacy_app_diff_coverage.py
+++ b/tests/test_legacy_app_diff_coverage.py
@@ -17,6 +17,7 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 
+from app.routers import health as health_router
 import legacy_app
 
 
@@ -46,11 +47,11 @@ async def test_readiness_logs_warning_when_insight_runtime_probe_fails(
 
     import llm
 
-    monkeypatch.setattr(legacy_app, "database_health", _database_health_stub)
+    monkeypatch.setattr(health_router, "database_health", _database_health_stub)
     monkeypatch.setattr(llm, "get_insight_runtime_readiness", _raise_runtime_probe)
 
     with caplog.at_level(logging.WARNING):
-        payload = await legacy_app.ready(session=None)
+        payload = await health_router.ready(session=None)
 
     assert payload["status"] == "ok"
     assert payload["insight_runtime"] == {"status": "unavailable"}

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -68,6 +68,37 @@ def test_legacy_growth_guard_rejects_reintroduced_legal_routes() -> None:
     ]
 
 
+def test_legacy_growth_guard_rejects_reintroduced_health_routes() -> None:
+    source = textwrap.dedent("""
+        @app.get("/health")
+        async def health():
+            return {"status": "legacy"}
+
+        @app.get("/api/v1/health", include_in_schema=False)
+        async def health_v1():
+            return await health()
+
+        @app.get("/health/db", include_in_schema=False)
+        async def database_health():
+            return {"status": "ok"}
+
+        @app.get("/ready", include_in_schema=False)
+        async def ready():
+            return {"status": "ok"}
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "decorator:get:/api/v1/health -> health_v1",
+        "legacy_app.py: unexpected legacy route growth: decorator:get:/health -> health",
+        "legacy_app.py: unexpected legacy route growth: "
+        "decorator:get:/health/db -> database_health",
+        "legacy_app.py: unexpected legacy route growth: decorator:get:/ready -> ready",
+    ]
+
+
 def test_legacy_growth_guard_rejects_new_router_registration() -> None:
     source = "app.include_router(new_router)\n"
 
@@ -384,8 +415,8 @@ def test_legacy_growth_guard_rejects_sensitive_local_assignment_alias_calls(
 
 def test_legacy_growth_guard_rejects_auth_dependency_on_allowed_route() -> None:
     source = textwrap.dedent("""
-        @app.get("/health", dependencies=[Depends(auth_guard)])
-        def health():
+        @app.get("/favicon.ico", dependencies=[Depends(auth_guard)])
+        def favicon():
             return {"ok": True}
         """)
 
@@ -408,8 +439,8 @@ def test_legacy_growth_guard_rejects_auth_dependency_on_allowed_router() -> None
         textwrap.dedent("""
             deps = [Depends(auth_guard)]
 
-            @app.get("/health", dependencies=deps)
-            def health():
+            @app.get("/favicon.ico", dependencies=deps)
+            def favicon():
                 return {"ok": True}
             """),
         textwrap.dedent("""
@@ -428,8 +459,8 @@ def test_legacy_growth_guard_rejects_api_key_surface_growth_on_current_baseline(
     source = (REPO_ROOT / "legacy_app.py").read_text(encoding="utf-8")
     source += textwrap.dedent("""
 
-        @app.get("/health", dependencies=[Depends(api_key_guard)])
-        def health():
+        @app.get("/favicon.ico", dependencies=[Depends(api_key_guard)])
+        def favicon():
             return {"ok": True}
         """)
 

--- a/tests/test_main_paywall_bootstrap.py
+++ b/tests/test_main_paywall_bootstrap.py
@@ -203,6 +203,27 @@ def test_health_route_registration_rejects_foreign_handlers(
         _bootstrap_temp_app(app)
 
 
+def test_health_route_registration_rejects_visible_existing_canonical_handlers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    app = FastAPI()
+    for route in app_main.health_router.routes:
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None) or set()
+        if path in app_main._HEALTH_ROUTE_PATHS and "GET" in methods:
+            app.add_api_route(
+                str(path),
+                getattr(route, "endpoint"),
+                methods=["GET"],
+                include_in_schema=True,
+            )
+
+    with pytest.raises(RuntimeError, match="hidden OpenAPI visibility"):
+        _bootstrap_temp_app(app)
+
+
 def test_health_route_registration_rejects_canonical_plus_foreign_duplicate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_main_paywall_bootstrap.py
+++ b/tests/test_main_paywall_bootstrap.py
@@ -16,13 +16,13 @@ def _restore_app_singleton() -> Generator[None, None, None]:
         app_main.app = original_app
 
 
-def _stub_router(path: str, *, method: str = "post") -> APIRouter:
+def _stub_router(path: str, *, method: str = "post", include_in_schema: bool = True) -> APIRouter:
     router = APIRouter()
 
     async def _handler() -> dict[str, str]:
         return {"status": path}
 
-    getattr(router, method)(path)(_handler)
+    getattr(router, method)(path, include_in_schema=include_in_schema)(_handler)
     return router
 
 
@@ -37,6 +37,38 @@ def _legal_stub_router() -> APIRouter:
 
     router.get("/privacy")(_privacy)
     router.get("/terms")(_terms)
+    return router
+
+
+def _health_stub_router(*, include_in_schema: bool = False) -> APIRouter:
+    router = APIRouter()
+
+    async def _health() -> dict[str, str]:
+        return {"status": "/health"}
+
+    async def _health_v1() -> dict[str, str]:
+        return {"status": "/api/v1/health"}
+
+    async def _health_db() -> dict[str, str]:
+        return {"status": "/health/db"}
+
+    async def _ready() -> dict[str, str]:
+        return {"status": "/ready"}
+
+    router.get("/health", include_in_schema=include_in_schema)(_health)
+    router.get("/api/v1/health", include_in_schema=include_in_schema)(_health_v1)
+    router.get("/health/db", include_in_schema=include_in_schema)(_health_db)
+    router.get("/ready", include_in_schema=include_in_schema)(_ready)
+    return router
+
+
+def _duplicate_health_stub_router() -> APIRouter:
+    router = _health_stub_router()
+
+    async def _second_health() -> dict[str, str]:
+        return {"status": "/health-duplicate"}
+
+    router.get("/health", include_in_schema=False)(_second_health)
     return router
 
 
@@ -60,6 +92,7 @@ def _prepare_bootstrap_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(app_main, "register_pro_contract_routes", lambda target_app: None)
     monkeypatch.setattr(app_main, "register_billing_routes", lambda target_app: None)
     monkeypatch.setattr(app_main, "feedback_router", _stub_router("/api/v1/feedback/rag"))
+    monkeypatch.setattr(app_main, "health_router", _health_stub_router())
     monkeypatch.setattr(app_main, "legal_router", _legal_stub_router())
     monkeypatch.setattr(app_main, "cbt_insight_router", _stub_router("/api/v1/pro/cbt/insight"))
     monkeypatch.setattr(
@@ -113,6 +146,114 @@ def test_paywall_route_registration_rejects_foreign_handler(
 
     with pytest.raises(RuntimeError, match="Duplicate /api/v1/internal/paywall/events route"):
         _bootstrap_temp_app(app)
+
+
+def test_health_route_registration_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    app = FastAPI()
+
+    _bootstrap_temp_app(app)
+    _bootstrap_temp_app(app)
+
+    for path in app_main._HEALTH_ROUTE_PATHS:
+        health_routes = [
+            route
+            for route in app.routes
+            if getattr(route, "path", None) == path
+            and "GET" in (getattr(route, "methods", None) or set())
+        ]
+        assert len(health_routes) == 1
+
+
+@pytest.mark.parametrize("existing_path", app_main._HEALTH_ROUTE_PATHS)
+def test_health_route_registration_rejects_partial_state(
+    monkeypatch: pytest.MonkeyPatch,
+    existing_path: str,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    app = FastAPI()
+
+    @app.get(existing_path)
+    async def _existing_health_route() -> dict[str, str]:
+        return {"status": existing_path}
+
+    with pytest.raises(RuntimeError, match="Partial health route registration detected"):
+        _bootstrap_temp_app(app)
+
+
+def test_health_route_registration_rejects_foreign_handlers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    app = FastAPI()
+
+    async def _foreign_health_route() -> dict[str, str]:
+        return {"status": "foreign"}
+
+    for path in app_main._HEALTH_ROUTE_PATHS:
+        app.add_api_route(path, _foreign_health_route, methods=["GET"])
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate .* route detected with a different health handler",
+    ):
+        _bootstrap_temp_app(app)
+
+
+def test_health_route_registration_rejects_canonical_plus_foreign_duplicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    app = FastAPI()
+    app.include_router(app_main.health_router)
+
+    @app.get("/health", include_in_schema=False)
+    async def _foreign_health_route() -> dict[str, str]:
+        return {"status": "foreign"}
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate /health route detected with a different health handler",
+    ):
+        _bootstrap_temp_app(app)
+
+
+def test_health_route_registration_rejects_malformed_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        app_main,
+        "health_router",
+        _stub_router("/ready", method="get", include_in_schema=False),
+    )
+
+    with pytest.raises(RuntimeError, match="Health router does not define"):
+        _bootstrap_temp_app(FastAPI())
+
+
+def test_health_route_registration_rejects_openapi_visible_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    monkeypatch.setattr(app_main, "health_router", _health_stub_router(include_in_schema=True))
+
+    with pytest.raises(RuntimeError, match="hidden OpenAPI visibility"):
+        _bootstrap_temp_app(FastAPI())
+
+
+def test_health_route_registration_rejects_duplicate_canonical_router_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    monkeypatch.setattr(app_main, "health_router", _duplicate_health_stub_router())
+
+    with pytest.raises(RuntimeError, match="Health router does not define"):
+        _bootstrap_temp_app(FastAPI())
 
 
 @pytest.mark.parametrize("existing_path", ["/privacy", "/terms"])


### PR DESCRIPTION
## Summary
- Extract `/health`, `/api/v1/health`, `/health/db`, and `/ready` from `legacy_app.py` into canonical `app.routers.health`.
- Register the health/readiness route family idempotently from `app/main.py` with fail-closed checks for partial, duplicate, foreign, or OpenAPI-visible registration.
- Remove the legacy guard allowlist for those routes and add owner/OpenAPI/bootstrap/guard/diff-coverage parity coverage.

## Goal
Move operational public route ownership out of `legacy_app.py` without changing runtime paths, response envelopes, readiness semantics, or public OpenAPI visibility.

## Business reason
This continues the legacy-migration pattern proven by legal route extraction: canonical routers own public/operational API surface, while `legacy_app.py` keeps shrinking as a compatibility seam.

## Scope
- Add `app/routers/health.py` with copied health/readiness behavior.
- Add canonical health router bootstrap in `app/main.py`.
- Remove the four route handlers from `legacy_app.py`.
- Shrink `scripts/ci/check_legacy_growth_guard.py` so reintroducing those decorators fails.
- Update narrow owner docs and add premortem / fixed-mapping evidence.

## Out of scope
- No Docker/Kubernetes/Cloudflare probe behavior changes.
- No DB health redesign.
- No auth/admin/debug/BMI/plan/insight/premium/export/FoodDB work.
- No OpenAPI or client regeneration.
- No full `make verify`; this is using the operator-approved narrow validation path for a machine-heavy repo.

## Key decisions
- Include `/health/db` because `/ready` delegates to DB readiness.
- Keep all four routes hidden from public OpenAPI.
- Keep `/favicon.ico` in legacy; it is intentionally not part of this slice.
- Document the raw `legacy_app:app` direct-serving risk instead of preserving legacy decorator ownership.

## Tests
- PASS: `python3 scripts/orchestration/check_preflight.py`
- PASS: `.venv/bin/python -m py_compile app/routers/health.py app/main.py legacy_app.py scripts/ci/check_legacy_growth_guard.py tests/test_app_endpoints_combined.py`
- PASS: `.venv/bin/python -m pytest -q tests/test_health_db.py tests/test_app_endpoints_combined.py tests/test_main_paywall_bootstrap.py tests/test_legacy_growth_guard.py tests/test_openapi_namespace_guards.py tests/test_app_openapi_coverage.py tests/test_legacy_app_diff_coverage.py tests/test_legacy_app_git_sha.py`
- PASS: `.venv/bin/python scripts/ci/check_legacy_growth_guard.py`
- PASS: `make validate-changed VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python`
- PASS: `PRE_COMMIT_HOME=/tmp/pre-commit-health-readiness-routes /Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/pre-commit run --all-files`
- PASS: local diff-cover repair check: `Coverage: 100%` for changed backend files against `origin/main` using `/tmp/pulseplate-pr1969-coverage.xml`.
- PASS: pre-push hooks on `git push` (`pip-audit`, backend pytest, full-repo bandit; Docker build skipped when no relevant files).
- PASS: Experiment Runner oracle-only result accepted; see artifact below.

## Security notes
- Public unauthenticated probe semantics are preserved; no new auth bypass surface is introduced.
- DB readiness remains fail-closed with `503 Database unavailable`.
- `/ready` keeps fail-soft safe `insight_runtime` fallback and does not expose secrets.
- The legacy growth guard now fails closed if health/readiness decorators return to `legacy_app.py`.
- Codex Security diff scan / finding discovery completed with no reportable findings.

## Risks / rollback
- Main operational risk: direct raw `legacy_app:app` serving no longer owns these probe decorators. Canonical entrypoint remains `app.main:app`; owner docs now call out the canonical source of truth.
- Rollback: revert this PR to restore legacy handler ownership and the previous guard baseline.

## Deferred / Follow-ups
- None for this slice. DB health redesign remains intentionally out of scope.

## Lane Start Provenance
- Branch: `codex/extract-health-readiness-routes-from-legacy`
- Packet: `artifacts/orchestration/task_packets/54dec1a9e980.json`
- Runtime dispatch manifest generated with `scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/54dec1a9e980.json --mode runtime --implementation-owner security-auditor --implementation-owner backend-engineer --pretty`.
- Pre-open role order completed: `agent-coordinator -> architecture-specialist -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`.

## Premortem Risk Review
- Skill: `pulseplate-premortem-risk-review`.
- Artifact: `docs/review/PR_HEALTH_READINESS_ROUTE_EXTRACTION_PREMORTEM.md`.
- Decision: proceed with changes; findings are fixed or dispositioned in this PR diff.

## Experiment Runner Evidence
- Mode: `oracle_only_governance_reviewer`.
- Packet: `artifacts/orchestration/experiments/health-readiness-oracle-packet.json`.
- Artifact: `artifacts/orchestration/experiments/results/health-readiness-oracle-result.json`
- Status: accepted; `mutated_paths=[]`; shared tree untouched; `coauthor_required=true`.
- Commit trailer present: `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1969_FIXED_MAPPING.md`
- CI diff-coverage failure at `app/routers/health.py:57,61,63` fixed by commit `e4dd4914e` and recorded in the mapping artifact.

## Merge Readiness
- Not claimed. Post-open role passes, Codex Security diff scan, and pulseplate-pr-review have completed with findings fixed or dispositioned in `docs/review/PR_1969_FIXED_MAPPING.md`.
- Latest pushed head: `09733508b7fce274801344e78fae7fd6796a5fa1`.
- Current-head CI for that head is still pending after the diff-coverage repair push.
- Bot review disposition, mandatory wait-window, and the strict merge-readiness wrapper are still required before any merge discussion.
