### PR TITLE
fix(ci): prepare docker source artifacts in cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,6 +72,11 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
           df -h
 
+      - name: Prepare Docker source artifacts
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/fetch_docker_source_artifacts.py
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0 / Node 24
 
@@ -459,6 +464,11 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
           df -h
+
+      - name: Prepare Docker source artifacts
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/fetch_docker_source_artifacts.py
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0 / Node 24

--- a/docs/review/PR_1978_FIXED_MAPPING.md
+++ b/docs/review/PR_1978_FIXED_MAPPING.md
@@ -50,13 +50,22 @@ provenance, or attestation semantics are changed.
 
 ### Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1978#discussion_r3410388443 -> 50a41bced2985f0facad77dd05aba9555d734d98
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1978#pullrequestreview-4493732314 -> c27f7a6ee3681702df5e32694f3e8584dd515003
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1978#pullrequestreview-4493732314
-Disposition: FIXED / NOT-A-BUG
-Commit: `50a41bced2985f0facad77dd05aba9555d734d98`; `c27f7a6ee3681702df5e32694f3e8584dd515003`
-Evidence: `tests/test_docker_workflow_build_path_contract.py:83` gets `context`; `tests/test_docker_workflow_build_path_contract.py:84` asserts `context == "."`; `tests/test_docker_workflow_build_path_contract.py:19` defines `EXPECTED_DOCKER_SOURCE_PREP_BUILD_STEPS`; `tests/test_docker_workflow_build_path_contract.py:408` asserts the named contract; focused pytest passed with `17 passed`.
-Reason: Codex inline review and Sourcery's named-constant suggestion were fixed. Sourcery's proposed `continue` for missing Docker build inputs is NOT-A-BUG because missing or non-dict `with` would weaken the reviewed fail-closed contract.
+Disposition: NOT-A-BUG
+Evidence: `tests/test_docker_workflow_build_path_contract.py:78` requires Docker build inputs, and `tests/test_docker_workflow_build_path_contract.py:83` through `tests/test_docker_workflow_build_path_contract.py:86` require explicit `context: .`.
+Reason: Sourcery's proposed `continue` for missing Docker build inputs would weaken the reviewed fail-closed contract.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1978#discussion_r3410388443
+Disposition: FIXED
+Commit: 50a41bced2985f0facad77dd05aba9555d734d98
+Evidence: `tests/test_docker_workflow_build_path_contract.py:83` gets `context`; `tests/test_docker_workflow_build_path_contract.py:84` asserts `context == "."`; focused pytest passed with `17 passed`.
+Reason: the guard no longer treats missing `with.context` as root path context, so a future switch to Docker Git context fails before CD can regress.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1978#pullrequestreview-4493732314
+Disposition: FIXED
+Commit: c27f7a6ee3681702df5e32694f3e8584dd515003
+Evidence: `tests/test_docker_workflow_build_path_contract.py:19` defines `EXPECTED_DOCKER_SOURCE_PREP_BUILD_STEPS`; `tests/test_docker_workflow_build_path_contract.py:408` asserts that the discovered workflow build steps cover that named contract.
+Reason: Sourcery's maintainability suggestion to stop hardcoding the expected workflow tuples inline was implemented.
 
 ## Role Dispatch Evidence
 

--- a/docs/review/PR_1978_FIXED_MAPPING.md
+++ b/docs/review/PR_1978_FIXED_MAPPING.md
@@ -1,0 +1,193 @@
+# PR 1978 Fixed in Commit Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1978>
+
+## Summary
+
+This follow-up lane fixes the post-merge CD fallout from the Docker source
+artifact remediation. The CD staging and production image builds now run the
+existing verified Docker source artifact fetcher before Buildx, registry auth,
+and Docker build/push. The workflow guard now checks `build.yml`, `trivy.yml`,
+and `cd.yml` so future root-context Docker builds must prepare source artifacts
+first and must keep explicit `context: .`.
+
+No Dockerfile, Trivy policy, GHCR push, private Python index secret, SBOM,
+provenance, or attestation semantics are changed.
+
+## Lane Start Provenance
+
+- Branch: `codex/fix-cd-docker-source-artifact-prep`
+- Base at PR open: `84f3fa02e15ef61a6847aa5a4c2941d4ac7d957a`
+- Initial implementation commit: `0936fbe946c5b522af1cafa3698faf5741fa4607`
+- Current head at mapping creation:
+  `c27f7a6ee3681702df5e32694f3e8584dd515003`
+- Packet: `artifacts/orchestration/task_packets/2ed6a60cee46.json`
+- Premortem artifact:
+  `artifacts/orchestration/premortem/cd-docker-source-artifact-prep-premortem.md`
+- Experiment Runner accepted result:
+  `artifacts/orchestration/experiments/results/cd-docker-source-artifact-prep-oracle-result-v2.json`
+- Machine-heavy exception: full local `make verify` is intentionally deferred
+  under the operator-approved emergency CI/CD scope. Focused local gates and
+  current-head CI remain required.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- [x] Initial GitHub review/comment scan completed.
+- [x] CodeRabbit issue comment `4703324821` is rate-limit metadata, not
+  actionable code review feedback. Disposition: NOT-A-BUG.
+  Evidence: the comment says CodeRabbit could not start the review due to rate
+  limits and lists only selected files.
+- [x] Sourcery issue comment `4703325041` is reviewer-guide metadata, not an
+  actionable review thread. Disposition: NOT-A-BUG.
+  Evidence: the comment summarizes the PR and provides bot usage instructions.
+- [x] Post-open role loop completed:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- [x] Codex Security diff scan and finding discovery completed.
+- [x] `pulseplate-pr-review` completed.
+- [x] GitHub review comments and bot actionables checked for the current head.
+
+### Fixed in Commit Mapping
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1978#discussion_r3410388443 -> 50a41bced2985f0facad77dd05aba9555d734d98
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1978#pullrequestreview-4493732314 -> c27f7a6ee3681702df5e32694f3e8584dd515003
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1978#pullrequestreview-4493732314
+Disposition: FIXED / NOT-A-BUG
+Commit: `50a41bced2985f0facad77dd05aba9555d734d98`; `c27f7a6ee3681702df5e32694f3e8584dd515003`
+Evidence: `tests/test_docker_workflow_build_path_contract.py:83` gets `context`; `tests/test_docker_workflow_build_path_contract.py:84` asserts `context == "."`; `tests/test_docker_workflow_build_path_contract.py:19` defines `EXPECTED_DOCKER_SOURCE_PREP_BUILD_STEPS`; `tests/test_docker_workflow_build_path_contract.py:408` asserts the named contract; focused pytest passed with `17 passed`.
+Reason: Codex inline review and Sourcery's named-constant suggestion were fixed. Sourcery's proposed `continue` for missing Docker build inputs is NOT-A-BUG because missing or non-dict `with` would weaken the reviewed fail-closed contract.
+
+## Role Dispatch Evidence
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: role dispatch manifest from packet
+  `artifacts/orchestration/task_packets/2ed6a60cee46.json`
+- Pre-open role order completed before PR open:
+  `agent-coordinator -> dev-operator -> security-auditor -> qa-engineer-agent -> bug-hunter -> cursor-specialist-agent -> web-research-agent`.
+- `agent-coordinator`: accepted narrow CD workflow fallout scope.
+- `dev-operator`: confirmed CD staging and production missed Docker source
+  artifact preparation.
+- `security-auditor`: required no weakening to secrets, SBOM, provenance,
+  attestation, or Trivy behavior.
+- `qa-engineer-agent`: accepted focused Docker workflow guard coverage.
+- `bug-hunter`: required generic coverage across build, Trivy, and CD workflow
+  build actions.
+- `cursor-specialist-agent`: confirmed prep ordering before Buildx/login/build.
+- `web-research-agent`: no external web evidence required for the local CD
+  workflow regression.
+
+## Post-Open Role Finding Closure
+
+- `qa-engineer-agent` read-only pass:
+Disposition: NOT-A-BUG
+Evidence: QA found no implementation blocker after the implementation diff and
+identified the missing fixed-mapping/current-head checks as governance
+blockers.
+Reason: the code path was accepted; mapping and current-head CI remained.
+
+- `bug-hunter` read-only pass:
+Disposition: FIXED
+Commit: `50a41bced2985f0facad77dd05aba9555d734d98`
+Evidence: bug-hunter found the same false-green `context` gap as the Codex
+inline review. `tests/test_docker_workflow_build_path_contract.py:83` through
+`tests/test_docker_workflow_build_path_contract.py:86` now fail closed on
+missing or non-`.` Docker path context.
+
+- `security-auditor` read-only pass:
+Disposition: NOT-A-BUG
+Evidence: security-auditor confirmed staging prep at `.github/workflows/cd.yml:75`,
+production prep at `.github/workflows/cd.yml:468`, registry auth after prep at
+`.github/workflows/cd.yml:88` and `.github/workflows/cd.yml:481`, and build/push
+after prep at `.github/workflows/cd.yml:95` and `.github/workflows/cd.yml:488`.
+Reason: no security/deploy supply-chain blocker remained in the reviewed diff.
+
+- Codex Security diff scan / finding discovery:
+Disposition: NOT-A-BUG
+Evidence: final-head scan directory
+`/tmp/codex-security-scans/fix-cd-docker-source-artifact-prep/c27f7a6ee_20260614T230408Z`
+validated `report.md` and rendered `report.html`; final result was 0
+reportable findings with 2/2 diff-scoped files reviewed.
+Reason: the automatic rank generator produced 0 rows for YAML/test governance
+changes, so the scan used an explicit manual diff-file worklist and closed both
+files with evidence.
+
+- `pulseplate-pr-review` dry-run:
+Disposition: NOT-A-BUG
+Evidence: local report generation completed and
+`/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_pr_review_report.py`
+passed with `9 passed`.
+Reason: the review reported the expected missing mapping artifact before this
+file was created and did not identify a code blocker.
+
+## Premortem Finding Closure
+
+- `F1` CD misses another Docker build path.
+Disposition: FIXED
+Commit: `0936fbe946c5b522af1cafa3698faf5741fa4607`
+Evidence: `tests/test_docker_workflow_build_path_contract.py:390` iterates
+`build.yml`, `trivy.yml`, and `cd.yml`; `tests/test_docker_workflow_build_path_contract.py:408`
+asserts expected Docker build coverage.
+
+- `F2` source fetch happens after privileged auth.
+Disposition: FIXED
+Commit: `0936fbe946c5b522af1cafa3698faf5741fa4607`
+Evidence: staging prep runs at `.github/workflows/cd.yml:75` before registry
+login at `.github/workflows/cd.yml:88`; production prep runs at
+`.github/workflows/cd.yml:468` before registry login at
+`.github/workflows/cd.yml:481`.
+
+- `F3` security weakening during hotfix.
+Disposition: FIXED
+Commit: `0936fbe946c5b522af1cafa3698faf5741fa4607`
+Evidence: the diff is limited to `.github/workflows/cd.yml` and
+`tests/test_docker_workflow_build_path_contract.py`; Dockerfile, Trivy policy,
+secret-envs, SBOM, provenance, and attestation semantics are unchanged.
+
+## Experiment Runner Evidence
+
+- Artifact: `artifacts/orchestration/experiments/results/cd-docker-source-artifact-prep-oracle-result-v2.json`
+- Mode: `oracle_only_governance_reviewer`
+- Status: accepted
+- Contribution: `commit_decision`
+- Co-author required: true; implementation commit includes
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+- Accepted oracle commands:
+  - `git diff --check`
+  - `python3 -m py_compile tests/test_docker_workflow_build_path_contract.py`
+  - dependency-free CD prep ordering assertion
+
+## Validation Evidence
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_docker_workflow_build_path_contract.py`
+  (`17 passed`)
+- PASS: `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
+- PASS: `PRE_COMMIT_HOME=/tmp/pre-commit-cd-docker-source-artifact-prep pre-commit run --all-files`
+- PASS during commit/push hooks: commit hooks, `pip-audit`, backend pre-push
+  pytest, full-repo Bandit.
+- PASS: Codex Security final-head report validation and HTML rendering:
+  `/tmp/codex-security-scans/fix-cd-docker-source-artifact-prep/c27f7a6ee_20260614T230408Z/report.md`
+  and
+  `/tmp/codex-security-scans/fix-cd-docker-source-artifact-prep/c27f7a6ee_20260614T230408Z/report.html`
+- PASS: `pulseplate-pr-review` dry-run tooling and
+  `tests/test_pr_review_report.py` (`9 passed`)
+
+## Merge Readiness
+
+Merge readiness is not claimed by this artifact alone. Required remaining proof:
+
+- current-head PR CI for `c27f7a6ee3681702df5e32694f3e8584dd515003`;
+- PR-body Phase2 and mapping guards after this artifact is committed and the PR
+  body mirror is refreshed;
+- strict merge-readiness wrapper with GitHub auth;
+- post-merge `main` CD run, because this PR fixes a push-only CD workflow path.
+
+## Risks / Rollback
+
+- Risk: CD source artifact preparation may still fail at runtime due external
+  source availability. Existing manifest/SHA3 verification remains fail-closed.
+- Risk: CD itself is push-only, so final runtime proof requires post-merge main
+  CD.
+- Rollback: revert this PR. It changes workflow ordering and tests only; runtime
+  app code and Dockerfile semantics are unchanged.

--- a/docs/review/PR_1978_FIXED_MAPPING.md
+++ b/docs/review/PR_1978_FIXED_MAPPING.md
@@ -19,7 +19,7 @@ provenance, or attestation semantics are changed.
 - Branch: `codex/fix-cd-docker-source-artifact-prep`
 - Base at PR open: `84f3fa02e15ef61a6847aa5a4c2941d4ac7d957a`
 - Initial implementation commit: `0936fbe946c5b522af1cafa3698faf5741fa4607`
-- Current head at mapping creation:
+- Implementation head before mapping artifact:
   `c27f7a6ee3681702df5e32694f3e8584dd515003`
 - Packet: `artifacts/orchestration/task_packets/2ed6a60cee46.json`
 - Premortem artifact:
@@ -177,7 +177,7 @@ secret-envs, SBOM, provenance, and attestation semantics are unchanged.
 
 Merge readiness is not claimed by this artifact alone. Required remaining proof:
 
-- current-head PR CI for `c27f7a6ee3681702df5e32694f3e8584dd515003`;
+- current-head PR CI for the latest pushed head;
 - PR-body Phase2 and mapping guards after this artifact is committed and the PR
   body mirror is refreshed;
 - strict merge-readiness wrapper with GitHub auth;

--- a/tests/test_docker_workflow_build_path_contract.py
+++ b/tests/test_docker_workflow_build_path_contract.py
@@ -70,8 +70,10 @@ def _root_context_docker_build_steps(
                 continue
             step_with = step.get("with")
             assert isinstance(step_with, dict)
-            if step_with.get("context", ".") != ".":
-                continue
+            context = step_with.get("context")
+            assert (
+                context == "."
+            ), f"{job_name}/{step.get('name')} must set docker build path context '.'"
             step_name = step.get("name")
             assert isinstance(step_name, str)
             build_steps.append((job_name, job, step_name))

--- a/tests/test_docker_workflow_build_path_contract.py
+++ b/tests/test_docker_workflow_build_path_contract.py
@@ -50,6 +50,34 @@ def _step_index(job: dict[str, object], step_name: str) -> int:
     return _step_names(job).index(step_name)
 
 
+def _root_context_docker_build_steps(
+    workflow: dict[str, object],
+) -> list[tuple[str, dict[str, object], str]]:
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    build_steps: list[tuple[str, dict[str, object], str]] = []
+    for job_name, job in jobs.items():
+        assert isinstance(job_name, str)
+        if not isinstance(job, dict):
+            continue
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            assert isinstance(step, dict)
+            uses = step.get("uses")
+            if not (isinstance(uses, str) and uses.startswith("docker/build-push-action@")):
+                continue
+            step_with = step.get("with")
+            assert isinstance(step_with, dict)
+            if step_with.get("context", ".") != ".":
+                continue
+            step_name = step.get("name")
+            assert isinstance(step_name, str)
+            build_steps.append((job_name, job, step_name))
+    return build_steps
+
+
 def _docker_source_manifest(
     *,
     payload: bytes = b"sqlite source",
@@ -349,32 +377,29 @@ def test_docker_source_artifact_fetcher_rejects_digest_mismatches(
 
 def test_docker_build_workflows_prefetch_source_artifacts_before_build() -> None:
     """Docker workflows prepare source artifacts explicitly before image build actions."""
-    workflow = _load_workflow(WORKFLOWS_DIR / "build.yml")
-    build_job = workflow["jobs"]["build"]
-    publish_job = workflow["jobs"]["publish"]
-    assert isinstance(build_job, dict)
-    assert isinstance(publish_job, dict)
+    checked_steps: set[tuple[str, str, str]] = set()
 
-    for job, build_step_name in (
-        (build_job, "Build Docker image (local, for tests)"),
-        (publish_job, "Build Docker image for publish scan"),
-    ):
-        prepare_step = _step_by_name(job, "Prepare Docker source artifacts")
-        assert "python3 scripts/ci/fetch_docker_source_artifacts.py" in prepare_step["run"]
-        assert _step_index(job, "Prepare Docker source artifacts") < _step_index(
-            job,
-            build_step_name,
-        )
+    for workflow_name in ("build.yml", "trivy.yml", "cd.yml"):
+        workflow = _load_workflow(WORKFLOWS_DIR / workflow_name)
+        for job_name, job, build_step_name in _root_context_docker_build_steps(workflow):
+            prepare_step = _step_by_name(job, "Prepare Docker source artifacts")
+            prepare_run = prepare_step["run"]
+            assert isinstance(prepare_run, str)
+            assert "set -euo pipefail" in prepare_run
+            assert "python3 scripts/ci/fetch_docker_source_artifacts.py" in prepare_run
+            assert _step_index(job, "Prepare Docker source artifacts") < _step_index(
+                job,
+                build_step_name,
+            )
+            checked_steps.add((workflow_name, job_name, build_step_name))
 
-    trivy_workflow = _load_workflow(WORKFLOWS_DIR / "trivy.yml")
-    trivy_job = trivy_workflow["jobs"]["build"]
-    assert isinstance(trivy_job, dict)
-    trivy_prepare_step = _step_by_name(trivy_job, "Prepare Docker source artifacts")
-    assert "python3 scripts/ci/fetch_docker_source_artifacts.py" in trivy_prepare_step["run"]
-    assert _step_index(trivy_job, "Prepare Docker source artifacts") < _step_index(
-        trivy_job,
-        "Build Docker image (production target)",
-    )
+    assert {
+        ("build.yml", "build", "Build Docker image (local, for tests)"),
+        ("build.yml", "publish", "Build Docker image for publish scan"),
+        ("trivy.yml", "build", "Build Docker image (production target)"),
+        ("cd.yml", "build", "Build & Push image (staging)"),
+        ("cd.yml", "build-production", "Build & Push image (production)"),
+    } <= checked_steps
 
 
 def test_makefile_docker_build_targets_prefetch_source_artifacts() -> None:

--- a/tests/test_docker_workflow_build_path_contract.py
+++ b/tests/test_docker_workflow_build_path_contract.py
@@ -16,6 +16,13 @@ from scripts.ci import fetch_docker_source_artifacts as docker_sources
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+EXPECTED_DOCKER_SOURCE_PREP_BUILD_STEPS = {
+    ("build.yml", "build", "Build Docker image (local, for tests)"),
+    ("build.yml", "publish", "Build Docker image for publish scan"),
+    ("trivy.yml", "build", "Build Docker image (production target)"),
+    ("cd.yml", "build", "Build & Push image (staging)"),
+    ("cd.yml", "build-production", "Build & Push image (production)"),
+}
 
 
 def _load_workflow(path: Path) -> dict[str, object]:
@@ -69,7 +76,10 @@ def _root_context_docker_build_steps(
             if not (isinstance(uses, str) and uses.startswith("docker/build-push-action@")):
                 continue
             step_with = step.get("with")
-            assert isinstance(step_with, dict)
+            assert isinstance(
+                step_with,
+                dict,
+            ), f"{job_name}/{step.get('name')} must define docker build inputs"
             context = step_with.get("context")
             assert (
                 context == "."
@@ -395,13 +405,7 @@ def test_docker_build_workflows_prefetch_source_artifacts_before_build() -> None
             )
             checked_steps.add((workflow_name, job_name, build_step_name))
 
-    assert {
-        ("build.yml", "build", "Build Docker image (local, for tests)"),
-        ("build.yml", "publish", "Build Docker image for publish scan"),
-        ("trivy.yml", "build", "Build Docker image (production target)"),
-        ("cd.yml", "build", "Build & Push image (staging)"),
-        ("cd.yml", "build-production", "Build & Push image (production)"),
-    } <= checked_steps
+    assert EXPECTED_DOCKER_SOURCE_PREP_BUILD_STEPS <= checked_steps
 
 
 def test_makefile_docker_build_targets_prefetch_source_artifacts() -> None:


### PR DESCRIPTION
## Summary
- Fixes latest `main` CD fallout after PR #1976: CD staging/production Docker builds now run the existing verified Docker source artifact fetcher before Buildx, registry auth, and Docker build/push.
- Strengthens the workflow contract guard so every Docker build-push action in `build.yml`, `trivy.yml`, and `cd.yml` must use explicit `context: .` and must have `Prepare Docker source artifacts` earlier in the same job.
- Does not change Dockerfile, Trivy policy, private Python index secret-envs, GHCR push, provenance, SBOM, attestation, or deploy gating semantics.

## Failure Evidence
- Latest `main` CD run `27513684290` failed in job `81318350197` at `Dockerfile:158` because `build/docker-sources/sqlite-autoconf-3530200.tar.gz` was missing from the CD build context.
- Latest `main` Docker Build and Push run `27513684299` passed, including the fail-closed Trivy image scan, SARIF upload, image push, SBOM, and attestations; this PR fixes the separate CD workflow drift.

## Lane Start Provenance
- Branch: `codex/fix-cd-docker-source-artifact-prep`
- Base at PR open: `84f3fa02e15ef61a6847aa5a4c2941d4ac7d957a`
- Current head: tracked by GitHub PR head; merge gates use current-head checks.
- Packet: `artifacts/orchestration/task_packets/2ed6a60cee46.json`
- Role order completed pre-open: `agent-coordinator -> dev-operator -> security-auditor -> qa-engineer-agent -> bug-hunter -> cursor-specialist-agent -> web-research-agent`.

## Premortem Finding Closure
- Artifact: `artifacts/orchestration/premortem/cd-docker-source-artifact-prep-premortem.md` (local gitignored evidence).
- `F1` CD misses another Docker build path: FIXED by generic guard over `build.yml`, `trivy.yml`, and `cd.yml` Docker build-push actions.
- `F2` source fetch after privileged auth: FIXED by placing prep before Buildx/login/build in CD staging and production.
- `F3` security weakening during hotfix: FIXED by keeping Dockerfile, Trivy policy, secret-envs, GHCR push, provenance, SBOM, and attestation semantics unchanged.

## Experiment Runner Evidence
- Packet: `artifacts/orchestration/experiments/cd-docker-source-artifact-prep-oracle-packet-v2.json`
Artifact: `artifacts/orchestration/experiments/results/cd-docker-source-artifact-prep-oracle-result-v2.json`
- Mode: `oracle_only_governance_reviewer`
- Contribution: `commit_decision`; implementation commit includes the canonical Experiment Runner co-author trailer.
- Oracles passed: `git diff --check`; `python3 -m py_compile tests/test_docker_workflow_build_path_contract.py`; dependency-free CD prep ordering assertion.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] CodeRabbit issue comment `4703324821` dispositioned as NOT-A-BUG rate-limit metadata.
- [x] Sourcery issue comment `4703325041` dispositioned as NOT-A-BUG reviewer-guide metadata.
- [x] Codex inline review `discussion_r3410388443` dispositioned as FIXED.
- [x] Sourcery review `pullrequestreview-4493732314` dispositioned: named-constant suggestion FIXED; proposed `continue` for missing Docker build inputs NOT-A-BUG because this guard must fail closed.
- [x] Post-open role loop completed: `qa-engineer-agent -> bug-hunter -> security-auditor`.
- [x] Codex Security diff scan and finding discovery completed: 2/2 diff-scoped files reviewed, 0 reportable findings.
- [x] `pulseplate-pr-review` completed.

### Fixed in Commit Mapping
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1978#discussion_r3410388443` -> `50a41bced2985f0facad77dd05aba9555d734d98`
  - Disposition: FIXED
  - Evidence: `tests/test_docker_workflow_build_path_contract.py:83` gets `context`; line 84 asserts `context == "."`; focused pytest passed with `17 passed`.
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1978#pullrequestreview-4493732314` -> `c27f7a6ee3681702df5e32694f3e8584dd515003`
  - Disposition: FIXED
  - Evidence: `tests/test_docker_workflow_build_path_contract.py:19` defines `EXPECTED_DOCKER_SOURCE_PREP_BUILD_STEPS`; line 408 asserts that discovered workflow build steps cover the named contract.
- `https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1978#pullrequestreview-4493732314`
  - Disposition: NOT-A-BUG
  - Evidence: `tests/test_docker_workflow_build_path_contract.py:78` requires Docker build inputs; lines 83-86 require explicit `context: .`.
  - Reason: skipping missing or non-dict `with` would weaken the reviewed fail-closed contract.

## Validation
- PASS: `python3 scripts/orchestration/check_preflight.py`
- PASS: `/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python -m pytest -q tests/test_docker_workflow_build_path_contract.py` (`17 passed`)
- PASS: `VENV_PYTHON=/Users/katsiaryna_kavaleuskaya/Developer/BMI-App_2025_clean/.venv/bin/python make validate-changed`
- PASS: `PRE_COMMIT_HOME=/tmp/pre-commit-cd-docker-source-artifact-prep pre-commit run --all-files`
- PASS during commit/push hooks: commit hooks, `pip-audit`, backend pre-push pytest, full-repo Bandit.
- PASS: Codex Security final-head report validation and HTML rendering at `/tmp/codex-security-scans/fix-cd-docker-source-artifact-prep/c27f7a6ee_20260614T230408Z/report.md` and `/tmp/codex-security-scans/fix-cd-docker-source-artifact-prep/c27f7a6ee_20260614T230408Z/report.html`.
- PASS: `pulseplate-pr-review` dry-run tooling and `tests/test_pr_review_report.py` (`9 passed`).

## Merge Readiness
- Not claimed yet.
- Awaiting current-head CI for the latest pushed head, strict merge-readiness wrapper with GitHub auth, and post-merge `main` CD proof because this PR fixes a push-only CD workflow path.
- No full local `make verify` run by operator-approved machine-heavy exception; focused local gates and current-head CI are the required proof for this emergency CI/CD lane.

## Risks / Rollback
- Risk: CD source artifact preparation can still fail if the external source is unavailable. Existing manifest/SHA3 verification remains fail-closed.
- Risk: CD is push-only, so final runtime proof requires post-merge `main` CD.
- Rollback: revert this PR. It changes workflow ordering and tests only; runtime app code and Dockerfile semantics are unchanged.
