### PR TITLE
refactor(api): extract admin debug operational routes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,10 @@ from app.bootstrap.tracing import register_tracing
 from app.routers.creative_research_internal import router as creative_research_internal_router
 from app.routers.paywall_analytics import ingest_paywall_event, router as paywall_analytics_router
 import app.routers.realtime_ws as realtime_ws
+from app.routers.admin_operations import (
+    ADMIN_OPERATION_ROUTE_SPECS,
+    router as admin_operations_router,
+)
 from app.routers.billing import register_billing_routes
 from app.routers.cbt_insight import router as cbt_insight_router
 from app.routers.feedback import router as feedback_router
@@ -61,6 +65,9 @@ _CBT_INSIGHT_ROUTE_PATH: str = "/api/v1/pro/cbt/insight"
 _FITCHEF_STRUCTURED_ROUTE_PATH: str = "/api/v1/pro/fitchef/explain"
 _CREATIVE_RESEARCH_PILOT_ROUTE_PATH: str = "/api/v1/internal/creative-research/pilot"
 _PAYWALL_EVENTS_ROUTE_PATH: str = "/api/v1/internal/paywall/events"
+_ADMIN_OPERATION_ROUTE_SPECS: tuple[tuple[str, str], ...] = tuple(
+    (path, method.upper()) for path, method in ADMIN_OPERATION_ROUTE_SPECS
+)
 
 
 def _has_route(
@@ -265,6 +272,89 @@ def _include_favicon_router_if_needed(target_app: FastAPI) -> None:
         )
 
 
+def _include_admin_operations_router_if_needed(target_app: FastAPI) -> None:
+    """Register admin/debug operational routes as one hidden atomic family."""
+
+    expected_specs = set(_ADMIN_OPERATION_ROUTE_SPECS)
+    expected_paths = {path for path, _method in expected_specs}
+    expected_methods_by_path = {path: method for path, method in expected_specs}
+    expected_endpoints: dict[tuple[str, str], object] = {}
+    expected_route_counts: dict[tuple[str, str], int] = {spec: 0 for spec in expected_specs}
+
+    for route in admin_operations_router.routes:
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None) or set()
+        if path not in expected_paths:
+            continue
+        expected_method = expected_methods_by_path[str(path)]
+        if expected_method not in methods:
+            raise RuntimeError("Admin operations router does not define the expected route family.")
+        unexpected_methods = set(methods) - {expected_method, "HEAD", "OPTIONS"}
+        if unexpected_methods:
+            raise RuntimeError("Admin operations router does not define the expected route family.")
+        expected_route_counts[(str(path), expected_method)] += 1
+        expected_endpoints[(str(path), expected_method)] = getattr(route, "endpoint", None)
+        if getattr(route, "include_in_schema", True):
+            raise RuntimeError(
+                "Admin operations router does not preserve hidden OpenAPI visibility."
+            )
+
+    if set(expected_endpoints) != expected_specs or any(
+        count != 1 for count in expected_route_counts.values()
+    ):
+        raise RuntimeError("Admin operations router does not define the expected route family.")
+
+    admin_routes = [
+        route for route in target_app.routes if getattr(route, "path", None) in expected_paths
+    ]
+    if not admin_routes:
+        target_app.include_router(admin_operations_router)
+        return
+
+    admin_paths_present = {
+        str(getattr(route, "path", ""))
+        for route in admin_routes
+        if expected_methods_by_path[str(getattr(route, "path", ""))]
+        in (getattr(route, "methods", None) or set())
+    }
+    if admin_paths_present != expected_paths:
+        existing = ", ".join(sorted(admin_paths_present))
+        missing = ", ".join(sorted(expected_paths - admin_paths_present))
+        raise RuntimeError(
+            "Partial admin operations route registration detected. "
+            f"Existing: {existing or '<none>'}; missing: {missing or '<none>'}."
+        )
+
+    for route in admin_routes:
+        path = str(getattr(route, "path", ""))
+        methods = getattr(route, "methods", None) or set()
+        expected_method = expected_methods_by_path[path]
+        if expected_method not in methods:
+            raise RuntimeError("Partial admin operations route registration detected.")
+        unexpected_methods = set(methods) - {expected_method, "HEAD", "OPTIONS"}
+        if unexpected_methods:
+            raise RuntimeError("Partial admin operations route registration detected.")
+
+    for (path, method), endpoint in expected_endpoints.items():
+        matching_routes = [
+            route
+            for route in target_app.routes
+            if getattr(route, "path", None) == path
+            and method in (getattr(route, "methods", None) or set())
+        ]
+        if (
+            len(matching_routes) != 1
+            or getattr(matching_routes[0], "endpoint", None) is not endpoint
+        ):
+            raise RuntimeError(
+                f"Duplicate {path} route detected with a different admin operations handler."
+            )
+        if getattr(matching_routes[0], "include_in_schema", True):
+            raise RuntimeError(
+                f"Existing {path} route does not preserve hidden OpenAPI visibility."
+            )
+
+
 def _internalize_users_openapi_surface(target_app: FastAPI) -> None:
     """Hide legacy users CRUD from the public OpenAPI contract.
 
@@ -349,6 +439,7 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     _include_health_router_if_needed(app)
     _include_legal_router_if_needed(app)
     _include_favicon_router_if_needed(app)
+    _include_admin_operations_router_if_needed(app)
 
     register_billing_routes(app)
 

--- a/app/routers/admin_operations.py
+++ b/app/routers/admin_operations.py
@@ -1,0 +1,90 @@
+"""Canonical hidden admin/debug operational routes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+
+from app.routers.api_key import require_app_api_key
+from app.services import admin_operations as service
+
+DEBUG_ENV_ROUTE_PATH = "/debug_env"
+ADMIN_STATUS_ROUTE_PATH = "/api/v1/admin/status"
+ADMIN_LOGS_CLEANUP_ROUTE_PATH = "/admin/logs/cleanup"
+ADMIN_DB_STATUS_ROUTE_PATH = "/api/v1/admin/db-status"
+ADMIN_FORCE_UPDATE_ROUTE_PATH = "/api/v1/admin/force-update"
+ADMIN_CHECK_UPDATES_ROUTE_PATH = "/api/v1/admin/check-updates"
+ADMIN_ROLLBACK_ROUTE_PATH = "/api/v1/admin/rollback"
+
+ADMIN_OPERATION_ROUTE_SPECS: tuple[tuple[str, str], ...] = (
+    (DEBUG_ENV_ROUTE_PATH, "GET"),
+    (ADMIN_STATUS_ROUTE_PATH, "GET"),
+    (ADMIN_LOGS_CLEANUP_ROUTE_PATH, "POST"),
+    (ADMIN_DB_STATUS_ROUTE_PATH, "GET"),
+    (ADMIN_FORCE_UPDATE_ROUTE_PATH, "POST"),
+    (ADMIN_CHECK_UPDATES_ROUTE_PATH, "GET"),
+    (ADMIN_ROLLBACK_ROUTE_PATH, "POST"),
+)
+
+router = APIRouter(tags=["admin-operations"], include_in_schema=False)
+
+
+@router.get(DEBUG_ENV_ROUTE_PATH, include_in_schema=False)
+async def debug_env() -> JSONResponse:
+    return await service.debug_env()
+
+
+@router.get(
+    ADMIN_STATUS_ROUTE_PATH,
+    dependencies=[Depends(require_app_api_key)],
+    include_in_schema=False,
+)
+async def admin_status() -> dict[str, str]:
+    return await service.admin_status()
+
+
+@router.post(
+    ADMIN_LOGS_CLEANUP_ROUTE_PATH,
+    dependencies=[Depends(require_app_api_key)],
+    include_in_schema=False,
+)
+async def cleanup_expired_logs(data_class: str | None = None) -> dict[str, Any]:
+    return await service.cleanup_expired_logs(data_class=data_class)
+
+
+@router.get(
+    ADMIN_DB_STATUS_ROUTE_PATH,
+    dependencies=[Depends(require_app_api_key)],
+    include_in_schema=False,
+)
+async def get_database_status() -> JSONResponse:
+    return await service.get_database_status()
+
+
+@router.post(
+    ADMIN_FORCE_UPDATE_ROUTE_PATH,
+    dependencies=[Depends(require_app_api_key)],
+    include_in_schema=False,
+)
+async def force_database_update(source: str | None = None) -> JSONResponse:
+    return await service.force_database_update(source=source)
+
+
+@router.get(
+    ADMIN_CHECK_UPDATES_ROUTE_PATH,
+    dependencies=[Depends(require_app_api_key)],
+    include_in_schema=False,
+)
+async def check_for_updates() -> JSONResponse:
+    return await service.check_for_updates()
+
+
+@router.post(
+    ADMIN_ROLLBACK_ROUTE_PATH,
+    dependencies=[Depends(require_app_api_key)],
+    include_in_schema=False,
+)
+async def rollback_database(source: str, target_version: str) -> dict[str, Any]:
+    return await service.rollback_database(source=source, target_version=target_version)

--- a/app/services/admin_operations.py
+++ b/app/services/admin_operations.py
@@ -22,23 +22,43 @@ logger = logging.getLogger(__name__)
 SchedulerGetter = Callable[[], Any]
 
 
-def _resolve_scheduler_getter() -> SchedulerGetter:
-    """Resolve the update scheduler seam while preserving legacy test patches."""
-
-    legacy_mod = sys.modules.get("legacy_app")
-    app_mod = sys.modules.get("app")
+def _select_scheduler_getter_from_modules(
+    legacy_mod: Any,
+    app_mod: Any,
+    app_module_mod: Any,
+) -> SchedulerGetter | None:
+    """Select a patched scheduler getter from legacy/app module aliases."""
 
     legacy_getter = getattr(legacy_mod, "get_update_scheduler", None)
     default_getter = getattr(legacy_mod, "_DEFAULT_GET_UPDATE_SCHEDULER", None)
     if callable(legacy_getter) and legacy_getter is not default_getter:
         return cast(SchedulerGetter, legacy_getter)
 
-    app_getter = getattr(app_mod, "get_update_scheduler", None)
-    if callable(app_getter) and app_getter is not default_getter:
-        return cast(SchedulerGetter, app_getter)
+    for candidate_mod in (app_mod, app_module_mod):
+        app_getter = getattr(candidate_mod, "get_update_scheduler", None)
+        if callable(app_getter) and app_getter is not default_getter:
+            return cast(SchedulerGetter, app_getter)
 
     if callable(default_getter):
         return cast(SchedulerGetter, default_getter)
+
+    return None
+
+
+def _resolve_scheduler_getter() -> SchedulerGetter:
+    """Resolve the update scheduler seam while preserving legacy test patches."""
+
+    legacy_mod = sys.modules.get("legacy_app")
+    app_mod = sys.modules.get("app")
+    app_module_mod = sys.modules.get("app_module")
+
+    selected_getter = _select_scheduler_getter_from_modules(
+        legacy_mod,
+        app_mod,
+        app_module_mod,
+    )
+    if selected_getter is not None:
+        return selected_getter
 
     from core.food_apis.scheduler import get_update_scheduler as scheduler_getter
 

--- a/app/services/admin_operations.py
+++ b/app/services/admin_operations.py
@@ -1,0 +1,238 @@
+"""Service layer for hidden admin/debug operational endpoints."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import os
+import sys
+from collections.abc import Callable
+from typing import Any, cast
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+from starlette.concurrency import run_in_threadpool
+
+from app.utils.feature_flags import _is_truthy
+from core.log_retention import DataClass, get_retention_manager
+from settings import is_explicit_developer_env
+
+logger = logging.getLogger(__name__)
+
+SchedulerGetter = Callable[[], Any]
+
+
+def _resolve_scheduler_getter() -> SchedulerGetter:
+    """Resolve the update scheduler seam while preserving legacy test patches."""
+
+    legacy_mod = sys.modules.get("legacy_app")
+    app_mod = sys.modules.get("app")
+
+    legacy_getter = getattr(legacy_mod, "get_update_scheduler", None)
+    default_getter = getattr(legacy_mod, "_DEFAULT_GET_UPDATE_SCHEDULER", None)
+    if callable(legacy_getter) and legacy_getter is not default_getter:
+        return cast(SchedulerGetter, legacy_getter)
+
+    app_getter = getattr(app_mod, "get_update_scheduler", None)
+    if callable(app_getter) and app_getter is not default_getter:
+        return cast(SchedulerGetter, app_getter)
+
+    if callable(default_getter):
+        return cast(SchedulerGetter, default_getter)
+
+    from core.food_apis.scheduler import get_update_scheduler as scheduler_getter
+
+    return cast(SchedulerGetter, scheduler_getter)
+
+
+async def _get_scheduler() -> Any:
+    getter = _resolve_scheduler_getter()
+    result = getter()
+    return await result if inspect.isawaitable(result) else result
+
+
+async def admin_status() -> dict[str, str]:
+    """Return scheduler availability for the hidden admin status endpoint."""
+
+    try:
+        scheduler = await _get_scheduler()
+        if scheduler is None:
+            raise RuntimeError("Scheduler unavailable")
+        return {"status": "ok", "scheduler": "available"}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail="Scheduler unavailable") from exc
+
+
+async def cleanup_expired_logs(data_class: str | None = None) -> dict[str, Any]:
+    """Cleanup expired log files based on retention policy."""
+
+    retention_manager = get_retention_manager()
+
+    data_class_enum = None
+    if data_class is not None:
+        try:
+            data_class_enum = DataClass(data_class)
+        except ValueError:
+            return {
+                "status": "error",
+                "deleted_files": 0,
+                "data_class": data_class,
+                "message": f"Invalid data_class: '{data_class}'. Must be one of: "
+                f"{', '.join([entry.value for entry in DataClass])}",
+            }
+
+    deleted_count = retention_manager.cleanup_expired_logs(data_class=data_class_enum)
+
+    return {
+        "status": "success",
+        "deleted_files": deleted_count,
+        "data_class": data_class or "ALL",
+        "message": f"Deleted {deleted_count} expired log file(s)",
+    }
+
+
+async def debug_env() -> JSONResponse:
+    """Return limited debug configuration in explicit developer/flagged mode only."""
+
+    debug_flag = _is_truthy(os.getenv("ENABLE_DEBUG_ENDPOINT"))
+    if not is_explicit_developer_env() and not debug_flag:
+        raise HTTPException(status_code=404, detail="Not found")
+
+    data = {
+        "FEATURE_INSIGHT": os.getenv("FEATURE_INSIGHT", ""),
+        "LLM_PROVIDER": os.getenv("LLM_PROVIDER", ""),
+        "PERPLEXITY_MODEL": os.getenv("PERPLEXITY_MODEL", ""),
+        "PERPLEXITY_ENDPOINT": os.getenv("PERPLEXITY_ENDPOINT", ""),
+    }
+    flag = str(os.getenv("FEATURE_INSIGHT", "")).strip().lower()
+    data["insight_enabled"] = str(flag in {"1", "true", "yes", "on"})
+    return JSONResponse(content=data)
+
+
+async def get_database_status() -> JSONResponse:
+    """Get status of all databases and update scheduler."""
+
+    try:
+        getter = _resolve_scheduler_getter()
+        logger.debug("get_database_status using getter: %r", getter)
+        scheduler = await _get_scheduler()
+        status = scheduler.get_status()
+        return JSONResponse(content=status)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to get database status: {str(exc)}",
+        ) from exc
+
+
+async def force_database_update(source: str | None = None) -> JSONResponse:
+    """Force immediate database update."""
+
+    try:
+        getter = _resolve_scheduler_getter()
+        logger.debug("force_database_update using getter: %r", getter)
+        scheduler = await _get_scheduler()
+        results = await scheduler.force_update(source)
+
+        response: dict[str, Any] = {
+            "message": f"Force update completed for {source or 'all sources'}",
+            "results": {},
+        }
+
+        for src, result in results.items():
+            response["results"][src] = {
+                "success": result.success,
+                "old_version": result.old_version,
+                "new_version": result.new_version,
+                "records_added": result.records_added,
+                "records_updated": result.records_updated,
+                "records_removed": result.records_removed,
+                "duration_seconds": result.duration_seconds,
+                "errors": result.errors,
+            }
+
+        return JSONResponse(content=response)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Force update failed: {str(exc)}") from exc
+
+
+async def check_for_updates() -> JSONResponse:
+    """Check for available updates without installing them."""
+
+    try:
+        scheduler = await _get_scheduler()
+        if scheduler is None:
+            raise RuntimeError("Scheduler resolved to None")
+
+        update_manager = getattr(scheduler, "update_manager", None)
+        if update_manager is None or not hasattr(update_manager, "check_for_updates"):
+            raise RuntimeError("Update manager missing or check_for_updates not supported")
+
+        available_updates = await update_manager.check_for_updates()
+
+        updates_available = available_updates or {}
+        total_sources_with_updates = sum(1 for value in updates_available.values() if bool(value))
+
+        response = {
+            "message": "Update check completed",
+            "updates_available": updates_available,
+            "total_sources_with_updates": int(total_sources_with_updates),
+        }
+
+        return JSONResponse(content=response)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Update check failed")
+        raise HTTPException(status_code=500, detail=f"Update check failed: {str(exc)}") from exc
+
+
+async def rollback_database(source: str, target_version: str) -> dict[str, Any]:
+    """Rollback database to a specific version."""
+
+    try:
+        scheduler = await _get_scheduler()
+        if scheduler is None:
+            raise ValueError("Scheduler returned None")
+    except Exception as exc:
+        logger.exception("Rollback: could not get scheduler")
+        error_detail = "Rollback operation failed: could not get scheduler"
+        raise HTTPException(status_code=500, detail=error_detail) from exc
+
+    update_manager = getattr(scheduler, "update_manager", None)
+    if update_manager is None:
+        raise HTTPException(
+            status_code=500,
+            detail="No update manager available; rollback operation failed",
+        )
+
+    rollback_callable = getattr(update_manager, "rollback_database", None)
+    if rollback_callable is None or not callable(rollback_callable):
+        raise HTTPException(
+            status_code=500,
+            detail="Rollback operation not supported by update manager",
+        )
+
+    try:
+        if inspect.iscoroutinefunction(rollback_callable):
+            success = await rollback_callable(source, target_version)
+        else:
+            success = await run_in_threadpool(rollback_callable, source, target_version)
+
+        if inspect.isawaitable(success):
+            success = await success
+    except Exception as exc:
+        logger.exception("Rollback callable raised")
+        error_msg = "Rollback operation failed; Rollback failed; see server logs for details"
+        raise HTTPException(status_code=500, detail=error_msg) from exc
+
+    if success:
+        return {
+            "message": f"Successfully rolled back {source} to version {target_version}",
+            "success": True,
+        }
+
+    error_detail = f"Rollback operation failed for {source} to version {target_version}"
+    raise HTTPException(status_code=500, detail=error_detail)

--- a/docs/review/PR_1980_FIXED_MAPPING.md
+++ b/docs/review/PR_1980_FIXED_MAPPING.md
@@ -1,0 +1,177 @@
+# PR 1980 Fixed in Commit Mapping
+
+PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1980>
+
+## Summary
+
+This PR extracts seven admin/debug operational routes from `legacy_app.py` into
+canonical hidden FastAPI router/service ownership:
+
+- `GET /debug_env`
+- `GET /api/v1/admin/status`
+- `POST /admin/logs/cleanup`
+- `GET /api/v1/admin/db-status`
+- `POST /api/v1/admin/force-update`
+- `GET /api/v1/admin/check-updates`
+- `POST /api/v1/admin/rollback`
+
+Runtime behavior, API-key fail-closed behavior, debug gating, scheduler seams,
+and public OpenAPI invisibility are preserved. BMI/planning, exports, FoodDB,
+insight, premium, billing, tiering, scheduler migration, auth policy redesign,
+and client changes are out of scope.
+
+## Lane Start Provenance
+
+- Branch: `codex/extract-admin-debug-operational-routes-from-legacy`
+- PR open base: `98a39596f583cbf8924d5d9749efda5c993ad8eb`
+- Implementation commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
+- Bootstrap packet: `artifacts/orchestration/task_packets/ee38f1c196fd.json`
+- Premortem artifact:
+  `artifacts/orchestration/premortem/pr2-admin-debug-operational-routes-premortem.md`
+- Experiment Runner packet:
+  `artifacts/orchestration/experiments/exp-71172ed5d6c9.json`
+- Experiment Runner result:
+  `artifacts/orchestration/experiments/results/exp-71172ed5d6c9.json`
+- Machine-heavy exception: full local `make verify` intentionally deferred
+  under the operator-approved narrow backend extraction scope. Focused local
+  gates and current-head CI remain required.
+
+## Discussion Thread Pass
+
+- [x] Pre-open bootstrap role order completed:
+  `agent-coordinator -> backend-engineer -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter`.
+- [x] `agent-coordinator`: confirmed seven-route extraction scope, touched
+  surfaces, role order, and DoD.
+- [x] `backend-engineer`: required tracking new router/service modules and
+  reviewing API-key response parity. New files are included in commit
+  `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`; security pass accepted auth body
+  behavior.
+- [x] `architecture-specialist`: accepted canonical `app.main:app` route
+  ownership and required guard threshold correction. Guard threshold fixed in
+  commit `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`.
+- [x] `security-auditor`: accepted API-key fail-closed behavior, debug gating,
+  and hidden live OpenAPI surface; required `api_key` guard baseline `15`.
+- [x] `qa-engineer-agent`: required deterministic valid-key cleanup coverage
+  and static OpenAPI disposition. Cleanup route tests and NOT-A-BUG static
+  OpenAPI disposition are recorded below.
+- [x] `bug-hunter`: found no concrete blocking runtime regression after fixes.
+- [ ] Post-open role loop pending:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- [ ] Codex Security diff scan / finding discovery pending.
+- [ ] `pulseplate-pr-review` pending.
+- [ ] GitHub review comments and bot actionables pending current-head review.
+
+### Fixed in Commit Mapping
+
+- Pre-open backend finding: new canonical modules were untracked.
+Disposition: FIXED
+Commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
+Evidence: `app/routers/admin_operations.py` and
+`app/services/admin_operations.py` are created in the implementation commit.
+
+- Pre-open architecture/security finding: legacy sensitive API-key app-surface
+limit was over-tightened to `14`.
+Disposition: FIXED
+Commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
+Evidence: `scripts/ci/check_legacy_growth_guard.py` uses `api_key: 15`; the
+guard CLI passed after the fix.
+
+- Pre-open QA finding: `/admin/logs/cleanup` needed deterministic valid-key
+execution coverage.
+Disposition: FIXED
+Commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
+Evidence: `tests/test_admin_endpoints_97.py` covers valid-key cleanup success
+and invalid `data_class` behavior through the canonical route/service path.
+
+- Pre-open architecture finding: direct raw `legacy_app.app` no longer owns the
+seven moved runtime routes.
+Disposition: NOT-A-BUG
+Evidence: repo runtime entrypoints use canonical `app.main:app`; tests and
+OpenAPI guards validate canonical runtime ownership. This PR intentionally moves
+route ownership out of `legacy_app.py` and leaves direct-call shims for imported
+functions.
+Reason: direct raw legacy ASGI runtime compatibility is not the canonical
+runtime contract for this extraction lane.
+
+- Pre-open QA finding: `app/static/openapi.json` still lists stale admin/debug
+paths.
+Disposition: NOT-A-BUG
+Evidence: live `app.main.app.openapi()` and `frontend/src/api/openapi.json`
+contain no extracted admin/debug paths; `tests/test_openapi_namespace_guards.py`
+asserts live OpenAPI absence.
+Reason: the PR plan explicitly treats live OpenAPI and generated frontend
+OpenAPI as contract surfaces; static `app/static/openapi.json` cleanup is out of
+scope for this lane.
+
+## Premortem Finding Closure
+
+- F1: Admin/debug routes accidentally exposed in public OpenAPI.
+Disposition: FIXED
+Commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
+Evidence: `app/routers/admin_operations.py` marks routes hidden;
+`app/main.py` rejects visible family registration; focused OpenAPI tests pass.
+
+- F2: Auth drift weakens protected admin routes.
+Disposition: FIXED
+Commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
+Evidence: protected route tests assert 403 for missing/invalid `X-API-Key` and
+valid-key behavior through scheduler/retention stubs.
+
+- F3: Scheduler monkeypatch seams break.
+Disposition: FIXED
+Commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
+Evidence: `app/services/admin_operations.py` resolves legacy/app scheduler
+seams before default fallback; focused admin tests pass with patched scheduler.
+
+- F4: Legacy guard shrink over-tightens the sensitive baseline.
+Disposition: FIXED
+Commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
+Evidence: `scripts/ci/check_legacy_growth_guard.py` uses `api_key: 15`; the
+guard CLI passed.
+
+- F5: Stale static OpenAPI mistaken for contract truth.
+Disposition: NOT-A-BUG
+Evidence: live OpenAPI and generated frontend OpenAPI remain free of the moved
+admin/debug paths; static cleanup is out of scope.
+Reason: this lane's contract surfaces are live `app.main.app.openapi()` and
+generated frontend OpenAPI.
+
+## Experiment Runner Evidence
+
+- Artifact: `artifacts/orchestration/experiments/results/exp-71172ed5d6c9.json`
+- Mode: `oracle_only_governance_reviewer`
+- Status: accepted
+- Contribution: `commit_decision`
+- Co-author required: true; implementation commit includes
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+- Accepted oracle commands:
+  - `python3 scripts/ci/check_legacy_growth_guard.py`
+  - `python3 scripts/orchestration/check_agent_consistency.py`
+
+## Validation Evidence
+
+- PASS: `.venv/bin/python -m pytest -q tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_admin_endpoints_97.py tests/test_app_endpoints_combined.py::TestDebugEndpoint tests/test_openapi_namespace_guards.py`
+  (`115 passed`)
+- PASS: `.venv/bin/python scripts/ci/check_legacy_growth_guard.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `make validate-changed`
+- PASS: `pre-commit run --all-files`
+- PASS during push hooks: mypy, pip-audit, backend pre-push pytest,
+  full-repo Bandit, and Docker build test.
+- Deferred: full local `make verify` under the operator-approved
+  machine-heavy exception; current-head CI plus strict merge wrapper are the
+  heavy signal.
+
+## Merge Readiness
+
+Not merge-ready yet. Required before merge:
+
+- [ ] Current-head required CI green with no pending required jobs.
+- [ ] Post-open role loop completed:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- [ ] Codex Security diff scan / finding discovery completed.
+- [ ] `pulseplate-pr-review` completed.
+- [ ] CodeRabbit, Sourcery, Cubic, and human/bot comments have no unresolved
+  actionable items, or every item is dispositioned above.
+- [ ] `check_merge_ready.py --require-auth` passes after latest review activity.
+- [ ] Mandatory wait window completes after latest bot/review activity.

--- a/docs/review/PR_1980_FIXED_MAPPING.md
+++ b/docs/review/PR_1980_FIXED_MAPPING.md
@@ -100,6 +100,11 @@ Commit: 4a650a5f2457d4a6292b5082c4dfaf72b143832a
 Evidence: tests/test_app_endpoints_combined.py explicitly enables ENABLE_DEBUG_ENDPOINT for the debug happy path.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1980#discussion_r3412526373 -> 4a650a5f2457d4a6292b5082c4dfaf72b143832a
 
+Disposition: FIXED
+Commit: 4a650a5f2457d4a6292b5082c4dfaf72b143832a
+Evidence: CodeRabbit review summary aggregated the three actionable inline comments mapped above; the same post-comment fix commit addresses scheduler alias resolution, JSON Content-Type assertions, and deterministic debug endpoint gating.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1980#pullrequestreview-4496262009 -> 4a650a5f2457d4a6292b5082c4dfaf72b143832a
+
 Disposition: NOT-A-BUG
 Evidence: CodeRabbit issue comment is walkthrough and pre-merge checklist metadata; actionable file comments are mapped above.
 Reason: No additional code action beyond the mapped review comments.

--- a/docs/review/PR_1980_FIXED_MAPPING.md
+++ b/docs/review/PR_1980_FIXED_MAPPING.md
@@ -69,10 +69,14 @@ and client changes are out of scope.
 - [x] Fixed in commit mapping completed
 - Post-open `qa-engineer-agent` pass completed and produced actionable
   CodeRabbit/parser findings now mapped below.
-- Remaining post-open role loop is still pending:
-  `bug-hunter -> security-auditor`.
-- Codex Security diff scan / finding discovery and `pulseplate-pr-review` are
-  still pending.
+- Post-open `bug-hunter` pass completed with PASS: no actionable P0/P1 bug
+  remains in the PR diff, and the three CodeRabbit fixes are addressed.
+- Post-open `security-auditor` pass completed with PASS: no actionable
+  security/auth/secret/OpenAPI exposure issue remains in the PR diff.
+- Codex Security diff scan / finding discovery completed with no reportable
+  findings.
+- `pulseplate-pr-review` completed with one advisory large-diff planning note,
+  dispositioned as NOT-A-BUG below.
 - GitHub review threads must not be resolved until the mapped fix commit is
   pushed and the strict disposition guard is rerun.
 
@@ -121,6 +125,54 @@ Reason: Not an actionable code review.
   premortem closure above.
 - `bug-hunter`: found no concrete blocking runtime regression after fixes.
 
+## Post-Open Role Review Evidence
+
+- `qa-engineer-agent`: HOLD until CodeRabbit/parser fixes were applied.
+  Disposition: FIXED by commit
+  `4a650a5f2457d4a6292b5082c4dfaf72b143832a` for scheduler alias seam,
+  JSON Content-Type assertions, and deterministic `/debug_env` happy path;
+  fixed mapping/parser shape was corrected in commit
+  `fbabe5ef8557070619d6a80270cfe8f66df433cb`.
+- `bug-hunter`: PASS. Evidence: confirmed no actionable P0/P1 bug remains,
+  all seven admin/debug runtime routes are canonical, hidden from OpenAPI, and
+  the three CodeRabbit fixes are addressed. Focused probe and pytest passed.
+- `security-auditor`: PASS. Evidence: confirmed six protected operational
+  routes use API-key dependency, `/debug_env` is env-gated with limited payload,
+  live OpenAPI has no leaks, and scheduler seam remains server-internal.
+
+## Codex Security Diff Scan / Finding Discovery
+
+- Skill: `codex-security:security-diff-scan`.
+- Scope: PR diff `origin/main...HEAD` for source-like changed files:
+  `app/main.py`, `app/routers/admin_operations.py`,
+  `app/services/admin_operations.py`, and `legacy_app.py`.
+- Scan directory:
+  `/tmp/codex-security-scans/extract-admin-debug-operational-routes-from-legacy/pr-1980-admin-debug-operational-routes-fbabe5ef8`.
+- Markdown report:
+  `/tmp/codex-security-scans/extract-admin-debug-operational-routes-from-legacy/pr-1980-admin-debug-operational-routes-fbabe5ef8/report.md`.
+- HTML report:
+  `/tmp/codex-security-scans/extract-admin-debug-operational-routes-from-legacy/pr-1980-admin-debug-operational-routes-fbabe5ef8/report.html`.
+- Work ledger:
+  `/tmp/codex-security-scans/extract-admin-debug-operational-routes-from-legacy/pr-1980-admin-debug-operational-routes-fbabe5ef8/artifacts/02_discovery/work_ledger.jsonl`.
+- Result: PASS, no reportable findings. Every `deep_review_input.csv` row has
+  a completion receipt, discovery emitted no candidates, and the final markdown
+  report passed `validate_report_format.py`.
+
+## PulsePlate PR Review
+
+- Skill: `pulseplate-pr-review`.
+- Context: `/tmp/pulseplate_pr_1980_review_context.json`.
+- Markdown report: `/tmp/pulseplate_pr_1980_review_report.md`.
+- JSON report: `/tmp/pulseplate_pr_1980_review_report.json`.
+- Finding: one advisory `note` for large-diff review planning because the diff
+  exceeds the 800 changed-line threshold.
+- Disposition: NOT-A-BUG.
+- Evidence: this PR is intentionally the bounded seven-route admin/debug
+  operational extraction slice. The line count is dominated by targeted route
+  extraction, bootstrap fail-closed tests, legacy guard shrink, focused endpoint
+  tests, and this canonical review artifact. Focused local gates,
+  post-open role reviews, Codex Security, and `make validate-changed` passed.
+
 ## Local Validation Evidence
 
 - PASS: `python3 scripts/orchestration/check_preflight.py`.
@@ -130,6 +182,7 @@ Reason: Not an actionable code review.
   after CodeRabbit/QA fixes.
 - PASS: `.venv/bin/python scripts/ci/check_legacy_growth_guard.py`.
 - PASS: `python3 scripts/orchestration/check_agent_consistency.py`.
+- PASS: `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1980`.
 - PASS: `make validate-changed`.
 - PASS: `pre-commit run --all-files`.
 - PASS during push hooks: mypy, pip-audit, backend pre-push pytest,
@@ -143,10 +196,10 @@ Reason: Not an actionable code review.
 Not merge-ready yet. Required before merge:
 
 - [ ] Current-head required CI green with no pending required jobs.
-- [ ] Remaining post-open role loop completed:
-  `bug-hunter -> security-auditor`.
-- [ ] Codex Security diff scan / finding discovery completed.
-- [ ] `pulseplate-pr-review` completed.
+- [x] Post-open role loop completed:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- [x] Codex Security diff scan / finding discovery completed.
+- [x] `pulseplate-pr-review` completed.
 - [ ] CodeRabbit, Sourcery, Cubic, and human/bot comments have no unresolved
   actionable items, or every item is dispositioned above.
 - [ ] `check_merge_ready.py --require-auth` passes after latest review activity.

--- a/docs/review/PR_1980_FIXED_MAPPING.md
+++ b/docs/review/PR_1980_FIXED_MAPPING.md
@@ -62,6 +62,9 @@ and client changes are out of scope.
 - Accepted oracle commands:
   - `python3 scripts/ci/check_legacy_growth_guard.py`
   - `python3 scripts/orchestration/check_agent_consistency.py`
+- PR body mirror note: the Experiment Runner artifact line must stay
+  parser-safe as `Artifact: artifacts/orchestration/experiments/results/exp-71172ed5d6c9.json`
+  with no trailing punctuation after the artifact path.
 
 ## Discussion Thread Pass
 

--- a/docs/review/PR_1980_FIXED_MAPPING.md
+++ b/docs/review/PR_1980_FIXED_MAPPING.md
@@ -22,123 +22,38 @@ and client changes are out of scope.
 
 ## Lane Start Provenance
 
+- Packet: `artifacts/orchestration/task_packets/ee38f1c196fd.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
 - Branch: `codex/extract-admin-debug-operational-routes-from-legacy`
 - PR open base: `98a39596f583cbf8924d5d9749efda5c993ad8eb`
-- Implementation commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
-- Bootstrap packet: `artifacts/orchestration/task_packets/ee38f1c196fd.json`
-- Premortem artifact:
-  `artifacts/orchestration/premortem/pr2-admin-debug-operational-routes-premortem.md`
-- Experiment Runner packet:
-  `artifacts/orchestration/experiments/exp-71172ed5d6c9.json`
-- Experiment Runner result:
-  `artifacts/orchestration/experiments/results/exp-71172ed5d6c9.json`
+- Task class: `Backend API`
+- PR phase: `pre_open`
+- Pre-open role order completed:
+  `agent-coordinator -> backend-engineer -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter`.
 - Machine-heavy exception: full local `make verify` intentionally deferred
   under the operator-approved narrow backend extraction scope. Focused local
   gates and current-head CI remain required.
 
-## Discussion Thread Pass
-
-- [x] Pre-open bootstrap role order completed:
-  `agent-coordinator -> backend-engineer -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter`.
-- [x] `agent-coordinator`: confirmed seven-route extraction scope, touched
-  surfaces, role order, and DoD.
-- [x] `backend-engineer`: required tracking new router/service modules and
-  reviewing API-key response parity. New files are included in commit
-  `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`; security pass accepted auth body
-  behavior.
-- [x] `architecture-specialist`: accepted canonical `app.main:app` route
-  ownership and required guard threshold correction. Guard threshold fixed in
-  commit `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`.
-- [x] `security-auditor`: accepted API-key fail-closed behavior, debug gating,
-  and hidden live OpenAPI surface; required `api_key` guard baseline `15`.
-- [x] `qa-engineer-agent`: required deterministic valid-key cleanup coverage
-  and static OpenAPI disposition. Cleanup route tests and NOT-A-BUG static
-  OpenAPI disposition are recorded below.
-- [x] `bug-hunter`: found no concrete blocking runtime regression after fixes.
-- [ ] Post-open role loop pending:
-  `qa-engineer-agent -> bug-hunter -> security-auditor`.
-- [ ] Codex Security diff scan / finding discovery pending.
-- [ ] `pulseplate-pr-review` pending.
-- [ ] GitHub review comments and bot actionables pending current-head review.
-
-### Fixed in Commit Mapping
-
-- Pre-open backend finding: new canonical modules were untracked.
-Disposition: FIXED
-Commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
-Evidence: `app/routers/admin_operations.py` and
-`app/services/admin_operations.py` are created in the implementation commit.
-
-- Pre-open architecture/security finding: legacy sensitive API-key app-surface
-limit was over-tightened to `14`.
-Disposition: FIXED
-Commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
-Evidence: `scripts/ci/check_legacy_growth_guard.py` uses `api_key: 15`; the
-guard CLI passed after the fix.
-
-- Pre-open QA finding: `/admin/logs/cleanup` needed deterministic valid-key
-execution coverage.
-Disposition: FIXED
-Commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
-Evidence: `tests/test_admin_endpoints_97.py` covers valid-key cleanup success
-and invalid `data_class` behavior through the canonical route/service path.
-
-- Pre-open architecture finding: direct raw `legacy_app.app` no longer owns the
-seven moved runtime routes.
-Disposition: NOT-A-BUG
-Evidence: repo runtime entrypoints use canonical `app.main:app`; tests and
-OpenAPI guards validate canonical runtime ownership. This PR intentionally moves
-route ownership out of `legacy_app.py` and leaves direct-call shims for imported
-functions.
-Reason: direct raw legacy ASGI runtime compatibility is not the canonical
-runtime contract for this extraction lane.
-
-- Pre-open QA finding: `app/static/openapi.json` still lists stale admin/debug
-paths.
-Disposition: NOT-A-BUG
-Evidence: live `app.main.app.openapi()` and `frontend/src/api/openapi.json`
-contain no extracted admin/debug paths; `tests/test_openapi_namespace_guards.py`
-asserts live OpenAPI absence.
-Reason: the PR plan explicitly treats live OpenAPI and generated frontend
-OpenAPI as contract surfaces; static `app/static/openapi.json` cleanup is out of
-scope for this lane.
-
 ## Premortem Finding Closure
 
-- F1: Admin/debug routes accidentally exposed in public OpenAPI.
-Disposition: FIXED
-Commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
-Evidence: `app/routers/admin_operations.py` marks routes hidden;
-`app/main.py` rejects visible family registration; focused OpenAPI tests pass.
-
-- F2: Auth drift weakens protected admin routes.
-Disposition: FIXED
-Commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
-Evidence: protected route tests assert 403 for missing/invalid `X-API-Key` and
-valid-key behavior through scheduler/retention stubs.
-
-- F3: Scheduler monkeypatch seams break.
-Disposition: FIXED
-Commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
-Evidence: `app/services/admin_operations.py` resolves legacy/app scheduler
-seams before default fallback; focused admin tests pass with patched scheduler.
-
-- F4: Legacy guard shrink over-tightens the sensitive baseline.
-Disposition: FIXED
-Commit: `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`
-Evidence: `scripts/ci/check_legacy_growth_guard.py` uses `api_key: 15`; the
-guard CLI passed.
-
-- F5: Stale static OpenAPI mistaken for contract truth.
-Disposition: NOT-A-BUG
-Evidence: live OpenAPI and generated frontend OpenAPI remain free of the moved
-admin/debug paths; static cleanup is out of scope.
-Reason: this lane's contract surfaces are live `app.main.app.openapi()` and
-generated frontend OpenAPI.
+- Artifact:
+  `artifacts/orchestration/premortem/pr2-admin-debug-operational-routes-premortem.md`.
+- F1 admin/debug routes accidentally exposed in public OpenAPI: FIXED by hidden
+  router declarations, bootstrap visibility rejection, and OpenAPI tests.
+- F2 auth drift weakens protected admin routes: FIXED by preserving
+  `Depends(require_app_api_key)` and valid/missing/invalid key tests.
+- F3 scheduler monkeypatch seams break: FIXED by service-level scheduler seam
+  resolution and admin endpoint tests.
+- F4 legacy guard shrink over-tightens sensitive baseline: FIXED by retaining
+  the correct `api_key: 15` legacy sensitive count.
+- F5 stale static OpenAPI mistaken for contract truth: NOT-A-BUG. Live
+  `app.main.app.openapi()` and generated frontend OpenAPI are this PR's
+  contract surfaces.
 
 ## Experiment Runner Evidence
 
 - Artifact: `artifacts/orchestration/experiments/results/exp-71172ed5d6c9.json`
+- Packet: `artifacts/orchestration/experiments/exp-71172ed5d6c9.json`
 - Mode: `oracle_only_governance_reviewer`
 - Status: accepted
 - Contribution: `commit_decision`
@@ -148,14 +63,75 @@ generated frontend OpenAPI.
   - `python3 scripts/ci/check_legacy_growth_guard.py`
   - `python3 scripts/orchestration/check_agent_consistency.py`
 
-## Validation Evidence
+## Discussion Thread Pass
 
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- Post-open `qa-engineer-agent` pass completed and produced actionable
+  CodeRabbit/parser findings now mapped below.
+- Remaining post-open role loop is still pending:
+  `bug-hunter -> security-auditor`.
+- Codex Security diff scan / finding discovery and `pulseplate-pr-review` are
+  still pending.
+- GitHub review threads must not be resolved until the mapped fix commit is
+  pushed and the strict disposition guard is rerun.
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 4a650a5f2457d4a6292b5082c4dfaf72b143832a
+Evidence: app/services/admin_operations.py preserves app_module scheduler alias selection and tests/test_admin_endpoints_97.py covers it.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1980#discussion_r3412526359 -> 4a650a5f2457d4a6292b5082c4dfaf72b143832a
+
+Disposition: FIXED
+Commit: 4a650a5f2457d4a6292b5082c4dfaf72b143832a
+Evidence: tests/test_admin_endpoints_97.py asserts JSON Content-Type before new admin route json parsing.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1980#discussion_r3412526368 -> 4a650a5f2457d4a6292b5082c4dfaf72b143832a
+
+Disposition: FIXED
+Commit: 4a650a5f2457d4a6292b5082c4dfaf72b143832a
+Evidence: tests/test_app_endpoints_combined.py explicitly enables ENABLE_DEBUG_ENDPOINT for the debug happy path.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1980#discussion_r3412526373 -> 4a650a5f2457d4a6292b5082c4dfaf72b143832a
+
+Disposition: NOT-A-BUG
+Evidence: CodeRabbit issue comment is walkthrough and pre-merge checklist metadata; actionable file comments are mapped above.
+Reason: No additional code action beyond the mapped review comments.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1980#issuecomment-4706585012
+
+Disposition: NOT-A-BUG
+Evidence: Codex connector issue comment reports code-review usage limit only.
+Reason: Not an actionable code review.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1980#issuecomment-4706584230
+
+## Pre-Open Role Finding Closure
+
+- `agent-coordinator`: confirmed the seven-route extraction scope, touched
+  surfaces, role order, and DoD.
+- `backend-engineer`: required tracking new router/service modules and reviewing
+  API-key response parity. New modules are included in commit
+  `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`; security pass accepted auth
+  body behavior.
+- `architecture-specialist`: accepted canonical `app.main:app` route ownership
+  and required guard threshold correction. Guard threshold is fixed in commit
+  `71980c45ae3ef83fa6cfbf0d9fa5e7d2a3e46c7b`.
+- `security-auditor`: accepted API-key fail-closed behavior, debug gating, and
+  hidden live OpenAPI surface; required `api_key` guard baseline `15`.
+- `qa-engineer-agent`: required deterministic valid-key cleanup coverage and
+  static OpenAPI disposition. Both are captured in implementation tests and
+  premortem closure above.
+- `bug-hunter`: found no concrete blocking runtime regression after fixes.
+
+## Local Validation Evidence
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`.
 - PASS: `.venv/bin/python -m pytest -q tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_admin_endpoints_97.py tests/test_app_endpoints_combined.py::TestDebugEndpoint tests/test_openapi_namespace_guards.py`
-  (`115 passed`)
-- PASS: `.venv/bin/python scripts/ci/check_legacy_growth_guard.py`
-- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
-- PASS: `make validate-changed`
-- PASS: `pre-commit run --all-files`
+  (`115 passed`) before post-open review fixes.
+- PASS: `.venv/bin/python -m pytest -q tests/test_admin_endpoints_97.py::TestAdminEndpoints tests/test_app_endpoints_combined.py::TestDebugEndpoint tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_openapi_namespace_guards.py`
+  after CodeRabbit/QA fixes.
+- PASS: `.venv/bin/python scripts/ci/check_legacy_growth_guard.py`.
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`.
+- PASS: `make validate-changed`.
+- PASS: `pre-commit run --all-files`.
 - PASS during push hooks: mypy, pip-audit, backend pre-push pytest,
   full-repo Bandit, and Docker build test.
 - Deferred: full local `make verify` under the operator-approved
@@ -167,8 +143,8 @@ generated frontend OpenAPI.
 Not merge-ready yet. Required before merge:
 
 - [ ] Current-head required CI green with no pending required jobs.
-- [ ] Post-open role loop completed:
-  `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- [ ] Remaining post-open role loop completed:
+  `bug-hunter -> security-auditor`.
 - [ ] Codex Security diff scan / finding discovery completed.
 - [ ] `pulseplate-pr-review` completed.
 - [ ] CodeRabbit, Sourcery, Cubic, and human/bot comments have no unresolved

--- a/docs/review/PR_1980_FIXED_MAPPING.md
+++ b/docs/review/PR_1980_FIXED_MAPPING.md
@@ -188,6 +188,12 @@ Reason: Not an actionable code review.
 - PASS: `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1980`.
 - PASS: `make validate-changed`.
 - PASS: `pre-commit run --all-files`.
+- PASS: reproduced CI `diff-coverage` locally with coverage over
+  `tests/test_main_paywall_bootstrap.py`, `tests/test_app_endpoints_combined.py`,
+  and `tests/test_legacy_app_diff_coverage.py`; `diff-cover coverage.xml
+  --compare-branch origin/main --fail-under 97 ...` reported 100% coverage for
+  `app/main.py`, `app/routers/admin_operations.py`,
+  `app/services/admin_operations.py`, and `legacy_app.py`.
 - PASS during push hooks: mypy, pip-audit, backend pre-push pytest,
   full-repo Bandit, and Docker build test.
 - Deferred: full local `make verify` under the operator-approved

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -907,48 +907,12 @@ def _get_api_key_dynamic(api_key: str = Depends(api_key_header)) -> str:
 # (moved to top with other imports)
 
 
-@app.get("/api/v1/admin/status", dependencies=[Depends(_get_api_key_dynamic)])
 async def admin_status() -> Dict[str, str]:
-    """Admin status endpoint: returns 200 if scheduler is available, 503 if not.
+    """Compatibility shim for direct imports; route ownership is canonical."""
 
-    Uses dynamic resolution for get_update_scheduler so tests can patch it easily.
-    """
-    try:
-        import inspect as _inspect
-        import sys as _sys
+    from app.services.admin_operations import admin_status as _admin_status
 
-        _pkg = _sys.modules.get("app") or _sys.modules.get(__name__)
-
-        patched_global = globals().get("get_update_scheduler", _DEFAULT_GET_UPDATE_SCHEDULER)
-        pkg_getter = getattr(_pkg, "get_update_scheduler", None)
-
-        # RU: Если тесты пропатчили legacy_app.get_update_scheduler — он должен иметь приоритет.
-        # EN: If tests patched legacy_app.get_update_scheduler, it must take precedence.
-        if patched_global is not _DEFAULT_GET_UPDATE_SCHEDULER:
-            _getter = patched_global
-        elif pkg_getter is not None and pkg_getter is not _DEFAULT_GET_UPDATE_SCHEDULER:
-            _getter = pkg_getter
-        else:
-            _getter = _DEFAULT_GET_UPDATE_SCHEDULER
-        scheduler = None
-        if callable(_getter):
-            _res = _getter()
-            scheduler = await _res if _inspect.isawaitable(_res) else _res
-
-        if scheduler is None:
-            raise HTTPException(
-                status_code=fastapi_status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Scheduler unavailable",
-            )
-        return {"status": "ok", "scheduler": "available"}
-    except HTTPException:
-        # Re-raise explicit HTTP errors
-        raise
-    except Exception as e:
-        raise HTTPException(
-            status_code=fastapi_status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Scheduler unavailable",
-        ) from e
+    return await _admin_status()
 
 
 # Include API routers
@@ -1438,50 +1402,14 @@ def add_visualization_if_requested(result: Dict[str, Any], req: BMIRequest) -> N
 # ---------- Core logic ----------
 
 
-@app.post("/admin/logs/cleanup", dependencies=[Depends(_get_api_key_dynamic)])
 async def cleanup_expired_logs(
     data_class: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Cleanup expired log files based on retention policy.
+    """Compatibility shim for direct imports; route ownership is canonical."""
 
-    RU: Очистка истекших лог-файлов на основе политики хранения.
-    EN: Cleanup expired log files based on retention policy.
+    from app.services.admin_operations import cleanup_expired_logs as _cleanup_expired_logs
 
-    Requires API key authentication. This endpoint enforces the data retention
-    policy by deleting logs that have exceeded their retention period.
-
-    Args:
-        data_class: Optional data classification to filter by (PSEUDONYMOUS, PUBLIC, SENSITIVE).
-                   If None, processes all classifications.
-        api_key: API key for authentication (via dependency)
-
-    Returns:
-        Dictionary with cleanup results
-    """
-    retention_manager = get_retention_manager()
-
-    # Map input string to DataClass Enum if provided, else None
-    data_class_enum = None
-    if data_class is not None:
-        try:
-            data_class_enum = DataClass(data_class)
-        except ValueError:
-            return {
-                "status": "error",
-                "deleted_files": 0,
-                "data_class": data_class,
-                "message": f"Invalid data_class: '{data_class}'. Must be one of: "
-                f"{', '.join([e.value for e in DataClass])}",
-            }
-
-    deleted_count = retention_manager.cleanup_expired_logs(data_class=data_class_enum)
-
-    return {
-        "status": "success",
-        "deleted_files": deleted_count,
-        "data_class": data_class or "ALL",
-        "message": f"Deleted {deleted_count} expired log file(s)",
-    }
+    return await _cleanup_expired_logs(data_class=data_class)
 
 
 # ---------- v0 endpoints (bmi/plan) ----------
@@ -4393,21 +4321,12 @@ async def api_nutrient_gaps(req: NutrientGapsRequest) -> NutrientGapsResponse:
         ) from e
 
 
-@app.get("/debug_env")
 async def debug_env() -> JSONResponse:
-    # Gate /debug_env to avoid leaking environment details in production
-    debug_flag = _is_truthy(os.getenv("ENABLE_DEBUG_ENDPOINT"))
-    if not is_explicit_developer_env() and not debug_flag:
-        raise HTTPException(status_code=404, detail="Not found")
-    data = {
-        "FEATURE_INSIGHT": os.getenv("FEATURE_INSIGHT", ""),
-        "LLM_PROVIDER": os.getenv("LLM_PROVIDER", ""),
-        "PERPLEXITY_MODEL": os.getenv("PERPLEXITY_MODEL", ""),
-        "PERPLEXITY_ENDPOINT": os.getenv("PERPLEXITY_ENDPOINT", ""),
-    }
-    flag = str(os.getenv("FEATURE_INSIGHT", "")).strip().lower()
-    data["insight_enabled"] = str(flag in {"1", "true", "yes", "on"})
-    return JSONResponse(content=data)
+    """Compatibility shim for direct imports; route ownership is canonical."""
+
+    from app.services.admin_operations import debug_env as _debug_env
+
+    return await _debug_env()
 
 
 # ========================================
@@ -4415,202 +4334,36 @@ async def debug_env() -> JSONResponse:
 # ========================================
 
 
-@app.get("/api/v1/admin/db-status", dependencies=[Depends(_get_api_key_dynamic)])
 async def get_database_status() -> JSONResponse:
-    """
-    RU: Получить статус всех баз данных и планировщика обновлений.
-    EN: Get status of all databases and update scheduler.
+    """Compatibility shim for direct imports; route ownership is canonical."""
 
-    Returns information about:
-    - Database versions and last update times
-    - Update scheduler status
-    - Retry counts and error states
-    - Data integrity checksums
-    """
-    try:
-        # Resolve getter dynamically to respect runtime patches in tests
-        import sys as _sys
+    from app.services.admin_operations import get_database_status as _get_database_status
 
-        _getter = getattr(_sys.modules[__name__], "get_update_scheduler")
-        logger.debug(f"get_database_status using getter: {_getter!r}")
-        scheduler = await _getter()
-        status = scheduler.get_status()
-        return JSONResponse(content=status)
-    except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Failed to get database status: {str(e)}"
-        ) from e
+    return await _get_database_status()
 
 
-@app.post("/api/v1/admin/force-update", dependencies=[Depends(_get_api_key_dynamic)])
 async def force_database_update(source: Optional[str] = None) -> JSONResponse:
-    """
-    RU: Принудительно запустить обновление баз данных.
-    EN: Force immediate database update.
+    """Compatibility shim for direct imports; route ownership is canonical."""
 
-    Args:
-        source: Optional specific source to update ("usda", "openfoodfacts")
-                If None, updates all sources
+    from app.services.admin_operations import force_database_update as _force_database_update
 
-    Returns:
-        Update results with statistics on records changed
-    """
-    try:
-        import sys as _sys
-
-        _getter = getattr(_sys.modules[__name__], "get_update_scheduler")
-        logger.debug(f"force_database_update using getter: {_getter!r}")
-        scheduler = await _getter()
-        results = await scheduler.force_update(source)
-
-        # Format response
-        response: Dict[str, Any] = {
-            "message": f"Force update completed for {source or 'all sources'}",
-            "results": {},
-        }
-
-        for src, result in results.items():
-            response["results"][src] = {
-                "success": result.success,
-                "old_version": result.old_version,
-                "new_version": result.new_version,
-                "records_added": result.records_added,
-                "records_updated": result.records_updated,
-                "records_removed": result.records_removed,
-                "duration_seconds": result.duration_seconds,
-                "errors": result.errors,
-            }
-
-        return JSONResponse(content=response)
-
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Force update failed: {str(e)}") from e
+    return await _force_database_update(source=source)
 
 
-@app.get("/api/v1/admin/check-updates", dependencies=[Depends(_get_api_key_dynamic)])
 async def check_for_updates() -> JSONResponse:
-    """
-    RU: Проверить наличие доступных обновлений без их установки.
-    EN: Check for available updates without installing them.
+    """Compatibility shim for direct imports; route ownership is canonical."""
 
-    Returns:
-        Dictionary showing which sources have updates available
-    """
-    try:
-        import sys as _sys
-        import inspect as _inspect
+    from app.services.admin_operations import check_for_updates as _check_for_updates
 
-        _pkg = _sys.modules.get("app") or _sys.modules.get(__name__)
-        patched_global = globals().get("get_update_scheduler", _DEFAULT_GET_UPDATE_SCHEDULER)
-        pkg_override = getattr(_pkg, "get_update_scheduler", None)
-        if pkg_override is not None and pkg_override is not _DEFAULT_GET_UPDATE_SCHEDULER:
-            _getter = pkg_override
-        else:
-            _getter = patched_global or _DEFAULT_GET_UPDATE_SCHEDULER
-
-        scheduler = None
-        if callable(_getter):
-            result = _getter()
-            scheduler = await result if _inspect.isawaitable(result) else result
-
-        if scheduler is None:
-            raise RuntimeError("Scheduler resolved to None")
-
-        update_manager = getattr(scheduler, "update_manager", None)
-        if update_manager is None or not hasattr(update_manager, "check_for_updates"):
-            raise RuntimeError("Update manager missing or check_for_updates not supported")
-
-        available_updates = await update_manager.check_for_updates()
-
-        updates_available = available_updates or {}
-        total_sources_with_updates = sum(1 for v in updates_available.values() if bool(v))
-
-        response = {
-            "message": "Update check completed",
-            "updates_available": updates_available,
-            "total_sources_with_updates": int(total_sources_with_updates),
-        }
-
-        return JSONResponse(content=response)
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.exception("Update check failed")
-        raise HTTPException(status_code=500, detail=f"Update check failed: {str(e)}") from e
+    return await _check_for_updates()
 
 
-@app.post("/api/v1/admin/rollback", dependencies=[Depends(_get_api_key_dynamic)])
 async def rollback_database(source: str, target_version: str) -> Dict[str, Any]:
-    """Rollback database to a specific version.
+    """Compatibility shim for direct imports; route ownership is canonical."""
 
-    Args:
-        source: Data source name ("usda", "openfoodfacts")
-        target_version: Version to rollback to
+    from app.services.admin_operations import rollback_database as _rollback_database
 
-    Returns:
-        Success status and rollback details
-    """
-    try:
-        import inspect as _inspect
-        import sys as _sys
-
-        # Rely on the currently imported get_update_scheduler to honor test patches
-        app_mod = _sys.modules.get("app")
-        _getter = getattr(app_mod, "get_update_scheduler", get_update_scheduler)
-        scheduler = None
-        _res = _getter()
-        scheduler = await _res if _inspect.isawaitable(_res) else _res
-        if scheduler is None:
-            raise ValueError("Scheduler returned None")
-    except Exception as e:
-        logger.exception("Rollback: could not get scheduler")
-        # Avoid leaking internal exception details in user-facing response
-        error_detail = "Rollback operation failed: could not get scheduler"
-        raise HTTPException(status_code=500, detail=error_detail) from e
-
-    # Gracefully handle missing update manager to satisfy direct function tests
-    update_manager = getattr(scheduler, "update_manager", None)
-    if update_manager is None:
-        raise HTTPException(
-            status_code=500,
-            detail="No update manager available; rollback operation failed",
-        )
-
-    rollback_callable = getattr(update_manager, "rollback_database", None)
-    if rollback_callable is None or not callable(rollback_callable):
-        raise HTTPException(
-            status_code=500,
-            detail="Rollback operation not supported by update manager",
-        )
-
-    try:
-        import inspect as _inspect
-
-        if _inspect.iscoroutinefunction(rollback_callable):
-            success = await rollback_callable(source, target_version)
-        else:
-            success = await run_in_threadpool(rollback_callable, source, target_version)
-
-        # AsyncMock may return an awaitable even when not detected as coroutinefunction
-        if _inspect.isawaitable(success):
-            success = await success
-    except Exception as e:
-        logger.exception("Rollback callable raised")
-        # Use generic error message to avoid leaking sensitive internal details,
-        # while still including a stable phrase for tests and operators.
-        error_msg = "Rollback operation failed; Rollback failed; see server logs for details"
-        raise HTTPException(status_code=500, detail=error_msg) from e
-
-    if success:
-        return {
-            "message": f"Successfully rolled back {source} to version {target_version}",
-            "success": True,
-        }
-
-    # Rollback returned False - this is an error condition
-    error_detail = f"Rollback operation failed for {source} to version {target_version}"
-    raise HTTPException(status_code=500, detail=error_detail)
+    return await _rollback_database(source=source, target_version=target_version)
 
 
 _APP_PACKAGE_REF: Optional[ModuleType] = sys.modules.get("app")

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -74,7 +74,7 @@ SENSITIVE_CALL_LIMITS: Mapping[str, int] = {
     "subscription": 0,
 }
 SENSITIVE_APP_SURFACE_LIMITS: Mapping[str, int] = {
-    "api_key": 21,
+    "api_key": 15,
     "auth": 0,
     "billing": 0,
     "entitlement": 0,
@@ -87,10 +87,8 @@ SENSITIVE_APP_SURFACE_LIMITS: Mapping[str, int] = {
 
 ALLOWED_LEGACY_ROUTE_FACTS = frozenset(
     {
-        LegacyFact("decorator", "get", "/api/v1/admin/status", "admin_status"),
         LegacyFact("decorator", "middleware", "http", "csp_nonce_middleware"),
         LegacyFact("decorator", "middleware", "http", "log_requests"),
-        LegacyFact("decorator", "post", "/admin/logs/cleanup", "cleanup_expired_logs"),
         LegacyFact("decorator", "post", "/bmi", "bmi_endpoint"),
         LegacyFact("decorator", "post", "/plan", "plan_endpoint"),
         LegacyFact("decorator", "post", "/api/v1/bmi", "bmi_endpoint_v1"),
@@ -103,11 +101,6 @@ ALLOWED_LEGACY_ROUTE_FACTS = frozenset(
         LegacyFact("decorator", "post", "/api/v1/premium/targets", "api_who_targets"),
         LegacyFact("decorator", "post", "/api/v1/premium/plan/week", "api_weekly_menu"),
         LegacyFact("decorator", "post", "/api/v1/premium/gaps", "api_nutrient_gaps"),
-        LegacyFact("decorator", "get", "/debug_env", "debug_env"),
-        LegacyFact("decorator", "get", "/api/v1/admin/db-status", "get_database_status"),
-        LegacyFact("decorator", "post", "/api/v1/admin/force-update", "force_database_update"),
-        LegacyFact("decorator", "get", "/api/v1/admin/check-updates", "check_for_updates"),
-        LegacyFact("decorator", "post", "/api/v1/admin/rollback", "rollback_database"),
         LegacyFact(
             "decorator",
             "get",

--- a/tests/test_admin_endpoints_97.py
+++ b/tests/test_admin_endpoints_97.py
@@ -32,6 +32,27 @@ def client(app: FastAPI):
 class TestAdminEndpoints:
     """Тесты admin endpoints - ключ к 97%"""
 
+    def test_scheduler_resolver_preserves_app_module_alias_seam(self) -> None:
+        async def _default_get_update_scheduler() -> object:
+            return object()
+
+        async def _app_module_get_update_scheduler() -> object:
+            return object()
+
+        legacy_module = SimpleNamespace(
+            get_update_scheduler=_default_get_update_scheduler,
+            _DEFAULT_GET_UPDATE_SCHEDULER=_default_get_update_scheduler,
+        )
+        app_module_alias = SimpleNamespace(get_update_scheduler=_app_module_get_update_scheduler)
+
+        getter = admin_operations_service._select_scheduler_getter_from_modules(
+            legacy_module,
+            None,
+            app_module_alias,
+        )
+
+        assert getter is _app_module_get_update_scheduler
+
     def test_admin_routes_reject_missing_or_invalid_api_key(
         self,
         client: TestClient,
@@ -112,18 +133,23 @@ class TestAdminEndpoints:
         )
 
         assert status_response.status_code == 200
+        assert status_response.headers.get("content-type", "").startswith("application/json")
         assert status_response.json() == {"status": "ok", "scheduler": "available"}
         assert db_status_response.status_code == 200
+        assert db_status_response.headers.get("content-type", "").startswith("application/json")
         assert db_status_response.json() == {"status": "ok"}
         assert force_response.status_code == 200
+        assert force_response.headers.get("content-type", "").startswith("application/json")
         assert force_response.json()["results"]["usda"]["success"] is True
         assert updates_response.status_code == 200
+        assert updates_response.headers.get("content-type", "").startswith("application/json")
         assert updates_response.json() == {
             "message": "Update check completed",
             "updates_available": {"usda": True, "openfoodfacts": False},
             "total_sources_with_updates": 1,
         }
         assert rollback_response.status_code == 200
+        assert rollback_response.headers.get("content-type", "").startswith("application/json")
         assert rollback_response.json() == {
             "message": "Successfully rolled back usda to version 1.0.0",
             "success": True,
@@ -155,6 +181,7 @@ class TestAdminEndpoints:
         )
 
         assert response.status_code == 200
+        assert response.headers.get("content-type", "").startswith("application/json")
         assert response.json() == {
             "status": "success",
             "deleted_files": 3,
@@ -176,6 +203,7 @@ class TestAdminEndpoints:
         )
 
         assert response.status_code == 200
+        assert response.headers.get("content-type", "").startswith("application/json")
         assert response.json() == {
             "status": "error",
             "deleted_files": 0,

--- a/tests/test_admin_endpoints_97.py
+++ b/tests/test_admin_endpoints_97.py
@@ -11,12 +11,14 @@
 """
 
 import os
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
 import app as app_mod
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from app.services import admin_operations as admin_operations_service
 from starlette.types import ASGIApp
 from tests.helpers.fast_update_stubs import make_scheduler_stub, patch_app_get_update_scheduler
 
@@ -29,6 +31,159 @@ def client(app: FastAPI):
 
 class TestAdminEndpoints:
     """Тесты admin endpoints - ключ к 97%"""
+
+    def test_admin_routes_reject_missing_or_invalid_api_key(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("API_KEY", "test_key")
+        protected_routes = [
+            ("get", "/api/v1/admin/status", {}),
+            ("post", "/admin/logs/cleanup", {}),
+            ("get", "/api/v1/admin/db-status", {}),
+            ("post", "/api/v1/admin/force-update", {}),
+            ("get", "/api/v1/admin/check-updates", {}),
+            (
+                "post",
+                "/api/v1/admin/rollback",
+                {"params": {"source": "usda", "target_version": "1.0.0"}},
+            ),
+        ]
+
+        for method, path, kwargs in protected_routes:
+            request = getattr(client, method)
+            missing_response = request(path, **kwargs)
+            invalid_response = request(path, headers={"X-API-Key": "wrong"}, **kwargs)
+
+            assert missing_response.status_code == 403
+            assert invalid_response.status_code == 403
+
+    def test_admin_routes_accept_valid_api_key_with_scheduler_stub(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("API_KEY", "test_key")
+
+        class _UpdateManager:
+            async def check_for_updates(self) -> dict[str, bool]:
+                return {"usda": True, "openfoodfacts": False}
+
+            def rollback_database(self, source: str, target_version: str) -> bool:
+                return source == "usda" and target_version == "1.0.0"
+
+        class _Scheduler:
+            update_manager = _UpdateManager()
+
+            def get_status(self) -> dict[str, str]:
+                return {"status": "ok"}
+
+            async def force_update(self, source: str | None = None) -> dict[str, object]:
+                _ = source
+                return {
+                    "usda": SimpleNamespace(
+                        success=True,
+                        old_version="1.0.0",
+                        new_version="1.0.1",
+                        records_added=1,
+                        records_updated=2,
+                        records_removed=0,
+                        duration_seconds=0.1,
+                        errors=[],
+                    )
+                }
+
+        patch_app_get_update_scheduler(monkeypatch, app_mod, _Scheduler())
+        headers = {"X-API-Key": "test_key"}
+
+        status_response = client.get("/api/v1/admin/status", headers=headers)
+        db_status_response = client.get("/api/v1/admin/db-status", headers=headers)
+        force_response = client.post(
+            "/api/v1/admin/force-update",
+            headers=headers,
+            params={"source": "usda"},
+        )
+        updates_response = client.get("/api/v1/admin/check-updates", headers=headers)
+        rollback_response = client.post(
+            "/api/v1/admin/rollback",
+            headers=headers,
+            params={"source": "usda", "target_version": "1.0.0"},
+        )
+
+        assert status_response.status_code == 200
+        assert status_response.json() == {"status": "ok", "scheduler": "available"}
+        assert db_status_response.status_code == 200
+        assert db_status_response.json() == {"status": "ok"}
+        assert force_response.status_code == 200
+        assert force_response.json()["results"]["usda"]["success"] is True
+        assert updates_response.status_code == 200
+        assert updates_response.json() == {
+            "message": "Update check completed",
+            "updates_available": {"usda": True, "openfoodfacts": False},
+            "total_sources_with_updates": 1,
+        }
+        assert rollback_response.status_code == 200
+        assert rollback_response.json() == {
+            "message": "Successfully rolled back usda to version 1.0.0",
+            "success": True,
+        }
+
+    def test_cleanup_logs_route_accepts_valid_api_key(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("API_KEY", "test_key")
+
+        class _RetentionManager:
+            def cleanup_expired_logs(self, data_class=None) -> int:
+                assert data_class is not None
+                assert data_class.value == "PSEUDONYMOUS"
+                return 3
+
+        monkeypatch.setattr(
+            admin_operations_service,
+            "get_retention_manager",
+            lambda: _RetentionManager(),
+        )
+
+        response = client.post(
+            "/admin/logs/cleanup",
+            headers={"X-API-Key": "test_key"},
+            params={"data_class": "PSEUDONYMOUS"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "status": "success",
+            "deleted_files": 3,
+            "data_class": "PSEUDONYMOUS",
+            "message": "Deleted 3 expired log file(s)",
+        }
+
+    def test_cleanup_logs_route_rejects_invalid_data_class_with_valid_api_key(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("API_KEY", "test_key")
+
+        response = client.post(
+            "/admin/logs/cleanup",
+            headers={"X-API-Key": "test_key"},
+            params={"data_class": "UNKNOWN"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "status": "error",
+            "deleted_files": 0,
+            "data_class": "UNKNOWN",
+            "message": (
+                "Invalid data_class: 'UNKNOWN'. Must be one of: " "PSEUDONYMOUS, PUBLIC, SENSITIVE"
+            ),
+        }
 
     def test_force_update_endpoint(
         self, client: TestClient, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -248,8 +248,14 @@ class TestHealthAndMonitoringEndpoints:
 class TestDebugEndpoint:
     """Test debug endpoints for development"""
 
-    def test_debug_env_endpoint(self, client: TestClient) -> None:
+    def test_debug_env_endpoint(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Test /debug_env returns environment info"""
+        monkeypatch.setenv("ENABLE_DEBUG_ENDPOINT", "true")
+
         route = _find_route(client, "/debug_env")
         assert route.endpoint.__module__ == "app.routers.admin_operations"
         assert getattr(route, "include_in_schema", True) is False

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -407,8 +407,7 @@ class TestAdminOperationsService:
             params={"source": "usda", "target_version": "1.0.0"},
         ).json() == {"source": "usda", "target_version": "1.0.0", "success": True}
 
-    @pytest.mark.asyncio
-    async def test_scheduler_getter_selection_default_and_import_fallback(
+    def test_scheduler_getter_selection_default_and_import_fallback(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -11,7 +11,8 @@ These are "easy coverage" tests that cover basic monitoring endpoints and app pa
 import asyncio
 import os
 import sys
-from typing import cast
+from types import SimpleNamespace
+from typing import Any, cast
 from xml.etree import ElementTree
 from fastapi import FastAPI, Request
 from fastapi.encoders import jsonable_encoder
@@ -23,6 +24,7 @@ from sqlalchemy.orm import Session
 import app as apppkg
 from app.routers import health as health_router
 from app.routers.admin_operations import ADMIN_OPERATION_ROUTE_SPECS
+from app.services import admin_operations as admin_operations_service
 from app.routers.legal import build_terms_endpoint_payload
 from app.bootstrap import public_discovery
 from core.compliance import build_privacy_endpoint_payload
@@ -303,6 +305,421 @@ class TestDebugEndpoint:
 
         for path, _method in ADMIN_OPERATION_ROUTE_SPECS:
             assert path not in paths
+
+
+class TestAdminOperationsService:
+    """Focused service coverage for canonical hidden admin/debug route logic."""
+
+    def test_cleanup_logs_route_accepts_valid_api_key(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("API_KEY", "test_key")
+
+        class _RetentionManager:
+            def cleanup_expired_logs(self, data_class=None) -> int:
+                assert data_class is None
+                return 5
+
+        monkeypatch.setattr(
+            admin_operations_service,
+            "get_retention_manager",
+            lambda: _RetentionManager(),
+        )
+
+        response = client.post(
+            "/admin/logs/cleanup",
+            headers={"X-API-Key": "test_key"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "status": "success",
+            "deleted_files": 5,
+            "data_class": "ALL",
+            "message": "Deleted 5 expired log file(s)",
+        }
+
+        invalid_response = client.post(
+            "/admin/logs/cleanup",
+            headers={"X-API-Key": "test_key"},
+            params={"data_class": "UNKNOWN"},
+        )
+        assert invalid_response.status_code == 200
+        assert invalid_response.json()["status"] == "error"
+        assert invalid_response.json()["data_class"] == "UNKNOWN"
+
+    def test_admin_operation_route_wrappers_delegate_to_services(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("API_KEY", "test_key")
+
+        async def _admin_status() -> dict[str, str]:
+            return {"status": "ok", "scheduler": "available"}
+
+        async def _get_database_status():
+            from fastapi.responses import JSONResponse
+
+            return JSONResponse({"db": "ok"})
+
+        async def _force_database_update(*, source: str | None = None):
+            from fastapi.responses import JSONResponse
+
+            return JSONResponse({"source": source})
+
+        async def _check_for_updates():
+            from fastapi.responses import JSONResponse
+
+            return JSONResponse({"updates": True})
+
+        async def _rollback_database(*, source: str, target_version: str) -> dict[str, Any]:
+            return {"source": source, "target_version": target_version, "success": True}
+
+        monkeypatch.setattr(admin_operations_service, "admin_status", _admin_status)
+        monkeypatch.setattr(admin_operations_service, "get_database_status", _get_database_status)
+        monkeypatch.setattr(
+            admin_operations_service, "force_database_update", _force_database_update
+        )
+        monkeypatch.setattr(admin_operations_service, "check_for_updates", _check_for_updates)
+        monkeypatch.setattr(admin_operations_service, "rollback_database", _rollback_database)
+
+        headers = {"X-API-Key": "test_key"}
+
+        assert client.get("/api/v1/admin/status", headers=headers).json() == {
+            "status": "ok",
+            "scheduler": "available",
+        }
+        assert client.get("/api/v1/admin/db-status", headers=headers).json() == {"db": "ok"}
+        assert client.post(
+            "/api/v1/admin/force-update",
+            headers=headers,
+            params={"source": "usda"},
+        ).json() == {"source": "usda"}
+        assert client.get("/api/v1/admin/check-updates", headers=headers).json() == {
+            "updates": True
+        }
+        assert client.post(
+            "/api/v1/admin/rollback",
+            headers=headers,
+            params={"source": "usda", "target_version": "1.0.0"},
+        ).json() == {"source": "usda", "target_version": "1.0.0", "success": True}
+
+    @pytest.mark.asyncio
+    async def test_scheduler_getter_selection_default_and_import_fallback(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def _default_getter() -> object:
+            return object()
+
+        async def _patched_legacy_getter() -> object:
+            return object()
+
+        patched_legacy_module = SimpleNamespace(
+            get_update_scheduler=_patched_legacy_getter,
+            _DEFAULT_GET_UPDATE_SCHEDULER=_default_getter,
+        )
+        legacy_module = SimpleNamespace(
+            get_update_scheduler=_default_getter,
+            _DEFAULT_GET_UPDATE_SCHEDULER=_default_getter,
+        )
+
+        assert (
+            admin_operations_service._select_scheduler_getter_from_modules(
+                patched_legacy_module,
+                SimpleNamespace(),
+                SimpleNamespace(),
+            )
+            is _patched_legacy_getter
+        )
+        assert (
+            admin_operations_service._select_scheduler_getter_from_modules(
+                legacy_module,
+                SimpleNamespace(),
+                SimpleNamespace(),
+            )
+            is _default_getter
+        )
+        assert (
+            admin_operations_service._select_scheduler_getter_from_modules(
+                SimpleNamespace(_DEFAULT_GET_UPDATE_SCHEDULER=None),
+                SimpleNamespace(),
+                SimpleNamespace(),
+            )
+            is None
+        )
+
+        import core.food_apis.scheduler as scheduler_mod
+
+        def _fallback_getter() -> object:
+            return object()
+
+        monkeypatch.setattr(scheduler_mod, "get_update_scheduler", _fallback_getter)
+        monkeypatch.setitem(sys.modules, "legacy_app", SimpleNamespace())
+        monkeypatch.setitem(sys.modules, "app", SimpleNamespace())
+        monkeypatch.setitem(sys.modules, "app_module", SimpleNamespace())
+
+        assert admin_operations_service._resolve_scheduler_getter() is _fallback_getter
+
+    @pytest.mark.asyncio
+    async def test_admin_status_success_generic_failure_and_http_exception(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def _scheduler_available() -> object:
+            return object()
+
+        async def _scheduler_missing() -> None:
+            return None
+
+        async def _raise_http_exception() -> object:
+            raise HTTPException(status_code=418, detail="scheduler rejected")
+
+        monkeypatch.setattr(admin_operations_service, "_get_scheduler", _scheduler_available)
+
+        assert await admin_operations_service.admin_status() == {
+            "status": "ok",
+            "scheduler": "available",
+        }
+
+        monkeypatch.setattr(admin_operations_service, "_get_scheduler", _scheduler_missing)
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_operations_service.admin_status()
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Scheduler unavailable"
+
+        monkeypatch.setattr(admin_operations_service, "_get_scheduler", _raise_http_exception)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_operations_service.admin_status()
+
+        assert exc_info.value.status_code == 418
+        assert exc_info.value.detail == "scheduler rejected"
+
+    @pytest.mark.asyncio
+    async def test_database_status_success_and_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class _Scheduler:
+            def get_status(self) -> dict[str, str]:
+                return {"status": "ok"}
+
+        async def _get_scheduler_success() -> _Scheduler:
+            return _Scheduler()
+
+        async def _get_scheduler_failure() -> object:
+            raise RuntimeError("db status unavailable")
+
+        monkeypatch.setattr(admin_operations_service, "_get_scheduler", _get_scheduler_success)
+
+        response = await admin_operations_service.get_database_status()
+        assert response.status_code == 200
+        assert response.body == b'{"status":"ok"}'
+
+        monkeypatch.setattr(admin_operations_service, "_get_scheduler", _get_scheduler_failure)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_operations_service.get_database_status()
+
+        assert exc_info.value.status_code == 500
+        assert "db status unavailable" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_force_database_update_success_and_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class _Scheduler:
+            async def force_update(self, source: str | None = None) -> dict[str, Any]:
+                assert source == "usda"
+                return {
+                    "usda": SimpleNamespace(
+                        success=True,
+                        old_version="1.0.0",
+                        new_version="1.0.1",
+                        records_added=1,
+                        records_updated=2,
+                        records_removed=0,
+                        duration_seconds=0.25,
+                        errors=[],
+                    )
+                }
+
+        async def _get_scheduler_success() -> _Scheduler:
+            return _Scheduler()
+
+        async def _get_scheduler_failure() -> object:
+            raise RuntimeError("force failed")
+
+        monkeypatch.setattr(admin_operations_service, "_get_scheduler", _get_scheduler_success)
+
+        response = await admin_operations_service.force_database_update(source="usda")
+        assert response.status_code == 200
+        assert b'"Force update completed for usda"' in response.body
+        assert b'"records_added":1' in response.body
+
+        monkeypatch.setattr(admin_operations_service, "_get_scheduler", _get_scheduler_failure)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_operations_service.force_database_update(source="usda")
+
+        assert exc_info.value.status_code == 500
+        assert "force failed" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_check_for_updates_success_and_error_paths(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class _UpdateManager:
+            async def check_for_updates(self) -> dict[str, bool]:
+                return {"usda": True, "off": False}
+
+        class _Scheduler:
+            update_manager = _UpdateManager()
+
+        async def _get_scheduler_success() -> _Scheduler:
+            return _Scheduler()
+
+        async def _get_scheduler_without_manager() -> object:
+            return SimpleNamespace(update_manager=None)
+
+        async def _get_scheduler_none() -> None:
+            return None
+
+        async def _raise_http_exception() -> object:
+            raise HTTPException(status_code=409, detail="updates rejected")
+
+        monkeypatch.setattr(admin_operations_service, "_get_scheduler", _get_scheduler_success)
+
+        response = await admin_operations_service.check_for_updates()
+        assert response.status_code == 200
+        assert b'"total_sources_with_updates":1' in response.body
+
+        monkeypatch.setattr(
+            admin_operations_service,
+            "_get_scheduler",
+            _get_scheduler_without_manager,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_operations_service.check_for_updates()
+
+        assert exc_info.value.status_code == 500
+        assert "check_for_updates not supported" in str(exc_info.value.detail)
+
+        monkeypatch.setattr(admin_operations_service, "_get_scheduler", _get_scheduler_none)
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_operations_service.check_for_updates()
+        assert exc_info.value.status_code == 500
+        assert "Scheduler resolved to None" in str(exc_info.value.detail)
+
+        monkeypatch.setattr(admin_operations_service, "_get_scheduler", _raise_http_exception)
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_operations_service.check_for_updates()
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == "updates rejected"
+
+    @pytest.mark.asyncio
+    async def test_rollback_database_success_and_error_paths(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class _SyncRollbackManager:
+            def rollback_database(self, source: str, target_version: str) -> bool:
+                assert (source, target_version) == ("usda", "1.0.0")
+                return True
+
+        class _FalseRollbackManager:
+            def rollback_database(self, source: str, target_version: str) -> bool:
+                return False
+
+        class _RaisingRollbackManager:
+            def rollback_database(self, source: str, target_version: str) -> bool:
+                raise RuntimeError("rollback boom")
+
+        class _AwaitableRollbackManager:
+            def rollback_database(self, source: str, target_version: str) -> object:
+                async def _success() -> bool:
+                    return True
+
+                return _success()
+
+        async def _scheduler_with_manager(manager: object) -> object:
+            return SimpleNamespace(update_manager=manager)
+
+        async def _scheduler_none() -> None:
+            return None
+
+        monkeypatch.setattr(
+            admin_operations_service,
+            "_get_scheduler",
+            lambda: _scheduler_with_manager(_SyncRollbackManager()),
+        )
+        assert await admin_operations_service.rollback_database("usda", "1.0.0") == {
+            "message": "Successfully rolled back usda to version 1.0.0",
+            "success": True,
+        }
+
+        monkeypatch.setattr(
+            admin_operations_service,
+            "_get_scheduler",
+            lambda: _scheduler_with_manager(_AwaitableRollbackManager()),
+        )
+        assert await admin_operations_service.rollback_database("usda", "1.0.0") == {
+            "message": "Successfully rolled back usda to version 1.0.0",
+            "success": True,
+        }
+
+        monkeypatch.setattr(admin_operations_service, "_get_scheduler", _scheduler_none)
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_operations_service.rollback_database("usda", "1.0.0")
+        assert exc_info.value.status_code == 500
+        assert "could not get scheduler" in str(exc_info.value.detail)
+
+        monkeypatch.setattr(
+            admin_operations_service,
+            "_get_scheduler",
+            lambda: _scheduler_with_manager(None),
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_operations_service.rollback_database("usda", "1.0.0")
+        assert exc_info.value.status_code == 500
+        assert "No update manager available" in str(exc_info.value.detail)
+
+        monkeypatch.setattr(
+            admin_operations_service,
+            "_get_scheduler",
+            lambda: _scheduler_with_manager(SimpleNamespace()),
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_operations_service.rollback_database("usda", "1.0.0")
+        assert exc_info.value.status_code == 500
+        assert "not supported" in str(exc_info.value.detail)
+
+        monkeypatch.setattr(
+            admin_operations_service,
+            "_get_scheduler",
+            lambda: _scheduler_with_manager(_RaisingRollbackManager()),
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_operations_service.rollback_database("usda", "1.0.0")
+        assert exc_info.value.status_code == 500
+        assert "Rollback failed" in str(exc_info.value.detail)
+
+        monkeypatch.setattr(
+            admin_operations_service,
+            "_get_scheduler",
+            lambda: _scheduler_with_manager(_FalseRollbackManager()),
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_operations_service.rollback_database("usda", "1.0.0")
+        assert exc_info.value.status_code == 500
+        assert "Rollback operation failed for usda" in str(exc_info.value.detail)
 
 
 class TestAppPackageShimEdges:

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -407,6 +407,103 @@ class TestAdminOperationsService:
             params={"source": "usda", "target_version": "1.0.0"},
         ).json() == {"source": "usda", "target_version": "1.0.0", "success": True}
 
+    def test_legacy_compatibility_shims_delegate_to_admin_services(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Legacy direct-call admin/debug helpers delegate to canonical services."""
+
+        import legacy_app
+        from fastapi.responses import JSONResponse
+
+        calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+        async def _cleanup_expired_logs(*, data_class: str | None = None) -> dict[str, Any]:
+            calls.append(("cleanup", (), {"data_class": data_class}))
+            return {"status": "success", "data_class": data_class}
+
+        async def _admin_status() -> dict[str, str]:
+            calls.append(("admin_status", (), {}))
+            return {"status": "ok", "scheduler": "available"}
+
+        async def _debug_env() -> JSONResponse:
+            calls.append(("debug", (), {}))
+            return JSONResponse({"debug": "ok"})
+
+        async def _get_database_status() -> JSONResponse:
+            calls.append(("db_status", (), {}))
+            return JSONResponse({"db": "ok"})
+
+        async def _force_database_update(*, source: str | None = None) -> JSONResponse:
+            calls.append(("force", (), {"source": source}))
+            return JSONResponse({"source": source})
+
+        async def _check_for_updates() -> JSONResponse:
+            calls.append(("updates", (), {}))
+            return JSONResponse({"updates": True})
+
+        async def _rollback_database(*, source: str, target_version: str) -> dict[str, Any]:
+            calls.append(("rollback", (), {"source": source, "target_version": target_version}))
+            return {"success": True}
+
+        monkeypatch.setattr(
+            admin_operations_service,
+            "cleanup_expired_logs",
+            _cleanup_expired_logs,
+        )
+        monkeypatch.setattr(admin_operations_service, "admin_status", _admin_status)
+        monkeypatch.setattr(admin_operations_service, "debug_env", _debug_env)
+        monkeypatch.setattr(
+            admin_operations_service,
+            "get_database_status",
+            _get_database_status,
+        )
+        monkeypatch.setattr(
+            admin_operations_service,
+            "force_database_update",
+            _force_database_update,
+        )
+        monkeypatch.setattr(
+            admin_operations_service,
+            "check_for_updates",
+            _check_for_updates,
+        )
+        monkeypatch.setattr(
+            admin_operations_service,
+            "rollback_database",
+            _rollback_database,
+        )
+
+        cleanup_payload = asyncio.run(legacy_app.cleanup_expired_logs(data_class="PUBLIC"))
+        admin_status_payload = asyncio.run(legacy_app.admin_status())
+        debug_response = asyncio.run(legacy_app.debug_env())
+        db_status_response = asyncio.run(legacy_app.get_database_status())
+        force_response = asyncio.run(legacy_app.force_database_update(source="usda"))
+        updates_response = asyncio.run(legacy_app.check_for_updates())
+        rollback_payload = asyncio.run(
+            legacy_app.rollback_database(
+                source="usda",
+                target_version="1.0.0",
+            )
+        )
+
+        assert cleanup_payload == {"status": "success", "data_class": "PUBLIC"}
+        assert admin_status_payload == {"status": "ok", "scheduler": "available"}
+        assert debug_response.body == b'{"debug":"ok"}'
+        assert db_status_response.body == b'{"db":"ok"}'
+        assert force_response.body == b'{"source":"usda"}'
+        assert updates_response.body == b'{"updates":true}'
+        assert rollback_payload == {"success": True}
+        assert calls == [
+            ("cleanup", (), {"data_class": "PUBLIC"}),
+            ("admin_status", (), {}),
+            ("debug", (), {}),
+            ("db_status", (), {}),
+            ("force", (), {"source": "usda"}),
+            ("updates", (), {}),
+            ("rollback", (), {"source": "usda", "target_version": "1.0.0"}),
+        ]
+
     def test_scheduler_getter_selection_default_and_import_fallback(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -463,8 +463,7 @@ class TestAdminOperationsService:
 
         assert admin_operations_service._resolve_scheduler_getter() is _fallback_getter
 
-    @pytest.mark.asyncio
-    async def test_admin_status_success_generic_failure_and_http_exception(
+    def test_admin_status_success_generic_failure_and_http_exception(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -479,27 +478,26 @@ class TestAdminOperationsService:
 
         monkeypatch.setattr(admin_operations_service, "_get_scheduler", _scheduler_available)
 
-        assert await admin_operations_service.admin_status() == {
+        assert asyncio.run(admin_operations_service.admin_status()) == {
             "status": "ok",
             "scheduler": "available",
         }
 
         monkeypatch.setattr(admin_operations_service, "_get_scheduler", _scheduler_missing)
         with pytest.raises(HTTPException) as exc_info:
-            await admin_operations_service.admin_status()
+            asyncio.run(admin_operations_service.admin_status())
         assert exc_info.value.status_code == 503
         assert exc_info.value.detail == "Scheduler unavailable"
 
         monkeypatch.setattr(admin_operations_service, "_get_scheduler", _raise_http_exception)
 
         with pytest.raises(HTTPException) as exc_info:
-            await admin_operations_service.admin_status()
+            asyncio.run(admin_operations_service.admin_status())
 
         assert exc_info.value.status_code == 418
         assert exc_info.value.detail == "scheduler rejected"
 
-    @pytest.mark.asyncio
-    async def test_database_status_success_and_failure(
+    def test_database_status_success_and_failure(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -515,20 +513,19 @@ class TestAdminOperationsService:
 
         monkeypatch.setattr(admin_operations_service, "_get_scheduler", _get_scheduler_success)
 
-        response = await admin_operations_service.get_database_status()
+        response = asyncio.run(admin_operations_service.get_database_status())
         assert response.status_code == 200
         assert response.body == b'{"status":"ok"}'
 
         monkeypatch.setattr(admin_operations_service, "_get_scheduler", _get_scheduler_failure)
 
         with pytest.raises(HTTPException) as exc_info:
-            await admin_operations_service.get_database_status()
+            asyncio.run(admin_operations_service.get_database_status())
 
         assert exc_info.value.status_code == 500
         assert "db status unavailable" in str(exc_info.value.detail)
 
-    @pytest.mark.asyncio
-    async def test_force_database_update_success_and_failure(
+    def test_force_database_update_success_and_failure(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -556,7 +553,7 @@ class TestAdminOperationsService:
 
         monkeypatch.setattr(admin_operations_service, "_get_scheduler", _get_scheduler_success)
 
-        response = await admin_operations_service.force_database_update(source="usda")
+        response = asyncio.run(admin_operations_service.force_database_update(source="usda"))
         assert response.status_code == 200
         assert b'"Force update completed for usda"' in response.body
         assert b'"records_added":1' in response.body
@@ -564,13 +561,12 @@ class TestAdminOperationsService:
         monkeypatch.setattr(admin_operations_service, "_get_scheduler", _get_scheduler_failure)
 
         with pytest.raises(HTTPException) as exc_info:
-            await admin_operations_service.force_database_update(source="usda")
+            asyncio.run(admin_operations_service.force_database_update(source="usda"))
 
         assert exc_info.value.status_code == 500
         assert "force failed" in str(exc_info.value.detail)
 
-    @pytest.mark.asyncio
-    async def test_check_for_updates_success_and_error_paths(
+    def test_check_for_updates_success_and_error_paths(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -595,7 +591,7 @@ class TestAdminOperationsService:
 
         monkeypatch.setattr(admin_operations_service, "_get_scheduler", _get_scheduler_success)
 
-        response = await admin_operations_service.check_for_updates()
+        response = asyncio.run(admin_operations_service.check_for_updates())
         assert response.status_code == 200
         assert b'"total_sources_with_updates":1' in response.body
 
@@ -606,25 +602,24 @@ class TestAdminOperationsService:
         )
 
         with pytest.raises(HTTPException) as exc_info:
-            await admin_operations_service.check_for_updates()
+            asyncio.run(admin_operations_service.check_for_updates())
 
         assert exc_info.value.status_code == 500
         assert "check_for_updates not supported" in str(exc_info.value.detail)
 
         monkeypatch.setattr(admin_operations_service, "_get_scheduler", _get_scheduler_none)
         with pytest.raises(HTTPException) as exc_info:
-            await admin_operations_service.check_for_updates()
+            asyncio.run(admin_operations_service.check_for_updates())
         assert exc_info.value.status_code == 500
         assert "Scheduler resolved to None" in str(exc_info.value.detail)
 
         monkeypatch.setattr(admin_operations_service, "_get_scheduler", _raise_http_exception)
         with pytest.raises(HTTPException) as exc_info:
-            await admin_operations_service.check_for_updates()
+            asyncio.run(admin_operations_service.check_for_updates())
         assert exc_info.value.status_code == 409
         assert exc_info.value.detail == "updates rejected"
 
-    @pytest.mark.asyncio
-    async def test_rollback_database_success_and_error_paths(
+    def test_rollback_database_success_and_error_paths(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -659,7 +654,7 @@ class TestAdminOperationsService:
             "_get_scheduler",
             lambda: _scheduler_with_manager(_SyncRollbackManager()),
         )
-        assert await admin_operations_service.rollback_database("usda", "1.0.0") == {
+        assert asyncio.run(admin_operations_service.rollback_database("usda", "1.0.0")) == {
             "message": "Successfully rolled back usda to version 1.0.0",
             "success": True,
         }
@@ -669,14 +664,14 @@ class TestAdminOperationsService:
             "_get_scheduler",
             lambda: _scheduler_with_manager(_AwaitableRollbackManager()),
         )
-        assert await admin_operations_service.rollback_database("usda", "1.0.0") == {
+        assert asyncio.run(admin_operations_service.rollback_database("usda", "1.0.0")) == {
             "message": "Successfully rolled back usda to version 1.0.0",
             "success": True,
         }
 
         monkeypatch.setattr(admin_operations_service, "_get_scheduler", _scheduler_none)
         with pytest.raises(HTTPException) as exc_info:
-            await admin_operations_service.rollback_database("usda", "1.0.0")
+            asyncio.run(admin_operations_service.rollback_database("usda", "1.0.0"))
         assert exc_info.value.status_code == 500
         assert "could not get scheduler" in str(exc_info.value.detail)
 
@@ -686,7 +681,7 @@ class TestAdminOperationsService:
             lambda: _scheduler_with_manager(None),
         )
         with pytest.raises(HTTPException) as exc_info:
-            await admin_operations_service.rollback_database("usda", "1.0.0")
+            asyncio.run(admin_operations_service.rollback_database("usda", "1.0.0"))
         assert exc_info.value.status_code == 500
         assert "No update manager available" in str(exc_info.value.detail)
 
@@ -696,7 +691,7 @@ class TestAdminOperationsService:
             lambda: _scheduler_with_manager(SimpleNamespace()),
         )
         with pytest.raises(HTTPException) as exc_info:
-            await admin_operations_service.rollback_database("usda", "1.0.0")
+            asyncio.run(admin_operations_service.rollback_database("usda", "1.0.0"))
         assert exc_info.value.status_code == 500
         assert "not supported" in str(exc_info.value.detail)
 
@@ -706,7 +701,7 @@ class TestAdminOperationsService:
             lambda: _scheduler_with_manager(_RaisingRollbackManager()),
         )
         with pytest.raises(HTTPException) as exc_info:
-            await admin_operations_service.rollback_database("usda", "1.0.0")
+            asyncio.run(admin_operations_service.rollback_database("usda", "1.0.0"))
         assert exc_info.value.status_code == 500
         assert "Rollback failed" in str(exc_info.value.detail)
 
@@ -716,7 +711,7 @@ class TestAdminOperationsService:
             lambda: _scheduler_with_manager(_FalseRollbackManager()),
         )
         with pytest.raises(HTTPException) as exc_info:
-            await admin_operations_service.rollback_database("usda", "1.0.0")
+            asyncio.run(admin_operations_service.rollback_database("usda", "1.0.0"))
         assert exc_info.value.status_code == 500
         assert "Rollback operation failed for usda" in str(exc_info.value.detail)
 

--- a/tests/test_app_endpoints_combined.py
+++ b/tests/test_app_endpoints_combined.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session
 
 import app as apppkg
 from app.routers import health as health_router
+from app.routers.admin_operations import ADMIN_OPERATION_ROUTE_SPECS
 from app.routers.legal import build_terms_endpoint_payload
 from app.bootstrap import public_discovery
 from core.compliance import build_privacy_endpoint_payload
@@ -249,31 +250,53 @@ class TestDebugEndpoint:
 
     def test_debug_env_endpoint(self, client: TestClient) -> None:
         """Test /debug_env returns environment info"""
+        route = _find_route(client, "/debug_env")
+        assert route.endpoint.__module__ == "app.routers.admin_operations"
+        assert getattr(route, "include_in_schema", True) is False
+
         response = client.get("/debug_env")
         assert response.status_code == 200
         data = response.json()
-        # Should contain meaningful debug information
-        assert isinstance(data, dict)
-        assert len(data) > 0, "Debug endpoint should return non-empty data"
+        assert set(data) == {
+            "FEATURE_INSIGHT",
+            "LLM_PROVIDER",
+            "PERPLEXITY_MODEL",
+            "PERPLEXITY_ENDPOINT",
+            "insight_enabled",
+        }
 
-        # Check for essential debug key categories (flexible assertions)
-        debug_keys = set(data.keys())
+    def test_debug_env_fails_closed_in_production_like_env(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.delenv("ENABLE_DEBUG_ENDPOINT", raising=False)
 
-        # Ensure at least one feature flag exists
-        feature_flags = [key for key in debug_keys if key.startswith("FEATURE_")]
-        assert len(feature_flags) > 0, "Expected at least one FEATURE_* flag in debug data"
+        response = client.get("/debug_env")
 
-        # Ensure LLM provider configuration exists
-        llm_keys = [
-            key for key in debug_keys if "PROVIDER" in key or "MODEL" in key or "ENDPOINT" in key
-        ]
-        assert (
-            len(llm_keys) > 0
-        ), "Expected at least one LLM-related key (PROVIDER/MODEL/ENDPOINT) in debug data"
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Not found"}
 
-        # Ensure insight functionality flag exists
-        insight_keys = [key for key in debug_keys if "insight" in key.lower()]
-        assert len(insight_keys) > 0, "Expected at least one insight-related key in debug data"
+    def test_admin_debug_operational_routes_are_owned_by_canonical_router(
+        self,
+        client: TestClient,
+    ) -> None:
+        for path, method in ADMIN_OPERATION_ROUTE_SPECS:
+            route = _find_route(client, path, method)
+            assert route.endpoint.__module__ == "app.routers.admin_operations"
+            assert getattr(route, "include_in_schema", True) is False
+
+    def test_admin_debug_operational_routes_stay_hidden_from_public_openapi(
+        self,
+        client: TestClient,
+    ) -> None:
+        app = cast(FastAPI, client.app)
+        paths = app.openapi()["paths"]
+
+        for path, _method in ADMIN_OPERATION_ROUTE_SPECS:
+            assert path not in paths
 
 
 class TestAppPackageShimEdges:

--- a/tests/test_legacy_app_diff_coverage.py
+++ b/tests/test_legacy_app_diff_coverage.py
@@ -14,9 +14,11 @@ from typing import Any, Callable
 
 import pytest
 from fastapi import HTTPException
+from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 
+from app.services import admin_operations as admin_operations_service
 from app.routers import health as health_router
 import legacy_app
 
@@ -119,6 +121,83 @@ async def test_get_update_scheduler_late_getter_path(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(sched, "get_update_scheduler", _late_getter)
     res = await legacy_app.get_update_scheduler()
     assert res is not None
+
+
+@pytest.mark.asyncio
+async def test_admin_operations_legacy_compatibility_shims_delegate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy direct-call admin/debug helpers delegate to canonical service functions."""
+
+    calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    async def _cleanup_expired_logs(*, data_class: str | None = None) -> dict[str, Any]:
+        calls.append(("cleanup", (), {"data_class": data_class}))
+        return {"status": "success", "data_class": data_class}
+
+    async def _admin_status() -> dict[str, str]:
+        calls.append(("admin_status", (), {}))
+        return {"status": "ok", "scheduler": "available"}
+
+    async def _debug_env() -> JSONResponse:
+        calls.append(("debug", (), {}))
+        return JSONResponse({"debug": "ok"})
+
+    async def _get_database_status() -> JSONResponse:
+        calls.append(("db_status", (), {}))
+        return JSONResponse({"db": "ok"})
+
+    async def _force_database_update(*, source: str | None = None) -> JSONResponse:
+        calls.append(("force", (), {"source": source}))
+        return JSONResponse({"source": source})
+
+    async def _check_for_updates() -> JSONResponse:
+        calls.append(("updates", (), {}))
+        return JSONResponse({"updates": True})
+
+    async def _rollback_database(*, source: str, target_version: str) -> dict[str, Any]:
+        calls.append(("rollback", (), {"source": source, "target_version": target_version}))
+        return {"success": True}
+
+    monkeypatch.setattr(
+        admin_operations_service,
+        "cleanup_expired_logs",
+        _cleanup_expired_logs,
+    )
+    monkeypatch.setattr(admin_operations_service, "admin_status", _admin_status)
+    monkeypatch.setattr(admin_operations_service, "debug_env", _debug_env)
+    monkeypatch.setattr(admin_operations_service, "get_database_status", _get_database_status)
+    monkeypatch.setattr(admin_operations_service, "force_database_update", _force_database_update)
+    monkeypatch.setattr(admin_operations_service, "check_for_updates", _check_for_updates)
+    monkeypatch.setattr(admin_operations_service, "rollback_database", _rollback_database)
+
+    cleanup_payload = await legacy_app.cleanup_expired_logs(data_class="PUBLIC")
+    admin_status_payload = await legacy_app.admin_status()
+    debug_response = await legacy_app.debug_env()
+    db_status_response = await legacy_app.get_database_status()
+    force_response = await legacy_app.force_database_update(source="usda")
+    updates_response = await legacy_app.check_for_updates()
+    rollback_payload = await legacy_app.rollback_database(
+        source="usda",
+        target_version="1.0.0",
+    )
+
+    assert cleanup_payload == {"status": "success", "data_class": "PUBLIC"}
+    assert admin_status_payload == {"status": "ok", "scheduler": "available"}
+    assert debug_response.body == b'{"debug":"ok"}'
+    assert db_status_response.body == b'{"db":"ok"}'
+    assert force_response.body == b'{"source":"usda"}'
+    assert updates_response.body == b'{"updates":true}'
+    assert rollback_payload == {"success": True}
+    assert calls == [
+        ("cleanup", (), {"data_class": "PUBLIC"}),
+        ("admin_status", (), {}),
+        ("debug", (), {}),
+        ("db_status", (), {}),
+        ("force", (), {"source": "usda"}),
+        ("updates", (), {}),
+        ("rollback", (), {"source": "usda", "target_version": "1.0.0"}),
+    ]
 
 
 def test_configure_session_bindings_sets_sessionlocal_when_none(

--- a/tests/test_legacy_app_diff_coverage.py
+++ b/tests/test_legacy_app_diff_coverage.py
@@ -14,11 +14,9 @@ from typing import Any, Callable
 
 import pytest
 from fastapi import HTTPException
-from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 
-from app.services import admin_operations as admin_operations_service
 from app.routers import health as health_router
 import legacy_app
 
@@ -121,83 +119,6 @@ async def test_get_update_scheduler_late_getter_path(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(sched, "get_update_scheduler", _late_getter)
     res = await legacy_app.get_update_scheduler()
     assert res is not None
-
-
-@pytest.mark.asyncio
-async def test_admin_operations_legacy_compatibility_shims_delegate(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Legacy direct-call admin/debug helpers delegate to canonical service functions."""
-
-    calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
-
-    async def _cleanup_expired_logs(*, data_class: str | None = None) -> dict[str, Any]:
-        calls.append(("cleanup", (), {"data_class": data_class}))
-        return {"status": "success", "data_class": data_class}
-
-    async def _admin_status() -> dict[str, str]:
-        calls.append(("admin_status", (), {}))
-        return {"status": "ok", "scheduler": "available"}
-
-    async def _debug_env() -> JSONResponse:
-        calls.append(("debug", (), {}))
-        return JSONResponse({"debug": "ok"})
-
-    async def _get_database_status() -> JSONResponse:
-        calls.append(("db_status", (), {}))
-        return JSONResponse({"db": "ok"})
-
-    async def _force_database_update(*, source: str | None = None) -> JSONResponse:
-        calls.append(("force", (), {"source": source}))
-        return JSONResponse({"source": source})
-
-    async def _check_for_updates() -> JSONResponse:
-        calls.append(("updates", (), {}))
-        return JSONResponse({"updates": True})
-
-    async def _rollback_database(*, source: str, target_version: str) -> dict[str, Any]:
-        calls.append(("rollback", (), {"source": source, "target_version": target_version}))
-        return {"success": True}
-
-    monkeypatch.setattr(
-        admin_operations_service,
-        "cleanup_expired_logs",
-        _cleanup_expired_logs,
-    )
-    monkeypatch.setattr(admin_operations_service, "admin_status", _admin_status)
-    monkeypatch.setattr(admin_operations_service, "debug_env", _debug_env)
-    monkeypatch.setattr(admin_operations_service, "get_database_status", _get_database_status)
-    monkeypatch.setattr(admin_operations_service, "force_database_update", _force_database_update)
-    monkeypatch.setattr(admin_operations_service, "check_for_updates", _check_for_updates)
-    monkeypatch.setattr(admin_operations_service, "rollback_database", _rollback_database)
-
-    cleanup_payload = await legacy_app.cleanup_expired_logs(data_class="PUBLIC")
-    admin_status_payload = await legacy_app.admin_status()
-    debug_response = await legacy_app.debug_env()
-    db_status_response = await legacy_app.get_database_status()
-    force_response = await legacy_app.force_database_update(source="usda")
-    updates_response = await legacy_app.check_for_updates()
-    rollback_payload = await legacy_app.rollback_database(
-        source="usda",
-        target_version="1.0.0",
-    )
-
-    assert cleanup_payload == {"status": "success", "data_class": "PUBLIC"}
-    assert admin_status_payload == {"status": "ok", "scheduler": "available"}
-    assert debug_response.body == b'{"debug":"ok"}'
-    assert db_status_response.body == b'{"db":"ok"}'
-    assert force_response.body == b'{"source":"usda"}'
-    assert updates_response.body == b'{"updates":true}'
-    assert rollback_payload == {"success": True}
-    assert calls == [
-        ("cleanup", (), {"data_class": "PUBLIC"}),
-        ("admin_status", (), {}),
-        ("debug", (), {}),
-        ("db_status", (), {}),
-        ("force", (), {"source": "usda"}),
-        ("updates", (), {}),
-        ("rollback", (), {"source": "usda", "target_version": "1.0.0"}),
-    ]
 
 
 def test_configure_session_bindings_sets_sessionlocal_when_none(

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -113,6 +113,56 @@ def test_legacy_growth_guard_rejects_reintroduced_favicon_route() -> None:
     ]
 
 
+def test_legacy_growth_guard_rejects_reintroduced_admin_debug_routes() -> None:
+    source = textwrap.dedent("""
+        @app.get("/debug_env")
+        async def debug_env():
+            return {"ok": True}
+
+        @app.get("/api/v1/admin/status")
+        async def admin_status():
+            return {"ok": True}
+
+        @app.post("/admin/logs/cleanup")
+        async def cleanup_expired_logs():
+            return {"ok": True}
+
+        @app.get("/api/v1/admin/db-status")
+        async def get_database_status():
+            return {"ok": True}
+
+        @app.post("/api/v1/admin/force-update")
+        async def force_database_update():
+            return {"ok": True}
+
+        @app.get("/api/v1/admin/check-updates")
+        async def check_for_updates():
+            return {"ok": True}
+
+        @app.post("/api/v1/admin/rollback")
+        async def rollback_database():
+            return {"ok": True}
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "decorator:get:/api/v1/admin/check-updates -> check_for_updates",
+        "legacy_app.py: unexpected legacy route growth: "
+        "decorator:get:/api/v1/admin/db-status -> get_database_status",
+        "legacy_app.py: unexpected legacy route growth: "
+        "decorator:get:/api/v1/admin/status -> admin_status",
+        "legacy_app.py: unexpected legacy route growth: decorator:get:/debug_env -> debug_env",
+        "legacy_app.py: unexpected legacy route growth: "
+        "decorator:post:/admin/logs/cleanup -> cleanup_expired_logs",
+        "legacy_app.py: unexpected legacy route growth: "
+        "decorator:post:/api/v1/admin/force-update -> force_database_update",
+        "legacy_app.py: unexpected legacy route growth: "
+        "decorator:post:/api/v1/admin/rollback -> rollback_database",
+    ]
+
+
 def test_legacy_growth_guard_rejects_new_router_registration() -> None:
     source = "app.include_router(new_router)\n"
 
@@ -429,8 +479,8 @@ def test_legacy_growth_guard_rejects_sensitive_local_assignment_alias_calls(
 
 def test_legacy_growth_guard_rejects_auth_dependency_on_allowed_route() -> None:
     source = textwrap.dedent("""
-        @app.get("/api/v1/admin/status", dependencies=[Depends(auth_guard)])
-        def admin_status():
+        @app.post("/bmi", dependencies=[Depends(auth_guard)])
+        def bmi_endpoint():
             return {"ok": True}
         """)
 
@@ -453,8 +503,8 @@ def test_legacy_growth_guard_rejects_auth_dependency_on_allowed_router() -> None
         textwrap.dedent("""
             deps = [Depends(auth_guard)]
 
-            @app.get("/api/v1/admin/status", dependencies=deps)
-            def admin_status():
+            @app.post("/bmi", dependencies=deps)
+            def bmi_endpoint():
                 return {"ok": True}
             """),
         textwrap.dedent("""
@@ -473,14 +523,14 @@ def test_legacy_growth_guard_rejects_api_key_surface_growth_on_current_baseline(
     source = (REPO_ROOT / "legacy_app.py").read_text(encoding="utf-8")
     source += textwrap.dedent("""
 
-        @app.get("/api/v1/admin/status", dependencies=[Depends(api_key_guard)])
-        def admin_status():
+        @app.post("/bmi", dependencies=[Depends(api_key_guard)])
+        def bmi_endpoint():
             return {"ok": True}
         """)
 
     errors = legacy_guard.validate_legacy_growth(source)
 
-    assert errors == ["legacy_app.py: sensitive app surface grew for api_key: 22 > 21"]
+    assert errors == ["legacy_app.py: sensitive app surface grew for api_key: 16 > 15"]
 
 
 def test_legacy_growth_guard_ignores_comments_and_strings() -> None:

--- a/tests/test_main_paywall_bootstrap.py
+++ b/tests/test_main_paywall_bootstrap.py
@@ -128,6 +128,70 @@ def _duplicate_admin_operations_stub_router() -> APIRouter:
     return router
 
 
+def _admin_operations_stub_router_with_unrelated_path() -> APIRouter:
+    router = _admin_operations_stub_router()
+
+    async def _unrelated_handler() -> dict[str, str]:
+        return {"status": "unrelated"}
+
+    router.get("/api/v1/unrelated-admin-probe", include_in_schema=False)(_unrelated_handler)
+    return router
+
+
+def _admin_operations_stub_router_with_combined_methods() -> APIRouter:
+    router = APIRouter()
+    combined_path, combined_method = app_main._ADMIN_OPERATION_ROUTE_SPECS[0]
+
+    for path, method in app_main._ADMIN_OPERATION_ROUTE_SPECS:
+
+        async def _admin_handler(path: str = path) -> dict[str, str]:
+            return {"status": path}
+
+        methods = [method]
+        if path == combined_path:
+            methods.append("POST" if combined_method == "GET" else "GET")
+        router.add_api_route(
+            path,
+            _admin_handler,
+            methods=methods,
+            include_in_schema=False,
+        )
+
+    return router
+
+
+def _app_with_admin_routes_and_extra_method(*, combined_route: bool) -> FastAPI:
+    app = FastAPI()
+    extra_path, extra_method = app_main._ADMIN_OPERATION_ROUTE_SPECS[0]
+
+    for path, method in app_main._ADMIN_OPERATION_ROUTE_SPECS:
+
+        async def _admin_handler(path: str = path) -> dict[str, str]:
+            return {"status": path}
+
+        app.add_api_route(path, _admin_handler, methods=[method], include_in_schema=False)
+
+    async def _extra_method_handler() -> dict[str, str]:
+        return {"status": "extra-method"}
+
+    if combined_route:
+        app.add_api_route(
+            extra_path,
+            _extra_method_handler,
+            methods=[extra_method, "POST" if extra_method == "GET" else "GET"],
+            include_in_schema=False,
+        )
+    else:
+        app.add_api_route(
+            extra_path,
+            _extra_method_handler,
+            methods=["POST" if extra_method == "GET" else "GET"],
+            include_in_schema=False,
+        )
+
+    return app
+
+
 def _duplicate_privacy_legal_stub_router() -> APIRouter:
     router = _legal_stub_router()
 
@@ -562,6 +626,56 @@ def test_admin_operations_route_registration_rejects_malformed_router(
         _bootstrap_temp_app(FastAPI())
 
 
+def test_admin_operations_route_registration_allows_router_with_unrelated_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        app_main,
+        "admin_operations_router",
+        _admin_operations_stub_router_with_unrelated_path(),
+    )
+
+    app = _bootstrap_temp_app(FastAPI())
+
+    assert any(
+        getattr(route, "path", None) == "/api/v1/unrelated-admin-probe" for route in app.routes
+    )
+
+
+def test_admin_operations_route_registration_rejects_router_wrong_method(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    wrong_path, wrong_method = app_main._ADMIN_OPERATION_ROUTE_SPECS[0]
+    monkeypatch.setattr(
+        app_main,
+        "admin_operations_router",
+        _admin_operations_stub_router(
+            method_overrides={
+                wrong_path: "POST" if wrong_method == "GET" else "GET",
+            },
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Admin operations router does not define"):
+        _bootstrap_temp_app(FastAPI())
+
+
+def test_admin_operations_route_registration_rejects_router_combined_methods(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        app_main,
+        "admin_operations_router",
+        _admin_operations_stub_router_with_combined_methods(),
+    )
+
+    with pytest.raises(RuntimeError, match="Admin operations router does not define"):
+        _bootstrap_temp_app(FastAPI())
+
+
 def test_admin_operations_route_registration_rejects_openapi_visible_router(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -588,6 +702,24 @@ def test_admin_operations_route_registration_rejects_duplicate_canonical_router_
 
     with pytest.raises(RuntimeError, match="Admin operations router does not define"):
         _bootstrap_temp_app(FastAPI())
+
+
+def test_admin_operations_route_registration_rejects_existing_wrong_method_after_full_family(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="Partial admin operations route registration detected"):
+        _bootstrap_temp_app(_app_with_admin_routes_and_extra_method(combined_route=False))
+
+
+def test_admin_operations_route_registration_rejects_existing_combined_methods(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="Partial admin operations route registration detected"):
+        _bootstrap_temp_app(_app_with_admin_routes_and_extra_method(combined_route=True))
 
 
 @pytest.mark.parametrize("existing_path", ["/privacy", "/terms"])

--- a/tests/test_main_paywall_bootstrap.py
+++ b/tests/test_main_paywall_bootstrap.py
@@ -72,6 +72,28 @@ def _favicon_stub_router(*, include_in_schema: bool = False) -> APIRouter:
     return router
 
 
+def _admin_operations_stub_router(
+    *,
+    include_in_schema: bool = False,
+    omit: frozenset[str] = frozenset(),
+    method_overrides: dict[str, str] | None = None,
+) -> APIRouter:
+    router = APIRouter()
+    overrides = method_overrides or {}
+
+    for path, method in app_main._ADMIN_OPERATION_ROUTE_SPECS:
+        if path in omit:
+            continue
+        route_method = overrides.get(path, method).lower()
+
+        async def _admin_handler(path: str = path) -> dict[str, str]:
+            return {"status": path}
+
+        getattr(router, route_method)(path, include_in_schema=include_in_schema)(_admin_handler)
+
+    return router
+
+
 def _duplicate_health_stub_router() -> APIRouter:
     router = _health_stub_router()
 
@@ -89,6 +111,20 @@ def _duplicate_favicon_stub_router() -> APIRouter:
         return Response(status_code=204)
 
     router.get(app_main.FAVICON_ROUTE_PATH, include_in_schema=False)(_second_favicon)
+    return router
+
+
+def _duplicate_admin_operations_stub_router() -> APIRouter:
+    router = _admin_operations_stub_router()
+    duplicate_path, duplicate_method = app_main._ADMIN_OPERATION_ROUTE_SPECS[0]
+
+    async def _second_admin_handler() -> dict[str, str]:
+        return {"status": "duplicate"}
+
+    getattr(router, duplicate_method.lower())(
+        duplicate_path,
+        include_in_schema=False,
+    )(_second_admin_handler)
     return router
 
 
@@ -112,6 +148,7 @@ def _prepare_bootstrap_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(app_main, "register_pro_contract_routes", lambda target_app: None)
     monkeypatch.setattr(app_main, "register_billing_routes", lambda target_app: None)
     monkeypatch.setattr(app_main, "feedback_router", _stub_router("/api/v1/feedback/rag"))
+    monkeypatch.setattr(app_main, "admin_operations_router", _admin_operations_stub_router())
     monkeypatch.setattr(app_main, "favicon_router", _favicon_stub_router())
     monkeypatch.setattr(app_main, "health_router", _health_stub_router())
     monkeypatch.setattr(app_main, "legal_router", _legal_stub_router())
@@ -403,6 +440,153 @@ def test_favicon_route_registration_rejects_duplicate_canonical_router_paths(
     monkeypatch.setattr(app_main, "favicon_router", _duplicate_favicon_stub_router())
 
     with pytest.raises(RuntimeError, match="Favicon router does not define"):
+        _bootstrap_temp_app(FastAPI())
+
+
+def test_admin_operations_route_registration_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    app = FastAPI()
+
+    _bootstrap_temp_app(app)
+    _bootstrap_temp_app(app)
+
+    for path, method in app_main._ADMIN_OPERATION_ROUTE_SPECS:
+        admin_routes = [
+            route
+            for route in app.routes
+            if getattr(route, "path", None) == path
+            and method in (getattr(route, "methods", None) or set())
+        ]
+        assert len(admin_routes) == 1
+        assert getattr(admin_routes[0], "include_in_schema", True) is False
+
+
+@pytest.mark.parametrize(
+    "existing_path",
+    [path for path, _method in app_main._ADMIN_OPERATION_ROUTE_SPECS],
+)
+def test_admin_operations_route_registration_rejects_partial_state(
+    monkeypatch: pytest.MonkeyPatch,
+    existing_path: str,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    app = FastAPI()
+
+    @app.get(existing_path, include_in_schema=False)
+    async def _existing_admin_route() -> dict[str, str]:
+        return {"status": existing_path}
+
+    with pytest.raises(RuntimeError, match="Partial admin operations route registration detected"):
+        _bootstrap_temp_app(app)
+
+
+def test_admin_operations_route_registration_rejects_wrong_method(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    app = FastAPI()
+
+    @app.post("/debug_env", include_in_schema=False)
+    async def _wrong_method_admin_route() -> dict[str, str]:
+        return {"status": "wrong-method"}
+
+    with pytest.raises(RuntimeError, match="Partial admin operations route registration detected"):
+        _bootstrap_temp_app(app)
+
+
+def test_admin_operations_route_registration_rejects_foreign_handlers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    app = FastAPI()
+
+    async def _foreign_admin_route() -> dict[str, str]:
+        return {"status": "foreign"}
+
+    for path, method in app_main._ADMIN_OPERATION_ROUTE_SPECS:
+        app.add_api_route(
+            path,
+            _foreign_admin_route,
+            methods=[method],
+            include_in_schema=False,
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate .* route detected with a different admin operations handler",
+    ):
+        _bootstrap_temp_app(app)
+
+
+def test_admin_operations_route_registration_rejects_visible_existing_canonical_handlers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    app = FastAPI()
+    expected_specs = set(app_main._ADMIN_OPERATION_ROUTE_SPECS)
+    for route in app_main.admin_operations_router.routes:
+        path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None) or set()
+        for expected_path, expected_method in expected_specs:
+            if path == expected_path and expected_method in methods:
+                app.add_api_route(
+                    str(path),
+                    getattr(route, "endpoint"),
+                    methods=[expected_method],
+                    include_in_schema=True,
+                )
+
+    with pytest.raises(RuntimeError, match="hidden OpenAPI visibility"):
+        _bootstrap_temp_app(app)
+
+
+def test_admin_operations_route_registration_rejects_malformed_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    omitted_path, _method = app_main._ADMIN_OPERATION_ROUTE_SPECS[0]
+    monkeypatch.setattr(
+        app_main,
+        "admin_operations_router",
+        _admin_operations_stub_router(omit=frozenset({omitted_path})),
+    )
+
+    with pytest.raises(RuntimeError, match="Admin operations router does not define"):
+        _bootstrap_temp_app(FastAPI())
+
+
+def test_admin_operations_route_registration_rejects_openapi_visible_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        app_main,
+        "admin_operations_router",
+        _admin_operations_stub_router(include_in_schema=True),
+    )
+
+    with pytest.raises(RuntimeError, match="hidden OpenAPI visibility"):
+        _bootstrap_temp_app(FastAPI())
+
+
+def test_admin_operations_route_registration_rejects_duplicate_canonical_router_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        app_main,
+        "admin_operations_router",
+        _duplicate_admin_operations_stub_router(),
+    )
+
+    with pytest.raises(RuntimeError, match="Admin operations router does not define"):
         _bootstrap_temp_app(FastAPI())
 
 

--- a/tests/test_openapi_namespace_guards.py
+++ b/tests/test_openapi_namespace_guards.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Iterable
 
 from app.main import app
+from app.routers.admin_operations import ADMIN_OPERATION_ROUTE_SPECS
 
 ALLOWED_PREFIXES: tuple[str, ...] = (
     "/api/v1/billing/",
@@ -73,6 +74,15 @@ def test_favicon_runtime_route_stays_hidden_from_openapi_schema() -> None:
 
     assert "/favicon.ico" in runtime_paths
     assert "/favicon.ico" not in paths
+
+
+def test_admin_debug_runtime_routes_stay_hidden_from_openapi_schema() -> None:
+    runtime_paths = _runtime_paths()
+    paths = set(_openapi_paths())
+
+    for route_path, _method in ADMIN_OPERATION_ROUTE_SPECS:
+        assert route_path in runtime_paths
+        assert route_path not in paths
 
 
 def test_users_routes_are_hidden_from_schema_at_registration_level() -> None:


### PR DESCRIPTION
## Goal
Extract admin/debug operational route ownership from `legacy_app.py` into a canonical hidden FastAPI router/service without auth, scheduler, runtime, or OpenAPI drift.

## Business Reason
Continue the legacy-removal epic by shrinking sensitive runtime route ownership in legacy while preserving operational compatibility and keeping the public API contract stable.

## Scope
- Add `app/routers/admin_operations.py` for hidden runtime routes: `GET /debug_env`, `GET /api/v1/admin/status`, `POST /admin/logs/cleanup`, `GET /api/v1/admin/db-status`, `POST /api/v1/admin/force-update`, `GET /api/v1/admin/check-updates`, and `POST /api/v1/admin/rollback`.
- Add `app/services/admin_operations.py` for moved logic and scheduler/retention seams.
- Register the route family from `app/main.py` with idempotent fail-closed bootstrap checks.
- Remove the seven legacy route decorators and keep direct-call compatibility shims.
- Shrink `check_legacy_growth_guard.py` and add route ownership/auth/debug/OpenAPI/guard tests.

## Out Of Scope
BMI/planning, exports, FoodDB, insight, premium, billing, tiering, scheduler migration, auth policy redesign, static `app/static/openapi.json` cleanup, and client changes.

## Key Decisions
- Canonical runtime entrypoint is `app.main:app`; direct raw `legacy_app.app` route loss is a NOT-A-BUG for this route-ownership extraction.
- Protected admin routes use canonical `require_app_api_key` and remain fail-closed.
- `/debug_env` remains unauthenticated but gated by explicit developer env or `ENABLE_DEBUG_ENDPOINT`.
- Live `app.main.app.openapi()` and generated frontend OpenAPI are contract surfaces for this PR; `app/static/openapi.json` is noncanonical/out of scope.

## Tests / Validation
- PASS: `python3 scripts/orchestration/check_preflight.py`.
- PASS: bootstrap role sequence in order: `agent-coordinator -> backend-engineer -> architecture-specialist -> security-auditor -> qa-engineer-agent -> bug-hunter`.
- PASS: post-open role sequence in order: `qa-engineer-agent -> bug-hunter -> security-auditor`.
- PASS: Codex Security diff scan / finding discovery: no reportable findings.
- PASS: `pulseplate-pr-review` completed; one advisory large-diff note dispositioned as NOT-A-BUG in the canonical artifact.
- PASS: `.venv/bin/python -m pytest -q tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_admin_endpoints_97.py tests/test_app_endpoints_combined.py::TestDebugEndpoint tests/test_openapi_namespace_guards.py`.
- PASS after CodeRabbit/QA fixes: `.venv/bin/python -m pytest -q tests/test_admin_endpoints_97.py::TestAdminEndpoints tests/test_app_endpoints_combined.py::TestDebugEndpoint tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_openapi_namespace_guards.py`.
- PASS: `.venv/bin/python scripts/ci/check_legacy_growth_guard.py`.
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`.
- PASS: `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1980`.
- PASS: `make validate-changed`.
- PASS: `pre-commit run --all-files`.
- PASS: pre-push hooks during latest `git push`, including pip-audit, backend tests, Bandit full repo, and Docker build test.
- Not run: full local `make verify`, per operator-approved machine-heavy exception; current-head CI plus strict merge wrapper are the heavy signal.

## Security Notes
- No new public OpenAPI paths.
- Protected admin routes stay behind API-key dependency.
- Debug endpoint remains 404 in production-like env without explicit enable flag.
- Scheduler and retention manager logic remains behind existing seams; no scheduler internals migrate in this PR.

## Risks / Rollback
Rollback is a single revert of this PR, restoring legacy route decorators and the prior guard allowlist. Main runtime risk is canonical bootstrap conflict if another router partially registers the same admin/debug family; bootstrap intentionally fails closed in that case.

## Deferred / Follow-ups
- Static `app/static/openapi.json` cleanup is out of scope for this PR because it is not the canonical OpenAPI contract surface for this lane.
- Continue legacy-removal sequence with the next route family only after this PR's current-head CI and review disposition gates pass.

## AGENTS.md Or Agent-Instruction Updates
None.

## Lane Start Provenance
- Packet: `artifacts/orchestration/task_packets/ee38f1c196fd.json`
- Starter: `scripts/orchestration/start_pr_lane.sh`

## Premortem
- Artifact: `artifacts/orchestration/premortem/pr2-admin-debug-operational-routes-premortem.md`.
- Decision: proceed with changes; findings are fixed or dispositioned in `docs/review/PR_1980_FIXED_MAPPING.md`.

## Experiment Runner Evidence
- Packet: `artifacts/orchestration/experiments/exp-71172ed5d6c9.json`.
- Artifact: `artifacts/orchestration/experiments/results/exp-71172ed5d6c9.json`
- Mode: `oracle_only_governance_reviewer`.
- Status: accepted.
- Co-author required: true; implementation commit includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
- Later CodeRabbit/QA/review-evidence commits are not attributed to Experiment Runner.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Post-open `qa-engineer-agent -> bug-hunter -> security-auditor`, Codex Security diff scan / finding discovery, and `pulseplate-pr-review` have completed. Actionable CodeRabbit comments are fixed and mapped in the canonical artifact.

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1980_FIXED_MAPPING.md`

## Merge Readiness
Not merge-ready yet. Required before merge: current-head required CI green, all bot/human comments dispositioned in fixed mapping, `check_merge_ready.py --require-auth` passes after latest review activity, mandatory wait window completes, then squash merge and cleanup.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin operations endpoints for managing system status, database operations (status, force updates, rollback), and log cleanup.
  * Admin endpoints are protected by API key authentication and hidden from public API documentation.
  * Added debug environment endpoint for development use.

* **Tests**
  * Added comprehensive test coverage for admin operations, route registration, and OpenAPI visibility.

* **Documentation**
  * Added review documentation for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->