### PR TITLE
fix(frontend): close dompurify and js-yaml alerts

### DIFF
--- a/docs/review/PR_1985_FIXED_MAPPING.md
+++ b/docs/review/PR_1985_FIXED_MAPPING.md
@@ -3,6 +3,7 @@
 ## Lane Start Provenance
 
 Packet: `artifacts/orchestration/task_packets/63a747529fee.json`
+- Post-open packet: `artifacts/orchestration/task_packets/39f82da35c37.json`
 - Branch: `codex/fix-frontend-dompurify-js-yaml-alerts`
 - Starter: `scripts/orchestration/start_pr_lane.sh`
 - Base: `origin/main` at `46d93e628444a5ef70e9283152297e98bb42a4e1`.
@@ -68,12 +69,12 @@ Packet: `artifacts/orchestration/task_packets/63a747529fee.json`
 
 - [x] Discussion-thread pass completed for initial PR open.
 - [x] Fixed in commit mapping completed
-- [ ] Post-open `qa-engineer-agent` pass completed.
-- [ ] Post-open `bug-hunter` pass completed.
-- [ ] Post-open `security-auditor` pass completed.
-- [ ] Codex Security diff scan / finding discovery completed.
-- [ ] CodeRabbit review completed when authenticated.
-- [ ] `pulseplate-pr-review` completed.
+- [x] Post-open `qa-engineer-agent` pass completed.
+- [x] Post-open `bug-hunter` pass completed.
+- [x] Post-open `security-auditor` pass completed.
+- [x] Codex Security diff scan / finding discovery completed.
+- [x] CodeRabbit review completed when authenticated.
+- [x] `pulseplate-pr-review` completed.
 - [ ] Current actionable bot/review comments must be fixed or dispositioned
   before merge readiness.
 
@@ -89,6 +90,45 @@ Disposition: DEFERRED
 Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-storybook-ws-ghsa-96hv`
 Evidence: `cd frontend && npm audit --audit-level=moderate --package-lock-only` reports only the out-of-scope Storybook `ws` advisory `GHSA-96hv-2xvq-fx4p`; target packages `dompurify`, `js-yaml`, `jspdf`, and `@redocly/openapi-core` are absent from the audit vulnerability set after this change.
 Reason: The `ws` finding is not part of Dependabot alerts #164-#171 and needs a separate frontend tooling dependency lane to avoid broad Storybook churn in this PR.
+
+## Role Review Finding Disposition
+
+- `qa-engineer-agent`: PASS on the dependency-remediation surface and FIXED for
+  local path hygiene before commit. Evidence: QA confirmed scoped lockfile
+  changes, all-entry `js-yaml` guard coverage, registry provenance, documented
+  `ws` deferral, and scope-governance labels/body. QA flagged local absolute
+  paths in the uncommitted mapping update; those paths were removed before this
+  artifact update.
+- `bug-hunter`: PASS on nested lock-entry risk, npm override semantics,
+  lockfile churn, residual audit wording, scope-governance proof, and
+  parser/local docs checks. Evidence: bug-hunter confirmed the only remaining
+  blockers were uncommitted mapping/body parity and current-head readiness, not
+  dependency-security logic.
+- `security-auditor`: PASS with no security-blocking findings. Evidence:
+  security-auditor confirmed override floors, npm registry-backed lock
+  provenance, deterministic guard coverage, no audit overclaim, live scope
+  labels/body, Codex Security zero-findings evidence, CodeRabbit NOT-A-BUG
+  disposition, and no absolute local path leakage.
+- `Codex Security diff scan`: NOT-A-BUG. Evidence:
+  scan bundle
+  `codex-security-scans/fix-frontend-dompurify-js-yaml-alerts/bcf82a26ebef_20260616T182320Z`
+  reports zero findings after reviewing the diff-scoped manifests, guard test,
+  docs, backlog, and mapping artifact; report-format validation passed.
+- `CodeRabbit CLI`: NOT-A-BUG for the minor suggestion to replace
+  `.venv/bin/python -m pytest -q tests/test_frontend_dependency_guards.py`
+  with `python3 -m pytest ...` in
+  `docs/security/GHSA-39q2-94rc-95cp-dompurify.md`. Evidence:
+  `AGENTS.md` states direct local pytest runs outside Make should use the repo
+  virtualenv, `AGENTS.md` also says to use `.venv/bin/python` for repo Python
+  commands and coordinator bootstrap, and `Makefile` defines
+  `VENV_PYTHON ?= .venv/bin/python`. Reason: the documented validation command
+  intentionally matches repo Python gate conventions and the operator-approved
+  PR validation plan.
+- `pulseplate-pr-review`: NOT-A-BUG for the advisory large-diff note. Evidence:
+  local report `pulseplate_pr1985_review_report.md` flags only review-planning evidence
+  for a diff above the 300-line review-risk threshold; this artifact documents
+  the split rationale and scope exception, `make validate-changed` passed, and
+  `.venv/bin/python -m pytest tests/test_pr_review_report.py -q` passed.
 
 ## Dependency Delta Proof
 
@@ -141,10 +181,10 @@ checks with auth, and the wait-window.
 Not ready at latest artifact update. Required before merge:
 
 - [ ] Numbered fixed-mapping artifact committed and PR body mirror updated.
-- [ ] Post-open role-agent review sequence completed.
-- [ ] Codex Security diff scan / finding discovery completed.
+- [x] Post-open role-agent review sequence completed.
+- [x] Codex Security diff scan / finding discovery completed.
 - [ ] CodeRabbit/Sourcery/Cubic actionable comments fixed or dispositioned.
-- [ ] `pulseplate-pr-review` completed.
+- [x] `pulseplate-pr-review` completed.
 - [ ] Current-head CI parity on latest pushed commit.
 - [ ] Strict merge-readiness check with `--require-auth`.
 - [ ] No unresolved actionable review or bot comments.

--- a/docs/review/PR_1985_FIXED_MAPPING.md
+++ b/docs/review/PR_1985_FIXED_MAPPING.md
@@ -11,6 +11,9 @@ Packet: `artifacts/orchestration/task_packets/63a747529fee.json`
   `agent-coordinator -> security-auditor -> frontend-engineer -> qa-engineer-agent -> bug-hunter -> architecture-specialist -> cursor-specialist-agent -> web-research-agent`
 - Operator override: `main` was accepted for PR start while current-head jobs
   were pending without a new failed job.
+- Operator approval: approved for frontend dependency security evidence lane.
+- Frontend/backend mix approval: approved for frontend dependency manifests
+  with security evidence docs.
 
 ## Scope Boundary
 
@@ -22,6 +25,9 @@ Packet: `artifacts/orchestration/task_packets/63a747529fee.json`
   Storybook `ws` remediation, backend runtime behavior, OpenAPI changes,
   frontend UI behavior, iOS/macOS, legacy routes, BMI/planning, FoodDB,
   premium, exports, and insight routes.
+- Scope-governance proof: PR body records `Operator approval: approved` and
+  `Frontend/backend mix approval: approved`; PR labels include
+  `scope/operator-approved` and `scope/frontend-backend-mix-approved`.
 
 ## Premortem Closure
 

--- a/docs/review/PR_1985_FIXED_MAPPING.md
+++ b/docs/review/PR_1985_FIXED_MAPPING.md
@@ -91,6 +91,12 @@ Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-storybook-ws-ghsa-96hv`
 Evidence: `cd frontend && npm audit --audit-level=moderate --package-lock-only` reports only the out-of-scope Storybook `ws` advisory `GHSA-96hv-2xvq-fx4p`; target packages `dompurify`, `js-yaml`, `jspdf`, and `@redocly/openapi-core` are absent from the audit vulnerability set after this change.
 Reason: The `ws` finding is not part of Dependabot alerts #164-#171 and needs a separate frontend tooling dependency lane to avoid broad Storybook churn in this PR.
 
+Disposition: FIXED
+Commit: 6540cc347acf578315c402ec47bfa1c0b9e481f7
+Evidence: `tests/test_frontend_dependency_guards.py` now relies on the all-entry `js-yaml` version/provenance invariant instead of a Redocly-specific nested-path absence assertion, and `_assert_npm_registry_resolution` documents that it is for the unscoped package names guarded here.
+Reason: Addresses Sourcery review feedback about avoiding dependency-layout coupling and clarifying the helper's unscoped package-name assumption.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1985#pullrequestreview-4506749080 -> 6540cc347acf578315c402ec47bfa1c0b9e481f7
+
 ## Role Review Finding Disposition
 
 - `qa-engineer-agent`: PASS on the dependency-remediation surface and FIXED for

--- a/docs/review/PR_1985_FIXED_MAPPING.md
+++ b/docs/review/PR_1985_FIXED_MAPPING.md
@@ -1,0 +1,145 @@
+# PR 1985 Fixed in Commit Mapping
+
+## Lane Start Provenance
+
+Packet: `artifacts/orchestration/task_packets/63a747529fee.json`
+- Branch: `codex/fix-frontend-dompurify-js-yaml-alerts`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+- Base: `origin/main` at `46d93e628444a5ef70e9283152297e98bb42a4e1`.
+- Current PR: <https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1985>
+- Role order executed pre-open:
+  `agent-coordinator -> security-auditor -> frontend-engineer -> qa-engineer-agent -> bug-hunter -> architecture-specialist -> cursor-specialist-agent -> web-research-agent`
+- Operator override: `main` was accepted for PR start while current-head jobs
+  were pending without a new failed job.
+
+## Scope Boundary
+
+- In scope: frontend dependency manifest overrides, frontend lockfile
+  regeneration for `dompurify` and `js-yaml`, frontend dependency guard tests,
+  security evidence docs, and a backlog entry for the remaining out-of-scope
+  Storybook `ws` audit finding.
+- Out of scope: torch/RAG/vector policy, Bandit lower-severity inventory,
+  Storybook `ws` remediation, backend runtime behavior, OpenAPI changes,
+  frontend UI behavior, iOS/macOS, legacy routes, BMI/planning, FoodDB,
+  premium, exports, and insight routes.
+
+## Premortem Closure
+
+- Artifact:
+  `artifacts/orchestration/premortem/63a747529fee_frontend_dependency_premortem.md`
+- Decision: proceed with a narrow frontend dependency-security fix.
+- `PM-1985-001`: false-green top-level package checks miss nested `js-yaml`.
+  Disposition: FIXED. Evidence: `tests/test_frontend_dependency_guards.py`
+  now scans every lock entry ending in `node_modules/js-yaml`, requires
+  `>=4.2.0`, and rejects non-registry provenance.
+- `PM-1985-002`: `npm audit` remains red because of unrelated `ws`.
+  Disposition: DEFERRED. Backlog:
+  `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-storybook-ws-ghsa-96hv`.
+- `PM-1985-003`: lock regeneration could cause broad OpenAPI/tooling churn.
+  Disposition: NOT-A-BUG. Evidence: only `frontend/package-lock.json` changed
+  in the frontend lock surface, `npm run generate-types` produced no generated
+  API diff, and frontend build/test gates passed locally.
+
+## Experiment Runner Evidence
+
+- Packet: `artifacts/orchestration/experiments/frontend-dompurify-js-yaml-oracle-packet.json`
+- Artifact: `artifacts/orchestration/experiments/results/exp-8fde291e58c6.json`
+- Status: accepted.
+- Runner mode: `oracle_only_governance_reviewer`.
+- Contribution kind: `oracle_review`.
+- Co-author required: `true`.
+- Source diff paths reviewed:
+  `frontend/package.json`, `frontend/package-lock.json`,
+  `tests/test_frontend_dependency_guards.py`, `docs/security/*dompurify*`,
+  `docs/security/GHSA-h67p-54hq-rp68-js-yaml.md`, and
+  `docs/roadmap/BACKLOG_LEDGER.md`.
+- Oracles verified `dompurify==3.4.10`, all resolved `js-yaml==4.2.0`, no
+  nested Redocly `js-yaml` lock entry, and `git diff --check`.
+- Implementation commit `d3fc69d67fa61edc3de339e8fa88eeae7983737b` includes:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed for initial PR open.
+- [x] Fixed in commit mapping completed
+- [ ] Post-open `qa-engineer-agent` pass completed.
+- [ ] Post-open `bug-hunter` pass completed.
+- [ ] Post-open `security-auditor` pass completed.
+- [ ] Codex Security diff scan / finding discovery completed.
+- [ ] CodeRabbit review completed when authenticated.
+- [ ] `pulseplate-pr-review` completed.
+- [ ] Current actionable bot/review comments must be fixed or dispositioned
+  before merge readiness.
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: d3fc69d67fa61edc3de339e8fa88eeae7983737b
+Evidence: `frontend/package.json`, `frontend/package-lock.json`, `tests/test_frontend_dependency_guards.py`, `docs/security/GHSA-39q2-94rc-95cp-dompurify.md`, `docs/security/CVE-2026-0540-dompurify.md`, `docs/security/GHSA-h67p-54hq-rp68-js-yaml.md`, and `docs/roadmap/BACKLOG_LEDGER.md`.
+Reason: Raises DOMPurify and js-yaml security floors, narrows lockfile regeneration to the frontend dependency surface, adds deterministic guard coverage for every resolved js-yaml lock entry, refreshes advisory evidence, and records the separate Storybook `ws` residual as a follow-up.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1985 -> d3fc69d67fa61edc3de339e8fa88eeae7983737b
+
+Disposition: DEFERRED
+Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-storybook-ws-ghsa-96hv`
+Evidence: `cd frontend && npm audit --audit-level=moderate --package-lock-only` reports only the out-of-scope Storybook `ws` advisory `GHSA-96hv-2xvq-fx4p`; target packages `dompurify`, `js-yaml`, `jspdf`, and `@redocly/openapi-core` are absent from the audit vulnerability set after this change.
+Reason: The `ws` finding is not part of Dependabot alerts #164-#171 and needs a separate frontend tooling dependency lane to avoid broad Storybook churn in this PR.
+
+## Dependency Delta Proof
+
+- `frontend/package.json` override: `dompurify` -> `3.4.10`.
+- `frontend/package.json` override: `js-yaml` -> `4.2.0`.
+- Lock proof: `node_modules/dompurify` resolves to `3.4.10` from
+  `https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz`.
+- Lock proof: `node_modules/js-yaml` resolves to `4.2.0` from
+  `https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz`.
+- Negative control: no nested
+  `node_modules/@redocly/openapi-core/node_modules/js-yaml` lock entry remains.
+
+## Local Validation Evidence
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS:
+  `.venv/bin/python -m pytest -q tests/test_frontend_dependency_guards.py tests/test_ci_workflow_pr_size_governance_contract.py::test_node24_runtime_baseline_surfaces_stay_coherent`
+- PASS:
+  `python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/GHSA-h67p-54hq-rp68-js-yaml.md docs/security/GHSA-39q2-94rc-95cp-dompurify.md docs/security/CVE-2026-0540-dompurify.md docs/roadmap/BACKLOG_LEDGER.md`
+- PASS: `cd frontend && npm install --package-lock-only --ignore-scripts`
+- PASS: `cd frontend && npm ci --ignore-scripts`
+- PASS: `cd frontend && npm ls dompurify js-yaml --package-lock-only --all`
+- PASS: `cd frontend && npm run build`
+- PASS: `cd frontend && npm run test:ci`
+- PASS:
+  `cd frontend && npm run generate-types && git diff --exit-code src/api/openapi.json src/api/schema.ts`
+- DEFERRED/OUT-OF-SCOPE:
+  `cd frontend && npm audit --audit-level=moderate --package-lock-only`
+  still reports Storybook `ws` advisory `GHSA-96hv-2xvq-fx4p`; tracked in
+  backlog as `ledger-p1-storybook-ws-ghsa-96hv`.
+- PASS: target-audit classifier confirmed `dompurify`, `js-yaml`, `jspdf`, and
+  `@redocly/openapi-core` are absent from `npm audit --json`
+  vulnerabilities.
+- PASS: `make validate-changed`
+- PASS: `pre-commit run --all-files`
+- PASS during push hooks: frontend tests, backend changed-file pytest,
+  `pip-audit`, full-repo Bandit, and docker build test.
+
+## Machine-Heavy Verification Deferral
+
+Full local `make verify` was not run. This PR uses the operator-approved
+machine-heavy exception for a narrow frontend dependency-security lane. Merge
+readiness requires the focused local gates above, pre-commit/pre-push evidence,
+current-head CI parity, review-thread disposition, strict merge-readiness
+checks with auth, and the wait-window.
+
+## Merge Readiness
+
+Not ready at latest artifact update. Required before merge:
+
+- [ ] Numbered fixed-mapping artifact committed and PR body mirror updated.
+- [ ] Post-open role-agent review sequence completed.
+- [ ] Codex Security diff scan / finding discovery completed.
+- [ ] CodeRabbit/Sourcery/Cubic actionable comments fixed or dispositioned.
+- [ ] `pulseplate-pr-review` completed.
+- [ ] Current-head CI parity on latest pushed commit.
+- [ ] Strict merge-readiness check with `--require-auth`.
+- [ ] No unresolved actionable review or bot comments.
+- [ ] Mandatory wait-window after latest bot/review activity.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -11471,6 +11471,32 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
       introduced in the same PR
 
 
+<a id="ledger-p1-storybook-ws-ghsa-96hv"></a>
+- [ ] P1: Remediate Storybook `ws` audit finding (`GHSA-96hv-2xvq-fx4p`)
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1 (dependency security / frontend tooling remediation)
+  - Target PR: next frontend dependency lane after
+    `codex/fix-frontend-dompurify-js-yaml-alerts`
+  - Status: Opened from PR1 local audit residual on 2026-06-16
+  - Reason: The `dompurify` / `js-yaml` remediation lane intentionally stays
+    scoped to Dependabot alerts `#164`-`#171`, but
+    `npm audit --audit-level=moderate --package-lock-only` still reports
+    `ws` `GHSA-96hv-2xvq-fx4p` through Storybook at `8.20.1` with a fixed
+    range above the current override. This must be handled in a separate
+    frontend tooling dependency PR rather than hidden by target-package audit
+    evidence.
+  - Links:
+    - `frontend/package.json`
+    - `frontend/package-lock.json`
+    - Advisory: `GHSA-96hv-2xvq-fx4p`
+  - DoD:
+    - Storybook's resolved `ws` dependency is outside the vulnerable range
+    - `npm audit --audit-level=moderate --package-lock-only` no longer reports
+      `ws` / Storybook
+    - frontend build and `npm run test:ci` pass
+    - no unrelated frontend runtime or OpenAPI type-generation churn is included
+
+
 <a id="ledger-p1-remove-pygments-pip-audit-ignore"></a>
 - [ ] P1: Remove temporary Pygments pip-audit ignore when patched release exists
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/security/CVE-2026-0540-dompurify.md
+++ b/docs/security/CVE-2026-0540-dompurify.md
@@ -7,20 +7,20 @@
 - **Package**: `dompurify`
 - **Alert type**: GitHub Dependabot alert `#47`
 - **Current repo scope**: transitive dependency resolved via `jspdf@4.2.1`
-- **Current state**: fixed in the merged dependency tree; no new dependency remediation PR is required for this lane
+- **Current state**: fixed in the merged dependency tree; no new dependency
+  remediation PR is required for this lane
 
 Dependabot originally reported an XSS vulnerability in DOMPurify affecting
 versions `2.5.3`–`2.5.8` and `3.1.3`–`3.3.1`. The repo is now on the merged
 steady-state path with published npm packages:
 
 - `jspdf@4.2.1`
-- `dompurify@3.4.0`
+- `dompurify@3.4.10`
 
 This document records the final merged security truth after the original
 remediation lane was completed. It remains a docs/evidence sync artifact, not a
 remediation plan. The repo has since moved one step further to
-`dompurify@3.4.0` because a later advisory (`GHSA-39q2-94rc-95cp`) raised the
-safe floor again.
+`dompurify@3.4.10` because later advisories raised the safe floor again.
 
 ## Practical repo exposure
 
@@ -32,7 +32,7 @@ package-manager override path, and there are no direct `dompurify` imports under
 This means the security scope for this lane is:
 
 - resolved dependency-tree truth for `jspdf -> dompurify`
-- current package-manager evidence that the fixed `dompurify@3.4.0` version is
+- current package-manager evidence that the fixed `dompurify@3.4.10` version is
   what the repo resolves
 
 This document does not claim a separate application-level runtime integration of
@@ -45,9 +45,8 @@ The lane closed in three merged steps:
 1. `PR #977` introduced the temporary override-based mitigation while upstream
    packaged the fix.
 2. `PR #987` closed Dependabot alert `#47`.
-3. `PR #1186` moved the repo to `jspdf@4.2.1`, and the current dependency tree
-   now resolves `dompurify@3.4.0` after the later
-   `GHSA-39q2-94rc-95cp` remediation lane.
+3. `PR #1186` moved the repo to `jspdf@4.2.1`, and the dependency tree later
+   moved to `dompurify@3.4.10` after additional DOMPurify advisory batches.
 
 GitHub alert state now shows the relevant `dompurify` / `jspdf` alerts as
 `fixed`, including Dependabot alert `#47`.
@@ -55,12 +54,14 @@ GitHub alert state now shows the relevant `dompurify` / `jspdf` alerts as
 ## Current evidence anchors
 
 - `frontend/package.json:38` — `dependencies.jspdf = ^4.2.1` (key: `dependencies.jspdf`)
-- `frontend/package.json:89` — `overrides.dompurify = 3.4.0` (key: `overrides.dompurify`)
+- `frontend/package.json` — `overrides.dompurify = 3.4.10` (key: `overrides.dompurify`)
 - `frontend/package-lock.json:21` — root package dependency on `jspdf`
-- `frontend/package-lock.json:7818` — `packages["node_modules/jspdf"].version = 4.2.1`
-- `frontend/package-lock.json:7830` — `packages["node_modules/jspdf"].optionalDependencies.dompurify = ^3.3.1`
-- `frontend/package-lock.json:5886` — `packages["node_modules/dompurify"].version = 3.4.0`
-- `frontend/src` — no direct `dompurify` import in application source (`rg -n 'dompurify' frontend/src`)
+- `frontend/package-lock.json` — `packages["node_modules/jspdf"].version = 4.2.1`
+- `frontend/package-lock.json` —
+  `packages["node_modules/jspdf"].optionalDependencies.dompurify = ^3.3.1`
+- `frontend/package-lock.json` — `packages["node_modules/dompurify"].version = 3.4.10`
+- `frontend/src` — no direct `dompurify` import in application source
+  (`rg -n 'dompurify' frontend/src`)
 
 ## Validation
 
@@ -69,7 +70,7 @@ cd frontend
 npm ls jspdf dompurify
 # Expect:
 # - jspdf@4.2.1 in the resolved tree
-# - dompurify@3.4.0 in the resolved tree
+# - dompurify@3.4.10 in the resolved tree
 
 npm run build
 npm run test:ci
@@ -79,9 +80,9 @@ npm run test:ci
 
 - The earlier git-commit override was an intermediate mitigation stage, not the
   final steady-state dependency truth.
-- The repo still keeps an active `overrides.dompurify = 3.4.0` safeguard in
+- The repo still keeps an active `overrides.dompurify = 3.4.10` safeguard in
   `frontend/package.json` while the resolved dependency tree stays on published
-  npm versions (`jspdf@4.2.1` -> `dompurify@3.4.0`).
+  npm versions (`jspdf@4.2.1` -> `dompurify@3.4.10`).
 - This document should not imply any additional dependency bump, lockfile
   change, runtime fix, or suppression wave for CVE-2026-0540.
 - If a future alert returns on this lane, treat it as a new security batch with

--- a/docs/security/GHSA-39q2-94rc-95cp-dompurify.md
+++ b/docs/security/GHSA-39q2-94rc-95cp-dompurify.md
@@ -5,34 +5,36 @@
 - Package: `dompurify`
 - GHSA: `GHSA-39q2-94rc-95cp`
 - Severity: medium
-- Fixed version: `3.4.0`
+- Current repo floor: `3.4.10`
 - Current repo scope: frontend npm override and resolved lock entry
 
-This lane remediates the new `dompurify` logic-bypass advisory by raising the
-frontend override floor from `3.3.2` to `3.4.0` and regenerating the frontend
-lockfile so the resolved npm artifact also lands on `3.4.0`.
+This advisory was originally remediated by raising the frontend override floor
+to `3.4.0`. A later June 2026 Dependabot batch reported additional `dompurify`
+findings against versions below the newer safe floor. The current repo floor is
+therefore `3.4.10`, the latest npm release observed on 2026-06-16.
 
 ## Repo Evidence
 
-- `frontend/package.json:89` - `overrides.dompurify = 3.4.0`
-- `frontend/package-lock.json:5885` - lockfile contains `node_modules/dompurify`
-- `frontend/package-lock.json:5886` - resolved version is `3.4.0`
-- `frontend/package-lock.json:5887` - resolved source is the npm registry tarball `dompurify-3.4.0.tgz`
-- `tests/test_frontend_dependency_guards.py:18` - frontend guard floor is `Version("3.4.0")`
-- `tests/test_frontend_dependency_guards.py:31` - guard asserts package override floor
-- `tests/test_frontend_dependency_guards.py:41` - guard asserts lockfile resolution floor
-- `tests/test_frontend_dependency_guards.py:48` - guard asserts npm-registry provenance
+- `frontend/package.json:92` - `overrides.dompurify = 3.4.10`
+- `frontend/package-lock.json:5568` -
+  `packages["node_modules/dompurify"].version = 3.4.10`
+- `frontend/package-lock.json:5569` - `packages["node_modules/dompurify"].resolved`
+  uses the npm registry tarball `dompurify-3.4.10.tgz`
+- `tests/test_frontend_dependency_guards.py:19` - frontend guard floor is
+  `Version("3.4.10")`
+- `tests/test_frontend_dependency_guards.py:44` - guard asserts package override
+  floor, lockfile resolution floor, and npm-registry provenance
 
 ## Validation
 
 ```bash
-npm --prefix frontend install --package-lock-only
-pytest -q tests/test_frontend_dependency_guards.py
+npm --prefix frontend install --package-lock-only --ignore-scripts
+.venv/bin/python -m pytest -q tests/test_frontend_dependency_guards.py
 ```
 
 ## Notes
 
-- `frontend/package-lock.json:7830` still shows `jspdf` requesting `dompurify` via
-  `^3.3.1`, but the repo-owned override forces the resolved artifact to `3.4.0`.
+- `frontend/package-lock.json` still shows `jspdf` requesting `dompurify` via
+  `^3.3.1`, but the repo-owned override forces the resolved artifact to `3.4.10`.
 - This note is intentionally separate from the older `CVE-2026-0540` history
-  because the current lane closes a different advisory with a higher patched floor.
+  because the current lane closes a different advisory batch with a higher patched floor.

--- a/docs/security/GHSA-h67p-54hq-rp68-js-yaml.md
+++ b/docs/security/GHSA-h67p-54hq-rp68-js-yaml.md
@@ -1,0 +1,45 @@
+# GHSA-h67p-54hq-rp68 - js-yaml
+
+## Summary
+
+- Package: `js-yaml`
+- GHSA: `GHSA-h67p-54hq-rp68`
+- CVE: `CVE-2026-53550`
+- Severity: medium
+- Current repo floor: `4.2.0`
+- Current repo scope: frontend npm override and resolved lock entry
+
+GitHub Dependabot alert `#164` reported `js-yaml` versions `<=4.1.1` from
+`frontend/package-lock.json`. The repo already had a safe top-level
+`node_modules/js-yaml@4.2.0`, but `@redocly/openapi-core` still resolved a
+nested `node_modules/@redocly/openapi-core/node_modules/js-yaml@4.1.1`.
+
+This lane adds a manifest-backed frontend override and regenerates the lockfile
+so every resolved `js-yaml` package entry lands on the npm `4.2.0` release.
+
+## Repo Evidence
+
+- `frontend/package.json:94` - `overrides.js-yaml = 4.2.0`
+- `frontend/package-lock.json:7347` - `packages["node_modules/js-yaml"].version = 4.2.0`
+- `frontend/package-lock.json` - no resolved package entry remains at
+  `node_modules/@redocly/openapi-core/node_modules/js-yaml`
+- `tests/test_frontend_dependency_guards.py:20` - frontend guard floor is
+  `Version("4.2.0")`
+- `tests/test_frontend_dependency_guards.py:82` - guard scans every lock package
+  path ending in `node_modules/js-yaml`
+
+## Validation
+
+```bash
+npm --prefix frontend install --package-lock-only --ignore-scripts
+npm --prefix frontend ls dompurify js-yaml --package-lock-only --all
+.venv/bin/python -m pytest -q tests/test_frontend_dependency_guards.py
+```
+
+## Notes
+
+- `@redocly/openapi-core` still declares `js-yaml: 4.1.1` in its dependency
+  metadata, but npm override resolution dedupes the actual installed lock entry
+  to `node_modules/js-yaml@4.2.0`.
+- `ws` / Storybook audit findings are intentionally out of scope for this
+  `dompurify` / `js-yaml` Dependabot lane.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3077,19 +3077,6 @@
         "npm": ">=9.5.0"
       }
     },
-    "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@redocly/openapi-core/node_modules/minimatch": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
@@ -5578,9 +5565,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,8 +89,9 @@
     "minimatch@10": {
       "brace-expansion": "5.0.6"
     },
-    "dompurify": "3.4.0",
+    "dompurify": "3.4.10",
     "esbuild": "0.28.1",
+    "js-yaml": "4.2.0",
     "path-to-regexp": "8.4.0",
     "ws": "8.20.1"
   },

--- a/tests/test_frontend_dependency_guards.py
+++ b/tests/test_frontend_dependency_guards.py
@@ -1,7 +1,7 @@
 """Deterministic frontend dependency security guards.
 
-RU: Проверяем, что dompurify закреплен на безопасной версии без git-override.
-EN: Ensure dompurify is pinned to a safe npm release without git overrides.
+RU: Проверяем frontend security overrides.
+EN: Ensure frontend security overrides are pinned to safe npm releases.
 """
 
 from __future__ import annotations
@@ -15,11 +15,26 @@ from packaging.version import Version
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FRONTEND_PACKAGE_JSON = REPO_ROOT / "frontend" / "package.json"
 FRONTEND_LOCK_JSON = REPO_ROOT / "frontend" / "package-lock.json"
-MIN_DOMPURIFY_VERSION = Version("3.4.0")
+NPM_REGISTRY_HOST = "registry.npmjs.org"
+MIN_DOMPURIFY_VERSION = Version("3.4.10")
+MIN_JS_YAML_VERSION = Version("4.2.0")
 
 
 def _load_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _assert_npm_registry_resolution(*, package_name: str, resolved: str) -> None:
+    assert isinstance(resolved, str) and resolved, f"{package_name} resolved URL missing"
+    parsed = urlparse(resolved.removeprefix("git+"))
+    assert parsed.scheme == "https", f"{package_name} lock resolution must use https"
+    assert parsed.netloc == NPM_REGISTRY_HOST, f"{package_name} must resolve from npm registry"
+    assert parsed.path.startswith(
+        f"/{package_name}/"
+    ), f"{package_name} lock resolution path mismatch"
+    assert not resolved.startswith(
+        "git+"
+    ), f"{package_name} lock resolution must not use git override"
 
 
 def test_frontend_package_has_dompurify_override_floor() -> None:
@@ -31,8 +46,17 @@ def test_frontend_package_has_dompurify_override_floor() -> None:
     assert Version(dompurify_override) >= MIN_DOMPURIFY_VERSION
 
 
+def test_frontend_package_has_js_yaml_override_floor() -> None:
+    """RU/EN: package.json override must keep js-yaml at secure floor version."""
+    package_json = _load_json(FRONTEND_PACKAGE_JSON)
+    overrides = package_json.get("overrides", {})
+    js_yaml_override = overrides.get("js-yaml")
+    assert isinstance(js_yaml_override, str), "frontend/package.json: overrides.js-yaml missing"
+    assert Version(js_yaml_override) >= MIN_JS_YAML_VERSION
+
+
 def test_frontend_lock_resolves_dompurify_to_safe_npm_release() -> None:
-    """RU/EN: package-lock must resolve dompurify from npm registry at secure floor version."""
+    """RU/EN: package-lock must resolve dompurify from npm registry."""
     package_lock = _load_json(FRONTEND_LOCK_JSON)
     dompurify_pkg = package_lock.get("packages", {}).get("node_modules/dompurify", {})
     lock_version = dompurify_pkg.get("version")
@@ -40,11 +64,26 @@ def test_frontend_lock_resolves_dompurify_to_safe_npm_release() -> None:
 
     assert isinstance(lock_version, str), "frontend/package-lock.json: dompurify version missing"
     assert Version(lock_version) >= MIN_DOMPURIFY_VERSION
+    _assert_npm_registry_resolution(package_name="dompurify", resolved=resolved)
+
+
+def test_frontend_lock_resolves_all_js_yaml_entries_to_safe_npm_release() -> None:
+    """RU/EN: every js-yaml package entry must use the secure npm release."""
+    package_lock = _load_json(FRONTEND_LOCK_JSON)
+    packages = package_lock.get("packages", {})
+    js_yaml_entries = {
+        path: package
+        for path, package in packages.items()
+        if path == "node_modules/js-yaml" or path.endswith("/node_modules/js-yaml")
+    }
+
+    assert js_yaml_entries, "frontend/package-lock.json: js-yaml package entries missing"
     assert (
-        isinstance(resolved, str) and resolved
-    ), "frontend/package-lock.json: dompurify resolved missing"
-    parsed = urlparse(resolved.removeprefix("git+"))
-    assert parsed.scheme == "https", "dompurify lock resolution must use https"
-    assert parsed.netloc == "registry.npmjs.org", "dompurify must resolve from npm registry"
-    assert parsed.path.startswith("/dompurify/"), "dompurify lock resolution path mismatch"
-    assert not resolved.startswith("git+"), "dompurify lock resolution must not use git override"
+        "node_modules/@redocly/openapi-core/node_modules/js-yaml" not in js_yaml_entries
+    ), "frontend/package-lock.json: vulnerable nested js-yaml lock entry remains"
+    for path, package in js_yaml_entries.items():
+        lock_version = package.get("version")
+        resolved = package.get("resolved", "")
+        assert isinstance(lock_version, str), f"{path}: js-yaml version missing"
+        assert Version(lock_version) >= MIN_JS_YAML_VERSION, f"{path}: js-yaml below secure floor"
+        _assert_npm_registry_resolution(package_name="js-yaml", resolved=resolved)

--- a/tests/test_frontend_dependency_guards.py
+++ b/tests/test_frontend_dependency_guards.py
@@ -25,6 +25,7 @@ def _load_json(path: Path) -> dict:
 
 
 def _assert_npm_registry_resolution(*, package_name: str, resolved: str) -> None:
+    """Assert npm registry provenance for the unscoped package names guarded here."""
     assert isinstance(resolved, str) and resolved, f"{package_name} resolved URL missing"
     parsed = urlparse(resolved.removeprefix("git+"))
     assert parsed.scheme == "https", f"{package_name} lock resolution must use https"
@@ -78,9 +79,6 @@ def test_frontend_lock_resolves_all_js_yaml_entries_to_safe_npm_release() -> Non
     }
 
     assert js_yaml_entries, "frontend/package-lock.json: js-yaml package entries missing"
-    assert (
-        "node_modules/@redocly/openapi-core/node_modules/js-yaml" not in js_yaml_entries
-    ), "frontend/package-lock.json: vulnerable nested js-yaml lock entry remains"
     for path, package in js_yaml_entries.items():
         lock_version = package.get("version")
         resolved = package.get("resolved", "")


### PR DESCRIPTION
## Goal
Close frontend Dependabot alerts for `dompurify` and `js-yaml` with a narrow frontend lock regeneration and deterministic dependency guard evidence.

## Business Reason
Remove known vulnerable frontend dependency surfaces without changing runtime behavior, public APIs, generated clients, iOS/macOS, backend logic, or unrelated dependency families.

## Scope
- Raise `frontend/package.json` overrides to `dompurify@3.4.10` and `js-yaml@4.2.0`.
- Regenerate only `frontend/package-lock.json` with `npm install --package-lock-only --ignore-scripts`.
- Harden frontend dependency guards so all resolved `js-yaml` entries are registry-backed and at least `4.2.0`.
- Refresh security evidence for DOMPurify and add js-yaml advisory evidence.
- Track the residual Storybook `ws` audit finding separately in `docs/roadmap/BACKLOG_LEDGER.md`.

## Out of Scope
- Torch / RAG vector policy alerts.
- Bandit lower-severity remediation or gate tightening.
- Storybook `ws` remediation beyond backlog tracking.
- Backend runtime behavior, OpenAPI surface changes, frontend UI behavior, iOS, macOS, exports, FoodDB, planning, BMI, premium, or legacy routes.

## Files Changed / Likely Touched
- `frontend/package.json`
- `frontend/package-lock.json`
- `tests/test_frontend_dependency_guards.py`
- `docs/security/GHSA-39q2-94rc-95cp-dompurify.md`
- `docs/security/CVE-2026-0540-dompurify.md`
- `docs/security/GHSA-h67p-54hq-rp68-js-yaml.md`
- `docs/roadmap/BACKLOG_LEDGER.md`
- `docs/review/PR_1985_FIXED_MAPPING.md`

## Key Decisions

Operator approval: approved for frontend dependency security evidence lane
Frontend/backend mix approval: approved for frontend dependency manifests with security evidence docs

- Used npm `overrides` to pin the vulnerable transitive surfaces without upgrading OpenAPI tooling or Storybook.
- Treated the remaining `ws` audit result as out of scope for this PR and recorded it as a follow-up instead of widening the dependency lane.
- Kept generated API artifacts unchanged after frontend build/type generation validation.

## Tests / Validation
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `.venv/bin/python -m pytest -q tests/test_frontend_dependency_guards.py tests/test_ci_workflow_pr_size_governance_contract.py::test_node24_runtime_baseline_surfaces_stay_coherent`
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/GHSA-h67p-54hq-rp68-js-yaml.md docs/security/GHSA-39q2-94rc-95cp-dompurify.md docs/security/CVE-2026-0540-dompurify.md docs/roadmap/BACKLOG_LEDGER.md docs/review/PR_1985_FIXED_MAPPING.md`
- `cd frontend && npm install --package-lock-only --ignore-scripts`
- `cd frontend && npm ci --ignore-scripts`
- `cd frontend && npm ls dompurify js-yaml --package-lock-only --all`
- `cd frontend && npm run build`
- `cd frontend && npm run test:ci`
- `cd frontend && npm run generate-types && git diff --exit-code src/api/openapi.json src/api/schema.ts`
- `make validate-changed`
- `pre-commit run --all-files`

`cd frontend && npm audit --audit-level=moderate --package-lock-only` is still red only for the out-of-scope Storybook `ws` advisory `GHSA-96hv-2xvq-fx4p`; target packages `dompurify`, `js-yaml`, `jspdf`, and `@redocly/openapi-core` are absent from the audit vulnerability set after this change. The `ws` finding is tracked in `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-storybook-ws-ghsa-96hv`.

Machine-heavy exception: per operator-approved narrow validation mode, full local `make verify` was not run. This PR uses focused local gates plus current-head CI/review governance before merge.

## Security Notes
- `dompurify` lock entry is now `3.4.10` from the npm registry.
- Every resolved `js-yaml` lock entry is now guarded at `>=4.2.0` and registry-backed.
- No public runtime behavior, API contract, auth, entitlement, or backend dependency surface is changed.

## Risks / Rollback
Risk is limited to frontend dependency resolution. Rollback is reverting this PR, which restores the previous lock/override state. The residual `ws` audit result remains tracked for a dedicated follow-up lane.

## Deferred / Follow-ups
- Storybook `ws` advisory `GHSA-96hv-2xvq-fx4p`: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-storybook-ws-ghsa-96hv`
- Torch CVE-2025-3000 RAG/vector policy lane remains separate.
- Bandit lower-severity inventory lane remains separate.

## AGENTS.md or Agent-Instruction Updates
None.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] Post-open `qa-engineer-agent` pass completed.
- [x] Post-open `bug-hunter` pass completed.
- [x] Post-open `security-auditor` pass completed.
- [x] Codex Security diff scan / finding discovery completed.
- [x] CodeRabbit review completed when authenticated.
- [x] `pulseplate-pr-review` completed.
- [ ] Current actionable bot/review comments must be fixed or dispositioned before merge readiness.

### Fixed in Commit Mapping
Canonical artifact: `docs/review/PR_1985_FIXED_MAPPING.md`

Disposition: FIXED
Commit: d3fc69d67fa61edc3de339e8fa88eeae7983737b
Evidence: `frontend/package.json`, `frontend/package-lock.json`, `tests/test_frontend_dependency_guards.py`, `docs/security/GHSA-39q2-94rc-95cp-dompurify.md`, `docs/security/CVE-2026-0540-dompurify.md`, `docs/security/GHSA-h67p-54hq-rp68-js-yaml.md`, and `docs/roadmap/BACKLOG_LEDGER.md`.
Reason: Raises DOMPurify and js-yaml security floors, narrows lockfile regeneration to the frontend dependency surface, adds deterministic guard coverage for every resolved js-yaml lock entry, refreshes advisory evidence, and records the separate Storybook `ws` residual as a follow-up.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1985 -> d3fc69d67fa61edc3de339e8fa88eeae7983737b

Disposition: DEFERRED
Backlog: `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-storybook-ws-ghsa-96hv`
Evidence: `cd frontend && npm audit --audit-level=moderate --package-lock-only` reports only the out-of-scope Storybook `ws` advisory `GHSA-96hv-2xvq-fx4p`; target packages are absent from the audit vulnerability set after this change.
Reason: The `ws` finding is not part of Dependabot alerts #164-#171 and needs a separate frontend tooling dependency lane to avoid broad Storybook churn in this PR.

Disposition: FIXED
Commit: 6540cc347acf578315c402ec47bfa1c0b9e481f7
Evidence: `tests/test_frontend_dependency_guards.py` now relies on the all-entry `js-yaml` version/provenance invariant instead of a Redocly-specific nested-path absence assertion, and `_assert_npm_registry_resolution` documents that it is for the unscoped package names guarded here.
Reason: Addresses Sourcery review feedback about avoiding dependency-layout coupling and clarifying the helper's unscoped package-name assumption.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1985#pullrequestreview-4506749080 -> 6540cc347acf578315c402ec47bfa1c0b9e481f7

## Role Review Finding Disposition
- `qa-engineer-agent`: PASS on the dependency-remediation surface and FIXED for local path hygiene before commit. Evidence: QA confirmed scoped lockfile changes, all-entry `js-yaml` guard coverage, registry provenance, documented `ws` deferral, and scope-governance labels/body; the local absolute-path mapping issue was scrubbed before commit.
- `bug-hunter`: PASS on nested lock-entry risk, npm override semantics, lockfile churn, residual audit wording, scope-governance proof, and parser/local docs checks. Evidence: bug-hunter confirmed remaining blockers were uncommitted mapping/body parity and current-head readiness, not dependency-security logic.
- `security-auditor`: PASS with no security-blocking findings. Evidence: security-auditor confirmed override floors, npm registry-backed lock provenance, deterministic guard coverage, no audit overclaim, live scope labels/body, Codex Security zero-findings evidence, CodeRabbit NOT-A-BUG disposition, and no absolute local path leakage.
- `Codex Security diff scan`: NOT-A-BUG. Evidence: `codex-security-scans/fix-frontend-dompurify-js-yaml-alerts/bcf82a26ebef_20260616T182320Z` reports zero findings; report-format validation passed.
- `CodeRabbit CLI`: NOT-A-BUG for the minor `.venv/bin/python` doc suggestion. Evidence: root `AGENTS.md` and `Makefile` use repo virtualenv / `VENV_PYTHON` for repo Python commands; the command matches the operator-approved PR validation plan.
- `pulseplate-pr-review`: NOT-A-BUG for the advisory large-diff note. Evidence: `pulseplate_pr1985_review_report.md` is review-planning only; split rationale and scope exception are documented, `make validate-changed` passed, and `tests/test_pr_review_report.py` passed.


## Merge Readiness
Not merge-ready yet. Required before merge:

- [ ] Numbered fixed-mapping artifact committed and PR body mirror updated.
- [x] Post-open role-agent review sequence completed.
- [x] Codex Security diff scan / finding discovery completed.
- [ ] CodeRabbit/Sourcery/Cubic actionable comments fixed or dispositioned.
- [x] `pulseplate-pr-review` completed.
- [ ] Current-head CI parity on latest pushed commit.
- [ ] Strict merge-readiness check with `--require-auth`.
- [ ] No unresolved actionable review or bot comments.
- [ ] Mandatory wait-window after latest bot/review activity.

## Next Best Step
Commit and push the fixed-mapping artifact, run post-open review passes, then wait for current-head CI/review governance.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated frontend dependency overrides to bump DOMPurify to **3.4.10**.
  * Added frontend overrides to ensure **js-yaml ≥ 4.2.0** across resolved packages.

* **Documentation**
  * Refreshed security evidence and remediation details for DOMPurify and js-yaml.
  * Added backlog ledger and PR fixed-mapping documentation for tracked remediation work (including Storybook `ws` audit follow-up).

* **Tests**
  * Strengthened dependency guard tests with stricter npm registry provenance checks and validation that all `js-yaml` entries meet the safe floor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



