### PR TITLE
fix(api): keep legacy export aliases reload-idempotent

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -45,6 +45,7 @@ from app.routers.fitchef_structured import router as fitchef_structured_router
 from app.routers.favicon import FAVICON_ROUTE_PATH, router as favicon_router
 from app.routers.health import router as health_router
 from app.routers.legal import router as legal_router
+from app.routers import legacy_export_aliases as legacy_export_aliases_module
 from app.routers.legacy_export_aliases import (
     LEGACY_EXPORT_ALIAS_ROUTE_SPECS,
     build_legacy_export_aliases_router,
@@ -129,9 +130,12 @@ legacy_export_aliases_router = _build_legacy_export_aliases_router()
 def _is_same_legacy_export_alias_endpoint(existing: object, expected: object) -> bool:
     if existing is expected:
         return True
+    if not callable(existing) or not callable(expected):
+        return False
+    expected_module = getattr(expected, "__module__", None)
     return (
-        getattr(existing, "__module__", None) == "app.routers.legacy_export_aliases"
-        and getattr(existing, "__module__", None) == getattr(expected, "__module__", None)
+        expected_module == legacy_export_aliases_module.__name__
+        and getattr(existing, "__module__", None) == expected_module
         and getattr(existing, "__name__", None) == getattr(expected, "__name__", None)
     )
 

--- a/app/main.py
+++ b/app/main.py
@@ -126,6 +126,16 @@ def _build_legacy_export_aliases_router() -> APIRouter:
 legacy_export_aliases_router = _build_legacy_export_aliases_router()
 
 
+def _is_same_legacy_export_alias_endpoint(existing: object, expected: object) -> bool:
+    if existing is expected:
+        return True
+    return (
+        getattr(existing, "__module__", None) == "app.routers.legacy_export_aliases"
+        and getattr(existing, "__module__", None) == getattr(expected, "__module__", None)
+        and getattr(existing, "__name__", None) == getattr(expected, "__name__", None)
+    )
+
+
 def _has_route(
     target_app: FastAPI,
     path: str,
@@ -584,9 +594,9 @@ def _include_legacy_export_alias_router_if_needed(target_app: FastAPI) -> None:
             if getattr(route, "path", None) == path
             and method in (getattr(route, "methods", None) or set())
         ]
-        if (
-            len(matching_routes) != 1
-            or getattr(matching_routes[0], "endpoint", None) is not endpoint
+        if len(matching_routes) != 1 or not _is_same_legacy_export_alias_endpoint(
+            getattr(matching_routes[0], "endpoint", None),
+            endpoint,
         ):
             raise RuntimeError(
                 f"Duplicate {path} route detected with a different legacy export alias handler."

--- a/docs/review/PR_1987_FIXED_MAPPING.md
+++ b/docs/review/PR_1987_FIXED_MAPPING.md
@@ -44,6 +44,7 @@ Reason: Addresses Sourcery review feedback about avoiding a hard-coded module st
 - PASS: `python3 scripts/orchestration/check_preflight.py --mode analyze --path app/main.py --path tests/test_main_paywall_bootstrap.py --path tests/test_legacy_export_aliases.py`
 - PASS: `python3 scripts/orchestration/task_bootstrap.py --goal "Stabilize post-merge main CI by making legacy export alias router idempotent across app.main reload/module purge" --task-class Bugfix --pr-phase pre_open --path app/main.py --path tests/test_main_paywall_bootstrap.py --path tests/test_legacy_export_aliases.py --requested-agent agent-coordinator --requested-agent qa-engineer-agent --requested-agent bug-hunter --requested-agent security-auditor`
 - PASS: `. .venv/bin/activate && pytest -q tests/test_legacy_export_aliases.py tests/test_main_paywall_bootstrap.py tests/test_module_purge.py::test_purge_modules_respects_exclusions_and_removes_only_targets tests/test_coverage_final_push.py::TestFinalCoveragePush::test_vip_import_fallbacks`
+- PASS: `. .venv/bin/activate && pytest -q tests/test_main_paywall_bootstrap.py::test_legacy_export_alias_endpoint_equivalence_rejects_non_callables tests/test_main_paywall_bootstrap.py::test_legacy_export_alias_route_registration_allows_reloaded_canonical_handlers tests/test_main_paywall_bootstrap.py::test_legacy_export_alias_route_registration_rejects_foreign_handlers`
 - PASS: `python3 scripts/ci/check_legacy_growth_guard.py`
 - PASS: `make validate-changed`
 - PASS: `pre-commit run --all-files`
@@ -51,6 +52,9 @@ Reason: Addresses Sourcery review feedback about avoiding a hard-coded module st
   tests, full-repo Bandit, and docker build test.
 - PR body mirror updated from `## Tests / Validation` to exact `## Tests`
   after `pr_scope_guard` reported the parser contract mismatch.
+- CI run `27654219927` initially failed `diff-coverage` on
+  `app/main.py:134`; `tests/test_main_paywall_bootstrap.py` now covers the
+  non-callable guard branch.
 
 ## Security Notes
 

--- a/docs/review/PR_1987_FIXED_MAPPING.md
+++ b/docs/review/PR_1987_FIXED_MAPPING.md
@@ -49,6 +49,8 @@ Reason: Addresses Sourcery review feedback about avoiding a hard-coded module st
 - PASS: `pre-commit run --all-files`
 - PASS during commit/push hooks: changed-file mypy, pip-audit, backend
   tests, full-repo Bandit, and docker build test.
+- PR body mirror updated from `## Tests / Validation` to exact `## Tests`
+  after `pr_scope_guard` reported the parser contract mismatch.
 
 ## Security Notes
 
@@ -64,7 +66,8 @@ Reason: Addresses Sourcery review feedback about avoiding a hard-coded module st
 Not ready at artifact creation. Required before merge:
 
 - [x] Numbered fixed-mapping artifact created.
-- [ ] PR body mirror updated to point to this artifact.
+- [x] PR body mirror updated to point to this artifact and include exact
+  `## Scope`, `## Out of Scope`, and `## Tests` headings.
 - [ ] Current-head CI parity on latest pushed commit.
 - [ ] Strict merge-readiness check with `--require-auth`.
 - [ ] No unresolved actionable review or bot comments.

--- a/docs/review/PR_1987_FIXED_MAPPING.md
+++ b/docs/review/PR_1987_FIXED_MAPPING.md
@@ -23,6 +23,7 @@
 - [x] Discussion-thread pass completed.
 - [x] Fixed in commit mapping completed.
 - [x] Initial PR open: no review threads existed at artifact creation.
+- [x] Sourcery post-open review fixed in `0a20a9764`.
 
 ## Fixed in Commit Mapping
 
@@ -31,6 +32,12 @@ Commit: 2e72dfa20
 Evidence: `app/main.py` now treats pre-existing canonical `app.routers.legacy_export_aliases` endpoints with the same function name as idempotent after reload, while still rejecting foreign duplicate handlers; `tests/test_main_paywall_bootstrap.py` covers reloaded canonical handlers; `tests/test_legacy_export_aliases.py` resolves the current `legacy_app` module after purge/reload.
 Reason: Fixes post-merge main CI failures from run `27649033733`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1987 -> 2e72dfa20
+
+Disposition: FIXED
+Commit: 0a20a9764
+Evidence: `app/main.py` derives the accepted legacy export alias module name from `app.routers.legacy_export_aliases` and explicitly rejects non-callable endpoint candidates before comparing module and function names.
+Reason: Addresses Sourcery review feedback about avoiding a hard-coded module string and making endpoint equivalence more defensive.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1987#pullrequestreview-4510864368 -> 0a20a9764
 
 ## Local Validation Evidence
 

--- a/docs/review/PR_1987_FIXED_MAPPING.md
+++ b/docs/review/PR_1987_FIXED_MAPPING.md
@@ -56,6 +56,17 @@ Reason: Addresses Sourcery review feedback about avoiding a hard-coded module st
   `app/main.py:134`; `tests/test_main_paywall_bootstrap.py` now covers the
   non-callable guard branch.
 
+## Experiment Runner Evidence
+
+- Artifact: `artifacts/orchestration/experiments/results/exp-3ff29cb73495.json`
+- PASS: oracle-only governance reviewer accepted the PR #1987 evidence packet.
+- PASS: oracle `python -m pytest -q tests/test_legacy_export_aliases.py tests/test_main_paywall_bootstrap.py`
+  returned 0 in the runner checkout.
+- PASS: oracle `python scripts/ci/check_legacy_growth_guard.py` returned 0 in
+  the runner checkout.
+- Result metadata: `mutated_paths: []`, `shared_tree_untouched: true`,
+  `promotion_ready: false`, `coauthor_required: true`.
+
 ## Security Notes
 
 - No auth, API-key, feature-gate, response, or rate-limit behavior changes.

--- a/docs/review/PR_1987_FIXED_MAPPING.md
+++ b/docs/review/PR_1987_FIXED_MAPPING.md
@@ -1,0 +1,64 @@
+# PR #1987 Fixed Mapping
+
+## Lane Start Provenance
+
+- Branch: `codex/fix-legacy-export-reload-idempotency`
+- Packet: `artifacts/orchestration/task_packets/a6cb67b5610b.json`
+- Base: `main` at post-merge PR #1986 commit
+  `083907804bad98e0c2a13e60e0a5e12b0861368b`.
+- Trigger: post-merge `main` CI run `27649033733` failed in
+  `test-main` matrix after PR #1986 merge.
+
+## Scope Boundary
+
+- In scope: route-bootstrap idempotency after `app.main` reload/module purge,
+  stale-module-safe legacy export alias test assertion, targeted regression
+  coverage, and two inline allowlist pragmas for existing synthetic Slack-token
+  test literals required by mandatory `detect-secrets`.
+- Out of scope: route semantics, auth/rate-limit behavior, legacy removal,
+  cache/runtime/FoodDB/frontend/iOS work.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed.
+- [x] Fixed in commit mapping completed.
+- [x] Initial PR open: no review threads existed at artifact creation.
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: 2e72dfa20
+Evidence: `app/main.py` now treats pre-existing canonical `app.routers.legacy_export_aliases` endpoints with the same function name as idempotent after reload, while still rejecting foreign duplicate handlers; `tests/test_main_paywall_bootstrap.py` covers reloaded canonical handlers; `tests/test_legacy_export_aliases.py` resolves the current `legacy_app` module after purge/reload.
+Reason: Fixes post-merge main CI failures from run `27649033733`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1987 -> 2e72dfa20
+
+## Local Validation Evidence
+
+- PASS: `python3 scripts/orchestration/check_preflight.py --mode analyze --path app/main.py --path tests/test_main_paywall_bootstrap.py --path tests/test_legacy_export_aliases.py`
+- PASS: `python3 scripts/orchestration/task_bootstrap.py --goal "Stabilize post-merge main CI by making legacy export alias router idempotent across app.main reload/module purge" --task-class Bugfix --pr-phase pre_open --path app/main.py --path tests/test_main_paywall_bootstrap.py --path tests/test_legacy_export_aliases.py --requested-agent agent-coordinator --requested-agent qa-engineer-agent --requested-agent bug-hunter --requested-agent security-auditor`
+- PASS: `. .venv/bin/activate && pytest -q tests/test_legacy_export_aliases.py tests/test_main_paywall_bootstrap.py tests/test_module_purge.py::test_purge_modules_respects_exclusions_and_removes_only_targets tests/test_coverage_final_push.py::TestFinalCoveragePush::test_vip_import_fallbacks`
+- PASS: `python3 scripts/ci/check_legacy_growth_guard.py`
+- PASS: `make validate-changed`
+- PASS: `pre-commit run --all-files`
+- PASS during commit/push hooks: changed-file mypy, pip-audit, backend
+  tests, full-repo Bandit, and docker build test.
+
+## Security Notes
+
+- No auth, API-key, feature-gate, response, or rate-limit behavior changes.
+- Existing route equivalence remains narrow: only canonical
+  `app.routers.legacy_export_aliases` endpoints with matching function names
+  are accepted after reload; foreign handlers still fail.
+- Slack-token strings are synthetic redaction-test fixtures and are marked with
+  inline `pragma: allowlist secret` comments only on the literal fixture lines.
+
+## Merge Readiness
+
+Not ready at artifact creation. Required before merge:
+
+- [x] Numbered fixed-mapping artifact created.
+- [ ] PR body mirror updated to point to this artifact.
+- [ ] Current-head CI parity on latest pushed commit.
+- [ ] Strict merge-readiness check with `--require-auth`.
+- [ ] No unresolved actionable review or bot comments.
+- [ ] Mandatory wait-window after latest bot/review activity.

--- a/tests/test_experiment_slack_kpp_renderer.py
+++ b/tests/test_experiment_slack_kpp_renderer.py
@@ -47,7 +47,7 @@ SECURITY_SENSITIVE_OUTCOME_CASES = tuple(sorted(SECURITY_SENSITIVE_OUTCOMES))
     "raw, expected",
     [
         ("Hello world", "Hello world"),
-        ("xoxb-1234567890-abcdef", "[redacted-secret]"),
+        ("xoxb-1234567890-abcdef", "[redacted-secret]"),  # pragma: allowlist secret
         ("ghp_abcdefghijklmnopqrstuvwxyz1234", "[redacted-secret]"),  # pragma: allowlist secret
         (
             "https://hooks.slack.com/services/T123/B456/xxx",  # pragma: allowlist secret
@@ -381,7 +381,7 @@ def test_json_no_raw_secrets() -> None:
         kpp_outcome=KPP_FAIL,
         experiment_id="test-001",
         evidence_summary=(
-            "xoxb-1234567890-secret-token",
+            "xoxb-1234567890-secret-token",  # pragma: allowlist secret
             "/Users/alice/local/path",
         ),
     )

--- a/tests/test_legacy_export_aliases.py
+++ b/tests/test_legacy_export_aliases.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import importlib
 import json
 import os
 from pathlib import Path
@@ -28,6 +29,7 @@ def _matching_routes(path: str, method: str) -> list[object]:
 
 
 def test_legacy_export_alias_routes_are_hidden_shim_owned_and_protected() -> None:
+    current_legacy_app = importlib.import_module("legacy_app")
     openapi_paths = app_main.app.openapi().get("paths", {})
 
     for path, method, include_in_schema in app_main._LEGACY_EXPORT_ALIAS_ROUTE_SPECS:
@@ -42,7 +44,7 @@ def test_legacy_export_alias_routes_are_hidden_shim_owned_and_protected() -> Non
         assert 429 in getattr(route, "responses", {})
         assert "request" in inspect.signature(endpoint).parameters
         assert any(
-            getattr(dependency, "dependency", None) is legacy_app._get_api_key_dynamic
+            getattr(dependency, "dependency", None) is current_legacy_app._get_api_key_dynamic
             for dependency in getattr(route, "dependencies", [])
         )
 

--- a/tests/test_main_paywall_bootstrap.py
+++ b/tests/test_main_paywall_bootstrap.py
@@ -1358,6 +1358,17 @@ def test_legacy_export_alias_route_registration_allows_reloaded_canonical_handle
         assert len(matching_routes) == 1
 
 
+def test_legacy_export_alias_endpoint_equivalence_rejects_non_callables() -> None:
+    expected_endpoint = next(
+        route.endpoint
+        for route in app_main.legacy_export_aliases_router.routes
+        if getattr(route, "path", None) == app_main._LEGACY_EXPORT_ALIAS_ROUTE_SPECS[0][0]
+    )
+
+    assert not app_main._is_same_legacy_export_alias_endpoint(None, expected_endpoint)
+    assert not app_main._is_same_legacy_export_alias_endpoint(expected_endpoint, None)
+
+
 def test_legacy_export_alias_route_registration_rejects_foreign_handlers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_main_paywall_bootstrap.py
+++ b/tests/test_main_paywall_bootstrap.py
@@ -1334,6 +1334,30 @@ def test_legacy_export_alias_route_registration_allows_unrelated_router_paths(
     )
 
 
+def test_legacy_export_alias_route_registration_allows_reloaded_canonical_handlers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(app_main._legacy_module, "EXPORTS_ENABLED", True)
+    app = FastAPI()
+    app.include_router(app_main._build_legacy_export_aliases_router())
+    monkeypatch.setattr(
+        app_main,
+        "legacy_export_aliases_router",
+        app_main._build_legacy_export_aliases_router(),
+    )
+
+    app_main._include_legacy_export_alias_router_if_needed(app)
+
+    for path, method, _include_in_schema in app_main._LEGACY_EXPORT_ALIAS_ROUTE_SPECS:
+        matching_routes = [
+            route
+            for route in app.routes
+            if getattr(route, "path", None) == path
+            and method in (getattr(route, "methods", None) or set())
+        ]
+        assert len(matching_routes) == 1
+
+
 def test_legacy_export_alias_route_registration_rejects_foreign_handlers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Goal
Stabilize post-merge `main` CI after PR #1986 by making legacy export alias route ownership idempotent across `app.main` reload/module-purge paths.

## Business Reason
Main CI red blocks the legacy extraction train. The failure is limited to canonical route bootstrap idempotency after module reloads.

## Scope
- Accept already-registered canonical `app.routers.legacy_export_aliases` endpoints when a fresh `app.main` import rebuilds equivalent shim function objects.
- Preserve rejection of foreign duplicate handlers.
- Make the route ownership test resolve the current `legacy_app` module after purge/reload.
- Add a regression test for reloaded canonical handlers.
- Mark existing synthetic Slack-token fixture literals with inline test allowlist pragmas so mandatory `detect-secrets` remains passable.

## Out of Scope
No route semantics changes, no auth/rate-limit changes, no legacy removal, no cache/runtime/FoodDB/frontend/iOS work.

## Tests
- `python3 scripts/orchestration/check_preflight.py --mode analyze --path app/main.py --path tests/test_main_paywall_bootstrap.py --path tests/test_legacy_export_aliases.py`
- `pytest -q tests/test_legacy_export_aliases.py tests/test_main_paywall_bootstrap.py tests/test_module_purge.py::test_purge_modules_respects_exclusions_and_removes_only_targets tests/test_coverage_final_push.py::TestFinalCoveragePush::test_vip_import_fallbacks`
- `python3 scripts/ci/check_legacy_growth_guard.py`
- `make validate-changed`
- `pre-commit run --all-files`
- Pre-push hooks: changed-file mypy, pip-audit, backend tests, full-repo Bandit, docker build test.

## Security Notes
The change does not weaken auth or rate limiting. The endpoint equivalence check only accepts handlers from `app.routers.legacy_export_aliases` with the same function name; foreign duplicate handlers still fail.

## Risks / Rollback
Rollback is reverting this PR, but that would restore post-merge `main` CI failures after module purge/reload. Risk is limited to bootstrap duplicate detection.

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/exp-3ff29cb73495.json`

Oracle-only governance reviewer accepted the evidence packet with `mutated_paths: []`, `shared_tree_untouched: true`, and `promotion_ready: false`. Oracles passed: `python -m pytest -q tests/test_legacy_export_aliases.py tests/test_main_paywall_bootstrap.py` and `python scripts/ci/check_legacy_growth_guard.py`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- [x] No review threads existed at PR creation.

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1987_FIXED_MAPPING.md`

## Merge Readiness
Not claimed until current-head CI and strict governance pass.

## Summary by Sourcery

Сделать регистрацию маршрутов псевдонимов устаревшего экспорта идемпотентной при повторных перезапусках приложения, сохранив защиту от внешних обработчиков, и соответствующим образом обновить тесты.

Bug Fixes:
- Разрешить повторную регистрацию канонических маршрутов псевдонимов устаревшего экспорта после перезапуска приложения без возникновения ошибок о дублирующихся обработчиках.
- Гарантировать, что маршруты псевдонимов устаревшего экспорта продолжают зависеть от зависимости API-ключа текущего модуля `legacy_app` после его перезагрузки.

Enhancements:
- Добавить помощник (helper), который рассматривает конечные точки из роутера псевдонимов устаревшего экспорта как эквивалентные, если они принадлежат одному и тому же модулю и имеют одно и то же имя функции.

Tests:
- Добавить регрессионный тест, проверяющий, что регистрация маршрутов псевдонимов устаревшего экспорта принимает перезагруженные канонические обработчики.
- Аннотировать секреты, связанные со Slack, pragma-комментариями allowlist, чтобы инструменты обнаружения секретов продолжали успешно проходить проверки без изменения поведения.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make legacy export alias route registration idempotent across app reloads while preserving protection against foreign handlers and update tests accordingly.

Bug Fixes:
- Allow re-registration of canonical legacy export alias routes after app reloads without triggering duplicate handler errors.
- Ensure legacy export alias routes continue to depend on the current legacy_app module’s API key dependency after module reloads.

Enhancements:
- Introduce a helper to treat endpoints from the legacy export aliases router as equivalent when they originate from the same module and have the same function name.

Tests:
- Add a regression test verifying that legacy export alias route registration accepts reloaded canonical handlers.
- Annotate Slack-related test secrets with allowlist pragmas to keep secret-detection tooling passing without altering behavior.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make legacy export alias registration idempotent across `app.main` reloads to prevent duplicate-route errors, while still rejecting foreign handlers. Tighten endpoint equivalence with module-derived checks and callable guards.

- **Bug Fixes**
  - Added `_is_same_legacy_export_alias_endpoint` to verify callables and match the module from `app.routers.legacy_export_aliases` plus function name, treating reloaded canonical handlers as identical.
  - Updated `_include_legacy_export_alias_router_if_needed` to use the new check and continue rejecting foreign duplicates.
  - Tests: added a regression for reloaded canonical handlers; added coverage for non-callable guard; resolved `legacy_app` via `importlib`; annotated synthetic Slack tokens with `pragma: allowlist secret`.
  - Docs: added `docs/review/PR_1987_FIXED_MAPPING.md` with experiment evidence and recorded the PR body gate fix.

<sup>Written for commit ed9b81e8edfae1d748ad28a3bf3cbeab46428dfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Strengthened internal route validation mechanism for legacy export aliases, improving endpoint matching verification.

* **Tests**
  * Added regression test to verify legacy export alias routes maintain proper behavior during system reloads.
  * Updated test infrastructure to use dynamic module loading for improved flexibility.
  * Applied security compliance annotations to test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



