### PR TITLE
test(api): tolerate legacy export dependency reloads

### DIFF
--- a/docs/review/PR_1988_FIXED_MAPPING.md
+++ b/docs/review/PR_1988_FIXED_MAPPING.md
@@ -1,0 +1,69 @@
+# PR #1988 Fixed Mapping
+
+## Lane Start Provenance
+
+- Branch: `codex/fix-legacy-export-api-key-contract-test`
+- Packet: `artifacts/orchestration/task_packets/bbe1149e83c7.json`
+- Base: `main` at post-merge PR #1987 commit
+  `f6c66ba5e16a178849b17670f7d9d1eb0ddefef5`.
+- Trigger: post-merge `main` CI run `27657385344` failed in
+  `test-main (3.11, 60)`.
+
+## Scope Boundary
+
+- In scope: make the legacy export alias route ownership test assert stable
+  API-key dependency contract by callable module/name instead of stale module
+  object identity.
+- Out of scope: runtime route changes, auth/rate-limit behavior changes, legacy
+  removal, cache/runtime/FoodDB/frontend/iOS work.
+
+## Discussion Thread Pass
+
+- [x] Discussion-thread pass completed.
+- [x] Fixed in commit mapping completed.
+- [x] Initial PR open: no review threads existed at artifact creation.
+
+## Fixed in Commit Mapping
+
+Disposition: FIXED
+Commit: faac8b570
+Evidence: `tests/test_legacy_export_aliases.py` now accepts the stable `legacy_app._get_api_key_dynamic` callable contract by module/name instead of requiring object identity across module reloads; focused legacy export alias tests and `make validate-changed` pass.
+Reason: Fixes post-merge main CI failure from run `27657385344`, `test-main (3.11, 60)`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1988 -> faac8b570
+
+## Local Validation Evidence
+
+- PASS: `python3 scripts/orchestration/check_preflight.py --mode analyze --path tests/test_legacy_export_aliases.py`
+- PASS: `python3 scripts/orchestration/task_bootstrap.py --goal "Stabilize post-merge main CI by making legacy export alias API-key dependency ownership test resilient to module reload identity churn" --task-class Bugfix --pr-phase pre_open --path tests/test_legacy_export_aliases.py --requested-agent agent-coordinator --requested-agent qa-engineer-agent --requested-agent bug-hunter --requested-agent security-auditor`
+- PASS: `. .venv/bin/activate && pytest -q tests/test_legacy_export_aliases.py::test_legacy_export_alias_routes_are_hidden_shim_owned_and_protected tests/test_legacy_export_aliases.py::test_legacy_export_aliases_reject_missing_api_key tests/test_main_paywall_bootstrap.py::test_legacy_export_alias_route_registration_allows_reloaded_canonical_handlers tests/test_main_paywall_bootstrap.py::test_legacy_export_alias_route_registration_rejects_foreign_handlers`
+- PASS: `. .venv/bin/activate && pytest -q tests/test_legacy_export_aliases.py`
+- PASS: `.venv/bin/ruff check tests/test_legacy_export_aliases.py`
+- PASS: `.venv/bin/black --check tests/test_legacy_export_aliases.py`
+- PASS: `make validate-changed`
+- PASS: `pre-commit run --all-files`
+- PASS during push hooks: pip-audit, backend tests, full-repo Bandit, and docker
+  build test.
+
+## Experiment Runner Evidence
+
+Not applicable: this PR is a test-oracle correction for a post-merge main CI
+failure; no Experiment Runner artifact shaped the code, tests, mapping, or
+commit decision.
+
+## Security Notes
+
+- Runtime auth behavior is unchanged.
+- The missing API-key 403 test still exercises FastAPI dependency execution.
+- This PR narrows only a stale object-identity test oracle.
+
+## Merge Readiness
+
+Not ready at artifact creation. Required before merge:
+
+- [x] Numbered fixed-mapping artifact created.
+- [ ] PR body mirror updated to point to this artifact and include exact
+  `## Scope`, `## Out of Scope`, and `## Tests` headings.
+- [ ] Current-head CI parity on latest pushed commit.
+- [ ] Strict merge-readiness check with `--require-auth`.
+- [ ] No unresolved actionable review or bot comments.
+- [ ] Mandatory wait-window after latest bot/review activity.

--- a/docs/review/PR_1988_FIXED_MAPPING.md
+++ b/docs/review/PR_1988_FIXED_MAPPING.md
@@ -31,6 +31,13 @@ Evidence: `tests/test_legacy_export_aliases.py` now accepts the stable `legacy_a
 Reason: Fixes post-merge main CI failure from run `27657385344`, `test-main (3.11, 60)`.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1988 -> faac8b570
 
+Disposition: FIXED
+Commit: 312bfbac773b077ec83f8f42bc9595fcdb154faa
+Evidence: `tests/test_legacy_export_aliases.py` now resolves the dependency module with `inspect.getmodule(...)` against `legacy_app.__name__` and includes method/path/dependency details in the failure message; `pytest -q tests/test_legacy_export_aliases.py`, `make validate-changed`, and `pre-commit run --all-files` pass.
+Reason: Addresses Sourcery review feedback on robust module matching and assertion diagnostics.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1988#discussion_r3425005305 -> 312bfbac773b077ec83f8f42bc9595fcdb154faa
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1988#pullrequestreview-4511526104 -> 312bfbac773b077ec83f8f42bc9595fcdb154faa
+
 ## Local Validation Evidence
 
 - PASS: `python3 scripts/orchestration/check_preflight.py --mode analyze --path tests/test_legacy_export_aliases.py`
@@ -41,6 +48,10 @@ Reason: Fixes post-merge main CI failure from run `27657385344`, `test-main (3.1
 - PASS: `.venv/bin/black --check tests/test_legacy_export_aliases.py`
 - PASS: `make validate-changed`
 - PASS: `pre-commit run --all-files`
+- PASS after Sourcery fix: `. .venv/bin/activate && pytest -q tests/test_legacy_export_aliases.py`
+- PASS after Sourcery fix: `.venv/bin/black tests/test_legacy_export_aliases.py && .venv/bin/ruff check tests/test_legacy_export_aliases.py`
+- PASS after Sourcery fix: `make validate-changed`
+- PASS after Sourcery fix: `pre-commit run --all-files`
 - PASS during push hooks: pip-audit, backend tests, full-repo Bandit, and docker
   build test.
 
@@ -61,7 +72,7 @@ commit decision.
 Not ready at artifact creation. Required before merge:
 
 - [x] Numbered fixed-mapping artifact created.
-- [ ] PR body mirror updated to point to this artifact and include exact
+- [x] PR body mirror updated to point to this artifact and include exact
   `## Scope`, `## Out of Scope`, and `## Tests` headings.
 - [ ] Current-head CI parity on latest pushed commit.
 - [ ] Strict merge-readiness check with `--require-auth`.

--- a/tests/test_legacy_export_aliases.py
+++ b/tests/test_legacy_export_aliases.py
@@ -29,9 +29,12 @@ def _matching_routes(path: str, method: str) -> list[object]:
 
 def _is_legacy_api_key_dependency(dependency: object) -> bool:
     callable_dependency = getattr(dependency, "dependency", None)
+    resolved_module = (
+        inspect.getmodule(callable_dependency) if callable(callable_dependency) else None
+    )
     return (
         callable(callable_dependency)
-        and getattr(callable_dependency, "__module__", "") == "legacy_app"
+        and getattr(resolved_module, "__name__", "") == legacy_app.__name__
         and getattr(callable_dependency, "__name__", "") == "_get_api_key_dynamic"
     )
 
@@ -50,7 +53,12 @@ def test_legacy_export_alias_routes_are_hidden_shim_owned_and_protected() -> Non
         assert path not in openapi_paths
         assert 429 in getattr(route, "responses", {})
         assert "request" in inspect.signature(endpoint).parameters
-        assert any(_is_legacy_api_key_dependency(dependency) for dependency in route.dependencies)
+        assert any(
+            _is_legacy_api_key_dependency(dependency) for dependency in route.dependencies
+        ), (
+            f"Expected legacy API-key dependency on {method} {path}, "
+            f"got {[getattr(dependency, 'dependency', dependency) for dependency in route.dependencies]}"
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_legacy_export_aliases.py
+++ b/tests/test_legacy_export_aliases.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-import importlib
 import json
 import os
 from pathlib import Path
@@ -28,8 +27,16 @@ def _matching_routes(path: str, method: str) -> list[object]:
     ]
 
 
+def _is_legacy_api_key_dependency(dependency: object) -> bool:
+    callable_dependency = getattr(dependency, "dependency", None)
+    return (
+        callable(callable_dependency)
+        and getattr(callable_dependency, "__module__", "") == "legacy_app"
+        and getattr(callable_dependency, "__name__", "") == "_get_api_key_dynamic"
+    )
+
+
 def test_legacy_export_alias_routes_are_hidden_shim_owned_and_protected() -> None:
-    current_legacy_app = importlib.import_module("legacy_app")
     openapi_paths = app_main.app.openapi().get("paths", {})
 
     for path, method, include_in_schema in app_main._LEGACY_EXPORT_ALIAS_ROUTE_SPECS:
@@ -43,10 +50,7 @@ def test_legacy_export_alias_routes_are_hidden_shim_owned_and_protected() -> Non
         assert path not in openapi_paths
         assert 429 in getattr(route, "responses", {})
         assert "request" in inspect.signature(endpoint).parameters
-        assert any(
-            getattr(dependency, "dependency", None) is current_legacy_app._get_api_key_dynamic
-            for dependency in getattr(route, "dependencies", [])
-        )
+        assert any(_is_legacy_api_key_dependency(dependency) for dependency in route.dependencies)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Goal
Stabilize post-merge main CI after PR #1987 by making the legacy export alias API-key dependency ownership assertion resilient to module reload identity churn.

## Business Reason
Current main CI is red in test-main (3.11, 60) on the legacy export alias ownership test. This blocks the legacy extraction train.

## Scope
- Replace object-identity-only dependency assertion with a stable callable contract check for legacy_app._get_api_key_dynamic.
- Preserve runtime auth coverage through the existing missing API-key 403 tests.

## Out of Scope
No runtime route changes, no auth/rate-limit changes, no legacy removal, no cache/runtime/FoodDB/frontend/iOS work.

## Tests
- pytest -q tests/test_legacy_export_aliases.py::test_legacy_export_alias_routes_are_hidden_shim_owned_and_protected tests/test_legacy_export_aliases.py::test_legacy_export_aliases_reject_missing_api_key tests/test_main_paywall_bootstrap.py::test_legacy_export_alias_route_registration_allows_reloaded_canonical_handlers tests/test_main_paywall_bootstrap.py::test_legacy_export_alias_route_registration_rejects_foreign_handlers
- pytest -q tests/test_legacy_export_aliases.py
- .venv/bin/ruff check tests/test_legacy_export_aliases.py
- .venv/bin/black --check tests/test_legacy_export_aliases.py
- make validate-changed
- pre-commit run --all-files
- Pre-push hooks: pip-audit, backend tests, full repo Bandit

## Security Notes
Runtime protection is unchanged. The endpoint still rejects missing API keys through FastAPI dependency execution; this PR only avoids stale module object identity as a test oracle.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1988_FIXED_MAPPING.md`

## Experiment Runner Evidence
Not applicable: this PR is a test-oracle correction for a post-merge main CI failure; no Experiment Runner artifact shaped the code, tests, mapping, or commit decision.

## Merge Readiness
Not claimed until current-head CI and strict governance pass.

## Summary by Sourcery

Tests:
- Обновить устаревший тест защиты маршрута псевдонима экспорта, чтобы он проверял стабильную сигнатуру зависимости устаревшего API-ключа вместо идентичности объектa на уровне модуля.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Update legacy export alias route protection test to assert against a stable legacy API-key dependency signature instead of module-level object identity.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes CI by making the legacy export alias API-key dependency check resilient to module reloads. The test now matches by module and function name and provides clearer failure context.

- **Bug Fixes**
  - Introduced `_is_legacy_api_key_dependency` using `inspect.getmodule` to match `legacy_app._get_api_key_dynamic` by module/name and improved the assertion message with method, path, and dependency list.
  - No runtime changes; existing 403 tests still validate missing API key protection.
  - Added `docs/review/PR_1988_FIXED_MAPPING.md` with scope, evidence, and the Sourcery finding mapping.

<sup>Written for commit aa9852de6edf8528a74645b72fb14e5b52793cc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Katsiarynakavaleuskaya/PulsePlate/pull/1988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for legacy API key dependency validation to use inspection-based matching instead of direct identity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
