### PR TITLE
chore/security: resolve torch CVE-2025-3000 vector-profile policy

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,7 +40,7 @@ jobs:
           if [[ -n "${PULSEPLATE_PYTHON_TRUSTED_HOST:-}" ]]; then
             pip_index_args+=(--trusted-host "$PULSEPLATE_PYTHON_TRUSTED_HOST")
           fi
-          python -m pip install "${pip_index_args[@]}" "safety>=3.7.0" -c constraints.txt
+          python -m pip install "${pip_index_args[@]}" "safety>=3.8.1" -c constraints.txt
           if ! command -v jq >/dev/null 2>&1; then
             sudo apt-get update
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends jq

--- a/constraints.txt
+++ b/constraints.txt
@@ -11,12 +11,12 @@ pytest-asyncio>=1.4.0
 coverage>=7.14.1  # Must match requirements-dev.txt minimum
 
 # Code quality - allow updates for new features/fixes
-# Note: Project uses Black for formatting; flake8 removed in favor of ruff for linting
+# Note: Makefile lint still uses flake8; ruff remains the fast companion guard.
 black>=26.5.1
 # mypy 1.13.x adds support for typing.ReadOnly (PEP 742).
 # Type-parameter defaults are available only when using the legacy TypeVar-like syntax.
 mypy>=2.1.0,<3.0.0
-ruff>=0.15.17  # Primary linter (replaces flake8)
+ruff>=0.15.17  # Fast local/pre-commit lint companion.
 
 # Security - allow patch updates for vulnerability fixes
 bandit>=1.8.6
@@ -53,8 +53,8 @@ mako>=1.3.12  # GHSA-v92g-xgxw-vvmm / GHSA-2h4p-vjrc-8xpq security floor
 psycopg>=3.2.3
 email-validator>=2.3.0
 cryptography>=48.0.1
-# PyArrow wheels for Python 3.13 (cp313) available since pyarrow 18.1.0
-pyarrow>=18.1.0
+# PyArrow floor mirrors requirements.in / requirements-ci-lite.in.
+pyarrow>=20.0.0
 # Guidance for agentops compatibility (agentops requires packaging<25).
 # Not enforced here to avoid conflicts with the current lock files.
 # If you need agentops locally, use an isolated venv or a separate constraints-agentops.txt.

--- a/docs/review/PR_1989_FIXED_MAPPING.md
+++ b/docs/review/PR_1989_FIXED_MAPPING.md
@@ -2,6 +2,7 @@
 
 ## Lane Start Provenance
 
+- Packet: `artifacts/orchestration/task_packets/341a9a60ff26.json`
 - Starter: `scripts/orchestration/start_pr_lane.sh`
 - Branch: `codex/resolve-torch-cve-2025-3000-vector-profile`
 - Bootstrap packet: `artifacts/orchestration/task_packets/341a9a60ff26.json`
@@ -39,6 +40,8 @@
 
 ## Discussion Thread Pass
 
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 - No review threads existed at PR open.
 - Post-open review passes are still required before merge readiness:
   `qa-engineer-agent -> bug-hunter -> security-auditor`, then Codex Security
@@ -47,8 +50,10 @@
 
 ## Fixed in Commit Mapping
 
-- No actionable review threads were resolved before this artifact was created.
-- Initial implementation evidence: `ab866229b`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1989#pullrequestreview-4513245105 -> 8ee7b117f
+Disposition: FIXED
+Commit: 8ee7b117f
+Evidence: `tests/test_python_supply_chain_controls.py` catches `InvalidRequirement`; `tests/guards/test_security_devtooling_regression_guards.py` checks stable advisory markers instead of full literal phrases.
 
 ## Premortem
 
@@ -61,10 +66,8 @@
 
 ## Experiment Runner Evidence
 
-- Packet:
-  `artifacts/orchestration/experiments/artifacts/orchestration/experiments/torch-cve-2025-3000-vector-policy-oracle-packet.json`
-- Result:
-  `artifacts/orchestration/experiments/results/torch-cve-2025-3000-vector-policy-oracle-result.json`
+- Packet: `artifacts/orchestration/experiments/artifacts/orchestration/experiments/torch-cve-2025-3000-vector-policy-oracle-packet.json`
+- Artifact: `artifacts/orchestration/experiments/results/torch-cve-2025-3000-vector-policy-oracle-result.json`
 - Mode: `oracle_only_governance_reviewer`
 - Status: `accepted`; `mutated_paths=[]`; oracle commands passed.
 - Contribution: `oracle_review`; implementation commit `ab866229b` includes:

--- a/docs/review/PR_1989_FIXED_MAPPING.md
+++ b/docs/review/PR_1989_FIXED_MAPPING.md
@@ -43,10 +43,13 @@
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 - No review threads existed at PR open.
-- Post-open review passes are still required before merge readiness:
-  `qa-engineer-agent -> bug-hunter -> security-auditor`, then Codex Security
-  diff scan when available, CodeRabbit/actionable bot review disposition, and
-  `pulseplate-pr-review`.
+- Post-open role order executed:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- Codex Security diff scan completed with no findings.
+- `pulseplate-pr-review` completed with one advisory large-diff planning note;
+  disposition below.
+- CodeRabbit was still pending at the latest artifact update; no actionable
+  CodeRabbit finding was available to map.
 
 ## Fixed in Commit Mapping
 
@@ -78,6 +81,18 @@ Evidence: `tests/test_python_supply_chain_controls.py` uses parser-backed canoni
 - Contribution: `oracle_review`; implementation commit `ab866229b` includes:
   `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
 
+## PulsePlate Review Disposition
+
+- Tool: `pulseplate-pr-review`
+- Finding: advisory `large-diff-risk`
+- Disposition: NOT-A-BUG
+- Evidence: Diff is intentionally docs/guards-heavy for a security evidence
+  lane; scoped local gates include `make validate-changed` and focused
+  supply-chain/security-devtooling tests. No product runtime, OpenAPI, legacy,
+  frontend, iOS, or broad lock-regeneration files are touched.
+- Reason: The advisory is review-planning evidence, not a code defect or
+  merge-blocking finding.
+
 ## Tests
 
 - PASS: `python3 scripts/orchestration/check_preflight.py`
@@ -91,6 +106,10 @@ Evidence: `tests/test_python_supply_chain_controls.py` uses parser-backed canoni
 - PASS: `pre-commit run --all-files`
 - PASS during push: pre-push hooks including backend pytest, pip-audit, and
   full-repo Bandit pre-push.
+- PASS: `pulseplate-pr-review` dry-run completed; advisory large-diff risk
+  dispositioned as `NOT-A-BUG` above.
+- PASS: Codex Security diff scan completed with no findings; report:
+  `/tmp/codex-security-scans/resolve-torch-cve-2025-3000-vector-profile/d72d2a53b529_20260617T115720Z/report.md`.
 
 ## Machine-Heavy Deferral
 
@@ -101,8 +120,11 @@ Evidence: `tests/test_python_supply_chain_controls.py` uses parser-backed canoni
 
 ## Merge Readiness
 
-- Not merge-ready at artifact creation time.
-- Required before merge: post-open role passes, Codex Security diff scan when
-  available, CodeRabbit/actionable bot disposition, `pulseplate-pr-review`,
-  current-head CI, strict merge-readiness with auth, wait-window, local `main`
-  sync, and lane-local cleanup.
+- Not merge-ready at latest artifact update because current-head CI and
+  CodeRabbit were still pending.
+- Superseded CI run `27686954746` contains cancelled `coverage-pr` and
+  `diff-coverage` rows after a newer CI run started; those cancelled rows are
+  stale and are not current-head failures.
+- Required before merge: CodeRabbit/actionable bot disposition, current-head CI,
+  strict merge-readiness with auth, wait-window, local `main` sync, and
+  lane-local cleanup.

--- a/docs/review/PR_1989_FIXED_MAPPING.md
+++ b/docs/review/PR_1989_FIXED_MAPPING.md
@@ -1,0 +1,100 @@
+# PR 1989 Fixed Mapping
+
+## Lane Start Provenance
+
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+- Branch: `codex/resolve-torch-cve-2025-3000-vector-profile`
+- Bootstrap packet: `artifacts/orchestration/task_packets/341a9a60ff26.json`
+- Pre-open role order executed:
+  `agent-coordinator -> security-auditor -> backend-engineer -> qa-engineer-agent -> bug-hunter -> architecture-specialist`
+- Packet creation was treated as provenance only, not role execution.
+
+## Scope
+
+- In scope: optional RAG/vector PyTorch `CVE-2025-3000` policy evidence,
+  scoped Safety waiver refresh, dependency-security floor alignment, and focused
+  supply-chain guards.
+- Out of scope: runtime behavior, app/core/legacy route changes, OpenAPI,
+  FoodDB, auth/BOLA, frontend/iOS/macOS, torch bump, broad lock regeneration,
+  and private emergency-wheel fallback changes.
+
+## Implementation Mapping
+
+- Initial implementation: `ab866229b`
+  - `safety-policy.yaml`: refreshed `SFTY-20250331-30014` waiver evidence and
+    expiry to `2026-07-17`.
+  - `docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md`: refreshed current
+    advisory state, no-patched-version evidence, and default-surface no-torch
+    notes.
+  - `docs/roadmap/BACKLOG_LEDGER.md`: refreshed the optional-vector backlog
+    item with 2026-06-17 source evidence and ci-lite graph-lag note.
+  - `constraints.txt`: aligned `pyarrow>=20.0.0` with canonical inputs and
+    corrected the flake8/ruff comment.
+  - `.github/workflows/security.yml`: aligned Security workflow Safety install
+    floor to `safety>=3.8.1`.
+  - `tests/test_python_supply_chain_controls.py` and
+    `tests/guards/test_security_devtooling_regression_guards.py`: added guards
+    for dependency floor alignment, optional-vector profile boundaries, and
+    waiver/advisory/backlog coherence.
+
+## Discussion Thread Pass
+
+- No review threads existed at PR open.
+- Post-open review passes are still required before merge readiness:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`, then Codex Security
+  diff scan when available, CodeRabbit/actionable bot review disposition, and
+  `pulseplate-pr-review`.
+
+## Fixed in Commit Mapping
+
+- No actionable review threads were resolved before this artifact was created.
+- Initial implementation evidence: `ab866229b`.
+
+## Premortem
+
+- Local artifact:
+  `artifacts/orchestration/premortem/torch-cve-2025-3000-vector-policy-premortem.md`
+- Decision: `proceed with changes`.
+- Closure: findings were addressed by keeping the PR in waiver/evidence mode,
+  adding optional-profile drift guards, and aligning waiver/advisory/backlog
+  dates.
+
+## Experiment Runner Evidence
+
+- Packet:
+  `artifacts/orchestration/experiments/artifacts/orchestration/experiments/torch-cve-2025-3000-vector-policy-oracle-packet.json`
+- Result:
+  `artifacts/orchestration/experiments/results/torch-cve-2025-3000-vector-policy-oracle-result.json`
+- Mode: `oracle_only_governance_reviewer`
+- Status: `accepted`; `mutated_paths=[]`; oracle commands passed.
+- Contribution: `oracle_review`; implementation commit `ab866229b` includes:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+
+## Tests
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS:
+  `.venv/bin/python -m pytest -q tests/test_python_supply_chain_controls.py tests/test_install_locked_python_requirements.py tests/test_run_safety_audit.py tests/guards/test_security_devtooling_regression_guards.py`
+- BLOCKED LOCALLY: `python3 scripts/ci/run_safety_audit.py` stopped before scan
+  because `SAFETY_API_KEY` is not exported in the local shell; CI must run it
+  with the repository secret.
+- PASS: `make validate-changed`
+- PASS: `pre-commit run --all-files`
+- PASS during push: pre-push hooks including backend pytest, pip-audit, and
+  full-repo Bandit pre-push.
+
+## Machine-Heavy Deferral
+
+- Operator-approved deferral: full local `make verify` was not run for this
+  dependency/security lane.
+- Required narrow local gates above were run.
+- Current-head CI is the heavy verification signal before merge.
+
+## Merge Readiness
+
+- Not merge-ready at artifact creation time.
+- Required before merge: post-open role passes, Codex Security diff scan when
+  available, CodeRabbit/actionable bot disposition, `pulseplate-pr-review`,
+  current-head CI, strict merge-readiness with auth, wait-window, local `main`
+  sync, and lane-local cleanup.

--- a/docs/review/PR_1989_FIXED_MAPPING.md
+++ b/docs/review/PR_1989_FIXED_MAPPING.md
@@ -63,6 +63,11 @@ Disposition: FIXED
 Commit: 137362472
 Evidence: `tests/test_python_supply_chain_controls.py` uses parser-backed canonical package-name checks across default `.in` and `.txt` surfaces and adds a bypass regression for case, compatible-release specs, direct references, and non-requirement lines.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1989#discussion_r3427944464
+Disposition: NOT-A-BUG
+Evidence: `find artifacts/orchestration/experiments -maxdepth 5 -type f` shows the Experiment Runner packet at `artifacts/orchestration/experiments/artifacts/orchestration/experiments/torch-cve-2025-3000-vector-policy-oracle-packet.json`; the suggested single-prefix path does not exist in the emitted local artifact tree.
+Reason: The duplicated-looking prefix is the actual path emitted by the Experiment Runner CLI for this lane, so changing the mapping to the suggested path would make the provenance reference less accurate.
+
 ## Premortem
 
 - Local artifact:

--- a/docs/review/PR_1989_FIXED_MAPPING.md
+++ b/docs/review/PR_1989_FIXED_MAPPING.md
@@ -68,6 +68,11 @@ Disposition: NOT-A-BUG
 Evidence: `find artifacts/orchestration/experiments -maxdepth 5 -type f` shows the Experiment Runner packet at `artifacts/orchestration/experiments/artifacts/orchestration/experiments/torch-cve-2025-3000-vector-policy-oracle-packet.json`; the suggested single-prefix path does not exist in the emitted local artifact tree.
 Reason: The duplicated-looking prefix is the actual path emitted by the Experiment Runner CLI for this lane, so changing the mapping to the suggested path would make the provenance reference less accurate.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1989#pullrequestreview-4515336600
+Disposition: NOT-A-BUG
+Evidence: The only actionable review item in this CodeRabbit review is mapped above at `discussion_r3427944464` with the same provenance evidence.
+Reason: The review-level aggregate is closed by the mapped inline CodeRabbit disposition; no additional independent finding exists in the review body.
+
 ## Premortem
 
 - Local artifact:

--- a/docs/review/PR_1989_FIXED_MAPPING.md
+++ b/docs/review/PR_1989_FIXED_MAPPING.md
@@ -55,6 +55,11 @@ Disposition: FIXED
 Commit: 8ee7b117f
 Evidence: `tests/test_python_supply_chain_controls.py` catches `InvalidRequirement`; `tests/guards/test_security_devtooling_regression_guards.py` checks stable advisory markers instead of full literal phrases.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1989#issuecomment-4727078656 -> 137362472
+Disposition: FIXED
+Commit: 137362472
+Evidence: `tests/test_python_supply_chain_controls.py` uses parser-backed canonical package-name checks across default `.in` and `.txt` surfaces and adds a bypass regression for case, compatible-release specs, direct references, and non-requirement lines.
+
 ## Premortem
 
 - Local artifact:

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -710,20 +710,25 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Retire PyTorch TorchScript CVE-2025-3000 Safety waiver for optional vector profile
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1 (supply-chain / optional RAG-vector profile)
-  - Target PR: TBD (land by 2026-07-11 or earlier if fixed torch builds are available)
+  - Target PR: PR2 security-alert sequence (land by 2026-07-17 or earlier if fixed torch builds are available)
   - Area: security / CI / dependencies / RAG-vector
-  - Reason (EN): PR #1925 current-head CI started failing Safety on
-    `SFTY-20250331-30014` / `CVE-2025-3000` for `torch==2.11.0` and
-    `torch==2.11.0+cpu` in optional RAG/vector manifests. Safety 3.8.1 reports
-    no fixed version for the advisory, while default production and Docker
-    runtime manifests pass Safety without torch. The waiver is scoped to the
-    optional vector profile and must be retired when a fixed build, upstream
+  - Reason (EN): Recheck on 2026-06-17 found GitHub Advisory
+    `GHSA-rrmf-rvhw-rf47` and Safety `SFTY-20250331-30014` still marking
+    `torch <=2.12.0` as affected by `CVE-2025-3000`, with no patched torch
+    release available; PyPI latest torch was `2.12.0`. PulsePlate pins
+    `torch==2.11.0` / `torch==2.11.0+cpu` only in optional RAG/vector
+    manifests. `requirements.txt`, `requirements-ci-lite.txt`,
+    `requirements-docker-runtime.txt`, and `requirements-lock.txt` have no
+    direct `torch` pin, so any CI-lite Dependabot alert is dependency graph lag
+    unless a future diff reintroduces torch there. The waiver remains scoped to
+    optional RAG/vector and must be retired when a fixed build, upstream
     advisory correction, or vector-profile replacement is available.
   - Links:
     - `docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md:1`
-    - `safety-policy.yaml:18`
+    - `safety-policy.yaml:16`
     - `requirements-rag-vector.txt:162`
     - `requirements-rag-vector-cpu.txt:119`
+    - `requirements-ci-lite.txt`: no direct `torch` pin
   - DoD:
     - Re-check Safety, OSV, GitHub Advisory Database, and PyTorch upstream for
       fixed-version truth before changing pins.

--- a/docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md
+++ b/docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md
@@ -2,33 +2,41 @@
 
 ## Summary
 
-Safety 3.8.1 flags `torch` in the optional RAG/vector manifests for
+Safety flags `torch` in the optional RAG/vector manifests for
 `SFTY-20250331-30014` / `CVE-2025-3000`. The advisory concerns
 `torch.jit.script` memory corruption. PulsePlate keeps `torch` out of the
-default production and Docker runtime manifests; the finding is limited to the
-optional vector profile.
+default production, CI-lite, Docker runtime, and full lock manifests; the
+finding is limited to the optional vector profile.
 
 ## Governance
 
 - **Owner:** @katsiaryna_kavaleuskaya
-- **Remove-by:** 2026-07-11
+- **Remove-by:** 2026-07-17
 - **Backlog:** `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-pytorch-jit-cve-2025-3000-vector-profile`
 - **Safety policy:** `safety-policy.yaml`
+- **Last checked:** 2026-06-17
 
 ## Current Repo State
 
-- `requirements.txt`: Safety PASS in PR #1925 current-head CI.
-- `requirements-docker-runtime.txt`: Safety PASS in PR #1925 current-head CI.
+- `requirements.txt`: no direct `torch` pin.
+- `requirements-ci-lite.txt`: no direct `torch` pin; any GitHub alert on this
+  file is treated as dependency-graph lag unless a future diff reintroduces
+  torch here.
+- `requirements-docker-runtime.txt`: no direct `torch` pin.
+- `requirements-lock.txt`: no direct `torch` pin.
 - `requirements-rag-vector.txt`: Safety flags `torch==2.11.0`.
 - `requirements-rag-vector-cpu.txt`: Safety flags `torch==2.11.0+cpu`.
-- Safety 3.8.1 reports no fixed version for this advisory in the PR #1925 CI log.
+- GitHub Advisory `GHSA-rrmf-rvhw-rf47`: affected `torch <= 2.12.0`.
+  Patched versions: none.
+- PyPI latest `torch` release checked on 2026-06-17: `2.12.0`.
+- Safety `SFTY-20250331-30014`: affected versions `<=2.12.0`.
 
 ## Evidence Anchors
 
 - `requirements-rag-vector.txt:162`
 - `requirements-rag-vector-cpu.txt:119`
-- `safety-policy.yaml:23`
-- `docs/roadmap/BACKLOG_LEDGER.md:665`
+- `safety-policy.yaml:16`
+- `docs/roadmap/BACKLOG_LEDGER.md:709`
 
 ## Exposure Assessment
 
@@ -53,4 +61,5 @@ artifacts, or routes user-controlled data into TorchScript compilation.
 - CVE: `https://www.cve.org/CVERecord?id=CVE-2025-3000`
 - NVD: `https://nvd.nist.gov/vuln/detail/CVE-2025-3000`
 - GitHub Advisory Database: `https://github.com/advisories/GHSA-rrmf-rvhw-rf47`
-- Safety entry: `https://getsafety.com/v/SFTY-20250331-30014/97c`
+- Safety entry: `https://getsafety.com/vulnerabilities/SFTY-20250331-30014`
+- PyPI torch: `https://pypi.org/project/torch/`

--- a/safety-policy.yaml
+++ b/safety-policy.yaml
@@ -8,9 +8,10 @@
 # Advisory: docs/security/FONTTOOLS_TTX_EVAL_ADVISORY.md
 #
 # SFTY-20250331-30014 / CVE-2025-3000 (PyTorch torch.jit.script memory
-# corruption): optional RAG/vector manifests pin torch while Safety reports no
-# fixed version. Remove by 2026-07-11 or earlier when a fixed torch build,
-# upstream correction, or vector-profile replacement is available.
+# corruption): optional RAG/vector manifests pin torch while GitHub Advisory,
+# Safety, and PyPI checks on 2026-06-17 show no fixed torch build. Remove by
+# 2026-07-17 or earlier when a fixed torch build, upstream correction, or
+# vector-profile replacement is available.
 # Advisory: docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md
 
 version: "3.0"
@@ -39,7 +40,7 @@ report:
           reason: >-
             Optional RAG/vector torch.jit.script advisory; remove when
             docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md is closed.
-          expires: "2026-07-11"
+          expires: "2026-07-17"
       cvss-severity: []
 
 fail-scan-with-exit-code:

--- a/tests/guards/test_security_devtooling_regression_guards.py
+++ b/tests/guards/test_security_devtooling_regression_guards.py
@@ -384,9 +384,14 @@ def test_pytorch_jit_cve_waiver_evidence_is_scoped_and_current() -> None:
         assert PYTORCH_JIT_WAIVER_REMOVE_BY in evidence_text
         assert "optional RAG/vector" in evidence_text
 
-    assert "requirements-ci-lite.txt`: no direct `torch` pin" in advisory_text
-    assert "requirements-lock.txt`: no direct `torch` pin" in advisory_text
-    assert "Patched versions: none" in advisory_text
+    for stable_marker in (
+        "requirements-ci-lite.txt",
+        "requirements-lock.txt",
+        "no direct `torch` pin",
+        "Patched versions",
+        "none",
+    ):
+        assert stable_marker in advisory_text
 
 
 def test_npm_dependency_submission_covers_root_and_frontend_lockfiles() -> None:

--- a/tests/guards/test_security_devtooling_regression_guards.py
+++ b/tests/guards/test_security_devtooling_regression_guards.py
@@ -45,6 +45,9 @@ SECURITY_DEPENDENCY_PROFILE_FILES: tuple[str, ...] = (
 SECURITY_DEPENDENCY_LOCKFILES: tuple[str, ...] = tuple(
     name for name in SECURITY_DEPENDENCY_PROFILE_FILES if name.endswith(".txt")
 )
+PYTORCH_JIT_SAFETY_ID = "SFTY-20250331-30014"
+PYTORCH_JIT_CVE_ID = "CVE-2025-3000"
+PYTORCH_JIT_WAIVER_REMOVE_BY = "2026-07-17"
 
 
 def _binary(name: str) -> str:
@@ -358,6 +361,32 @@ def test_dependency_profiles_are_covered_by_all_security_surfaces() -> None:
         assert profile.backend_shared is True
         assert profile.run_backend_blocking is True
         assert profile.run_security is True
+
+
+def test_pytorch_jit_cve_waiver_evidence_is_scoped_and_current() -> None:
+    safety_policy = yaml.safe_load((REPO_ROOT / "safety-policy.yaml").read_text(encoding="utf-8"))
+    assert isinstance(safety_policy, dict)
+    vulnerabilities = safety_policy["report"]["dependency-vulnerabilities"][
+        "auto-ignore-in-report"
+    ]["vulnerabilities"]
+    torch_waiver = vulnerabilities[PYTORCH_JIT_SAFETY_ID]
+
+    assert torch_waiver["expires"] == PYTORCH_JIT_WAIVER_REMOVE_BY
+
+    advisory_text = (REPO_ROOT / "docs/security/PYTORCH_JIT_CVE_2025_3000_ADVISORY.md").read_text(
+        encoding="utf-8"
+    )
+    backlog_text = (REPO_ROOT / "docs/roadmap/BACKLOG_LEDGER.md").read_text(encoding="utf-8")
+
+    for evidence_text in (advisory_text, backlog_text):
+        assert PYTORCH_JIT_SAFETY_ID in evidence_text
+        assert PYTORCH_JIT_CVE_ID in evidence_text
+        assert PYTORCH_JIT_WAIVER_REMOVE_BY in evidence_text
+        assert "optional RAG/vector" in evidence_text
+
+    assert "requirements-ci-lite.txt`: no direct `torch` pin" in advisory_text
+    assert "requirements-lock.txt`: no direct `torch` pin" in advisory_text
+    assert "Patched versions: none" in advisory_text
 
 
 def test_npm_dependency_submission_covers_root_and_frontend_lockfiles() -> None:

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -10,6 +10,7 @@ import subprocess
 
 from packaging.requirements import InvalidRequirement
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 import pytest
 import yaml
@@ -57,8 +58,11 @@ OPTIONAL_VECTOR_STACK_PACKAGES = (
     "transformers",
 )
 DEFAULT_INSTALL_REQUIREMENT_FILES = (
+    "requirements.in",
     "requirements.txt",
+    "requirements-ci-lite.in",
     "requirements-ci-lite.txt",
+    "requirements-docker-runtime.in",
     "requirements-docker-runtime.txt",
     "requirements-lock.txt",
     "requirements-test.txt",
@@ -144,6 +148,7 @@ def _workflow_step_names(path: str, job_name: str) -> list[str]:
 def _requirement_package_versions(path: Path, package_name: str) -> set[str]:
     """Return exact or minimum package versions declared in a requirement surface."""
 
+    canonical_package_name = canonicalize_name(package_name)
     versions: set[str] = set()
     for raw_line in path.read_text(encoding="utf-8").splitlines():
         line = raw_line.split("#", 1)[0].strip()
@@ -153,12 +158,48 @@ def _requirement_package_versions(path: Path, package_name: str) -> set[str]:
             requirement = Requirement(line)
         except InvalidRequirement:
             continue
-        if requirement.name != package_name:
+        if canonicalize_name(requirement.name) != canonical_package_name:
             continue
         for specifier in requirement.specifier:
             if specifier.operator in {"==", ">="}:
                 versions.add(specifier.version)
     return versions
+
+
+def _requirement_package_names(path: Path) -> set[str]:
+    """Return canonical package names declared in a requirement surface."""
+
+    package_names: set[str] = set()
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line or line.startswith(PIP_REQUIREMENT_DIRECTIVE_PREFIXES):
+            continue
+        try:
+            requirement = Requirement(line)
+        except InvalidRequirement:
+            continue
+        package_names.add(canonicalize_name(requirement.name))
+    return package_names
+
+
+def test_requirement_parser_canonicalizes_names_and_skips_non_requirements(tmp_path: Path) -> None:
+    requirements_path = tmp_path / "requirements.txt"
+    requirements_path.write_text(
+        "\n".join(
+            (
+                "--extra-index-url https://download.pytorch.org/whl/cpu",
+                "Torch~=2.11",
+                "sentence-transformers @ https://example.invalid/sentence.whl",
+                "-e git+https://example.invalid/repo.git#egg=ignored",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    package_names = _requirement_package_names(requirements_path)
+    assert "torch" in package_names
+    assert "sentence-transformers" in package_names
+    assert "ignored" not in package_names
 
 
 def test_dependency_security_schema_blocks_known_bad_litellm_versions() -> None:
@@ -644,22 +685,21 @@ def test_rag_vector_dependency_profile_contains_extracted_vector_ml_stack() -> N
 
 def test_torch_and_vector_stack_stay_optional_to_rag_vector_profiles() -> None:
     for requirement_file in DEFAULT_INSTALL_REQUIREMENT_FILES:
-        requirement_text = (REPO_ROOT / requirement_file).read_text(encoding="utf-8")
+        package_names = _requirement_package_names(REPO_ROOT / requirement_file)
         disallowed_packages = (
             OPTIONAL_VECTOR_STACK_PACKAGES
             if requirement_file != "requirements-test.txt"
             else ("sentence-transformers", "torch", "transformers")
         )
         for package in disallowed_packages:
-            assert f"{package}==" not in requirement_text
-            assert f"{package}>=" not in requirement_text
+            assert canonicalize_name(package) not in package_names
 
     observed_torch_versions: set[str] = set()
     for requirement_file in OPTIONAL_VECTOR_REQUIREMENT_FILES:
         requirement_path = REPO_ROOT / requirement_file
-        requirement_text = requirement_path.read_text(encoding="utf-8")
+        package_names = _requirement_package_names(requirement_path)
         for package in OPTIONAL_VECTOR_STACK_PACKAGES:
-            assert f"{package}==" in requirement_text
+            assert canonicalize_name(package) in package_names
         observed_torch_versions.update(_requirement_package_versions(requirement_path, "torch"))
 
     assert observed_torch_versions == {"2.11.0", "2.11.0+cpu"}

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -8,6 +8,8 @@ import re
 from pathlib import Path
 import subprocess
 
+from packaging.requirements import Requirement
+from packaging.version import Version
 import pytest
 import yaml
 
@@ -35,7 +37,37 @@ APPROVED_TRUSTED_HOST_EXPRESSION = (
     "${{ secrets.PULSEPLATE_PYTHON_TRUSTED_HOST || vars.PULSEPLATE_PYTHON_TRUSTED_HOST }}"
 )
 PIP_INSTALL_PATTERN = re.compile(r"\b\S*python\S*\s+-m\s+pip\s+install\b")
+PIP_REQUIREMENT_DIRECTIVE_PREFIXES = (
+    "-i ",
+    "--index-url ",
+    "--extra-index-url ",
+    "-f ",
+    "--find-links ",
+    "-r ",
+    "--requirement ",
+    "-c ",
+    "--constraint ",
+)
 PINNED_CHECKOUT_ACTION = "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+OPTIONAL_VECTOR_STACK_PACKAGES = (
+    "pgvector",
+    "sentence-transformers",
+    "torch",
+    "transformers",
+)
+DEFAULT_INSTALL_REQUIREMENT_FILES = (
+    "requirements.txt",
+    "requirements-ci-lite.txt",
+    "requirements-docker-runtime.txt",
+    "requirements-lock.txt",
+    "requirements-test.txt",
+)
+OPTIONAL_VECTOR_REQUIREMENT_FILES = (
+    "requirements-rag-vector.in",
+    "requirements-rag-vector.txt",
+    "requirements-rag-vector-cpu.in",
+    "requirements-rag-vector-cpu.txt",
+)
 
 
 def _load_workflow(path: str) -> dict[str, object]:
@@ -106,6 +138,23 @@ def _workflow_step_names(path: str, job_name: str) -> list[str]:
     """Return display names for a workflow job's steps."""
 
     return [str(step["name"]) for step in _workflow_steps(path, job_name)]
+
+
+def _requirement_package_versions(path: Path, package_name: str) -> set[str]:
+    """Return exact or minimum package versions declared in a requirement surface."""
+
+    versions: set[str] = set()
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line or line.startswith(PIP_REQUIREMENT_DIRECTIVE_PREFIXES):
+            continue
+        requirement = Requirement(line)
+        if requirement.name != package_name:
+            continue
+        for specifier in requirement.specifier:
+            if specifier.operator in {"==", ">="}:
+                versions.add(specifier.version)
+    return versions
 
 
 def test_dependency_security_schema_blocks_known_bad_litellm_versions() -> None:
@@ -345,9 +394,36 @@ def test_security_scan_workflow_uses_ci_lite_direct_proxy_setup() -> None:
     )
     install_script = install_step["run"]
     assert "bandit==" not in install_script
-    assert '"safety>=3.7.0"' in install_script
+    assert '"safety>=3.8.1"' in install_script
     assert 'python -m pip install "${pip_index_args[@]}"' in install_script
     assert "-c constraints.txt" in install_script
+
+
+def test_constraints_keep_dependency_security_floors_aligned() -> None:
+    constraints_path = REPO_ROOT / "constraints.txt"
+    requirements_in = REPO_ROOT / "requirements.in"
+    requirements_ci_lite_in = REPO_ROOT / "requirements-ci-lite.in"
+
+    constraints_text = constraints_path.read_text(encoding="utf-8")
+    assert "flake8 removed in favor of ruff" not in constraints_text
+    assert "replaces flake8" not in constraints_text
+    assert _requirement_package_versions(constraints_path, "safety") == {"3.8.1"}
+
+    constraints_pyarrow = _requirement_package_versions(constraints_path, "pyarrow")
+    assert constraints_pyarrow == {"20.0.0"}
+    assert constraints_pyarrow == _requirement_package_versions(requirements_in, "pyarrow")
+    assert constraints_pyarrow == _requirement_package_versions(
+        requirements_ci_lite_in,
+        "pyarrow",
+    )
+    for lock_surface in (
+        REPO_ROOT / "requirements.txt",
+        REPO_ROOT / "requirements-ci-lite.txt",
+        REPO_ROOT / "requirements-lock.txt",
+    ):
+        pinned_versions = _requirement_package_versions(lock_surface, "pyarrow")
+        assert pinned_versions
+        assert all(Version(version) >= Version("20.0.0") for version in pinned_versions)
 
 
 def test_ci_security_job_installs_safety_through_locked_installer() -> None:
@@ -560,6 +636,29 @@ def test_rag_vector_dependency_profile_contains_extracted_vector_ml_stack() -> N
     assert "transformers==" in requirements_rag_vector
     assert "torch==" in requirements_rag_vector
     assert "pgvector==" in requirements_rag_vector
+
+
+def test_torch_and_vector_stack_stay_optional_to_rag_vector_profiles() -> None:
+    for requirement_file in DEFAULT_INSTALL_REQUIREMENT_FILES:
+        requirement_text = (REPO_ROOT / requirement_file).read_text(encoding="utf-8")
+        disallowed_packages = (
+            OPTIONAL_VECTOR_STACK_PACKAGES
+            if requirement_file != "requirements-test.txt"
+            else ("sentence-transformers", "torch", "transformers")
+        )
+        for package in disallowed_packages:
+            assert f"{package}==" not in requirement_text
+            assert f"{package}>=" not in requirement_text
+
+    observed_torch_versions: set[str] = set()
+    for requirement_file in OPTIONAL_VECTOR_REQUIREMENT_FILES:
+        requirement_path = REPO_ROOT / requirement_file
+        requirement_text = requirement_path.read_text(encoding="utf-8")
+        for package in OPTIONAL_VECTOR_STACK_PACKAGES:
+            assert f"{package}==" in requirement_text
+        observed_torch_versions.update(_requirement_package_versions(requirement_path, "torch"))
+
+    assert observed_torch_versions == {"2.11.0", "2.11.0+cpu"}
 
 
 def test_production_target_docker_workflows_use_runtime_requirements_profile() -> None:

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -8,6 +8,7 @@ import re
 from pathlib import Path
 import subprocess
 
+from packaging.requirements import InvalidRequirement
 from packaging.requirements import Requirement
 from packaging.version import Version
 import pytest
@@ -148,7 +149,10 @@ def _requirement_package_versions(path: Path, package_name: str) -> set[str]:
         line = raw_line.split("#", 1)[0].strip()
         if not line or line.startswith(PIP_REQUIREMENT_DIRECTIVE_PREFIXES):
             continue
-        requirement = Requirement(line)
+        try:
+            requirement = Requirement(line)
+        except InvalidRequirement:
+            continue
         if requirement.name != package_name:
             continue
         for specifier in requirement.specifier:


### PR DESCRIPTION
## Summary
- Refreshes the optional RAG/vector PyTorch `CVE-2025-3000` / `SFTY-20250331-30014` policy evidence without changing torch pins or regenerating locks.
- Keeps `torch==2.11.0` / `torch==2.11.0+cpu` only in optional RAG/vector profiles because GitHub Advisory and Safety still report affected `<=2.12.0` with no patched version, and PyPI latest checked on 2026-06-17 is `2.12.0`.
- Aligns dependency-security drift that supports this lane: `constraints.txt` pyarrow floor to `>=20.0.0`, Security workflow Safety floor to `>=3.8.1`, and the flake8/ruff comment with current repo lint reality.

## Lane Start Provenance
- Packet: `artifacts/orchestration/task_packets/341a9a60ff26.json`
- Starter: `scripts/orchestration/start_pr_lane.sh`
- Branch: `codex/resolve-torch-cve-2025-3000-vector-profile`
- Role order executed pre-open: `agent-coordinator -> security-auditor -> backend-engineer -> qa-engineer-agent -> bug-hunter -> architecture-specialist`.
- Packet creation was treated as provenance only, not role execution.

## Scope
- In scope: `safety-policy.yaml`, optional-vector advisory/backlog evidence, dependency-security floor alignment, focused supply-chain guards.
- Out of scope: runtime behavior, app/core/legacy routes, OpenAPI, FoodDB, auth/BOLA, frontend/iOS/macOS, torch bump, broad lock regeneration, private wheel fallback changes.

## Security Notes
- Current source posture checked on 2026-06-17: [GitHub Advisory GHSA-rrmf-rvhw-rf47](https://github.com/advisories/GHSA-rrmf-rvhw-rf47), [NVD CVE-2025-3000](https://nvd.nist.gov/vuln/detail/CVE-2025-3000), [Safety SFTY-20250331-30014](https://getsafety.com/vulnerabilities/SFTY-20250331-30014), and [PyPI torch](https://pypi.org/project/torch/).
- `requirements.txt`, `requirements-ci-lite.txt`, `requirements-docker-runtime.txt`, and `requirements-lock.txt` have no direct `torch` pin; any ci-lite torch alert is treated as dependency graph lag unless a future diff reintroduces torch there.
- The waiver remains scoped, dated, and ledger-backed with remove-by `2026-07-17`.

## Tests
- PASS: `python3 scripts/orchestration/check_preflight.py`
- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
- PASS: `.venv/bin/python -m pytest -q tests/test_python_supply_chain_controls.py tests/test_install_locked_python_requirements.py tests/test_run_safety_audit.py tests/guards/test_security_devtooling_regression_guards.py`
- PASS: `.venv/bin/python -m pytest -q tests/test_python_supply_chain_controls.py tests/guards/test_security_devtooling_regression_guards.py` after Sourcery and bug-hunter guard fixes.
- BLOCKED LOCALLY: `python3 scripts/ci/run_safety_audit.py` stopped before scan because `SAFETY_API_KEY` is not exported in the local shell; CI runs this with the repository secret.
- PASS: `make validate-changed`
- PASS: `pre-commit run --all-files`
- PASS during push: pre-push hooks including backend pytest, pip-audit, and full-repo Bandit pre-push.

## Machine-Heavy Deferral
- Operator-approved deferral: full local `make verify` was not run for this dependency/security lane. Required narrow local gates above were run; current-head CI is the heavy verification signal before merge.

## Premortem
- Local artifact: `artifacts/orchestration/premortem/torch-cve-2025-3000-vector-policy-premortem.md`.
- Decision: `proceed with changes`; findings were addressed by keeping waiver/evidence mode, adding optional-profile drift guards, and aligning waiver/advisory/backlog dates.

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/torch-cve-2025-3000-vector-policy-oracle-result.json`
- Packet: `artifacts/orchestration/experiments/artifacts/orchestration/experiments/torch-cve-2025-3000-vector-policy-oracle-packet.json`
- Mode: `oracle_only_governance_reviewer`.
- Status: `accepted`; `mutated_paths=[]`; oracle commands passed.
- Contribution: `oracle_review`; commit `ab866229b` includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed
- No review threads existed at PR open.
- Sourcery high-level review was fixed in commits `8ee7b117f` and `137362472` and mapped in `docs/review/PR_1989_FIXED_MAPPING.md`.
- Post-open role order executed: `qa-engineer-agent -> bug-hunter -> security-auditor`.
- Codex Security diff scan completed with no findings; report: `/tmp/codex-security-scans/resolve-torch-cve-2025-3000-vector-profile/d72d2a53b529_20260617T115720Z/report.md`.
- `pulseplate-pr-review` completed; advisory `large-diff-risk` is dispositioned as `NOT-A-BUG` in `docs/review/PR_1989_FIXED_MAPPING.md`.
- CodeRabbit completed after the latest push. Its artifact-path suggestion is dispositioned as `NOT-A-BUG` in `docs/review/PR_1989_FIXED_MAPPING.md` because the nested Experiment Runner packet path is the actual emitted local artifact path.

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1989_FIXED_MAPPING.md`

## Merge Readiness
- Not merge-ready at latest body update because current-head CI and CodeRabbit were still pending.
- Superseded CI run `27686954746` contains cancelled `coverage-pr` and `diff-coverage` rows after a newer CI run started; those cancelled rows are stale and are not current-head failures.
- Required before merge: CodeRabbit/actionable bot disposition, current-head CI, strict merge-readiness with auth, wait-window, local `main` sync, and lane-local cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Security Updates**
  * Updated the security scan workflow to use **safety ≥3.8.1** and align installs with **constraints**.
  * Increased **PyArrow** minimum requirement to **≥20.0.0** for consistency.

* **New Features**
  * Added stronger regression guards covering PyTorch JIT waiver timing and supply-chain requirement parsing, including security-floor and optional vector/RAG version alignment.

* **Documentation**
  * Refreshed PyTorch JIT CVE/advisory and Safety policy waiver timing, plus related waiver/backlog records and evidence links.

* **Tests**
  * Extended verification to confirm constraint alignment and torch/version behavior across optional profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

