### PR TITLE
chore/security: baseline Bandit lower-severity inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,38 +486,10 @@ jobs:
       - name: Enforce Bandit HIGH severity gate
         run: |
           set -euo pipefail
-
-          if [ ! -f bandit-report.json ]; then
-            echo "❌ Bandit report not found"
-            exit 1
-          fi
-
-          read -r total_findings high_severity_findings <<EOF
-          $(python3 - <<'PY'
-          import json
-          from pathlib import Path
-
-          report = Path("bandit-report.json")
-          data = json.loads(report.read_text())
-          results = data.get("results", [])
-          high = sum(1 for item in results if item.get("issue_severity") == "HIGH")
-          print(len(results), high)
-          PY
-          )
-          EOF
-
-          if [ "$high_severity_findings" -gt 0 ]; then
-            echo "❌ Found $high_severity_findings HIGH severity security issues in Bandit report"
-            echo "::error::Bandit found $high_severity_findings HIGH severity issues that must be addressed"
-            exit 1
-          fi
-
-          if [ "$total_findings" -gt 0 ]; then
-            echo "⚠️ Bandit reported $total_findings findings below HIGH severity"
-            echo "::warning::Bandit reported findings below HIGH severity – review bandit-report.json"
-          else
-            echo "✅ No HIGH severity issues found in Bandit report"
-          fi
+          python3 scripts/ci/summarize_bandit_report.py \
+            --report bandit-report.json \
+            --fail-on-high \
+            --github-annotations
 
       - name: Install Safety
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,14 +41,11 @@ jobs:
             pip_index_args+=(--trusted-host "$PULSEPLATE_PYTHON_TRUSTED_HOST")
           fi
           python -m pip install "${pip_index_args[@]}" "safety>=3.8.1" -c constraints.txt
-          if ! command -v jq >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends jq
-            sudo rm -rf /var/lib/apt/lists/*
-          fi
 
       - name: Run Bandit (security lint)
         run: |
+          set -euo pipefail
+
           bandit_exit_code=0
           # Main repository scan (production code) - no B101 skip
           bandit -q -r . \
@@ -77,18 +74,14 @@ jobs:
           fi
 
           echo "=== Bandit Report Analysis ==="
-          high_severity_count=$(jq '[.results[] | select(.issue_severity == "HIGH")] | length' bandit-report.json 2>/dev/null || echo "0")
-          if [ "$high_severity_count" -gt 0 ]; then
-            echo "❌ Found $high_severity_count HIGH severity security issues in Bandit report"
-            echo "::error::Bandit found $high_severity_count HIGH severity issues that must be addressed"
-            exit 1
-          fi
+          python3 scripts/ci/summarize_bandit_report.py \
+            --report bandit-report.json \
+            --fail-on-high \
+            --github-annotations
 
-          if [ "$bandit_exit_code" -eq 1 ] || [ "$bandit_tests_exit" -eq 1 ] || [ "$bandit_tests_strict_exit" -eq 1 ]; then
-            echo "⚠️  Bandit reported issues below HIGH severity (exit codes: main=$bandit_exit_code, tests=$bandit_tests_exit, tests_strict=$bandit_tests_strict_exit)"
-            echo "::warning::Bandit reported issues below HIGH severity – review bandit-report.json and test scan output"
-          else
-            echo "✅ No HIGH severity issues found in Bandit report"
+          if [ "$bandit_tests_exit" -eq 1 ] || [ "$bandit_tests_strict_exit" -eq 1 ]; then
+            echo "⚠️  Bandit reported issues in test scan output (exit codes: tests=$bandit_tests_exit, tests_strict=$bandit_tests_strict_exit)"
+            echo "::warning::Bandit reported issues in test scan output – review the Bandit log"
           fi
 
       - name: Run Safety (dependency audit with policy)

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,7 +166,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 668
+        "line_number": 640
       }
     ],
     ".github/workflows/frontend-ci.yml": [
@@ -1743,5 +1743,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-16T07:37:48Z"
+  "generated_at": "2026-06-17T14:01:45Z"
 }

--- a/docs/review/PR_1990_FIXED_MAPPING.md
+++ b/docs/review/PR_1990_FIXED_MAPPING.md
@@ -36,6 +36,7 @@
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#pullrequestreview-4516545531
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428869504
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428869542
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428892178
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428922972
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428922995
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428922999
@@ -50,6 +51,7 @@ Evidence: `scripts/ci/summarize_bandit_report.py` uses `_severity_sort_key`, pre
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#pullrequestreview-4516545531 -> d4cafeadc
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428869504 -> d4cafeadc
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428869542 -> d4cafeadc
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428892178 -> d4cafeadc
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428922972 -> 637f49c2d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428922995 -> 637f49c2d
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428922999 -> 637f49c2d
@@ -61,6 +63,11 @@ Evidence: `scripts/ci/summarize_bandit_report.py` uses `_severity_sort_key`, pre
 Disposition: NOT-A-BUG
 Evidence: `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1990 --body "$(gh pr view 1990 --json body --jq .body)" --commit-range origin/main..HEAD` passes with the canonical parser-safe artifact shape.
 Reason: The duplicate CodeRabbit review suggested per-entry nested inline detail, but the canonical mapping parser rejects nested bullet detail inside `## Fixed in Commit Mapping`; the parser-safe section already lists each URL and the disposition/proof block required by repo governance.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3431071358
+Disposition: NOT-A-BUG
+Evidence: local `git merge-base --is-ancestor d4cafeadc HEAD` and `git merge-base --is-ancestor 637f49c2d HEAD` both returned `0` on PR head `2d7362d26961e3121a8456c8354a911c1e645ffc`; local `git cat-file -t 61de4d77` found no such object in this PR checkout.
+Reason: The comment evaluates a synthetic squash-preview SHA, while repo merge-readiness and disposition guards evaluate the committed PR branch history and exact per-thread mappings.
 
 ## Local Role Finding Disposition
 

--- a/docs/review/PR_1990_FIXED_MAPPING.md
+++ b/docs/review/PR_1990_FIXED_MAPPING.md
@@ -24,9 +24,10 @@
 
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
-- Post-open role order executed through `qa-engineer-agent` and `bug-hunter`.
-- `security-auditor`, Codex Security diff scan, and `pulseplate-pr-review`
-  remain required before merge readiness.
+- Post-open role order executed through `qa-engineer-agent`, `bug-hunter`, and
+  `security-auditor`.
+- Codex Security diff scan and `pulseplate-pr-review` completed after review
+  fixes were pushed.
 - Codex connector review had no actionable finding in its review body.
 
 ## Fixed in Commit Mapping
@@ -50,6 +51,14 @@ Evidence: `scripts/ci/summarize_bandit_report.py` uses `_severity_sort_key`, pre
   Evidence: malformed, missing, or unsupported Bandit `issue_severity` values
   now fail closed before HIGH counts are reported; regressions cover missing
   and unsupported severity values.
+- `pulseplate-pr-review`: NOT-A-BUG.
+  Evidence: dry-run report flagged only advisory large-diff review risk. Scope
+  remained one coherent CI/security tooling lane, full local `make verify` is
+  operator-deferred, and required narrow gates plus pre-push hooks passed.
+- Codex Security diff scan: NOT-A-BUG.
+  Evidence: diff scan report
+  `/tmp/codex-security-scans/bandit-lower-severity-inventory-baseline/541546e53f90_20260617T194529Z/report.md`
+  reviewed 11/11 diff/supporting files with no surviving reportable findings.
 
 ## Premortem Closure
 
@@ -108,10 +117,18 @@ Artifact: `artifacts/orchestration/experiments/results/exp-5662555828dd.json`
 - PASS: `make validate-changed`
 - PASS:
   `PATH=".../.venv/bin:$PATH" bash scripts/ci_bandit.sh --exclude "tests,tests_strict,htmlcov,.git,.venv,venv,node_modules,.mypy_cache,.pytest_cache" --output /tmp/bandit-report.json`
-  - 0 HIGH findings and 37,577 below-HIGH grouped findings
+  - 0 HIGH findings and 37,598 below-HIGH grouped findings
 - PASS: `pre-commit run --all-files`
 - PASS: push hooks, including backend pre-push tests, full-repo Bandit
   pre-push, and docker build test
+- PASS: Codex Security diff scan
+  - Report:
+    `/tmp/codex-security-scans/bandit-lower-severity-inventory-baseline/541546e53f90_20260617T194529Z/report.md`
+  - HTML:
+    `/tmp/codex-security-scans/bandit-lower-severity-inventory-baseline/541546e53f90_20260617T194529Z/report.html`
+- PASS: `pulseplate-pr-review` dry run
+  - Finding: advisory large-diff review risk only; dispositioned as
+    NOT-A-BUG with narrow scope and gate evidence.
 
 ## Machine-Heavy Deferral
 
@@ -131,7 +148,7 @@ added.
 
 - [ ] Current-head PR CI complete and passing.
 - [ ] No unresolved actionable review or bot comments.
-- [ ] Post-open `security-auditor` pass complete.
-- [ ] Codex Security diff scan and `pulseplate-pr-review` complete.
+- [x] Post-open `security-auditor` pass complete.
+- [x] Codex Security diff scan and `pulseplate-pr-review` complete.
 - [ ] Strict merge-readiness with auth passes.
 - [ ] Mandatory wait-window satisfied.

--- a/docs/review/PR_1990_FIXED_MAPPING.md
+++ b/docs/review/PR_1990_FIXED_MAPPING.md
@@ -32,11 +32,35 @@
 
 ## Fixed in Commit Mapping
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#pullrequestreview-4516481618
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#pullrequestreview-4516545531
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428869504
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428869542
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428922972
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428922995
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428922999
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428923022
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428923042
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428923049
+Disposition: FIXED
+Commit: see mapping entries below
+Evidence: `scripts/ci/summarize_bandit_report.py` uses `_severity_sort_key`, preserves `.github/workflows` bucketing, and escapes Bandit-derived raw display fields; `scripts/ci_bandit.sh` passes `--fail-on-high`; `tests/test_summarize_bandit_report.py` covers severity ordering, `.github/workflows` bucketing, workflow-command injection, and non-strict wrapper HIGH failure; `tests/guards/test_security_devtooling_regression_guards.py` asserts `--github-annotations` workflow wiring; `docs/review/PR_1990_FIXED_MAPPING.md` includes the required discussion checkboxes and merge-readiness checklist shape.
+
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#pullrequestreview-4516481618 -> d4cafeadc
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#pullrequestreview-4516545531 -> d4cafeadc
-Disposition: FIXED
-Commit: d4cafeadc
-Evidence: `scripts/ci/summarize_bandit_report.py` uses `_severity_sort_key`, preserves `.github/workflows` bucketing, and escapes Bandit-derived raw display fields; `scripts/ci_bandit.sh` passes `--fail-on-high`; `tests/test_summarize_bandit_report.py` covers severity ordering, `.github/workflows` bucketing, workflow-command injection, and non-strict wrapper HIGH failure; `tests/guards/test_security_devtooling_regression_guards.py` asserts `--github-annotations` workflow wiring.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428869504 -> d4cafeadc
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428869542 -> d4cafeadc
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428922972 -> 637f49c2d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428922995 -> 637f49c2d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428922999 -> 637f49c2d
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428923022 -> d4cafeadc
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428923042 -> d4cafeadc
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#discussion_r3428923049 -> d4cafeadc
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#pullrequestreview-4519106700
+Disposition: NOT-A-BUG
+Evidence: `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1990 --body "$(gh pr view 1990 --json body --jq .body)" --commit-range origin/main..HEAD` passes with the canonical parser-safe artifact shape.
+Reason: The duplicate CodeRabbit review suggested per-entry nested inline detail, but the canonical mapping parser rejects nested bullet detail inside `## Fixed in Commit Mapping`; the parser-safe section already lists each URL and the disposition/proof block required by repo governance.
 
 ## Local Role Finding Disposition
 

--- a/docs/review/PR_1990_FIXED_MAPPING.md
+++ b/docs/review/PR_1990_FIXED_MAPPING.md
@@ -69,6 +69,11 @@ Disposition: NOT-A-BUG
 Evidence: local `git merge-base --is-ancestor d4cafeadc HEAD` and `git merge-base --is-ancestor 637f49c2d HEAD` both returned `0` on PR head `2d7362d26961e3121a8456c8354a911c1e645ffc`; local `git cat-file -t 61de4d77` found no such object in this PR checkout.
 Reason: The comment evaluates a synthetic squash-preview SHA, while repo merge-readiness and disposition guards evaluate the committed PR branch history and exact per-thread mappings.
 
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#pullrequestreview-4519210929 -> 957af236e
+Disposition: FIXED
+Commit: 957af236e
+Evidence: `docs/review/PR_1990_FIXED_MAPPING.md` now keeps the Merge Readiness checklist items unchecked until the final merge cycle. The same review's nested inline-proof suggestion is NOT-A-BUG because `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1990 --body "$(gh pr view 1990 --json body --jq .body)" --commit-range origin/main..HEAD` passes only with the canonical parser-safe mapping shape.
+
 ## Local Role Finding Disposition
 
 - `qa-engineer-agent`: FIXED by `d4cafeadc`.

--- a/docs/review/PR_1990_FIXED_MAPPING.md
+++ b/docs/review/PR_1990_FIXED_MAPPING.md
@@ -179,7 +179,7 @@ added.
 
 - [ ] Current-head PR CI complete and passing.
 - [ ] No unresolved actionable review or bot comments.
-- [x] Post-open `security-auditor` pass complete.
-- [x] Codex Security diff scan and `pulseplate-pr-review` complete.
+- [ ] Post-open `security-auditor` pass complete.
+- [ ] Codex Security diff scan and `pulseplate-pr-review` complete.
 - [ ] Strict merge-readiness with auth passes.
 - [ ] Mandatory wait-window satisfied.

--- a/docs/review/PR_1990_FIXED_MAPPING.md
+++ b/docs/review/PR_1990_FIXED_MAPPING.md
@@ -46,6 +46,10 @@ Evidence: `scripts/ci/summarize_bandit_report.py` uses `_severity_sort_key`, pre
   Evidence: non-strict wrapper HIGH failure, Bandit-derived raw output command
   injection, `.github/workflows` path bucketing, docs Phase1 anchors, and
   parser-safe mapping/body shape were fixed or are fixed in this mapping update.
+- `security-auditor`: FIXED by `d6a0e6e31`.
+  Evidence: malformed, missing, or unsupported Bandit `issue_severity` values
+  now fail closed before HIGH counts are reported; regressions cover missing
+  and unsupported severity values.
 
 ## Premortem Closure
 
@@ -93,7 +97,10 @@ Artifact: `artifacts/orchestration/experiments/results/exp-5662555828dd.json`
   - 69 tests
 - PASS:
   `.venv/bin/python -m pytest -q tests/test_summarize_bandit_report.py tests/guards/test_security_devtooling_regression_guards.py tests/test_python_supply_chain_controls.py`
-  - 82 tests
+  - 84 tests
+- PASS:
+  `.venv/bin/python -m pytest -q tests/test_summarize_bandit_report.py`
+  - 15 tests
 - PASS:
   `.venv/bin/python -m pytest -q tests/test_summarize_bandit_report.py tests/guards/test_security_devtooling_regression_guards.py -k 'bandit or summarize'`
   - 17 tests

--- a/docs/review/PR_1990_FIXED_MAPPING.md
+++ b/docs/review/PR_1990_FIXED_MAPPING.md
@@ -1,0 +1,121 @@
+# PR 1990 Fixed Mapping
+
+## Lane Start Provenance
+
+- PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990
+- Branch: `codex/bandit-lower-severity-inventory-baseline`
+- Base: `origin/main` at `74fddbcee3d207f40703386c0f76fa66efe0fbaa`
+- Starter packet: `artifacts/orchestration/task_packets/ee3353e7b384.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+- Operator exception: PR3 branch started while current-head `main` was pending
+  with no failed jobs. Before PR open, canonical `CI` for `74fddbcee` completed
+  successfully.
+
+## Scope
+
+This PR is limited to Bandit lower-severity inventory reporting:
+
+- shared Bandit JSON summary helper,
+- CI/security workflow wiring for grouped warning output,
+- HIGH fail-closed preservation,
+- workflow/parser/exclude guard coverage,
+- security evidence and backlog tracking for phased remediation.
+
+Out of scope: dependency bumps, requirements cleanup, eval/data locks, legacy
+extraction, FoodDB, auth/BOLA, frontend/iOS/macOS runtime behavior, pyproject
+migration, mass `# nosec`, and MEDIUM gate tightening.
+
+## Discussion Thread Pass
+
+No GitHub review threads existed when this artifact was created.
+
+Post-open review order remains required before merge readiness:
+
+1. `qa-engineer-agent`
+2. `bug-hunter`
+3. `security-auditor`
+4. Codex Security diff scan
+5. CodeRabbit, if authenticated
+6. `pulseplate-pr-review`
+
+## Premortem Closure
+
+- Finding: scheduled Security Scan could keep stale inline parsing and create
+  false-green Bandit evidence.
+  - Disposition: FIXED
+  - Commit: `38e287899`
+  - Evidence: `.github/workflows/security.yml` uses
+    `scripts/ci/summarize_bandit_report.py`.
+- Finding: lower-severity reporting could accidentally weaken HIGH fail-closed
+  behavior.
+  - Disposition: FIXED
+  - Commit: `38e287899`
+  - Evidence: `scripts/ci/summarize_bandit_report.py`,
+    `tests/test_summarize_bandit_report.py`, and
+    `tests/guards/test_security_devtooling_regression_guards.py`.
+- Finding: the inventory could become a substitute for remediation.
+  - Disposition: DEFERRED
+  - Backlog:
+    `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-bandit-lower-severity-remediation`
+  - Evidence: `docs/security/BANDIT_LOWER_SEVERITY_INVENTORY.md`.
+
+## Experiment Runner Evidence
+
+- Accepted artifact:
+  `artifacts/orchestration/experiments/results/exp-5662555828dd.json`
+- Status: accepted
+- Shared tree: untouched
+- Source diff: applied in isolated checkout
+- Oracle commands:
+  - `python -m pytest -q tests/test_summarize_bandit_report.py tests/guards/test_security_devtooling_regression_guards.py -k bandit`
+  - `python -m pytest -q tests/test_python_supply_chain_controls.py -k bandit`
+- Commit attribution: `38e287899` includes
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
+
+## Fixed in Commit Mapping
+
+- Initial implementation -> `38e287899`
+- Premortem false-green Security Scan parser finding -> `38e287899`
+- Premortem HIGH fail-closed preservation finding -> `38e287899`
+- Premortem lower-severity remediation backlog finding -> `38e287899`
+
+## Tests
+
+- `python3 scripts/orchestration/check_preflight.py` - pass
+- `python3 scripts/orchestration/check_agent_consistency.py` - pass
+- `.venv/bin/python -m pytest -q tests/test_summarize_bandit_report.py tests/guards/test_security_devtooling_regression_guards.py tests/test_python_supply_chain_controls.py tests/test_ci_workflow_pr_size_governance_contract.py`
+  - pass, 106 tests
+- `.venv/bin/python -m pytest -q tests/guards/test_security_devtooling_regression_guards.py tests/test_python_supply_chain_controls.py`
+  - pass, 69 tests
+- `make validate-changed`
+  - pass; selected the changed Bandit/security test surface after commit
+- `PATH=".../.venv/bin:$PATH" bash scripts/ci_bandit.sh --exclude "tests,tests_strict,htmlcov,.git,.venv,venv,node_modules,.mypy_cache,.pytest_cache" --output /tmp/bandit-report.json`
+  - pass; 0 HIGH findings and 37,577 below-HIGH grouped findings
+- `pre-commit run --all-files` - pass
+- Push hooks - pass, including backend pre-push tests, full-repo Bandit
+  pre-push, and docker build test
+
+## Machine-Heavy Deferral
+
+Operator-approved exception: full local `make verify` was not run for this
+CI/tooling security PR. Narrow local gates, pre-commit, pre-push hooks,
+Experiment Runner oracle evidence, and current-head CI are the validation
+signals for this lane.
+
+## Security Notes
+
+HIGH severity Bandit findings remain fail-closed. Missing or malformed Bandit
+JSON fails the shared helper. LOW/MEDIUM findings remain warning-only and are
+now grouped for remediation. No new suppressions or allowlist entries were
+added.
+
+## Merge Readiness
+
+Not merge-ready at artifact creation. Required before merge:
+
+- current-head PR CI complete and passing,
+- no unresolved actionable review or bot comments,
+- post-open role passes complete,
+- Codex Security diff scan and `pulseplate-pr-review` complete,
+- strict merge-readiness with auth passes,
+- mandatory wait-window satisfied.

--- a/docs/review/PR_1990_FIXED_MAPPING.md
+++ b/docs/review/PR_1990_FIXED_MAPPING.md
@@ -2,41 +2,50 @@
 
 ## Lane Start Provenance
 
-- PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990
+- Packet: `artifacts/orchestration/task_packets/ee3353e7b384.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
 - Branch: `codex/bandit-lower-severity-inventory-baseline`
 - Base: `origin/main` at `74fddbcee3d207f40703386c0f76fa66efe0fbaa`
-- Starter packet: `artifacts/orchestration/task_packets/ee3353e7b384.json`
-- Starter: `scripts/orchestration/start_pr_lane.sh`
 - Operator exception: PR3 branch started while current-head `main` was pending
   with no failed jobs. Before PR open, canonical `CI` for `74fddbcee` completed
   successfully.
+- Packet creation was treated as provenance only, not role execution.
 
 ## Scope
 
-This PR is limited to Bandit lower-severity inventory reporting:
-
-- shared Bandit JSON summary helper,
-- CI/security workflow wiring for grouped warning output,
-- HIGH fail-closed preservation,
-- workflow/parser/exclude guard coverage,
-- security evidence and backlog tracking for phased remediation.
-
-Out of scope: dependency bumps, requirements cleanup, eval/data locks, legacy
-extraction, FoodDB, auth/BOLA, frontend/iOS/macOS runtime behavior, pyproject
-migration, mass `# nosec`, and MEDIUM gate tightening.
+- In scope: Bandit lower-severity summary tooling, CI/security workflow warning
+  output, HIGH fail-closed preservation, workflow/exclude/parser guards,
+  security evidence, and backlog tracking.
+- Out of scope: dependency bumps, requirements cleanup, eval/data locks, legacy
+  extraction, FoodDB, auth/BOLA, frontend/iOS/macOS runtime behavior, pyproject
+  migration, mass `# nosec`, and MEDIUM gate tightening.
 
 ## Discussion Thread Pass
 
-No GitHub review threads existed when this artifact was created.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+- Post-open role order executed through `qa-engineer-agent` and `bug-hunter`.
+- `security-auditor`, Codex Security diff scan, and `pulseplate-pr-review`
+  remain required before merge readiness.
+- Codex connector review had no actionable finding in its review body.
 
-Post-open review order remains required before merge readiness:
+## Fixed in Commit Mapping
 
-1. `qa-engineer-agent`
-2. `bug-hunter`
-3. `security-auditor`
-4. Codex Security diff scan
-5. CodeRabbit, if authenticated
-6. `pulseplate-pr-review`
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#pullrequestreview-4516481618 -> d4cafeadc
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1990#pullrequestreview-4516545531 -> d4cafeadc
+Disposition: FIXED
+Commit: d4cafeadc
+Evidence: `scripts/ci/summarize_bandit_report.py` uses `_severity_sort_key`, preserves `.github/workflows` bucketing, and escapes Bandit-derived raw display fields; `scripts/ci_bandit.sh` passes `--fail-on-high`; `tests/test_summarize_bandit_report.py` covers severity ordering, `.github/workflows` bucketing, workflow-command injection, and non-strict wrapper HIGH failure; `tests/guards/test_security_devtooling_regression_guards.py` asserts `--github-annotations` workflow wiring.
+
+## Local Role Finding Disposition
+
+- `qa-engineer-agent`: FIXED by `d4cafeadc`.
+  Evidence: equal-count severity ordering and `--github-annotations` workflow
+  guard regressions were added.
+- `bug-hunter`: FIXED by `d4cafeadc`.
+  Evidence: non-strict wrapper HIGH failure, Bandit-derived raw output command
+  injection, `.github/workflows` path bucketing, docs Phase1 anchors, and
+  parser-safe mapping/body shape were fixed or are fixed in this mapping update.
 
 ## Premortem Closure
 
@@ -49,9 +58,9 @@ Post-open review order remains required before merge readiness:
 - Finding: lower-severity reporting could accidentally weaken HIGH fail-closed
   behavior.
   - Disposition: FIXED
-  - Commit: `38e287899`
+  - Commit: `38e287899`, `d4cafeadc`
   - Evidence: `scripts/ci/summarize_bandit_report.py`,
-    `tests/test_summarize_bandit_report.py`, and
+    `scripts/ci_bandit.sh`, `tests/test_summarize_bandit_report.py`, and
     `tests/guards/test_security_devtooling_regression_guards.py`.
 - Finding: the inventory could become a substitute for remediation.
   - Disposition: DEFERRED
@@ -61,8 +70,8 @@ Post-open review order remains required before merge readiness:
 
 ## Experiment Runner Evidence
 
-- Accepted artifact:
-  `artifacts/orchestration/experiments/results/exp-5662555828dd.json`
+Artifact: `artifacts/orchestration/experiments/results/exp-5662555828dd.json`
+
 - Status: accepted
 - Shared tree: untouched
 - Source diff: applied in isolated checkout
@@ -72,35 +81,37 @@ Post-open review order remains required before merge readiness:
 - Commit attribution: `38e287899` includes
   `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`.
 
-## Fixed in Commit Mapping
-
-- Initial implementation -> `38e287899`
-- Premortem false-green Security Scan parser finding -> `38e287899`
-- Premortem HIGH fail-closed preservation finding -> `38e287899`
-- Premortem lower-severity remediation backlog finding -> `38e287899`
-
 ## Tests
 
-- `python3 scripts/orchestration/check_preflight.py` - pass
-- `python3 scripts/orchestration/check_agent_consistency.py` - pass
-- `.venv/bin/python -m pytest -q tests/test_summarize_bandit_report.py tests/guards/test_security_devtooling_regression_guards.py tests/test_python_supply_chain_controls.py tests/test_ci_workflow_pr_size_governance_contract.py`
-  - pass, 106 tests
-- `.venv/bin/python -m pytest -q tests/guards/test_security_devtooling_regression_guards.py tests/test_python_supply_chain_controls.py`
-  - pass, 69 tests
-- `make validate-changed`
-  - pass; selected the changed Bandit/security test surface after commit
-- `PATH=".../.venv/bin:$PATH" bash scripts/ci_bandit.sh --exclude "tests,tests_strict,htmlcov,.git,.venv,venv,node_modules,.mypy_cache,.pytest_cache" --output /tmp/bandit-report.json`
-  - pass; 0 HIGH findings and 37,577 below-HIGH grouped findings
-- `pre-commit run --all-files` - pass
-- Push hooks - pass, including backend pre-push tests, full-repo Bandit
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS:
+  `.venv/bin/python -m pytest -q tests/test_summarize_bandit_report.py tests/guards/test_security_devtooling_regression_guards.py tests/test_python_supply_chain_controls.py tests/test_ci_workflow_pr_size_governance_contract.py`
+  - 106 tests
+- PASS:
+  `.venv/bin/python -m pytest -q tests/guards/test_security_devtooling_regression_guards.py tests/test_python_supply_chain_controls.py`
+  - 69 tests
+- PASS:
+  `.venv/bin/python -m pytest -q tests/test_summarize_bandit_report.py tests/guards/test_security_devtooling_regression_guards.py tests/test_python_supply_chain_controls.py`
+  - 82 tests
+- PASS:
+  `.venv/bin/python -m pytest -q tests/test_summarize_bandit_report.py tests/guards/test_security_devtooling_regression_guards.py -k 'bandit or summarize'`
+  - 17 tests
+- PASS: `python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/BANDIT_LOWER_SEVERITY_INVENTORY.md docs/roadmap/BACKLOG_LEDGER.md docs/review/PR_1990_FIXED_MAPPING.md`
+- PASS: `make validate-changed`
+- PASS:
+  `PATH=".../.venv/bin:$PATH" bash scripts/ci_bandit.sh --exclude "tests,tests_strict,htmlcov,.git,.venv,venv,node_modules,.mypy_cache,.pytest_cache" --output /tmp/bandit-report.json`
+  - 0 HIGH findings and 37,577 below-HIGH grouped findings
+- PASS: `pre-commit run --all-files`
+- PASS: push hooks, including backend pre-push tests, full-repo Bandit
   pre-push, and docker build test
 
 ## Machine-Heavy Deferral
 
-Operator-approved exception: full local `make verify` was not run for this
-CI/tooling security PR. Narrow local gates, pre-commit, pre-push hooks,
-Experiment Runner oracle evidence, and current-head CI are the validation
-signals for this lane.
+- Operator-approved deferral: full local `make verify` was not run for this
+  CI/tooling security PR.
+- Required narrow local gates above were run.
+- Current-head CI is the heavy verification signal before merge.
 
 ## Security Notes
 
@@ -111,11 +122,9 @@ added.
 
 ## Merge Readiness
 
-Not merge-ready at artifact creation. Required before merge:
-
-- current-head PR CI complete and passing,
-- no unresolved actionable review or bot comments,
-- post-open role passes complete,
-- Codex Security diff scan and `pulseplate-pr-review` complete,
-- strict merge-readiness with auth passes,
-- mandatory wait-window satisfied.
+- [ ] Current-head PR CI complete and passing.
+- [ ] No unresolved actionable review or bot comments.
+- [ ] Post-open `security-auditor` pass complete.
+- [ ] Codex Security diff scan and `pulseplate-pr-review` complete.
+- [ ] Strict merge-readiness with auth passes.
+- [ ] Mandatory wait-window satisfied.

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -3829,6 +3829,31 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - Guard no longer uses allowlist (or allowlist file removed)
 
 
+<a id="ledger-p1-bandit-lower-severity-remediation"></a>
+- [ ] P1: Phase 2 — Remediate Bandit lower-severity findings by rule family
+  - Owner: @katsiaryna_kavaleuskaya
+  - Priority: P1
+  - Target PR: PR-TBD-BANDIT-LOWER-SEVERITY-REMEDIATION
+  - Area: security / CI / static analysis
+  - Finding Type: Bandit LOW/MEDIUM inventory follow-up
+  - Reason: PR3 adds deterministic grouped inventory for Bandit findings below
+    HIGH severity while keeping HIGH fail-closed. The inventory is not a
+    suppression mechanism and does not tighten the merge gate to MEDIUM yet;
+    remediation should proceed in narrow follow-up PRs by Bandit rule id and
+    path bucket.
+  - Links:
+    - `docs/security/BANDIT_LOWER_SEVERITY_INVENTORY.md`
+    - `scripts/ci/summarize_bandit_report.py`
+    - `.github/workflows/ci.yml` (`Enforce Bandit HIGH severity gate`)
+  - DoD:
+    - One rule family or path bucket remediated per PR unless coordinator opens
+      a broader lane
+    - No broad `# nosec` additions; every unavoidable suppression follows root
+      `AGENTS.md` nosec policy
+    - MEDIUM gate tightening considered only after grouped inventory shrinks to
+      an actionable baseline
+
+
 <a id="ledger-p1-compose-v2-migration"></a>
 - [x] P1: Migrate command surface to `docker compose` v2 only
   - Owner: @katsiaryna_kavaleuskaya

--- a/docs/security/BANDIT_LOWER_SEVERITY_INVENTORY.md
+++ b/docs/security/BANDIT_LOWER_SEVERITY_INVENTORY.md
@@ -1,0 +1,26 @@
+# Bandit Lower-Severity Inventory
+
+## Status
+
+PulsePlate keeps Bandit HIGH findings fail-closed in canonical CI. LOW and
+MEDIUM findings are warning-only inventory until each rule family is remediated
+or dispositioned through normal security review.
+
+## PR3 Baseline
+
+PR3 adds deterministic grouping for the existing Bandit JSON report. The grouped
+summary is advisory evidence only: it does not suppress findings, add `# nosec`,
+or change the HIGH severity merge gate.
+
+The summary groups below-HIGH findings by:
+
+- Bandit rule id.
+- Severity.
+- Confidence.
+- Path bucket.
+
+## Follow-up Policy
+
+Future remediation PRs should target one rule family or path bucket at a time.
+Suppressions remain governed by the root `AGENTS.md` nosec policy and require a
+rule id, justification, remove-by date, and tracked reference.

--- a/docs/security/BANDIT_LOWER_SEVERITY_INVENTORY.md
+++ b/docs/security/BANDIT_LOWER_SEVERITY_INVENTORY.md
@@ -12,6 +12,11 @@ PR3 adds deterministic grouping for the existing Bandit JSON report. The grouped
 summary is advisory evidence only: it does not suppress findings, add `# nosec`,
 or change the HIGH severity merge gate.
 
+Evidence anchors: `.github/workflows/ci.yml:489` invokes the shared helper with
+`--fail-on-high`, `scripts/ci/summarize_bandit_report.py:252` keeps the helper
+exit gate centralized, and `tests/test_summarize_bandit_report.py:220` covers
+workflow-command injection in Bandit-derived output.
+
 The summary groups below-HIGH findings by:
 
 - Bandit rule id.

--- a/scripts/ci/summarize_bandit_report.py
+++ b/scripts/ci/summarize_bandit_report.py
@@ -38,6 +38,10 @@ def _github_escape(value: str) -> str:
     return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
 
 
+def _display_escape(value: str) -> str:
+    return _github_escape(value)
+
+
 def _annotation(kind: str, message: str) -> str:
     return f"::{kind}::{_github_escape(message)}"
 
@@ -58,7 +62,9 @@ def _line_number(value: object) -> int:
 
 
 def _path_bucket(filename: str) -> str:
-    normalized = filename.replace("\\", "/").lstrip("./")
+    normalized = filename.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
     if normalized == "legacy_app.py":
         return "legacy_app"
     if normalized.startswith("app/security/"):
@@ -128,23 +134,31 @@ def _finding_sort_key(finding: Finding) -> tuple[tuple[int, str], str, str, str,
     )
 
 
-def _group_sort_key(item: tuple[GroupKey, Sequence[Finding]]) -> tuple[int, str, str, str, str]:
+def _group_sort_key(
+    item: tuple[GroupKey, Sequence[Finding]],
+) -> tuple[int, tuple[int, str], str, str, str]:
     key, findings = item
     return (
         -len(findings),
-        key.severity,
+        _severity_sort_key(key.severity),
         key.test_id,
         key.confidence,
         key.path_bucket,
     )
 
 
-def _format_location(finding: Finding) -> str:
+def _maybe_display_escape(value: str, *, escape_display: bool) -> str:
+    return _display_escape(value) if escape_display else value
+
+
+def _format_location(finding: Finding, *, escape_display: bool = True) -> str:
     suffix = f":{finding.line_number}" if finding.line_number else ""
-    return f"{finding.filename}{suffix}"
+    return f"{_maybe_display_escape(finding.filename, escape_display=escape_display)}{suffix}"
 
 
-def _summary_lines(findings: Sequence[Finding], *, top: int, samples: int) -> list[str]:
+def _summary_lines(
+    findings: Sequence[Finding], *, top: int, samples: int, escape_display: bool = True
+) -> list[str]:
     lower_findings = [finding for finding in findings if finding.severity != "HIGH"]
     if not lower_findings:
         return []
@@ -163,11 +177,17 @@ def _summary_lines(findings: Sequence[Finding], *, top: int, samples: int) -> li
     lines = ["Bandit lower-severity grouped inventory:"]
     for key, grouped_findings in sorted(grouped.items(), key=_group_sort_key)[:top]:
         sorted_findings = sorted(grouped_findings, key=_finding_sort_key)
-        examples = ", ".join(_format_location(finding) for finding in sorted_findings[:samples])
+        examples = ", ".join(
+            _format_location(finding, escape_display=escape_display)
+            for finding in sorted_findings[:samples]
+        )
         lines.append(
             "- "
-            f"{key.severity} | {key.confidence} confidence | {key.test_id} | "
-            f"{key.path_bucket}: {len(sorted_findings)}"
+            f"{_maybe_display_escape(key.severity, escape_display=escape_display)} | "
+            f"{_maybe_display_escape(key.confidence, escape_display=escape_display)} confidence | "
+            f"{_maybe_display_escape(key.test_id, escape_display=escape_display)} | "
+            f"{_maybe_display_escape(key.path_bucket, escape_display=escape_display)}: "
+            f"{len(sorted_findings)}"
             f" (examples: {examples})"
         )
     return lines
@@ -205,18 +225,25 @@ def _print_analysis(
         )[:samples]:
             print(
                 "- "
-                f"{finding.test_id} | {finding.confidence} confidence | "
-                f"{_format_location(finding)} | {finding.issue_text}"
+                f"{_display_escape(finding.test_id)} | "
+                f"{_display_escape(finding.confidence)} confidence | "
+                f"{_format_location(finding)} | {_display_escape(finding.issue_text)}"
             )
 
     if below_high_count:
-        group_lines = _summary_lines(findings, top=top, samples=samples)
-        warning_summary = "; ".join(line.removeprefix("- ") for line in group_lines[1:4])
+        display_group_lines = _summary_lines(findings, top=top, samples=samples)
+        annotation_group_lines = _summary_lines(
+            findings,
+            top=top,
+            samples=samples,
+            escape_display=False,
+        )
+        warning_summary = "; ".join(line.removeprefix("- ") for line in annotation_group_lines[1:4])
         message = f"Bandit reported {below_high_count} findings below HIGH severity" + (
             f": {warning_summary}" if warning_summary else ""
         )
         print(_annotation("warning", message) if github_annotations else f"WARNING: {message}")
-        for line in group_lines:
+        for line in display_group_lines:
             print(line)
     elif not high_count:
         print("No HIGH severity issues found in Bandit report")

--- a/scripts/ci/summarize_bandit_report.py
+++ b/scripts/ci/summarize_bandit_report.py
@@ -10,7 +10,8 @@ from pathlib import Path
 import sys
 from typing import Any, Iterable, Mapping, NamedTuple, Sequence
 
-SEVERITY_ORDER = {"HIGH": 0, "MEDIUM": 1, "LOW": 2, "UNDEFINED": 3, "UNKNOWN": 4}
+SEVERITY_ORDER = {"HIGH": 0, "MEDIUM": 1, "LOW": 2}
+VALID_SEVERITIES = frozenset(SEVERITY_ORDER)
 
 
 class BanditReportError(ValueError):
@@ -51,6 +52,19 @@ def _normalize_label(value: object, *, fallback: str = "UNKNOWN") -> str:
         return fallback
     normalized = value.strip().upper()
     return normalized or fallback
+
+
+def _severity_label(value: object) -> str:
+    if not isinstance(value, str):
+        raise BanditReportError("Bandit report finding missing string `issue_severity`")
+    normalized = value.strip().upper()
+    if normalized not in VALID_SEVERITIES:
+        allowed = ", ".join(sorted(VALID_SEVERITIES))
+        raise BanditReportError(
+            f"Bandit report finding has unsupported `issue_severity`: {normalized or '<empty>'}. "
+            f"Allowed: {allowed}"
+        )
+    return normalized
 
 
 def _line_number(value: object) -> int:
@@ -109,7 +123,7 @@ def _load_report(path: Path) -> list[Mapping[str, Any]]:
 def _finding(item: Mapping[str, Any]) -> Finding:
     filename = str(item.get("filename") or "<unknown>")
     return Finding(
-        severity=_normalize_label(item.get("issue_severity"), fallback="UNKNOWN"),
+        severity=_severity_label(item.get("issue_severity")),
         confidence=_normalize_label(item.get("issue_confidence"), fallback="UNKNOWN"),
         test_id=str(item.get("test_id") or "UNKNOWN").strip() or "UNKNOWN",
         filename=filename,

--- a/scripts/ci/summarize_bandit_report.py
+++ b/scripts/ci/summarize_bandit_report.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Summarize Bandit JSON output and enforce the HIGH-severity gate."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+import json
+from pathlib import Path
+import sys
+from typing import Any, Iterable, Mapping, NamedTuple, Sequence
+
+SEVERITY_ORDER = {"HIGH": 0, "MEDIUM": 1, "LOW": 2, "UNDEFINED": 3, "UNKNOWN": 4}
+
+
+class BanditReportError(ValueError):
+    """Raised when a Bandit report is missing or malformed."""
+
+
+class GroupKey(NamedTuple):
+    severity: str
+    confidence: str
+    test_id: str
+    path_bucket: str
+
+
+class Finding(NamedTuple):
+    severity: str
+    confidence: str
+    test_id: str
+    filename: str
+    line_number: int
+    issue_text: str
+    path_bucket: str
+
+
+def _github_escape(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _annotation(kind: str, message: str) -> str:
+    return f"::{kind}::{_github_escape(message)}"
+
+
+def _normalize_label(value: object, *, fallback: str = "UNKNOWN") -> str:
+    if not isinstance(value, str):
+        return fallback
+    normalized = value.strip().upper()
+    return normalized or fallback
+
+
+def _line_number(value: object) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return 0
+
+
+def _path_bucket(filename: str) -> str:
+    normalized = filename.replace("\\", "/").lstrip("./")
+    if normalized == "legacy_app.py":
+        return "legacy_app"
+    if normalized.startswith("app/security/"):
+        return "app/security"
+    if normalized.startswith("app/"):
+        return "app"
+    if normalized.startswith("scripts/ci/"):
+        return "scripts/ci"
+    if normalized.startswith("scripts/"):
+        return "scripts"
+    if normalized.startswith("core/"):
+        return "core"
+    if normalized.startswith("providers/"):
+        return "providers"
+    if normalized.startswith("tests/") or normalized == "tests":
+        return "tests"
+    if normalized.startswith(".github/workflows/"):
+        return "github/workflows"
+    if normalized.startswith("docs/"):
+        return "docs"
+    return "other"
+
+
+def _load_report(path: Path) -> list[Mapping[str, Any]]:
+    if not path.is_file():
+        raise BanditReportError(f"Bandit report not found: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise BanditReportError(f"Bandit report is not valid JSON: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise BanditReportError("Bandit report root must be a JSON object")
+    results = payload.get("results")
+    if not isinstance(results, list):
+        raise BanditReportError("Bandit report `.results` must be a list")
+    for index, item in enumerate(results):
+        if not isinstance(item, dict):
+            raise BanditReportError(f"Bandit report `.results[{index}]` must be an object")
+    return results
+
+
+def _finding(item: Mapping[str, Any]) -> Finding:
+    filename = str(item.get("filename") or "<unknown>")
+    return Finding(
+        severity=_normalize_label(item.get("issue_severity"), fallback="UNKNOWN"),
+        confidence=_normalize_label(item.get("issue_confidence"), fallback="UNKNOWN"),
+        test_id=str(item.get("test_id") or "UNKNOWN").strip() or "UNKNOWN",
+        filename=filename,
+        line_number=_line_number(item.get("line_number")),
+        issue_text=str(item.get("issue_text") or "").strip(),
+        path_bucket=_path_bucket(filename),
+    )
+
+
+def _severity_sort_key(severity: str) -> tuple[int, str]:
+    return (SEVERITY_ORDER.get(severity, 99), severity)
+
+
+def _finding_sort_key(finding: Finding) -> tuple[tuple[int, str], str, str, str, int, str]:
+    return (
+        _severity_sort_key(finding.severity),
+        finding.test_id,
+        finding.path_bucket,
+        finding.filename,
+        finding.line_number,
+        finding.issue_text,
+    )
+
+
+def _group_sort_key(item: tuple[GroupKey, Sequence[Finding]]) -> tuple[int, str, str, str, str]:
+    key, findings = item
+    return (
+        -len(findings),
+        key.severity,
+        key.test_id,
+        key.confidence,
+        key.path_bucket,
+    )
+
+
+def _format_location(finding: Finding) -> str:
+    suffix = f":{finding.line_number}" if finding.line_number else ""
+    return f"{finding.filename}{suffix}"
+
+
+def _summary_lines(findings: Sequence[Finding], *, top: int, samples: int) -> list[str]:
+    lower_findings = [finding for finding in findings if finding.severity != "HIGH"]
+    if not lower_findings:
+        return []
+
+    grouped: dict[GroupKey, list[Finding]] = defaultdict(list)
+    for finding in lower_findings:
+        grouped[
+            GroupKey(
+                finding.severity,
+                finding.confidence,
+                finding.test_id,
+                finding.path_bucket,
+            )
+        ].append(finding)
+
+    lines = ["Bandit lower-severity grouped inventory:"]
+    for key, grouped_findings in sorted(grouped.items(), key=_group_sort_key)[:top]:
+        sorted_findings = sorted(grouped_findings, key=_finding_sort_key)
+        examples = ", ".join(_format_location(finding) for finding in sorted_findings[:samples])
+        lines.append(
+            "- "
+            f"{key.severity} | {key.confidence} confidence | {key.test_id} | "
+            f"{key.path_bucket}: {len(sorted_findings)}"
+            f" (examples: {examples})"
+        )
+    return lines
+
+
+def _severity_counts(findings: Iterable[Finding]) -> Counter[str]:
+    return Counter(finding.severity for finding in findings)
+
+
+def _print_analysis(
+    findings: Sequence[Finding],
+    *,
+    github_annotations: bool,
+    top: int,
+    samples: int,
+) -> None:
+    counts = _severity_counts(findings)
+    high_count = counts.get("HIGH", 0)
+    below_high_count = len(findings) - high_count
+
+    print("=== Bandit Report Analysis ===")
+    print(f"Total findings: {len(findings)}")
+    print(f"HIGH severity findings: {high_count}")
+
+    if high_count:
+        message = (
+            f"Bandit found {high_count} HIGH severity "
+            f"{'issue' if high_count == 1 else 'issues'} that must be addressed"
+        )
+        print(_annotation("error", message) if github_annotations else f"ERROR: {message}")
+        print("HIGH severity samples:")
+        for finding in sorted(
+            (finding for finding in findings if finding.severity == "HIGH"),
+            key=_finding_sort_key,
+        )[:samples]:
+            print(
+                "- "
+                f"{finding.test_id} | {finding.confidence} confidence | "
+                f"{_format_location(finding)} | {finding.issue_text}"
+            )
+
+    if below_high_count:
+        group_lines = _summary_lines(findings, top=top, samples=samples)
+        warning_summary = "; ".join(line.removeprefix("- ") for line in group_lines[1:4])
+        message = f"Bandit reported {below_high_count} findings below HIGH severity" + (
+            f": {warning_summary}" if warning_summary else ""
+        )
+        print(_annotation("warning", message) if github_annotations else f"WARNING: {message}")
+        for line in group_lines:
+            print(line)
+    elif not high_count:
+        print("No HIGH severity issues found in Bandit report")
+
+
+def summarize_report(
+    report: Path,
+    *,
+    fail_on_high: bool,
+    github_annotations: bool,
+    top: int,
+    samples: int,
+) -> int:
+    try:
+        findings = [_finding(item) for item in _load_report(report)]
+    except BanditReportError as exc:
+        message = str(exc)
+        print(_annotation("error", message) if github_annotations else f"ERROR: {message}")
+        return 2
+
+    _print_analysis(
+        findings,
+        github_annotations=github_annotations,
+        top=top,
+        samples=samples,
+    )
+    if fail_on_high and any(finding.severity == "HIGH" for finding in findings):
+        return 1
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", required=True, type=Path, help="Bandit JSON report path.")
+    parser.add_argument(
+        "--fail-on-high",
+        action="store_true",
+        help="Exit 1 when HIGH severity findings are present.",
+    )
+    parser.add_argument(
+        "--github-annotations",
+        action="store_true",
+        help="Emit GitHub Actions ::warning::/::error:: command annotations.",
+    )
+    parser.add_argument("--top", type=int, default=10, help="Maximum grouped rows to print.")
+    parser.add_argument("--samples", type=int, default=3, help="Sample locations per group.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    return summarize_report(
+        args.report,
+        fail_on_high=args.fail_on_high,
+        github_annotations=args.github_annotations,
+        top=args.top,
+        samples=args.samples,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci_bandit.sh
+++ b/scripts/ci_bandit.sh
@@ -60,7 +60,7 @@ fi
 
 if [[ -f "$SUMMARY_HELPER" ]]; then
   SUMMARY_RC=0
-  python3 "$SUMMARY_HELPER" --report "$OUTPUT" --github-annotations || SUMMARY_RC=$?
+  python3 "$SUMMARY_HELPER" --report "$OUTPUT" --fail-on-high --github-annotations || SUMMARY_RC=$?
   if [[ $SUMMARY_RC -ne 0 ]]; then
     exit "$SUMMARY_RC"
   fi

--- a/scripts/ci_bandit.sh
+++ b/scripts/ci_bandit.sh
@@ -43,6 +43,8 @@ if ! command -v bandit >/dev/null 2>&1; then
   exit 0
 fi
 
+SUMMARY_HELPER="scripts/ci/summarize_bandit_report.py"
+
 echo "[ci_bandit] Running Bandit scan (strict=${STRICT})..." >&2
 
 # Run bandit recursively; in non-strict mode do not fail pipeline on findings
@@ -50,6 +52,21 @@ set +e
 bandit -r . -x "$EXCLUDES" -f json -o "$OUTPUT" "${BANDIT_ARGS[@]}"
 RC=$?
 set -e
+
+if [[ $RC -gt 1 ]]; then
+  echo "[ci_bandit] Bandit failed to complete successfully (exit code: $RC)" >&2
+  exit "$RC"
+fi
+
+if [[ -f "$SUMMARY_HELPER" ]]; then
+  SUMMARY_RC=0
+  python3 "$SUMMARY_HELPER" --report "$OUTPUT" --github-annotations || SUMMARY_RC=$?
+  if [[ $SUMMARY_RC -ne 0 ]]; then
+    exit "$SUMMARY_RC"
+  fi
+else
+  echo "[ci_bandit] $SUMMARY_HELPER not found; skipping grouped summary" >&2
+fi
 
 if [[ "$STRICT" == "true" ]]; then
   if [[ $RC -ne 0 ]]; then

--- a/tests/guards/test_security_devtooling_regression_guards.py
+++ b/tests/guards/test_security_devtooling_regression_guards.py
@@ -471,6 +471,7 @@ def test_ci_security_job_uses_shared_bandit_summary_helper() -> None:
     assert BANDIT_SUMMARY_HELPER in gate_script
     assert "--report bandit-report.json" in gate_script
     assert "--fail-on-high" in gate_script
+    assert "--github-annotations" in gate_script
     assert "json.loads" not in gate_script
     assert "jq " not in gate_script
     assert "continue-on-error" not in gate_script
@@ -489,6 +490,7 @@ def test_security_scan_workflow_uses_shared_bandit_summary_helper() -> None:
     assert BANDIT_SUMMARY_HELPER in bandit_script
     assert "--report bandit-report.json" in bandit_script
     assert "--fail-on-high" in bandit_script
+    assert "--github-annotations" in bandit_script
     assert 'select(.issue_severity == "HIGH")' not in bandit_script
     assert "|| true" not in bandit_script
     assert "continue-on-error" not in bandit_script

--- a/tests/guards/test_security_devtooling_regression_guards.py
+++ b/tests/guards/test_security_devtooling_regression_guards.py
@@ -29,6 +29,8 @@ from scripts.evals import judgment_validity
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MAKEFILE = REPO_ROOT / "Makefile"
+CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
+SECURITY_WORKFLOW = REPO_ROOT / ".github/workflows/security.yml"
 PYTHON_DEPENDENCY_SUBMISSION = REPO_ROOT / ".github/workflows/python-dependency-submission.yml"
 NPM_DEPENDENCY_SUBMISSION = REPO_ROOT / ".github/workflows/npm-dependency-submission.yml"
 PIP_AUDIT_HELPER = REPO_ROOT / "scripts/ci_pip_audit.sh"
@@ -48,6 +50,50 @@ SECURITY_DEPENDENCY_LOCKFILES: tuple[str, ...] = tuple(
 PYTORCH_JIT_SAFETY_ID = "SFTY-20250331-30014"
 PYTORCH_JIT_CVE_ID = "CVE-2025-3000"
 PYTORCH_JIT_WAIVER_REMOVE_BY = "2026-07-17"
+BANDIT_SUMMARY_HELPER = "python3 scripts/ci/summarize_bandit_report.py"
+CI_BANDIT_EXCLUDES = {
+    "tests",
+    "tests_strict",
+    "htmlcov",
+    ".git",
+    ".venv",
+    "venv",
+    "node_modules",
+    ".mypy_cache",
+    ".pytest_cache",
+}
+SECURITY_BANDIT_EXCLUDES = {
+    "tests",
+    "test_cache",
+    "cache",
+    "frontend/build",
+    "htmlcov",
+    "releases",
+    "data",
+    "external",
+    "node_modules",
+    "dist",
+    "build",
+    ".venv",
+}
+FORBIDDEN_BANDIT_EXCLUDES = {
+    "app",
+    "app/",
+    "app/**",
+    "app/security",
+    "app/security/",
+    "app/security/**",
+    "core",
+    "core/",
+    "core/**",
+    "scripts",
+    "scripts/",
+    "scripts/**",
+    "scripts/ci",
+    "scripts/ci/",
+    "scripts/ci/**",
+    "legacy_app.py",
+}
 
 
 def _binary(name: str) -> str:
@@ -114,6 +160,18 @@ def _job_named_step(workflow: dict[str, Any], *, job_id: str, step_name: str) ->
 def _csv_values(value: object) -> set[str]:
     assert isinstance(value, str), "expected comma-separated string"
     return {item.strip() for item in value.split(",") if item.strip()}
+
+
+def _shell_assignment_values(script: str, variable_name: str) -> set[str]:
+    match = re.search(rf'^\s*{re.escape(variable_name)}="([^"]*)"', script, flags=re.MULTILINE)
+    assert match, f"missing shell assignment: {variable_name}"
+    return _csv_values(match.group(1))
+
+
+def _bandit_exclude_values(script: str) -> set[str]:
+    match = re.search(r'--exclude\s+"([^"]+)"', script)
+    assert match, "missing Bandit --exclude argument"
+    return _csv_values(match.group(1))
 
 
 def _function_source(module_path: Path, function_name: str) -> str:
@@ -392,6 +450,74 @@ def test_pytorch_jit_cve_waiver_evidence_is_scoped_and_current() -> None:
         "none",
     ):
         assert stable_marker in advisory_text
+
+
+def test_ci_security_job_uses_shared_bandit_summary_helper() -> None:
+    workflow = _workflow(CI_WORKFLOW)
+    scan_step = _job_named_step(
+        workflow,
+        job_id="security",
+        step_name="Security scan with Bandit",
+    )
+    gate_step = _job_named_step(
+        workflow,
+        job_id="security",
+        step_name="Enforce Bandit HIGH severity gate",
+    )
+    scan_script = scan_step["run"]
+    gate_script = gate_step["run"]
+
+    assert "bandit-report.json" in scan_script
+    assert BANDIT_SUMMARY_HELPER in gate_script
+    assert "--report bandit-report.json" in gate_script
+    assert "--fail-on-high" in gate_script
+    assert "json.loads" not in gate_script
+    assert "jq " not in gate_script
+    assert "continue-on-error" not in gate_script
+
+
+def test_security_scan_workflow_uses_shared_bandit_summary_helper() -> None:
+    workflow = _workflow(SECURITY_WORKFLOW)
+    bandit_step = _job_named_step(
+        workflow,
+        job_id="bandit",
+        step_name="Run Bandit (security lint)",
+    )
+    bandit_script = bandit_step["run"]
+
+    assert "bandit-report.json" in bandit_script
+    assert BANDIT_SUMMARY_HELPER in bandit_script
+    assert "--report bandit-report.json" in bandit_script
+    assert "--fail-on-high" in bandit_script
+    assert 'select(.issue_severity == "HIGH")' not in bandit_script
+    assert "|| true" not in bandit_script
+    assert "continue-on-error" not in bandit_script
+
+
+def test_bandit_excludes_do_not_widen_in_ci_workflow() -> None:
+    workflow = _workflow(CI_WORKFLOW)
+    scan_step = _job_named_step(
+        workflow,
+        job_id="security",
+        step_name="Security scan with Bandit",
+    )
+    excludes = _shell_assignment_values(scan_step["run"], "EXCLUDES")
+
+    assert excludes == CI_BANDIT_EXCLUDES
+    assert excludes.isdisjoint(FORBIDDEN_BANDIT_EXCLUDES)
+
+
+def test_bandit_excludes_do_not_widen_in_security_workflow() -> None:
+    workflow = _workflow(SECURITY_WORKFLOW)
+    bandit_step = _job_named_step(
+        workflow,
+        job_id="bandit",
+        step_name="Run Bandit (security lint)",
+    )
+    excludes = _bandit_exclude_values(bandit_step["run"])
+
+    assert excludes == SECURITY_BANDIT_EXCLUDES
+    assert excludes.isdisjoint(FORBIDDEN_BANDIT_EXCLUDES)
 
 
 def test_npm_dependency_submission_covers_root_and_frontend_lockfiles() -> None:

--- a/tests/test_python_supply_chain_controls.py
+++ b/tests/test_python_supply_chain_controls.py
@@ -919,6 +919,36 @@ def test_safety_dependency_audit_uses_shared_helper_without_shell_loop() -> None
     assert "SAFETY_API_KEY" in nightly_text
 
 
+def test_bandit_high_gate_uses_shared_summary_helper_without_inline_parsers() -> None:
+    workflow_paths = (
+        ".github/workflows/ci.yml",
+        ".github/workflows/security.yml",
+    )
+    summary_helper_text = (REPO_ROOT / "scripts" / "ci" / "summarize_bandit_report.py").read_text(
+        encoding="utf-8"
+    )
+
+    for workflow_path in workflow_paths:
+        workflow_text = (REPO_ROOT / workflow_path).read_text(encoding="utf-8")
+        step_name = (
+            "Enforce Bandit HIGH severity gate"
+            if workflow_path.endswith("ci.yml")
+            else "Run Bandit (security lint)"
+        )
+        job_name = "security" if workflow_path.endswith("ci.yml") else "bandit"
+        bandit_step = _workflow_step_by_name(workflow_path, job_name, step_name)
+        bandit_script = str(bandit_step["run"])
+
+        assert "python3 scripts/ci/summarize_bandit_report.py" in workflow_text
+        assert "--report bandit-report.json" in bandit_script
+        assert "--fail-on-high" in bandit_script
+        assert 'select(.issue_severity == "HIGH")' not in workflow_text
+        assert "json.loads(report.read_text())" not in bandit_script
+
+    assert "issue_severity" in summary_helper_text
+    assert "fail_on_high" in summary_helper_text
+
+
 def test_requirements_lock_excludes_optional_rag_vector_stack() -> None:
     requirements_lock = (REPO_ROOT / "requirements-lock.txt").read_text(encoding="utf-8")
 

--- a/tests/test_summarize_bandit_report.py
+++ b/tests/test_summarize_bandit_report.py
@@ -81,6 +81,30 @@ def test_malformed_schema_fails_closed(tmp_path: Path) -> None:
     assert ".results` must be a list" in result.stdout
 
 
+def test_missing_finding_severity_fails_closed(tmp_path: Path) -> None:
+    report = tmp_path / "bandit-report.json"
+    finding = _finding(severity="LOW")
+    del finding["issue_severity"]
+    _write_report(report, [finding])
+
+    result = _run_helper(report, "--fail-on-high")
+
+    assert result.returncode == 2
+    assert "missing string `issue_severity`" in result.stdout
+    assert "HIGH severity findings: 0" not in result.stdout
+
+
+def test_unknown_finding_severity_fails_closed(tmp_path: Path) -> None:
+    report = tmp_path / "bandit-report.json"
+    _write_report(report, [_finding(severity="CRITICAL")])
+
+    result = _run_helper(report, "--fail-on-high")
+
+    assert result.returncode == 2
+    assert "unsupported `issue_severity`: CRITICAL" in result.stdout
+    assert "HIGH severity findings: 0" not in result.stdout
+
+
 def test_high_severity_findings_fail_even_with_lower_findings(tmp_path: Path) -> None:
     report = tmp_path / "bandit-report.json"
     _write_report(

--- a/tests/test_summarize_bandit_report.py
+++ b/tests/test_summarize_bandit_report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -161,6 +162,37 @@ def test_summary_output_is_deterministically_sorted(tmp_path: Path) -> None:
     assert first.stdout.index("scripts/a.py:1") < first.stdout.index("scripts/z.py:2")
 
 
+def test_equal_count_summary_groups_follow_severity_order(tmp_path: Path) -> None:
+    report = tmp_path / "bandit-report.json"
+    _write_report(
+        report,
+        [
+            _finding(severity="LOW", test_id="B101", filename="app/low.py"),
+            _finding(severity="MEDIUM", test_id="B602", filename="app/medium.py"),
+        ],
+    )
+
+    result = _run_helper(report, "--fail-on-high")
+
+    assert result.returncode == 0
+    assert result.stdout.index("MEDIUM | HIGH confidence | B602") < result.stdout.index(
+        "LOW | HIGH confidence | B101"
+    )
+
+
+def test_github_workflow_path_bucket_is_reachable(tmp_path: Path) -> None:
+    report = tmp_path / "bandit-report.json"
+    _write_report(
+        report,
+        [_finding(severity="LOW", test_id="B101", filename="./.github/workflows/ci.yml")],
+    )
+
+    result = _run_helper(report, "--fail-on-high")
+
+    assert result.returncode == 0
+    assert "LOW | HIGH confidence | B101 | github/workflows: 1" in result.stdout
+
+
 def test_github_annotation_escapes_bandit_control_characters(tmp_path: Path) -> None:
     report = tmp_path / "bandit-report.json"
     _write_report(
@@ -183,3 +215,105 @@ def test_github_annotation_escapes_bandit_control_characters(tmp_path: Path) -> 
     assert "%0A" in annotation
     assert "\n::warning:: injected" not in annotation
     assert "\rline" not in annotation
+
+
+def test_bandit_derived_raw_output_cannot_emit_workflow_commands(tmp_path: Path) -> None:
+    report = tmp_path / "bandit-report.json"
+    _write_report(
+        report,
+        [
+            _finding(
+                severity="HIGH",
+                test_id="B999\n::error:: injected",
+                filename="app/security/high.py\n::add-mask::secret",
+                issue_text="high\n::warning:: injected",
+            ),
+            _finding(
+                severity="LOW",
+                test_id="B101\n::warning:: injected",
+                filename="tests/low.py",
+            ),
+        ],
+    )
+
+    result = _run_helper(report, "--fail-on-high")
+
+    assert result.returncode == 1
+    command_lines = [
+        line
+        for line in result.stdout.splitlines()
+        if line.startswith(("::warning:: injected", "::error:: injected", "::add-mask::"))
+    ]
+    assert command_lines == []
+
+
+def _write_fake_bandit(fake_bin: Path, *, severity: str) -> None:
+    fake_bin.mkdir()
+    fake_bandit = fake_bin / "bandit"
+    fake_bandit.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [[ -z "$output" ]]; then
+  exit 2
+fi
+cat > "$output" <<'JSON'
+{{"results":[{{"filename":"app/security/example.py","issue_confidence":"HIGH","issue_severity":"{severity}","issue_text":"fake finding","line_number":1,"test_id":"B999"}}]}}
+JSON
+exit 1
+""",
+        encoding="utf-8",
+    )
+    fake_bandit.chmod(0o755)
+
+
+def _run_ci_bandit_with_fake_bandit(
+    tmp_path: Path, *, severity: str
+) -> subprocess.CompletedProcess[str]:
+    fake_bin = tmp_path / "fake-bin"
+    _write_fake_bandit(fake_bin, severity=severity)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+    }
+    return subprocess.run(
+        [
+            "bash",
+            "scripts/ci_bandit.sh",
+            "--exclude",
+            "tests",
+            "--output",
+            str(tmp_path / "bandit-report.json"),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_ci_bandit_wrapper_fails_high_findings_in_non_strict_mode(tmp_path: Path) -> None:
+    result = _run_ci_bandit_with_fake_bandit(tmp_path, severity="HIGH")
+
+    assert result.returncode == 1
+    assert "::error::Bandit found 1 HIGH severity issue" in result.stdout
+
+
+def test_ci_bandit_wrapper_keeps_lower_findings_warning_only(tmp_path: Path) -> None:
+    result = _run_ci_bandit_with_fake_bandit(tmp_path, severity="LOW")
+
+    assert result.returncode == 0
+    assert "::warning::Bandit reported 1 findings below HIGH severity" in result.stdout
+    assert "continuing (non-strict)" in result.stderr

--- a/tests/test_summarize_bandit_report.py
+++ b/tests/test_summarize_bandit_report.py
@@ -1,0 +1,185 @@
+"""Tests for deterministic Bandit report summarization."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELPER = REPO_ROOT / "scripts" / "ci" / "summarize_bandit_report.py"
+
+
+def _finding(
+    *,
+    severity: str,
+    confidence: str = "HIGH",
+    test_id: str = "B602",
+    filename: str = "scripts/example.py",
+    line_number: int = 10,
+    issue_text: str = "example finding",
+) -> dict[str, object]:
+    return {
+        "filename": filename,
+        "issue_confidence": confidence,
+        "issue_severity": severity,
+        "issue_text": issue_text,
+        "line_number": line_number,
+        "test_id": test_id,
+    }
+
+
+def _write_report(path: Path, results: list[dict[str, object]]) -> None:
+    path.write_text(json.dumps({"results": results}), encoding="utf-8")
+
+
+def _run_helper(report: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(HELPER),
+            "--report",
+            str(report),
+            "--github-annotations",
+            *extra_args,
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_missing_report_fails_closed(tmp_path: Path) -> None:
+    result = _run_helper(tmp_path / "missing.json", "--fail-on-high")
+
+    assert result.returncode == 2
+    assert "::error::Bandit report not found" in result.stdout
+    assert "::warning::" not in result.stdout
+
+
+def test_malformed_json_fails_closed(tmp_path: Path) -> None:
+    report = tmp_path / "bandit-report.json"
+    report.write_text("{not valid", encoding="utf-8")
+
+    result = _run_helper(report, "--fail-on-high")
+
+    assert result.returncode == 2
+    assert "::error::Bandit report is not valid JSON" in result.stdout
+    assert "Traceback" not in result.stderr
+
+
+def test_malformed_schema_fails_closed(tmp_path: Path) -> None:
+    report = tmp_path / "bandit-report.json"
+    report.write_text(json.dumps({"results": {"bad": "shape"}}), encoding="utf-8")
+
+    result = _run_helper(report, "--fail-on-high")
+
+    assert result.returncode == 2
+    assert ".results` must be a list" in result.stdout
+
+
+def test_high_severity_findings_fail_even_with_lower_findings(tmp_path: Path) -> None:
+    report = tmp_path / "bandit-report.json"
+    _write_report(
+        report,
+        [
+            _finding(severity="MEDIUM", filename="scripts/medium.py", line_number=5),
+            _finding(
+                severity="HIGH",
+                confidence="MEDIUM",
+                test_id="B999",
+                filename="app/security/high.py",
+                line_number=12,
+                issue_text="high risk",
+            ),
+            _finding(severity="LOW", filename="legacy_app.py", line_number=20),
+        ],
+    )
+
+    result = _run_helper(report, "--fail-on-high")
+
+    assert result.returncode == 1
+    assert "::error::Bandit found 1 HIGH severity issue" in result.stdout
+    assert "B999 | MEDIUM confidence | app/security/high.py:12 | high risk" in result.stdout
+    assert "::warning::Bandit reported 2 findings below HIGH severity" in result.stdout
+
+
+def test_low_and_medium_findings_warn_but_do_not_fail(tmp_path: Path) -> None:
+    report = tmp_path / "bandit-report.json"
+    _write_report(
+        report,
+        [
+            _finding(severity="LOW", confidence="LOW", test_id="B101", filename="app/main.py"),
+            _finding(severity="MEDIUM", test_id="B602", filename="scripts/ci/tool.py"),
+            _finding(severity="MEDIUM", test_id="B602", filename="scripts/ci/other.py"),
+        ],
+    )
+
+    result = _run_helper(report, "--fail-on-high")
+
+    assert result.returncode == 0
+    assert "::error::" not in result.stdout
+    assert "::warning::Bandit reported 3 findings below HIGH severity" in result.stdout
+    assert "MEDIUM | HIGH confidence | B602 | scripts/ci: 2" in result.stdout
+    assert "LOW | LOW confidence | B101 | app: 1" in result.stdout
+
+
+def test_clean_report_exits_zero_without_warning(tmp_path: Path) -> None:
+    report = tmp_path / "bandit-report.json"
+    _write_report(report, [])
+
+    result = _run_helper(report, "--fail-on-high")
+
+    assert result.returncode == 0
+    assert "No HIGH severity issues found in Bandit report" in result.stdout
+    assert "::warning::" not in result.stdout
+    assert "::error::" not in result.stdout
+
+
+def test_summary_output_is_deterministically_sorted(tmp_path: Path) -> None:
+    findings = [
+        _finding(severity="MEDIUM", test_id="B602", filename="scripts/z.py", line_number=2),
+        _finding(severity="LOW", test_id="B101", filename="app/a.py", line_number=7),
+        _finding(severity="MEDIUM", test_id="B602", filename="scripts/a.py", line_number=1),
+    ]
+    first_report = tmp_path / "first.json"
+    second_report = tmp_path / "second.json"
+    _write_report(first_report, findings)
+    _write_report(second_report, list(reversed(findings)))
+
+    first = _run_helper(first_report, "--fail-on-high")
+    second = _run_helper(second_report, "--fail-on-high")
+
+    assert first.returncode == 0
+    assert second.returncode == 0
+    assert first.stdout.replace(str(first_report), "<report>") == second.stdout.replace(
+        str(second_report),
+        "<report>",
+    )
+    assert first.stdout.index("scripts/a.py:1") < first.stdout.index("scripts/z.py:2")
+
+
+def test_github_annotation_escapes_bandit_control_characters(tmp_path: Path) -> None:
+    report = tmp_path / "bandit-report.json"
+    _write_report(
+        report,
+        [
+            _finding(
+                severity="LOW",
+                test_id="B%1\n::warning:: injected\rline",
+                issue_text="percent marker",
+            )
+        ],
+    )
+
+    result = _run_helper(report, "--fail-on-high")
+
+    assert result.returncode == 0
+    annotation = next(line for line in result.stdout.splitlines() if line.startswith("::warning::"))
+    assert "%25" in annotation
+    assert "%0D" in annotation
+    assert "%0A" in annotation
+    assert "\n::warning:: injected" not in annotation
+    assert "\rline" not in annotation


### PR DESCRIPTION
## Goal
Baseline Bandit lower-severity inventory so `CI / security` keeps HIGH findings fail-closed while LOW/MEDIUM findings become grouped, deterministic remediation evidence instead of one raw count.

## Business reason
Security debt is now visible after the Safety/Trivy/Bandit hardening train. This PR turns the 37k below-HIGH Bandit warning into an auditable backlog without widening the release gate or hiding real risk.

## Scope
- Add `scripts/ci/summarize_bandit_report.py` for deterministic Bandit JSON grouping by rule id, severity, confidence, and path bucket.
- Wire canonical `CI`, scheduled `Security Scan`, and `scripts/ci_bandit.sh` through the shared helper.
- Preserve HIGH fail-closed behavior and leave LOW/MEDIUM warning-only.
- Guard workflow parser usage, `--github-annotations`, wrapper HIGH behavior, output sanitization, and Bandit exclude boundaries.
- Add focused evidence and backlog tracking for phased lower-severity remediation.

## Out of scope
- No dependency bumps, requirements cleanup, eval/data locks, legacy extraction, FoodDB, auth/BOLA, frontend/iOS/macOS runtime behavior, pyproject migration, mass `# nosec`, or MEDIUM gate tightening.
- Does not close the remaining Dependabot torch alerts. Current default-branch snapshot reported 3 low alerts after push.

## Lane Start Provenance
- Packet: `artifacts/orchestration/task_packets/ee3353e7b384.json`
- Starter: `scripts/orchestration/start_pr_lane.sh`
- Branch: `codex/bandit-lower-severity-inventory-baseline`
- Base: `origin/main` at `74fddbcee3d207f40703386c0f76fa66efe0fbaa`.
- Operator exception at branch start: current-head `main` was pending with no failed jobs; before PR open, canonical `CI` for `74fddbcee` completed success.

## Role Passes
- Pre-open role order completed: `agent-coordinator -> security-auditor -> backend-engineer -> qa-engineer-agent -> bug-hunter -> architecture-specialist`.
- Post-open `qa-engineer-agent` completed; findings fixed in `d4cafeadc`.
- Post-open `bug-hunter` completed; findings fixed in `d4cafeadc` and mapping/body fixes in `637f49c2d`.
- Post-open `security-auditor` completed; finding fixed in `d6a0e6e31`.
- Codex Security diff scan completed; no surviving reportable findings after 11/11 diff/supporting file receipts.
- `pulseplate-pr-review` completed; advisory large-diff review risk dispositioned as NOT-A-BUG with narrow scope and gate evidence.

## Premortem
- Finding: scheduled Security Scan could keep stale inline parsing and create false-green Bandit evidence. Disposition: FIXED by routing both workflows through `scripts/ci/summarize_bandit_report.py`.
- Finding: lower-severity reporting could accidentally weaken HIGH fail-closed behavior. Disposition: FIXED by helper and wrapper exit semantics, workflow guards, unit tests, and Bandit wrapper smoke.
- Finding: inventory could become a substitute for remediation. Disposition: DEFERRED with backlog tracking in `docs/roadmap/BACKLOG_LEDGER.md#ledger-p1-bandit-lower-severity-remediation`.

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/exp-5662555828dd.json`

- Oracle commands executed: focused summarizer/workflow guard tests and Python supply-chain Bandit guard test.
- Result: accepted; shared tree untouched; source diff applied; co-author trailer included in commit `38e287899`.

## Tests
- `python3 scripts/orchestration/check_preflight.py` - pass
- `python3 scripts/orchestration/check_agent_consistency.py` - pass
- `.venv/bin/python -m pytest -q tests/test_summarize_bandit_report.py tests/guards/test_security_devtooling_regression_guards.py tests/test_python_supply_chain_controls.py tests/test_ci_workflow_pr_size_governance_contract.py` - pass, 106 tests
- `.venv/bin/python -m pytest -q tests/guards/test_security_devtooling_regression_guards.py tests/test_python_supply_chain_controls.py` - pass, 69 tests
- `.venv/bin/python -m pytest -q tests/test_summarize_bandit_report.py tests/guards/test_security_devtooling_regression_guards.py tests/test_python_supply_chain_controls.py` - pass, 84 tests
- `.venv/bin/python -m pytest -q tests/test_summarize_bandit_report.py tests/guards/test_security_devtooling_regression_guards.py -k 'bandit or summarize'` - pass, 17 tests
- `.venv/bin/python -m pytest -q tests/test_summarize_bandit_report.py` - pass, 15 tests
- `python3 scripts/ci/check_docs_phase1_gates.py --files docs/security/BANDIT_LOWER_SEVERITY_INVENTORY.md docs/roadmap/BACKLOG_LEDGER.md docs/review/PR_1990_FIXED_MAPPING.md` - pass
- `python3 scripts/ci/check_pr_body_phase2_gates.py --pr-number 1990 --commit-range origin/main..HEAD` - pass for canonical artifact
- `make validate-changed` - pass; selected the changed Bandit/security test surface after commit
- `PATH=".../.venv/bin:$PATH" bash scripts/ci_bandit.sh --exclude "tests,tests_strict,htmlcov,.git,.venv,venv,node_modules,.mypy_cache,.pytest_cache" --output /tmp/bandit-report.json` - pass; 0 HIGH, 37,598 below-HIGH grouped findings
- `pre-commit run --all-files` - pass
- Push hooks - pass, including backend pre-push tests, full-repo Bandit pre-push, and docker build test
- Codex Security diff scan - pass; report `/tmp/codex-security-scans/bandit-lower-severity-inventory-baseline/541546e53f90_20260617T194529Z/report.md`, HTML `/tmp/codex-security-scans/bandit-lower-severity-inventory-baseline/541546e53f90_20260617T194529Z/report.html`
- `pulseplate-pr-review` dry run - pass; advisory large-diff review risk only, dispositioned as NOT-A-BUG

## Machine-heavy deferral
Operator-approved exception: full local `make verify` was not run for this CI/tooling security PR. Narrow local gates, pre-commit, pre-push hooks, Experiment Runner oracle evidence, and current-head CI are used instead.

## Security notes
No fail-closed behavior is weakened. The HIGH gate remains blocking, malformed or missing Bandit JSON is fatal, lower-severity findings are warning-only with grouped evidence, and Bandit-derived raw display output is sanitized against workflow-command injection. No new suppressions or allowlist entries were added.

## Risks / rollback
Rollback is reverting this PR to restore the prior inline Bandit parsing. The main risk is CI-output formatting drift; guard tests cover helper usage, exclude boundaries, malformed reports, deterministic ordering, empty reports, HIGH visibility, GitHub annotation escaping, wrapper HIGH behavior, and output sanitization.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1990_FIXED_MAPPING.md`

## Merge Readiness
- [ ] Current-head PR CI complete and passing.
- [ ] No unresolved actionable review or bot comments.
- [x] Post-open `security-auditor` pass complete.
- [x] Codex Security diff scan and `pulseplate-pr-review` complete.
- [ ] Strict merge-readiness with auth passes.
- [ ] Mandatory wait-window satisfied.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Bandit CI/security gating to use a shared summarized-report helper for severity handling: **HIGH fails the gate**, while **LOW/MEDIUM remain warning-only**.
  * Improved GitHub annotations for scan results and added targeted warnings when scans in test directories report issues.
* **Documentation**
  * Refreshed Bandit lower-severity inventory policy and updated CI guard/backlog remediation guidance; added a fixed-mapping review artifact.
* **Tests**
  * Expanded regression coverage for helper consistency, deterministic output ordering, and stronger safety against malformed/unsafe scan output.
* **Chores**
  * Updated the secrets baseline reference data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
