### PR TITLE
chore(security): add production runtime invariant guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1040,6 +1040,7 @@ jobs:
                   tests/test_metrics.py \
                   tests/test_paywall_exposure_ledger_api.py \
                   tests/test_paywall_exposure_ledger_service.py \
+                  tests/test_production_runtime_invariants.py \
                   tests/test_pro_vip_route_dependency_guard.py \
                   tests/test_semantic_cache_bounded_insight_experiment_contract.py \
                   tests/test_semantic_cache_backend_selection_contract.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,6 +472,11 @@ jobs:
           requirements-profile: ci-lite
           install-mode: direct-proxy
 
+      - name: Production runtime invariant guard
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check_production_runtime_invariants.py --synthetic-production
+
       - name: Security scan with Bandit
         run: |
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -760,6 +760,7 @@ jobs:
                   tests/test_metrics.py \
                   tests/test_paywall_exposure_ledger_api.py \
                   tests/test_paywall_exposure_ledger_service.py \
+                  tests/test_production_runtime_invariants.py \
                   tests/test_pro_vip_route_dependency_guard.py \
                   tests/test_semantic_cache_bounded_insight_experiment_contract.py \
                   tests/test_semantic_cache_backend_selection_contract.py \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,6 +42,11 @@ jobs:
           fi
           python -m pip install "${pip_index_args[@]}" "safety>=3.8.1" -c constraints.txt
 
+      - name: Production runtime invariant guard
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/check_production_runtime_invariants.py --synthetic-production
+
       - name: Run Bandit (security lint)
         run: |
           set -euo pipefail

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,7 +166,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 640
+        "line_number": 645
       }
     ],
     ".github/workflows/frontend-ci.yml": [
@@ -1743,5 +1743,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-18T07:38:11Z"
+  "generated_at": "2026-06-18T11:30:10Z"
 }

--- a/app/bootstrap/startup_guards.py
+++ b/app/bootstrap/startup_guards.py
@@ -12,6 +12,7 @@ from app.security.llm_monthly_quota import (
     require_pro_llm_monthly_limit,
     require_vip_llm_monthly_limit,
 )
+from app.security.production_invariants import assert_production_runtime_invariants
 from app.security.server_salt import require_server_salt
 from settings import (
     get_runtime_env_name,
@@ -54,3 +55,4 @@ def run_startup_guards() -> None:
     validate_apple_receipt_verification_config()
     validate_api_key_toggle_guard()
     _require_subscription_db_in_production_like_env()
+    assert_production_runtime_invariants()

--- a/app/bootstrap/startup_guards.py
+++ b/app/bootstrap/startup_guards.py
@@ -42,7 +42,7 @@ def _require_subscription_db_in_production_like_env() -> None:
     )
 
 
-def run_startup_guards() -> None:
+def run_startup_guards(app: object | None = None) -> None:
     """Execute startup-time hard guards before the app serves traffic.
 
     RU: Выполняет обязательные startup guards до начала обработки запросов.
@@ -55,4 +55,4 @@ def run_startup_guards() -> None:
     validate_apple_receipt_verification_config()
     validate_api_key_toggle_guard()
     _require_subscription_db_in_production_like_env()
-    assert_production_runtime_invariants()
+    assert_production_runtime_invariants(app=app)

--- a/app/security/production_invariants.py
+++ b/app/security/production_invariants.py
@@ -18,8 +18,8 @@ from settings import (
     validate_apple_receipt_verification_config,
 )
 
-_PRODUCTION_TRUE_FLAGS = ("API_KEY_REQUIRED", "SUBSCRIPTION_DB_ENABLED")
-_PRODUCTION_FALSE_FLAGS = (
+PRODUCTION_TRUE_FLAGS = ("API_KEY_REQUIRED", "SUBSCRIPTION_DB_ENABLED")
+PRODUCTION_FALSE_FLAGS = (
     "ALLOW_DEV_API_KEY",
     "ALLOW_ANONYMOUS_API_KEYS",
     "DEBUG",
@@ -46,7 +46,7 @@ def _runtime_env_label() -> str:
 def _require_truthy_env_flags() -> None:
     """Require production/staging flags that must be explicitly enabled."""
 
-    missing = [flag for flag in _PRODUCTION_TRUE_FLAGS if not is_truthy_env_var(flag, "false")]
+    missing = [flag for flag in PRODUCTION_TRUE_FLAGS if not is_truthy_env_var(flag, "false")]
     if missing:
         joined = ", ".join(missing)
         raise RuntimeError(
@@ -58,7 +58,7 @@ def _require_truthy_env_flags() -> None:
 def _reject_truthy_env_flags() -> None:
     """Reject dev/test/debug escape hatches in production/staging."""
 
-    invalid = [flag for flag in _PRODUCTION_FALSE_FLAGS if is_truthy_env_var(flag, "false")]
+    invalid = [flag for flag in PRODUCTION_FALSE_FLAGS if is_truthy_env_var(flag, "false")]
     if invalid:
         joined = ", ".join(invalid)
         raise RuntimeError(
@@ -122,4 +122,8 @@ def assert_production_runtime_invariants() -> None:
     require_rate_limiting_ready_for_production()
 
 
-__all__ = ["assert_production_runtime_invariants"]
+__all__ = [
+    "PRODUCTION_FALSE_FLAGS",
+    "PRODUCTION_TRUE_FLAGS",
+    "assert_production_runtime_invariants",
+]

--- a/app/security/production_invariants.py
+++ b/app/security/production_invariants.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from typing import Any
 
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import ArgumentError
@@ -106,7 +107,7 @@ def _require_private_exports_enabled() -> None:
         )
 
 
-def assert_production_runtime_invariants() -> None:
+def assert_production_runtime_invariants(app: Any | None = None) -> None:
     """Fail closed when production/staging runtime posture is unsafe."""
 
     if not is_production_like_env():
@@ -119,7 +120,7 @@ def assert_production_runtime_invariants() -> None:
     validate_apple_receipt_verification_config()
     _require_private_exports_enabled()
     _require_production_database_url()
-    require_rate_limiting_ready_for_production()
+    require_rate_limiting_ready_for_production(app=app)
 
 
 __all__ = [

--- a/app/security/production_invariants.py
+++ b/app/security/production_invariants.py
@@ -1,0 +1,125 @@
+"""Fail-closed production/staging runtime invariant guards."""
+
+from __future__ import annotations
+
+import os
+
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ArgumentError
+from app.security.rate_limit import require_rate_limiting_ready_for_production
+from app.security.server_salt import require_server_salt
+from settings import (
+    get_export_token_secret,
+    get_runtime_env_name,
+    is_private_exports_enabled,
+    is_production_like_env,
+    is_truthy_env_var,
+    validate_api_key_toggle_guard,
+    validate_apple_receipt_verification_config,
+)
+
+_PRODUCTION_TRUE_FLAGS = ("API_KEY_REQUIRED", "SUBSCRIPTION_DB_ENABLED")
+_PRODUCTION_FALSE_FLAGS = (
+    "ALLOW_DEV_API_KEY",
+    "ALLOW_ANONYMOUS_API_KEYS",
+    "DEBUG",
+    "TESTING",
+    "ENABLE_TEST_ROUTES",
+    "ENABLE_DEBUG_ENDPOINT",
+    "METRICS_TEST_BYPASS",
+)
+_EXPORT_SIGNING_PLACEHOLDERS = frozenset(
+    {
+        "__set_me__",
+        "replace_me",
+        "replace_me_with_export_secret",
+    }
+)
+
+
+def _runtime_env_label() -> str:
+    """Return safe env label for error messages."""
+
+    return get_runtime_env_name() or "unknown"
+
+
+def _require_truthy_env_flags() -> None:
+    """Require production/staging flags that must be explicitly enabled."""
+
+    missing = [flag for flag in _PRODUCTION_TRUE_FLAGS if not is_truthy_env_var(flag, "false")]
+    if missing:
+        joined = ", ".join(missing)
+        raise RuntimeError(
+            f"{joined} must be true in production/staging environments "
+            f"(current env: {_runtime_env_label()})."
+        )
+
+
+def _reject_truthy_env_flags() -> None:
+    """Reject dev/test/debug escape hatches in production/staging."""
+
+    invalid = [flag for flag in _PRODUCTION_FALSE_FLAGS if is_truthy_env_var(flag, "false")]
+    if invalid:
+        joined = ", ".join(invalid)
+        raise RuntimeError(
+            f"{joined} must be false in production/staging environments "
+            f"(current env: {_runtime_env_label()})."
+        )
+
+
+def _require_production_database_url() -> None:
+    """Require a canonical Postgres DATABASE_URL in production/staging."""
+
+    database_url = (os.getenv("DATABASE_URL") or "").strip()
+    if not database_url:
+        raise RuntimeError(
+            "DATABASE_URL is required in production-like environments "
+            f"(resolved env: {_runtime_env_label()})."
+        )
+    try:
+        backend_name = make_url(database_url).get_backend_name().lower()
+    except ArgumentError as exc:
+        raise RuntimeError(
+            "DATABASE_URL must be a valid PostgreSQL URL in production/staging "
+            f"environments (current env: {_runtime_env_label()})."
+        ) from exc
+    if backend_name != "postgresql":
+        raise RuntimeError(
+            "DATABASE_URL must use PostgreSQL in production/staging environments "
+            f"(current env: {_runtime_env_label()})."
+        )
+
+
+def _require_private_exports_enabled() -> None:
+    """Require signed export links in production/staging."""
+
+    if not is_private_exports_enabled():
+        raise RuntimeError(
+            "PRIVATE_EXPORTS_ENABLED must be true in production/staging environments; "
+            "disabling it makes export token validation a no-op."
+        )
+    secret = get_export_token_secret().strip()
+    if not secret or secret.lower() in _EXPORT_SIGNING_PLACEHOLDERS:
+        raise RuntimeError(
+            "EXPORT_TOKEN_SECRET must be set to a non-default secret in "
+            "production/staging environments."
+        )
+
+
+def assert_production_runtime_invariants() -> None:
+    """Fail closed when production/staging runtime posture is unsafe."""
+
+    if not is_production_like_env():
+        return
+
+    _reject_truthy_env_flags()
+    _require_truthy_env_flags()
+    validate_api_key_toggle_guard()
+    require_server_salt()
+    validate_apple_receipt_verification_config()
+    _require_private_exports_enabled()
+    _require_production_database_url()
+    require_rate_limiting_ready_for_production()
+
+
+__all__ = ["assert_production_runtime_invariants"]

--- a/app/security/rate_limit.py
+++ b/app/security/rate_limit.py
@@ -293,6 +293,29 @@ def wire_rate_limiting(app: FastAPI) -> None:
     logger.info("Rate limiting enabled (slowapi)")
 
 
+def require_rate_limiting_ready_for_production() -> None:
+    """Fail closed when production/staging cannot enforce rate limits."""
+
+    from settings import is_production_like_env, is_truthy_env_var
+
+    if not is_production_like_env():
+        return
+    if is_truthy_env_var("TESTING", "false"):
+        raise RuntimeError(
+            "TESTING must be false in production/staging environments; "
+            "it can disable rate limiting."
+        )
+    if limiter is None:
+        raise RuntimeError("SlowAPI limiter is required in production/staging environments.")
+    if RateLimitExceeded is None or SlowAPIMiddleware is None:
+        raise RuntimeError(
+            "SlowAPI middleware and exception handler are required in "
+            "production/staging environments."
+        )
+    if not _rate_limiting_enabled() or not getattr(limiter, "enabled", True):
+        raise RuntimeError("Rate limiting must be enabled in production/staging environments.")
+
+
 LimitValue = str | Callable[[], str]
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -328,6 +351,7 @@ __all__ = [
     "rate_limit_client_key",
     "wire_rate_limiting",
     "limit_if_available",
+    "require_rate_limiting_ready_for_production",
     "RATE_LIMIT_429_RESPONSES",
     "RateLimitErrorResponse",
     "RATE_LIMIT_INSIGHT",

--- a/app/security/rate_limit.py
+++ b/app/security/rate_limit.py
@@ -217,6 +217,8 @@ except ImportError:  # pragma: no cover - optional dependency
     SlowAPIMiddleware = None  # type: ignore[misc,assignment]
     _rate_limit_exceeded_handler = None  # type: ignore[assignment]
 
+_rate_limiting_app_wired = False
+
 
 def _rate_limit_exceeded_json_handler(request: Request, exc: Exception) -> JSONResponse:
     """Return JSON error envelope for 429 rate limit exceeded.
@@ -290,6 +292,8 @@ def wire_rate_limiting(app: FastAPI) -> None:
     if SlowAPIMiddleware is not None:
         app.add_middleware(SlowAPIMiddleware)
 
+    global _rate_limiting_app_wired
+    _rate_limiting_app_wired = True
     logger.info("Rate limiting enabled (slowapi)")
 
 
@@ -314,6 +318,11 @@ def require_rate_limiting_ready_for_production() -> None:
         )
     if not _rate_limiting_enabled() or not getattr(limiter, "enabled", True):
         raise RuntimeError("Rate limiting must be enabled in production/staging environments.")
+    if not _rate_limiting_app_wired:
+        raise RuntimeError(
+            "SlowAPI rate limiting must be wired into the FastAPI app before serving "
+            "production/staging traffic."
+        )
 
 
 LimitValue = str | Callable[[], str]

--- a/app/security/rate_limit.py
+++ b/app/security/rate_limit.py
@@ -217,7 +217,7 @@ except ImportError:  # pragma: no cover - optional dependency
     SlowAPIMiddleware = None  # type: ignore[misc,assignment]
     _rate_limit_exceeded_handler = None  # type: ignore[assignment]
 
-_rate_limiting_app_wired = False
+_rate_limiting_wired_app_ids: set[int] = set()
 
 
 def _rate_limit_exceeded_json_handler(request: Request, exc: Exception) -> JSONResponse:
@@ -292,12 +292,22 @@ def wire_rate_limiting(app: FastAPI) -> None:
     if SlowAPIMiddleware is not None:
         app.add_middleware(SlowAPIMiddleware)
 
-    global _rate_limiting_app_wired
-    _rate_limiting_app_wired = True
+    _rate_limiting_wired_app_ids.add(id(app))
     logger.info("Rate limiting enabled (slowapi)")
 
 
-def require_rate_limiting_ready_for_production() -> None:
+def _is_rate_limiting_wired_for_app(app: FastAPI | None) -> bool:
+    if app is None:
+        return bool(_rate_limiting_wired_app_ids)
+    return (
+        id(app) in _rate_limiting_wired_app_ids
+        and getattr(app.state, "limiter", None) is limiter
+        and RateLimitExceeded in app.exception_handlers
+        and any(middleware.cls is SlowAPIMiddleware for middleware in app.user_middleware)
+    )
+
+
+def require_rate_limiting_ready_for_production(app: FastAPI | None = None) -> None:
     """Fail closed when production/staging cannot enforce rate limits."""
 
     from settings import is_production_like_env, is_truthy_env_var
@@ -318,7 +328,7 @@ def require_rate_limiting_ready_for_production() -> None:
         )
     if not _rate_limiting_enabled() or not getattr(limiter, "enabled", True):
         raise RuntimeError("Rate limiting must be enabled in production/staging environments.")
-    if not _rate_limiting_app_wired:
+    if not _is_rate_limiting_wired_for_app(app):
         raise RuntimeError(
             "SlowAPI rate limiting must be wired into the FastAPI app before serving "
             "production/staging traffic."

--- a/app/security/rate_limit.py
+++ b/app/security/rate_limit.py
@@ -297,6 +297,8 @@ def wire_rate_limiting(app: FastAPI) -> None:
 
 
 def _is_rate_limiting_wired_for_app(app: FastAPI | None) -> bool:
+    # app=None is reserved for focused tests/CI that validate the other
+    # production invariants with a pre-populated wired-app receipt.
     if app is None:
         return bool(_rate_limiting_wired_app_ids)
     return (

--- a/app/security/web_session.py
+++ b/app/security/web_session.py
@@ -21,6 +21,7 @@ from cryptography.fernet import Fernet, InvalidToken
 from fastapi import Response
 
 from app.security.server_salt import require_server_salt
+from settings import is_explicit_developer_env, is_production_like_env
 
 WEB_SESSION_COOKIE_NAME = "pp_web_session"
 WEB_SESSION_TTL_ENV = "WEB_SESSION_TTL_SECONDS"
@@ -311,8 +312,9 @@ def verify_web_session(
 def _is_secure_cookie_environment() -> bool:
     """Return Secure-cookie mode (fail-closed by default)."""
 
-    app_env = (os.getenv("APP_ENV") or "").strip().lower()
-    return app_env not in {"local", "dev", "development", "test"}
+    if is_production_like_env():
+        return True
+    return not is_explicit_developer_env()
 
 
 def set_web_session_cookie(

--- a/docs/review/PRODUCTION_RUNTIME_INVARIANTS_PREMORTEM.md
+++ b/docs/review/PRODUCTION_RUNTIME_INVARIANTS_PREMORTEM.md
@@ -1,0 +1,78 @@
+# Production Runtime Invariants Premortem
+
+Mode: `pr-premortem`
+
+Skill: `pulseplate-premortem-risk-review`
+
+Packet: `artifacts/orchestration/task_packets/3112b85f242c.json`
+
+Frame: It is 48 hours from now. This security guard PR made things worse. We are
+looking backward to understand why.
+
+## Summary
+
+This PR adds fail-closed production/staging runtime invariant guards for
+security posture, rate limiting, private exports, secure cookies, and synthetic
+CI verification.
+
+## Most Likely Failure
+
+The most likely failure is a false-green guard caused by tests exercising only
+the synthetic helper while startup behavior or workflow wiring drifts. The PR
+closes this by calling `assert_production_runtime_invariants()` from
+`run_startup_guards()`, adding workflow-contract tests for both security
+workflows, and covering the startup wiring directly.
+
+Disposition: FIXED
+
+Evidence:
+
+- `app/bootstrap/startup_guards.py`
+- `tests/test_production_runtime_invariants.py::test_startup_guards_call_production_invariants`
+- `tests/guards/test_security_devtooling_regression_guards.py::test_security_workflows_run_production_runtime_invariant_guard`
+
+## Most Dangerous Failure
+
+The most dangerous failure is accidentally weakening production protections by
+making a readiness assertion mutate shared limiter state or accept malformed
+production DB URLs. That would let CI repair unsafe runtime state instead of
+proving it is safe. The PR closes this with read-only rate-limit readiness,
+PostgreSQL URL validation, and explicit regression tests.
+
+Disposition: FIXED
+
+Evidence:
+
+- `app/security/rate_limit.py`
+- `app/security/production_invariants.py`
+- `tests/test_production_runtime_invariants.py::test_rate_limit_readiness_does_not_mutate_limiter_state`
+- `tests/test_production_runtime_invariants.py::test_production_runtime_invariants_reject_non_postgres_database_url`
+
+## Hidden Assumption
+
+The hidden assumption was that existing settings helpers enforce every
+production-like mode consistently. They already cover explicit production,
+prod, and staging, but the new guard treats unknown runtime labels with
+`DEBUG=false` as production-like too. The PR closes this by enforcing export
+secret placeholders inside the production invariant layer itself.
+
+Disposition: FIXED
+
+Evidence:
+
+- `app/security/production_invariants.py`
+- `tests/test_production_runtime_invariants.py::test_production_runtime_invariants_reject_export_secret_placeholder_for_unknown_prod_like_env`
+
+## Pre-Merge Checklist
+
+- Run coordinator bootstrap and role order from packet `3112b85f242c`.
+- Run focused invariant, workflow, lifespan, cookie, and export tests.
+- Run `scripts/ci/check_production_runtime_invariants.py --synthetic-production` through repo Python.
+- Run `make validate-changed` and `pre-commit run --all-files`.
+- Open non-draft PR and create `docs/review/PR_<N>_FIXED_MAPPING.md`.
+- Run post-open QA, bug-hunter, security-auditor, Codex Security diff scan, and `pulseplate-pr-review`.
+
+## Decision
+
+`proceed with changes` before implementation; all identified premortem changes
+are now fixed in code, tests, or workflow guards before PR open.

--- a/docs/review/PR_1992_FIXED_MAPPING.md
+++ b/docs/review/PR_1992_FIXED_MAPPING.md
@@ -152,6 +152,10 @@ Post-open CodeRabbit findings:
   - Evidence:
     `tests/test_production_runtime_invariants.py::test_synthetic_production_invariant_ci_checks`
   - Evidence: `.venv/bin/python -m pytest -q tests/test_production_runtime_invariants.py`
+- Missing inline comment for intentional `app=None` fallback: FIXED
+  - Commit: `b2ea2e419`
+  - Evidence: `app/security/rate_limit.py`
+  - Evidence: `.venv/bin/python -m pytest -q tests/test_production_runtime_invariants.py`
 
 Post-open governance still required:
 
@@ -200,6 +204,8 @@ Post-open governance still required:
 - CodeRabbit synthetic limiter test cleanup: `43c116bc4`
   - Evidence:
     `tests/test_production_runtime_invariants.py::test_synthetic_production_invariant_ci_checks`
+- CodeRabbit app-none fallback comment: `b2ea2e419`
+  - Evidence: `app/security/rate_limit.py`
 
 ## Deferred / Follow-Ups
 

--- a/docs/review/PR_1992_FIXED_MAPPING.md
+++ b/docs/review/PR_1992_FIXED_MAPPING.md
@@ -1,4 +1,4 @@
-# PR 1992 Fixed Mapping
+# PR 1992 Fixed in Commit Mapping
 
 PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1992
 
@@ -10,6 +10,22 @@ This PR adds fail-closed production runtime invariant guards for existing
 security posture assumptions without dependency updates, legacy extraction,
 OpenAPI changes, FoodDB/data migration, auth rewrite, frontend, iOS, or macOS
 runtime changes.
+
+## Scope
+
+- Add `app/security/production_invariants.py` for production/staging posture checks.
+- Add production fail-closed rate-limit readiness checks in
+  `app/security/rate_limit.py`.
+- Wire startup guards through `app/bootstrap/startup_guards.py` and pass the
+  serving FastAPI app from `legacy_app.py`.
+- Align secure-cookie production detection in `app/security/web_session.py`.
+- Add synthetic CI coverage, focused tests, and security evidence.
+
+## Out Of Scope
+
+Dependency updates, RAG/vector/torch alert handling, legacy route extraction,
+FoodDB/data migration, entitlement/auth architecture rewrite, OpenAPI changes,
+frontend, iOS, macOS, pyproject/uv migration, and runtime feature behavior.
 
 ## Operator Exceptions
 
@@ -26,186 +42,84 @@ runtime changes.
 - `.venv/bin/python -m pytest -q tests/test_production_runtime_invariants.py tests/guards/test_security_devtooling_regression_guards.py tests/test_pro_session_cookie_auth.py tests/test_app_lifespan_additional.py tests/test_plan_export_additional.py tests/test_python_supply_chain_controls.py tests/test_app_public_surface.py tests/test_app_openapi_coverage.py tests/test_app_creation_coverage.py tests/test_openapi_namespace_guards.py tests/test_app_endpoints_combined.py` -> PASS
 - `.venv/bin/python scripts/ci/check_production_runtime_invariants.py --synthetic-production` -> PASS
 - `.venv/bin/python -m mypy app/security/production_invariants.py app/security/rate_limit.py app/security/web_session.py app/bootstrap/startup_guards.py scripts/ci/check_production_runtime_invariants.py` -> PASS
-- `make validate-changed` -> PASS; selected changed Python tests after commit
+- `make validate-changed` -> PASS
 - `pre-commit run --all-files` -> PASS
-- pre-push hooks -> PASS, including changed-file mypy, pip-audit, pre-push
+- Pre-push hooks -> PASS, including changed-file mypy, pip-audit, pre-push
   backend tests, full-repo Bandit, and docker build test
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/3112b85f242c.json`
+- Starter: `scripts/orchestration/start_pr_lane.sh`
+- Pre-open role order executed:
+  `agent-coordinator -> security-auditor -> backend-engineer -> qa-engineer-agent -> bug-hunter -> architecture-specialist`
+- Post-open role order executed:
+  `qa-engineer-agent -> bug-hunter -> security-auditor -> Codex Security diff scan -> pulseplate-pr-review`
 
 ## Premortem
 
 Artifact: `docs/review/PRODUCTION_RUNTIME_INVARIANTS_PREMORTEM.md`
 
-Dispositions:
+Disposition summary:
 
-- False-green startup/workflow guard risk: FIXED
-  - Evidence: `app/bootstrap/startup_guards.py`
-  - Evidence: `tests/test_production_runtime_invariants.py`
-  - Evidence: `tests/guards/test_security_devtooling_regression_guards.py`
-- Readiness guard mutation / malformed DB URL risk: FIXED
-  - Evidence: `app/security/rate_limit.py`
-  - Evidence: `app/security/production_invariants.py`
-  - Evidence: `tests/test_production_runtime_invariants.py`
-- Export placeholder hidden assumption risk: FIXED
-  - Evidence: `app/security/production_invariants.py`
-  - Evidence: `tests/test_production_runtime_invariants.py`
+- False-green startup/workflow guard risk: FIXED.
+- Readiness guard mutation / malformed DB URL risk: FIXED.
+- Export placeholder hidden assumption risk: FIXED.
 
-## Experiment Runner
+Evidence: `app/bootstrap/startup_guards.py`,
+`app/security/production_invariants.py`, `app/security/rate_limit.py`,
+`tests/test_production_runtime_invariants.py`, and
+`tests/guards/test_security_devtooling_regression_guards.py`.
 
-Packet: `artifacts/orchestration/experiments/production-runtime-invariants-oracle.json`
+## Experiment Runner Evidence
 
-Result: `artifacts/orchestration/experiments/results/production-runtime-invariants-oracle-result.json`
-
-Disposition: ACCEPTED
-
-Evidence:
-
-- Oracle 1 focused pytest -> PASS
-- Oracle 2 synthetic production invariant script -> PASS
-- Oracle 3 focused mypy -> PASS
-
-Attribution:
-
-- Commit `f45139cfb` includes
+- Packet: `artifacts/orchestration/experiments/production-runtime-invariants-oracle.json`
+- Artifact:
+  `artifacts/orchestration/experiments/results/production-runtime-invariants-oracle-result.json`
+- Status: accepted.
+- Oracle evidence: focused pytest passed, synthetic production invariant script
+  passed, and focused mypy passed.
+- Attribution: commit `f45139cfb` includes
   `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>` because the
   accepted oracle-only result materially shaped validation and commit decision.
 
-## Codex Security Diff Scan
+## Post-Open Review Evidence
 
-Scan directory:
-`/tmp/codex-security-scans/BMI-App_2025_clean/0b7fdef76_20260618T120841Z`
-
-Disposition: PASS / no reportable findings
-
-Evidence:
-
-- Final markdown:
-  `/tmp/codex-security-scans/BMI-App_2025_clean/0b7fdef76_20260618T120841Z/report.md`
-- Final HTML:
-  `/tmp/codex-security-scans/BMI-App_2025_clean/0b7fdef76_20260618T120841Z/report.html`
-- Work ledger:
-  `/tmp/codex-security-scans/BMI-App_2025_clean/0b7fdef76_20260618T120841Z/artifacts/02_discovery/work_ledger.jsonl`
-- Report validator: PASS
+- `qa-engineer-agent`: FIXED valid app-wiring coverage and synthetic flag-drift
+  findings in `8c7e51f37`.
+- `bug-hunter`: FIXED app-wiring false-green risk in `828fcbc0e`.
+- `security-auditor`: FIXED global marker vs app-specific wiring risk in
+  `a8bffffe7`.
+- `pulseplate-pr-review`: NOT-A-BUG for large-diff advisory note. The scope is
+  bounded to one coordinator-owned production invariant lane, and
+  `make validate-changed` passed.
+- Codex Security diff scan: PASS / no reportable findings. Report directory:
+  `/tmp/codex-security-scans/BMI-App_2025_clean/0b7fdef76_20260618T120841Z`.
+- CodeRabbit: two actionable findings fixed and resolved; see canonical mapping
+  entries below.
 
 ## Discussion Thread Pass
 
-No GitHub review threads existed at PR open.
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
-Post-open `qa-engineer-agent` findings:
-
-- Rate-limit readiness app-wiring coverage gap: FIXED
-  - Commit: `8c7e51f37`
-  - Evidence:
-    `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
-- Synthetic CI helper drift against invariant flag constants: FIXED
-  - Commit: `8c7e51f37`
-  - Evidence: `app/security/production_invariants.py`
-  - Evidence: `scripts/ci/check_production_runtime_invariants.py`
-  - Evidence:
-    `tests/test_production_runtime_invariants.py::test_synthetic_ci_checker_covers_all_invariant_flag_constants`
-- Duplicate startup helper calls concern: NOT-A-BUG
-  - Evidence: `app/bootstrap/startup_guards.py`
-  - Evidence: `app/security/production_invariants.py`
-  - Reason: The calls are idempotent and intentionally preserve existing
-    startup behavior while the new invariant guard adds stricter production
-    posture checks.
-
-Post-open `bug-hunter` findings:
-
-- Rate-limit app wiring can still false-green if the call-site is removed:
-  FIXED
-  - Commit: `828fcbc0e`
-  - Evidence: `app/security/rate_limit.py`
-  - Evidence:
-    `tests/test_production_runtime_invariants.py::test_rate_limit_readiness_rejects_unwired_app_in_production`
-  - Evidence:
-    `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
-
-Post-open `security-auditor` findings:
-
-- Rate-limit wiring marker is global, not app-specific: FIXED
-  - Commit: `a8bffffe7`
-  - Evidence: `app/security/rate_limit.py`
-  - Evidence: `app/security/production_invariants.py`
-  - Evidence: `app/bootstrap/startup_guards.py`
-  - Evidence: `legacy_app.py`
-  - Evidence:
-    `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
-  - Evidence:
-    `tests/test_production_runtime_invariants.py::test_legacy_app_wires_rate_limiting_to_serving_app_call_site`
-
-Post-open `pulseplate-pr-review` findings:
-
-- Large diff review-risk note over threshold: NOT-A-BUG
-  - Evidence: `/tmp/pulseplate_pr1992_review_report.md`
-  - Evidence: `make validate-changed` passed after committed diff selection
-  - Reason: The diff is larger than the advisory threshold because this PR adds
-    the runtime guard, synthetic CI guard, workflow wiring, deterministic tests,
-    security evidence, and required review-governance artifacts in one
-    coordinator-owned security lane. Scope stayed bounded to production runtime
-    invariants and did not include dependency/RAG/legacy extraction/FoodDB/auth
-    rewrite/OpenAPI/frontend/iOS/macOS work.
-
-Post-open CodeRabbit findings:
-
-- Manual limiter save/restore in synthetic invariant test: FIXED
-  - Commit: `43c116bc4`
-  - Evidence:
-    `tests/test_production_runtime_invariants.py::test_synthetic_production_invariant_ci_checks`
-  - Evidence: `.venv/bin/python -m pytest -q tests/test_production_runtime_invariants.py`
-- Missing inline comment for intentional `app=None` fallback: FIXED
-  - Commit: `b2ea2e419`
-  - Evidence: `app/security/rate_limit.py`
-  - Evidence: `.venv/bin/python -m pytest -q tests/test_production_runtime_invariants.py`
-
-Post-open governance still required:
-
-- Codex Security diff scan when available
-- CodeRabbit when authenticated
+All actionable review threads are recorded below with disposition and proof
+before resolution.
 
 ## Fixed in Commit Mapping
 
-- Initial implementation: `f45139cfb`
-  - Evidence: `app/security/production_invariants.py`
-  - Evidence: `app/security/rate_limit.py`
-  - Evidence: `app/security/web_session.py`
-  - Evidence: `app/bootstrap/startup_guards.py`
-  - Evidence: `scripts/ci/check_production_runtime_invariants.py`
-  - Evidence: `.github/workflows/ci.yml`
-  - Evidence: `.github/workflows/security.yml`
-  - Evidence: `tests/test_production_runtime_invariants.py`
-- Post-open QA gap fixes: `8c7e51f37`
-  - Evidence:
-    `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
-  - Evidence:
-    `tests/test_production_runtime_invariants.py::test_synthetic_ci_checker_covers_all_invariant_flag_constants`
-  - Evidence: `scripts/ci/check_production_runtime_invariants.py`
-  - Evidence: `app/security/production_invariants.py`
-- Post-open bug-hunter app-wiring fix: `828fcbc0e`
-  - Evidence: `app/security/rate_limit.py`
-  - Evidence: `scripts/ci/check_production_runtime_invariants.py`
-  - Evidence:
-    `tests/test_production_runtime_invariants.py::test_rate_limit_readiness_rejects_unwired_app_in_production`
-  - Evidence:
-    `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
-- Post-open security app-specific wiring fix: `a8bffffe7`
-  - Evidence: `app/security/rate_limit.py`
-  - Evidence: `app/security/production_invariants.py`
-  - Evidence: `app/bootstrap/startup_guards.py`
-  - Evidence: `legacy_app.py`
-  - Evidence:
-    `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
-  - Evidence:
-    `tests/test_production_runtime_invariants.py::test_legacy_app_wires_rate_limiting_to_serving_app_call_site`
-- PulsePlate PR review large-diff note: NOT-A-BUG
-  - Evidence: `/tmp/pulseplate_pr1992_review_report.md`
-  - Evidence: `make validate-changed`
-  - Reason: Advisory review-planning note, not a behavioral defect; split
-    rationale and local gate evidence are documented above.
-- CodeRabbit synthetic limiter test cleanup: `43c116bc4`
-  - Evidence:
-    `tests/test_production_runtime_invariants.py::test_synthetic_production_invariant_ci_checks`
-- CodeRabbit app-none fallback comment: `b2ea2e419`
-  - Evidence: `app/security/rate_limit.py`
+Disposition: FIXED
+Commit: 43c116bc4
+Evidence: `tests/test_production_runtime_invariants.py::test_synthetic_production_invariant_ci_checks`
+Evidence: `.venv/bin/python -m pytest -q tests/test_production_runtime_invariants.py` -> PASS
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1992#discussion_r3435535472 -> 43c116bc4
+
+Disposition: FIXED
+Commit: b2ea2e419
+Evidence: `app/security/rate_limit.py`
+Evidence: `.venv/bin/python -m pytest -q tests/test_production_runtime_invariants.py` -> PASS
+Evidence: `.venv/bin/python -m mypy app/security/rate_limit.py` -> PASS
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1992#discussion_r3435660191 -> b2ea2e419
 
 ## Deferred / Follow-Ups
 
@@ -215,12 +129,11 @@ Post-open governance still required:
 
 ## Merge Readiness
 
-Status: NOT READY at artifact creation.
+Status: NOT READY while current-head PR CI is pending or failing.
 
 Required before merge:
 
 - Current-head PR CI parity.
 - No unresolved actionable human or bot review comments.
-- Post-open role passes and security review complete.
 - Strict merge-readiness with auth.
 - Mandatory wait-window after latest review/bot activity.

--- a/docs/review/PR_1992_FIXED_MAPPING.md
+++ b/docs/review/PR_1992_FIXED_MAPPING.md
@@ -145,6 +145,14 @@ Post-open `pulseplate-pr-review` findings:
     invariants and did not include dependency/RAG/legacy extraction/FoodDB/auth
     rewrite/OpenAPI/frontend/iOS/macOS work.
 
+Post-open CodeRabbit findings:
+
+- Manual limiter save/restore in synthetic invariant test: FIXED
+  - Commit: `43c116bc4`
+  - Evidence:
+    `tests/test_production_runtime_invariants.py::test_synthetic_production_invariant_ci_checks`
+  - Evidence: `.venv/bin/python -m pytest -q tests/test_production_runtime_invariants.py`
+
 Post-open governance still required:
 
 - Codex Security diff scan when available
@@ -189,6 +197,9 @@ Post-open governance still required:
   - Evidence: `make validate-changed`
   - Reason: Advisory review-planning note, not a behavioral defect; split
     rationale and local gate evidence are documented above.
+- CodeRabbit synthetic limiter test cleanup: `43c116bc4`
+  - Evidence:
+    `tests/test_production_runtime_invariants.py::test_synthetic_production_invariant_ci_checks`
 
 ## Deferred / Follow-Ups
 

--- a/docs/review/PR_1992_FIXED_MAPPING.md
+++ b/docs/review/PR_1992_FIXED_MAPPING.md
@@ -103,9 +103,21 @@ Post-open `bug-hunter` findings:
   - Evidence:
     `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
 
+Post-open `security-auditor` findings:
+
+- Rate-limit wiring marker is global, not app-specific: FIXED
+  - Commit: `a8bffffe7`
+  - Evidence: `app/security/rate_limit.py`
+  - Evidence: `app/security/production_invariants.py`
+  - Evidence: `app/bootstrap/startup_guards.py`
+  - Evidence: `legacy_app.py`
+  - Evidence:
+    `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
+  - Evidence:
+    `tests/test_production_runtime_invariants.py::test_legacy_app_wires_rate_limiting_to_serving_app_call_site`
+
 Post-open governance still required:
 
-- `security-auditor`
 - Codex Security diff scan when available
 - CodeRabbit when authenticated
 - `pulseplate-pr-review`
@@ -135,6 +147,15 @@ Post-open governance still required:
     `tests/test_production_runtime_invariants.py::test_rate_limit_readiness_rejects_unwired_app_in_production`
   - Evidence:
     `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
+- Post-open security app-specific wiring fix: `a8bffffe7`
+  - Evidence: `app/security/rate_limit.py`
+  - Evidence: `app/security/production_invariants.py`
+  - Evidence: `app/bootstrap/startup_guards.py`
+  - Evidence: `legacy_app.py`
+  - Evidence:
+    `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
+  - Evidence:
+    `tests/test_production_runtime_invariants.py::test_legacy_app_wires_rate_limiting_to_serving_app_call_site`
 
 ## Deferred / Follow-Ups
 

--- a/docs/review/PR_1992_FIXED_MAPPING.md
+++ b/docs/review/PR_1992_FIXED_MAPPING.md
@@ -69,6 +69,23 @@ Attribution:
   `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>` because the
   accepted oracle-only result materially shaped validation and commit decision.
 
+## Codex Security Diff Scan
+
+Scan directory:
+`/tmp/codex-security-scans/BMI-App_2025_clean/0b7fdef76_20260618T120841Z`
+
+Disposition: PASS / no reportable findings
+
+Evidence:
+
+- Final markdown:
+  `/tmp/codex-security-scans/BMI-App_2025_clean/0b7fdef76_20260618T120841Z/report.md`
+- Final HTML:
+  `/tmp/codex-security-scans/BMI-App_2025_clean/0b7fdef76_20260618T120841Z/report.html`
+- Work ledger:
+  `/tmp/codex-security-scans/BMI-App_2025_clean/0b7fdef76_20260618T120841Z/artifacts/02_discovery/work_ledger.jsonl`
+- Report validator: PASS
+
 ## Discussion Thread Pass
 
 No GitHub review threads existed at PR open.
@@ -116,11 +133,22 @@ Post-open `security-auditor` findings:
   - Evidence:
     `tests/test_production_runtime_invariants.py::test_legacy_app_wires_rate_limiting_to_serving_app_call_site`
 
+Post-open `pulseplate-pr-review` findings:
+
+- Large diff review-risk note over threshold: NOT-A-BUG
+  - Evidence: `/tmp/pulseplate_pr1992_review_report.md`
+  - Evidence: `make validate-changed` passed after committed diff selection
+  - Reason: The diff is larger than the advisory threshold because this PR adds
+    the runtime guard, synthetic CI guard, workflow wiring, deterministic tests,
+    security evidence, and required review-governance artifacts in one
+    coordinator-owned security lane. Scope stayed bounded to production runtime
+    invariants and did not include dependency/RAG/legacy extraction/FoodDB/auth
+    rewrite/OpenAPI/frontend/iOS/macOS work.
+
 Post-open governance still required:
 
 - Codex Security diff scan when available
 - CodeRabbit when authenticated
-- `pulseplate-pr-review`
 
 ## Fixed in Commit Mapping
 
@@ -156,6 +184,11 @@ Post-open governance still required:
     `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
   - Evidence:
     `tests/test_production_runtime_invariants.py::test_legacy_app_wires_rate_limiting_to_serving_app_call_site`
+- PulsePlate PR review large-diff note: NOT-A-BUG
+  - Evidence: `/tmp/pulseplate_pr1992_review_report.md`
+  - Evidence: `make validate-changed`
+  - Reason: Advisory review-planning note, not a behavioral defect; split
+    rationale and local gate evidence are documented above.
 
 ## Deferred / Follow-Ups
 

--- a/docs/review/PR_1992_FIXED_MAPPING.md
+++ b/docs/review/PR_1992_FIXED_MAPPING.md
@@ -71,11 +71,29 @@ Attribution:
 
 ## Discussion Thread Pass
 
-No review threads existed at PR open.
+No GitHub review threads existed at PR open.
+
+Post-open `qa-engineer-agent` findings:
+
+- Rate-limit readiness app-wiring coverage gap: FIXED
+  - Commit: `8c7e51f37`
+  - Evidence:
+    `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
+- Synthetic CI helper drift against invariant flag constants: FIXED
+  - Commit: `8c7e51f37`
+  - Evidence: `app/security/production_invariants.py`
+  - Evidence: `scripts/ci/check_production_runtime_invariants.py`
+  - Evidence:
+    `tests/test_production_runtime_invariants.py::test_synthetic_ci_checker_covers_all_invariant_flag_constants`
+- Duplicate startup helper calls concern: NOT-A-BUG
+  - Evidence: `app/bootstrap/startup_guards.py`
+  - Evidence: `app/security/production_invariants.py`
+  - Reason: The calls are idempotent and intentionally preserve existing
+    startup behavior while the new invariant guard adds stricter production
+    posture checks.
 
 Post-open governance still required:
 
-- `qa-engineer-agent`
 - `bug-hunter`
 - `security-auditor`
 - Codex Security diff scan when available
@@ -93,6 +111,13 @@ Post-open governance still required:
   - Evidence: `.github/workflows/ci.yml`
   - Evidence: `.github/workflows/security.yml`
   - Evidence: `tests/test_production_runtime_invariants.py`
+- Post-open QA gap fixes: `8c7e51f37`
+  - Evidence:
+    `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
+  - Evidence:
+    `tests/test_production_runtime_invariants.py::test_synthetic_ci_checker_covers_all_invariant_flag_constants`
+  - Evidence: `scripts/ci/check_production_runtime_invariants.py`
+  - Evidence: `app/security/production_invariants.py`
 
 ## Deferred / Follow-Ups
 

--- a/docs/review/PR_1992_FIXED_MAPPING.md
+++ b/docs/review/PR_1992_FIXED_MAPPING.md
@@ -109,9 +109,18 @@ before resolution.
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
+Commit: 8c7e51f37
+Evidence: `app/security/production_invariants.py`
+Evidence: `scripts/ci/check_production_runtime_invariants.py`
+Evidence: `tests/test_production_runtime_invariants.py::test_synthetic_ci_checker_covers_all_invariant_flag_constants`
+Reason: Sourcery review surfaced synthetic invariant drift and duplicate startup-helper concerns; the drift was fixed and the duplicate helper concern is covered by idempotent startup behavior.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1992#pullrequestreview-4524528879 -> 8c7e51f37
+
+Disposition: FIXED
 Commit: 43c116bc4
 Evidence: `tests/test_production_runtime_invariants.py::test_synthetic_production_invariant_ci_checks`
 Evidence: `.venv/bin/python -m pytest -q tests/test_production_runtime_invariants.py` -> PASS
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1992#pullrequestreview-4524586993 -> 43c116bc4
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1992#discussion_r3435535472 -> 43c116bc4
 
 Disposition: FIXED
@@ -119,6 +128,7 @@ Commit: b2ea2e419
 Evidence: `app/security/rate_limit.py`
 Evidence: `.venv/bin/python -m pytest -q tests/test_production_runtime_invariants.py` -> PASS
 Evidence: `.venv/bin/python -m mypy app/security/rate_limit.py` -> PASS
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1992#pullrequestreview-4524729900 -> b2ea2e419
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1992#discussion_r3435660191 -> b2ea2e419
 
 ## Deferred / Follow-Ups

--- a/docs/review/PR_1992_FIXED_MAPPING.md
+++ b/docs/review/PR_1992_FIXED_MAPPING.md
@@ -1,0 +1,113 @@
+# PR 1992 Fixed Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1992
+
+Branch: `codex/add-production-runtime-invariant-guards`
+
+## Summary
+
+This PR adds fail-closed production runtime invariant guards for existing
+security posture assumptions without dependency updates, legacy extraction,
+OpenAPI changes, FoodDB/data migration, auth rewrite, frontend, iOS, or macOS
+runtime changes.
+
+## Operator Exceptions
+
+- Full local `make verify` was not run under the operator-approved
+  machine-heavy exception.
+- Validation uses focused local gates, `make validate-changed`,
+  `pre-commit run --all-files`, pre-push hooks, and current-head GitHub CI as
+  the heavy signal.
+
+## Local Validation
+
+- `python3 scripts/orchestration/check_preflight.py` -> PASS
+- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS
+- `.venv/bin/python -m pytest -q tests/test_production_runtime_invariants.py tests/guards/test_security_devtooling_regression_guards.py tests/test_pro_session_cookie_auth.py tests/test_app_lifespan_additional.py tests/test_plan_export_additional.py tests/test_python_supply_chain_controls.py tests/test_app_public_surface.py tests/test_app_openapi_coverage.py tests/test_app_creation_coverage.py tests/test_openapi_namespace_guards.py tests/test_app_endpoints_combined.py` -> PASS
+- `.venv/bin/python scripts/ci/check_production_runtime_invariants.py --synthetic-production` -> PASS
+- `.venv/bin/python -m mypy app/security/production_invariants.py app/security/rate_limit.py app/security/web_session.py app/bootstrap/startup_guards.py scripts/ci/check_production_runtime_invariants.py` -> PASS
+- `make validate-changed` -> PASS; selected changed Python tests after commit
+- `pre-commit run --all-files` -> PASS
+- pre-push hooks -> PASS, including changed-file mypy, pip-audit, pre-push
+  backend tests, full-repo Bandit, and docker build test
+
+## Premortem
+
+Artifact: `docs/review/PRODUCTION_RUNTIME_INVARIANTS_PREMORTEM.md`
+
+Dispositions:
+
+- False-green startup/workflow guard risk: FIXED
+  - Evidence: `app/bootstrap/startup_guards.py`
+  - Evidence: `tests/test_production_runtime_invariants.py`
+  - Evidence: `tests/guards/test_security_devtooling_regression_guards.py`
+- Readiness guard mutation / malformed DB URL risk: FIXED
+  - Evidence: `app/security/rate_limit.py`
+  - Evidence: `app/security/production_invariants.py`
+  - Evidence: `tests/test_production_runtime_invariants.py`
+- Export placeholder hidden assumption risk: FIXED
+  - Evidence: `app/security/production_invariants.py`
+  - Evidence: `tests/test_production_runtime_invariants.py`
+
+## Experiment Runner
+
+Packet: `artifacts/orchestration/experiments/production-runtime-invariants-oracle.json`
+
+Result: `artifacts/orchestration/experiments/results/production-runtime-invariants-oracle-result.json`
+
+Disposition: ACCEPTED
+
+Evidence:
+
+- Oracle 1 focused pytest -> PASS
+- Oracle 2 synthetic production invariant script -> PASS
+- Oracle 3 focused mypy -> PASS
+
+Attribution:
+
+- Commit `f45139cfb` includes
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>` because the
+  accepted oracle-only result materially shaped validation and commit decision.
+
+## Discussion Thread Pass
+
+No review threads existed at PR open.
+
+Post-open governance still required:
+
+- `qa-engineer-agent`
+- `bug-hunter`
+- `security-auditor`
+- Codex Security diff scan when available
+- CodeRabbit when authenticated
+- `pulseplate-pr-review`
+
+## Fixed in Commit Mapping
+
+- Initial implementation: `f45139cfb`
+  - Evidence: `app/security/production_invariants.py`
+  - Evidence: `app/security/rate_limit.py`
+  - Evidence: `app/security/web_session.py`
+  - Evidence: `app/bootstrap/startup_guards.py`
+  - Evidence: `scripts/ci/check_production_runtime_invariants.py`
+  - Evidence: `.github/workflows/ci.yml`
+  - Evidence: `.github/workflows/security.yml`
+  - Evidence: `tests/test_production_runtime_invariants.py`
+
+## Deferred / Follow-Ups
+
+- Existing default-branch Dependabot alerts are not claimed closed by this PR.
+- Torch/RAG alert handling remains separate and upstream-blocked unless a
+  patched torch release appears or the optional vector profile is retired.
+
+## Merge Readiness
+
+Status: NOT READY at artifact creation.
+
+Required before merge:
+
+- Current-head PR CI parity.
+- No unresolved actionable human or bot review comments.
+- Post-open role passes and security review complete.
+- Strict merge-readiness with auth.
+- Mandatory wait-window after latest review/bot activity.

--- a/docs/review/PR_1992_FIXED_MAPPING.md
+++ b/docs/review/PR_1992_FIXED_MAPPING.md
@@ -92,9 +92,19 @@ Post-open `qa-engineer-agent` findings:
     startup behavior while the new invariant guard adds stricter production
     posture checks.
 
+Post-open `bug-hunter` findings:
+
+- Rate-limit app wiring can still false-green if the call-site is removed:
+  FIXED
+  - Commit: `828fcbc0e`
+  - Evidence: `app/security/rate_limit.py`
+  - Evidence:
+    `tests/test_production_runtime_invariants.py::test_rate_limit_readiness_rejects_unwired_app_in_production`
+  - Evidence:
+    `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
+
 Post-open governance still required:
 
-- `bug-hunter`
 - `security-auditor`
 - Codex Security diff scan when available
 - CodeRabbit when authenticated
@@ -118,6 +128,13 @@ Post-open governance still required:
     `tests/test_production_runtime_invariants.py::test_synthetic_ci_checker_covers_all_invariant_flag_constants`
   - Evidence: `scripts/ci/check_production_runtime_invariants.py`
   - Evidence: `app/security/production_invariants.py`
+- Post-open bug-hunter app-wiring fix: `828fcbc0e`
+  - Evidence: `app/security/rate_limit.py`
+  - Evidence: `scripts/ci/check_production_runtime_invariants.py`
+  - Evidence:
+    `tests/test_production_runtime_invariants.py::test_rate_limit_readiness_rejects_unwired_app_in_production`
+  - Evidence:
+    `tests/test_production_runtime_invariants.py::test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware`
 
 ## Deferred / Follow-Ups
 

--- a/docs/roadmap/BACKLOG_LEDGER.md
+++ b/docs/roadmap/BACKLOG_LEDGER.md
@@ -2152,8 +2152,8 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
 - [ ] P1: Release environment security contract for `API_KEY_REQUIRED` and tier-gating env truth
   - Owner: @katsiaryna_kavaleuskaya
   - Priority: P1
-  - Target PR: PR-TBD-RELEASE-ENV-SECURITY-CONTRACT
-  - Status: 📋 Planned
+  - Target PR: `codex/add-production-runtime-invariant-guards`
+  - Status: 🚧 In progress via production runtime invariant guard PR
   - Area: deploy / security / release operations
   - Finding Type: runtime env contract gap
   - Reason (EN): Repo docs describe `API_KEY_REQUIRED` and related auth/tier env flags, but there is no canonical release contract that makes staging/production values explicit and auditable. Without that contract, a release can drift into a weaker env posture than local docs imply.
@@ -2162,6 +2162,9 @@ Entries are sorted by priority, then theme, then title. Theme uses `Area:` when 
     - `docker-compose.yaml`
     - `README.md`
     - `docs/deploy/OVERVIEW.md`
+    - `docs/security/PRODUCTION_RUNTIME_INVARIANTS.md`
+    - `app/security/production_invariants.py`
+    - `scripts/ci/check_production_runtime_invariants.py`
   - DoD:
     - Canonical release-env doc defines expected values for `API_KEY_REQUIRED` and other auth/tier-critical env flags across local, staging, and production
     - Verification path for staging/prod env truth is documented and linked from release runbooks

--- a/docs/security/PRODUCTION_RUNTIME_INVARIANTS.md
+++ b/docs/security/PRODUCTION_RUNTIME_INVARIANTS.md
@@ -42,6 +42,15 @@ The script builds an in-memory synthetic production profile, verifies it passes,
 then verifies representative unsafe toggles fail closed. It does not print
 secret values or database URLs.
 
+Evidence anchors:
+
+- `app/security/production_invariants.py:110` defines the production runtime
+  invariant entrypoint.
+- `app/security/rate_limit.py:312` defines the production rate-limit readiness
+  guard.
+- `scripts/ci/check_production_runtime_invariants.py:112` runs the synthetic
+  safe/unsafe posture checks used by CI.
+
 ## Rollback
 
 If a deployment fails this guard, fix the runtime environment rather than

--- a/docs/security/PRODUCTION_RUNTIME_INVARIANTS.md
+++ b/docs/security/PRODUCTION_RUNTIME_INVARIANTS.md
@@ -1,0 +1,50 @@
+# Production Runtime Invariants
+
+PulsePlate treats `production`, `prod`, and `staging` as production-like
+runtime environments. These environments must fail closed before serving traffic
+when local/test security assumptions leak into runtime configuration.
+
+## Enforced Invariants
+
+`app.security.production_invariants.assert_production_runtime_invariants()`
+runs from startup guards and from the synthetic CI checker.
+
+Production-like runtime requires:
+
+- `API_KEY_REQUIRED=true`
+- `SUBSCRIPTION_DB_ENABLED=true`
+- non-placeholder `SERVER_SALT`
+- non-placeholder `APPLE_SHARED_SECRET`
+- `PRIVATE_EXPORTS_ENABLED=true`
+- non-placeholder `EXPORT_TOKEN_SECRET`
+- valid PostgreSQL `DATABASE_URL`
+- SlowAPI limiter, middleware, and exception handler available and enabled
+
+Production-like runtime rejects:
+
+- `DEBUG=true`
+- `TESTING=true`
+- `ALLOW_DEV_API_KEY=true`
+- `ALLOW_ANONYMOUS_API_KEYS=true`
+- `ENABLE_TEST_ROUTES=1`
+- `ENABLE_DEBUG_ENDPOINT=true`
+- `METRICS_TEST_BYPASS=true`
+
+## CI Evidence
+
+Run the synthetic guard without real production secrets:
+
+```bash
+python3 scripts/ci/check_production_runtime_invariants.py --synthetic-production
+```
+
+The script builds an in-memory synthetic production profile, verifies it passes,
+then verifies representative unsafe toggles fail closed. It does not print
+secret values or database URLs.
+
+## Rollback
+
+If a deployment fails this guard, fix the runtime environment rather than
+weakening startup behavior. Local/dev/test environments remain explicit
+developer environments and may keep local ergonomics such as disabled rate
+limiting or local API-key defaults.

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -518,7 +518,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # RU: Делегируем startup hard guards в bootstrap seam, чтобы legacy layer оставался thin.
     # EN: Delegate startup hard guards to bootstrap seam to keep legacy layer thin.
-    run_startup_guards()
+    run_startup_guards(app)
 
     try:
         init_db()

--- a/scripts/ci/check_production_runtime_invariants.py
+++ b/scripts/ci/check_production_runtime_invariants.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Synthetic production-runtime invariant guard for CI."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from contextlib import contextmanager
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from app.security.production_invariants import assert_production_runtime_invariants
+from app.security import rate_limit
+
+_MANAGED_ENV = (
+    "APP_ENV",
+    "ENVIRONMENT",
+    "DEBUG",
+    "TESTING",
+    "ALLOW_DEV_API_KEY",
+    "ALLOW_ANONYMOUS_API_KEYS",
+    "API_KEY_REQUIRED",
+    "SUBSCRIPTION_DB_ENABLED",
+    "SERVER_SALT",
+    "APPLE_SHARED_SECRET",
+    "PRIVATE_EXPORTS_ENABLED",
+    "EXPORT_TOKEN_SECRET",
+    "DATABASE_URL",
+    "ENABLE_TEST_ROUTES",
+    "ENABLE_DEBUG_ENDPOINT",
+    "METRICS_TEST_BYPASS",
+    "RATE_LIMITING_IN_TESTS",
+)
+
+
+@contextmanager
+def _patched_env(values: Mapping[str, str | None]) -> Iterator[None]:
+    previous = {name: os.environ.get(name) for name in _MANAGED_ENV}
+    try:
+        for name in _MANAGED_ENV:
+            os.environ.pop(name, None)
+        for name, value in values.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        yield
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def _safe_production_env(**overrides: str) -> dict[str, str]:
+    env = {
+        "APP_ENV": "production",
+        "ENVIRONMENT": "production",
+        "DEBUG": "false",
+        "TESTING": "false",
+        "ALLOW_DEV_API_KEY": "false",  # pragma: allowlist secret
+        "ALLOW_ANONYMOUS_API_KEYS": "false",  # pragma: allowlist secret
+        "API_KEY_REQUIRED": "true",  # pragma: allowlist secret
+        "SUBSCRIPTION_DB_ENABLED": "true",
+        "SERVER_SALT": "SyntheticServerSaltForProductionInvariantCI123!",  # pragma: allowlist secret
+        "APPLE_SHARED_SECRET": "synthetic-apple-shared-secret",  # pragma: allowlist secret
+        "PRIVATE_EXPORTS_ENABLED": "true",
+        "EXPORT_TOKEN_SECRET": "synthetic-export-token-secret",  # pragma: allowlist secret
+        "DATABASE_URL": "postgresql+psycopg://db/pulseplate",
+        "ENABLE_TEST_ROUTES": "0",
+        "ENABLE_DEBUG_ENDPOINT": "false",
+        "METRICS_TEST_BYPASS": "false",
+    }
+    env.update(overrides)
+    return env
+
+
+# fmt: off
+UNSAFE_DEV_KEY_OVERRIDE = {"ALLOW_DEV_API_KEY": "true"}  # pragma: allowlist secret
+UNSAFE_ANONYMOUS_KEYS_OVERRIDE = {"ALLOW_ANONYMOUS_API_KEYS": "true"}  # pragma: allowlist secret
+UNSAFE_API_KEY_REQUIRED_OVERRIDE = {"API_KEY_REQUIRED": "false"}  # pragma: allowlist secret
+UNSAFE_SUBSCRIPTION_DB_OVERRIDE = {"SUBSCRIPTION_DB_ENABLED": "false"}
+# fmt: on
+
+
+def _expect_pass() -> None:
+    with _patched_env(_safe_production_env()):
+        assert_production_runtime_invariants()
+
+
+def _expect_failure(name: str, **overrides: str) -> None:
+    with _patched_env(_safe_production_env(**overrides)):
+        try:
+            assert_production_runtime_invariants()
+        except RuntimeError:
+            return
+    raise AssertionError(f"expected production invariant failure for {name}")
+
+
+def run_synthetic_production_checks() -> None:
+    """Run deterministic safe/unsafe production posture checks."""
+
+    limiter = rate_limit.limiter
+    previous_limiter_enabled = getattr(limiter, "enabled", None)
+    try:
+        if limiter is not None:
+            limiter.enabled = True
+        _expect_pass()
+        _expect_failure("debug flag", DEBUG="true")
+        _expect_failure("testing flag", TESTING="true")
+        _expect_failure("dev key toggle", **UNSAFE_DEV_KEY_OVERRIDE)
+        _expect_failure("anonymous key toggle", **UNSAFE_ANONYMOUS_KEYS_OVERRIDE)
+        _expect_failure("api requirement disabled", **UNSAFE_API_KEY_REQUIRED_OVERRIDE)
+        _expect_failure("subscription db disabled", **UNSAFE_SUBSCRIPTION_DB_OVERRIDE)
+        _expect_failure("test routes enabled", ENABLE_TEST_ROUTES="1")
+        _expect_failure("debug endpoint enabled", ENABLE_DEBUG_ENDPOINT="true")
+        _expect_failure("metrics test bypass enabled", METRICS_TEST_BYPASS="true")
+        _expect_failure("private exports disabled", PRIVATE_EXPORTS_ENABLED="false")
+        _expect_failure("sqlite database url", DATABASE_URL="sqlite:///cache/app.db")
+    finally:
+        if limiter is not None and previous_limiter_enabled is not None:
+            limiter.enabled = previous_limiter_enabled
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--synthetic-production",
+        action="store_true",
+        help="run deterministic synthetic production checks",
+    )
+    args = parser.parse_args()
+
+    if not args.synthetic_production:
+        parser.error("--synthetic-production is required")
+    run_synthetic_production_checks()
+    print("PASS: production runtime invariant synthetic checks")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_production_runtime_invariants.py
+++ b/scripts/ci/check_production_runtime_invariants.py
@@ -14,7 +14,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from app.security.production_invariants import assert_production_runtime_invariants
+from app.security.production_invariants import (
+    PRODUCTION_FALSE_FLAGS,
+    PRODUCTION_TRUE_FLAGS,
+    assert_production_runtime_invariants,
+)
 from app.security import rate_limit
 
 _MANAGED_ENV = (
@@ -81,12 +85,8 @@ def _safe_production_env(**overrides: str) -> dict[str, str]:
     return env
 
 
-# fmt: off
-UNSAFE_DEV_KEY_OVERRIDE = {"ALLOW_DEV_API_KEY": "true"}  # pragma: allowlist secret
-UNSAFE_ANONYMOUS_KEYS_OVERRIDE = {"ALLOW_ANONYMOUS_API_KEYS": "true"}  # pragma: allowlist secret
-UNSAFE_API_KEY_REQUIRED_OVERRIDE = {"API_KEY_REQUIRED": "false"}  # pragma: allowlist secret
-UNSAFE_SUBSCRIPTION_DB_OVERRIDE = {"SUBSCRIPTION_DB_ENABLED": "false"}
-# fmt: on
+_UNSAFE_FALSE_FLAG_OVERRIDES = {flag: {flag: "true"} for flag in PRODUCTION_FALSE_FLAGS}
+_UNSAFE_TRUE_FLAG_OVERRIDES = {flag: {flag: "false"} for flag in PRODUCTION_TRUE_FLAGS}
 
 
 def _expect_pass() -> None:
@@ -112,15 +112,12 @@ def run_synthetic_production_checks() -> None:
         if limiter is not None:
             limiter.enabled = True
         _expect_pass()
-        _expect_failure("debug flag", DEBUG="true")
-        _expect_failure("testing flag", TESTING="true")
-        _expect_failure("dev key toggle", **UNSAFE_DEV_KEY_OVERRIDE)
-        _expect_failure("anonymous key toggle", **UNSAFE_ANONYMOUS_KEYS_OVERRIDE)
-        _expect_failure("api requirement disabled", **UNSAFE_API_KEY_REQUIRED_OVERRIDE)
-        _expect_failure("subscription db disabled", **UNSAFE_SUBSCRIPTION_DB_OVERRIDE)
-        _expect_failure("test routes enabled", ENABLE_TEST_ROUTES="1")
-        _expect_failure("debug endpoint enabled", ENABLE_DEBUG_ENDPOINT="true")
-        _expect_failure("metrics test bypass enabled", METRICS_TEST_BYPASS="true")
+        for flag in PRODUCTION_FALSE_FLAGS:
+            override = _UNSAFE_FALSE_FLAG_OVERRIDES[flag]
+            _expect_failure(f"{flag} enabled", **override)
+        for flag in PRODUCTION_TRUE_FLAGS:
+            override = _UNSAFE_TRUE_FLAG_OVERRIDES[flag]
+            _expect_failure(f"{flag} disabled", **override)
         _expect_failure("private exports disabled", PRIVATE_EXPORTS_ENABLED="false")
         _expect_failure("sqlite database url", DATABASE_URL="sqlite:///cache/app.db")
     finally:

--- a/scripts/ci/check_production_runtime_invariants.py
+++ b/scripts/ci/check_production_runtime_invariants.py
@@ -10,6 +10,8 @@ from contextlib import contextmanager
 from collections.abc import Iterator, Mapping
 from pathlib import Path
 
+from fastapi import FastAPI
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -91,6 +93,8 @@ _UNSAFE_TRUE_FLAG_OVERRIDES = {flag: {flag: "false"} for flag in PRODUCTION_TRUE
 
 def _expect_pass() -> None:
     with _patched_env(_safe_production_env()):
+        if rate_limit.limiter is not None:
+            rate_limit.wire_rate_limiting(FastAPI())
         assert_production_runtime_invariants()
 
 
@@ -108,6 +112,7 @@ def run_synthetic_production_checks() -> None:
 
     limiter = rate_limit.limiter
     previous_limiter_enabled = getattr(limiter, "enabled", None)
+    previous_app_wired = getattr(rate_limit, "_rate_limiting_app_wired", False)
     try:
         if limiter is not None:
             limiter.enabled = True
@@ -123,6 +128,7 @@ def run_synthetic_production_checks() -> None:
     finally:
         if limiter is not None and previous_limiter_enabled is not None:
             limiter.enabled = previous_limiter_enabled
+        rate_limit._rate_limiting_app_wired = previous_app_wired
 
 
 def main() -> int:

--- a/scripts/ci/check_production_runtime_invariants.py
+++ b/scripts/ci/check_production_runtime_invariants.py
@@ -93,9 +93,11 @@ _UNSAFE_TRUE_FLAG_OVERRIDES = {flag: {flag: "false"} for flag in PRODUCTION_TRUE
 
 def _expect_pass() -> None:
     with _patched_env(_safe_production_env()):
+        app = None
         if rate_limit.limiter is not None:
-            rate_limit.wire_rate_limiting(FastAPI())
-        assert_production_runtime_invariants()
+            app = FastAPI()
+            rate_limit.wire_rate_limiting(app)
+        assert_production_runtime_invariants(app=app)
 
 
 def _expect_failure(name: str, **overrides: str) -> None:
@@ -112,7 +114,7 @@ def run_synthetic_production_checks() -> None:
 
     limiter = rate_limit.limiter
     previous_limiter_enabled = getattr(limiter, "enabled", None)
-    previous_app_wired = getattr(rate_limit, "_rate_limiting_app_wired", False)
+    previous_wired_app_ids = set(rate_limit._rate_limiting_wired_app_ids)
     try:
         if limiter is not None:
             limiter.enabled = True
@@ -128,7 +130,8 @@ def run_synthetic_production_checks() -> None:
     finally:
         if limiter is not None and previous_limiter_enabled is not None:
             limiter.enabled = previous_limiter_enabled
-        rate_limit._rate_limiting_app_wired = previous_app_wired
+        rate_limit._rate_limiting_wired_app_ids.clear()
+        rate_limit._rate_limiting_wired_app_ids.update(previous_wired_app_ids)
 
 
 def main() -> int:

--- a/tests/guards/test_security_devtooling_regression_guards.py
+++ b/tests/guards/test_security_devtooling_regression_guards.py
@@ -519,6 +519,13 @@ def test_security_workflows_run_production_runtime_invariant_guard() -> None:
         assert "continue-on-error" not in script
 
 
+def test_ci_route_contract_suite_covers_production_runtime_invariants() -> None:
+    workflow_text = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "route_contract_safety)" in workflow_text
+    assert "tests/test_production_runtime_invariants.py" in workflow_text
+
+
 def test_bandit_excludes_do_not_widen_in_ci_workflow() -> None:
     workflow = _workflow(CI_WORKFLOW)
     scan_step = _job_named_step(

--- a/tests/guards/test_security_devtooling_regression_guards.py
+++ b/tests/guards/test_security_devtooling_regression_guards.py
@@ -51,6 +51,9 @@ PYTORCH_JIT_SAFETY_ID = "SFTY-20250331-30014"
 PYTORCH_JIT_CVE_ID = "CVE-2025-3000"
 PYTORCH_JIT_WAIVER_REMOVE_BY = "2026-07-17"
 BANDIT_SUMMARY_HELPER = "python3 scripts/ci/summarize_bandit_report.py"
+PRODUCTION_RUNTIME_INVARIANT_HELPER = (
+    "python3 scripts/ci/check_production_runtime_invariants.py --synthetic-production"
+)
 CI_BANDIT_EXCLUDES = {
     "tests",
     "tests_strict",
@@ -494,6 +497,26 @@ def test_security_scan_workflow_uses_shared_bandit_summary_helper() -> None:
     assert 'select(.issue_severity == "HIGH")' not in bandit_script
     assert "|| true" not in bandit_script
     assert "continue-on-error" not in bandit_script
+
+
+def test_security_workflows_run_production_runtime_invariant_guard() -> None:
+    for workflow_path, job_id in (
+        (CI_WORKFLOW, "security"),
+        (SECURITY_WORKFLOW, "bandit"),
+    ):
+        workflow = _workflow(workflow_path)
+        step = _job_named_step(
+            workflow,
+            job_id=job_id,
+            step_name="Production runtime invariant guard",
+        )
+        script = step["run"]
+
+        assert PRODUCTION_RUNTIME_INVARIANT_HELPER in script
+        assert "set -euo pipefail" in script
+        assert "|| true" not in script
+        assert "continue-on-error" not in step
+        assert "continue-on-error" not in script
 
 
 def test_bandit_excludes_do_not_widen_in_ci_workflow() -> None:

--- a/tests/test_app_lifespan_additional.py
+++ b/tests/test_app_lifespan_additional.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import pytest
 from unittest.mock import AsyncMock, patch
 
@@ -16,8 +17,17 @@ def _reset_core_db_state() -> None:
     core_db.reset_db_for_tests()
 
 
-@pytest.mark.asyncio
-async def test_lifespan_validate_template_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def _run_lifespan_once() -> None:
+    """Enter the app lifespan once without requiring a pytest async plugin."""
+
+    async def _runner() -> None:
+        async with app.lifespan(app.app):
+            pass
+
+    asyncio.run(_runner())
+
+
+def test_lifespan_validate_template_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
     lifespan_globals = app.lifespan.__wrapped__.__globals__
     monkeypatch.setitem(lifespan_globals, "init_db", lambda: None)
 
@@ -27,12 +37,10 @@ async def test_lifespan_validate_template_runtime_error(monkeypatch: pytest.Monk
     monkeypatch.setitem(lifespan_globals, "validate_template_dir", raise_runtime)
 
     with pytest.raises(RuntimeError):
-        async with app.lifespan(app.app):
-            pass
+        _run_lifespan_once()
 
 
-@pytest.mark.asyncio
-async def test_lifespan_validate_template_generic_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_lifespan_validate_template_generic_error(monkeypatch: pytest.MonkeyPatch) -> None:
     lifespan_globals = app.lifespan.__wrapped__.__globals__
     monkeypatch.setitem(lifespan_globals, "init_db", lambda: None)
 
@@ -42,12 +50,10 @@ async def test_lifespan_validate_template_generic_error(monkeypatch: pytest.Monk
     monkeypatch.setitem(lifespan_globals, "validate_template_dir", raise_value)
 
     with pytest.raises(ValueError):
-        async with app.lifespan(app.app):
-            pass
+        _run_lifespan_once()
 
 
-@pytest.mark.asyncio
-async def test_lifespan_background_update_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_lifespan_background_update_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     import legacy_app
 
     failing_start = AsyncMock(side_effect=RuntimeError("failure"))
@@ -63,14 +69,12 @@ async def test_lifespan_background_update_failure(monkeypatch: pytest.MonkeyPatc
         patch.object(legacy_app, "validate_template_dir", return_value=None),
     ):
         # Should suppress the failing start call and still enter context
-        async with app.lifespan(app.app):
-            pass
+        _run_lifespan_once()
 
     failing_start.assert_awaited_once_with(update_interval_hours=24)
 
 
-@pytest.mark.asyncio
-async def test_lifespan_init_db_raises_calls_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_lifespan_init_db_raises_calls_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     """Cover legacy_app lifespan except path (lines 458–459): init_db raises -> _attempt_db_fallback."""
     from unittest.mock import patch
 
@@ -82,12 +86,10 @@ async def test_lifespan_init_db_raises_calls_fallback(monkeypatch: pytest.Monkey
 
     with patch("core.db_fallback._attempt_db_fallback", side_effect=OSError("DB unreachable")):
         with pytest.raises(OSError, match="DB unreachable"):
-            async with app.lifespan(app.app):
-                pass
+            _run_lifespan_once()
 
 
-@pytest.mark.asyncio
-async def test_lifespan_rejects_anonymous_api_toggle_in_env_production(
+def test_lifespan_rejects_anonymous_api_toggle_in_env_production(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """RU: Startup должен падать на anonymous toggle в prod-like ENVIRONMENT.
@@ -103,12 +105,10 @@ async def test_lifespan_rejects_anonymous_api_toggle_in_env_production(
     monkeypatch.setenv("DEBUG", "false")
 
     with pytest.raises(RuntimeError, match="ALLOW_ANONYMOUS_API_KEYS"):
-        async with app.lifespan(app.app):
-            pass
+        _run_lifespan_once()
 
 
-@pytest.mark.asyncio
-async def test_lifespan_rejects_dev_api_toggle_in_env_staging(
+def test_lifespan_rejects_dev_api_toggle_in_env_staging(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """RU: Startup должен падать на dev API toggle в staging.
@@ -124,12 +124,10 @@ async def test_lifespan_rejects_dev_api_toggle_in_env_staging(
     monkeypatch.setenv("DEBUG", "false")
 
     with pytest.raises(RuntimeError, match="ALLOW_DEV_API_KEY"):
-        async with app.lifespan(app.app):
-            pass
+        _run_lifespan_once()
 
 
-@pytest.mark.asyncio
-async def test_lifespan_requires_apple_shared_secret(
+def test_lifespan_requires_apple_shared_secret(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """RU: Startup должен падать без Apple shared secret.
@@ -144,12 +142,10 @@ async def test_lifespan_requires_apple_shared_secret(
     monkeypatch.delenv("APPLE_SHARED_SECRET", raising=False)
 
     with pytest.raises(RuntimeError, match="APPLE_SHARED_SECRET"):
-        async with app.lifespan(app.app):
-            pass
+        _run_lifespan_once()
 
 
-@pytest.mark.asyncio
-async def test_lifespan_requires_valid_pro_llm_monthly_limit(
+def test_lifespan_requires_valid_pro_llm_monthly_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """RU: Startup должен падать при невалидной PRO LLM квоте.
@@ -173,12 +169,10 @@ async def test_lifespan_requires_valid_pro_llm_monthly_limit(
     monkeypatch.setenv("PRO_LLM_INSIGHT_REQUESTS_PER_MONTH", "invalid")
 
     with pytest.raises(RuntimeError, match="PRO_LLM_INSIGHT_REQUESTS_PER_MONTH"):
-        async with app.lifespan(app.app):
-            pass
+        _run_lifespan_once()
 
 
-@pytest.mark.asyncio
-async def test_lifespan_accepts_valid_pro_llm_monthly_limit(
+def test_lifespan_accepts_valid_pro_llm_monthly_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """RU: Startup должен проходить с валидной PRO LLM квотой.
@@ -214,13 +208,11 @@ async def test_lifespan_accepts_valid_pro_llm_monthly_limit(
     if rate_limit.limiter is not None:
         rate_limit.limiter.enabled = True
 
-    async with app.lifespan(app.app):
-        pass
+    _run_lifespan_once()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("runtime_env", ["production", "staging"])
-async def test_lifespan_requires_subscription_db_enabled_in_production_like_env(
+def test_lifespan_requires_subscription_db_enabled_in_production_like_env(
     monkeypatch: pytest.MonkeyPatch,
     runtime_env: str,
 ) -> None:
@@ -239,13 +231,11 @@ async def test_lifespan_requires_subscription_db_enabled_in_production_like_env(
     monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "false")
 
     with pytest.raises(RuntimeError, match="SUBSCRIPTION_DB_ENABLED"):
-        async with app.lifespan(app.app):
-            pass
+        _run_lifespan_once()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("runtime_env", ["production", "staging", "prod", "live"])
-async def test_lifespan_requires_database_url_in_production_like_env(
+def test_lifespan_requires_database_url_in_production_like_env(
     monkeypatch: pytest.MonkeyPatch,
     runtime_env: str,
 ) -> None:
@@ -274,8 +264,7 @@ async def test_lifespan_requires_database_url_in_production_like_env(
         monkeypatch.delenv("DB_FALLBACK_URL", raising=False)
 
         with pytest.raises(RuntimeError, match="DATABASE_URL is required"):
-            async with app.lifespan(app.app):
-                pass
+            _run_lifespan_once()
     finally:
         _reset_core_db_state()
 
@@ -377,9 +366,8 @@ def test_is_sqlite_database_url_falls_back_to_scheme_check_when_make_url_fails()
         assert core_db._is_sqlite_database_url("SQLITE+Pysqlite:///./cache/app.db") is True
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("runtime_env", ["local", "dev", "development", "test", "testing", "ci"])
-async def test_lifespan_allows_subscription_db_disabled_outside_production_like_env(
+def test_lifespan_allows_subscription_db_disabled_outside_production_like_env(
     monkeypatch: pytest.MonkeyPatch,
     runtime_env: str,
 ) -> None:
@@ -397,12 +385,10 @@ async def test_lifespan_allows_subscription_db_disabled_outside_production_like_
     monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "false")
     monkeypatch.delenv("APPLE_SHARED_SECRET", raising=False)
 
-    async with app.lifespan(app.app):
-        pass
+    _run_lifespan_once()
 
 
-@pytest.mark.asyncio
-async def test_lifespan_allows_missing_apple_shared_secret_in_test_env(
+def test_lifespan_allows_missing_apple_shared_secret_in_test_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     lifespan_globals = app.lifespan.__wrapped__.__globals__
@@ -411,5 +397,4 @@ async def test_lifespan_allows_missing_apple_shared_secret_in_test_env(
     monkeypatch.setenv("DEBUG", "true")
     monkeypatch.delenv("APPLE_SHARED_SECRET", raising=False)
 
-    async with app.lifespan(app.app):
-        pass
+    _run_lifespan_once()

--- a/tests/test_app_lifespan_additional.py
+++ b/tests/test_app_lifespan_additional.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import pytest
 from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
 
 import app
 import core.db as core_db
 from app.bootstrap import startup_guards as bootstrap_guards
+from app.security import rate_limit
 from tests.helpers.fast_update_stubs import patch_background_update_callables
 
 
@@ -160,10 +162,15 @@ async def test_lifespan_requires_valid_pro_llm_monthly_limit(
     monkeypatch.setitem(lifespan_globals, "run_startup_guards", bootstrap_guards.run_startup_guards)
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("TESTING", "false")
     monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
     monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "false")
-    monkeypatch.setenv("APPLE_SHARED_SECRET", "apple-shared-secret-for-tests")
-    monkeypatch.setenv("SERVER_SALT", "StrongServerSaltForTests123456789!")
+    monkeypatch.setenv(
+        "APPLE_SHARED_SECRET", "apple-shared-secret-for-tests"
+    )  # pragma: allowlist secret
+    monkeypatch.setenv(
+        "SERVER_SALT", "StrongServerSaltForTests123456789!"
+    )  # pragma: allowlist secret
     monkeypatch.setenv("PRO_LLM_INSIGHT_REQUESTS_PER_MONTH", "invalid")
 
     with pytest.raises(RuntimeError, match="PRO_LLM_INSIGHT_REQUESTS_PER_MONTH"):
@@ -185,12 +192,23 @@ async def test_lifespan_accepts_valid_pro_llm_monthly_limit(
     monkeypatch.setitem(lifespan_globals, "run_startup_guards", bootstrap_guards.run_startup_guards)
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("TESTING", "false")
     monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
     monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "false")
+    monkeypatch.setenv("API_KEY_REQUIRED", "true")
     monkeypatch.setenv("APPLE_SHARED_SECRET", "apple-shared-secret-for-tests")
     monkeypatch.setenv("SERVER_SALT", "StrongServerSaltForTests123456789!")
     monkeypatch.setenv("PRO_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
+    monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
     monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
+    monkeypatch.setenv("PRIVATE_EXPORTS_ENABLED", "true")
+    monkeypatch.setenv(
+        "EXPORT_TOKEN_SECRET", "export-token-secret-for-tests"
+    )  # pragma: allowlist secret
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://db/pulseplate")
+    monkeypatch.setattr(rate_limit, "limiter", SimpleNamespace(enabled=True))
+    monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
+    monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
 
     async with app.lifespan(app.app):
         pass
@@ -237,13 +255,17 @@ async def test_lifespan_requires_database_url_in_production_like_env(
         )
         monkeypatch.setenv("ENVIRONMENT", runtime_env)
         monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("TESTING", "false")
         monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
         monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "false")
+        monkeypatch.setenv("API_KEY_REQUIRED", "true")
         monkeypatch.setenv("APPLE_SHARED_SECRET", "apple-shared-secret-for-tests")
         monkeypatch.setenv("SERVER_SALT", "StrongServerSaltForTests123456789!")
         monkeypatch.setenv("PRO_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
         monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
         monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
+        monkeypatch.setenv("PRIVATE_EXPORTS_ENABLED", "true")
+        monkeypatch.setenv("EXPORT_TOKEN_SECRET", "export-token-secret-for-tests")
         monkeypatch.delenv("DATABASE_URL", raising=False)
         monkeypatch.delenv("DB_FALLBACK_URL", raising=False)
 

--- a/tests/test_app_lifespan_additional.py
+++ b/tests/test_app_lifespan_additional.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pytest
 from unittest.mock import AsyncMock, patch
-from types import SimpleNamespace
 
 import app
 import core.db as core_db
@@ -206,10 +205,14 @@ async def test_lifespan_accepts_valid_pro_llm_monthly_limit(
         "EXPORT_TOKEN_SECRET", "export-token-secret-for-tests"
     )  # pragma: allowlist secret
     monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://db/pulseplate")
-    monkeypatch.setattr(rate_limit, "limiter", SimpleNamespace(enabled=True))
-    monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
-    monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
-    monkeypatch.setattr(rate_limit, "_rate_limiting_app_wired", True)
+    monkeypatch.setattr(
+        rate_limit,
+        "_is_rate_limiting_wired_for_app",
+        lambda target_app: target_app is app.app,
+    )
+    monkeypatch.setattr(rate_limit, "_rate_limiting_enabled", lambda: True)
+    if rate_limit.limiter is not None:
+        rate_limit.limiter.enabled = True
 
     async with app.lifespan(app.app):
         pass

--- a/tests/test_app_lifespan_additional.py
+++ b/tests/test_app_lifespan_additional.py
@@ -209,6 +209,7 @@ async def test_lifespan_accepts_valid_pro_llm_monthly_limit(
     monkeypatch.setattr(rate_limit, "limiter", SimpleNamespace(enabled=True))
     monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
     monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
+    monkeypatch.setattr(rate_limit, "_rate_limiting_app_wired", True)
 
     async with app.lifespan(app.app):
         pass

--- a/tests/test_pro_session_cookie_auth.py
+++ b/tests/test_pro_session_cookie_auth.py
@@ -14,7 +14,11 @@ from starlette.requests import Request
 import app.routers.pro_session as pro_session_mod
 from app.main import app as main_app
 from app.middleware.api_tiers import AuthSource, SubscriptionTier, TEST_KEY_PRO, TierAuthContext
-from app.security.web_session import WEB_SESSION_COOKIE_NAME, issue_web_session
+from app.security.web_session import (
+    WEB_SESSION_COOKIE_NAME,
+    issue_web_session,
+    set_web_session_cookie,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -66,6 +70,22 @@ def test_exchange_success_sets_hardened_cookie(
     assert "Path=/" in set_cookie
     assert "samesite=lax" in set_cookie.lower()
     assert "secure" not in set_cookie.lower()
+
+
+def test_set_web_session_cookie_uses_environment_production_for_secure_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ENVIRONMENT=production should enable Secure even when APP_ENV is local."""
+
+    monkeypatch.setenv("APP_ENV", "local")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("DEBUG", "false")
+
+    response = Response()
+    set_web_session_cookie(response=response, token="session-token", ttl_seconds=60)
+
+    set_cookie = response.headers.get("set-cookie", "")
+    assert "secure" in set_cookie.lower()
 
 
 def test_exchange_fail_invalid_key(isolated_client: TestClient) -> None:

--- a/tests/test_production_runtime_invariants.py
+++ b/tests/test_production_runtime_invariants.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import ast
+from pathlib import Path
+
 import pytest
 from fastapi import FastAPI
 
@@ -50,8 +53,7 @@ def _set_rate_limit_ready(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(rate_limit, "limiter", _FakeLimiter())
     monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
     monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
-    monkeypatch.setattr(rate_limit, "_rate_limiting_app_wired", True)
-    monkeypatch.setattr(rate_limit, "_rate_limiting_app_wired", True)
+    monkeypatch.setattr(rate_limit, "_rate_limiting_wired_app_ids", {1})
 
 
 def test_production_runtime_invariants_accept_safe_profile(
@@ -168,12 +170,14 @@ def test_startup_guards_call_production_invariants(
         lambda: None,
     )
 
-    def _record_call() -> None:
-        called["value"] = True
+    def _record_call(*, app: object | None = None) -> None:
+        called["value"] = app is sentinel_app
 
     monkeypatch.setattr(startup_guards, "assert_production_runtime_invariants", _record_call)
 
-    startup_guards.run_startup_guards()
+    sentinel_app = object()
+
+    startup_guards.run_startup_guards(sentinel_app)
 
     assert called["value"] is True
 
@@ -233,7 +237,7 @@ def test_rate_limit_readiness_rejects_disabled_limiter_in_production(
     monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
     monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
     monkeypatch.setattr(rate_limit, "_rate_limiting_enabled", lambda: False)
-    monkeypatch.setattr(rate_limit, "_rate_limiting_app_wired", True)
+    monkeypatch.setattr(rate_limit, "_rate_limiting_wired_app_ids", {1})
 
     with pytest.raises(RuntimeError, match="Rate limiting must be enabled"):
         rate_limit.require_rate_limiting_ready_for_production()
@@ -247,7 +251,7 @@ def test_rate_limit_readiness_does_not_mutate_limiter_state(
     monkeypatch.setattr(rate_limit, "limiter", fake_limiter)
     monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
     monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
-    monkeypatch.setattr(rate_limit, "_rate_limiting_app_wired", True)
+    monkeypatch.setattr(rate_limit, "_rate_limiting_wired_app_ids", {1})
 
     with pytest.raises(RuntimeError, match="Rate limiting must be enabled"):
         rate_limit.require_rate_limiting_ready_for_production()
@@ -262,17 +266,18 @@ def test_rate_limit_readiness_rejects_unwired_app_in_production(
     monkeypatch.setattr(rate_limit, "limiter", _FakeLimiter())
     monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
     monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
-    monkeypatch.setattr(rate_limit, "_rate_limiting_app_wired", False)
+    monkeypatch.setattr(rate_limit, "_rate_limiting_wired_app_ids", set())
+    app = FastAPI()
 
     with pytest.raises(RuntimeError, match="wired into the FastAPI app"):
-        rate_limit.require_rate_limiting_ready_for_production()
+        rate_limit.require_rate_limiting_ready_for_production(app=app)
 
 
 def test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("TESTING", "false")
-    monkeypatch.setattr(rate_limit, "_rate_limiting_app_wired", False)
+    monkeypatch.setattr(rate_limit, "_rate_limiting_wired_app_ids", set())
     app = FastAPI()
 
     rate_limit.wire_rate_limiting(app)
@@ -280,7 +285,28 @@ def test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware(
     assert app.state.limiter is rate_limit.limiter
     assert rate_limit.RateLimitExceeded in app.exception_handlers
     assert any(middleware.cls is rate_limit.SlowAPIMiddleware for middleware in app.user_middleware)
-    assert rate_limit._rate_limiting_app_wired is True
+    assert id(app) in rate_limit._rate_limiting_wired_app_ids
+    rate_limit.require_rate_limiting_ready_for_production(app=app)
+
+
+def test_legacy_app_wires_rate_limiting_to_serving_app_call_site() -> None:
+    module = ast.parse(Path("legacy_app.py").read_text(encoding="utf-8"))
+
+    assert any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "app.security.rate_limit"
+        and any(alias.name == "wire_rate_limiting" for alias in node.names)
+        for node in ast.walk(module)
+    )
+    assert any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "wire_rate_limiting"
+        and len(node.args) == 1
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "app"
+        for node in ast.walk(module)
+    )
 
 
 def test_rate_limit_readiness_allows_local_noop(

--- a/tests/test_production_runtime_invariants.py
+++ b/tests/test_production_runtime_invariants.py
@@ -339,13 +339,12 @@ def test_web_session_cookie_remains_insecure_in_explicit_local_env(
     assert web_session._is_secure_cookie_environment() is False
 
 
-def test_synthetic_production_invariant_ci_checks() -> None:
-    previous_limiter = rate_limit.limiter
-    rate_limit.limiter = _FakeLimiter()
-    try:
-        run_synthetic_production_checks()
-    finally:
-        rate_limit.limiter = previous_limiter
+def test_synthetic_production_invariant_ci_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rate_limit, "limiter", _FakeLimiter())
+
+    run_synthetic_production_checks()
 
 
 def test_synthetic_ci_checker_covers_all_invariant_flag_constants() -> None:

--- a/tests/test_production_runtime_invariants.py
+++ b/tests/test_production_runtime_invariants.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import pytest
+from fastapi import FastAPI
 
 from app.bootstrap import startup_guards
 from app.security import production_invariants, rate_limit, web_session
-from scripts.ci.check_production_runtime_invariants import run_synthetic_production_checks
+from scripts.ci.check_production_runtime_invariants import (
+    _UNSAFE_FALSE_FLAG_OVERRIDES,
+    _UNSAFE_TRUE_FLAG_OVERRIDES,
+    run_synthetic_production_checks,
+)
 
 
 class _FakeLimiter:
@@ -246,6 +251,19 @@ def test_rate_limit_readiness_does_not_mutate_limiter_state(
     assert fake_limiter.enabled is False
 
 
+def test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TESTING", "false")
+    app = FastAPI()
+
+    rate_limit.wire_rate_limiting(app)
+
+    assert app.state.limiter is rate_limit.limiter
+    assert rate_limit.RateLimitExceeded in app.exception_handlers
+    assert any(middleware.cls is rate_limit.SlowAPIMiddleware for middleware in app.user_middleware)
+
+
 def test_rate_limit_readiness_allows_local_noop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -283,3 +301,8 @@ def test_synthetic_production_invariant_ci_checks() -> None:
         run_synthetic_production_checks()
     finally:
         rate_limit.limiter = previous_limiter
+
+
+def test_synthetic_ci_checker_covers_all_invariant_flag_constants() -> None:
+    assert set(_UNSAFE_FALSE_FLAG_OVERRIDES) == set(production_invariants.PRODUCTION_FALSE_FLAGS)
+    assert set(_UNSAFE_TRUE_FLAG_OVERRIDES) == set(production_invariants.PRODUCTION_TRUE_FLAGS)

--- a/tests/test_production_runtime_invariants.py
+++ b/tests/test_production_runtime_invariants.py
@@ -1,0 +1,285 @@
+"""Tests for production/staging runtime invariant guards."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.bootstrap import startup_guards
+from app.security import production_invariants, rate_limit, web_session
+from scripts.ci.check_production_runtime_invariants import run_synthetic_production_checks
+
+
+class _FakeLimiter:
+    def __init__(self, *, enabled: bool = True) -> None:
+        self.enabled = enabled
+
+
+def _set_safe_production_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("TESTING", "false")
+    monkeypatch.setenv("ALLOW_DEV_API_KEY", "false")
+    monkeypatch.setenv("ALLOW_ANONYMOUS_API_KEYS", "false")
+    monkeypatch.setenv("API_KEY_REQUIRED", "true")
+    monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "true")
+    monkeypatch.setenv(
+        "SERVER_SALT", "StrongServerSaltForTests123456789!"
+    )  # pragma: allowlist secret
+    monkeypatch.setenv(
+        "APPLE_SHARED_SECRET", "apple-shared-secret-for-tests"
+    )  # pragma: allowlist secret
+    monkeypatch.setenv("PRIVATE_EXPORTS_ENABLED", "true")
+    monkeypatch.setenv(
+        "EXPORT_TOKEN_SECRET", "export-token-secret-for-tests"
+    )  # pragma: allowlist secret
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://db/pulseplate")
+    monkeypatch.setenv("PRO_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
+    monkeypatch.setenv("VIP_LLM_INSIGHT_REQUESTS_PER_MONTH", "50")
+    monkeypatch.setenv("ENABLE_TEST_ROUTES", "0")
+    monkeypatch.setenv("ENABLE_DEBUG_ENDPOINT", "false")
+    monkeypatch.setenv("METRICS_TEST_BYPASS", "false")
+
+
+def _set_rate_limit_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rate_limit, "limiter", _FakeLimiter())
+    monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
+    monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
+
+
+def test_production_runtime_invariants_accept_safe_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_safe_production_env(monkeypatch)
+    _set_rate_limit_ready(monkeypatch)
+
+    production_invariants.assert_production_runtime_invariants()
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value", "message"),
+    [
+        ("DEBUG", "true", "DEBUG"),
+        ("TESTING", "true", "TESTING"),
+        ("ALLOW_DEV_API_KEY", "true", "ALLOW_DEV_API_KEY"),
+        ("ALLOW_ANONYMOUS_API_KEYS", "true", "ALLOW_ANONYMOUS_API_KEYS"),
+        ("API_KEY_REQUIRED", "false", "API_KEY_REQUIRED"),
+        ("SUBSCRIPTION_DB_ENABLED", "false", "SUBSCRIPTION_DB_ENABLED"),
+        ("ENABLE_TEST_ROUTES", "1", "ENABLE_TEST_ROUTES"),
+        ("ENABLE_DEBUG_ENDPOINT", "true", "ENABLE_DEBUG_ENDPOINT"),
+        ("METRICS_TEST_BYPASS", "true", "METRICS_TEST_BYPASS"),
+    ],
+)
+def test_production_runtime_invariants_reject_unsafe_flags(
+    monkeypatch: pytest.MonkeyPatch,
+    env_name: str,
+    env_value: str,
+    message: str,
+) -> None:
+    _set_safe_production_env(monkeypatch)
+    monkeypatch.setenv(env_name, env_value)
+
+    with pytest.raises(RuntimeError, match=message):
+        production_invariants.assert_production_runtime_invariants()
+
+
+def test_production_runtime_invariants_reject_disabled_private_exports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_safe_production_env(monkeypatch)
+    monkeypatch.setenv("PRIVATE_EXPORTS_ENABLED", "false")
+
+    with pytest.raises(RuntimeError, match="PRIVATE_EXPORTS_ENABLED"):
+        production_invariants.assert_production_runtime_invariants()
+
+
+def test_production_runtime_invariants_reject_export_secret_placeholder_for_unknown_prod_like_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_safe_production_env(monkeypatch)
+    _set_rate_limit_ready(monkeypatch)
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "live")
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("EXPORT_TOKEN_SECRET", "__set_me__")
+
+    with pytest.raises(RuntimeError, match="EXPORT_TOKEN_SECRET"):
+        production_invariants.assert_production_runtime_invariants()
+
+
+@pytest.mark.parametrize(
+    ("database_url", "message"),
+    [
+        ("not-a-url", "valid PostgreSQL URL"),
+        ("http://example.invalid/db", "PostgreSQL"),
+        ("mysql://db/pulseplate", "PostgreSQL"),
+        ("sqlite:///cache/app.db", "PostgreSQL"),
+        ("sqlite+pysqlite:///cache/app.db", "PostgreSQL"),
+        ("sqlite+aiosqlite:///cache/app.db", "PostgreSQL"),
+    ],
+)
+def test_production_runtime_invariants_reject_non_postgres_database_url(
+    monkeypatch: pytest.MonkeyPatch,
+    database_url: str,
+    message: str,
+) -> None:
+    _set_safe_production_env(monkeypatch)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+
+    with pytest.raises(RuntimeError, match=message):
+        production_invariants.assert_production_runtime_invariants()
+
+
+def test_production_runtime_invariants_allow_explicit_local_dev(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("APP_ENV", "local")
+    monkeypatch.setenv("ENVIRONMENT", "local")
+    monkeypatch.setenv("DEBUG", "true")
+    monkeypatch.setenv("TESTING", "true")
+    monkeypatch.setenv("API_KEY_REQUIRED", "false")
+    monkeypatch.setenv("SUBSCRIPTION_DB_ENABLED", "false")
+    monkeypatch.delenv("SERVER_SALT", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    production_invariants.assert_production_runtime_invariants()
+
+
+def test_startup_guards_call_production_invariants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = {"value": False}
+
+    monkeypatch.setattr(startup_guards, "require_server_salt", lambda: "salt")
+    monkeypatch.setattr(startup_guards, "require_pro_llm_monthly_limit", lambda: 50)
+    monkeypatch.setattr(startup_guards, "require_vip_llm_monthly_limit", lambda: 50)
+    monkeypatch.setattr(startup_guards, "validate_apple_receipt_verification_config", lambda: None)
+    monkeypatch.setattr(startup_guards, "validate_api_key_toggle_guard", lambda: None)
+    monkeypatch.setattr(
+        startup_guards,
+        "_require_subscription_db_in_production_like_env",
+        lambda: None,
+    )
+
+    def _record_call() -> None:
+        called["value"] = True
+
+    monkeypatch.setattr(startup_guards, "assert_production_runtime_invariants", _record_call)
+
+    startup_guards.run_startup_guards()
+
+    assert called["value"] is True
+
+
+def test_rate_limit_readiness_rejects_missing_limiter_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_safe_production_env(monkeypatch)
+    monkeypatch.setattr(rate_limit, "limiter", None)
+
+    with pytest.raises(RuntimeError, match="SlowAPI limiter"):
+        rate_limit.require_rate_limiting_ready_for_production()
+
+
+def test_rate_limit_readiness_rejects_testing_flag_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_safe_production_env(monkeypatch)
+    monkeypatch.setenv("TESTING", "true")
+    monkeypatch.setattr(rate_limit, "limiter", _FakeLimiter())
+    monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
+    monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
+
+    with pytest.raises(RuntimeError, match="TESTING"):
+        rate_limit.require_rate_limiting_ready_for_production()
+
+
+def test_rate_limit_readiness_rejects_missing_exception_handler_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_safe_production_env(monkeypatch)
+    monkeypatch.setattr(rate_limit, "limiter", _FakeLimiter())
+    monkeypatch.setattr(rate_limit, "RateLimitExceeded", None)
+    monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
+
+    with pytest.raises(RuntimeError, match="SlowAPI middleware"):
+        rate_limit.require_rate_limiting_ready_for_production()
+
+
+def test_rate_limit_readiness_rejects_missing_middleware_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_safe_production_env(monkeypatch)
+    monkeypatch.setattr(rate_limit, "limiter", _FakeLimiter())
+    monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
+    monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", None)
+
+    with pytest.raises(RuntimeError, match="SlowAPI middleware"):
+        rate_limit.require_rate_limiting_ready_for_production()
+
+
+def test_rate_limit_readiness_rejects_disabled_limiter_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_safe_production_env(monkeypatch)
+    monkeypatch.setattr(rate_limit, "limiter", _FakeLimiter())
+    monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
+    monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
+    monkeypatch.setattr(rate_limit, "_rate_limiting_enabled", lambda: False)
+
+    with pytest.raises(RuntimeError, match="Rate limiting must be enabled"):
+        rate_limit.require_rate_limiting_ready_for_production()
+
+
+def test_rate_limit_readiness_does_not_mutate_limiter_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_safe_production_env(monkeypatch)
+    fake_limiter = _FakeLimiter(enabled=False)
+    monkeypatch.setattr(rate_limit, "limiter", fake_limiter)
+    monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
+    monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
+
+    with pytest.raises(RuntimeError, match="Rate limiting must be enabled"):
+        rate_limit.require_rate_limiting_ready_for_production()
+
+    assert fake_limiter.enabled is False
+
+
+def test_rate_limit_readiness_allows_local_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("APP_ENV", "local")
+    monkeypatch.setenv("DEBUG", "true")
+    monkeypatch.setattr(rate_limit, "limiter", None)
+
+    rate_limit.require_rate_limiting_ready_for_production()
+
+
+def test_web_session_secure_cookie_uses_canonical_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("APP_ENV", "local")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("DEBUG", "false")
+
+    assert web_session._is_secure_cookie_environment() is True
+
+
+def test_web_session_cookie_remains_insecure_in_explicit_local_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("APP_ENV", "local")
+    monkeypatch.setenv("ENVIRONMENT", "local")
+    monkeypatch.setenv("DEBUG", "true")
+
+    assert web_session._is_secure_cookie_environment() is False
+
+
+def test_synthetic_production_invariant_ci_checks() -> None:
+    previous_limiter = rate_limit.limiter
+    rate_limit.limiter = _FakeLimiter()
+    try:
+        run_synthetic_production_checks()
+    finally:
+        rate_limit.limiter = previous_limiter

--- a/tests/test_production_runtime_invariants.py
+++ b/tests/test_production_runtime_invariants.py
@@ -50,6 +50,8 @@ def _set_rate_limit_ready(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(rate_limit, "limiter", _FakeLimiter())
     monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
     monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
+    monkeypatch.setattr(rate_limit, "_rate_limiting_app_wired", True)
+    monkeypatch.setattr(rate_limit, "_rate_limiting_app_wired", True)
 
 
 def test_production_runtime_invariants_accept_safe_profile(
@@ -231,6 +233,7 @@ def test_rate_limit_readiness_rejects_disabled_limiter_in_production(
     monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
     monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
     monkeypatch.setattr(rate_limit, "_rate_limiting_enabled", lambda: False)
+    monkeypatch.setattr(rate_limit, "_rate_limiting_app_wired", True)
 
     with pytest.raises(RuntimeError, match="Rate limiting must be enabled"):
         rate_limit.require_rate_limiting_ready_for_production()
@@ -244,6 +247,7 @@ def test_rate_limit_readiness_does_not_mutate_limiter_state(
     monkeypatch.setattr(rate_limit, "limiter", fake_limiter)
     monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
     monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
+    monkeypatch.setattr(rate_limit, "_rate_limiting_app_wired", True)
 
     with pytest.raises(RuntimeError, match="Rate limiting must be enabled"):
         rate_limit.require_rate_limiting_ready_for_production()
@@ -251,10 +255,24 @@ def test_rate_limit_readiness_does_not_mutate_limiter_state(
     assert fake_limiter.enabled is False
 
 
+def test_rate_limit_readiness_rejects_unwired_app_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_safe_production_env(monkeypatch)
+    monkeypatch.setattr(rate_limit, "limiter", _FakeLimiter())
+    monkeypatch.setattr(rate_limit, "RateLimitExceeded", object())
+    monkeypatch.setattr(rate_limit, "SlowAPIMiddleware", object())
+    monkeypatch.setattr(rate_limit, "_rate_limiting_app_wired", False)
+
+    with pytest.raises(RuntimeError, match="wired into the FastAPI app"):
+        rate_limit.require_rate_limiting_ready_for_production()
+
+
 def test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("TESTING", "false")
+    monkeypatch.setattr(rate_limit, "_rate_limiting_app_wired", False)
     app = FastAPI()
 
     rate_limit.wire_rate_limiting(app)
@@ -262,6 +280,7 @@ def test_wire_rate_limiting_attaches_app_limiter_handler_and_middleware(
     assert app.state.limiter is rate_limit.limiter
     assert rate_limit.RateLimitExceeded in app.exception_handlers
     assert any(middleware.cls is rate_limit.SlowAPIMiddleware for middleware in app.user_middleware)
+    assert rate_limit._rate_limiting_app_wired is True
 
 
 def test_rate_limit_readiness_allows_local_noop(


### PR DESCRIPTION
## Goal
Add fail-closed production/staging runtime invariant guards for existing PulsePlate security posture assumptions.

## Business reason
This turns release-critical configuration assumptions into deterministic startup and CI contracts before they can silently degrade in production-like environments.

## Scope
- Add `app/security/production_invariants.py` and call it from startup guards.
- Require production-like runtimes to reject dev/test/debug toggles, disabled API key/subscription DB posture, SQLite or malformed DB URLs, weak salt, missing Apple receipt secret, disabled/private export secret gaps, and placeholder export secrets.
- Add production rate-limit readiness validation without mutating limiter state.
- Centralize web-session secure-cookie environment detection through existing settings helpers.
- Add synthetic CI guard wiring in canonical CI and scheduled security workflows.
- Add focused tests, security evidence, backlog tracking, premortem artifact, and canonical fixed-mapping evidence.

## Out of scope
No dependency updates, no `requirements-rag-vector*` or torch alert changes, no legacy extraction, no FoodDB/data migration, no auth/BOLA rewrite, no OpenAPI changes, and no frontend/iOS/macOS runtime behavior changes.

## Operator-approved privileged scope exception
operator approval: approved
privileged scope exception: approved

This privileged security/workflow PR intentionally stays at 17 changed files because the runtime guard, rate-limit readiness check, startup call-site, synthetic CI script, workflow wiring, focused regression tests, security evidence, backlog note, and review mapping form one fail-closed production invariant contract. Splitting below the 15-file privileged target would either land production startup behavior without the CI proof path, or land workflow/test evidence without the runtime guard it verifies. The scope remains bounded to production runtime invariants and does not include dependency/RAG/legacy/FoodDB/auth rewrite/OpenAPI/frontend/iOS/macOS work.

## Split Justification
The PR keeps the guard implementation, CI invocation, and deterministic tests together because each part validates the same production invariant contract. Follow-up debt such as torch/RAG alerts, requirements cleanup, legacy extraction, and Bandit remediation remains separate.

## Key decisions
- Production-like guard is idempotent and no-ops outside production-like runtimes.
- Rate-limit readiness is read-only: it verifies limiter state instead of repairing it.
- The synthetic CI script uses placeholder values only and restores modified process state.
- Experiment Runner oracle-only review materially shaped validation and commit decision, so the implementation commit includes the canonical co-author trailer.

## Tests
- `python3 scripts/orchestration/check_preflight.py` -> PASS
- `python3 scripts/orchestration/check_agent_consistency.py` -> PASS
- `.venv/bin/python -m pytest -q tests/test_production_runtime_invariants.py tests/guards/test_security_devtooling_regression_guards.py tests/test_pro_session_cookie_auth.py tests/test_app_lifespan_additional.py tests/test_plan_export_additional.py tests/test_python_supply_chain_controls.py tests/test_app_public_surface.py tests/test_app_openapi_coverage.py tests/test_app_creation_coverage.py tests/test_openapi_namespace_guards.py tests/test_app_endpoints_combined.py` -> PASS
- `.venv/bin/python scripts/ci/check_production_runtime_invariants.py --synthetic-production` -> PASS
- `.venv/bin/python -m mypy app/security/production_invariants.py app/security/rate_limit.py app/security/web_session.py app/bootstrap/startup_guards.py scripts/ci/check_production_runtime_invariants.py` -> PASS
- `make validate-changed` -> PASS
- `pre-commit run --all-files` -> PASS
- Pre-push hooks -> PASS, including changed-file mypy, pip-audit, pre-push backend tests, full-repo Bandit, and docker build test

## Machine-heavy exception
Full local `make verify` was not run under the operator-approved machine-heavy exception. This PR uses focused local gates, `make validate-changed`, `pre-commit run --all-files`, pre-push hooks, and current-head GitHub CI as the heavy validation signal.

## Security notes
- This PR strengthens production posture and preserves fail-closed behavior.
- It adds line-level `detect-secrets` false-positive pragmas only for synthetic placeholder values/toggle names in the CI helper and tests; no scanner rule is disabled globally.
- Codex Security diff scan reported no reportable findings for the changed file worklist.
- Existing default-branch Dependabot alerts are not claimed closed by this PR.

## Risks / rollback
Risk: a production deployment with intentionally incomplete secrets/config will fail startup instead of degrading. That is intended for production-like runtimes. Rollback is reverting this PR or fixing the deployment config to satisfy the documented invariant contract.

## Governance
- Coordinator packet: `artifacts/orchestration/task_packets/3112b85f242c.json`
- Pre-open role order executed: `agent-coordinator -> security-auditor -> backend-engineer -> qa-engineer-agent -> bug-hunter -> architecture-specialist`
- Post-open role order executed: `qa-engineer-agent -> bug-hunter -> security-auditor -> Codex Security diff scan -> pulseplate-pr-review`
- Premortem: `docs/review/PRODUCTION_RUNTIME_INVARIANTS_PREMORTEM.md`
- Experiment Runner oracle-only result: `artifacts/orchestration/experiments/results/production-runtime-invariants-oracle-result.json`, status `accepted`
- Fixed mapping artifact: `docs/review/PR_1992_FIXED_MAPPING.md`

## Experiment Runner Evidence
- Packet: `artifacts/orchestration/experiments/production-runtime-invariants-oracle.json`
- Artifact: `artifacts/orchestration/experiments/results/production-runtime-invariants-oracle-result.json`
- Status: accepted.
- Oracle evidence: focused pytest passed, synthetic production invariant script passed, and focused mypy passed.
- Attribution: commit `f45139cfb` includes `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>` because the accepted oracle-only result materially shaped validation and commit decision.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_1992_FIXED_MAPPING.md`

## Merge Readiness
Not merge-ready while current-head CI is pending or failing. Required before merge: current-head CI parity, no unresolved actionable human/bot comments, strict merge-readiness with auth, and wait-window after latest bot/review activity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fail-closed production runtime invariant guards that validate critical security settings at startup and in CI, including environment flags, database configuration, private export settings, and rate limiting readiness.
  * Enhanced production environment validation to enforce API key requirements, subscription database enabling, secure secrets, and proper rate limiting configuration.

* **Bug Fixes**
  * Improved secure cookie detection logic for production-like environments.

* **Documentation**
  * Added comprehensive production runtime security invariants documentation.

* **Tests**
  * Added extensive test coverage for production guards, rate limiting validation, and environment configuration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->