### PR TITLE
refactor(api): move plan export registration to canonical bootstrap

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, Awaitable, Callable, cast
 
 import legacy_app as _legacy_module
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, Depends, FastAPI
 from fastapi.responses import HTMLResponse
 
 from legacy_app import (
@@ -50,6 +50,11 @@ from app.routers.legacy_export_aliases import (
     LEGACY_EXPORT_ALIAS_ROUTE_SPECS,
     build_legacy_export_aliases_router,
 )
+from app.routers.plan_export import (
+    PLAN_EXPORT_ROUTE_SPECS,
+    export_router,
+    plan_router,
+)
 from app.routers.vip_registration import register_vip_routes
 from app.schemas.direct_api_root import DirectApiRootProbe
 
@@ -84,6 +89,10 @@ _BMI_COMPAT_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
 _LEGACY_EXPORT_ALIAS_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
     (path, method.upper(), include_in_schema)
     for path, method, include_in_schema in LEGACY_EXPORT_ALIAS_ROUTE_SPECS
+)
+_PLAN_EXPORT_ROUTE_SPECS: tuple[tuple[str, str, bool], ...] = tuple(
+    (path, method.upper(), include_in_schema)
+    for path, method, include_in_schema in PLAN_EXPORT_ROUTE_SPECS
 )
 
 
@@ -137,6 +146,27 @@ def _is_same_legacy_export_alias_endpoint(existing: object, expected: object) ->
         expected_module == legacy_export_aliases_module.__name__
         and getattr(existing, "__module__", None) == expected_module
         and getattr(existing, "__name__", None) == getattr(expected, "__name__", None)
+    )
+
+
+def _is_same_plan_export_callable(existing: object, expected: object) -> bool:
+    if existing is expected:
+        return True
+    if not callable(existing) or not callable(expected):
+        return False
+    return getattr(existing, "__module__", None) == getattr(
+        expected, "__module__", None
+    ) and getattr(existing, "__qualname__", getattr(existing, "__name__", None)) == getattr(
+        expected, "__qualname__", getattr(expected, "__name__", None)
+    )
+
+
+def _route_has_dependency_call(route: object, expected: object) -> bool:
+    dependant = getattr(route, "dependant", None)
+    dependencies = getattr(dependant, "dependencies", None) or []
+    return any(
+        _is_same_plan_export_callable(getattr(dependency, "call", None), expected)
+        for dependency in dependencies
     )
 
 
@@ -614,6 +644,110 @@ def _include_legacy_export_alias_router_if_needed(target_app: FastAPI) -> None:
             )
 
 
+def _include_plan_export_routers_if_needed(target_app: FastAPI) -> None:
+    """Register canonical plan/export routes as one protected atomic family."""
+
+    api_key_dependency = getattr(_legacy_module, "_get_api_key_dynamic", None)
+    if not callable(api_key_dependency):
+        raise RuntimeError("Plan export API key dependency is unavailable.")
+
+    expected_specs = {(path, method) for path, method, _include in _PLAN_EXPORT_ROUTE_SPECS}
+    expected_paths = {path for path, _method in expected_specs}
+    expected_methods_by_path = {path: method for path, method in expected_specs}
+    expected_visibility = {
+        (path, method): include_in_schema
+        for path, method, include_in_schema in _PLAN_EXPORT_ROUTE_SPECS
+    }
+    expected_endpoints: dict[tuple[str, str], object] = {}
+    expected_route_counts: dict[tuple[str, str], int] = {spec: 0 for spec in expected_specs}
+
+    for router in (export_router, plan_router):
+        for route in router.routes:
+            path = getattr(route, "path", None)
+            methods = getattr(route, "methods", None) or set()
+            if path not in expected_paths:
+                continue
+            expected_method = expected_methods_by_path[str(path)]
+            if expected_method not in methods:
+                raise RuntimeError("Plan export router does not define the expected route family.")
+            unexpected_methods = set(methods) - {expected_method, "HEAD", "OPTIONS"}
+            if unexpected_methods:
+                raise RuntimeError("Plan export router does not define the expected route family.")
+            spec = (str(path), expected_method)
+            expected_route_counts[spec] += 1
+            expected_endpoints[spec] = getattr(route, "endpoint", None)
+            if getattr(route, "include_in_schema", True) is not expected_visibility[spec]:
+                raise RuntimeError("Plan export router does not preserve OpenAPI visibility.")
+            if 429 not in (getattr(route, "responses", None) or {}):
+                raise RuntimeError("Plan export router does not preserve 429 response metadata.")
+
+    if set(expected_endpoints) != expected_specs or any(
+        count != 1 for count in expected_route_counts.values()
+    ):
+        raise RuntimeError("Plan export router does not define the expected route family.")
+
+    plan_export_routes = [
+        route for route in target_app.routes if getattr(route, "path", None) in expected_paths
+    ]
+    if not plan_export_routes:
+        dependencies = [Depends(api_key_dependency)]
+        target_app.include_router(export_router, dependencies=dependencies)
+        target_app.include_router(plan_router, dependencies=dependencies)
+        return
+
+    plan_export_paths_present = {
+        str(getattr(route, "path", ""))
+        for route in plan_export_routes
+        if expected_methods_by_path[str(getattr(route, "path", ""))]
+        in (getattr(route, "methods", None) or set())
+    }
+    if plan_export_paths_present != expected_paths:
+        existing = ", ".join(sorted(plan_export_paths_present))
+        missing = ", ".join(sorted(expected_paths - plan_export_paths_present))
+        raise RuntimeError(
+            "Partial plan export route registration detected. "
+            f"Existing: {existing or '<none>'}; missing: {missing or '<none>'}."
+        )
+
+    for route in plan_export_routes:
+        path = str(getattr(route, "path", ""))
+        methods = getattr(route, "methods", None) or set()
+        expected_method = expected_methods_by_path[path]
+        if expected_method not in methods:
+            raise RuntimeError("Partial plan export route registration detected.")
+        unexpected_methods = set(methods) - {expected_method, "HEAD", "OPTIONS"}
+        if unexpected_methods:
+            raise RuntimeError("Partial plan export route registration detected.")
+
+    for (path, method), endpoint in expected_endpoints.items():
+        matching_routes = [
+            route
+            for route in target_app.routes
+            if getattr(route, "path", None) == path
+            and method in (getattr(route, "methods", None) or set())
+        ]
+        if len(matching_routes) != 1 or not _is_same_plan_export_callable(
+            getattr(matching_routes[0], "endpoint", None),
+            endpoint,
+        ):
+            raise RuntimeError(
+                f"Duplicate {path} route detected with a different plan export handler."
+            )
+        if (
+            getattr(matching_routes[0], "include_in_schema", True)
+            is not expected_visibility[(path, method)]
+        ):
+            raise RuntimeError(
+                f"Existing {path} route does not preserve plan export OpenAPI visibility."
+            )
+        if 429 not in (getattr(matching_routes[0], "responses", None) or {}):
+            raise RuntimeError(f"Existing {path} route does not preserve 429 response metadata.")
+        if not _route_has_dependency_call(matching_routes[0], api_key_dependency):
+            raise RuntimeError(
+                f"Existing {path} route does not preserve plan export API key dependency."
+            )
+
+
 def _internalize_users_openapi_surface(target_app: FastAPI) -> None:
     """Hide legacy users CRUD from the public OpenAPI contract.
 
@@ -700,6 +834,7 @@ def ensure_canonical_app_bootstrap(target_app: FastAPI) -> FastAPI:
     _include_favicon_router_if_needed(app)
     _include_admin_operations_router_if_needed(app)
     _include_bmi_compat_router_if_needed(app)
+    _include_plan_export_routers_if_needed(app)
     _include_legacy_export_alias_router_if_needed(app)
 
     register_billing_routes(app)

--- a/app/main.py
+++ b/app/main.py
@@ -136,37 +136,50 @@ def _build_legacy_export_aliases_router() -> APIRouter:
 legacy_export_aliases_router = _build_legacy_export_aliases_router()
 
 
+def _is_same_callable_by_module_and_name(
+    existing: object,
+    expected: object,
+    *,
+    use_qualname: bool = True,
+) -> bool:
+    if existing is expected:
+        return True
+    if not callable(existing) or not callable(expected):
+        return False
+    name_attr = "__qualname__" if use_qualname else "__name__"
+    return getattr(existing, "__module__", None) == getattr(
+        expected, "__module__", None
+    ) and getattr(existing, name_attr, getattr(existing, "__name__", None)) == getattr(
+        expected, name_attr, getattr(expected, "__name__", None)
+    )
+
+
 def _is_same_legacy_export_alias_endpoint(existing: object, expected: object) -> bool:
     if existing is expected:
         return True
-    if not callable(existing) or not callable(expected):
+    if not _is_same_callable_by_module_and_name(existing, expected, use_qualname=False):
         return False
     expected_module = getattr(expected, "__module__", None)
-    return (
-        expected_module == legacy_export_aliases_module.__name__
-        and getattr(existing, "__module__", None) == expected_module
-        and getattr(existing, "__name__", None) == getattr(expected, "__name__", None)
-    )
+    return expected_module == legacy_export_aliases_module.__name__
 
 
 def _is_same_plan_export_callable(existing: object, expected: object) -> bool:
-    if existing is expected:
-        return True
-    if not callable(existing) or not callable(expected):
-        return False
-    return getattr(existing, "__module__", None) == getattr(
-        expected, "__module__", None
-    ) and getattr(existing, "__qualname__", getattr(existing, "__name__", None)) == getattr(
-        expected, "__qualname__", getattr(expected, "__name__", None)
-    )
+    return _is_same_callable_by_module_and_name(existing, expected)
 
 
 def _route_has_dependency_call(route: object, expected: object) -> bool:
     dependant = getattr(route, "dependant", None)
-    dependencies = getattr(dependant, "dependencies", None) or []
+
+    def _iter_dependency_calls(dependencies: object) -> list[object]:
+        calls: list[object] = []
+        for dependency in dependencies or []:
+            calls.append(getattr(dependency, "call", None))
+            calls.extend(_iter_dependency_calls(getattr(dependency, "dependencies", None)))
+        return calls
+
     return any(
-        _is_same_plan_export_callable(getattr(dependency, "call", None), expected)
-        for dependency in dependencies
+        _is_same_plan_export_callable(call, expected)
+        for call in _iter_dependency_calls(getattr(dependant, "dependencies", None))
     )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ Keep imports deterministic: do NOT use importlib exec_module, do NOT mutate sys.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any, Awaitable, Callable, cast
 
 import legacy_app as _legacy_module
@@ -160,7 +161,7 @@ def _is_same_legacy_export_alias_endpoint(existing: object, expected: object) ->
     if not _is_same_callable_by_module_and_name(existing, expected, use_qualname=False):
         return False
     expected_module = getattr(expected, "__module__", None)
-    return expected_module == legacy_export_aliases_module.__name__
+    return bool(expected_module == legacy_export_aliases_module.__name__)
 
 
 def _is_same_plan_export_callable(existing: object, expected: object) -> bool:
@@ -170,9 +171,9 @@ def _is_same_plan_export_callable(existing: object, expected: object) -> bool:
 def _route_has_dependency_call(route: object, expected: object) -> bool:
     dependant = getattr(route, "dependant", None)
 
-    def _iter_dependency_calls(dependencies: object) -> list[object]:
+    def _iter_dependency_calls(dependencies: Iterable[object] | None) -> list[object]:
         calls: list[object] = []
-        for dependency in dependencies or []:
+        for dependency in dependencies if dependencies is not None else ():
             calls.append(getattr(dependency, "call", None))
             calls.extend(_iter_dependency_calls(getattr(dependency, "dependencies", None)))
         return calls

--- a/app/routers/plan_export.py
+++ b/app/routers/plan_export.py
@@ -51,6 +51,7 @@ WEEK_EXPORT_CSV_ROUTE = "/week/export.csv"
 WEEK_EXPORT_PDF_ROUTE = "/week/export.pdf"
 WEEK_EXPORT_CSV_PATH = f"{PLAN_ROUTE_PREFIX}{WEEK_EXPORT_CSV_ROUTE}"
 WEEK_EXPORT_PDF_PATH = f"{PLAN_ROUTE_PREFIX}{WEEK_EXPORT_PDF_ROUTE}"
+# Route specs: (path, HTTP method, include_in_schema)
 PLAN_EXPORT_ROUTE_SPECS = (
     ("/api/v1/export/sign", "POST", True),
     (WEEK_EXPORT_CSV_PATH, "GET", True),

--- a/app/routers/plan_export.py
+++ b/app/routers/plan_export.py
@@ -51,6 +51,11 @@ WEEK_EXPORT_CSV_ROUTE = "/week/export.csv"
 WEEK_EXPORT_PDF_ROUTE = "/week/export.pdf"
 WEEK_EXPORT_CSV_PATH = f"{PLAN_ROUTE_PREFIX}{WEEK_EXPORT_CSV_ROUTE}"
 WEEK_EXPORT_PDF_PATH = f"{PLAN_ROUTE_PREFIX}{WEEK_EXPORT_PDF_ROUTE}"
+PLAN_EXPORT_ROUTE_SPECS = (
+    ("/api/v1/export/sign", "POST", True),
+    (WEEK_EXPORT_CSV_PATH, "GET", True),
+    (WEEK_EXPORT_PDF_PATH, "GET", True),
+)
 
 plan_router = APIRouter(prefix=PLAN_ROUTE_PREFIX, tags=["plan"])
 export_router = APIRouter(prefix="/api/v1/export", tags=["export"])
@@ -617,4 +622,4 @@ def sign_export_link_route(request: Request, payload: SignRequest) -> SignedLink
     return SignedLinkResponse(**sign_export_link(payload))
 
 
-__all__ = ["plan_router", "export_router"]
+__all__ = ["PLAN_EXPORT_ROUTE_SPECS", "plan_router", "export_router"]

--- a/docs/architecture/backend_routing_map.md
+++ b/docs/architecture/backend_routing_map.md
@@ -19,7 +19,8 @@ This is a **runtime truth** view (not a product wishlist).
 
 - Runtime entrypoint: `uvicorn app.main:app` (`Dockerfile:102-105`)
 - `app/main.py` uses `legacy_app.app` as the FastAPI instance and applies bootstrap (`app/main.py:11-22`).
-- Most route registration currently happens in `legacy_app.py`.
+- Most legacy route registration still happens in `legacy_app.py`; canonical bootstrap-owned
+  route families are registered from `app/main.py`.
 
 ## Router registration: always-on vs conditional
 
@@ -33,9 +34,29 @@ Evidence: `legacy_app.py:811-820`
 - `recipes_router` (`app/routers/recipes.py`)
 - `users_router` (`app/routers/users.py`)
 - `catalog_router` (`app/routers/catalog.py`)
-- `export_router` (`app/routers/shoplist_export.py`) — included with `dependencies=[Depends(_get_api_key_dynamic)]`
-- `plan_router` (`app/routers/plan_export.py`) — included with `dependencies=[Depends(_get_api_key_dynamic)]`
 - `shoplist_router` (`app/routers/shoplist_export.py`) — included with `dependencies=[Depends(_get_api_key_dynamic)]`
+
+### Canonical plan export routers (canonical bootstrap-owned)
+
+Anchor (stable): `app/main.py -> _include_plan_export_routers_if_needed(app)`
+
+Evidence:
+- `app/main.py` — registers `export_router` and `plan_router` from `app/routers/plan_export.py`
+  with `dependencies=[Depends(_legacy_module._get_api_key_dynamic)]`
+- `app/routers/plan_export.py` — owns implementation, rate-limit decorators, signed export token
+  guard for weekly CSV/PDF, response schemas, and `PLAN_EXPORT_ROUTE_SPECS`
+
+Runtime effect:
+- `POST /api/v1/export/sign`
+- `GET /api/v1/plan/week/export.csv`
+- `GET /api/v1/plan/week/export.pdf`
+
+OpenAPI effect:
+- Source `APIRoute.include_in_schema` remains `True`.
+- Final public `app.openapi()` continues to hide these export/plan paths through the canonical
+  OpenAPI builder.
+- Hidden legacy export aliases remain a separate compatibility router owned by
+  `app/routers/legacy_export_aliases.py`.
 
 ### VIP routes (feature-flag gated, centralized)
 

--- a/docs/review/PR_1997_FIXED_MAPPING.md
+++ b/docs/review/PR_1997_FIXED_MAPPING.md
@@ -70,8 +70,7 @@ claim.
 
 - Packet:
   `artifacts/orchestration/experiments/artifacts/orchestration/experiments/pr5_plan_export_registration_oracle_packet.json`
-- Result artifact:
-  `artifacts/orchestration/experiments/results/exp-7a6bc3ab3b0e.json`
+- Artifact: `artifacts/orchestration/experiments/results/exp-7a6bc3ab3b0e.json`
 - Status: accepted.
 - Oracles passed:
   - `python3 scripts/ci/check_legacy_growth_guard.py`
@@ -122,6 +121,13 @@ passed after the premortem.
 - CodeRabbit: FIXED merge-readiness checklist finding in `54e9ef7f5`.
   Evidence: `docs/review/PR_1997_FIXED_MAPPING.md` now uses unchecked
   checklist items under `Required before merge`.
+- Sourcery: FIXED callable-helper and dependency-depth review in `73f806833`.
+  Evidence: `app/main.py` now shares callable comparison semantics and walks
+  nested FastAPI dependency calls.
+- CodeRabbit: FIXED route-spec documentation review in `73f806833`.
+  Evidence: `app/routers/plan_export.py` documents `PLAN_EXPORT_ROUTE_SPECS`.
+- CodeRabbit: FIXED `bot/human` style review in `73f806833`.
+  Evidence: this artifact now uses `bot or human`.
 - Codex Security diff scan / finding discovery: unavailable in this Codex
   runtime. `tool_search` did not expose callable Codex Security scan tools.
 - `bug-hunter`, `security-auditor`, and `pulseplate-pr-review`: pending after
@@ -129,12 +135,11 @@ passed after the premortem.
 
 ## Discussion Thread Pass
 
-- [x] Initial discussion-thread pass completed
-- [x] Fixed in commit mapping artifact created
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
-No GitHub review threads existed at artifact creation time. Review threads must
-not be resolved without disposition evidence and this pass must be repeated
-after any new bot or human review activity.
+Review threads must not be resolved without disposition evidence and this pass
+must be repeated after any new bot or human review activity.
 
 ## Fixed in Commit Mapping
 
@@ -143,10 +148,35 @@ Disposition: FIXED
 Commit: 54e9ef7f5
 
 Evidence: `docs/review/PR_1997_FIXED_MAPPING.md` uses unchecked
-merge-readiness checklist items; focused diff-cover reports 100% changed-line
-coverage for `app/main.py` and `app/routers/plan_export.py`.
+Evidence: focused diff-cover reports 100% changed-line coverage for `app/main.py` and `app/routers/plan_export.py`.
 
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#discussion_r3444327264 -> 54e9ef7f5
+
+Disposition: FIXED
+
+Commit: 73f806833
+
+Evidence: `app/main.py` shares callable comparison semantics and recursively checks nested FastAPI dependency calls.
+Evidence: `tests/test_main_paywall_bootstrap.py` covers nested dependency detection.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534070939 -> 73f806833
+
+Disposition: FIXED
+
+Commit: 73f806833
+
+Evidence: `app/routers/plan_export.py` documents the route-spec tuple shape.
+Reason: The larger generic router-family extraction suggestion is intentionally out of scope for this narrow registration-ownership PR; CodeRabbit itself classified the current tradeoff as acceptable for this PR.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534091296 -> 73f806833
+
+Disposition: FIXED
+
+Commit: 73f806833
+
+Evidence: `docs/review/PR_1997_FIXED_MAPPING.md` uses `bot or human` wording and keeps merge-readiness checklist items unchecked.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534993087 -> 73f806833
 
 ## Deferred / Follow-Ups
 

--- a/docs/review/PR_1997_FIXED_MAPPING.md
+++ b/docs/review/PR_1997_FIXED_MAPPING.md
@@ -1,0 +1,150 @@
+# PR 1997 Fixed in Commit Mapping
+
+PR: https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997
+
+Branch: `codex/shrink-legacy-export-router-registration-seam`
+
+## Summary
+
+This PR moves canonical `plan_export` router registration ownership from
+`legacy_app.py` into canonical `app/main.py` bootstrap. It preserves the public
+method/path surface, app-level API-key dependency, weekly export signed-token
+guard, rate-limit metadata, route-level OpenAPI visibility, final public OpenAPI
+hiding, and hidden legacy export aliases.
+
+## Scope
+
+- Remove only `export_router` / `plan_router` import and registration from
+  `legacy_app.py`.
+- Add `PLAN_EXPORT_ROUTE_SPECS` in `app/routers/plan_export.py`.
+- Register `export_router` and `plan_router` from `app/main.py` through an
+  idempotent fail-closed helper.
+- Tighten `scripts/ci/check_legacy_growth_guard.py` so reintroduced legacy
+  imports/includes fail.
+- Add focused bootstrap, guard, export auth/dependency, 429 metadata, and
+  OpenAPI-hiding tests.
+- Update `docs/architecture/backend_routing_map.md` for route ownership truth.
+
+## Out Of Scope
+
+No OAuth/OIDC rewrite, auth rewrite, tier semantics change, dependency update,
+semantic cache, FoodDB, frontend/iOS work, or re-extraction of legacy export
+aliases.
+
+## Lane Start Provenance
+
+- Packet: `artifacts/orchestration/task_packets/437b193fba29.json`
+- Runtime dispatch manifest:
+  `python3 scripts/orchestration/role_dispatch_bridge.py --packet artifacts/orchestration/task_packets/437b193fba29.json --mode runtime --implementation-owner security-auditor --implementation-owner backend-engineer --pretty`
+- Pre-open role order executed:
+  `agent-coordinator -> architecture-specialist -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`
+- Starter: `check_preflight.py`, `check_agent_consistency.py`, and
+  `task_bootstrap.py`; packet creation was treated as provenance only, not role
+  execution.
+
+## Local Validation
+
+- PASS: `python3 scripts/orchestration/check_preflight.py`
+- PASS: `python3 scripts/orchestration/check_agent_consistency.py`
+- PASS: `python3 scripts/ci/check_legacy_growth_guard.py`
+- PASS: `. .venv/bin/activate && pytest -q tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_app_endpoints_combined.py tests/test_plan_export_additional.py tests/test_export_signed.py tests/test_legacy_export_aliases.py tests/test_rate_limit_llm_and_exports_api.py tests/security/test_api_auth_tier_contract_pack.py tests/test_pro_vip_route_dependency_guard.py tests/test_openapi_namespace_guards.py tests/test_openapi_determinism.py tests/test_week_export_csv.py tests/test_signed_links.py`
+  (`256 passed`)
+- PASS: `. .venv/bin/activate && pytest -q tests/test_rate_limit_llm_and_exports_api.py::test_plan_week_export_csv_rate_limited_200_then_429 tests/test_rate_limit_llm_and_exports_api.py::test_export_sign_rate_limited_200_then_429`
+- PASS: `make openapi && git diff --exit-code -- frontend/src/api/openapi.json frontend/src/api/schema.ts`
+- PASS: `make validate-changed`; note: selected no files, so it is not treated
+  as sufficient changed-surface evidence for this PR.
+- PASS: `pre-commit run --all-files`
+- PASS: commit/push hooks, including changed-file backend tests,
+  changed-file mypy, full-repo Bandit, pip-audit, and Docker build test.
+
+## Machine-Heavy Verification Deferral
+
+Operator override applies: no deliberate full local `make verify` for this PR.
+The accidental earlier `make verify` invocation is discarded and is not PR-5
+gate evidence; it failed on inherited `legacy_app.py` lint unrelated to this
+validation plan. Current-head CI parity, post-open review disposition, strict
+merge-readiness, and the mandatory wait-window still apply before any merge
+claim.
+
+## Experiment Runner Evidence
+
+- Packet:
+  `artifacts/orchestration/experiments/artifacts/orchestration/experiments/pr5_plan_export_registration_oracle_packet.json`
+- Result artifact:
+  `artifacts/orchestration/experiments/results/exp-7a6bc3ab3b0e.json`
+- Status: accepted.
+- Oracles passed:
+  - `python3 scripts/ci/check_legacy_growth_guard.py`
+  - `pytest -q tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_plan_export_additional.py tests/security/test_api_auth_tier_contract_pack.py`
+  - `pytest -q tests/test_openapi_namespace_guards.py tests/test_openapi_determinism.py`
+- Attribution: no co-author trailer. The oracle was validation evidence and did
+  not materially shape code, tests, mapping, or commit decisions.
+
+## Premortem Findings
+
+Disposition: FIXED
+
+Finding: `PR5-P1-001` reported that the reviewed diff was only in the working
+tree and would be omitted if the PR opened before commit/push.
+
+Commit: a90daa4ad
+
+Evidence: implementation commit `a90daa4ad` contains the eight tracked PR files,
+and `git push -u origin codex/shrink-legacy-export-router-registration-seam`
+created the remote branch.
+
+Disposition: NOT-A-BUG
+
+Finding: `PR5-P2-001` noted that the authz contract pack uses
+`ApiExposure.PUBLIC_OPENAPI` for `/api/v1/export/sign` because that registry
+tracks source `APIRoute.include_in_schema`, while final `app.openapi()` hides the
+path.
+
+Evidence: `tests/test_plan_export_additional.py` asserts both source
+`include_in_schema` preservation and final public OpenAPI hiding for all
+canonical plan/export routes. This is intended route metadata behavior, not
+final schema exposure.
+
+Disposition: FIXED
+
+Finding: `PR5-P2-002` requested deterministic export rate-limit behavior checks.
+
+Evidence: `. .venv/bin/activate && pytest -q tests/test_rate_limit_llm_and_exports_api.py::test_plan_week_export_csv_rate_limited_200_then_429 tests/test_rate_limit_llm_and_exports_api.py::test_export_sign_rate_limited_200_then_429`
+passed after the premortem.
+
+## Post-Open Review Evidence
+
+Pending. This artifact was created immediately after PR open and before
+post-open bot/human review. Mandatory post-open role review and Codex Security
+scan/finding discovery remain required before merge-readiness.
+
+## Discussion Thread Pass
+
+- [x] Initial discussion-thread pass completed
+- [x] Fixed in commit mapping artifact created
+
+No GitHub review threads existed at artifact creation time. Review threads must
+not be resolved without disposition evidence and this pass must be repeated
+after any new bot or human review activity.
+
+## Fixed in Commit Mapping
+
+No GitHub review-thread mappings yet.
+
+## Deferred / Follow-Ups
+
+No product follow-up. Full local `make verify` remains deferred by operator
+override as documented above.
+
+## Merge Readiness
+
+Status: NOT READY while post-open role review, Codex Security scan/finding
+discovery, current-head CI, bot/human review disposition, strict
+merge-readiness, and the mandatory wait-window remain pending.
+
+Required before merge:
+
+- Fresh current-head PR CI parity.
+- No unresolved actionable human or bot review comments.
+- Strict merge-readiness with auth passes.
+- Mandatory wait-window after latest review/bot activity.

--- a/docs/review/PR_1997_FIXED_MAPPING.md
+++ b/docs/review/PR_1997_FIXED_MAPPING.md
@@ -108,6 +108,8 @@ Disposition: FIXED
 
 Finding: `PR5-P2-002` requested deterministic export rate-limit behavior checks.
 
+Commit: a90daa4ad
+
 Evidence: `. .venv/bin/activate && pytest -q tests/test_rate_limit_llm_and_exports_api.py::test_plan_week_export_csv_rate_limited_200_then_429 tests/test_rate_limit_llm_and_exports_api.py::test_export_sign_rate_limited_200_then_429`
 passed after the premortem.
 
@@ -153,38 +155,26 @@ must be repeated after any new bot or human review activity.
 ## Fixed in Commit Mapping
 
 Disposition: FIXED
-
 Commit: 54e9ef7f5
-
 Evidence: `docs/review/PR_1997_FIXED_MAPPING.md` uses unchecked
 Evidence: focused diff-cover reports 100% changed-line coverage for `app/main.py` and `app/routers/plan_export.py`.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#discussion_r3444327264 -> 54e9ef7f5
 
 Disposition: FIXED
-
 Commit: 891a1438c
-
 Evidence: `app/main.py` shares callable comparison semantics and recursively checks nested FastAPI dependency calls.
 Evidence: `tests/test_main_paywall_bootstrap.py` covers nested dependency detection.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534070939 -> 891a1438c
 
 Disposition: FIXED
-
 Commit: e255e0244
-
 Evidence: `app/routers/plan_export.py` documents the route-spec tuple shape.
 Reason: The larger generic router-family extraction suggestion is intentionally out of scope for this narrow registration-ownership PR; CodeRabbit itself classified the current tradeoff as acceptable for this PR.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534091296 -> e255e0244
 
 Disposition: FIXED
-
 Commit: e255e0244
-
 Evidence: `docs/review/PR_1997_FIXED_MAPPING.md` uses `bot or human` wording and keeps merge-readiness checklist items unchecked.
-
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534993087 -> e255e0244
 
 ## Deferred / Follow-Ups

--- a/docs/review/PR_1997_FIXED_MAPPING.md
+++ b/docs/review/PR_1997_FIXED_MAPPING.md
@@ -121,7 +121,7 @@ passed after the premortem.
 - CodeRabbit: FIXED merge-readiness checklist finding in `54e9ef7f5`.
   Evidence: `docs/review/PR_1997_FIXED_MAPPING.md` now uses unchecked
   checklist items under `Required before merge`.
-- Sourcery: FIXED callable-helper and dependency-depth review in `e255e0244`.
+- Sourcery: FIXED callable-helper and dependency-depth review in `891a1438c`.
   Evidence: `app/main.py` now shares callable comparison semantics and walks
   nested FastAPI dependency calls.
 - CodeRabbit: FIXED route-spec documentation review in `e255e0244`.
@@ -154,12 +154,12 @@ Evidence: focused diff-cover reports 100% changed-line coverage for `app/main.py
 
 Disposition: FIXED
 
-Commit: e255e0244
+Commit: 891a1438c
 
 Evidence: `app/main.py` shares callable comparison semantics and recursively checks nested FastAPI dependency calls.
 Evidence: `tests/test_main_paywall_bootstrap.py` covers nested dependency detection.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534070939 -> e255e0244
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534070939 -> 891a1438c
 
 Disposition: FIXED
 

--- a/docs/review/PR_1997_FIXED_MAPPING.md
+++ b/docs/review/PR_1997_FIXED_MAPPING.md
@@ -114,9 +114,18 @@ passed after the premortem.
 
 ## Post-Open Review Evidence
 
-Pending. This artifact was created immediately after PR open and before
-post-open bot/human review. Mandatory post-open role review and Codex Security
-scan/finding discovery remain required before merge-readiness.
+- `qa-engineer-agent`: FIXED valid governance checklist and diff-coverage
+  findings in `54e9ef7f5`. Evidence:
+  `docs/review/PR_1997_FIXED_MAPPING.md` uses unchecked merge-readiness
+  checklist items, and focused diff-cover reported `app/main.py (100%)`,
+  `app/routers/plan_export.py (100%)`, total changed-line coverage `100%`.
+- CodeRabbit: FIXED merge-readiness checklist finding in `54e9ef7f5`.
+  Evidence: `docs/review/PR_1997_FIXED_MAPPING.md` now uses unchecked
+  checklist items under `Required before merge`.
+- Codex Security diff scan / finding discovery: unavailable in this Codex
+  runtime. `tool_search` did not expose callable Codex Security scan tools.
+- `bug-hunter`, `security-auditor`, and `pulseplate-pr-review`: pending after
+  the `54e9ef7f5` fix commit.
 
 ## Discussion Thread Pass
 
@@ -129,7 +138,15 @@ after any new bot or human review activity.
 
 ## Fixed in Commit Mapping
 
-No GitHub review-thread mappings yet.
+Disposition: FIXED
+
+Commit: 54e9ef7f5
+
+Evidence: `docs/review/PR_1997_FIXED_MAPPING.md` uses unchecked
+merge-readiness checklist items; focused diff-cover reports 100% changed-line
+coverage for `app/main.py` and `app/routers/plan_export.py`.
+
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#discussion_r3444327264 -> 54e9ef7f5
 
 ## Deferred / Follow-Ups
 

--- a/docs/review/PR_1997_FIXED_MAPPING.md
+++ b/docs/review/PR_1997_FIXED_MAPPING.md
@@ -144,7 +144,7 @@ merge-readiness, and the mandatory wait-window remain pending.
 
 Required before merge:
 
-- Fresh current-head PR CI parity.
-- No unresolved actionable human or bot review comments.
-- Strict merge-readiness with auth passes.
-- Mandatory wait-window after latest review/bot activity.
+- [ ] Fresh current-head PR CI parity.
+- [ ] No unresolved actionable human or bot review comments.
+- [ ] Strict merge-readiness with auth passes.
+- [ ] Mandatory wait-window after latest review/bot activity.

--- a/docs/review/PR_1997_FIXED_MAPPING.md
+++ b/docs/review/PR_1997_FIXED_MAPPING.md
@@ -128,10 +128,19 @@ passed after the premortem.
   Evidence: `app/routers/plan_export.py` documents `PLAN_EXPORT_ROUTE_SPECS`.
 - CodeRabbit: FIXED `bot/human` style review in `e255e0244`.
   Evidence: this artifact now uses `bot or human`.
+- `bug-hunter`: FIXED Phase 2 parser and mapping-shape findings in
+  `9f6beef12` and `e255e0244`. Evidence: local
+  `check_pr_body_phase2_gates.py` passed against the live PR body after the
+  mapping/body mirror updates.
+- `security-auditor`: PASS on `e551bfcb5`; no blocking code or security
+  findings. Evidence: read-only pass confirmed API-key dependency preservation,
+  429 metadata enforcement, signed-token guard placement, legacy guard coverage,
+  and zero unresolved review threads.
+- `pulseplate-pr-review`: PASS on `e551bfcb5`; no blocking findings. Evidence:
+  read-only pass confirmed coherent ownership move, auth preservation, route
+  metadata tests, passing Phase 2 body gate, and no unresolved review threads.
 - Codex Security diff scan / finding discovery: unavailable in this Codex
   runtime. `tool_search` did not expose callable Codex Security scan tools.
-- `bug-hunter`, `security-auditor`, and `pulseplate-pr-review`: pending after
-  the `54e9ef7f5` fix commit.
 
 ## Discussion Thread Pass
 
@@ -185,9 +194,9 @@ override as documented above.
 
 ## Merge Readiness
 
-Status: NOT READY while post-open role review, Codex Security scan/finding
-discovery, current-head CI, bot/human review disposition, strict
-merge-readiness, and the mandatory wait-window remain pending.
+Status: NOT READY while current-head CI, Codecov coverage supersession or
+disposition, strict merge-readiness, and the mandatory wait-window remain
+pending.
 
 Required before merge:
 

--- a/docs/review/PR_1997_FIXED_MAPPING.md
+++ b/docs/review/PR_1997_FIXED_MAPPING.md
@@ -121,12 +121,12 @@ passed after the premortem.
 - CodeRabbit: FIXED merge-readiness checklist finding in `54e9ef7f5`.
   Evidence: `docs/review/PR_1997_FIXED_MAPPING.md` now uses unchecked
   checklist items under `Required before merge`.
-- Sourcery: FIXED callable-helper and dependency-depth review in `73f806833`.
+- Sourcery: FIXED callable-helper and dependency-depth review in `e255e0244`.
   Evidence: `app/main.py` now shares callable comparison semantics and walks
   nested FastAPI dependency calls.
-- CodeRabbit: FIXED route-spec documentation review in `73f806833`.
+- CodeRabbit: FIXED route-spec documentation review in `e255e0244`.
   Evidence: `app/routers/plan_export.py` documents `PLAN_EXPORT_ROUTE_SPECS`.
-- CodeRabbit: FIXED `bot/human` style review in `73f806833`.
+- CodeRabbit: FIXED `bot/human` style review in `e255e0244`.
   Evidence: this artifact now uses `bot or human`.
 - Codex Security diff scan / finding discovery: unavailable in this Codex
   runtime. `tool_search` did not expose callable Codex Security scan tools.
@@ -154,29 +154,29 @@ Evidence: focused diff-cover reports 100% changed-line coverage for `app/main.py
 
 Disposition: FIXED
 
-Commit: 73f806833
+Commit: e255e0244
 
 Evidence: `app/main.py` shares callable comparison semantics and recursively checks nested FastAPI dependency calls.
 Evidence: `tests/test_main_paywall_bootstrap.py` covers nested dependency detection.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534070939 -> 73f806833
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534070939 -> e255e0244
 
 Disposition: FIXED
 
-Commit: 73f806833
+Commit: e255e0244
 
 Evidence: `app/routers/plan_export.py` documents the route-spec tuple shape.
 Reason: The larger generic router-family extraction suggestion is intentionally out of scope for this narrow registration-ownership PR; CodeRabbit itself classified the current tradeoff as acceptable for this PR.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534091296 -> 73f806833
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534091296 -> e255e0244
 
 Disposition: FIXED
 
-Commit: 73f806833
+Commit: e255e0244
 
 Evidence: `docs/review/PR_1997_FIXED_MAPPING.md` uses `bot or human` wording and keeps merge-readiness checklist items unchecked.
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534993087 -> 73f806833
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534993087 -> e255e0244
 
 ## Deferred / Follow-Ups
 

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -56,7 +56,6 @@ from app.routers.business import router as business_router
 from app.routers.catalog import router as catalog_router
 from app.routers.foods import router as foods_router
 from app.routers.nutrition_recommendations import router as nutrition_recommendations_router
-from app.routers.plan_export import export_router, plan_router
 from app.routers.pro_registration import register_pro_routes as _register_pro_routes
 from app.routers.recipes import router as recipes_router
 from app.routers.restaurants import (
@@ -932,8 +931,6 @@ app.include_router(
     dependencies=[protected_dependency],
     include_in_schema=False,
 )
-app.include_router(export_router, dependencies=[protected_dependency])
-app.include_router(plan_router, dependencies=[protected_dependency])
 app.include_router(shoplist_router, dependencies=[protected_dependency])
 
 # Register VIP routes (centralized, explicit registration)

--- a/scripts/ci/check_legacy_growth_guard.py
+++ b/scripts/ci/check_legacy_growth_guard.py
@@ -74,7 +74,7 @@ SENSITIVE_CALL_LIMITS: Mapping[str, int] = {
     "subscription": 0,
 }
 SENSITIVE_APP_SURFACE_LIMITS: Mapping[str, int] = {
-    "api_key": 10,
+    "api_key": 8,
     "auth": 0,
     "billing": 0,
     "entitlement": 0,
@@ -105,8 +105,6 @@ ALLOWED_LEGACY_ROUTE_FACTS = frozenset(
         LegacyFact("registration", "include_router", "users_router", ""),
         LegacyFact("registration", "include_router", "catalog_router", ""),
         LegacyFact("registration", "include_router", "restaurant_moderation_router", ""),
-        LegacyFact("registration", "include_router", "export_router", ""),
-        LegacyFact("registration", "include_router", "plan_router", ""),
         LegacyFact("registration", "include_router", "shoplist_router", ""),
         LegacyFact("registration", "include_router", "shopping_list_pro_router", ""),
         LegacyFact("registration", "include_router", "shoplist_day_router", ""),
@@ -154,8 +152,6 @@ ALLOWED_ROUTER_IMPORT_FACTS = frozenset(
             "router",
             "nutrition_recommendations_router",
         ),
-        LegacyFact("router_import", "app.routers.plan_export", "export_router", ""),
-        LegacyFact("router_import", "app.routers.plan_export", "plan_router", ""),
         LegacyFact(
             "router_import", "app.routers.pro_nutrition_contracts", "pro_nutrition_plate", ""
         ),

--- a/tests/test_legacy_growth_guard.py
+++ b/tests/test_legacy_growth_guard.py
@@ -448,6 +448,50 @@ def test_legacy_growth_guard_rejects_legal_router_import() -> None:
     ]
 
 
+def test_legacy_growth_guard_rejects_reintroduced_plan_export_router_registration() -> None:
+    source = textwrap.dedent("""
+        from app.routers.plan_export import export_router, plan_router
+
+        app.include_router(export_router, dependencies=[protected_dependency])
+        app.include_router(plan_router, dependencies=[protected_dependency])
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:export_router",
+        "legacy_app.py: unexpected legacy route growth: " "registration:include_router:plan_router",
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:app.routers.plan_export:export_router",
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:app.routers.plan_export:plan_router",
+    ]
+
+
+def test_legacy_growth_guard_rejects_reintroduced_aliased_plan_export_registration() -> None:
+    source = textwrap.dedent("""
+        from app.routers.plan_export import export_router as canonical_export_router
+        from app.routers.plan_export import plan_router as canonical_plan_router
+
+        app.include_router(canonical_export_router, dependencies=[protected_dependency])
+        app.include_router(canonical_plan_router, dependencies=[protected_dependency])
+        """)
+
+    errors = legacy_guard.validate_legacy_growth(source)
+
+    assert errors == [
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:canonical_export_router",
+        "legacy_app.py: unexpected legacy route growth: "
+        "registration:include_router:canonical_plan_router",
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:app.routers.plan_export:export_router -> canonical_export_router",
+        "legacy_app.py: unexpected app.routers import growth: "
+        "router_import:app.routers.plan_export:plan_router -> canonical_plan_router",
+    ]
+
+
 def test_legacy_growth_guard_rejects_normal_router_import() -> None:
     source = "import app.routers.new_surface as new_surface\n"
 
@@ -614,7 +658,7 @@ def test_legacy_growth_guard_rejects_api_key_surface_growth_on_current_baseline(
 
     errors = legacy_guard.validate_legacy_growth(source)
 
-    assert errors == ["legacy_app.py: sensitive app surface grew for api_key: 11 > 10"]
+    assert errors == ["legacy_app.py: sensitive app surface grew for api_key: 9 > 8"]
 
 
 def test_legacy_growth_guard_ignores_comments_and_strings() -> None:

--- a/tests/test_main_paywall_bootstrap.py
+++ b/tests/test_main_paywall_bootstrap.py
@@ -224,6 +224,16 @@ def _plan_export_stub_routers_with_combined_methods() -> tuple[APIRouter, APIRou
     return export_stub_router, plan_stub_router
 
 
+def _plan_export_stub_routers_with_unrelated_path() -> tuple[APIRouter, APIRouter]:
+    export_stub_router, plan_stub_router = _plan_export_stub_routers()
+
+    async def _unrelated_handler() -> dict[str, str]:
+        return {"status": "unrelated"}
+
+    plan_stub_router.get("/api/v1/unrelated-plan-export-probe")(_unrelated_handler)
+    return export_stub_router, plan_stub_router
+
+
 def _duplicate_health_stub_router() -> APIRouter:
     router = _health_stub_router()
 
@@ -403,6 +413,34 @@ def _app_with_legacy_export_alias_routes_and_extra_method(*, combined_route: boo
         _extra_method_handler,
         methods=extra_methods,
         include_in_schema=extra_include,
+    )
+    return app
+
+
+def _app_with_plan_export_routes_and_extra_method(*, combined_route: bool) -> FastAPI:
+    app = FastAPI()
+    extra_path, extra_method, extra_include = app_main._PLAN_EXPORT_ROUTE_SPECS[0]
+
+    app.include_router(
+        app_main.export_router,
+        dependencies=[Depends(app_main._legacy_module._get_api_key_dynamic)],
+    )
+    app.include_router(
+        app_main.plan_router,
+        dependencies=[Depends(app_main._legacy_module._get_api_key_dynamic)],
+    )
+
+    async def _extra_method_handler() -> dict[str, str]:
+        return {"status": "extra-method"}
+
+    opposite_method = "POST" if extra_method == "GET" else "GET"
+    extra_methods = [extra_method, opposite_method] if combined_route else [opposite_method]
+    app.add_api_route(
+        extra_path,
+        _extra_method_handler,
+        methods=extra_methods,
+        include_in_schema=extra_include,
+        responses={429: {"description": "Rate limit exceeded"}},
     )
     return app
 
@@ -1257,6 +1295,19 @@ def test_plan_export_route_registration_rejects_partial_state(
         _bootstrap_temp_app(app)
 
 
+def test_plan_export_route_registration_rejects_missing_api_key_dependency_symbol(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    monkeypatch.setattr(app_main._legacy_module, "_get_api_key_dynamic", None)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Plan export API key dependency is unavailable",
+    ):
+        _bootstrap_temp_app(FastAPI())
+
+
 def test_plan_export_route_registration_rejects_wrong_method(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1277,6 +1328,30 @@ def test_plan_export_route_registration_rejects_wrong_method(
         match="Partial plan export route registration detected",
     ):
         _bootstrap_temp_app(app)
+
+
+def test_plan_export_route_registration_rejects_existing_wrong_method_after_full_family(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Partial plan export route registration detected",
+    ):
+        _bootstrap_temp_app(_app_with_plan_export_routes_and_extra_method(combined_route=False))
+
+
+def test_plan_export_route_registration_rejects_existing_combined_methods(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Partial plan export route registration detected",
+    ):
+        _bootstrap_temp_app(_app_with_plan_export_routes_and_extra_method(combined_route=True))
 
 
 def test_plan_export_route_registration_rejects_wrong_method_in_router(
@@ -1311,6 +1386,33 @@ def test_plan_export_route_registration_rejects_combined_methods_in_router(
         match="Plan export router does not define the expected route family",
     ):
         _bootstrap_temp_app(FastAPI())
+
+
+def test_plan_export_route_registration_allows_unrelated_router_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    export_stub_router, plan_stub_router = _plan_export_stub_routers_with_unrelated_path()
+    monkeypatch.setattr(app_main, "export_router", export_stub_router)
+    monkeypatch.setattr(app_main, "plan_router", plan_stub_router)
+
+    app = _bootstrap_temp_app(FastAPI())
+
+    assert any(
+        getattr(route, "path", None) == "/api/v1/unrelated-plan-export-probe"
+        for route in app.routes
+    )
+
+
+def test_plan_export_callable_equivalence_rejects_non_callables() -> None:
+    expected_endpoint = next(
+        route.endpoint
+        for route in app_main.export_router.routes
+        if getattr(route, "path", None) == app_main._PLAN_EXPORT_ROUTE_SPECS[0][0]
+    )
+
+    assert not app_main._is_same_plan_export_callable(None, expected_endpoint)
+    assert not app_main._is_same_plan_export_callable(expected_endpoint, None)
 
 
 def test_plan_export_route_registration_rejects_foreign_handlers(
@@ -1390,6 +1492,32 @@ def test_plan_export_route_registration_rejects_existing_openapi_visibility_drif
     with pytest.raises(
         RuntimeError,
         match="Existing .* route does not preserve plan export OpenAPI visibility",
+    ):
+        app_main._include_plan_export_routers_if_needed(app)
+
+
+def test_plan_export_route_registration_rejects_existing_429_metadata_drift() -> None:
+    app = FastAPI()
+    app.include_router(
+        app_main.export_router,
+        dependencies=[Depends(app_main._legacy_module._get_api_key_dynamic)],
+    )
+    app.include_router(
+        app_main.plan_router,
+        dependencies=[Depends(app_main._legacy_module._get_api_key_dynamic)],
+    )
+    path, method, _include_in_schema = app_main._PLAN_EXPORT_ROUTE_SPECS[0]
+    matching_route = next(
+        route
+        for route in app.routes
+        if getattr(route, "path", None) == path
+        and method in (getattr(route, "methods", None) or set())
+    )
+    matching_route.responses.pop(429, None)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing .* route does not preserve 429 response metadata",
     ):
         app_main._include_plan_export_routers_if_needed(app)
 

--- a/tests/test_main_paywall_bootstrap.py
+++ b/tests/test_main_paywall_bootstrap.py
@@ -1496,6 +1496,36 @@ def test_plan_export_route_registration_rejects_existing_openapi_visibility_drif
         app_main._include_plan_export_routers_if_needed(app)
 
 
+def test_plan_export_dependency_detection_walks_nested_dependencies() -> None:
+    app = FastAPI()
+
+    async def _outer_dependency(
+        _guard: None = Depends(app_main._legacy_module._get_api_key_dynamic),
+    ) -> None:
+        return None
+
+    async def _nested_dependency_probe() -> dict[str, str]:
+        return {"status": "nested"}
+
+    app.add_api_route(
+        "/api/v1/nested-plan-export-dependency-probe",
+        _nested_dependency_probe,
+        methods=["GET"],
+        dependencies=[Depends(_outer_dependency)],
+    )
+
+    route = next(
+        route
+        for route in app.routes
+        if getattr(route, "path", None) == "/api/v1/nested-plan-export-dependency-probe"
+    )
+
+    assert app_main._route_has_dependency_call(
+        route,
+        app_main._legacy_module._get_api_key_dynamic,
+    )
+
+
 def test_plan_export_route_registration_rejects_existing_429_metadata_drift() -> None:
     app = FastAPI()
     app.include_router(

--- a/tests/test_main_paywall_bootstrap.py
+++ b/tests/test_main_paywall_bootstrap.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, FastAPI, Response
+from fastapi import APIRouter, Depends, FastAPI, Response
 from fastapi.testclient import TestClient
 import pytest
 from typing import Generator
@@ -143,6 +143,85 @@ def _legacy_export_alias_stub_router(
         )
 
     return router
+
+
+def _plan_export_stub_routers(
+    *,
+    omit: frozenset[str] = frozenset(),
+    method_overrides: dict[str, str] | None = None,
+    include_overrides: dict[str, bool] | None = None,
+    include_429: bool = True,
+) -> tuple[APIRouter, APIRouter]:
+    export_stub_router = APIRouter()
+    plan_stub_router = APIRouter()
+    method_override_map = method_overrides or {}
+    include_override_map = include_overrides or {}
+    responses = {429: {"description": "Rate limit exceeded"}} if include_429 else None
+
+    for path, method, include_in_schema in app_main._PLAN_EXPORT_ROUTE_SPECS:
+        if path in omit:
+            continue
+        route_method = method_override_map.get(path, method).lower()
+        route_include = include_override_map.get(path, include_in_schema)
+        target_router = (
+            export_stub_router if path.startswith("/api/v1/export/") else plan_stub_router
+        )
+
+        async def _plan_export_handler(path: str = path) -> dict[str, str]:
+            return {"status": path}
+
+        getattr(target_router, route_method)(
+            path,
+            include_in_schema=route_include,
+            responses=responses,
+        )(_plan_export_handler)
+
+    return export_stub_router, plan_stub_router
+
+
+def _duplicate_plan_export_stub_routers() -> tuple[APIRouter, APIRouter]:
+    export_stub_router, plan_stub_router = _plan_export_stub_routers()
+    duplicate_path, duplicate_method, duplicate_include = app_main._PLAN_EXPORT_ROUTE_SPECS[0]
+    target_router = (
+        export_stub_router if duplicate_path.startswith("/api/v1/export/") else plan_stub_router
+    )
+
+    async def _second_plan_export_handler() -> dict[str, str]:
+        return {"status": "duplicate"}
+
+    getattr(target_router, duplicate_method.lower())(
+        duplicate_path,
+        include_in_schema=duplicate_include,
+        responses={429: {"description": "Rate limit exceeded"}},
+    )(_second_plan_export_handler)
+    return export_stub_router, plan_stub_router
+
+
+def _plan_export_stub_routers_with_combined_methods() -> tuple[APIRouter, APIRouter]:
+    export_stub_router = APIRouter()
+    plan_stub_router = APIRouter()
+    combined_path, combined_method, combined_include = app_main._PLAN_EXPORT_ROUTE_SPECS[0]
+
+    for path, method, include_in_schema in app_main._PLAN_EXPORT_ROUTE_SPECS:
+        target_router = (
+            export_stub_router if path.startswith("/api/v1/export/") else plan_stub_router
+        )
+
+        async def _plan_export_handler(path: str = path) -> dict[str, str]:
+            return {"status": path}
+
+        methods = [method]
+        if path == combined_path:
+            methods.append("GET" if combined_method == "POST" else "POST")
+        target_router.add_api_route(
+            path,
+            _plan_export_handler,
+            methods=methods,
+            include_in_schema=combined_include if path == combined_path else include_in_schema,
+            responses={429: {"description": "Rate limit exceeded"}},
+        )
+
+    return export_stub_router, plan_stub_router
 
 
 def _duplicate_health_stub_router() -> APIRouter:
@@ -1126,6 +1205,221 @@ def test_bmi_compat_route_registration_rejects_duplicate_canonical_router_paths(
     with pytest.raises(
         RuntimeError,
         match="BMI compatibility router does not define the expected route family",
+    ):
+        _bootstrap_temp_app(FastAPI())
+
+
+def test_plan_export_route_registration_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+
+    app = FastAPI()
+
+    _bootstrap_temp_app(app)
+    _bootstrap_temp_app(app)
+
+    for path, method, include_in_schema in app_main._PLAN_EXPORT_ROUTE_SPECS:
+        matching_routes = [
+            route
+            for route in app.routes
+            if getattr(route, "path", None) == path
+            and method in (getattr(route, "methods", None) or set())
+        ]
+        assert len(matching_routes) == 1
+        assert getattr(matching_routes[0], "endpoint").__module__ == "app.routers.plan_export"
+        assert getattr(matching_routes[0], "include_in_schema", True) is include_in_schema
+        assert 429 in (getattr(matching_routes[0], "responses", None) or {})
+        assert app_main._route_has_dependency_call(
+            matching_routes[0],
+            app_main._legacy_module._get_api_key_dynamic,
+        )
+
+
+def test_plan_export_route_registration_rejects_partial_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    app = FastAPI()
+    path, method, include_in_schema = app_main._PLAN_EXPORT_ROUTE_SPECS[0]
+
+    async def _existing_plan_export_route() -> dict[str, str]:
+        return {"status": "partial"}
+
+    getattr(app, method.lower())(path, include_in_schema=include_in_schema)(
+        _existing_plan_export_route
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Partial plan export route registration detected",
+    ):
+        _bootstrap_temp_app(app)
+
+
+def test_plan_export_route_registration_rejects_wrong_method(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    app = FastAPI()
+    path, method, include_in_schema = app_main._PLAN_EXPORT_ROUTE_SPECS[0]
+
+    async def _wrong_method_plan_export_route() -> dict[str, str]:
+        return {"status": "wrong-method"}
+
+    wrong_method = "GET" if method == "POST" else "POST"
+    getattr(app, wrong_method.lower())(path, include_in_schema=include_in_schema)(
+        _wrong_method_plan_export_route
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Partial plan export route registration detected",
+    ):
+        _bootstrap_temp_app(app)
+
+
+def test_plan_export_route_registration_rejects_wrong_method_in_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    path, method, _include_in_schema = app_main._PLAN_EXPORT_ROUTE_SPECS[0]
+    wrong_method = "GET" if method == "POST" else "POST"
+    export_stub_router, plan_stub_router = _plan_export_stub_routers(
+        method_overrides={path: wrong_method}
+    )
+    monkeypatch.setattr(app_main, "export_router", export_stub_router)
+    monkeypatch.setattr(app_main, "plan_router", plan_stub_router)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Plan export router does not define the expected route family",
+    ):
+        _bootstrap_temp_app(FastAPI())
+
+
+def test_plan_export_route_registration_rejects_combined_methods_in_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    export_stub_router, plan_stub_router = _plan_export_stub_routers_with_combined_methods()
+    monkeypatch.setattr(app_main, "export_router", export_stub_router)
+    monkeypatch.setattr(app_main, "plan_router", plan_stub_router)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Plan export router does not define the expected route family",
+    ):
+        _bootstrap_temp_app(FastAPI())
+
+
+def test_plan_export_route_registration_rejects_foreign_handlers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    app = FastAPI()
+
+    for path, method, include_in_schema in app_main._PLAN_EXPORT_ROUTE_SPECS:
+
+        async def _foreign_plan_export_route(path: str = path) -> dict[str, str]:
+            return {"status": path}
+
+        getattr(app, method.lower())(path, include_in_schema=include_in_schema)(
+            _foreign_plan_export_route
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Duplicate .* route detected with a different plan export handler",
+    ):
+        _bootstrap_temp_app(app)
+
+
+def test_plan_export_route_registration_rejects_missing_api_key_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    app = FastAPI()
+    app.include_router(app_main.export_router)
+    app.include_router(app_main.plan_router)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing .* route does not preserve plan export API key dependency",
+    ):
+        app_main._include_plan_export_routers_if_needed(app)
+
+
+def test_plan_export_route_registration_rejects_openapi_visibility_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    path, _method, include_in_schema = app_main._PLAN_EXPORT_ROUTE_SPECS[0]
+    export_stub_router, plan_stub_router = _plan_export_stub_routers(
+        include_overrides={path: not include_in_schema}
+    )
+    monkeypatch.setattr(app_main, "export_router", export_stub_router)
+    monkeypatch.setattr(app_main, "plan_router", plan_stub_router)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Plan export router does not preserve OpenAPI visibility",
+    ):
+        _bootstrap_temp_app(FastAPI())
+
+
+def test_plan_export_route_registration_rejects_existing_openapi_visibility_drift() -> None:
+    app = FastAPI()
+    app.include_router(
+        app_main.export_router,
+        dependencies=[Depends(app_main._legacy_module._get_api_key_dynamic)],
+    )
+    app.include_router(
+        app_main.plan_router,
+        dependencies=[Depends(app_main._legacy_module._get_api_key_dynamic)],
+    )
+    path, method, include_in_schema = app_main._PLAN_EXPORT_ROUTE_SPECS[0]
+    matching_route = next(
+        route
+        for route in app.routes
+        if getattr(route, "path", None) == path
+        and method in (getattr(route, "methods", None) or set())
+    )
+    matching_route.include_in_schema = not include_in_schema
+
+    with pytest.raises(
+        RuntimeError,
+        match="Existing .* route does not preserve plan export OpenAPI visibility",
+    ):
+        app_main._include_plan_export_routers_if_needed(app)
+
+
+def test_plan_export_route_registration_rejects_missing_429_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    export_stub_router, plan_stub_router = _plan_export_stub_routers(include_429=False)
+    monkeypatch.setattr(app_main, "export_router", export_stub_router)
+    monkeypatch.setattr(app_main, "plan_router", plan_stub_router)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Plan export router does not preserve 429 response metadata",
+    ):
+        _bootstrap_temp_app(FastAPI())
+
+
+def test_plan_export_route_registration_rejects_duplicate_canonical_router_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_bootstrap_dependencies(monkeypatch)
+    export_stub_router, plan_stub_router = _duplicate_plan_export_stub_routers()
+    monkeypatch.setattr(app_main, "export_router", export_stub_router)
+    monkeypatch.setattr(app_main, "plan_router", plan_stub_router)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Plan export router does not define the expected route family",
     ):
         _bootstrap_temp_app(FastAPI())
 

--- a/tests/test_plan_export_additional.py
+++ b/tests/test_plan_export_additional.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import inspect
 from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
+from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 
+from legacy_app import _get_api_key_dynamic
 from app.main import app
 from app.routers import plan_export
 import settings
+from tests.security._api_authz_contracts import _contains_dependency, _flatten_dependency_calls
 
 
 def test_slogan_default() -> None:
@@ -178,26 +182,33 @@ def test_export_token_ttl_rejects_non_positive_value(
 
 
 def test_export_routes_are_registered_but_hidden_from_public_openapi() -> None:
-    runtime_paths = {
-        getattr(route, "path", None)
-        for route in app.routes
-        if getattr(route, "path", None)
-        in {
-            "/api/v1/export/sign",
-            plan_export.WEEK_EXPORT_CSV_PATH,
-            plan_export.WEEK_EXPORT_PDF_PATH,
-            plan_export.SHOPLIST_EXPORT_PDF_PATH,
-        }
+    expected_routes = {
+        (method, path): include_in_schema
+        for path, method, include_in_schema in plan_export.PLAN_EXPORT_ROUTE_SPECS
     }
     public_paths = app.openapi()["paths"]
 
-    assert runtime_paths == {
-        "/api/v1/export/sign",
-        plan_export.WEEK_EXPORT_CSV_PATH,
-        plan_export.WEEK_EXPORT_PDF_PATH,
-        plan_export.SHOPLIST_EXPORT_PDF_PATH,
-    }
-    assert "/api/v1/export/sign" not in public_paths
-    assert plan_export.WEEK_EXPORT_CSV_PATH not in public_paths
-    assert plan_export.WEEK_EXPORT_PDF_PATH not in public_paths
+    for (method, path), include_in_schema in expected_routes.items():
+        matching_routes = [
+            route
+            for route in app.routes
+            if isinstance(route, APIRoute)
+            and route.path == path
+            and method in (route.methods or set())
+        ]
+        assert len(matching_routes) == 1
+        route = matching_routes[0]
+        flattened_calls = _flatten_dependency_calls(route)
+
+        assert route.endpoint.__module__ == "app.routers.plan_export"
+        assert route.include_in_schema is include_in_schema
+        assert 429 in route.responses
+        assert "request" in inspect.signature(route.endpoint).parameters
+        assert _contains_dependency(flattened_calls, _get_api_key_dynamic)
+        if path in {plan_export.WEEK_EXPORT_CSV_PATH, plan_export.WEEK_EXPORT_PDF_PATH}:
+            assert _contains_dependency(flattened_calls, plan_export._require_valid_token)
+        else:
+            assert not _contains_dependency(flattened_calls, plan_export._require_valid_token)
+        assert path not in public_paths
+
     assert plan_export.SHOPLIST_EXPORT_PDF_PATH not in public_paths


### PR DESCRIPTION
## Goal
Move canonical `plan_export` router registration ownership from `legacy_app.py` into canonical `app/main.py` bootstrap while preserving public behavior and legacy export alias compatibility.

## Business reason
This shrinks the remaining legacy registration seam after the export alias extraction series without changing user-visible export behavior, auth, signed-link behavior, or OpenAPI output.

## Scope
- Remove only canonical `export_router` / `plan_router` import and registration from `legacy_app.py`.
- Register `export_router` and `plan_router` from `app/main.py` via a fail-closed, idempotent helper.
- Add shared `PLAN_EXPORT_ROUTE_SPECS` in `app/routers/plan_export.py`.
- Tighten `check_legacy_growth_guard.py` so legacy reintroduction fails.
- Add focused bootstrap, guard, export auth, 429 metadata, and OpenAPI-hiding tests.
- Update `docs/architecture/backend_routing_map.md` for route ownership truth.
- Add canonical review artifact `docs/review/PR_1997_FIXED_MAPPING.md`.

## Out of scope
No OAuth/OIDC rewrite, auth rewrite, tier semantics change, dependency update, semantic cache, FoodDB, frontend/iOS work, or re-extraction of legacy export aliases.

## Key decisions
- Keep `_legacy_module._get_api_key_dynamic` as the app-level dependency for all three canonical export routes.
- Preserve `_require_valid_token` only on weekly CSV/PDF exports.
- Preserve route-level `include_in_schema=True` while final public `app.openapi()` continues hiding the paths.
- Keep hidden legacy export aliases as a separate compatibility router.

## Tests / validation
- `python3 scripts/orchestration/check_preflight.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `python3 scripts/orchestration/task_bootstrap.py ... --pr-phase pre_open` PASS, packet `artifacts/orchestration/task_packets/437b193fba29.json`
- Role order completed pre-open: `agent-coordinator -> architecture-specialist -> backend-engineer -> security-auditor -> qa-engineer-agent -> bug-hunter`
- `python3 scripts/ci/check_legacy_growth_guard.py` PASS
- `. .venv/bin/activate && pytest -q tests/test_legacy_growth_guard.py tests/test_main_paywall_bootstrap.py tests/test_app_endpoints_combined.py tests/test_plan_export_additional.py tests/test_export_signed.py tests/test_legacy_export_aliases.py tests/test_rate_limit_llm_and_exports_api.py tests/security/test_api_auth_tier_contract_pack.py tests/test_pro_vip_route_dependency_guard.py tests/test_openapi_namespace_guards.py tests/test_openapi_determinism.py tests/test_week_export_csv.py tests/test_signed_links.py` PASS, 256 passed
- `. .venv/bin/activate && pytest -q tests/test_rate_limit_llm_and_exports_api.py::test_plan_week_export_csv_rate_limited_200_then_429 tests/test_rate_limit_llm_and_exports_api.py::test_export_sign_rate_limited_200_then_429` PASS
- Focused diff-cover after coverage fix: `app/main.py (100%)`, `app/routers/plan_export.py (100%)`, total changed-line coverage `100%`
- Focused post-review helper validation: `. .venv/bin/activate && pytest -q tests/test_main_paywall_bootstrap.py tests/test_plan_export_additional.py tests/test_legacy_growth_guard.py tests/security/test_api_auth_tier_contract_pack.py` PASS
- `mypy --no-incremental --cache-dir=/dev/null app/main.py` PASS
- `make openapi && git diff --exit-code -- frontend/src/api/openapi.json frontend/src/api/schema.ts` PASS
- `make validate-changed` PASS but selected no files, so not used as sufficient evidence for this PR surface
- `pre-commit run --all-files` PASS
- Commit/push hooks PASS, including changed-file backend tests, changed-file mypy, full-repo Bandit, pip-audit, and Docker build test where applicable

## Machine-heavy verification deferral
Operator override applies: no deliberate full local `make verify` for PR-5. The accidental earlier `make verify` invocation is discarded and is not PR-5 gate evidence; it failed on inherited `legacy_app.py` lint unrelated to this validation plan. This PR uses focused local gates plus current-head CI parity before any readiness claim.

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/exp-7a6bc3ab3b0e.json`

Status: accepted. The oracle-only governance reviewer passed legacy-growth, plan-export/bootstrap/auth, and OpenAPI namespace/determinism oracles.

## Post-Open Review Evidence
- `qa-engineer-agent`: FIXED governance checklist and diff-coverage findings in `54e9ef7f5`.
- `bug-hunter`: FIXED Phase 2 parser and mapping-shape findings in `9f6beef12` and `e255e0244`; live PR body Phase 2 gate passed after mapping/body mirror updates.
- `security-auditor`: PASS on `e551bfcb5`; no blocking code or security findings.
- `pulseplate-pr-review`: PASS on `e551bfcb5`; no blocking findings.
- Codex Security diff scan / finding discovery: unavailable in this Codex runtime; `tool_search` did not expose callable Codex Security scan tools.

## Security notes
No auth semantics are changed. The new bootstrap helper fails closed on partial, duplicate, foreign-handler, wrong-method, route visibility, missing 429 metadata, and missing API-key dependency states. Raw API keys are not logged.

## Risks / rollback
Primary risk is export auth/OpenAPI drift from moving registration ownership. Rollback is reverting this PR, which restores legacy registration ownership. Focused tests pin auth dependency, signed-token guard, route count, 429 metadata, final OpenAPI hiding, defensive bootstrap branches, and nested dependency detection.

## Deferred / follow-ups
No product follow-up. Machine-heavy full local `make verify` remains deferred by operator override; current-head CI and strict merge-readiness gates still apply before any merge claim.

## AGENTS.md or agent-instruction updates
None.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Review threads must not be resolved without disposition evidence and this pass must be repeated after any new bot or human review activity.

### Fixed in Commit Mapping
Disposition: FIXED
Commit: 54e9ef7f5
Evidence: `docs/review/PR_1997_FIXED_MAPPING.md` uses unchecked merge-readiness checklist items; focused diff-cover reports 100% changed-line coverage for `app/main.py` and `app/routers/plan_export.py`.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#discussion_r3444327264 -> 54e9ef7f5

Disposition: FIXED
Commit: 891a1438c
Evidence: `app/main.py` shares callable comparison semantics and recursively checks nested FastAPI dependency calls.
Evidence: `tests/test_main_paywall_bootstrap.py` covers nested dependency detection.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534070939 -> 891a1438c

Disposition: FIXED
Commit: e255e0244
Evidence: `app/routers/plan_export.py` documents the route-spec tuple shape.
Reason: The larger generic router-family extraction suggestion is intentionally out of scope for this narrow registration-ownership PR; CodeRabbit itself classified the current tradeoff as acceptable for this PR.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534091296 -> e255e0244

Disposition: FIXED
Commit: e255e0244
Evidence: `docs/review/PR_1997_FIXED_MAPPING.md` uses `bot or human` wording and keeps merge-readiness checklist items unchecked.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/1997#pullrequestreview-4534993087 -> e255e0244

## Merge Readiness
Not ready for merge. Pending current-head CI, Codecov coverage supersession or disposition, strict merge wrapper with auth, and mandatory wait-window.

Required before merge:

- [ ] Fresh current-head PR CI parity
- [ ] No unresolved actionable human or bot review comments
- [ ] Strict merge-readiness with auth passes
- [ ] Mandatory wait-window after latest review/bot activity

## Next best step
Wait for current-head CI parity and coverage supersession, then run strict merge-readiness with auth after the mandatory wait-window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized canonical plan/export route registration in the main bootstrap with idempotent, legacy-compatible behavior.
  * Preserved protected access (API-key dependency), `429` rate-limit response documentation, and “hidden in public OpenAPI but still functional” handling.
  * Removed plan/export router wiring from the legacy app to avoid duplicate route inclusion.
* **Documentation**
  * Updated backend routing architecture notes to reflect canonical registration and OpenAPI hiding.
* **Tests**
  * Expanded regression coverage for idempotency, route metadata (429/OpenAPI), dependency wiring, and legacy reintroduction prevention.
* **Chores**
  * Tightened the legacy compatibility growth guard thresholds to reduce the chance of reintroducing plan/export routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

