### PR TITLE
refactor(nutrition): centralize profile-derived planning targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,16 @@ The merge-readiness gate remains separate and still requires `GITHUB_TOKEN` for 
 - CI runs `pre-commit run --all-files` and will fail if hooks would modify files that aren't committed.
 - This is not optional: uncommitted hook modifications guarantee CI failure.
 - **One-time setup:** Run `pre-commit install` locally once to enable automatic hook execution on `git commit` (reduces CI noise).
+- **Async test marker rule for pre-commit-selected tests:** CI lint runs
+  `pre-commit run --all-files`, and its `backend-tests` hook can execute changed
+  tests in an environment where `pytest-asyncio` is not loaded even if the local
+  venv has it. For tests selected by `scripts/run-backend-tests-pre-commit.sh`
+  (especially diff-coverage/changed-file tests), do not add `pytest.mark.asyncio`
+  or `async def` test functions unless the hook environment is explicitly proven
+  to load the async plugin. Prefer sync tests that call simple coroutines with
+  `asyncio.run(...)` or exercise routes through `TestClient`, and validate with
+  `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")" BRANCH_DIFF_MODE=1 bash scripts/run-backend-tests-pre-commit.sh`
+  plus `pre-commit run --all-files`. See `docs/ENGINEERING_LESSONS.md` lesson 25.
 
 **Pre-commit and "expected red" PRs (guard policy):**
 

--- a/app/routers/premium_week.py
+++ b/app/routers/premium_week.py
@@ -24,14 +24,13 @@ from app.schemas.weekly_plan import (
     require_weekly_plan_payload_shape,
     normalize_weekly_plan_payload,
 )
+from app.services import nutrition_targets as nutrition_targets_service
 from app.services.intervention_trigger_engine import build_weekly_plan_next_action
 from app.services.weekly_plan.pipeline import run_weekly_pipeline_guarded
 
 from core.food_db_new import FoodDB
 from core.meal_i18n import Language
 from core.recipe_db_new import RecipeDB
-from core.recommendations import build_nutrition_targets
-from core.targets import UserProfile
 from core.weekly_plan_new import build_week
 
 router = APIRouter(prefix="/api/v1/premium", tags=["premium"])
@@ -102,79 +101,6 @@ def _missing_profile_detail(field: str) -> str:
     return f"Missing user profile data (Missing required field: {field})"
 
 
-def _is_complete_targets(d: Dict[str, Any]) -> bool:
-    """Check if targets dict has all required keys and non-empty micro/macros.
-
-    Note: activity_week is optional but validated if present.
-    """
-    required_keys = {"kcal", "macros", "micro", "water_ml"}
-    if not required_keys.issubset(d.keys()):
-        return False
-    if not isinstance(d.get("macros"), dict):
-        return False
-    if not isinstance(d.get("micro"), dict):
-        return False
-    # If activity_week is present, it must be a dict
-    if "activity_week" in d and d.get("activity_week") is not None:
-        if not isinstance(d["activity_week"], dict):
-            return False
-    # micro must not be empty, otherwise core may produce unexpected results
-    if not d.get("micro"):
-        return False
-    # macros must not be empty, for consistency with micro validation
-    if not d.get("macros"):
-        return False
-    return True
-
-
-# TODO(#286): Deduplicate estimate_targets_minimal by moving it into app/services/nutrition_targets.py
-# Keep parity between /api/v1/pro/meal/weekly and deprecated /api/v1/premium/plan/week-flexible.
-def estimate_targets_minimal(
-    sex: Literal["female", "male"],
-    age: int,
-    height_cm: float,
-    weight_kg: float,
-    activity: Literal["sedentary", "light", "moderate", "active", "very_active"],
-    goal: Literal["loss", "maintain", "gain"],
-) -> Dict[str, Any]:
-    """Temporary function to estimate targets from user profile (DEPRECATED endpoint).
-
-    WARNING: This function is duplicated in pro.py to maintain backward compatibility.
-    Any changes here MUST be mirrored in pro.py until extraction is complete.
-    """
-    # Create a UserProfile object
-    profile = UserProfile(
-        sex=sex,
-        age=age,
-        height_cm=height_cm,
-        weight_kg=weight_kg,
-        activity=activity,
-        goal=goal,
-    )
-
-    # Build nutrition targets using existing WHO-based system
-    targets = build_nutrition_targets(profile)
-
-    # Convert to the format expected by the weekly plan generator
-    return {
-        "kcal": targets.kcal_daily,
-        "macros": {
-            "protein_g": targets.macros.protein_g,
-            "fat_g": targets.macros.fat_g,
-            "carbs_g": targets.macros.carbs_g,
-            "fiber_g": targets.macros.fiber_g,
-        },
-        "micro": targets.micros.get_priority_nutrients(),
-        "water_ml": targets.water_ml_daily,
-        "activity_week": {
-            "moderate_aerobic_min": targets.activity.moderate_aerobic_min,
-            "vigorous_aerobic_min": targets.activity.vigorous_aerobic_min,
-            "strength_sessions": targets.activity.strength_sessions,
-            "steps_daily": targets.activity.steps_daily,
-        },
-    }
-
-
 @router.post(
     "/plan/week-flexible",
     response_model=PremiumWeekPlanResponse,
@@ -235,7 +161,7 @@ async def generate_week_plan(
         req.targets.model_dump(exclude_none=True) if req.targets is not None else {}
     )
 
-    if _is_complete_targets(targets_from_request):
+    if nutrition_targets_service.is_complete_planning_targets(targets_from_request):
         targets: Dict[str, Any] = targets_from_request
     else:
         # Fallback: derive from profile, otherwise 400 (DRY error messages with helper)
@@ -254,19 +180,22 @@ async def generate_week_plan(
             raise HTTPException(status_code=400, detail=_missing_profile_detail("goal"))
 
         # After all None checks above, types are narrowed to non-None
-        targets = estimate_targets_minimal(
-            sex=req.sex,
-            age=req.age,
-            height_cm=float(req.height_cm),
-            weight_kg=float(req.weight_kg),
-            activity=req.activity,
-            goal=req.goal,
+        targets = cast(
+            Dict[str, Any],
+            nutrition_targets_service.estimate_targets_from_profile(
+                sex=req.sex,
+                age=req.age,
+                height_cm=float(req.height_cm),
+                weight_kg=float(req.weight_kg),
+                activity=req.activity,
+                goal=req.goal,
+            ),
         )
 
     # Hard guard: never pass None/malformed targets to core
     if not isinstance(targets, dict):
         raise HTTPException(status_code=400, detail="Unable to derive targets")
-    if not _is_complete_targets(targets):
+    if not nutrition_targets_service.is_complete_planning_targets(targets):
         raise HTTPException(status_code=400, detail="Unable to derive targets")
 
     # 2) Построить неделю (generation stage) + postprocess (pipeline with ordering guard)

--- a/app/routers/pro.py
+++ b/app/routers/pro.py
@@ -15,7 +15,7 @@ Endpoints:
 
 import logging
 from datetime import date as Date
-from typing import Any, Dict, List, Literal, Optional, Union, cast
+from typing import Any, Dict, List, Literal, Optional, TypeAlias, Union, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import JSONResponse
@@ -28,6 +28,7 @@ from app.schemas.weekly_plan import (
     require_weekly_plan_payload_shape,
     normalize_weekly_plan_payload,
 )
+from app.services import nutrition_targets as nutrition_targets_service
 from app.services.intervention_trigger_engine import build_weekly_plan_next_action
 from app.services.weekly_plan.pipeline import run_weekly_pipeline_guarded
 
@@ -113,7 +114,7 @@ class ProWeekPlanRequest(BaseModel):
     lang: Language = "en"
 
 
-ProWeekPlanResponse = WeeklyMealPlanResponse
+ProWeekPlanResponse: TypeAlias = WeeklyMealPlanResponse
 
 
 class NutritionSegmentData(BaseModel):
@@ -153,90 +154,6 @@ def _missing_profile_detail(field: str) -> str:
     TODO: Add i18n support via t(lang, "translation_key") for multilingual error messages.
     """
     return f"Missing user profile data (Missing required field: {field})"
-
-
-def _is_complete_targets(d: Dict[str, Any]) -> bool:
-    """Check if targets dict has all required keys and non-empty micro/macros.
-
-    Note: activity_week is optional but validated if present.
-    """
-    required_keys = {"kcal", "macros", "micro", "water_ml"}
-    if not required_keys.issubset(d.keys()):
-        return False
-    if not isinstance(d.get("macros"), dict):
-        return False
-    if not isinstance(d.get("micro"), dict):
-        return False
-    # If activity_week is present, it must be a dict
-    if "activity_week" in d and d.get("activity_week") is not None:
-        if not isinstance(d["activity_week"], dict):
-            return False
-    # micro must not be empty, otherwise core may produce unexpected results
-    if not d.get("micro"):
-        return False
-    # macros must not be empty, for consistency with micro validation
-    if not d.get("macros"):
-        return False
-    return True
-
-
-# TODO(#286): Deduplicate estimate_targets_minimal by moving it into app/services/nutrition_targets.py
-# Keep parity between /api/v1/pro/meal/weekly and deprecated /api/v1/premium/plan/week-flexible.
-def estimate_targets_minimal(
-    sex: Literal["female", "male"],
-    age: int,
-    height_cm: float,
-    weight_kg: float,
-    activity: Literal["sedentary", "light", "moderate", "active", "very_active"],
-    goal: Literal["loss", "maintain", "gain"],
-) -> Dict[str, Any]:
-    """Estimate nutrition targets from user profile.
-
-    WARNING: This function is duplicated in premium_week.py to maintain backward compatibility.
-    Any changes here MUST be mirrored in premium_week.py until extraction is complete.
-
-    Args:
-        sex: Biological sex
-        age: Age in years
-        height_cm: Height in centimeters
-        weight_kg: Weight in kilograms
-        activity: Activity level
-        goal: Nutrition goal
-
-    Returns:
-        Dictionary with nutrition targets (kcal, macros, micro, water, activity)
-    """
-    # Create a UserProfile object
-    profile = UserProfile(
-        sex=sex,
-        age=age,
-        height_cm=height_cm,
-        weight_kg=weight_kg,
-        activity=activity,
-        goal=goal,
-    )
-
-    # Build nutrition targets using existing WHO-based system
-    targets = build_nutrition_targets(profile)
-
-    # Convert to the format expected by the weekly plan generator
-    return {
-        "kcal": targets.kcal_daily,
-        "macros": {
-            "protein_g": targets.macros.protein_g,
-            "fat_g": targets.macros.fat_g,
-            "carbs_g": targets.macros.carbs_g,
-            "fiber_g": targets.macros.fiber_g,
-        },
-        "micro": targets.micros.get_priority_nutrients(),
-        "water_ml": targets.water_ml_daily,
-        "activity_week": {
-            "moderate_aerobic_min": targets.activity.moderate_aerobic_min,
-            "vigorous_aerobic_min": targets.activity.vigorous_aerobic_min,
-            "strength_sessions": targets.activity.strength_sessions,
-            "steps_daily": targets.activity.steps_daily,
-        },
-    }
 
 
 @router.post(
@@ -281,7 +198,7 @@ async def generate_week_plan(req: ProWeekPlanRequest) -> Union[ProWeekPlanRespon
         req.targets.model_dump(exclude_none=True) if req.targets is not None else {}
     )
 
-    if _is_complete_targets(targets_from_request):
+    if nutrition_targets_service.is_complete_planning_targets(targets_from_request):
         targets: Dict[str, Any] = targets_from_request
     else:
         # Fallback: derive from profile, otherwise 400 (DRY error messages with helper)
@@ -300,19 +217,22 @@ async def generate_week_plan(req: ProWeekPlanRequest) -> Union[ProWeekPlanRespon
             raise HTTPException(status_code=400, detail=_missing_profile_detail("goal"))
 
         # After all None checks above, types are narrowed to non-None
-        targets = estimate_targets_minimal(
-            sex=req.sex,
-            age=req.age,
-            height_cm=float(req.height_cm),
-            weight_kg=float(req.weight_kg),
-            activity=req.activity,
-            goal=req.goal,
+        targets = cast(
+            Dict[str, Any],
+            nutrition_targets_service.estimate_targets_from_profile(
+                sex=req.sex,
+                age=req.age,
+                height_cm=float(req.height_cm),
+                weight_kg=float(req.weight_kg),
+                activity=req.activity,
+                goal=req.goal,
+            ),
         )
 
     # Hard guard: never pass None/malformed targets to core
     if not isinstance(targets, dict):
         raise HTTPException(status_code=400, detail="Unable to derive targets")
-    if not _is_complete_targets(targets):
+    if not nutrition_targets_service.is_complete_planning_targets(targets):
         raise HTTPException(status_code=400, detail="Unable to derive targets")
 
     # Build week (generation stage) + postprocess (pipeline with ordering guard)
@@ -357,7 +277,7 @@ async def generate_week_plan(req: ProWeekPlanRequest) -> Union[ProWeekPlanRespon
         # IMPORTANT: bypass response_model validation
         return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content=result)
 
-    if not isinstance(result, ProWeekPlanResponse):
+    if not isinstance(result, WeeklyMealPlanResponse):
         raise TypeError(
             "Expected ProWeekPlanResponse from weekly pipeline, "
             f"got type={type(result).__name__} value={result!r}"

--- a/app/services/nutrition_targets.py
+++ b/app/services/nutrition_targets.py
@@ -1,0 +1,76 @@
+"""Application-level nutrition target adapters for weekly planning."""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from core.recommendations import build_nutrition_targets
+from core.targets import Activity, Goal, Sex, UserProfile
+
+
+class PlanningTargetsPayload(TypedDict):
+    """Weekly-planning target payload shape consumed by plan generators."""
+
+    kcal: int
+    macros: dict[str, int]
+    micro: dict[str, float]
+    water_ml: int
+    activity_week: dict[str, int]
+
+
+def is_complete_planning_targets(targets: dict[str, Any]) -> bool:
+    """Return whether a target payload is complete enough for weekly planning."""
+    required_keys = {"kcal", "macros", "micro", "water_ml"}
+    if not required_keys.issubset(targets.keys()):
+        return False
+    if not isinstance(targets.get("macros"), dict):
+        return False
+    if not isinstance(targets.get("micro"), dict):
+        return False
+    if "activity_week" in targets and targets.get("activity_week") is not None:
+        if not isinstance(targets["activity_week"], dict):
+            return False
+    if not targets.get("micro"):
+        return False
+    if not targets.get("macros"):
+        return False
+    return True
+
+
+def estimate_targets_from_profile(
+    *,
+    sex: Sex,
+    age: int,
+    height_cm: float,
+    weight_kg: float,
+    activity: Activity,
+    goal: Goal,
+) -> PlanningTargetsPayload:
+    """Build existing WHO-based core targets and adapt them for weekly planning."""
+    profile = UserProfile(
+        sex=sex,
+        age=age,
+        height_cm=height_cm,
+        weight_kg=weight_kg,
+        activity=activity,
+        goal=goal,
+    )
+    targets = build_nutrition_targets(profile)
+
+    return {
+        "kcal": targets.kcal_daily,
+        "macros": {
+            "protein_g": targets.macros.protein_g,
+            "fat_g": targets.macros.fat_g,
+            "carbs_g": targets.macros.carbs_g,
+            "fiber_g": targets.macros.fiber_g,
+        },
+        "micro": targets.micros.get_priority_nutrients(),
+        "water_ml": targets.water_ml_daily,
+        "activity_week": {
+            "moderate_aerobic_min": targets.activity.moderate_aerobic_min,
+            "vigorous_aerobic_min": targets.activity.vigorous_aerobic_min,
+            "strength_sessions": targets.activity.strength_sessions,
+            "steps_daily": targets.activity.steps_daily,
+        },
+    }

--- a/app/services/nutrition_targets.py
+++ b/app/services/nutrition_targets.py
@@ -7,13 +7,15 @@ from typing import Any, TypedDict
 from core.recommendations import build_nutrition_targets
 from core.targets import Activity, Goal, Sex, UserProfile
 
+PlanningNumeric = int | float
+
 
 class PlanningTargetsPayload(TypedDict):
     """Weekly-planning target payload shape consumed by plan generators."""
 
     kcal: int
-    macros: dict[str, int]
-    micro: dict[str, float]
+    macros: dict[str, PlanningNumeric]
+    micro: dict[str, PlanningNumeric]
     water_ml: int
     activity_week: dict[str, int]
 

--- a/docs/ENGINEERING_LESSONS.md
+++ b/docs/ENGINEERING_LESSONS.md
@@ -632,6 +632,59 @@ For GitHub Actions runtime migrations, guard the whole active action surface:
 - one coherent guard update before publishing, rather than mapping-only
   follow-up commits after each bot rediscovery
 
+## 25) Pre-commit-selected tests must not rely on async pytest plugin state
+
+### Problem
+CI lint runs `pre-commit run --all-files`, and the local `backend-tests` hook
+selects changed Python tests through `scripts/run-backend-tests-pre-commit.sh`.
+That hook can execute in an environment where `pytest-asyncio` is not installed
+or not loaded, even when the developer venv or a broader pytest run has it.
+
+When a changed diff-coverage test uses `pytest.mark.asyncio` or an `async def`
+test function, the CI-only lint failure can look like:
+
+- `async def functions are not natively supported`
+- `PytestConfigWarning: Unknown config option: asyncio_mode`
+- `PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope`
+
+This is an environment/plugin-state drift, not a product bug, but it still
+breaks the PR because lint owns the pre-commit backend-tests hook.
+
+### Real incident (PR #2006)
+
+PR #2006 changed `tests/test_diff_coverage_pr339.py`. Local focused tests and
+`pre-commit run --all-files` passed in the developer environment, but
+current-head CI lint failed when the backend-tests hook selected that file without the
+async pytest plugin loaded. The first failure appeared on one parametrized async
+test, but the file contained multiple async tests that would have failed next.
+
+### Rule
+
+For tests selected by `scripts/run-backend-tests-pre-commit.sh`, especially
+diff-coverage and changed-file tests:
+
+1. Do not add `pytest.mark.asyncio` or `async def` test functions unless the
+   hook environment is explicitly proven to load the async plugin.
+2. Prefer sync tests that call simple router/service coroutines with
+   `asyncio.run(...)`, or exercise route behavior through FastAPI `TestClient`.
+3. After fixing the first async-marker failure, scan the entire selected test
+   bundle for `pytest.mark.asyncio` and `async def`; do not stop at the first
+   failing test.
+4. Validate with the exact backend-tests hook path:
+
+```bash
+VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")" BRANCH_DIFF_MODE=1 bash scripts/run-backend-tests-pre-commit.sh
+pre-commit run --all-files
+```
+
+### Use instead
+
+- Sync test wrappers around simple coroutine entrypoints:
+  `response = asyncio.run(generate_week_plan(request))`.
+- `TestClient` for route-level behavior when HTTP semantics matter.
+- A full selected-bundle scan before pushing:
+  `rg -n "pytest\\.mark\\.asyncio|async def" <selected-test-files>`.
+
 ---
 
 ## Repo Commands Reference

--- a/docs/review/PR_2006_FIXED_MAPPING.md
+++ b/docs/review/PR_2006_FIXED_MAPPING.md
@@ -52,6 +52,18 @@ Evidence: `app/services/nutrition_targets.py` widens `PlanningTargetsPayload.mac
 Disposition: FIXED
 Commit: 366d6a18d
 Evidence: `tests/test_pro_premium_contract_parity.py` asserts JSON `content-type` before parsing both explicit-target and profile-derived weekly parity responses; `pytest -q tests/test_pro_premium_contract_parity.py` passed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2006#pullrequestreview-4544483234 -> 8d972fbf9
+Disposition: FIXED
+Commit: 8d972fbf9
+Evidence: `app/services/nutrition_targets.py` widens macro/micro value types through `PlanningNumeric = int | float`; the `activity_week` return-payload key remains required because `estimate_targets_from_profile(...)` always returns the exact weekly planning payload shape, while `is_complete_planning_targets(...)` intentionally preserves existing compatibility for explicit targets that omit `activity_week`.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2006#pullrequestreview-4544546239 -> 3f5504350
+Disposition: FIXED
+Commit: 3f5504350
+Evidence: `tests/test_diff_coverage_pr339.py` and `tests/test_final_coverage_96.py` add explicit return/fixture type annotations; `tests/test_premium_week_endpoint_simple_96.py` no longer claims to cover an unpatched unable-to-derive branch and instead preserves current legacy alias behavior; `tests/disabled_hypothesis/test_premium_week_hypothesis_simple.py` is reverted out of the net PR diff. `pre-commit run --all-files` passed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2006#pullrequestreview-4544563348 -> 3f5504350
+Disposition: FIXED
+Commit: 3f5504350
+Evidence: `docs/review/PR_2006_FIXED_MAPPING.md` now uses unchecked checklist entries under `## Merge Readiness`; `pre-commit run --all-files` passed.
 
 ## Implementation Commits
 
@@ -66,6 +78,10 @@ Evidence: `tests/test_pro_premium_contract_parity.py` asserts JSON `content-type
   artifact.
 - `366d6a18d` - asserts weekly parity response JSON content types for CodeRabbit
   feedback.
+- `715735355` - maps the fixed CodeRabbit content-type thread in the PR #2006
+  mapping artifact.
+- `3f5504350` - addresses CodeRabbit outside-diff test/mapping findings and
+  removes the disabled hypothesis file from the net PR diff.
 
 ## Premortem Evidence
 

--- a/docs/review/PR_2006_FIXED_MAPPING.md
+++ b/docs/review/PR_2006_FIXED_MAPPING.md
@@ -27,6 +27,8 @@ preserving canonical PRO and deprecated premium weekly endpoint behavior.
   shared service for weekly planning target derivation/completeness.
 - Updated tests to patch and validate the new service seam.
 - Added profile-derived PRO/premium weekly parity coverage.
+- Added CI-smoke coverage for the shared planning-target service and
+  profile-derived weekly router branches.
 - Fixed `legacy_app.py` import hygiene surfaced by local `make verify` lint.
 
 ## Out Of Scope
@@ -116,6 +118,10 @@ FoodDB cutover, frontend/iOS, or broad legacy rewrite scope is included.
 - `9e59c3791` - records the CI lint fix in the PR #2006 mapping artifact.
 - `6738ed9b8` - documents the async marker/pre-commit environment rule in
   root `AGENTS.md`, `tests/AGENTS.md`, and `docs/ENGINEERING_LESSONS.md`.
+- `04c500acc` - covers profile-derived planning-target service/router branches
+  inside the CI smoke `tests/edges` coverage set after current-head
+  `diff-coverage` reported missing lines in `app/services/nutrition_targets.py`,
+  `app/routers/pro.py`, and `app/routers/premium_week.py`.
 
 ## Premortem Evidence
 
@@ -168,6 +174,16 @@ async test markers and passes without relying on `pytest-asyncio`.
 Operator-requested process memory from the same incident is captured in
 `6738ed9b8`: pre-commit-selected tests must not rely on async pytest plugin
 state unless that hook environment is explicitly proven to load it.
+
+Current-head CI `diff-coverage` failure on `31134b866` was fixed in
+`04c500acc` by adding synchronous `tests/edges/test_premium_week_edges.py`
+coverage for `is_complete_planning_targets(...)`,
+`estimate_targets_from_profile(...)`, and the profile-derived PRO/premium weekly
+router branches. Local CI-smoke coverage evidence:
+`PYTHONPATH="$PWD:$PWD/tests" VIP_MODULE_ENABLED=true APP_ENV=test ENVIRONMENT=test FEATURE_PREMIUM_NUTRITION=true API_KEY=test_key PYTHONUNBUFFERED=1 PYTHONFAULTHANDLER=1 PYTHONMALLOC=malloc python -m coverage run -m pytest -q tests/edges --maxfail=3 && python -m coverage xml && diff-cover coverage.xml --compare-branch origin/main --fail-under 97 ...`
+reported `app/routers/premium_week.py (100%)`, `app/routers/pro.py (100%)`,
+`app/services/nutrition_targets.py (100%)`, `legacy_app.py (100%)`, total
+`44` diff lines, missing `0`, coverage `100%`.
 
 Full `make verify` was attempted once. The first run exposed the
 `legacy_app.py` lint issue fixed in `6eec0ea99`. The rerun passed verify-env,

--- a/docs/review/PR_2006_FIXED_MAPPING.md
+++ b/docs/review/PR_2006_FIXED_MAPPING.md
@@ -40,8 +40,7 @@ legacy rewrite.
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-No review threads existed at PR open. One post-open Sourcery thread is mapped
-below.
+Post-open Sourcery and CodeRabbit findings are mapped below.
 
 ## Fixed in Commit Mapping
 
@@ -123,10 +122,10 @@ readiness signal.
 Not merge-ready yet.
 
 Required before merge:
-- Current-head CI must pass.
-- Bot/human review comments must be dispositioned.
-- Post-open role passes must run:
+- [ ] Current-head CI passes.
+- [ ] Bot/human review comments dispositioned.
+- [ ] Post-open role passes completed:
   `qa-engineer-agent -> bug-hunter -> security-auditor`.
-- Codex Security diff scan/finding discovery must run if available.
-- `pulseplate-pr-review` must run.
-- Strict merge-readiness checks must pass.
+- [ ] Codex Security diff scan/finding discovery run if available.
+- [ ] `pulseplate-pr-review` passed.
+- [ ] Strict merge-readiness checks passed.

--- a/docs/review/PR_2006_FIXED_MAPPING.md
+++ b/docs/review/PR_2006_FIXED_MAPPING.md
@@ -65,6 +65,21 @@ Disposition: FIXED
 Commit: 3f5504350
 Evidence: `docs/review/PR_2006_FIXED_MAPPING.md` now uses unchecked checklist entries under `## Merge Readiness`; `pre-commit run --all-files` passed.
 
+## PulsePlate PR Review Disposition
+
+Finding: `large-diff-risk` advisory from `pulseplate-pr-review`.
+
+Disposition: NOT-A-BUG
+Evidence: `make validate-changed` selected the changed Python test surface and
+passed; focused weekly/pro/premium pytest bundles, targeted mypy,
+`make openapi-check`, `pre-commit run --all-files`, and `git diff --check`
+passed.
+Reason: The line-count threshold is crossed by focused test updates and the
+canonical review artifact, while production code scope remains limited to the
+shared nutrition target service, two weekly routers, and a `legacy_app.py`
+import-compat hygiene fix. No route/auth/tier, OpenAPI/client, migration,
+FoodDB cutover, frontend/iOS, or broad legacy rewrite scope is included.
+
 ## Implementation Commits
 
 - `6eec0ea99` - centralizes profile-derived weekly planning targets, updates
@@ -82,6 +97,7 @@ Evidence: `docs/review/PR_2006_FIXED_MAPPING.md` now uses unchecked checklist en
   mapping artifact.
 - `3f5504350` - addresses CodeRabbit outside-diff test/mapping findings and
   removes the disabled hypothesis file from the net PR diff.
+- `42a1b4140` - maps PR #2006 review-level bot comments.
 
 ## Premortem Evidence
 
@@ -118,14 +134,12 @@ Passed locally:
 - `. .venv/bin/activate && pytest -q tests/test_pro_vip_route_dependency_guard.py tests/security/test_api_auth_tier_contract_pack.py tests/test_paid_route_guards.py`
 - `. .venv/bin/activate && mypy app/services/nutrition_targets.py app/routers/pro.py app/routers/premium_week.py`
 - `make openapi-check`
+- `make validate-changed`
 - `make lint`
 - `pre-commit run --all-files`
 - `git diff --check`
 - Pre-push hooks: changed-files mypy, backend tests, full-repo Bandit, Docker
   build test.
-
-`make validate-changed` passed but selected no Python files in the local branch
-state, so it is explicitly not treated as sufficient evidence for this PR.
 
 Full `make verify` was attempted once. The first run exposed the
 `legacy_app.py` lint issue fixed in `6eec0ea99`. The rerun passed verify-env,

--- a/docs/review/PR_2006_FIXED_MAPPING.md
+++ b/docs/review/PR_2006_FIXED_MAPPING.md
@@ -108,6 +108,11 @@ FoodDB cutover, frontend/iOS, or broad legacy rewrite scope is included.
 - `42a1b4140` - maps PR #2006 review-level bot comments.
 - `8362e21fe` - asserts JSON content type before parsing the legacy premium
   weekly alias response.
+- `f1178c2e5` - maps the fixed CodeRabbit legacy alias finding in the PR #2006
+  mapping artifact.
+- `e6212bd4f` - removes async test markers from the changed diff-coverage test
+  surface so CI pre-commit backend-tests do not require the optional
+  `pytest-asyncio` plugin in the lint environment.
 
 ## Premortem Evidence
 
@@ -148,8 +153,14 @@ Passed locally:
 - `make lint`
 - `pre-commit run --all-files`
 - `git diff --check`
+- `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")" BRANCH_DIFF_MODE=1 bash scripts/run-backend-tests-pre-commit.sh`
 - Pre-push hooks: changed-files mypy, backend tests, full-repo Bandit, Docker
   build test.
+
+Current-head CI lint failure on `f1178c2e5` was fixed in `e6212bd4f` by
+removing `pytest.mark.asyncio`/`async def` from the changed diff-coverage tests
+selected by the pre-commit backend-tests hook. The selected bundle now has no
+async test markers and passes without relying on `pytest-asyncio`.
 
 Full `make verify` was attempted once. The first run exposed the
 `legacy_app.py` lint issue fixed in `6eec0ea99`. The rerun passed verify-env,

--- a/docs/review/PR_2006_FIXED_MAPPING.md
+++ b/docs/review/PR_2006_FIXED_MAPPING.md
@@ -113,6 +113,9 @@ FoodDB cutover, frontend/iOS, or broad legacy rewrite scope is included.
 - `e6212bd4f` - removes async test markers from the changed diff-coverage test
   surface so CI pre-commit backend-tests do not require the optional
   `pytest-asyncio` plugin in the lint environment.
+- `9e59c3791` - records the CI lint fix in the PR #2006 mapping artifact.
+- `6738ed9b8` - documents the async marker/pre-commit environment rule in
+  root `AGENTS.md`, `tests/AGENTS.md`, and `docs/ENGINEERING_LESSONS.md`.
 
 ## Premortem Evidence
 
@@ -161,6 +164,10 @@ Current-head CI lint failure on `f1178c2e5` was fixed in `e6212bd4f` by
 removing `pytest.mark.asyncio`/`async def` from the changed diff-coverage tests
 selected by the pre-commit backend-tests hook. The selected bundle now has no
 async test markers and passes without relying on `pytest-asyncio`.
+
+Operator-requested process memory from the same incident is captured in
+`6738ed9b8`: pre-commit-selected tests must not rely on async pytest plugin
+state unless that hook environment is explicitly proven to load it.
 
 Full `make verify` was attempted once. The first run exposed the
 `legacy_app.py` lint issue fixed in `6eec0ea99`. The rerun passed verify-env,

--- a/docs/review/PR_2006_FIXED_MAPPING.md
+++ b/docs/review/PR_2006_FIXED_MAPPING.md
@@ -16,8 +16,7 @@ preserving canonical PRO and deprecated premium weekly endpoint behavior.
 
 - Base branch: `main`
 - Start head: `2fd053128c7e5ac3d45873007867c8f4b7500f04`
-- Task packet:
-  `artifacts/orchestration/task_packets/b7f6dbc6858b.json`
+- Packet: `artifacts/orchestration/task_packets/b7f6dbc6858b.json`
 - Required pre-implementation role order completed:
   `agent-coordinator -> qa-engineer-agent -> security-auditor -> backend-engineer -> architecture-specialist`
 
@@ -38,16 +37,21 @@ legacy rewrite.
 
 ## Discussion Thread Pass
 
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
+
 No review threads existed at PR open.
 
-## Fixed In Commit Mapping
+## Fixed in Commit Mapping
 
-No review-thread fixes yet.
+- No actionable review comments
 
-Implementation:
+## Implementation Commits
+
 - `6eec0ea99` - centralizes profile-derived weekly planning targets, updates
   PRO/premium weekly routers and tests, preserves deprecated compatibility, and
   fixes the `legacy_app.py` flake8 import-hygiene gate.
+- `1118b0583` - adds PR #2006 fixed-mapping governance artifact.
 
 ## Premortem Evidence
 
@@ -66,7 +70,7 @@ Implementation:
 ## Experiment Runner Evidence
 
 - Packet: `artifacts/orchestration/experiments/exp-ed836b5c000a.json`
-- Result: `artifacts/orchestration/experiments/results/exp-ed836b5c000a.json`
+- Artifact: `artifacts/orchestration/experiments/results/exp-ed836b5c000a.json`
 - Status: `accepted`
 - Runner mode: `oracle_only_governance_reviewer`
 - Contribution kind: `oracle_review`

--- a/docs/review/PR_2006_FIXED_MAPPING.md
+++ b/docs/review/PR_2006_FIXED_MAPPING.md
@@ -40,11 +40,15 @@ legacy rewrite.
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-No review threads existed at PR open.
+No review threads existed at PR open. One post-open Sourcery thread is mapped
+below.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2006#discussion_r3452568392 -> 8d972fbf9
+Disposition: FIXED
+Commit: 8d972fbf9
+Evidence: `app/services/nutrition_targets.py` widens `PlanningTargetsPayload.macros` and `PlanningTargetsPayload.micro` through `PlanningNumeric = int | float`; targeted mypy and service/diff coverage tests passed.
 
 ## Implementation Commits
 
@@ -52,6 +56,9 @@ No review threads existed at PR open.
   PRO/premium weekly routers and tests, preserves deprecated compatibility, and
   fixes the `legacy_app.py` flake8 import-hygiene gate.
 - `1118b0583` - adds PR #2006 fixed-mapping governance artifact.
+- `923a8fb5d` - aligns fixed-mapping artifact syntax with Phase2 gates.
+- `8d972fbf9` - widens planning target numeric payload types for Sourcery
+  feedback.
 
 ## Premortem Evidence
 

--- a/docs/review/PR_2006_FIXED_MAPPING.md
+++ b/docs/review/PR_2006_FIXED_MAPPING.md
@@ -49,6 +49,10 @@ below.
 Disposition: FIXED
 Commit: 8d972fbf9
 Evidence: `app/services/nutrition_targets.py` widens `PlanningTargetsPayload.macros` and `PlanningTargetsPayload.micro` through `PlanningNumeric = int | float`; targeted mypy and service/diff coverage tests passed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2006#discussion_r3452622130 -> 366d6a18d
+Disposition: FIXED
+Commit: 366d6a18d
+Evidence: `tests/test_pro_premium_contract_parity.py` asserts JSON `content-type` before parsing both explicit-target and profile-derived weekly parity responses; `pytest -q tests/test_pro_premium_contract_parity.py` passed.
 
 ## Implementation Commits
 
@@ -58,6 +62,10 @@ Evidence: `app/services/nutrition_targets.py` widens `PlanningTargetsPayload.mac
 - `1118b0583` - adds PR #2006 fixed-mapping governance artifact.
 - `923a8fb5d` - aligns fixed-mapping artifact syntax with Phase2 gates.
 - `8d972fbf9` - widens planning target numeric payload types for Sourcery
+  feedback.
+- `cf0a52117` - maps the fixed Sourcery typing thread in the PR #2006 mapping
+  artifact.
+- `366d6a18d` - asserts weekly parity response JSON content types for CodeRabbit
   feedback.
 
 ## Premortem Evidence

--- a/docs/review/PR_2006_FIXED_MAPPING.md
+++ b/docs/review/PR_2006_FIXED_MAPPING.md
@@ -1,0 +1,113 @@
+# PR #2006 Fixed in Commit Mapping
+
+## Summary
+
+PR: `refactor(nutrition): centralize profile-derived planning targets`
+
+Branch: `codex/centralize-profile-derived-planning-targets`
+
+Implementation commit: `6eec0ea99`
+
+This PR centralizes weekly-plan profile-derived nutrition target derivation and
+target-shape completeness checks in `app/services/nutrition_targets.py` while
+preserving canonical PRO and deprecated premium weekly endpoint behavior.
+
+## Lane Start Provenance
+
+- Base branch: `main`
+- Start head: `2fd053128c7e5ac3d45873007867c8f4b7500f04`
+- Task packet:
+  `artifacts/orchestration/task_packets/b7f6dbc6858b.json`
+- Required pre-implementation role order completed:
+  `agent-coordinator -> qa-engineer-agent -> security-auditor -> backend-engineer -> architecture-specialist`
+
+## Scope
+
+- Added `app/services/nutrition_targets.py`.
+- Updated `app/routers/pro.py` and `app/routers/premium_week.py` to use the
+  shared service for weekly planning target derivation/completeness.
+- Updated tests to patch and validate the new service seam.
+- Added profile-derived PRO/premium weekly parity coverage.
+- Fixed `legacy_app.py` import hygiene surfaced by local `make verify` lint.
+
+## Out Of Scope
+
+No FoodDB/Postgres/OFF/catalog cutover, DB migration, generated-client work,
+route registration change, frontend/iOS work, AI/compliance change, or broad
+legacy rewrite.
+
+## Discussion Thread Pass
+
+No review threads existed at PR open.
+
+## Fixed In Commit Mapping
+
+No review-thread fixes yet.
+
+Implementation:
+- `6eec0ea99` - centralizes profile-derived weekly planning targets, updates
+  PRO/premium weekly routers and tests, preserves deprecated compatibility, and
+  fixes the `legacy_app.py` flake8 import-hygiene gate.
+
+## Premortem Evidence
+
+- Artifact:
+  `artifacts/orchestration/premortem/centralize-profile-derived-planning-targets-premortem.md`
+- Decision: `proceed with changes`
+- Findings closed before PR open:
+  - Stale router-local test patch points: fixed by moving active patches to
+    `app.services.nutrition_targets`.
+  - `make validate-changed` false-green risk: mitigated with explicit focused
+    pytest/mypy/pre-commit evidence.
+  - Existing `legacy_app.py` lint failure: fixed in `6eec0ea99`.
+  - Experiment Runner source diff visibility: fixed by staging the coherent diff
+    before oracle-only evidence.
+
+## Experiment Runner Evidence
+
+- Packet: `artifacts/orchestration/experiments/exp-ed836b5c000a.json`
+- Result: `artifacts/orchestration/experiments/results/exp-ed836b5c000a.json`
+- Status: `accepted`
+- Runner mode: `oracle_only_governance_reviewer`
+- Contribution kind: `oracle_review`
+- Co-author required: yes
+- Co-author trailer included in `6eec0ea99`:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+
+## Validation
+
+Passed locally:
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `. .venv/bin/activate && pytest -q tests/test_nutrition_targets_service.py tests/test_diff_coverage_pr339.py tests/test_pro_router.py tests/test_premium_week_router.py tests/test_premium_week_router_isolated.py tests/edges/test_premium_week_edges.py tests/test_pro_premium_contract_parity.py tests/test_weekly_plan_endpoints_error_envelope_diff_coverage.py tests/test_weekly_plan_postprocess_error_envelope_diff_coverage.py`
+- `. .venv/bin/activate && pytest -q tests/test_pro_vip_route_dependency_guard.py tests/security/test_api_auth_tier_contract_pack.py tests/test_paid_route_guards.py`
+- `. .venv/bin/activate && mypy app/services/nutrition_targets.py app/routers/pro.py app/routers/premium_week.py`
+- `make openapi-check`
+- `make lint`
+- `pre-commit run --all-files`
+- `git diff --check`
+- Pre-push hooks: changed-files mypy, backend tests, full-repo Bandit, Docker
+  build test.
+
+`make validate-changed` passed but selected no Python files in the local branch
+state, so it is explicitly not treated as sufficient evidence for this PR.
+
+Full `make verify` was attempted once. The first run exposed the
+`legacy_app.py` lint issue fixed in `6eec0ea99`. The rerun passed verify-env,
+lint, mypy, and smoke tests, then entered the full pytest/diff-cov phase and was
+interrupted per operator machine-heavy policy. It is not claimed as a completed
+readiness signal.
+
+## Merge Readiness
+
+Not merge-ready yet.
+
+Required before merge:
+- Current-head CI must pass.
+- Bot/human review comments must be dispositioned.
+- Post-open role passes must run:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- Codex Security diff scan/finding discovery must run if available.
+- `pulseplate-pr-review` must run.
+- Strict merge-readiness checks must pass.

--- a/docs/review/PR_2006_FIXED_MAPPING.md
+++ b/docs/review/PR_2006_FIXED_MAPPING.md
@@ -64,6 +64,14 @@ Evidence: `tests/test_diff_coverage_pr339.py` and `tests/test_final_coverage_96.
 Disposition: FIXED
 Commit: 3f5504350
 Evidence: `docs/review/PR_2006_FIXED_MAPPING.md` now uses unchecked checklist entries under `## Merge Readiness`; `pre-commit run --all-files` passed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2006#discussion_r3452821243 -> 8362e21fe
+Disposition: FIXED
+Commit: 8362e21fe
+Evidence: `tests/test_premium_week_endpoint_simple_96.py` asserts JSON `content-type` before parsing the legacy premium weekly alias response; `pytest -q tests/test_premium_week_endpoint_simple_96.py` passed.
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2006#pullrequestreview-4544801394 -> 8362e21fe
+Disposition: FIXED
+Commit: 8362e21fe
+Evidence: `tests/test_premium_week_endpoint_simple_96.py` asserts JSON `content-type` before parsing the legacy premium weekly alias response; `pytest -q tests/test_premium_week_endpoint_simple_96.py` passed.
 
 ## PulsePlate PR Review Disposition
 
@@ -98,6 +106,8 @@ FoodDB cutover, frontend/iOS, or broad legacy rewrite scope is included.
 - `3f5504350` - addresses CodeRabbit outside-diff test/mapping findings and
   removes the disabled hypothesis file from the net PR diff.
 - `42a1b4140` - maps PR #2006 review-level bot comments.
+- `8362e21fe` - asserts JSON content type before parsing the legacy premium
+  weekly alias response.
 
 ## Premortem Evidence
 

--- a/legacy_app.py
+++ b/legacy_app.py
@@ -86,12 +86,6 @@ from app.services.bmi_compat import (
     add_visualization_if_requested,
     generate_bmi_visualization,
 )
-
-_BMI_COMPAT_REEXPORTS = (
-    MATPLOTLIB_AVAILABLE,
-    add_visualization_if_requested,
-    generate_bmi_visualization,
-)
 from core.fingerprint_security import _client_fingerprint
 from core.log_retention import (
     DATA_CLASS_PSEUDONYMOUS,
@@ -129,6 +123,21 @@ from app.security.llm_monthly_quota import (
 from app.utils.nutrition_wrappers import (
     _calculate_all_bmr_wrapper,
     _calculate_all_tdee_wrapper,
+)
+
+_BMI_COMPAT_REEXPORTS = (
+    MATPLOTLIB_AVAILABLE,
+    add_visualization_if_requested,
+    generate_bmi_visualization,
+)
+
+_LEGACY_IMPORT_COMPAT_REEXPORTS = (
+    DataClass,
+    get_retention_manager,
+    get_session,
+    Language,
+    normalize_lang,
+    _short_git_sha,
 )
 
 # PR-633: thin alias to canonical import-safe schema (no local validation).

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -21,6 +21,14 @@
 - **Prefer `monkeypatch.setattr()` over `@patch` decorator** — `@patch` on `@contextmanager` targets
   fails silently under Python 3.12 + xdist (see `docs/ENGINEERING_LESSONS.md` lesson 11).
   Use autouse `monkeypatch.setenv()` fixtures instead of `os.environ` mutation in `setup_method()`.
+- **Do not add async pytest markers to tests selected by the pre-commit backend-tests hook.**
+  CI lint may run `scripts/run-backend-tests-pre-commit.sh` without
+  `pytest-asyncio` loaded even when the local venv has it. For diff-coverage or
+  changed-file tests selected by that hook, prefer sync tests that call simple
+  coroutines with `asyncio.run(...)` or exercise routes through `TestClient`.
+  After editing selected tests, scan the whole selected bundle for
+  `pytest.mark.asyncio` and `async def`, then run the backend-tests hook command
+  and `pre-commit run --all-files`. See `docs/ENGINEERING_LESSONS.md` lesson 25.
 - For background update / lifespan tests, patch both `app` facade and `legacy_app` / `app_module`
   alias surfaces when replacing `start_background_updates` or `stop_background_updates`.
   Patching only one side is forbidden because production resolvers read multiple module aliases.

--- a/tests/disabled_hypothesis/test_premium_week_hypothesis_simple.py
+++ b/tests/disabled_hypothesis/test_premium_week_hypothesis_simple.py
@@ -239,7 +239,7 @@ class TestPremiumWeekHypothesisSimple:
             )
 
             # Should succeed and cover lines 104-113
-            # (profile-derived planning target call and targets check)
+            # (estimate_targets_minimal call and targets check)
             assert response.status_code == 200
             data = response.json()
             assert "daily_menus" in data

--- a/tests/disabled_hypothesis/test_premium_week_hypothesis_simple.py
+++ b/tests/disabled_hypothesis/test_premium_week_hypothesis_simple.py
@@ -239,7 +239,7 @@ class TestPremiumWeekHypothesisSimple:
             )
 
             # Should succeed and cover lines 104-113
-            # (estimate_targets_minimal call and targets check)
+            # (profile-derived planning target call and targets check)
             assert response.status_code == 200
             data = response.json()
             assert "daily_menus" in data

--- a/tests/edges/test_premium_week_edges.py
+++ b/tests/edges/test_premium_week_edges.py
@@ -1,11 +1,14 @@
-from typing import cast
+from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import patch
 import os
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.types import ASGIApp
 
+from app.middleware.api_tiers import require_pro_tier
 from app.routers import premium_week
 
 
@@ -13,6 +16,72 @@ def _make_client() -> TestClient:
     app = FastAPI()
     app.include_router(premium_week.router)
     return TestClient(cast(ASGIApp, app))
+
+
+def _make_pro_client() -> TestClient:
+    from app.routers import pro
+
+    app = FastAPI()
+    app.dependency_overrides[require_pro_tier] = lambda: None
+    app.include_router(pro.router)
+    return TestClient(cast(ASGIApp, app))
+
+
+def _complete_targets() -> dict[str, Any]:
+    return {
+        "kcal": 2100,
+        "macros": {
+            "protein_g": 120.0,
+            "fat_g": 70.0,
+            "carbs_g": 230.0,
+            "fiber_g": 31.0,
+        },
+        "micro": {"vitamin_c_mg": 90.0, "iron_mg": 14.0},
+        "water_ml": 2300,
+        "activity_week": {
+            "moderate_aerobic_min": 150,
+            "vigorous_aerobic_min": 75,
+            "strength_sessions": 2,
+            "steps_daily": 8500,
+        },
+    }
+
+
+def _canonical_week_payload() -> dict[str, Any]:
+    return {
+        "daily_menus": [
+            {
+                "meals": [
+                    {
+                        "title": "lentil_bowl",
+                        "title_translated": "Lentil bowl",
+                        "grams": {"lentils": 180.0},
+                        "kcal": 430.0,
+                        "macros": {
+                            "protein_g": 26.0,
+                            "fat_g": 12.0,
+                            "carbs_g": 58.0,
+                        },
+                        "micros": {"iron_mg": 6.0},
+                        "price_est": "4.50",
+                    }
+                ],
+                "kcal": 430.0,
+                "macros": {
+                    "protein_g": 26.0,
+                    "fat_g": 12.0,
+                    "carbs_g": 58.0,
+                },
+                "micros": {"iron_mg": 6.0},
+                "coverage": {"iron_mg": 60.0},
+                "tips": ["Add greens"],
+            }
+        ],
+        "weekly_coverage": {"protein_g": 1.0},
+        "shopping_list": {"lentils_g": 500.0},
+        "total_cost": 4.5,
+        "adherence_score": 1.0,
+    }
 
 
 @patch.dict(os.environ, {"APP_ENV": "test", "DEBUG": "true"})
@@ -98,3 +167,155 @@ def test_premium_week_with_explicit_targets_happy_path_200():
     body = resp.json()
     assert "daily_menus" in body and isinstance(body["daily_menus"], list)
     assert "weekly_coverage" in body and isinstance(body["weekly_coverage"], dict)
+
+
+def test_planning_target_service_validation_branches_for_ci_coverage() -> None:
+    from app.services import nutrition_targets
+
+    assert not nutrition_targets.is_complete_planning_targets({})
+    assert not nutrition_targets.is_complete_planning_targets(
+        {"kcal": 2000, "macros": "bad", "micro": {"iron_mg": 14.0}, "water_ml": 2000}
+    )
+    assert not nutrition_targets.is_complete_planning_targets(
+        {"kcal": 2000, "macros": {"protein_g": 100.0}, "micro": "bad", "water_ml": 2000}
+    )
+    assert not nutrition_targets.is_complete_planning_targets(
+        {
+            "kcal": 2000,
+            "macros": {"protein_g": 100.0},
+            "micro": {"iron_mg": 14.0},
+            "water_ml": 2000,
+            "activity_week": "bad",
+        }
+    )
+    assert not nutrition_targets.is_complete_planning_targets(
+        {"kcal": 2000, "macros": {"protein_g": 100.0}, "micro": {}, "water_ml": 2000}
+    )
+    assert not nutrition_targets.is_complete_planning_targets(
+        {"kcal": 2000, "macros": {}, "micro": {"iron_mg": 14.0}, "water_ml": 2000}
+    )
+    assert nutrition_targets.is_complete_planning_targets(_complete_targets())
+
+
+def test_estimate_targets_from_profile_maps_core_payload_for_ci_coverage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services import nutrition_targets
+
+    captured_profiles: list[Any] = []
+
+    targets = SimpleNamespace(
+        kcal_daily=2100,
+        macros=SimpleNamespace(
+            protein_g=120.0,
+            fat_g=70.0,
+            carbs_g=230.0,
+            fiber_g=31.0,
+        ),
+        micros=SimpleNamespace(
+            get_priority_nutrients=lambda: {"vitamin_c_mg": 90.0, "iron_mg": 14.0},
+        ),
+        water_ml_daily=2300,
+        activity=SimpleNamespace(
+            moderate_aerobic_min=150,
+            vigorous_aerobic_min=75,
+            strength_sessions=2,
+            steps_daily=8500,
+        ),
+    )
+
+    def _fake_build_nutrition_targets(profile: Any) -> Any:
+        captured_profiles.append(profile)
+        return targets
+
+    monkeypatch.setattr(
+        nutrition_targets,
+        "build_nutrition_targets",
+        _fake_build_nutrition_targets,
+    )
+
+    payload = nutrition_targets.estimate_targets_from_profile(
+        sex="female",
+        age=34,
+        height_cm=168.0,
+        weight_kg=64.0,
+        activity="active",
+        goal="maintain",
+    )
+
+    assert len(captured_profiles) == 1
+    assert captured_profiles[0].sex == "female"
+    assert captured_profiles[0].activity == "active"
+    assert payload == _complete_targets()
+
+
+@patch.dict(os.environ, {"APP_ENV": "test", "DEBUG": "true"})
+def test_premium_week_profile_derived_targets_branch_is_ci_covered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services import nutrition_targets
+
+    client = _make_client()
+    monkeypatch.setattr(premium_week, "_get_food_db", lambda: object())
+    monkeypatch.setattr(premium_week, "_get_recipe_db", lambda: object())
+    monkeypatch.setattr(
+        premium_week, "build_week", lambda *_args, **_kwargs: _canonical_week_payload()
+    )
+    monkeypatch.setattr(
+        nutrition_targets,
+        "estimate_targets_from_profile",
+        lambda **_kwargs: _complete_targets(),
+    )
+
+    resp = client.post(
+        "/api/v1/premium/plan/week-flexible",
+        json={
+            "sex": "female",
+            "age": 34,
+            "height_cm": 168,
+            "weight_kg": 64,
+            "activity": "active",
+            "goal": "maintain",
+            "diet_flags": [],
+            "lang": "en",
+        },
+        headers={"X-API-Key": "test_pro_key"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["daily_menus"][0]["meals"][0]["price_est"] == 4.5
+
+
+@patch.dict(os.environ, {"APP_ENV": "test", "DEBUG": "true"})
+def test_pro_week_profile_derived_targets_branch_is_ci_covered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.routers import pro
+    from app.services import nutrition_targets
+
+    client = _make_pro_client()
+    monkeypatch.setattr(pro, "get_food_db", lambda: object())
+    monkeypatch.setattr(pro, "get_recipe_db", lambda: object())
+    monkeypatch.setattr(pro, "build_week", lambda *_args, **_kwargs: _canonical_week_payload())
+    monkeypatch.setattr(
+        nutrition_targets,
+        "estimate_targets_from_profile",
+        lambda **_kwargs: _complete_targets(),
+    )
+
+    resp = client.post(
+        "/api/v1/pro/meal/weekly",
+        json={
+            "sex": "female",
+            "age": 34,
+            "height_cm": 168,
+            "weight_kg": 64,
+            "activity": "active",
+            "goal": "maintain",
+            "diet_flags": [],
+            "lang": "en",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["daily_menus"][0]["meals"][0]["price_est"] == 4.5

--- a/tests/test_diff_coverage_pr339.py
+++ b/tests/test_diff_coverage_pr339.py
@@ -12,8 +12,8 @@ introduced in the PR, specifically targeting:
 Focus: Hit new/changed lines with minimal dependencies on core/CSV.
 """
 
-from typing import Any, Dict
 from types import SimpleNamespace
+from typing import Any, Dict
 from unittest.mock import MagicMock
 
 import pytest
@@ -23,7 +23,7 @@ from fastapi import HTTPException
 class TestPRORouterDiffCoverage:
     """Cover new branches in app/routers/pro.py added by PR #339."""
 
-    def test_missing_profile_detail_helper_format(self):
+    def test_missing_profile_detail_helper_format(self) -> None:
         """Verify _missing_profile_detail() includes both required substrings."""
         from app.routers.pro import _missing_profile_detail
 
@@ -31,7 +31,7 @@ class TestPRORouterDiffCoverage:
         assert "Missing user profile data" in msg
         assert "Missing required field: age" in msg
 
-    def test_is_complete_planning_targets_all_branches(self):
+    def test_is_complete_planning_targets_all_branches(self) -> None:
         """Cover all return paths in is_complete_planning_targets()."""
         from app.services.nutrition_targets import is_complete_planning_targets
 
@@ -115,7 +115,7 @@ class TestPRORouterDiffCoverage:
             }
         )
 
-    def test_estimate_targets_from_profile_smoke(self, monkeypatch):
+    def test_estimate_targets_from_profile_smoke(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Smoke test for estimate_targets_from_profile() happy path."""
         from app.services.nutrition_targets import estimate_targets_from_profile
 
@@ -157,7 +157,7 @@ class TestPRORouterDiffCoverage:
         assert result["macros"]["protein_g"] == 100
         assert result["activity_week"]["steps_daily"] == 8000
 
-    def test_cache_init_and_reuse_branches(self, monkeypatch):
+    def test_cache_init_and_reuse_branches(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Cover cache initialization (None → instance) and reuse paths."""
         from app.routers import pro as pro_router
 

--- a/tests/test_diff_coverage_pr339.py
+++ b/tests/test_diff_coverage_pr339.py
@@ -12,6 +12,7 @@ introduced in the PR, specifically targeting:
 Focus: Hit new/changed lines with minimal dependencies on core/CSV.
 """
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any, Dict
 from unittest.mock import MagicMock
@@ -196,7 +197,6 @@ class TestPRORouterDiffCoverage:
             pro_router._food_db_cache = original_food_cache
             pro_router._recipe_db_cache = original_recipe_cache
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "kwargs, expected_field",
         [
@@ -226,7 +226,7 @@ class TestPRORouterDiffCoverage:
             ),
         ],
     )
-    async def test_generate_week_plan_missing_profile_fields(
+    def test_generate_week_plan_missing_profile_fields(
         self, monkeypatch, kwargs: Dict[str, Any], expected_field: str
     ):
         """Cover all missing profile field branches in PRO router."""
@@ -238,13 +238,12 @@ class TestPRORouterDiffCoverage:
         req = ProWeekPlanRequest(**kwargs)
 
         with pytest.raises(HTTPException) as exc_info:
-            await generate_week_plan(req)
+            asyncio.run(generate_week_plan(req))
 
         assert exc_info.value.status_code == 400
         assert expected_field in exc_info.value.detail
 
-    @pytest.mark.asyncio
-    async def test_generate_week_plan_hard_guard_not_dict(self, monkeypatch):
+    def test_generate_week_plan_hard_guard_not_dict(self, monkeypatch):
         """Cover hard guard: targets is not a dict → 400."""
         from app.routers.pro import ProWeekPlanRequest, generate_week_plan
 
@@ -259,13 +258,12 @@ class TestPRORouterDiffCoverage:
         req = ProWeekPlanRequest(sex="female", age=25, height_cm=165, weight_kg=60)
 
         with pytest.raises(HTTPException) as exc_info:
-            await generate_week_plan(req)
+            asyncio.run(generate_week_plan(req))
 
         assert exc_info.value.status_code == 400
         assert "Unable to derive targets" in exc_info.value.detail
 
-    @pytest.mark.asyncio
-    async def test_generate_week_plan_hard_guard_incomplete(self, monkeypatch):
+    def test_generate_week_plan_hard_guard_incomplete(self, monkeypatch):
         """Cover hard guard: targets dict incomplete → 400."""
         from app.routers.pro import ProWeekPlanRequest, generate_week_plan
 
@@ -280,13 +278,12 @@ class TestPRORouterDiffCoverage:
         req = ProWeekPlanRequest(sex="male", age=30, height_cm=175, weight_kg=70)
 
         with pytest.raises(HTTPException) as exc_info:
-            await generate_week_plan(req)
+            asyncio.run(generate_week_plan(req))
 
         assert exc_info.value.status_code == 400
         assert "Unable to derive targets" in exc_info.value.detail
 
-    @pytest.mark.asyncio
-    async def test_generate_week_plan_with_valid_targets(self, monkeypatch):
+    def test_generate_week_plan_with_valid_targets(self, monkeypatch):
         """Cover happy path: valid targets dict from request."""
         from app.routers.pro import ProWeekPlanRequest, generate_week_plan
 
@@ -318,7 +315,7 @@ class TestPRORouterDiffCoverage:
             }
         )
 
-        resp = await generate_week_plan(req)
+        resp = asyncio.run(generate_week_plan(req))
         assert resp.weekly_coverage["kcal"] == 1.0
 
 
@@ -489,8 +486,7 @@ class TestPremiumWeekDiffCoverage:
         assert result["macros"]["fat_g"] == 70
         assert result["activity_week"]["steps_daily"] == 8000
 
-    @pytest.mark.asyncio
-    async def test_deprecation_event_both_states(self, monkeypatch):
+    def test_deprecation_event_both_states(self, monkeypatch):
         """Cover deprecation logging Event transitions (not set → set)."""
         from app.routers.premium_week import (
             PremiumWeekPlanRequest,
@@ -526,14 +522,13 @@ class TestPremiumWeekDiffCoverage:
         )
 
         # First call: event not set → log warning + set event
-        await generate_week_plan(req)
+        asyncio.run(generate_week_plan(req))
         assert _deprecation_logged.is_set()
 
         # Second call: event already set → skip logging
-        await generate_week_plan(req)
+        asyncio.run(generate_week_plan(req))
 
-    @pytest.mark.asyncio
-    async def test_hard_guard_malformed_targets(self, monkeypatch):
+    def test_hard_guard_malformed_targets(self, monkeypatch):
         """Cover hard guard for malformed targets after derivation."""
         from app.routers.premium_week import PremiumWeekPlanRequest, generate_week_plan
 
@@ -548,13 +543,12 @@ class TestPremiumWeekDiffCoverage:
         req = PremiumWeekPlanRequest(sex="female", age=28, height_cm=160, weight_kg=55)
 
         with pytest.raises(HTTPException) as exc_info:
-            await generate_week_plan(req)
+            asyncio.run(generate_week_plan(req))
 
         assert exc_info.value.status_code == 400
         assert "Unable to derive targets" in exc_info.value.detail
 
-    @pytest.mark.asyncio
-    async def test_premium_hard_guard_targets_not_dict(self, monkeypatch):
+    def test_premium_hard_guard_targets_not_dict(self, monkeypatch):
         """Cover hard guard where derived targets are not a dict."""
         from app.routers.premium_week import PremiumWeekPlanRequest, generate_week_plan
 
@@ -568,12 +562,11 @@ class TestPremiumWeekDiffCoverage:
         req = PremiumWeekPlanRequest(sex="female", age=28, height_cm=160, weight_kg=55)
 
         with pytest.raises(HTTPException) as exc_info:
-            await generate_week_plan(req)
+            asyncio.run(generate_week_plan(req))
 
         assert exc_info.value.status_code == 400
         assert "Unable to derive targets" in exc_info.value.detail
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "kwargs, expected_field",
         [
@@ -603,7 +596,7 @@ class TestPremiumWeekDiffCoverage:
             ),
         ],
     )
-    async def test_premium_generate_week_plan_missing_profile_fields(
+    def test_premium_generate_week_plan_missing_profile_fields(
         self, monkeypatch, kwargs: Dict[str, Any], expected_field: str
     ):
         """Cover missing profile field branches in premium router."""
@@ -618,7 +611,7 @@ class TestPremiumWeekDiffCoverage:
         req = PremiumWeekPlanRequest(**kwargs)
 
         with pytest.raises(HTTPException) as exc_info:
-            await generate_week_plan(req)
+            asyncio.run(generate_week_plan(req))
 
         assert exc_info.value.status_code == 400
         assert expected_field in exc_info.value.detail

--- a/tests/test_diff_coverage_pr339.py
+++ b/tests/test_diff_coverage_pr339.py
@@ -3,7 +3,7 @@ Diff coverage tests for PR #339 - PRO tier router standardization.
 
 These tests ensure 97%+ patch coverage by exercising all code branches
 introduced in the PR, specifically targeting:
-- _is_complete_targets() validation logic (all return paths)
+- is_complete_planning_targets() validation logic (all return paths)
 - Hard guards for malformed targets
 - Missing profile field error messages
 - Cache initialization branches
@@ -31,16 +31,16 @@ class TestPRORouterDiffCoverage:
         assert "Missing user profile data" in msg
         assert "Missing required field: age" in msg
 
-    def test_is_complete_targets_all_branches(self):
-        """Cover all return paths in _is_complete_targets()."""
-        from app.routers.pro import _is_complete_targets
+    def test_is_complete_planning_targets_all_branches(self):
+        """Cover all return paths in is_complete_planning_targets()."""
+        from app.services.nutrition_targets import is_complete_planning_targets
 
         # Missing required keys
-        assert not _is_complete_targets({})
-        assert not _is_complete_targets({"kcal": 2000})
+        assert not is_complete_planning_targets({})
+        assert not is_complete_planning_targets({"kcal": 2000})
 
         # macros not a dict
-        assert not _is_complete_targets(
+        assert not is_complete_planning_targets(
             {
                 "kcal": 2000,
                 "macros": "invalid",
@@ -51,7 +51,7 @@ class TestPRORouterDiffCoverage:
         )
 
         # micro not a dict
-        assert not _is_complete_targets(
+        assert not is_complete_planning_targets(
             {
                 "kcal": 2000,
                 "macros": {"protein_g": 100},
@@ -62,7 +62,7 @@ class TestPRORouterDiffCoverage:
         )
 
         # micro is empty (required to be non-empty)
-        assert not _is_complete_targets(
+        assert not is_complete_planning_targets(
             {
                 "kcal": 2000,
                 "macros": {"protein_g": 100},
@@ -73,7 +73,7 @@ class TestPRORouterDiffCoverage:
         )
 
         # macros is empty (required to be non-empty)
-        assert not _is_complete_targets(
+        assert not is_complete_planning_targets(
             {
                 "kcal": 2000,
                 "macros": {},
@@ -84,7 +84,7 @@ class TestPRORouterDiffCoverage:
         )
 
         # Valid complete targets
-        assert _is_complete_targets(
+        assert is_complete_planning_targets(
             {
                 "kcal": 2000,
                 "macros": {"protein_g": 100},
@@ -95,7 +95,7 @@ class TestPRORouterDiffCoverage:
         )
 
         # Valid targets without activity_week (optional field)
-        assert _is_complete_targets(
+        assert is_complete_planning_targets(
             {
                 "kcal": 2000,
                 "macros": {"protein_g": 100},
@@ -105,7 +105,7 @@ class TestPRORouterDiffCoverage:
         )
 
         # Invalid: activity_week wrong type (not dict)
-        assert not _is_complete_targets(
+        assert not is_complete_planning_targets(
             {
                 "kcal": 2000,
                 "macros": {"protein_g": 100},
@@ -115,9 +115,9 @@ class TestPRORouterDiffCoverage:
             }
         )
 
-    def test_estimate_targets_minimal_smoke(self, monkeypatch):
-        """Smoke test for estimate_targets_minimal() happy path."""
-        from app.routers.pro import estimate_targets_minimal
+    def test_estimate_targets_from_profile_smoke(self, monkeypatch):
+        """Smoke test for estimate_targets_from_profile() happy path."""
+        from app.services.nutrition_targets import estimate_targets_from_profile
 
         mock_targets = SimpleNamespace(
             kcal_daily=2000,
@@ -140,11 +140,11 @@ class TestPRORouterDiffCoverage:
         )
 
         monkeypatch.setattr(
-            "app.routers.pro.build_nutrition_targets",
+            "app.services.nutrition_targets.build_nutrition_targets",
             lambda profile: mock_targets,
         )
 
-        result = estimate_targets_minimal(
+        result = estimate_targets_from_profile(
             sex="female",
             age=30,
             height_cm=165.0,
@@ -252,7 +252,7 @@ class TestPRORouterDiffCoverage:
         monkeypatch.setattr("app.routers.pro.get_food_db", lambda: MagicMock())
         monkeypatch.setattr("app.routers.pro.get_recipe_db", lambda: MagicMock())
         monkeypatch.setattr(
-            "app.routers.pro.estimate_targets_minimal",
+            "app.services.nutrition_targets.estimate_targets_from_profile",
             lambda *args, **kwargs: "not_a_dict",  # Type guard should catch this
         )
 
@@ -273,7 +273,7 @@ class TestPRORouterDiffCoverage:
         monkeypatch.setattr("app.routers.pro.get_food_db", lambda: MagicMock())
         monkeypatch.setattr("app.routers.pro.get_recipe_db", lambda: MagicMock())
         monkeypatch.setattr(
-            "app.routers.pro.estimate_targets_minimal",
+            "app.services.nutrition_targets.estimate_targets_from_profile",
             lambda *args, **kwargs: {"kcal": 2000, "macros": {}, "micro": {}},  # Missing keys
         )
 
@@ -333,15 +333,15 @@ class TestPremiumWeekDiffCoverage:
         assert "Missing user profile data" in msg
         assert "Missing required field: height_cm" in msg
 
-    def test_is_complete_targets_all_branches(self):
-        """Cover all return paths in _is_complete_targets()."""
-        from app.routers.premium_week import _is_complete_targets
+    def test_is_complete_planning_targets_all_branches(self):
+        """Cover all return paths in is_complete_planning_targets()."""
+        from app.services.nutrition_targets import is_complete_planning_targets
 
         # Missing required keys
-        assert not _is_complete_targets({})
+        assert not is_complete_planning_targets({})
 
         # macros not a dict
-        assert not _is_complete_targets(
+        assert not is_complete_planning_targets(
             {
                 "kcal": 2000,
                 "macros": None,
@@ -352,7 +352,7 @@ class TestPremiumWeekDiffCoverage:
         )
 
         # micro is empty
-        assert not _is_complete_targets(
+        assert not is_complete_planning_targets(
             {
                 "kcal": 2000,
                 "macros": {"protein_g": 100},
@@ -363,7 +363,7 @@ class TestPremiumWeekDiffCoverage:
         )
 
         # micro not a dict
-        assert not _is_complete_targets(
+        assert not is_complete_planning_targets(
             {
                 "kcal": 2000,
                 "macros": {"protein_g": 100},
@@ -374,7 +374,7 @@ class TestPremiumWeekDiffCoverage:
         )
 
         # macros is empty
-        assert not _is_complete_targets(
+        assert not is_complete_planning_targets(
             {
                 "kcal": 2000,
                 "macros": {},
@@ -385,7 +385,7 @@ class TestPremiumWeekDiffCoverage:
         )
 
         # Valid
-        assert _is_complete_targets(
+        assert is_complete_planning_targets(
             {
                 "kcal": 2000,
                 "macros": {"protein_g": 100},
@@ -396,7 +396,7 @@ class TestPremiumWeekDiffCoverage:
         )
 
         # Valid without activity_week (optional)
-        assert _is_complete_targets(
+        assert is_complete_planning_targets(
             {
                 "kcal": 2000,
                 "macros": {"protein_g": 100},
@@ -406,7 +406,7 @@ class TestPremiumWeekDiffCoverage:
         )
 
         # Invalid: activity_week wrong type
-        assert not _is_complete_targets(
+        assert not is_complete_planning_targets(
             {
                 "kcal": 2000,
                 "macros": {"protein_g": 100},
@@ -447,9 +447,9 @@ class TestPremiumWeekDiffCoverage:
         rdb2 = premium_router._get_recipe_db()
         assert rdb2 is rdb1
 
-    def test_premium_estimate_targets_minimal_smoke(self, monkeypatch):
-        """Smoke test for premium estimate_targets_minimal() happy path."""
-        from app.routers.premium_week import estimate_targets_minimal
+    def test_premium_estimate_targets_from_profile_smoke(self, monkeypatch):
+        """Smoke test for premium estimate_targets_from_profile() happy path."""
+        from app.services.nutrition_targets import estimate_targets_from_profile
 
         mock_targets = SimpleNamespace(
             kcal_daily=2000,
@@ -472,11 +472,11 @@ class TestPremiumWeekDiffCoverage:
         )
 
         monkeypatch.setattr(
-            "app.routers.premium_week.build_nutrition_targets",
+            "app.services.nutrition_targets.build_nutrition_targets",
             lambda profile: mock_targets,
         )
 
-        result = estimate_targets_minimal(
+        result = estimate_targets_from_profile(
             sex="male",
             age=40,
             height_cm=180.0,
@@ -541,7 +541,7 @@ class TestPremiumWeekDiffCoverage:
         monkeypatch.setattr("app.routers.premium_week._get_food_db", lambda: MagicMock())
         monkeypatch.setattr("app.routers.premium_week._get_recipe_db", lambda: MagicMock())
         monkeypatch.setattr(
-            "app.routers.premium_week.estimate_targets_minimal",
+            "app.services.nutrition_targets.estimate_targets_from_profile",
             lambda *args, **kwargs: {"kcal": 2000},  # Incomplete
         )
 
@@ -561,7 +561,7 @@ class TestPremiumWeekDiffCoverage:
         monkeypatch.setattr("app.routers.premium_week._get_food_db", lambda: MagicMock())
         monkeypatch.setattr("app.routers.premium_week._get_recipe_db", lambda: MagicMock())
         monkeypatch.setattr(
-            "app.routers.premium_week.estimate_targets_minimal",
+            "app.services.nutrition_targets.estimate_targets_from_profile",
             lambda *args, **kwargs: "not_a_dict",
         )
 

--- a/tests/test_final_coverage_96.py
+++ b/tests/test_final_coverage_96.py
@@ -10,12 +10,12 @@ from app.services.nutrition_targets import estimate_targets_from_profile
 class TestFinalCoverage96:
     """Tests to reach final 96% coverage target."""
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         """Setup test environment"""
         os.environ["API_KEY"] = "test_key"
         os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
 
-    def test_premium_week_estimate_targets_from_profile(self):
+    def test_premium_week_estimate_targets_from_profile(self) -> None:
         """Test estimate_targets_from_profile function."""
         result = estimate_targets_from_profile(
             sex="male",
@@ -33,7 +33,7 @@ class TestFinalCoverage96:
         assert "water_ml" in result
         assert "activity_week" in result
 
-    def test_premium_week_estimate_targets_from_profile_female(self):
+    def test_premium_week_estimate_targets_from_profile_female(self) -> None:
         """Test estimate_targets_from_profile with female profile."""
         result = estimate_targets_from_profile(
             sex="female",
@@ -49,7 +49,7 @@ class TestFinalCoverage96:
         assert "macros" in result
         assert "micro" in result
 
-    def test_premium_week_estimate_targets_from_profile_elderly(self):
+    def test_premium_week_estimate_targets_from_profile_elderly(self) -> None:
         """Test estimate_targets_from_profile with elderly profile."""
         result = estimate_targets_from_profile(
             sex="male",
@@ -65,7 +65,7 @@ class TestFinalCoverage96:
         assert "macros" in result
         assert "micro" in result
 
-    def test_premium_week_estimate_targets_from_profile_teen(self):
+    def test_premium_week_estimate_targets_from_profile_teen(self) -> None:
         """Test estimate_targets_from_profile with teen profile."""
         result = estimate_targets_from_profile(
             sex="female",
@@ -81,7 +81,7 @@ class TestFinalCoverage96:
         assert "macros" in result
         assert "micro" in result
 
-    def test_premium_week_estimate_targets_from_profile_athlete(self):
+    def test_premium_week_estimate_targets_from_profile_athlete(self) -> None:
         """Test estimate_targets_from_profile with athlete profile."""
         result = estimate_targets_from_profile(
             sex="male",
@@ -97,7 +97,7 @@ class TestFinalCoverage96:
         assert "macros" in result
         assert "micro" in result
 
-    def test_premium_week_estimate_targets_from_profile_obese(self):
+    def test_premium_week_estimate_targets_from_profile_obese(self) -> None:
         """Test estimate_targets_from_profile with obese profile."""
         result = estimate_targets_from_profile(
             sex="female",
@@ -113,7 +113,7 @@ class TestFinalCoverage96:
         assert "macros" in result
         assert "micro" in result
 
-    def test_premium_week_estimate_targets_from_profile_underweight(self):
+    def test_premium_week_estimate_targets_from_profile_underweight(self) -> None:
         """Test estimate_targets_from_profile with underweight profile."""
         result = estimate_targets_from_profile(
             sex="male",
@@ -129,7 +129,7 @@ class TestFinalCoverage96:
         assert "macros" in result
         assert "micro" in result
 
-    def test_premium_week_estimate_targets_from_profile_edge_cases(self):
+    def test_premium_week_estimate_targets_from_profile_edge_cases(self) -> None:
         """Test estimate_targets_from_profile with edge case profiles."""
         # Test minimum age
         result = estimate_targets_from_profile(
@@ -153,7 +153,7 @@ class TestFinalCoverage96:
         )
         assert result is not None
 
-    def test_premium_week_estimate_targets_from_profile_all_activities(self):
+    def test_premium_week_estimate_targets_from_profile_all_activities(self) -> None:
         """Test estimate_targets_from_profile with all activity levels."""
         activities = ["sedentary", "light", "moderate", "active", "very_active"]
 
@@ -169,7 +169,7 @@ class TestFinalCoverage96:
             assert result is not None
             assert "kcal" in result
 
-    def test_premium_week_estimate_targets_from_profile_all_goals(self):
+    def test_premium_week_estimate_targets_from_profile_all_goals(self) -> None:
         """Test estimate_targets_from_profile with all goal types."""
         goals = ["loss", "maintain", "gain"]
 

--- a/tests/test_final_coverage_96.py
+++ b/tests/test_final_coverage_96.py
@@ -4,7 +4,7 @@ import os
 Final coverage tests to reach 96% target.
 """
 
-from app.routers.premium_week import estimate_targets_minimal
+from app.services.nutrition_targets import estimate_targets_from_profile
 
 
 class TestFinalCoverage96:
@@ -15,9 +15,9 @@ class TestFinalCoverage96:
         os.environ["API_KEY"] = "test_key"
         os.environ["FEATURE_PREMIUM_NUTRITION"] = "true"
 
-    def test_premium_week_estimate_targets_minimal(self):
-        """Test estimate_targets_minimal function - lines 58-71."""
-        result = estimate_targets_minimal(
+    def test_premium_week_estimate_targets_from_profile(self):
+        """Test estimate_targets_from_profile function."""
+        result = estimate_targets_from_profile(
             sex="male",
             age=30,
             height_cm=175.0,
@@ -33,9 +33,9 @@ class TestFinalCoverage96:
         assert "water_ml" in result
         assert "activity_week" in result
 
-    def test_premium_week_estimate_targets_minimal_female(self):
-        """Test estimate_targets_minimal with female profile - lines 58-71."""
-        result = estimate_targets_minimal(
+    def test_premium_week_estimate_targets_from_profile_female(self):
+        """Test estimate_targets_from_profile with female profile."""
+        result = estimate_targets_from_profile(
             sex="female",
             age=25,
             height_cm=165.0,
@@ -49,9 +49,9 @@ class TestFinalCoverage96:
         assert "macros" in result
         assert "micro" in result
 
-    def test_premium_week_estimate_targets_minimal_elderly(self):
-        """Test estimate_targets_minimal with elderly profile - lines 58-71."""
-        result = estimate_targets_minimal(
+    def test_premium_week_estimate_targets_from_profile_elderly(self):
+        """Test estimate_targets_from_profile with elderly profile."""
+        result = estimate_targets_from_profile(
             sex="male",
             age=65,
             height_cm=170.0,
@@ -65,9 +65,9 @@ class TestFinalCoverage96:
         assert "macros" in result
         assert "micro" in result
 
-    def test_premium_week_estimate_targets_minimal_teen(self):
-        """Test estimate_targets_minimal with teen profile - lines 58-71."""
-        result = estimate_targets_minimal(
+    def test_premium_week_estimate_targets_from_profile_teen(self):
+        """Test estimate_targets_from_profile with teen profile."""
+        result = estimate_targets_from_profile(
             sex="female",
             age=16,
             height_cm=160.0,
@@ -81,9 +81,9 @@ class TestFinalCoverage96:
         assert "macros" in result
         assert "micro" in result
 
-    def test_premium_week_estimate_targets_minimal_athlete(self):
-        """Test estimate_targets_minimal with athlete profile - lines 58-71."""
-        result = estimate_targets_minimal(
+    def test_premium_week_estimate_targets_from_profile_athlete(self):
+        """Test estimate_targets_from_profile with athlete profile."""
+        result = estimate_targets_from_profile(
             sex="male",
             age=28,
             height_cm=185.0,
@@ -97,9 +97,9 @@ class TestFinalCoverage96:
         assert "macros" in result
         assert "micro" in result
 
-    def test_premium_week_estimate_targets_minimal_obese(self):
-        """Test estimate_targets_minimal with obese profile - lines 58-71."""
-        result = estimate_targets_minimal(
+    def test_premium_week_estimate_targets_from_profile_obese(self):
+        """Test estimate_targets_from_profile with obese profile."""
+        result = estimate_targets_from_profile(
             sex="female",
             age=40,
             height_cm=160.0,
@@ -113,9 +113,9 @@ class TestFinalCoverage96:
         assert "macros" in result
         assert "micro" in result
 
-    def test_premium_week_estimate_targets_minimal_underweight(self):
-        """Test estimate_targets_minimal with underweight profile - lines 58-71."""
-        result = estimate_targets_minimal(
+    def test_premium_week_estimate_targets_from_profile_underweight(self):
+        """Test estimate_targets_from_profile with underweight profile."""
+        result = estimate_targets_from_profile(
             sex="male",
             age=22,
             height_cm=180.0,
@@ -129,10 +129,10 @@ class TestFinalCoverage96:
         assert "macros" in result
         assert "micro" in result
 
-    def test_premium_week_estimate_targets_minimal_edge_cases(self):
-        """Test estimate_targets_minimal with edge case profiles - lines 58-71."""
+    def test_premium_week_estimate_targets_from_profile_edge_cases(self):
+        """Test estimate_targets_from_profile with edge case profiles."""
         # Test minimum age
-        result = estimate_targets_minimal(
+        result = estimate_targets_from_profile(
             sex="male",
             age=11,
             height_cm=140.0,
@@ -143,7 +143,7 @@ class TestFinalCoverage96:
         assert result is not None
 
         # Test maximum age
-        result = estimate_targets_minimal(
+        result = estimate_targets_from_profile(
             sex="female",
             age=89,
             height_cm=150.0,
@@ -153,12 +153,12 @@ class TestFinalCoverage96:
         )
         assert result is not None
 
-    def test_premium_week_estimate_targets_minimal_all_activities(self):
-        """Test estimate_targets_minimal with all activity levels - lines 58-71."""
+    def test_premium_week_estimate_targets_from_profile_all_activities(self):
+        """Test estimate_targets_from_profile with all activity levels."""
         activities = ["sedentary", "light", "moderate", "active", "very_active"]
 
         for activity in activities:
-            result = estimate_targets_minimal(
+            result = estimate_targets_from_profile(
                 sex="male",
                 age=30,
                 height_cm=175.0,
@@ -169,12 +169,12 @@ class TestFinalCoverage96:
             assert result is not None
             assert "kcal" in result
 
-    def test_premium_week_estimate_targets_minimal_all_goals(self):
-        """Test estimate_targets_minimal with all goal types - lines 58-71."""
+    def test_premium_week_estimate_targets_from_profile_all_goals(self):
+        """Test estimate_targets_from_profile with all goal types."""
         goals = ["loss", "maintain", "gain"]
 
         for goal in goals:
-            result = estimate_targets_minimal(
+            result = estimate_targets_from_profile(
                 sex="female",
                 age=30,
                 height_cm=165.0,

--- a/tests/test_nutrition_targets_service.py
+++ b/tests/test_nutrition_targets_service.py
@@ -1,0 +1,181 @@
+"""Tests for profile-derived weekly planning target adapters."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.services import nutrition_targets
+from core.targets import UserProfile
+
+
+def test_estimate_targets_from_profile_builds_profile_and_maps_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_profiles: list[UserProfile] = []
+    priority_micros = {
+        "iron_mg": 18.0,
+        "calcium_mg": 1000.0,
+        "vitamin_d_iu": 600.0,
+    }
+
+    mock_targets = SimpleNamespace(
+        kcal_daily=2075,
+        macros=SimpleNamespace(
+            protein_g=118,
+            fat_g=69,
+            carbs_g=246,
+            fiber_g=31,
+        ),
+        micros=SimpleNamespace(
+            get_priority_nutrients=lambda: dict(priority_micros),
+        ),
+        water_ml_daily=2300,
+        activity=SimpleNamespace(
+            moderate_aerobic_min=150,
+            vigorous_aerobic_min=75,
+            strength_sessions=2,
+            steps_daily=8500,
+        ),
+    )
+
+    def fake_build_nutrition_targets(profile: UserProfile) -> Any:
+        captured_profiles.append(profile)
+        return mock_targets
+
+    monkeypatch.setattr(
+        nutrition_targets,
+        "build_nutrition_targets",
+        fake_build_nutrition_targets,
+    )
+
+    payload = nutrition_targets.estimate_targets_from_profile(
+        sex="female",
+        age=34,
+        height_cm=168.5,
+        weight_kg=64.2,
+        activity="active",
+        goal="maintain",
+    )
+
+    assert len(captured_profiles) == 1
+    profile = captured_profiles[0]
+    assert profile == UserProfile(
+        sex="female",
+        age=34,
+        height_cm=168.5,
+        weight_kg=64.2,
+        activity="active",
+        goal="maintain",
+    )
+    assert set(payload) == {"kcal", "macros", "micro", "water_ml", "activity_week"}
+    assert payload["kcal"] == 2075
+    assert payload["macros"] == {
+        "protein_g": 118,
+        "fat_g": 69,
+        "carbs_g": 246,
+        "fiber_g": 31,
+    }
+    assert payload["micro"] == priority_micros
+    assert payload["water_ml"] == 2300
+    assert payload["activity_week"] == {
+        "moderate_aerobic_min": 150,
+        "vigorous_aerobic_min": 75,
+        "strength_sessions": 2,
+        "steps_daily": 8500,
+    }
+
+
+@pytest.mark.parametrize(
+    "targets, expected",
+    [
+        ({}, False),
+        ({"kcal": 2000}, False),
+        (
+            {
+                "kcal": 2000,
+                "macros": "invalid",
+                "micro": {"iron_mg": 18.0},
+                "water_ml": 2000,
+            },
+            False,
+        ),
+        (
+            {
+                "kcal": 2000,
+                "macros": {"protein_g": 110},
+                "micro": "invalid",
+                "water_ml": 2000,
+            },
+            False,
+        ),
+        (
+            {
+                "kcal": 2000,
+                "macros": {},
+                "micro": {"iron_mg": 18.0},
+                "water_ml": 2000,
+            },
+            False,
+        ),
+        (
+            {
+                "kcal": 2000,
+                "macros": {"protein_g": 110},
+                "micro": {},
+                "water_ml": 2000,
+            },
+            False,
+        ),
+        (
+            {
+                "kcal": 2000,
+                "macros": {"protein_g": 110},
+                "micro": {"iron_mg": 18.0},
+                "water_ml": 2000,
+                "activity_week": "invalid",
+            },
+            False,
+        ),
+        (
+            {
+                "kcal": 2000,
+                "macros": {"protein_g": 110},
+                "micro": {"iron_mg": 18.0},
+                "water_ml": 2000,
+            },
+            True,
+        ),
+        (
+            {
+                "kcal": 2000,
+                "macros": {"protein_g": 110},
+                "micro": {"iron_mg": 18.0},
+                "water_ml": 2000,
+                "activity_week": {"steps_daily": 8000},
+            },
+            True,
+        ),
+    ],
+)
+def test_is_complete_planning_targets(targets: dict[str, Any], expected: bool) -> None:
+    assert nutrition_targets.is_complete_planning_targets(targets) is expected
+
+
+def test_service_has_no_fastapi_or_pydantic_imports() -> None:
+    source_path = Path(nutrition_targets.__file__).resolve()
+    tree = ast.parse(source_path.read_text())
+
+    imported_roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_roots.update(alias.name.split(".", maxsplit=1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_roots.add(node.module.split(".", maxsplit=1)[0])
+
+    assert "fastapi" not in imported_roots
+    assert "pydantic" not in imported_roots

--- a/tests/test_premium_week_endpoint_96.py
+++ b/tests/test_premium_week_endpoint_96.py
@@ -150,14 +150,14 @@ class TestPremiumWeekEndpoint96:
             patch.dict(os.environ, {"API_KEY": "test_api_key"}),
             patch("core.food_db_new.FoodDB") as mock_fooddb,
             patch("core.recipe_db_new.RecipeDB") as mock_recipedb,
-            patch("app.routers.premium_week.estimate_targets_minimal") as mock_estimate,
+            patch("app.services.nutrition_targets.estimate_targets_from_profile") as mock_estimate,
             patch("app.routers.premium_week.build_week") as mock_build_week,
         ):
             # Mock database objects
             mock_fooddb.return_value = Mock()
             mock_recipedb.return_value = Mock()
 
-            # Mock estimate_targets_minimal response
+            # Mock profile-derived planning target response.
             mock_estimate.return_value = {
                 "kcal": 2000,
                 "macros": {"protein_g": 150, "fat_g": 65, "carbs_g": 250},
@@ -236,14 +236,14 @@ class TestPremiumWeekEndpoint96:
             patch.dict(os.environ, {"API_KEY": "test_api_key"}),
             patch("core.food_db_new.FoodDB") as mock_fooddb,
             patch("core.recipe_db_new.RecipeDB") as mock_recipedb,
-            patch("app.routers.premium_week.estimate_targets_minimal") as mock_estimate,
+            patch("app.services.nutrition_targets.estimate_targets_from_profile") as mock_estimate,
             patch("app.routers.premium_week.build_week") as mock_build_week,
         ):
             # Mock database objects
             mock_fooddb.return_value = Mock()
             mock_recipedb.return_value = Mock()
 
-            # Mock estimate_targets_minimal to return None
+            # Mock profile-derived planning target adapter to return None.
             mock_estimate.return_value = None
 
             # Mock build_week to return a predictable result
@@ -281,14 +281,16 @@ class TestPremiumWeekEndpoint96:
                 patch.dict(os.environ, {"API_KEY": "test_api_key"}),
                 patch("core.food_db_new.FoodDB") as mock_fooddb,
                 patch("core.recipe_db_new.RecipeDB") as mock_recipedb,
-                patch("app.routers.premium_week.estimate_targets_minimal") as mock_estimate,
+                patch(
+                    "app.services.nutrition_targets.estimate_targets_from_profile"
+                ) as mock_estimate,
                 patch("app.routers.premium_week.build_week") as mock_build_week,
             ):
                 # Mock database objects
                 mock_fooddb.return_value = Mock()
                 mock_recipedb.return_value = Mock()
 
-                # Mock estimate_targets_minimal response
+                # Mock profile-derived planning target response.
                 mock_estimate.return_value = {
                     "kcal": 2000,
                     "macros": {"protein_g": 150, "fat_g": 65, "carbs_g": 250},
@@ -338,14 +340,16 @@ class TestPremiumWeekEndpoint96:
                 patch.dict(os.environ, {"API_KEY": "test_api_key"}),
                 patch("core.food_db_new.FoodDB") as mock_fooddb,
                 patch("core.recipe_db_new.RecipeDB") as mock_recipedb,
-                patch("app.routers.premium_week.estimate_targets_minimal") as mock_estimate,
+                patch(
+                    "app.services.nutrition_targets.estimate_targets_from_profile"
+                ) as mock_estimate,
                 patch("app.routers.premium_week.build_week") as mock_build_week,
             ):
                 # Mock database objects
                 mock_fooddb.return_value = Mock()
                 mock_recipedb.return_value = Mock()
 
-                # Mock estimate_targets_minimal response
+                # Mock profile-derived planning target response.
                 mock_estimate.return_value = {
                     "kcal": 2000,
                     "macros": {"protein_g": 150, "fat_g": 65, "carbs_g": 250},

--- a/tests/test_premium_week_endpoint_simple_96.py
+++ b/tests/test_premium_week_endpoint_simple_96.py
@@ -210,5 +210,6 @@ class TestPremiumWeekEndpointSimple96:
             )
 
             assert response.status_code == 200
+            assert response.headers.get("content-type", "").startswith("application/json")
             data = response.json()
             assert "daily_menus" in data or "week_summary" in data

--- a/tests/test_premium_week_endpoint_simple_96.py
+++ b/tests/test_premium_week_endpoint_simple_96.py
@@ -100,14 +100,14 @@ class TestPremiumWeekEndpointSimple96:
             patch.dict(os.environ, {"API_KEY": "test_api_key"}),
             patch("app.routers.premium_week.FoodDB") as mock_fooddb,
             patch("app.routers.premium_week.RecipeDB") as mock_recipedb,
-            patch("app.routers.premium_week.estimate_targets_minimal") as mock_estimate,
+            patch("app.services.nutrition_targets.estimate_targets_from_profile") as mock_estimate,
             patch("app.routers.premium_week.build_week") as mock_build_week,
         ):
             # Mock database objects
             mock_fooddb.return_value = Mock()
             mock_recipedb.return_value = Mock()
 
-            # Mock estimate_targets_minimal response
+            # Mock profile-derived planning target response.
             mock_estimate.return_value = {
                 "kcal": 2000,
                 "macros": {"protein_g": 150, "fat_g": 65, "carbs_g": 250},
@@ -187,13 +187,13 @@ class TestPremiumWeekEndpointSimple96:
             patch.dict(os.environ, {"API_KEY": "test_api_key"}),
             patch("app.routers.premium_week.FoodDB") as mock_fooddb,
             patch("app.routers.premium_week.RecipeDB") as mock_recipedb,
-            patch("app.routers.premium_week.estimate_targets_minimal") as mock_estimate,
+            patch("app.services.nutrition_targets.estimate_targets_from_profile") as mock_estimate,
         ):
             # Mock database objects
             mock_fooddb.return_value = Mock()
             mock_recipedb.return_value = Mock()
 
-            # Mock estimate_targets_minimal to return None
+            # Mock profile-derived planning target adapter to return None.
             mock_estimate.return_value = None
 
             payload = {

--- a/tests/test_premium_week_endpoint_simple_96.py
+++ b/tests/test_premium_week_endpoint_simple_96.py
@@ -179,22 +179,18 @@ class TestPremiumWeekEndpointSimple96:
             assert any("height_cm" in str(error) for error in detail)
             assert any("weight_kg" in str(error) for error in detail)
 
-    def test_generate_week_plan_unable_to_derive_targets(self) -> None:
-        """Test generate_week_plan when unable to derive targets - lines 112-113."""
+    def test_generate_week_plan_profile_payload_legacy_alias(self) -> None:
+        """Test legacy premium week alias with a profile-derived payload."""
         client = TestClient(app)
 
         with (
             patch.dict(os.environ, {"API_KEY": "test_api_key"}),
             patch("app.routers.premium_week.FoodDB") as mock_fooddb,
             patch("app.routers.premium_week.RecipeDB") as mock_recipedb,
-            patch("app.services.nutrition_targets.estimate_targets_from_profile") as mock_estimate,
         ):
             # Mock database objects
             mock_fooddb.return_value = Mock()
             mock_recipedb.return_value = Mock()
-
-            # Mock profile-derived planning target adapter to return None.
-            mock_estimate.return_value = None
 
             payload = {
                 "sex": "male",
@@ -213,7 +209,6 @@ class TestPremiumWeekEndpointSimple96:
                 headers={"X-API-Key": "test_api_key"},
             )
 
-            assert response.status_code == 200  # Mocking doesn't work for main.py endpoint
-            # The endpoint actually works and returns a response
+            assert response.status_code == 200
             data = response.json()
             assert "daily_menus" in data or "week_summary" in data

--- a/tests/test_premium_week_router.py
+++ b/tests/test_premium_week_router.py
@@ -105,7 +105,7 @@ class TestPremiumWeekRouter:
     @patch("app.routers.premium_week.FoodDB")
     @patch("app.routers.premium_week.RecipeDB")
     @patch("app.routers.premium_week.build_week")
-    @patch("app.routers.premium_week.estimate_targets_minimal")
+    @patch("app.services.nutrition_targets.estimate_targets_from_profile")
     def test_generate_week_plan_with_profile(
         self, mock_estimate_targets, mock_build_week, mock_recipe_db, mock_food_db
     ) -> None:
@@ -117,7 +117,7 @@ class TestPremiumWeekRouter:
         mock_recipe_db_instance = MagicMock()
         mock_recipe_db.return_value = mock_recipe_db_instance
 
-        # Mock the estimate_targets_minimal function
+        # Mock the profile-derived planning target adapter.
         mock_estimate_targets.return_value = {
             "kcal": 2000,
             "macros": {"protein_g": 150.0, "fat_g": 65.0, "carbs_g": 250.0},
@@ -201,7 +201,7 @@ class TestPremiumWeekRouter:
 
     @patch("app.routers.premium_week.FoodDB")
     @patch("app.routers.premium_week.RecipeDB")
-    @patch("app.routers.premium_week.estimate_targets_minimal")
+    @patch("app.services.nutrition_targets.estimate_targets_from_profile")
     def test_generate_week_plan_unable_to_derive_targets(
         self, mock_estimate_targets, mock_recipe_db, mock_food_db
     ) -> None:
@@ -213,7 +213,7 @@ class TestPremiumWeekRouter:
         mock_recipe_db_instance = MagicMock()
         mock_recipe_db.return_value = mock_recipe_db_instance
 
-        # Mock the estimate_targets_minimal function to return None
+        # Mock the profile-derived planning target adapter to return None.
         mock_estimate_targets.return_value = None
 
         response = self.client.post(

--- a/tests/test_premium_week_router_isolated.py
+++ b/tests/test_premium_week_router_isolated.py
@@ -31,7 +31,9 @@ def test_premium_week_pipeline_type_mismatch_raises_typeerror(
     monkeypatch.setattr(premium_mod, "_get_recipe_db", lambda: object())
 
     # Bypass profile/targets validation to focus on pipeline contract.
-    monkeypatch.setattr(premium_mod, "_is_complete_targets", lambda _d: True)
+    from app.services import nutrition_targets as nutrition_targets_service
+
+    monkeypatch.setattr(nutrition_targets_service, "is_complete_planning_targets", lambda _d: True)
 
     def _fake_pipeline(**_kwargs: Any) -> str:
         return "not-a-week-plan-response"
@@ -59,7 +61,9 @@ def test_premium_week_pipeline_invalid_payload_surfaces_postprocess_error(
 
     monkeypatch.setattr(premium_mod, "_get_food_db", lambda: object())
     monkeypatch.setattr(premium_mod, "_get_recipe_db", lambda: object())
-    monkeypatch.setattr(premium_mod, "_is_complete_targets", lambda _d: True)
+    from app.services import nutrition_targets as nutrition_targets_service
+
+    monkeypatch.setattr(nutrition_targets_service, "is_complete_planning_targets", lambda _d: True)
 
     def _fake_pipeline(**kwargs: Any) -> dict[str, Any]:
         postprocess_fn = kwargs["postprocess_fn"]

--- a/tests/test_pro_premium_contract_parity.py
+++ b/tests/test_pro_premium_contract_parity.py
@@ -161,6 +161,37 @@ def test_premium_weekly_matches_pro_weekly(client: TestClient) -> None:
     assert premium_payload["next_best_action"] == pro_payload["next_best_action"]
 
 
+def test_premium_weekly_profile_derived_matches_pro_weekly(client: TestClient) -> None:
+    payload = {
+        "sex": "female",
+        "age": 34,
+        "height_cm": 168,
+        "weight_kg": 64,
+        "activity": "active",
+        "goal": "maintain",
+        "diet_flags": [],
+        "lang": "en",
+    }
+
+    r_premium = client.post(
+        "/api/v1/premium/plan/week-flexible",
+        json=payload,
+        headers=_pro_headers(),
+    )
+    assert r_premium.status_code == 200, r_premium.text
+
+    r_pro = client.post("/api/v1/pro/meal/weekly", json=payload, headers=_pro_headers())
+    assert r_pro.status_code == 200, r_pro.text
+
+    premium_payload = r_premium.json()
+    pro_payload = r_pro.json()
+    assert premium_payload["next_best_action"]["type"] == "upgrade_for_export"
+    assert premium_payload["next_best_action"]["recommended_surface"] == "vip_export"
+    assert premium_payload["next_best_action"]["trigger_reason"] == "weekly_plan_ready"
+    assert premium_payload["next_best_action"]["why_now"] == "weekly_plan_ready_export_and_share"
+    assert premium_payload["next_best_action"] == pro_payload["next_best_action"]
+
+
 def test_guard_divergence_targets_premium_is_legacy_guarded_pro_is_pro_tier_guarded(
     client: TestClient,
 ) -> None:

--- a/tests/test_pro_premium_contract_parity.py
+++ b/tests/test_pro_premium_contract_parity.py
@@ -152,6 +152,8 @@ def test_premium_weekly_matches_pro_weekly(client: TestClient) -> None:
     r_pro = client.post("/api/v1/pro/meal/weekly", json=payload, headers=_pro_headers())
     assert r_pro.status_code == 200, r_pro.text
 
+    assert r_premium.headers.get("content-type", "").startswith("application/json")
+    assert r_pro.headers.get("content-type", "").startswith("application/json")
     premium_payload = r_premium.json()
     pro_payload = r_pro.json()
     assert premium_payload["next_best_action"]["type"] == "upgrade_for_export"
@@ -183,6 +185,8 @@ def test_premium_weekly_profile_derived_matches_pro_weekly(client: TestClient) -
     r_pro = client.post("/api/v1/pro/meal/weekly", json=payload, headers=_pro_headers())
     assert r_pro.status_code == 200, r_pro.text
 
+    assert r_premium.headers.get("content-type", "").startswith("application/json")
+    assert r_pro.headers.get("content-type", "").startswith("application/json")
     premium_payload = r_premium.json()
     pro_payload = r_pro.json()
     assert premium_payload["next_best_action"]["type"] == "upgrade_for_export"

--- a/tests/test_pro_router.py
+++ b/tests/test_pro_router.py
@@ -148,7 +148,11 @@ class TestProRouterIsolated:
         monkeypatch.setattr(self.pro_mod, "get_recipe_db", lambda: object())
 
         # Bypass profile/targets validation to focus on pipeline contract.
-        monkeypatch.setattr(self.pro_mod, "_is_complete_targets", lambda _d: True)
+        from app.services import nutrition_targets as nutrition_targets_service
+
+        monkeypatch.setattr(
+            nutrition_targets_service, "is_complete_planning_targets", lambda _d: True
+        )
 
         def _fake_pipeline(**_kwargs: Any) -> str:
             return "not-a-week-plan-response"
@@ -164,7 +168,11 @@ class TestProRouterIsolated:
         """Malformed build output must fail closed in the postprocess stage."""
         monkeypatch.setattr(self.pro_mod, "get_food_db", lambda: object())
         monkeypatch.setattr(self.pro_mod, "get_recipe_db", lambda: object())
-        monkeypatch.setattr(self.pro_mod, "_is_complete_targets", lambda _d: True)
+        from app.services import nutrition_targets as nutrition_targets_service
+
+        monkeypatch.setattr(
+            nutrition_targets_service, "is_complete_planning_targets", lambda _d: True
+        )
 
         def _fake_pipeline(**kwargs: Any) -> dict[str, Any]:
             postprocess_fn = kwargs["postprocess_fn"]


### PR DESCRIPTION
## Goal
Centralize weekly-plan profile-derived nutrition target estimation and target-shape completeness checks in a shared application service while preserving PRO and deprecated premium endpoint behavior.

## Business Reason
This closes TODO #286 with a narrow backend refactor: fewer duplicated nutrition-planning seams, lower parity risk between canonical PRO weekly planning and deprecated premium weekly aliases, and no contract/client drift.

## Scope
- Added `app/services/nutrition_targets.py` with `estimate_targets_from_profile(...)`, `PlanningTargetsPayload`, and `is_complete_planning_targets(...)`.
- Updated `app/routers/pro.py` and `app/routers/premium_week.py` to call the shared service for weekly planning target derivation/completeness.
- Kept `_missing_profile_detail` router-local to preserve HTTP copy/error-surface behavior.
- Preserved `/api/v1/pro/nutrition/daily` direct core target path in `pro.py`.
- Fixed `legacy_app.py` flake8 import-hygiene failure surfaced by `make verify` without changing endpoint behavior.
- Fixed CI pre-commit lint fallout by removing async markers from the changed diff-coverage tests selected by the backend-tests hook.
- Documented the async marker/pre-commit environment rule in root `AGENTS.md`, `tests/AGENTS.md`, and `docs/ENGINEERING_LESSONS.md`.
- Added canonical mapping artifact `docs/review/PR_2006_FIXED_MAPPING.md`.
- Added CI-smoke coverage for profile-derived target service/router branches after current-head `diff-coverage` reported missing lines.

## Out Of Scope
No FoodDB/Postgres/OFF/catalog cutover, DB migrations, OpenAPI/client contract changes, route registration changes, generated clients, frontend/iOS work, BMI extraction, AI/compliance changes, or broad legacy rewrite.

## Key Decisions
- The new service is an application adapter only; nutrition math remains in `core.recommendations` / `core.targets`.
- Deprecated premium weekly route keeps its deprecation metadata and compatibility semantics.
- Explicit `targets` payloads and malformed derived-target hard guards retain the existing fail-closed behavior.
- `PlanningTargetsPayload.activity_week` stays required for the derived service return payload because the adapter always returns the exact weekly-plan payload shape; `is_complete_planning_targets(...)` preserves existing explicit-target compatibility when `activity_week` is absent.
- Changed diff-coverage tests now call async router coroutines through `asyncio.run(...)` from sync tests so the CI pre-commit lint environment does not depend on optional async pytest plugin state.

## Lane Start Provenance
Packet: `artifacts/orchestration/task_packets/b7f6dbc6858b.json`

Role order completed before implementation: `agent-coordinator -> qa-engineer-agent -> security-auditor -> backend-engineer -> architecture-specialist`.

## Tests
Passed locally:
- `python3 scripts/orchestration/check_preflight.py`
- `python3 scripts/orchestration/check_agent_consistency.py`
- `. .venv/bin/activate && pytest -q tests/test_agent_docs_registry_guard.py`
- `. .venv/bin/activate && pytest -q tests/test_nutrition_targets_service.py tests/test_diff_coverage_pr339.py tests/test_pro_router.py tests/test_premium_week_router.py tests/test_premium_week_router_isolated.py tests/edges/test_premium_week_edges.py tests/test_pro_premium_contract_parity.py tests/test_weekly_plan_endpoints_error_envelope_diff_coverage.py tests/test_weekly_plan_postprocess_error_envelope_diff_coverage.py`
- `. .venv/bin/activate && pytest -q tests/test_pro_vip_route_dependency_guard.py tests/security/test_api_auth_tier_contract_pack.py tests/test_paid_route_guards.py`
- `. .venv/bin/activate && pytest -q tests/test_diff_coverage_pr339.py tests/test_final_coverage_96.py tests/test_premium_week_endpoint_simple_96.py tests/test_nutrition_targets_service.py`
- `. .venv/bin/activate && pytest -q tests/test_premium_week_endpoint_simple_96.py`
- `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")" BRANCH_DIFF_MODE=1 bash scripts/run-backend-tests-pre-commit.sh`
- `. .venv/bin/activate && mypy app/services/nutrition_targets.py app/routers/pro.py app/routers/premium_week.py`
- `make openapi-check`
- `make validate-changed`
- `make lint`
- `pre-commit run --all-files`
- `git diff --check`
- `PYTHONPATH="$PWD:$PWD/tests" VIP_MODULE_ENABLED=true APP_ENV=test ENVIRONMENT=test FEATURE_PREMIUM_NUTRITION=true API_KEY=test_key PYTHONUNBUFFERED=1 PYTHONFAULTHANDLER=1 PYTHONMALLOC=malloc python -m coverage run -m pytest -q tests/edges --maxfail=3 && python -m coverage xml && diff-cover coverage.xml --compare-branch origin/main --fail-under 97 ...` (diff-cover: 44 lines, missing 0, coverage 100%)
- `GH_TOKEN="$(gh auth token)" python3 scripts/orchestration/check_review_threads_disposition.py --pr-number 2006 --require-auth`
- `python3 scripts/ci/check_pr_body_phase2_gates.py --body "$BODY" --pr-number 2006 --commit-range origin/main..HEAD --experiment-runner-evidence-mode required`
- Pre-push hooks passed: changed-files mypy, backend tests, full-repo Bandit, Docker build test.

Full `make verify` status:
- Attempted once. Initial `make lint` failure in `legacy_app.py` was fixed.
- Rerun passed verify-env, lint, mypy, and smoke tests, then entered full pytest/diff-cov phase and was interrupted per operator machine-heavy policy. This is not claimed as a completed readiness signal.

CI follow-up:
- Current-head CI on `f1178c2e5` exposed a lint/pre-commit backend-tests failure because the CI lint environment did not load `pytest-asyncio` while selected diff-coverage tests still used `pytest.mark.asyncio`/`async def`.
- Fixed in `e6212bd4f`; selected backend-tests bundle now has no async test markers/functions and passes locally without relying on async pytest plugin state.
- Captured as a durable rule in `6738ed9b8` and mapped in `31134b866`.
- Current-head CI on `31134b866` exposed a `diff-coverage` failure: missing lines in `app/services/nutrition_targets.py`, `app/routers/pro.py`, and `app/routers/premium_week.py`. Fixed in `04c500acc` by adding synchronous `tests/edges` coverage for the shared service and profile-derived weekly router branches; mapped in `6e1e091e2`.

## Security Notes
No auth/tier logic changed. `require_pro_tier` dependencies stay in place. No secrets, network calls, persistence, migrations, suppressions, or fail-open behavior added.

## Governance Evidence

Operator approval: approved because the operator requested capturing the CI async marker failure rule in engineering lessons and agent instructions.
Privileged scope exception: approved because that operator-requested instruction update adds root/test agent rules and raises the privileged file count to 17 while preserving the narrow production refactor scope.
- Premortem artifact: `artifacts/orchestration/premortem/centralize-profile-derived-planning-targets-premortem.md`.
- Fixed mapping artifact: `docs/review/PR_2006_FIXED_MAPPING.md`.
- Post-open role passes completed: `qa-engineer-agent`, `bug-hunter`, `security-auditor`.
- Codex Security diff scan/finding discovery: PASS, no findings. Report: `/tmp/codex-security-scans/BMI-App_2025_clean/42a1b41400ff_20260622T140235Z/report.md`.
- `pulseplate-pr-review`: advisory `large-diff-risk` note dispositioned as NOT-A-BUG in the canonical artifact with scope/gate evidence.

## Experiment Runner Evidence
Artifact: `artifacts/orchestration/experiments/results/exp-ed836b5c000a.json`

Status: `accepted`. Contribution kind: `oracle_review`. The canonical co-author trailer is included in Experiment-shaped commits through `715735355`. Later review-disposition/CI-fix/process-rule commits `3f5504350`, `42a1b4140`, `6934bdf76`, `8362e21fe`, `f1178c2e5`, `e6212bd4f`, `9e59c3791`, `6738ed9b8`, and `31134b866` were based on CI/CodeRabbit/self-review/operator evidence, not on Experiment Runner output.

## Risks / Rollback
Rollback is a normal revert of commits `6eec0ea99`, `1118b0583`, `923a8fb5d`, `8d972fbf9`, `cf0a52117`, `366d6a18d`, `715735355`, `3f5504350`, `42a1b4140`, `6934bdf76`, `8362e21fe`, `f1178c2e5`, `e6212bd4f`, `9e59c3791`, `6738ed9b8`, `31134b866`, `04c500acc`, and `6e1e091e2`. Main residual risk is CI-only diff coverage/full-suite behavior because local full `make verify` was intentionally not completed.

## Deferred / Follow-ups
None for this PR scope.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Post-open Sourcery and CodeRabbit findings are mapped below.

### Fixed in Commit Mapping
- canonical artifact: `docs/review/PR_2006_FIXED_MAPPING.md`
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2006#discussion_r3452568392 -> 8d972fbf9
Disposition: FIXED
Commit: 8d972fbf9
Evidence: `app/services/nutrition_targets.py` widens macro/micro value types through `PlanningNumeric = int | float`.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2006#discussion_r3452622130 -> 366d6a18d
Disposition: FIXED
Commit: 366d6a18d
Evidence: `tests/test_pro_premium_contract_parity.py` asserts JSON `content-type` before parsing weekly parity responses.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2006#pullrequestreview-4544483234 -> 8d972fbf9
Disposition: FIXED
Commit: 8d972fbf9
Evidence: macro/micro payload values now use `PlanningNumeric = int | float`; `activity_week` remains required for the derived return payload and optional only for explicit-target compatibility validation.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2006#pullrequestreview-4544546239 -> 3f5504350
Disposition: FIXED
Commit: 3f5504350
Evidence: changed test methods are typed, the misleading legacy alias test no longer claims the unable-to-derive branch, and the disabled hypothesis file is removed from the net PR diff.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2006#pullrequestreview-4544563348 -> 3f5504350
Disposition: FIXED
Commit: 3f5504350
Evidence: `docs/review/PR_2006_FIXED_MAPPING.md` now uses unchecked merge-readiness checklist entries.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2006#discussion_r3452821243 -> 8362e21fe
Disposition: FIXED
Commit: 8362e21fe
Evidence: `tests/test_premium_week_endpoint_simple_96.py` asserts JSON `content-type` before parsing the legacy premium weekly alias response.
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2006#pullrequestreview-4544801394 -> 8362e21fe
Disposition: FIXED
Commit: 8362e21fe
Evidence: `tests/test_premium_week_endpoint_simple_96.py` asserts JSON `content-type` before parsing the legacy premium weekly alias response.

PulsePlate PR Review:
- Finding: `large-diff-risk`
Disposition: NOT-A-BUG
Evidence: `make validate-changed` selected and passed the changed Python test surface; production code scope remains narrow and out-of-scope rails are unchanged.

Implementation:
- `6eec0ea99` - centralizes profile-derived weekly planning targets, updates PRO/premium weekly routers and tests, preserves deprecated compatibility, and fixes the `legacy_app.py` flake8 import-hygiene gate.
- `1118b0583` - adds PR #2006 fixed-mapping governance artifact.
- `923a8fb5d` - aligns fixed-mapping artifact syntax with Phase2 gates.
- `8d972fbf9` - widens planning target numeric payload types for Sourcery feedback.
- `cf0a52117` - maps the fixed Sourcery typing thread in the PR #2006 mapping artifact.
- `366d6a18d` - asserts weekly parity response JSON content types for CodeRabbit feedback.
- `715735355` - maps the fixed CodeRabbit content-type thread in the PR #2006 mapping artifact.
- `3f5504350` - addresses CodeRabbit outside-diff test/mapping findings and removes the disabled hypothesis file from the net PR diff.
- `42a1b4140` - maps PR #2006 review-level bot comments.
- `6934bdf76` - dispositioned the `pulseplate-pr-review` self-review note.
- `8362e21fe` - asserts JSON content type before parsing the legacy premium weekly alias response.
- `f1178c2e5` - maps the fixed CodeRabbit legacy alias finding in the PR #2006 mapping artifact.
- `e6212bd4f` - removes async markers/functions from changed diff-coverage tests selected by the CI pre-commit backend-tests hook.
- `9e59c3791` - records the CI lint fix in the PR #2006 mapping artifact.
- `6738ed9b8` - documents the async marker/pre-commit environment rule in root/tests agent instructions and engineering lessons.
- `31134b866` - records the async marker rule update in the PR #2006 mapping artifact.
- `04c500acc` - covers profile-derived planning-target service/router branches inside the CI smoke `tests/edges` coverage set.
- `6e1e091e2` - records the PR #2006 diff-coverage fix in the canonical mapping artifact.

## Merge Readiness
Not merge-ready yet.

Required before merge:
- [ ] Current-head CI passes.
- [ ] Bot/human review comments dispositioned.
- [x] Post-open role passes completed: `qa-engineer-agent -> bug-hunter -> security-auditor`.
- [x] Codex Security diff scan/finding discovery run if available.
- [x] `pulseplate-pr-review` passed/dispositioned.
- [ ] Strict merge-readiness checks passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized meal-planning target validation and estimation into a dedicated service, improving code maintainability and consistency across weekly plan endpoints.
  
* **Tests**
  * Updated test suites to align with new internal service architecture and improved async test handling to support CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
