### PR TITLE
fix(ci): serialize design token parity in main shards

### DIFF
--- a/docs/review/PR_2007_FIXED_MAPPING.md
+++ b/docs/review/PR_2007_FIXED_MAPPING.md
@@ -1,0 +1,109 @@
+# PR #2007 Fixed in Commit Mapping
+
+## Summary
+
+PR: `fix(ci): serialize design token parity in main shards`
+
+Branch: `codex/fix-main-token-parity-shard-toolchain`
+
+Implementation commit: `cfa68539d`
+
+This PR restores post-merge `main` CI health by running
+`tests/test_design_token_parity.py` as a serial pre-shard in the main test
+runner, while preserving fail-closed toolchain validation and coverage
+enforcement.
+
+## Lane Start Provenance
+
+- Base branch: `main`
+- Start head: `92a28aa6739a876eb3127c4adcd089592c22a7ef`
+- Packet: `artifacts/orchestration/task_packets/e7266cc0a9cc.json`
+- Dispatch manifest:
+  `agent-coordinator -> qa-engineer-agent -> security-auditor -> backend-engineer -> bug-hunter`
+
+## Scope
+
+- Added a serial main-test shard for `tests/test_design_token_parity.py`.
+- Excluded that file from process-parallel main shard partitioning.
+- Combined serial shard coverage before regular shard coverage.
+- Added regression tests for serial discovery, fail-before-parallel behavior,
+  coverage combine wiring, and `main()` orchestration.
+
+## Out Of Scope
+
+No product/runtime behavior, OpenAPI, auth, billing, nutrition, frontend
+runtime, iOS, npm install, dependency, skip/xfail, or coverage-threshold change.
+
+## Discussion Thread Pass
+
+- [ ] Discussion-thread pass completed
+- [ ] Fixed in commit mapping completed
+
+No review threads yet.
+
+## Fixed in Commit Mapping
+
+No review threads yet.
+
+## Implementation Commits
+
+- `cfa68539d` - serializes the design-token parity file before process-parallel
+  main shards and adds runner regression coverage.
+
+## Premortem Evidence
+
+- Artifact:
+  `artifacts/orchestration/premortem/pr2007-main-shard-token-parity-premortem.md`
+- Findings closed before PR open:
+  - Avoid skip/xfail or toolchain weakening: FIXED by preserving the existing
+    fail-closed token parity test path.
+  - Avoid losing coverage: FIXED by combining serial shard coverage before
+    regular shard coverage.
+  - Avoid missing JUnit artifacts: NOT-A-BUG because the serial shard uses the
+    existing `tests/results-<label>-shard-0.xml` pattern covered by workflow
+    artifact globs.
+  - Avoid wasting parallel shard time after serial failure: FIXED by returning
+    serial status before `run_all_shards`.
+
+## Experiment Runner Evidence
+
+- Packet: `artifacts/orchestration/experiments/pr2007-main-shard-token-parity-v2.json`
+- Artifact:
+  `artifacts/orchestration/experiments/results/pr2007-main-shard-token-parity-result-v2.json`
+- Status: `accepted`
+- Runner mode: `oracle_only_governance_reviewer`
+- Contribution kind: `oracle_review`
+- Co-author required: yes
+- Co-author trailer included in `cfa68539d`:
+  `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
+
+## Validation
+
+Passed locally:
+
+- `python3 scripts/orchestration/check_preflight.py`
+- `python3 scripts/orchestration/check_agent_consistency.py`
+- `. .venv/bin/activate && pytest -q tests/test_main_test_shards.py tests/test_design_token_parity.py::test_token_build_script_is_deterministic`
+- `. .venv/bin/activate && mypy scripts/ci/run_main_test_shards.py`
+- `. .venv/bin/activate && python scripts/ci/run_main_test_shards.py --python-version 3.11 --shard-count 4 --max-parallel 4 --list-shards | rg "MAIN_TEST_SERIAL_PLAN|MAIN_TEST_SHARD_PLAN|test_design_token_parity.py"`
+- `make validate-changed`
+- `pre-commit run --all-files`
+- `git diff --check`
+- Pre-push hooks: changed-files mypy, backend tests, full-repo Bandit, Docker
+  build test.
+
+Full local `make verify` was not run for this CI/tooling hotfix. The lane uses
+the operator-preferred narrow bundle plus current-head CI as the heavy signal.
+
+## Merge Readiness
+
+Not merge-ready yet.
+
+Required before merge:
+- [ ] Current-head CI passes.
+- [ ] Bot/human review comments dispositioned.
+- [ ] Post-open role passes completed:
+  `qa-engineer-agent -> bug-hunter -> security-auditor`.
+- [ ] Codex Security diff scan/finding discovery run if available.
+- [ ] `pulseplate-pr-review` passed.
+- [ ] Strict merge-readiness checks passed.

--- a/docs/review/PR_2007_FIXED_MAPPING.md
+++ b/docs/review/PR_2007_FIXED_MAPPING.md
@@ -48,6 +48,14 @@ Disposition: FIXED
 Commit: e2b99c1c0
 Evidence: `scripts/ci/run_main_test_shards.py` now uses shared `build_test_file(...)` metadata construction from both regular and serial test discovery paths; `tests/test_main_test_shards.py` adds `test_build_test_file_normalizes_relative_path_and_weight`. Focused pytest and targeted mypy passed.
 
+## PulsePlate PR Review Disposition
+
+Finding: `large-diff-risk` advisory from `pulseplate-pr-review`.
+
+Disposition: NOT-A-BUG
+Evidence: The line count is driven by focused runner regression tests and the canonical review artifact. Production scope is limited to CI/test orchestration; focused pytest, targeted mypy, `make validate-changed`, `pre-commit run --all-files`, pre-push hooks, and `git diff --check` passed.
+Reason: The PR is intentionally narrow despite crossing the dry-run line-count threshold; no runtime product, API, dependency, coverage-threshold, skip/xfail, auth, billing, nutrition, frontend runtime, or iOS scope is included.
+
 ## Implementation Commits
 
 - `cfa68539d` - serializes the design-token parity file before process-parallel

--- a/docs/review/PR_2007_FIXED_MAPPING.md
+++ b/docs/review/PR_2007_FIXED_MAPPING.md
@@ -56,12 +56,22 @@ Disposition: NOT-A-BUG
 Evidence: The line count is driven by focused runner regression tests and the canonical review artifact. Production scope is limited to CI/test orchestration; focused pytest, targeted mypy, `make validate-changed`, `pre-commit run --all-files`, pre-push hooks, and `git diff --check` passed.
 Reason: The PR is intentionally narrow despite crossing the dry-run line-count threshold; no runtime product, API, dependency, coverage-threshold, skip/xfail, auth, billing, nutrition, frontend runtime, or iOS scope is included.
 
+## CI Failure Disposition
+
+Finding: Current-head `lint` / `backend-tests` failed because `tests/test_main_test_shards.py` imported `coverage.cmdline` at module import time, but CI lint uses the `ci-lite` dependency profile where `coverage` is not installed.
+
+Disposition: FIXED
+Commit: 90f943239
+Evidence: `scripts/ci/run_main_test_shards.py` now allows `run_coverage_command(...)` to receive an injected `coverage_main`, and `tests/test_main_test_shards.py` no longer imports `coverage.cmdline` during collection. `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")" BRANCH_DIFF_MODE=1 bash scripts/run-backend-tests-pre-commit.sh` passed.
+
 ## Implementation Commits
 
 - `cfa68539d` - serializes the design-token parity file before process-parallel
   main shards and adds runner regression coverage.
 - `e2b99c1c0` - shares test-file metadata construction between regular and
   serial main test discovery in response to Sourcery feedback.
+- `90f943239` - removes the top-level `coverage.cmdline` test import so CI
+  lint's `ci-lite` backend-tests hook can collect `tests/test_main_test_shards.py`.
 
 ## Premortem Evidence
 

--- a/docs/review/PR_2007_FIXED_MAPPING.md
+++ b/docs/review/PR_2007_FIXED_MAPPING.md
@@ -64,6 +64,12 @@ Disposition: FIXED
 Commit: 911fa570e
 Evidence: `scripts/ci/run_main_test_shards.py` now allows `run_coverage_command(...)` to receive an injected `coverage_main`, and `tests/test_main_test_shards.py` no longer imports `coverage.cmdline` during collection. `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")" BRANCH_DIFF_MODE=1 bash scripts/run-backend-tests-pre-commit.sh` passed.
 
+Finding: Current-head `lint` / `backend-tests` then failed because the child-process isolation test exercised pytest with `--cov` arguments in the `ci-lite` environment where `pytest-cov` is not installed.
+
+Disposition: FIXED
+Commit: b833664d1
+Evidence: `scripts/ci/run_main_test_shards.py` detects `pytest_cov` before adding `--cov` pytest arguments, while coverage combine/report still enforce failure when real coverage artifacts are missing. `tests/test_main_test_shards.py` covers both pytest-cov-present and pytest-cov-missing argument construction. Exact backend-tests hook, focused pytest, targeted mypy, and `git diff --check` passed.
+
 ## Implementation Commits
 
 - `32c3bbd8b` - serializes the design-token parity file before process-parallel
@@ -72,6 +78,8 @@ Evidence: `scripts/ci/run_main_test_shards.py` now allows `run_coverage_command(
   serial main test discovery in response to Sourcery feedback.
 - `911fa570e` - removes the top-level `coverage.cmdline` test import so CI
   lint's `ci-lite` backend-tests hook can collect `tests/test_main_test_shards.py`.
+- `b833664d1` - omits pytest-cov command-line arguments when pytest-cov is not
+  installed, while preserving coverage combine/report enforcement.
 
 ## Premortem Evidence
 

--- a/docs/review/PR_2007_FIXED_MAPPING.md
+++ b/docs/review/PR_2007_FIXED_MAPPING.md
@@ -39,16 +39,25 @@ runtime, iOS, npm install, dependency, skip/xfail, or coverage-threshold change.
 - [x] Discussion-thread pass completed
 - [x] Fixed in commit mapping completed
 
-No review threads are present at this checkpoint.
+Sourcery review-level feedback is mapped below.
 
 ## Fixed in Commit Mapping
 
-- No actionable review comments
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2007#pullrequestreview-4547611166 -> e2b99c1c0
+Disposition: FIXED
+Commit: e2b99c1c0
+Evidence: `scripts/ci/run_main_test_shards.py` now uses shared
+`build_test_file(...)` metadata construction from both regular and serial test
+discovery paths; `tests/test_main_test_shards.py` adds
+`test_build_test_file_normalizes_relative_path_and_weight`. Focused pytest and
+targeted mypy passed.
 
 ## Implementation Commits
 
 - `cfa68539d` - serializes the design-token parity file before process-parallel
   main shards and adds runner regression coverage.
+- `e2b99c1c0` - shares test-file metadata construction between regular and
+  serial main test discovery in response to Sourcery feedback.
 
 ## Premortem Evidence
 

--- a/docs/review/PR_2007_FIXED_MAPPING.md
+++ b/docs/review/PR_2007_FIXED_MAPPING.md
@@ -46,11 +46,7 @@ Sourcery review-level feedback is mapped below.
 - https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2007#pullrequestreview-4547611166 -> e2b99c1c0
 Disposition: FIXED
 Commit: e2b99c1c0
-Evidence: `scripts/ci/run_main_test_shards.py` now uses shared
-`build_test_file(...)` metadata construction from both regular and serial test
-discovery paths; `tests/test_main_test_shards.py` adds
-`test_build_test_file_normalizes_relative_path_and_weight`. Focused pytest and
-targeted mypy passed.
+Evidence: `scripts/ci/run_main_test_shards.py` now uses shared `build_test_file(...)` metadata construction from both regular and serial test discovery paths; `tests/test_main_test_shards.py` adds `test_build_test_file_normalizes_relative_path_and_weight`. Focused pytest and targeted mypy passed.
 
 ## Implementation Commits
 

--- a/docs/review/PR_2007_FIXED_MAPPING.md
+++ b/docs/review/PR_2007_FIXED_MAPPING.md
@@ -36,14 +36,12 @@ runtime, iOS, npm install, dependency, skip/xfail, or coverage-threshold change.
 
 ## Discussion Thread Pass
 
-- [ ] Discussion-thread pass completed
-- [ ] Fixed in commit mapping completed
+- [x] Discussion-thread pass completed
+- [x] Fixed in commit mapping completed
 
-No review threads yet.
+No review threads are present at this checkpoint.
 
 ## Fixed in Commit Mapping
-
-No review threads yet.
 
 ## Implementation Commits
 

--- a/docs/review/PR_2007_FIXED_MAPPING.md
+++ b/docs/review/PR_2007_FIXED_MAPPING.md
@@ -6,7 +6,7 @@ PR: `fix(ci): serialize design token parity in main shards`
 
 Branch: `codex/fix-main-token-parity-shard-toolchain`
 
-Implementation commit: `cfa68539d`
+Implementation commit: `32c3bbd8b`
 
 This PR restores post-merge `main` CI health by running
 `tests/test_design_token_parity.py` as a serial pre-shard in the main test
@@ -43,9 +43,9 @@ Sourcery review-level feedback is mapped below.
 
 ## Fixed in Commit Mapping
 
-- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2007#pullrequestreview-4547611166 -> e2b99c1c0
+- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2007#pullrequestreview-4547611166 -> 2b45be038
 Disposition: FIXED
-Commit: e2b99c1c0
+Commit: 2b45be038
 Evidence: `scripts/ci/run_main_test_shards.py` now uses shared `build_test_file(...)` metadata construction from both regular and serial test discovery paths; `tests/test_main_test_shards.py` adds `test_build_test_file_normalizes_relative_path_and_weight`. Focused pytest and targeted mypy passed.
 
 ## PulsePlate PR Review Disposition
@@ -61,16 +61,16 @@ Reason: The PR is intentionally narrow despite crossing the dry-run line-count t
 Finding: Current-head `lint` / `backend-tests` failed because `tests/test_main_test_shards.py` imported `coverage.cmdline` at module import time, but CI lint uses the `ci-lite` dependency profile where `coverage` is not installed.
 
 Disposition: FIXED
-Commit: 90f943239
+Commit: 911fa570e
 Evidence: `scripts/ci/run_main_test_shards.py` now allows `run_coverage_command(...)` to receive an injected `coverage_main`, and `tests/test_main_test_shards.py` no longer imports `coverage.cmdline` during collection. `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")" BRANCH_DIFF_MODE=1 bash scripts/run-backend-tests-pre-commit.sh` passed.
 
 ## Implementation Commits
 
-- `cfa68539d` - serializes the design-token parity file before process-parallel
+- `32c3bbd8b` - serializes the design-token parity file before process-parallel
   main shards and adds runner regression coverage.
-- `e2b99c1c0` - shares test-file metadata construction between regular and
+- `2b45be038` - shares test-file metadata construction between regular and
   serial main test discovery in response to Sourcery feedback.
-- `90f943239` - removes the top-level `coverage.cmdline` test import so CI
+- `911fa570e` - removes the top-level `coverage.cmdline` test import so CI
   lint's `ci-lite` backend-tests hook can collect `tests/test_main_test_shards.py`.
 
 ## Premortem Evidence
@@ -97,7 +97,7 @@ Evidence: `scripts/ci/run_main_test_shards.py` now allows `run_coverage_command(
 - Runner mode: `oracle_only_governance_reviewer`
 - Contribution kind: `oracle_review`
 - Co-author required: yes
-- Co-author trailer included in `cfa68539d`:
+- Co-author trailer included in `32c3bbd8b`:
   `Co-authored-by: PulsePlate Experiment Runner <pulseplate@pm.me>`
 
 ## Validation

--- a/docs/review/PR_2007_FIXED_MAPPING.md
+++ b/docs/review/PR_2007_FIXED_MAPPING.md
@@ -43,6 +43,8 @@ No review threads are present at this checkpoint.
 
 ## Fixed in Commit Mapping
 
+- No actionable review comments
+
 ## Implementation Commits
 
 - `cfa68539d` - serializes the design-token parity file before process-parallel

--- a/scripts/ci/run_main_test_shards.py
+++ b/scripts/ci/run_main_test_shards.py
@@ -60,6 +60,15 @@ class TestShard:
         return f"tests/results-{self.artifact_label}-shard-{self.index}.xml"
 
 
+def build_test_file(repo_root: Path, test_path: Path) -> TestFile:
+    """Return the normalized shard metadata for one pytest file."""
+
+    return TestFile(
+        path=test_path.relative_to(repo_root),
+        weight=max(test_path.stat().st_size, 1),
+    )
+
+
 def discover_test_files(
     repo_root: Path,
     excluded_paths: frozenset[Path] = frozenset(),
@@ -77,12 +86,7 @@ def discover_test_files(
             continue
         if any(part.startswith(".") for part in relative_path.parts):
             continue
-        discovered.append(
-            TestFile(
-                path=relative_path,
-                weight=max(test_path.stat().st_size, 1),
-            )
-        )
+        discovered.append(build_test_file(repo_root, test_path))
     return discovered
 
 
@@ -93,7 +97,7 @@ def discover_serial_test_files(repo_root: Path) -> list[TestFile]:
     for relative_path in sorted(SERIAL_MAIN_TEST_PATHS):
         test_path = repo_root / relative_path
         if test_path.is_file():
-            discovered.append(TestFile(path=relative_path, weight=max(test_path.stat().st_size, 1)))
+            discovered.append(build_test_file(repo_root, test_path))
     return discovered
 
 

--- a/scripts/ci/run_main_test_shards.py
+++ b/scripts/ci/run_main_test_shards.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import concurrent.futures
 import hashlib
+import importlib.util
 import multiprocessing
 import os
 import signal
@@ -203,10 +204,16 @@ def shard_basetemp_dir(repo_root: Path, shard: TestShard) -> Path:
     raise RuntimeError("unable to resolve pytest basetemp path outside repo")
 
 
+def pytest_cov_available() -> bool:
+    """Return whether the active interpreter can load pytest-cov."""
+
+    return importlib.util.find_spec("pytest_cov") is not None
+
+
 def build_pytest_args(shard: TestShard, repo_root: Path) -> list[str]:
     """Build one no-xdist pytest argv for a shard."""
 
-    return [
+    pytest_args = [
         "-c",
         "pyproject.toml",
         "-p",
@@ -219,14 +226,16 @@ def build_pytest_args(shard: TestShard, repo_root: Path) -> list[str]:
         f"faulthandler_timeout={DEFAULT_FAULTHANDLER_TIMEOUT_SECONDS}",
         "--basetemp",
         str(shard_basetemp_dir(repo_root, shard)),
-        "--cov=.",
-        "--cov-report=",
         "--junitxml",
         shard.junit_file,
         "-o",
         f"junit_family={JUNIT_FAMILY}",
         *[str(test_file.path) for test_file in shard.files],
     ]
+    if pytest_cov_available():
+        junit_index = pytest_args.index("--junitxml")
+        pytest_args[junit_index:junit_index] = ["--cov=.", "--cov-report="]
+    return pytest_args
 
 
 def build_shard_env(base_env: dict[str, str], shard: TestShard, repo_root: Path) -> dict[str, str]:

--- a/scripts/ci/run_main_test_shards.py
+++ b/scripts/ci/run_main_test_shards.py
@@ -27,6 +27,7 @@ PYTEST_BASETEMP_ROOT_NAME = "pulseplate-main-test-shards"
 PYTEST_BASETEMP_FALLBACK_ROOT_NAME = "pulseplate-main-test-shards-external"
 POSIX_TEMP_ROOT = Path(os.sep) / "tmp"
 WINDOWS_TEMP_ROOT = Path(os.environ.get("SystemRoot", r"C:\Windows")) / "Temp"
+SERIAL_MAIN_TEST_PATHS = frozenset({Path("tests/test_design_token_parity.py")})
 
 
 @dataclass(frozen=True)
@@ -59,7 +60,10 @@ class TestShard:
         return f"tests/results-{self.artifact_label}-shard-{self.index}.xml"
 
 
-def discover_test_files(repo_root: Path) -> list[TestFile]:
+def discover_test_files(
+    repo_root: Path,
+    excluded_paths: frozenset[Path] = frozenset(),
+) -> list[TestFile]:
     """Return all first-class pytest files for the main suite."""
 
     tests_root = repo_root / "tests"
@@ -68,15 +72,45 @@ def discover_test_files(repo_root: Path) -> list[TestFile]:
     for test_path in sorted(tests_root.rglob("test_*.py")):
         if disabled_root in test_path.parents:
             continue
-        if any(part.startswith(".") for part in test_path.relative_to(repo_root).parts):
+        relative_path = test_path.relative_to(repo_root)
+        if relative_path in excluded_paths:
+            continue
+        if any(part.startswith(".") for part in relative_path.parts):
             continue
         discovered.append(
             TestFile(
-                path=test_path.relative_to(repo_root),
+                path=relative_path,
                 weight=max(test_path.stat().st_size, 1),
             )
         )
     return discovered
+
+
+def discover_serial_test_files(repo_root: Path) -> list[TestFile]:
+    """Return tests that must run outside the process-parallel main shards."""
+
+    discovered: list[TestFile] = []
+    for relative_path in sorted(SERIAL_MAIN_TEST_PATHS):
+        test_path = repo_root / relative_path
+        if test_path.is_file():
+            discovered.append(TestFile(path=relative_path, weight=max(test_path.stat().st_size, 1)))
+    return discovered
+
+
+def build_serial_shards(repo_root: Path, artifact_label: str) -> list[TestShard]:
+    """Build deterministic serial shard wrappers for global/toolchain tests."""
+
+    serial_tests = discover_serial_test_files(repo_root)
+    if not serial_tests:
+        return []
+    return [
+        TestShard(
+            index=0,
+            artifact_label=artifact_label,
+            files=serial_tests,
+            weight=sum(test_file.weight for test_file in serial_tests),
+        )
+    ]
 
 
 def normalize_python_label(value: str) -> str:
@@ -462,6 +496,7 @@ def run_all_shards(
     shards: Sequence[TestShard],
     max_parallel: int,
     base_env: dict[str, str],
+    extra_coverage_files: Sequence[str] = (),
 ) -> int:
     """Run all shards, then combine and enforce coverage if all pass."""
 
@@ -517,7 +552,7 @@ def run_all_shards(
         print(f"MAIN_TEST_SHARDS_FAILED shards={failing_shards}", file=sys.stderr)
         return 1
 
-    coverage_files = [shard.coverage_file for shard in shards]
+    coverage_files = [*extra_coverage_files, *[shard.coverage_file for shard in shards]]
     combine_status = run_coverage_command(repo_root, ["combine", *coverage_files])
     if combine_status != 0:
         _log_coverage_failure("combine", combine_status)
@@ -530,6 +565,26 @@ def run_all_shards(
     if report_status != 0:
         _log_coverage_failure("report", report_status)
     return report_status
+
+
+def run_serial_shards(
+    repo_root: Path,
+    serial_shards: Sequence[TestShard],
+    base_env: dict[str, str],
+) -> int:
+    """Run global/toolchain tests sequentially before process-parallel shards."""
+
+    for shard in serial_shards:
+        exit_code = run_shard(repo_root, shard, base_env)
+        if exit_code != 0:
+            print(
+                f"MAIN_TEST_SERIAL_SHARD_FAILED label={shard.artifact_label} "
+                f"index={shard.index} exit_code={exit_code}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return exit_code
+    return 0
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
@@ -585,8 +640,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         shard = _build_explicit_shard(args, artifact_label)
         return run_shard_child(repo_root, shard, os.environ.copy())
 
-    test_files = discover_test_files(repo_root)
+    serial_shards = build_serial_shards(repo_root, artifact_label)
+    test_files = discover_test_files(repo_root, excluded_paths=SERIAL_MAIN_TEST_PATHS)
     shards = partition_test_files(test_files, args.shard_count, artifact_label)
+
+    for serial_shard in serial_shards:
+        print(
+            f"MAIN_TEST_SERIAL_PLAN label={serial_shard.artifact_label} "
+            f"index={serial_shard.index} files={len(serial_shard.files)} "
+            f"weight={serial_shard.weight}",
+            flush=True,
+        )
+        if args.list_shards:
+            for test_file in serial_shard.files:
+                print(f"  {test_file.path}")
 
     for shard in shards:
         print(
@@ -601,8 +668,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.list_shards:
         return 0
 
-    remove_previous_outputs(repo_root, shards)
-    return run_all_shards(repo_root, shards, args.max_parallel, os.environ.copy())
+    all_shards = [*serial_shards, *shards]
+    remove_previous_outputs(repo_root, all_shards)
+    base_env = os.environ.copy()
+    serial_status = run_serial_shards(repo_root, serial_shards, base_env)
+    if serial_status != 0:
+        return serial_status
+    return run_all_shards(
+        repo_root,
+        shards,
+        args.max_parallel,
+        base_env,
+        extra_coverage_files=[shard.coverage_file for shard in serial_shards],
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/ci/run_main_test_shards.py
+++ b/scripts/ci/run_main_test_shards.py
@@ -14,7 +14,7 @@ import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 DEFAULT_SHARD_COUNT = 2
 DEFAULT_MAX_PARALLEL = 2
@@ -398,17 +398,24 @@ def _build_explicit_shard(args: argparse.Namespace, artifact_label: str) -> Test
     return shard
 
 
-def run_coverage_command(repo_root: Path, args: Sequence[str]) -> int:
+def run_coverage_command(
+    repo_root: Path,
+    args: Sequence[str],
+    coverage_main: Callable[[list[str]], int | None] | None = None,
+) -> int:
     """Run a coverage command after all pytest shards pass."""
 
-    import coverage.cmdline
+    if coverage_main is None:
+        import coverage.cmdline
+
+        coverage_main = coverage.cmdline.main
 
     old_cwd = Path.cwd()
     old_coverage_file = os.environ.pop("COVERAGE_FILE", None)
     old_cov_core_datafile = os.environ.pop("COV_CORE_DATAFILE", None)
     try:
         os.chdir(repo_root)
-        return int(coverage.cmdline.main(list(args)) or 0)
+        return int(coverage_main(list(args)) or 0)
     finally:
         if old_coverage_file is not None:
             os.environ["COVERAGE_FILE"] = old_coverage_file

--- a/tests/test_main_test_shards.py
+++ b/tests/test_main_test_shards.py
@@ -273,6 +273,42 @@ def test_build_pytest_args_disables_xdist_and_emits_junit(tmp_path: Path) -> Non
     assert "tests/test_alpha.py" in pytest_args
 
 
+def test_build_pytest_args_omits_cov_args_when_pytest_cov_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    shard = runner.TestShard(
+        index=1,
+        artifact_label="py313",
+        files=[runner.TestFile(Path("tests/test_alpha.py"), 10)],
+        weight=10,
+    )
+    monkeypatch.setattr(runner, "pytest_cov_available", lambda: False)
+
+    pytest_args = runner.build_pytest_args(shard, tmp_path)
+
+    assert "--cov=." not in pytest_args
+    assert "--cov-report=" not in pytest_args
+
+
+def test_build_pytest_args_includes_cov_args_when_pytest_cov_is_available(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    shard = runner.TestShard(
+        index=1,
+        artifact_label="py313",
+        files=[runner.TestFile(Path("tests/test_alpha.py"), 10)],
+        weight=10,
+    )
+    monkeypatch.setattr(runner, "pytest_cov_available", lambda: True)
+
+    pytest_args = runner.build_pytest_args(shard, tmp_path)
+
+    assert "--cov=." in pytest_args
+    assert "--cov-report=" in pytest_args
+
+
 def test_build_shard_env_isolates_database_and_coverage(tmp_path: Path) -> None:
     shard = runner.TestShard(index=1, artifact_label="py313")
     env = runner.build_shard_env(

--- a/tests/test_main_test_shards.py
+++ b/tests/test_main_test_shards.py
@@ -44,6 +44,41 @@ def test_discover_test_files_includes_edges_and_excludes_disabled(tmp_path: Path
     ]
 
 
+def test_discover_test_files_excludes_serial_main_tests(tmp_path: Path) -> None:
+    _write_test_file(tmp_path, "tests/test_alpha.py", "def test_alpha(): pass\n")
+    _write_test_file(
+        tmp_path,
+        "tests/test_design_token_parity.py",
+        "def test_design_token_parity(): pass\n",
+    )
+
+    discovered = runner.discover_test_files(
+        tmp_path,
+        excluded_paths=runner.SERIAL_MAIN_TEST_PATHS,
+    )
+
+    assert [test_file.path.as_posix() for test_file in discovered] == ["tests/test_alpha.py"]
+
+
+def test_build_serial_shards_selects_toolchain_sensitive_tests(tmp_path: Path) -> None:
+    design_tokens = _write_test_file(
+        tmp_path,
+        "tests/test_design_token_parity.py",
+        "def test_design_token_parity(): pass\n",
+    )
+
+    serial_shards = runner.build_serial_shards(tmp_path, "py311")
+
+    assert len(serial_shards) == 1
+    assert serial_shards[0].index == 0
+    assert serial_shards[0].artifact_label == "py311"
+    assert serial_shards[0].coverage_file == ".coverage.py311-main-shard-0"
+    assert serial_shards[0].junit_file == "tests/results-py311-shard-0.xml"
+    assert serial_shards[0].files == [
+        runner.TestFile(Path("tests/test_design_token_parity.py"), design_tokens.stat().st_size)
+    ]
+
+
 def test_partition_test_files_balances_by_weight_and_keeps_all_files() -> None:
     files = [
         runner.TestFile(Path("tests/test_big.py"), 100),
@@ -598,6 +633,215 @@ def test_run_all_shards_max_parallel_one_uses_child_process_isolation(
         ["xml"],
         ["report", "-m", "--fail-under=97"],
     ]
+
+
+def test_run_all_shards_combines_serial_coverage_before_parallel_shards(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    shard = runner.TestShard(
+        index=1,
+        artifact_label="py311",
+        files=[runner.TestFile(Path("tests/test_alpha.py"), 1)],
+        weight=1,
+    )
+    coverage_calls: list[list[str]] = []
+    submitted: list[int] = []
+
+    class FakeExecutor:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+        def shutdown(self, *, wait: bool, cancel_futures: bool = False) -> None:
+            assert wait is True
+            assert cancel_futures is False
+
+        def submit(
+            self,
+            func: object,
+            repo_root: Path,
+            submitted_shard: runner.TestShard,
+            base_env: dict[str, str],
+        ) -> Future[int]:
+            del func
+            assert repo_root == tmp_path
+            assert base_env == {}
+            submitted.append(submitted_shard.index)
+            future: Future[int] = Future()
+            future.set_result(0)
+            return future
+
+    def fake_wait(
+        futures: set[Future[int]] | dict[Future[int], int],
+        *,
+        return_when: object,
+    ) -> tuple[set[Future[int]], set[Future[int]]]:
+        assert return_when is runner.concurrent.futures.FIRST_COMPLETED
+        return set(futures), set()
+
+    def fake_coverage(repo_root: Path, args: list[str]) -> int:
+        assert repo_root == tmp_path
+        coverage_calls.append(list(args))
+        return 0
+
+    monkeypatch.setattr(runner.concurrent.futures, "ProcessPoolExecutor", FakeExecutor)
+    monkeypatch.setattr(runner.concurrent.futures, "wait", fake_wait)
+    monkeypatch.setattr(runner, "run_coverage_command", fake_coverage)
+
+    assert (
+        runner.run_all_shards(
+            tmp_path,
+            [shard],
+            1,
+            {},
+            extra_coverage_files=[".coverage.py311-main-shard-0"],
+        )
+        == 0
+    )
+    assert submitted == [1]
+    assert coverage_calls == [
+        ["combine", ".coverage.py311-main-shard-0", ".coverage.py311-main-shard-1"],
+        ["xml"],
+        ["report", "-m", "--fail-under=97"],
+    ]
+
+
+def test_run_serial_shards_stops_before_parallel_phase_on_failure(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    serial_shard = runner.TestShard(
+        index=0,
+        artifact_label="py311",
+        files=[runner.TestFile(Path("tests/test_design_token_parity.py"), 1)],
+        weight=1,
+    )
+
+    monkeypatch.setattr(runner, "run_shard", lambda *args, **kwargs: 5)
+
+    assert runner.run_serial_shards(tmp_path, [serial_shard], {}) == 5
+    assert (
+        "MAIN_TEST_SERIAL_SHARD_FAILED label=py311 index=0 exit_code=5" in capsys.readouterr().err
+    )
+
+
+def test_main_stops_before_parallel_shards_when_serial_tests_fail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _write_test_file(tmp_path, "tests/test_alpha.py", "def test_alpha(): pass\n")
+    _write_test_file(
+        tmp_path,
+        "tests/test_design_token_parity.py",
+        "def test_design_token_parity(): pass\n",
+    )
+    captured_serial: dict[str, object] = {}
+
+    def fake_run_serial(
+        repo_root: Path,
+        serial_shards: list[runner.TestShard],
+        base_env: dict[str, str],
+    ) -> int:
+        del base_env
+        captured_serial["repo_root"] = repo_root
+        captured_serial["serial_paths"] = [
+            test_file.path.as_posix()
+            for serial_shard in serial_shards
+            for test_file in serial_shard.files
+        ]
+        return 5
+
+    monkeypatch.setattr(runner, "run_serial_shards", fake_run_serial)
+    monkeypatch.setattr(
+        runner,
+        "run_all_shards",
+        lambda *args, **kwargs: pytest.fail("parallel shards must not run"),
+    )
+
+    assert (
+        runner.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "--python-version",
+                "3.11",
+                "--shard-count",
+                "2",
+            ]
+        )
+        == 5
+    )
+    assert captured_serial == {
+        "repo_root": tmp_path.resolve(),
+        "serial_paths": ["tests/test_design_token_parity.py"],
+    }
+
+
+def test_main_passes_serial_coverage_into_parallel_combine(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _write_test_file(tmp_path, "tests/test_alpha.py", "def test_alpha(): pass\n")
+    _write_test_file(
+        tmp_path,
+        "tests/test_design_token_parity.py",
+        "def test_design_token_parity(): pass\n",
+    )
+    captured: dict[str, object] = {}
+
+    def fake_run_serial(
+        repo_root: Path,
+        serial_shards: list[runner.TestShard],
+        base_env: dict[str, str],
+    ) -> int:
+        del base_env
+        captured["serial_repo_root"] = repo_root
+        captured["serial_coverage"] = [serial_shard.coverage_file for serial_shard in serial_shards]
+        return 0
+
+    def fake_run_all(
+        repo_root: Path,
+        shards: list[runner.TestShard],
+        max_parallel: int,
+        base_env: dict[str, str],
+        extra_coverage_files: list[str],
+    ) -> int:
+        del base_env
+        captured["parallel_repo_root"] = repo_root
+        captured["parallel_paths"] = [
+            test_file.path.as_posix() for shard in shards for test_file in shard.files
+        ]
+        captured["max_parallel"] = max_parallel
+        captured["extra_coverage_files"] = extra_coverage_files
+        return 0
+
+    monkeypatch.setattr(runner, "run_serial_shards", fake_run_serial)
+    monkeypatch.setattr(runner, "run_all_shards", fake_run_all)
+
+    assert (
+        runner.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "--python-version",
+                "3.11",
+                "--shard-count",
+                "2",
+                "--max-parallel",
+                "1",
+            ]
+        )
+        == 0
+    )
+    assert captured == {
+        "serial_repo_root": tmp_path.resolve(),
+        "serial_coverage": [".coverage.py311-main-shard-0"],
+        "parallel_repo_root": tmp_path.resolve(),
+        "parallel_paths": ["tests/test_alpha.py"],
+        "max_parallel": 1,
+        "extra_coverage_files": [".coverage.py311-main-shard-0"],
+    }
 
 
 def test_collect_shard_results_reports_worker_exceptions(

--- a/tests/test_main_test_shards.py
+++ b/tests/test_main_test_shards.py
@@ -10,7 +10,6 @@ import tempfile
 from concurrent.futures import Future
 from pathlib import Path
 
-import coverage.cmdline
 import pytest
 
 from scripts.ci import run_main_test_shards as runner
@@ -952,9 +951,7 @@ def test_run_coverage_command_uses_coverage_api(
         captured["cov_core_datafile"] = os.environ.get("COV_CORE_DATAFILE")
         return 0
 
-    monkeypatch.setattr(coverage.cmdline, "main", fake_main)
-
-    assert runner.run_coverage_command(tmp_path, ["xml"]) == 0
+    assert runner.run_coverage_command(tmp_path, ["xml"], coverage_main=fake_main) == 0
     assert captured == {
         "args": ["xml"],
         "cwd": tmp_path,

--- a/tests/test_main_test_shards.py
+++ b/tests/test_main_test_shards.py
@@ -44,6 +44,18 @@ def test_discover_test_files_includes_edges_and_excludes_disabled(tmp_path: Path
     ]
 
 
+def test_build_test_file_normalizes_relative_path_and_weight(tmp_path: Path) -> None:
+    test_path = _write_test_file(
+        tmp_path,
+        "tests/test_alpha.py",
+        "def test_alpha(): pass\n",
+    )
+
+    test_file = runner.build_test_file(tmp_path, test_path)
+
+    assert test_file == runner.TestFile(Path("tests/test_alpha.py"), test_path.stat().st_size)
+
+
 def test_discover_test_files_excludes_serial_main_tests(tmp_path: Path) -> None:
     _write_test_file(tmp_path, "tests/test_alpha.py", "def test_alpha(): pass\n")
     _write_test_file(


### PR DESCRIPTION
## Goal
Fix current `main` CI failure on merge commit `92a28aa6739a876eb3127c4adcd089592c22a7ef`: `test-main (3.11, 60)` failed in `tests/test_design_token_parity.py::test_token_build_script_is_deterministic` while the process-parallel main shard runner was active.

## Business Reason
Restore protected `main` health after PR #2006 merge without widening product, API, frontend runtime, iOS, auth, billing, or nutrition behavior.

## Scope
- Run `tests/test_design_token_parity.py` as a serial pre-shard in `scripts/ci/run_main_test_shards.py`.
- Exclude that file from the process-parallel main shard partition.
- Preserve fail-closed toolchain behavior and coverage enforcement by combining serial shard coverage before regular shard coverage.
- Add regression coverage in `tests/test_main_test_shards.py` for serial discovery, failure-before-parallel behavior, coverage combine wiring, and main orchestration.
- Add canonical fixed-mapping artifact at `docs/review/PR_2007_FIXED_MAPPING.md`.
- Share `TestFile` metadata construction between regular and serial discovery in response to Sourcery feedback.

## Out Of Scope
- No npm install/workflow dependency changes.
- No coverage threshold weakening.
- No skip/xfail or async-marker changes.
- No product/runtime code changes.

## Validation
- `python3 scripts/orchestration/check_preflight.py` PASS
- `python3 scripts/orchestration/check_agent_consistency.py` PASS
- `. .venv/bin/activate && pytest -q tests/test_main_test_shards.py tests/test_design_token_parity.py::test_token_build_script_is_deterministic` PASS: 44 tests after Sourcery fix
- `VENV_PYTHON="$(. scripts/hooks/repo_python.sh; resolve_repo_python "$PWD")" BRANCH_DIFF_MODE=1 bash scripts/run-backend-tests-pre-commit.sh` PASS after CI lint fixes
- `. .venv/bin/activate && mypy scripts/ci/run_main_test_shards.py` PASS
- `. .venv/bin/activate && python scripts/ci/run_main_test_shards.py --python-version 3.11 --shard-count 4 --max-parallel 4 --list-shards | rg "MAIN_TEST_SERIAL_PLAN|MAIN_TEST_SHARD_PLAN|test_design_token_parity.py"` PASS: design-token file appears only under `MAIN_TEST_SERIAL_PLAN`
- `make validate-changed` PASS: selected `tests/test_main_test_shards.py`
- `pre-commit run --all-files` PASS
- `git diff --check` PASS
- pre-push hook PASS: backend pre-push tests, full Bandit, docker build test

## Governance Evidence
- Task packet: local `artifacts/orchestration/task_packets/e7266cc0a9cc.json`
- Dispatch manifest: `agent-coordinator -> qa-engineer-agent -> security-auditor -> backend-engineer -> bug-hunter`, missing agents none
- QA role pass: Hooke reported no blocking QA finding; recommended extra `main()` orchestration tests were added
- Premortem: local `artifacts/orchestration/premortem/pr2007-main-shard-token-parity-premortem.md`; all findings FIXED or NOT-A-BUG with evidence
- Experiment Runner oracle-only: local `artifacts/orchestration/experiments/results/pr2007-main-shard-token-parity-result-v2.json`, status accepted, all oracle commands exit 0
- Fixed mapping artifact: `docs/review/PR_2007_FIXED_MAPPING.md`
- Bug-hunter role pass: Turing reported no P0/P1 findings.
- Security-auditor role pass: Sartre reported no security/governance blockers.
- PulsePlate PR review: one `large-diff-risk` advisory dispositioned as NOT-A-BUG in `docs/review/PR_2007_FIXED_MAPPING.md`.

## Machine-Heavy Local Verify Note
Full local `make verify` was not run for this CI/tooling hotfix. The lane uses the operator-preferred narrow bundle plus current-head CI as the heavy signal. This does not waive any failing focused gate.

## Security Notes
No privileged runtime, auth, billing, secrets, deployment credential, API, DB, or network behavior changes. The change only affects local/CI pytest orchestration.

## Risks / Rollback
Risk: serial pre-shard adds a small amount of wall time before parallel shards. Rollback: revert this PR to return to previous parallel partitioning.

## Deferred / Follow-Ups
None.

## Discussion Thread Pass
- [x] Discussion-thread pass completed
- [x] Fixed in commit mapping completed

Sourcery review-level feedback is mapped in `docs/review/PR_2007_FIXED_MAPPING.md`.

### Fixed in Commit Mapping
- https://github.com/Katsiarynakavaleuskaya/PulsePlate/pull/2007#pullrequestreview-4547611166 -> 2b45be038
Disposition: FIXED
Commit: 2b45be038
Evidence: `scripts/ci/run_main_test_shards.py` now uses shared `build_test_file(...)` metadata construction from both regular and serial discovery paths; `tests/test_main_test_shards.py` adds `test_build_test_file_normalizes_relative_path_and_weight`. Focused pytest and targeted mypy passed.

## PulsePlate PR Review Disposition
Finding: `large-diff-risk` advisory from `pulseplate-pr-review`.

Disposition: NOT-A-BUG
Evidence: The line count is driven by focused runner regression tests and the canonical review artifact. Production scope is limited to CI/test orchestration; focused pytest, targeted mypy, `make validate-changed`, `pre-commit run --all-files`, pre-push hooks, and `git diff --check` passed.
Reason: The PR is intentionally narrow despite crossing the dry-run line-count threshold; no runtime product, API, dependency, coverage-threshold, skip/xfail, auth, billing, nutrition, frontend runtime, or iOS scope is included.

## CI Failure Disposition
Finding: Current-head `lint` / `backend-tests` failed because `tests/test_main_test_shards.py` imported `coverage.cmdline` at module import time, but CI lint uses the `ci-lite` dependency profile where `coverage` is not installed.

Disposition: FIXED
Commit: 911fa570e
Evidence: `scripts/ci/run_main_test_shards.py` now allows `run_coverage_command(...)` to receive an injected `coverage_main`, and `tests/test_main_test_shards.py` no longer imports `coverage.cmdline` during collection. Exact backend-tests hook passed locally.

Finding: Current-head `lint` / `backend-tests` then failed because the child-process isolation test exercised pytest with `--cov` arguments in the `ci-lite` environment where `pytest-cov` is not installed.

Disposition: FIXED
Commit: b833664d1
Evidence: `scripts/ci/run_main_test_shards.py` detects `pytest_cov` before adding `--cov` pytest arguments, while coverage combine/report still enforce failure when real coverage artifacts are missing. `tests/test_main_test_shards.py` covers both pytest-cov-present and pytest-cov-missing argument construction. Exact backend-tests hook, focused pytest, targeted mypy, and `git diff --check` passed.

## Merge Readiness
Not merge-ready yet. Await current-head CI, Codex Security diff scan/finding discovery, and strict merge-readiness wrapper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented deterministic serial execution for design token parity tests alongside parallel test execution.
  * Added conditional coverage flag injection based on tool availability.

* **Chores**
  * Added documentation for CI mapping and PR fixing procedures.

* **Tests**
  * Expanded test coverage for test-shard runner and CI orchestration logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->